### PR TITLE
support short and long type in data frame

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/dataframe/ColumnType.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataframe/ColumnType.java
@@ -14,15 +14,25 @@ package org.opensearch.ml.common.dataframe;
 
 public enum ColumnType {
     STRING,
+    SHORT,
     INTEGER,
+    LONG,
     DOUBLE,
     BOOLEAN,
     FLOAT,
     NULL;
 
     public static ColumnType from(Object object) {
+        if(object instanceof Short) {
+            return SHORT;
+        }
+
         if(object instanceof Integer) {
             return INTEGER;
+        }
+
+        if(object instanceof Long) {
+            return LONG;
         }
 
         if(object instanceof String) {

--- a/common/src/main/java/org/opensearch/ml/common/dataframe/ColumnValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataframe/ColumnValue.java
@@ -25,8 +25,16 @@ public interface ColumnValue extends Writeable, ToXContentObject {
 
     Object getValue();
 
+    default short shortValue() {
+        throw new RuntimeException("the value isn't Short type");
+    }
+
     default int intValue() {
         throw new RuntimeException("the value isn't Integer type");
+    }
+
+    default long longValue() {
+        throw new RuntimeException("the value isn't Long type");
     }
 
     default String stringValue() {

--- a/common/src/main/java/org/opensearch/ml/common/dataframe/ColumnValueBuilder.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataframe/ColumnValueBuilder.java
@@ -29,8 +29,16 @@ public class ColumnValueBuilder {
             return new NullValue();
         }
 
+        if(object instanceof Short) {
+            return new ShortValue((Short)object);
+        }
+
         if(object instanceof Integer) {
             return new IntValue((Integer)object);
+        }
+
+        if(object instanceof Long) {
+            return new LongValue((Long)object);
         }
 
         if(object instanceof String) {

--- a/common/src/main/java/org/opensearch/ml/common/dataframe/ColumnValueReader.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataframe/ColumnValueReader.java
@@ -22,8 +22,12 @@ public class ColumnValueReader implements Writeable.Reader<ColumnValue> {
     public ColumnValue read(StreamInput in) throws IOException {
         ColumnType columnType = in.readEnum(ColumnType.class);
         switch (columnType){
+            case SHORT:
+                return new ShortValue(in.readShort());
             case INTEGER:
                 return new IntValue(in.readInt());
+            case LONG:
+                return new LongValue(in.readLong());
             case DOUBLE:
                 return new DoubleValue(in.readDouble());
             case STRING:

--- a/common/src/main/java/org/opensearch/ml/common/dataframe/LongValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataframe/LongValue.java
@@ -1,35 +1,27 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- *
  */
 
 package org.opensearch.ml.common.dataframe;
-
-import java.io.IOException;
-
-import org.opensearch.common.io.stream.StreamOutput;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.FieldDefaults;
+import org.opensearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
 
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @RequiredArgsConstructor
 @ToString
-public class IntValue implements ColumnValue {
-    int value;
+public class LongValue implements ColumnValue {
+    long value;
 
     @Override
     public ColumnType columnType() {
-        return ColumnType.INTEGER;
+        return ColumnType.LONG;
     }
 
     @Override
@@ -38,18 +30,18 @@ public class IntValue implements ColumnValue {
     }
 
     @Override
-    public int intValue() {
+    public long longValue() {
         return value;
     }
 
     @Override
     public double doubleValue() {
-        return Integer.valueOf(value).doubleValue();
+        return Long.valueOf(value).doubleValue();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeEnum(columnType());
-        out.writeInt(value);
+        out.writeLong(value);
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/dataframe/ShortValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataframe/ShortValue.java
@@ -1,35 +1,27 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- *
  */
 
 package org.opensearch.ml.common.dataframe;
-
-import java.io.IOException;
-
-import org.opensearch.common.io.stream.StreamOutput;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.FieldDefaults;
+import org.opensearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
 
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @RequiredArgsConstructor
 @ToString
-public class IntValue implements ColumnValue {
-    int value;
+public class ShortValue implements ColumnValue {
+    short value;
 
     @Override
     public ColumnType columnType() {
-        return ColumnType.INTEGER;
+        return ColumnType.SHORT;
     }
 
     @Override
@@ -38,18 +30,18 @@ public class IntValue implements ColumnValue {
     }
 
     @Override
-    public int intValue() {
+    public short shortValue() {
         return value;
     }
 
     @Override
     public double doubleValue() {
-        return Integer.valueOf(value).doubleValue();
+        return Short.valueOf(value).doubleValue();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeEnum(columnType());
-        out.writeInt(value);
+        out.writeShort(value);
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnValueBuilderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnValueBuilderTest.java
@@ -33,6 +33,7 @@ public class ColumnValueBuilderTest {
         value = ColumnValueBuilder.build(2);
         assertEquals(ColumnType.INTEGER, value.columnType());
         assertEquals(2, value.intValue());
+        assertEquals(2.0d, value.doubleValue(), 1e-5);
 
         value = ColumnValueBuilder.build("string");
         assertEquals(ColumnType.STRING, value.columnType());
@@ -49,6 +50,17 @@ public class ColumnValueBuilderTest {
         value = ColumnValueBuilder.build(2.1f);
         assertEquals(ColumnType.FLOAT, value.columnType());
         assertEquals(2.1f, value.floatValue(), 1e-5);
+        assertEquals(2.1d, value.doubleValue(), 1e-5);
+
+        value = ColumnValueBuilder.build((short)2);
+        assertEquals(ColumnType.SHORT, value.columnType());
+        assertEquals(2, value.shortValue());
+        assertEquals(2.0d, value.doubleValue(), 1e-5);
+
+        value = ColumnValueBuilder.build((long)2);
+        assertEquals(ColumnType.LONG, value.columnType());
+        assertEquals(2, value.longValue());
+        assertEquals(2.0d, value.doubleValue(), 1e-5);
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnValueReaderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnValueReaderTest.java
@@ -90,4 +90,24 @@ public class ColumnValueReaderTest {
         assertEquals(ColumnType.FLOAT, value.columnType());
         assertEquals(2.1f, value.floatValue(), 1e-5);
     }
+
+    @Test
+    public void read_ShortValue() throws IOException {
+        ColumnValue value = new ShortValue((short)2);
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        value.writeTo(bytesStreamOutput);
+        value = reader.read(bytesStreamOutput.bytes().streamInput());
+        assertEquals(ColumnType.SHORT, value.columnType());
+        assertEquals(2, value.shortValue());
+    }
+
+    @Test
+    public void read_LongValue() throws IOException {
+        ColumnValue value = new LongValue((long)2);
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        value.writeTo(bytesStreamOutput);
+        value = reader.read(bytesStreamOutput.bytes().streamInput());
+        assertEquals(ColumnType.LONG, value.columnType());
+        assertEquals(2, value.longValue());
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnValueTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnValueTest.java
@@ -57,7 +57,7 @@ public class ColumnValueTest {
     public void wrongDoubleValue() {
         exceptionRule.expect(RuntimeException.class);
         exceptionRule.expectMessage("the value isn't Double type");
-        ColumnValue value = new IntValue(1);
+        ColumnValue value = new BooleanValue(true);
         value.doubleValue();
     }
 
@@ -67,5 +67,21 @@ public class ColumnValueTest {
         exceptionRule.expectMessage("the value isn't Float type");
         ColumnValue value = new IntValue(1);
         value.floatValue();
+    }
+
+    @Test
+    public void wrongShortValue() {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage("the value isn't Short type");
+        ColumnValue value = new IntValue(1);
+        value.shortValue();
+    }
+
+    @Test
+    public void wrongLongValue() {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage("the value isn't Long type");
+        ColumnValue value = new IntValue(1);
+        value.longValue();
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/LongValueTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/LongValueTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.dataframe;
+
+import org.junit.Test;
+import org.opensearch.common.Strings;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class LongValueTest {
+
+    @Test
+    public void longValue() {
+        LongValue longValue = new LongValue((long)2);
+        assertEquals(ColumnType.LONG, longValue.columnType());
+        assertEquals(2L, longValue.getValue());
+        assertEquals(2.0d, longValue.doubleValue(), 1e-5);
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        LongValue longValue = new LongValue((long)2);
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        longValue.toXContent(builder);
+
+        assertNotNull(builder);
+        String jsonStr = Strings.toString(builder);
+        assertEquals("{\"column_type\":\"LONG\",\"value\":2}", jsonStr);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/ShortValueTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/ShortValueTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.dataframe;
+
+import org.junit.Test;
+import org.opensearch.common.Strings;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ShortValueTest {
+
+    @Test
+    public void shortValue() {
+        ShortValue shortValue = new ShortValue((short)2);
+        assertEquals(ColumnType.SHORT, shortValue.columnType());
+        assertEquals(2, shortValue.getValue());
+        assertEquals(2.0d, shortValue.doubleValue(), 1e-5);
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        ShortValue shortValue = new ShortValue((short)2);
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        shortValue.toXContent(builder);
+
+        assertNotNull(builder);
+        String jsonStr = Strings.toString(builder);
+        assertEquals("{\"column_type\":\"SHORT\",\"value\":2}", jsonStr);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/ShortValueTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/ShortValueTest.java
@@ -22,7 +22,7 @@ public class ShortValueTest {
     public void shortValue() {
         ShortValue shortValue = new ShortValue((short)2);
         assertEquals(ColumnType.SHORT, shortValue.columnType());
-        assertEquals(2, shortValue.getValue());
+        assertEquals((short)2, shortValue.getValue());
         assertEquals(2.0d, shortValue.doubleValue(), 1e-5);
     }
 


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Support short and long data type 
 
### Issues Resolved
#128 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
