### PR TITLE
add java 17 to CI workflow

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -11,7 +11,7 @@ jobs:
   Build-ml:
     strategy:
       matrix:
-        java: [8, 11, 14]
+        java: [8, 11, 14, 17]
 
     name: Build and Test MLCommons Plugin
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Add java 17 to CI workflow
 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
