### PR TITLE
fix no permission to create model/task index bug;add security IT for train/predict API

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -518,6 +518,36 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
         verifyResponse(function, response);
     }
 
+    public void deleteModel(RestClient client, String modelId, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "DELETE", "/_plugins/_ml/models/" + modelId, null, "", null);
+        verifyResponse(function, response);
+    }
+
+    public void deleteTask(RestClient client, String taskId, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "DELETE", "/_plugins/_ml/tasks/" + taskId, null, "", null);
+        verifyResponse(function, response);
+    }
+
+    public void searchModelsWithAlgoName(RestClient client, String algoName, Consumer<Map<String, Object>> function) throws IOException {
+        String query = String.format(Locale.ROOT, "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"algorithm\":\"%s\"}}]}}}", algoName);
+        searchModels(client, query, function);
+    }
+
+    public void searchModels(RestClient client, String query, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "GET", "/_plugins/_ml/models/_search", null, query, null);
+        verifyResponse(function, response);
+    }
+
+    public void searchTasksWithAlgoName(RestClient client, String algoName, Consumer<Map<String, Object>> function) throws IOException {
+        String query = String.format(Locale.ROOT, "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"function_name\":\"%s\"}}]}}}", algoName);
+        searchTasks(client, query, function);
+    }
+
+    public void searchTasks(RestClient client, String query, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "GET", "/_plugins/_ml/tasks/_search", null, query, null);
+        verifyResponse(function, response);
+    }
+
     private void verifyResponse(Consumer<Map<String, Object>> function, Response response) throws IOException {
         HttpEntity entity = response.getEntity();
         assertNotNull(response);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelActionTests.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.opensearch.common.Strings;
 import org.opensearch.rest.RestHandler;
@@ -27,20 +26,17 @@ public class RestMLGetModelActionTests extends OpenSearchTestCase {
         restMLGetModelAction = new RestMLGetModelAction();
     }
 
-    @Test
     public void testConstructor() {
         RestMLGetModelAction mlGetModelAction = new RestMLGetModelAction();
         assertNotNull(mlGetModelAction);
     }
 
-    @Test
     public void testGetName() {
         String actionName = restMLGetModelAction.getName();
         assertFalse(Strings.isNullOrEmpty(actionName));
         assertEquals("ml_get_model_action", actionName);
     }
 
-    @Test
     public void testRoutes() {
         List<RestHandler.Route> routes = restMLGetModelAction.routes();
         assertNotNull(routes);

--- a/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
@@ -230,6 +230,7 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
             try {
                 // Failed to delete model with read only client
                 deleteModel(mlReadOnlyClient, modelId, null);
+                throw new RuntimeException("Delete model for readonly user does not fail");
             } catch (Exception e) {
                 assertEquals(ResponseException.class, e.getClass());
                 assertTrue(Throwables.getStackTraceAsString(e).contains("no permissions for [cluster:admin/opensearch/ml/models/delete]"));
@@ -258,6 +259,7 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
             try {
                 // Failed to delete task with read only client
                 deleteTask(mlReadOnlyClient, taskId, null);
+                throw new RuntimeException("Delete task for readonly user does not fail");
             } catch (Exception e) {
                 assertEquals(ResponseException.class, e.getClass());
                 assertTrue(Throwables.getStackTraceAsString(e).contains("no permissions for [cluster:admin/opensearch/ml/tasks/delete]"));


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
- Fix no permission to create model/task index bug. ML model and task index are system index. Need to stash thread context to create.
- Add security IT for train/predict API
 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
