### PR TITLE
rename the release note file

### DIFF
--- a/release-notes/opensearch-ml-common.release-notes-1.3.0.0.md
+++ b/release-notes/opensearch-ml-common.release-notes-1.3.0.0.md
@@ -62,6 +62,7 @@ Compatible with OpenSearch 1.3.0
 * add more UT and IT for rest actions ([#192](https://github.com/opensearch-project/ml-commons/pull/192))
 * add more UT to client module ([#203](https://github.com/opensearch-project/ml-commons/pull/203))
 * add more UT for task manager/runner ([#206](https://github.com/opensearch-project/ml-commons/pull/206))
+* create config and workflow files for release note ([#209](https://github.com/opensearch-project/ml-commons/pull/209))
 * use 1.3.0 docker to run CI ([#212](https://github.com/opensearch-project/ml-commons/pull/212))
 
 ### Documentation


### PR DESCRIPTION
Signed-off-by: Xun Zhang <xunzh@amazon.com>

### Description
Fix the name of the release note file.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
