### PR TITLE
Fix a NullPointerException bug of the prediction transport action request when the parameters is null

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/prediction/MLPredictionTaskRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/prediction/MLPredictionTaskRequest.java
@@ -16,6 +16,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -93,7 +94,7 @@ public class MLPredictionTaskRequest extends ActionRequest {
         super.writeTo(out);
         out.writeInt(this.version);
         out.writeString(this.algorithm);
-        out.writeList(this.parameters);
+        out.writeList(this.parameters == null ? new ArrayList<>() : this.parameters);
         out.writeOptionalString(this.modelId);
         this.inputDataset.writeTo(out);
     }

--- a/common/src/test/java/org/opensearch/ml/common/transport/prediction/MLPredictionTaskRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/prediction/MLPredictionTaskRequestTest.java
@@ -157,4 +157,22 @@ public class MLPredictionTaskRequestTest {
         };
         MLPredictionTaskRequest.fromActionRequest(actionRequest);
     }
+
+    @Test
+    public void fromActionRequest_Success_WithNullParameters() throws IOException {
+        MLPredictionTaskRequest request = MLPredictionTaskRequest.builder()
+            .algorithm("algo")
+            .parameters(null)
+            .inputDataset(DataFrameInputDataset.builder()
+                .dataFrame(DataFrameBuilder.load(Collections.singletonList(new HashMap<String, Object>() {{
+                    put("key1", 2.0D); }})))
+                .build())
+            .build();
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        request.writeTo(bytesStreamOutput);
+        request = new MLPredictionTaskRequest(bytesStreamOutput.bytes().streamInput());
+        assertEquals("algo", request.getAlgorithm());
+        assertEquals(0, request.getParameters().size());
+        assertNull(request.getModelId());
+    }
 }


### PR DESCRIPTION
Fix a NullPointerException bug of the prediction transport action request when the parameters is null

Signed-off-by: Alex <pengsun@amazon.com>
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/72
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
