### PR TITLE
more strict check on input parameters by applying non-coerce mode

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/parameter/AnomalyDetectionParams.java
+++ b/common/src/main/java/org/opensearch/ml/common/parameter/AnomalyDetectionParams.java
@@ -88,22 +88,22 @@ public class AnomalyDetectionParams implements MLAlgoParams {
                     kernelType = ADKernelType.from(parser.text().toUpperCase(Locale.ROOT));
                     break;
                 case GAMMA_FIELD:
-                    gamma = parser.doubleValue();
+                    gamma = parser.doubleValue(false);
                     break;
                 case NU_FIELD:
-                    nu = parser.doubleValue();
+                    nu = parser.doubleValue(false);
                     break;
                 case COST_FIELD:
-                    cost = parser.doubleValue();
+                    cost = parser.doubleValue(false);
                     break;
                 case COEFF_FIELD:
-                    coeff = parser.doubleValue();
+                    coeff = parser.doubleValue(false);
                     break;
                 case EPSILON_FIELD:
-                    epsilon = parser.doubleValue();
+                    epsilon = parser.doubleValue(false);
                     break;
                 case DEGREE_FIELD:
-                    degree = parser.intValue();
+                    degree = parser.intValue(false);
                     break;
                 default:
                     parser.skipChildren();

--- a/common/src/main/java/org/opensearch/ml/common/parameter/BatchRCFParams.java
+++ b/common/src/main/java/org/opensearch/ml/common/parameter/BatchRCFParams.java
@@ -91,22 +91,22 @@ public class BatchRCFParams implements MLAlgoParams{
 
             switch (fieldName) {
                 case NUMBER_OF_TREES:
-                    numberOfTrees = parser.intValue();
+                    numberOfTrees = parser.intValue(false);
                     break;
                 case SHINGLE_SIZE:
-                    shingleSize = parser.intValue();
+                    shingleSize = parser.intValue(false);
                     break;
                 case SAMPLE_SIZE:
-                    sampleSize = parser.intValue();
+                    sampleSize = parser.intValue(false);
                     break;
                 case OUTPUT_AFTER:
-                    outputAfter = parser.intValue();
+                    outputAfter = parser.intValue(false);
                     break;
                 case TRAINING_DATA_SIZE:
-                    trainingDataSize = parser.intValue();
+                    trainingDataSize = parser.intValue(false);
                     break;
                 case ANOMALY_SCORE_THRESHOLD:
-                    anomalyScoreThreshold = parser.doubleValue();
+                    anomalyScoreThreshold = parser.doubleValue(false);
                     break;
                 default:
                     parser.skipChildren();

--- a/common/src/main/java/org/opensearch/ml/common/parameter/FitRCFParams.java
+++ b/common/src/main/java/org/opensearch/ml/common/parameter/FitRCFParams.java
@@ -112,22 +112,22 @@ public class FitRCFParams implements MLAlgoParams{
 
             switch (fieldName) {
                 case NUMBER_OF_TREES:
-                    numberOfTrees = parser.intValue();
+                    numberOfTrees = parser.intValue(false);
                     break;
                 case SHINGLE_SIZE:
-                    shingleSize = parser.intValue();
+                    shingleSize = parser.intValue(false);
                     break;
                 case SAMPLE_SIZE:
-                    sampleSize = parser.intValue();
+                    sampleSize = parser.intValue(false);
                     break;
                 case OUTPUT_AFTER:
-                    outputAfter = parser.intValue();
+                    outputAfter = parser.intValue(false);
                     break;
                 case TIME_DECAY:
-                    timeDecay = parser.doubleValue();
+                    timeDecay = parser.doubleValue(false);
                     break;
                 case ANOMALY_RATE:
-                    anomalyRate = parser.doubleValue();
+                    anomalyRate = parser.doubleValue(false);
                     break;
                 case TIME_FIELD:
                     timeField = parser.text();

--- a/common/src/main/java/org/opensearch/ml/common/parameter/KMeansParams.java
+++ b/common/src/main/java/org/opensearch/ml/common/parameter/KMeansParams.java
@@ -7,7 +7,6 @@ package org.opensearch.ml.common.parameter;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -70,10 +69,10 @@ public class KMeansParams implements MLAlgoParams {
 
             switch (fieldName) {
                 case CENTROIDS_FIELD:
-                    k = parser.intValue();
+                    k = parser.intValue(false);
                     break;
                 case ITERATIONS_FIELD:
-                    iterations = parser.intValue();
+                    iterations = parser.intValue(false);
                     break;
                 case DISTANCE_TYPE_FIELD:
                     distanceType = DistanceType.from(parser.text());

--- a/common/src/main/java/org/opensearch/ml/common/parameter/LinearRegressionParams.java
+++ b/common/src/main/java/org/opensearch/ml/common/parameter/LinearRegressionParams.java
@@ -126,34 +126,34 @@ public class LinearRegressionParams implements MLAlgoParams {
                     optimizerType = OptimizerType.valueOf(parser.text().toUpperCase(Locale.ROOT));
                     break;
                 case LEARNING_RATE_FIELD:
-                    learningRate = parser.doubleValue();
+                    learningRate = parser.doubleValue(false);
                     break;
                 case MOMENTUM_TYPE_FIELD:
                     momentumType = MomentumType.valueOf(parser.text().toUpperCase(Locale.ROOT));
                     break;
                 case MOMENTUM_FACTOR_FIELD:
-                    momentumFactor = parser.doubleValue();
+                    momentumFactor = parser.doubleValue(false);
                     break;
                 case EPSILON_FIELD:
-                    epsilon = parser.doubleValue();
+                    epsilon = parser.doubleValue(false);
                     break;
                 case BETA1_FIELD:
-                    beta1 = parser.doubleValue();
+                    beta1 = parser.doubleValue(false);
                     break;
                 case BETA2_FIELD:
-                    beta2 = parser.doubleValue();
+                    beta2 = parser.doubleValue(false);
                     break;
                 case DECAY_RATE_FIELD:
-                    decayRate = parser.doubleValue();
+                    decayRate = parser.doubleValue(false);
                     break;
                 case EPOCHS_FIELD:
-                    epochs = parser.intValue();
+                    epochs = parser.intValue(false);
                     break;
                 case BATCH_SIZE_FIELD:
-                    batchSize = parser.intValue();
+                    batchSize = parser.intValue(false);
                     break;
                 case SEED_FIELD:
-                    seed = parser.longValue();
+                    seed = parser.longValue(false);
                     break;
                 case TARGET_FIELD:
                     target = parser.text();

--- a/common/src/main/java/org/opensearch/ml/common/parameter/LocalSampleCalculatorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/parameter/LocalSampleCalculatorInput.java
@@ -48,7 +48,7 @@ public class LocalSampleCalculatorInput implements Input {
                 case INPUT_DATA_FIELD:
                     ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                        inputData.add(parser.doubleValue());
+                        inputData.add(parser.doubleValue(false));
                     }
                     break;
                 default:

--- a/common/src/main/java/org/opensearch/ml/common/parameter/MLModel.java
+++ b/common/src/main/java/org/opensearch/ml/common/parameter/MLModel.java
@@ -113,7 +113,7 @@ public class MLModel implements ToXContentObject {
                     content = parser.text();
                     break;
                 case MODEL_VERSION:
-                    version = parser.intValue();
+                    version = parser.intValue(false);
                     break;
                 case USER:
                     user = User.parse(parser);

--- a/common/src/main/java/org/opensearch/ml/common/parameter/SampleAlgoParams.java
+++ b/common/src/main/java/org/opensearch/ml/common/parameter/SampleAlgoParams.java
@@ -51,7 +51,7 @@ public class SampleAlgoParams implements MLAlgoParams {
 
             switch (fieldName) {
                 case SAMPLE_PARAM_FIELD:
-                    sampleParam = parser.intValue();
+                    sampleParam = parser.intValue(false);
                     break;
                 default:
                     parser.skipChildren();

--- a/common/src/test/java/org/opensearch/ml/common/TestHelper.java
+++ b/common/src/test/java/org/opensearch/ml/common/TestHelper.java
@@ -45,6 +45,12 @@ public class TestHelper {
         obj.equals(parsedObj);
     }
 
+    public static String contentObjectToString(ToXContentObject obj) throws IOException {
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        obj.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        return xContentBuilderToString(builder);
+    }
+
     public static String xContentBuilderToString(XContentBuilder builder) {
         return BytesReference.bytes(builder).utf8ToString();
     }

--- a/common/src/test/java/org/opensearch/ml/common/parameter/KMeansParamsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/parameter/KMeansParamsTest.java
@@ -6,7 +6,9 @@
 package org.opensearch.ml.common.parameter;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.xcontent.XContentParser;
@@ -16,8 +18,12 @@ import java.io.IOException;
 import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
+import static org.opensearch.ml.common.TestHelper.contentObjectToString;
+import static org.opensearch.ml.common.TestHelper.testParseFromString;
 
 public class KMeansParamsTest {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
 
     KMeansParams params;
     private Function<XContentParser, KMeansParams> function = parser -> {
@@ -40,6 +46,22 @@ public class KMeansParamsTest {
     @Test
     public void parse_KMeansParams() throws IOException {
         TestHelper.testParse(params, function);
+    }
+
+    @Test
+    public void parse_KMeansParams_InvalidDoubleValue() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("10.01 cannot be converted to Integer without data loss");
+        String paramsStr = contentObjectToString(params);
+        testParseFromString(params, paramsStr.replace("\"iterations\":10,", "\"iterations\":10.01,"), function);
+    }
+
+    @Test
+    public void parse_KMeansParams_InvalidDoubleString() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Integer value passed as String");
+        String paramsStr = contentObjectToString(params);
+        testParseFromString(params, paramsStr.replace("\"iterations\":10,", "\"iterations\":\"10.01\","), function);
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/parameter/LinearRegressionParamsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/parameter/LinearRegressionParamsTest.java
@@ -6,7 +6,9 @@
 package org.opensearch.ml.common.parameter;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.xcontent.XContentParser;
@@ -16,8 +18,13 @@ import java.io.IOException;
 import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
+import static org.opensearch.ml.common.TestHelper.contentObjectToString;
+import static org.opensearch.ml.common.TestHelper.testParseFromString;
 
 public class LinearRegressionParamsTest {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
 
     private Function<XContentParser, LinearRegressionParams> function = parser -> {
         try {
@@ -57,6 +64,36 @@ public class LinearRegressionParamsTest {
         StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
         LinearRegressionParams parsedParams = new LinearRegressionParams(streamInput);
         assertEquals(params, parsedParams);
+    }
+
+    @Test
+    public void parse_PassIntValueToDoubleField() throws IOException {
+        LinearRegressionParams params = LinearRegressionParams
+                .builder()
+                .objectiveType(LinearRegressionParams.ObjectiveType.ABSOLUTE_LOSS)
+                .optimizerType(LinearRegressionParams.OptimizerType.ADAM)
+                .learningRate(0.1)
+                .momentumType(LinearRegressionParams.MomentumType.NESTEROV)
+                .momentumFactor(0.2)
+                .epsilon(3.0)
+                .beta1(0.4)
+                .beta2(0.5)
+                .decayRate(0.6)
+                .epochs(1)
+                .batchSize(2)
+                .seed(3L)
+                .target("test_target")
+                .build();
+        String paramsStr = contentObjectToString(params);
+        testParseFromString(params, paramsStr.replace("\"epsilon\":3.0,", "\"epsilon\":3,"), function);
+    }
+
+    @Test
+    public void parse_InvalidParam_InvalidDoubleValue() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Double value passed as String");
+        String paramsStr = contentObjectToString(params);
+        testParseFromString(params, paramsStr.replace("\"epsilon\":0.3,", "\"epsilon\":\"0.3\","), function);
     }
 
     @Test

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/anomalylocalization/AnomalyLocalizationInput.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/anomalylocalization/AnomalyLocalizationInput.java
@@ -93,23 +93,23 @@ public class AnomalyLocalizationInput implements Input {
                     break;
                 case FIELD_START_TIME:
                     parser.nextToken();
-                    startTime = parser.longValue();
+                    startTime = parser.longValue(false);
                     break;
                 case FIELD_END_TIME:
                     parser.nextToken();
-                    endTime = parser.longValue();
+                    endTime = parser.longValue(false);
                     break;
                 case FIELD_MIN_TIME_INTERVAL:
                     parser.nextToken();
-                    minTimeInterval = parser.longValue();
+                    minTimeInterval = parser.longValue(false);
                     break;
                 case FIELD_NUM_OUTPUTS:
                     parser.nextToken();
-                    numOutputs = parser.intValue();
+                    numOutputs = parser.intValue(false);
                     break;
                 case FIELD_ANOMALY_START_TIME:
                     parser.nextToken();
-                    anomalyStartTime = Optional.of(parser.longValue());
+                    anomalyStartTime = Optional.of(parser.longValue(false));
                     break;
                 case FIELD_FILTER_QUERY:
                     ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
When pass non-integer value like Double, OpenSearch parser will parse value to Double, then convert it into int. This PR adds more strict checking, will throw exception if pass double value to int field.
 
### Issues Resolved
Close #164 https://github.com/opensearch-project/OpenSearch/issues/2375
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
