### PR TITLE
fix EpochMilli parse error in MLTask

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/parameter/MLTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/parameter/MLTask.java
@@ -238,10 +238,10 @@ public class MLTask implements ToXContentObject, Writeable {
                     workerNode = parser.text();
                     break;
                 case CREATE_TIME_FIELD:
-                    createTime = Instant.parse(parser.text());
+                    createTime = Instant.ofEpochMilli(parser.longValue());
                     break;
                 case LAST_UPDATE_TIME_FIELD:
-                    lastUpdateTime = Instant.parse(parser.text());
+                    lastUpdateTime = Instant.ofEpochMilli(parser.longValue());
                     break;
                 case ERROR_FIELD:
                     error = parser.text();


### PR DESCRIPTION
### Description
Fix the parse error for EpochMilli in Task APIs
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
