### PR TITLE
fix jarhell error from SQL build

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     compile group: 'org.reflections', name: 'reflections', version: '0.9.12'
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    compile "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
+    compileOnly "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     compile "org.opensearch:common-utils:${common_utils_version}"
 }
 
@@ -45,3 +45,4 @@ jacocoTestCoverageVerification {
 check.dependsOn jacocoTestCoverageVerification
 
 lombok.config['lombok.nonNull.exceptionType'] = 'JDK'
+


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
From @jackiehanyang , SQL build will throw JarHell error
```
> Task :doctest:runRestTestCluster FAILED
Exec output and error:
| Output for ./bin/opensearch-plugin:warning: no-jdk distributions that do not bundle a JDK are deprecated and will be removed in a future release
| -> Installing file:/home/runner/work/sql/sql/plugin/build/distributions/opensearch-sql-1.3.0.0-SNAPSHOT.zip
| -> Downloading file:/home/runner/work/sql/sql/plugin/build/distributions/opensearch-sql-1.3.0.0-SNAPSHOT.zip
| -> Failed installing file:/home/runner/work/sql/sql/plugin/build/distributions/opensearch-sql-1.3.0.0-SNAPSHOT.zip
| -> Rolling back file:/home/runner/work/sql/sql/plugin/build/distributions/opensearch-sql-1.3.0.0-SNAPSHOT.zip
| -> Rolled back file:/home/runner/work/sql/sql/plugin/build/distributions/opensearch-sql-1.3.0.0-SNAPSHOT.zip
| Exception in thread "main" java.lang.IllegalStateException: failed to load plugin opensearch-sql due to jar hell
|     at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:678)
|     at org.opensearch.plugins.InstallPluginCommand.jarHellCheck(InstallPluginCommand.java:845)
|     at org.opensearch.plugins.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:813)
|     at org.opensearch.plugins.InstallPluginCommand.installPlugin(InstallPluginCommand.java:858)
|     at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:263)
|     at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:237)
|     at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:100)
|     at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|     at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
|     at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|     at org.opensearch.cli.Command.main(Command.java:101)
|     at org.opensearch.plugins.PluginCli.main(PluginCli.java:60)
| Caused by: java.lang.IllegalStateException: jar hell!
| class: org.opensearch.client.Cancellable$1
| jar1: /home/runner/work/sql/sql/doctest/build/testclusters/docTestCluster-0/distro/1.3.0-INTEG_TEST/plugins/.installing-7463547768418079680/opensearch-rest-client-1.3.0-SNAPSHOT.jar
| jar2: /home/runner/work/sql/sql/doctest/build/testclusters/docTestCluster-0/distro/1.3.0-INTEG_TEST/plugins/.installing-7463547768418079680/opensearch-ml-client-1.3.0.0.jar
|     at org.opensearch.bootstrap.JarHell.checkClass(JarHell.java:317)
|     at org.opensearch.bootstrap.JarHell.checkJarHell(JarHell.java:212)
|     at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:664)
|     ... 11 more
```
Check latest changes of MLCommons, see we add this line `compile "org.opensearch.client:opensearch-rest-client:${opensearch_version}"` in PR #117. We need to change to `compileOnly "org.opensearch.client:opensearch-rest-client:${opensearch_version}"`
 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
