### PR TITLE
use 1.3.0 docker to run CI

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           plugin=`ls plugin/build/distributions/*.zip`
           echo MLCommons plugin $plugin
-          version=1.3.0-SNAPSHOT
+          version=1.3.0
           plugin_version=1.3.0.0-SNAPSHOT
           echo Using OpenSearch $version with MLCommons $plugin_version
           cd ..


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
use 1.3.0 docker to run CI
 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
