### PR TITLE
support train ML model in either sync or async way

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/parameter/MLTrainingOutput.java
+++ b/common/src/main/java/org/opensearch/ml/common/parameter/MLTrainingOutput.java
@@ -27,20 +27,24 @@ public class MLTrainingOutput extends MLOutput{
 
     private static final MLOutputType OUTPUT_TYPE = MLOutputType.TRAINING;
     public static final String MODEL_ID_FIELD = "model_id";
+    public static final String TASK_ID_FIELD = "task_id";
     public static final String STATUS_FIELD = "status";
     private String modelId;
+    private String taskId;
     private String status;
 
     @Builder
-    public MLTrainingOutput(String modelId, String status) {
+    public MLTrainingOutput(String modelId, String taskId, String status) {
         super(OUTPUT_TYPE);
         this.modelId = modelId;
+        this.taskId = taskId;
         this.status= status;
     }
 
     public MLTrainingOutput(StreamInput in) throws IOException {
         super(OUTPUT_TYPE);
         this.modelId = in.readOptionalString();
+        this.taskId = in.readOptionalString();
         this.status = in.readOptionalString();
     }
 
@@ -53,13 +57,19 @@ public class MLTrainingOutput extends MLOutput{
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeOptionalString(modelId);
+        out.writeOptionalString(taskId);
         out.writeOptionalString(status);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(MODEL_ID_FIELD, modelId);
+        if (modelId != null) {
+            builder.field(MODEL_ID_FIELD, modelId);
+        }
+        if (taskId != null) {
+            builder.field(TASK_ID_FIELD, taskId);
+        }
         builder.field(STATUS_FIELD, status);
         builder.endObject();
         return builder;

--- a/common/src/main/java/org/opensearch/ml/common/transport/training/MLTrainingTaskRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/training/MLTrainingTaskRequest.java
@@ -42,15 +42,18 @@ public class MLTrainingTaskRequest extends ActionRequest {
      * the name of algorithm
      */
     MLInput mlInput;
+    boolean async;
 
     @Builder
-    public MLTrainingTaskRequest(MLInput mlInput) {
+    public MLTrainingTaskRequest(MLInput mlInput, boolean async) {
         this.mlInput = mlInput;
+        this.async = async;
     }
 
     public MLTrainingTaskRequest(StreamInput in) throws IOException {
         super(in);
         this.mlInput = new MLInput(in);
+        this.async = in.readBoolean();
     }
 
     @Override
@@ -69,6 +72,7 @@ public class MLTrainingTaskRequest extends ActionRequest {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         this.mlInput.writeTo(out);
+        out.writeBoolean(async);
     }
 
     public static MLTrainingTaskRequest fromActionRequest(ActionRequest actionRequest) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/Model.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/Model.java
@@ -14,6 +14,7 @@ package org.opensearch.ml.engine;
 
 import lombok.Data;
 
+//TODO: remove this class, use MLModel
 @Data
 public class Model {
     String name;

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -209,7 +209,9 @@ List<String> jacocoExclusions = [
         'org.opensearch.ml.task.MLPredictTaskRunner',
         'org.opensearch.ml.rest.RestMLTrainingAction',
         'org.opensearch.ml.rest.RestMLPredictionAction',
-        'org.opensearch.ml.utils.RestActionUtils'
+        'org.opensearch.ml.utils.RestActionUtils',
+        'org.opensearch.ml.task.MLTaskCache',
+        'org.opensearch.ml.task.MLTaskManager'
 ]
 
 jacocoTestCoverageVerification {

--- a/plugin/src/main/java/org/opensearch/ml/model/MLTask.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLTask.java
@@ -46,10 +46,12 @@ public class MLTask implements ToXContentObject, Writeable {
     public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
     public static final String ERROR_FIELD = "error";
     public static final String USER_FIELD = "user";
+    public static final String IS_ASYNC_TASK_FIELD = "is_async";
 
     @Setter
     private String taskId;
-    private final String modelId;
+    @Setter
+    private String modelId;
     private final MLTaskType taskType;
     private final FunctionName functionName;
     @Setter
@@ -63,6 +65,7 @@ public class MLTask implements ToXContentObject, Writeable {
     @Setter
     private String error;
     private User user; // TODO: support document level access control later
+    private boolean async;
 
     @Builder
     public MLTask(
@@ -78,7 +81,8 @@ public class MLTask implements ToXContentObject, Writeable {
         Instant createTime,
         Instant lastUpdateTime,
         String error,
-        User user
+        User user,
+        boolean async
     ) {
         this.taskId = taskId;
         this.modelId = modelId;
@@ -93,6 +97,7 @@ public class MLTask implements ToXContentObject, Writeable {
         this.lastUpdateTime = lastUpdateTime;
         this.error = error;
         this.user = user;
+        this.async = async;
     }
 
     public MLTask(StreamInput input) throws IOException {
@@ -113,6 +118,7 @@ public class MLTask implements ToXContentObject, Writeable {
         } else {
             this.user = null;
         }
+        this.async = input.readBoolean();
     }
 
     @Override
@@ -134,6 +140,7 @@ public class MLTask implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
+        out.writeBoolean(async);
     }
 
     @Override
@@ -178,6 +185,7 @@ public class MLTask implements ToXContentObject, Writeable {
         if (user != null) {
             builder.field(USER_FIELD, user);
         }
+        builder.field(IS_ASYNC_TASK_FIELD, async);
         return builder.endObject();
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLTrainingAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLTrainingAction.java
@@ -15,6 +15,7 @@ import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedT
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_ALGORITHM;
 import static org.opensearch.ml.utils.RestActionUtils.getAlgorithm;
+import static org.opensearch.ml.utils.RestActionUtils.isAsync;
 
 import java.io.IOException;
 import java.util.List;
@@ -66,11 +67,12 @@ public class RestMLTrainingAction extends BaseRestHandler {
     @VisibleForTesting
     MLTrainingTaskRequest getRequest(RestRequest request) throws IOException {
         String algorithm = getAlgorithm(request);
+        boolean async = isAsync(request);
 
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         MLInput mlInput = MLInput.parse(parser, algorithm);
 
-        return new MLTrainingTaskRequest(mlInput);
+        return new MLTrainingTaskRequest(mlInput, async);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskCache.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskCache.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.ml.task;
+
+import java.util.concurrent.Semaphore;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import org.opensearch.ml.model.MLTask;
+
+@Getter
+public class MLTaskCache {
+    MLTask mlTask;
+    Semaphore updateTaskIndexSemaphore;
+
+    @Builder
+    public MLTaskCache(MLTask mlTask) {
+        this.mlTask = mlTask;
+        if (mlTask.isAsync()) {
+            updateTaskIndexSemaphore = new Semaphore(1);
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -16,6 +16,7 @@ import org.opensearch.rest.RestRequest;
 public class RestActionUtils {
 
     public static final String PARAMETER_ALGORITHM = "algorithm";
+    public static final String PARAMETER_ASYNC = "async";
     public static final String PARAMETER_MODEL_ID = "model_id";
 
     public static String getAlgorithm(RestRequest request) {
@@ -24,6 +25,10 @@ public class RestActionUtils {
             throw new IllegalArgumentException("Request should contain algorithm!");
         }
         return algorithm.toUpperCase(Locale.ROOT);
+    }
+
+    public static boolean isAsync(RestRequest request) {
+        return request.paramAsBoolean(PARAMETER_ASYNC, false);
     }
 
     /**
@@ -44,7 +49,9 @@ public class RestActionUtils {
      * Create SearchQueryInputDataset from a RestRequest
      *
      * @param request RestRequest
+     * @param client node client
      * @return SearchQueryInputDataset with indices and search source
+     * @throws IOException throw IOException when fail to parse search request
      */
     public static SearchQueryInputDataset buildSearchQueryInput(RestRequest request, NodeClient client) throws IOException {
         SearchRequest searchRequest = new SearchRequest();

--- a/plugin/src/test/java/org/opensearch/ml/action/training/TrainingITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/training/TrainingITTests.java
@@ -86,7 +86,7 @@ public class TrainingITTests extends OpenSearchIntegTestCase {
     // Train a model without dataset.
     public void testTrainingWithoutDataset() {
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.KMEANS).build();
-        MLTrainingTaskRequest trainingRequest = new MLTrainingTaskRequest(mlInput);
+        MLTrainingTaskRequest trainingRequest = new MLTrainingTaskRequest(mlInput, true);
         expectThrows(ActionRequestValidationException.class, () -> {
             ActionFuture<MLTrainingTaskResponse> trainingFuture = client().execute(MLTrainingTaskAction.INSTANCE, trainingRequest);
             trainingFuture.actionGet();
@@ -99,7 +99,7 @@ public class TrainingITTests extends OpenSearchIntegTestCase {
         searchSourceBuilder.query(QueryBuilders.matchQuery("noSuchName", ""));
         MLInputDataset inputDataset = new SearchQueryInputDataset(Collections.singletonList(TESTING_INDEX_NAME), searchSourceBuilder);
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.KMEANS).inputDataset(inputDataset).build();
-        MLTrainingTaskRequest trainingRequest = new MLTrainingTaskRequest(mlInput);
+        MLTrainingTaskRequest trainingRequest = new MLTrainingTaskRequest(mlInput, false);
 
         expectThrows(IllegalArgumentException.class, () -> client().execute(MLTrainingTaskAction.INSTANCE, trainingRequest).actionGet());
     }

--- a/plugin/src/test/java/org/opensearch/ml/model/MLTaskTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLTaskTests.java
@@ -69,7 +69,7 @@ public class MLTaskTests {
             "{\"task_id\":\"dummy taskId\",\"model_id\":\"test_model_id\",\"task_type\":\"PREDICTION\","
                 + "\"function_name\":\"KMEANS\",\"state\":\"RUNNING\",\"input_type\":\"DATA_FRAME\",\"progress\":0.0,"
                 + "\"output_index\":\"test_index\",\"worker_node\":\"node1\",\"create_time\":1641599940000,"
-                + "\"last_update_time\":1641600000000,\"error\":\"test_error\"}",
+                + "\"last_update_time\":1641600000000,\"error\":\"test_error\",\"is_async\":false}",
             taskContent
         );
     }
@@ -80,6 +80,7 @@ public class MLTaskTests {
         MLTask task = MLTask.builder().build();
         task.toXContent(builder, ToXContent.EMPTY_PARAMS);
         String taskContent = TestHelper.xContentBuilderToString(builder);
-        assertEquals("{}", taskContent);
+        System.out.println(taskContent);
+        assertEquals("{\"is_async\":false}", taskContent);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/utils/IntegTestUtils.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/IntegTestUtils.java
@@ -122,7 +122,7 @@ public class IntegTestUtils extends OpenSearchIntegTestCase {
     // Train a model.
     public static String trainModel(MLInputDataset inputDataset) throws ExecutionException, InterruptedException {
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.KMEANS).inputDataset(inputDataset).build();
-        MLTrainingTaskRequest trainingRequest = new MLTrainingTaskRequest(mlInput);
+        MLTrainingTaskRequest trainingRequest = new MLTrainingTaskRequest(mlInput, true); // TODO: support train test in sync way
         ActionFuture<MLTrainingTaskResponse> trainingFuture = client().execute(MLTrainingTaskAction.INSTANCE, trainingRequest);
         MLTrainingTaskResponse trainingResponse = trainingFuture.actionGet();
         assertNotNull(trainingResponse);


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Support training ML model in either sync or async way.
For example, PPL user should be able to train ML model in sync way; and user can use async way if the model training will be time consuming.

Main changes:
1. Support `async` URL parameter in train API. Add `?async=true` if need to train model in async way, by default will train model in sync way.
2. If train model in sync way, won't persist task in index.
3. For sync way, will return both model id and task id. For async way, will just return task id and user need to poll task to know its state/progress.
4. Use `GetRequest` to get model in predict task runner
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
