### PR TITLE
fix update task semaphore; don't return task id for sync request

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -123,7 +123,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
             ActionListener<DataFrame> dataFrameActionListener = ActionListener
                 .wrap(dataFrame -> { predict(mlTask, dataFrame, request, listener); }, e -> {
                     log.error("Failed to generate DataFrame from search query", e);
-                    handleMLTaskFailure(mlTask, e);
+                    handleAsyncMLTaskFailure(mlTask, e);
                     listener.onFailure(e);
                 });
             mlInputDatasetHandler
@@ -189,12 +189,11 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
                             output = MLEngine
                                 .predict(mlInput.toBuilder().inputDataset(new DataFrameInputDataset(inputDataFrame)).build(), model);
                             if (output instanceof MLPredictionOutput) {
-                                ((MLPredictionOutput) output).setTaskId(mlTask.getTaskId());
                                 ((MLPredictionOutput) output).setStatus(MLTaskState.COMPLETED.name());
                             }
 
                             // Once prediction complete, reduce ML_EXECUTING_TASK_COUNT and update task state
-                            handleMLTaskComplete(mlTask);
+                            handleAsyncMLTaskComplete(mlTask);
                         } catch (Exception e) {
                             // todo need to specify what exception
                             log.error("Failed to predict " + mlInput.getAlgorithm() + ", modelId: " + model.getName(), e);
@@ -225,7 +224,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
     }
 
     private void handlePredictFailure(MLTask mlTask, ActionListener<MLTaskResponse> listener, Exception e) {
-        handleMLTaskFailure(mlTask, e);
+        handleAsyncMLTaskFailure(mlTask, e);
         listener.onFailure(e);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskRunner.java
@@ -52,7 +52,7 @@ public abstract class MLTaskRunner<Request, Response> {
         this.mlCircuitBreakerService = mlCircuitBreakerService;
     }
 
-    protected void handleMLTaskFailure(MLTask mlTask, Exception e) {
+    protected void handleAsyncMLTaskFailure(MLTask mlTask, Exception e) {
         // update task state to MLTaskState.FAILED
         // update task error
         if (mlTask.isAsync()) {
@@ -63,7 +63,7 @@ public abstract class MLTaskRunner<Request, Response> {
         }
     }
 
-    protected void handleMLTaskComplete(MLTask mlTask) {
+    protected void handleAsyncMLTaskComplete(MLTask mlTask) {
         // update task state to MLTaskState.COMPLETED
         if (mlTask.isAsync()) {
             Map<String, Object> updatedFields = new HashMap<>();

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunner.java
@@ -140,9 +140,8 @@ public class MLTrainAndPredictTaskRunner extends MLTaskRunner<MLTrainingTaskRequ
         try {
             mlTaskManager.updateTaskState(mlTask.getTaskId(), MLTaskState.RUNNING, mlTask.isAsync());
             MLOutput output = MLEngine.trainAndPredict(mlInput.toBuilder().inputDataset(new DataFrameInputDataset(inputDataFrame)).build());
-            handleMLTaskComplete(mlTask);
+            handleAsyncMLTaskComplete(mlTask);
             if (output instanceof MLPredictionOutput) {
-                ((MLPredictionOutput) output).setTaskId(mlTask.getTaskId());
                 ((MLPredictionOutput) output).setStatus(MLTaskState.COMPLETED.name());
             }
 
@@ -158,7 +157,7 @@ public class MLTrainAndPredictTaskRunner extends MLTaskRunner<MLTrainingTaskRequ
     }
 
     private void handlePredictFailure(MLTask mlTask, ActionListener<MLTaskResponse> listener, Exception e) {
-        handleMLTaskFailure(mlTask, e);
+        handleAsyncMLTaskFailure(mlTask, e);
         listener.onFailure(e);
     }
 }


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Fix update task semaphore.
Don't return task id for sync request. For sync request, the task is only cached in memory and will be removed once task done. Return task id for sync request may confuse user. We just need to return task id for async request.
 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
