### PR TITLE
move anomaly localization to the last position to avoid BWC issue

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/parameter/FunctionName.java
+++ b/common/src/main/java/org/opensearch/ml/common/parameter/FunctionName.java
@@ -11,9 +11,9 @@ public enum FunctionName {
     AD_LIBSVM,
     SAMPLE_ALGO,
     LOCAL_SAMPLE_CALCULATOR,
-    ANOMALY_LOCALIZATION,
     FIT_RCF,
-    BATCH_RCF;
+    BATCH_RCF,
+    ANOMALY_LOCALIZATION;
 
     public static FunctionName from(String value) {
         try {


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
When test today's tarball on multi-node cluster, we see `failed to parse ActionRequest into MLTrainingTaskRequest` error
```
POST _plugins/_ppl
{
  "query": "source=nyc_taxi | fields timestamp,value | ad time_field='timestamp'"
}

{
  "error": {
    "reason": "There was internal problem at backend",
    "details": "failed to parse ActionRequest into MLTrainingTaskRequest",
    "type": "UncheckedIOException"
  },
  "status": 503
}
```

SQL is using client from main branch, so When parse action request, it will try to map `BATCh_RCF` to the 8th enum, but `FunctionName` in 1.3 only have 7 enum items. So will fail to parse. This PR moves `ANOMALY_LOCALIZATION` to the last position to avoid such issue in future.

```
# main branch
public enum FunctionName {
    LINEAR_REGRESSION,
    KMEANS,
    AD_LIBSVM,
    SAMPLE_ALGO,
    LOCAL_SAMPLE_CALCULATOR,
    ANOMALY_LOCALIZATION,
    FIT_RCF,
    BATCH_RCF;
    
# 1.3 branch
public enum FunctionName {
    LINEAR_REGRESSION,
    KMEANS,
    AD_LIBSVM,
    SAMPLE_ALGO,
    LOCAL_SAMPLE_CALCULATOR,
    FIT_RCF,
    BATCH_RCF;
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
