### PR TITLE
use threadpool in execute task runner

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/task/MLExecuteTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLExecuteTaskRunner.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.task;
 
+import static org.opensearch.ml.plugin.MachineLearningPlugin.TASK_THREAD_POOL;
+
 import lombok.extern.log4j.Log4j2;
 
 import org.opensearch.action.ActionListener;
@@ -61,10 +63,12 @@ public class MLExecuteTaskRunner extends MLTaskRunner<MLExecuteTaskRequest, MLEx
         TransportService transportService,
         ActionListener<MLExecuteTaskResponse> listener
     ) {
-        Input input = request.getInput();
-        Output output = MLEngine.execute(input);
-        MLExecuteTaskResponse response = MLExecuteTaskResponse.builder().output(output).build();
-        listener.onResponse(response);
+        threadPool.executor(TASK_THREAD_POOL).execute(() -> {
+            Input input = request.getInput();
+            Output output = MLEngine.execute(input);
+            MLExecuteTaskResponse response = MLExecuteTaskResponse.builder().output(output).build();
+            listener.onResponse(response);
+        });
     }
 
 }


### PR DESCRIPTION
Signed-off-by: lai <57818076+wnbts@users.noreply.github.com>

### Description
Executables are not running on the task thead pool like train/predict tasks and hang when implementation contains async callbacks.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
