### PR TITLE
add more IT for train/predict and train&predict action

### DIFF
--- a/client/src/test/java/org/opensearch/ml/client/MachineLearningNodeClientTest.java
+++ b/client/src/test/java/org/opensearch/ml/client/MachineLearningNodeClientTest.java
@@ -37,7 +37,6 @@ import org.opensearch.ml.common.parameter.MLPredictionOutput;
 import org.opensearch.ml.common.parameter.MLTask;
 import org.opensearch.ml.common.parameter.MLTaskState;
 import org.opensearch.ml.common.parameter.MLTrainingOutput;
-import org.opensearch.ml.common.parameter.Output;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.model.MLModelDeleteAction;
 import org.opensearch.ml.common.transport.model.MLModelDeleteRequest;
@@ -121,7 +120,6 @@ public class MachineLearningNodeClientTest {
         MockitoAnnotations.openMocks(this);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void predict() {
         doAnswer(invocation -> {
@@ -144,8 +142,7 @@ public class MachineLearningNodeClientTest {
                 .build();
         machineLearningNodeClient.predict(null, mlInput, dataFrameActionListener);
 
-        verify(client).execute(eq(MLPredictionTaskAction.INSTANCE), isA(MLPredictionTaskRequest.class),
-                any(ActionListener.class));
+        verify(client).execute(eq(MLPredictionTaskAction.INSTANCE), isA(MLPredictionTaskRequest.class), any());
         verify(dataFrameActionListener).onResponse(dataFrameArgumentCaptor.capture());
         assertEquals(output, ((MLPredictionOutput)dataFrameArgumentCaptor.getValue()).getPredictionResult());
     }
@@ -170,7 +167,6 @@ public class MachineLearningNodeClientTest {
         machineLearningNodeClient.predict(null, mlInput, dataFrameActionListener);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void train() {
         String modelId = "test_model_id";
@@ -194,8 +190,7 @@ public class MachineLearningNodeClientTest {
                 .build();
         machineLearningNodeClient.train(mlInput, false, trainingActionListener);
 
-        verify(client).execute(eq(MLTrainingTaskAction.INSTANCE), isA(MLTrainingTaskRequest.class),
-                any(ActionListener.class));
+        verify(client).execute(eq(MLTrainingTaskAction.INSTANCE), isA(MLTrainingTaskRequest.class), any());
         verify(trainingActionListener).onResponse(argumentCaptor.capture());
         assertEquals(modelId, ((MLTrainingOutput)argumentCaptor.getValue()).getModelId());
         assertEquals(status, ((MLTrainingOutput)argumentCaptor.getValue()).getStatus());
@@ -240,8 +235,7 @@ public class MachineLearningNodeClientTest {
                 .build();
         machineLearningNodeClient.trainAndPredict(mlInput, trainingActionListener);
 
-        verify(client).execute(eq(MLTrainAndPredictionTaskAction.INSTANCE), isA(MLTrainingTaskRequest.class),
-                any(ActionListener.class));
+        verify(client).execute(eq(MLTrainAndPredictionTaskAction.INSTANCE), isA(MLTrainingTaskRequest.class), any());
         verify(trainingActionListener).onResponse(argumentCaptor.capture());
         assertEquals(MLTaskState.COMPLETED.name(), ((MLPredictionOutput)argumentCaptor.getValue()).getStatus());
         assertEquals(output, ((MLPredictionOutput)argumentCaptor.getValue()).getPredictionResult());
@@ -267,8 +261,7 @@ public class MachineLearningNodeClientTest {
         ArgumentCaptor<MLModel> argumentCaptor = ArgumentCaptor.forClass(MLModel.class);
         machineLearningNodeClient.getModel("modelId", getModelActionListener);
 
-        verify(client).execute(eq(MLModelGetAction.INSTANCE), isA(MLModelGetRequest.class),
-                any(ActionListener.class));
+        verify(client).execute(eq(MLModelGetAction.INSTANCE), isA(MLModelGetRequest.class), any());
         verify(getModelActionListener).onResponse(argumentCaptor.capture());
         assertEquals(FunctionName.KMEANS, argumentCaptor.getValue().getAlgorithm());
         assertEquals(modelContent, argumentCaptor.getValue().getContent());
@@ -288,8 +281,7 @@ public class MachineLearningNodeClientTest {
         ArgumentCaptor<DeleteResponse> argumentCaptor = ArgumentCaptor.forClass(DeleteResponse.class);
         machineLearningNodeClient.deleteModel(modelId, deleteModelActionListener);
 
-        verify(client).execute(eq(MLModelDeleteAction.INSTANCE), isA(MLModelDeleteRequest.class),
-                any(ActionListener.class));
+        verify(client).execute(eq(MLModelDeleteAction.INSTANCE), isA(MLModelDeleteRequest.class), any());
         verify(deleteModelActionListener).onResponse(argumentCaptor.capture());
         assertEquals(modelId, argumentCaptor.getValue().getId());
     }
@@ -313,8 +305,7 @@ public class MachineLearningNodeClientTest {
         SearchRequest searchREquest = new SearchRequest();
         machineLearningNodeClient.searchModel(searchREquest, searchModelActionListener);
 
-        verify(client).execute(eq(MLModelSearchAction.INSTANCE), isA(SearchRequest.class),
-                any(ActionListener.class));
+        verify(client).execute(eq(MLModelSearchAction.INSTANCE), isA(SearchRequest.class), any());
         verify(searchModelActionListener).onResponse(argumentCaptor.capture());
         Map<String, Object> source = argumentCaptor.getValue().getHits().getAt(0).getSourceAsMap();
         assertEquals(modelContent, source.get(MLModel.MODEL_CONTENT));
@@ -341,8 +332,7 @@ public class MachineLearningNodeClientTest {
         ArgumentCaptor<MLTask> argumentCaptor = ArgumentCaptor.forClass(MLTask.class);
         machineLearningNodeClient.getTask(taskId, getTaskActionListener);
 
-        verify(client).execute(eq(MLTaskGetAction.INSTANCE), isA(MLTaskGetRequest.class),
-                any(ActionListener.class));
+        verify(client).execute(eq(MLTaskGetAction.INSTANCE), isA(MLTaskGetRequest.class), any());
         verify(getTaskActionListener).onResponse(argumentCaptor.capture());
         assertEquals(FunctionName.KMEANS, argumentCaptor.getValue().getFunctionName());
         assertEquals(modelId, argumentCaptor.getValue().getModelId());
@@ -363,8 +353,7 @@ public class MachineLearningNodeClientTest {
         ArgumentCaptor<DeleteResponse> argumentCaptor = ArgumentCaptor.forClass(DeleteResponse.class);
         machineLearningNodeClient.deleteTask(taskId, deleteTaskActionListener);
 
-        verify(client).execute(eq(MLTaskDeleteAction.INSTANCE), isA(MLTaskDeleteRequest.class),
-                any(ActionListener.class));
+        verify(client).execute(eq(MLTaskDeleteAction.INSTANCE), isA(MLTaskDeleteRequest.class), any());
         verify(deleteTaskActionListener).onResponse(argumentCaptor.capture());
         assertEquals(taskId, argumentCaptor.getValue().getId());
     }
@@ -389,8 +378,7 @@ public class MachineLearningNodeClientTest {
         SearchRequest searchREquest = new SearchRequest();
         machineLearningNodeClient.searchTask(searchREquest, searchTaskActionListener);
 
-        verify(client).execute(eq(MLTaskSearchAction.INSTANCE), isA(SearchRequest.class),
-                any(ActionListener.class));
+        verify(client).execute(eq(MLTaskSearchAction.INSTANCE), isA(SearchRequest.class), any());
         verify(searchTaskActionListener).onResponse(argumentCaptor.capture());
         assertEquals(1, argumentCaptor.getValue().getHits().getTotalHits().value);
         Map<String, Object> source = argumentCaptor.getValue().getHits().getAt(0).getSourceAsMap();

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -10,7 +10,6 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/clustering/KMeans.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/clustering/KMeans.java
@@ -47,7 +47,7 @@ public class KMeans implements TrainAndPredictable {
     //The number of threads.
     private KMeansParams parameters;
 
-    private int numThreads = Runtime.getRuntime().availableProcessors() + 1; //Assume cpu-bound.
+    private int numThreads = Math.max(Runtime.getRuntime().availableProcessors() / 2, 1); //Assume cpu-bound.
     //The random seed.
     private long seed = System.currentTimeMillis();
     private KMeansTrainer.Distance distance;

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -204,7 +204,10 @@ jacocoTestReport {
 
 List<String> jacocoExclusions = [
         // TODO: add more unit test to meet the minimal test coverage.
-        'org.opensearch.ml.action.*',
+        'org.opensearch.ml.action.models.*',
+        'org.opensearch.ml.action.tasks.*',
+        'org.opensearch.ml.action.handler.*',
+        'org.opensearch.ml.action.execute.*',
         'org.opensearch.ml.constant.CommonValue',
         'org.opensearch.ml.indices.MLInputDatasetHandler',
         'org.opensearch.ml.plugin.*',

--- a/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.opensearch.action.ActionFuture;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.ml.common.dataframe.ColumnMeta;
+import org.opensearch.ml.common.dataframe.ColumnType;
+import org.opensearch.ml.common.dataframe.DataFrame;
+import org.opensearch.ml.common.dataframe.DefaultDataFrame;
+import org.opensearch.ml.common.dataset.MLInputDataset;
+import org.opensearch.ml.common.dataset.SearchQueryInputDataset;
+import org.opensearch.ml.common.parameter.FunctionName;
+import org.opensearch.ml.common.parameter.KMeansParams;
+import org.opensearch.ml.common.parameter.MLAlgoParams;
+import org.opensearch.ml.common.parameter.MLInput;
+import org.opensearch.ml.common.parameter.MLModel;
+import org.opensearch.ml.common.parameter.MLPredictionOutput;
+import org.opensearch.ml.common.parameter.MLTask;
+import org.opensearch.ml.common.parameter.MLTrainingOutput;
+import org.opensearch.ml.common.transport.MLTaskResponse;
+import org.opensearch.ml.common.transport.model.MLModelGetAction;
+import org.opensearch.ml.common.transport.model.MLModelGetResponse;
+import org.opensearch.ml.common.transport.task.MLTaskGetAction;
+import org.opensearch.ml.common.transport.task.MLTaskGetRequest;
+import org.opensearch.ml.common.transport.task.MLTaskGetResponse;
+import org.opensearch.ml.common.transport.training.MLTrainingTaskAction;
+import org.opensearch.ml.common.transport.training.MLTrainingTaskRequest;
+import org.opensearch.ml.common.transport.trainpredict.MLTrainAndPredictionTaskAction;
+import org.opensearch.ml.plugin.MachineLearningPlugin;
+import org.opensearch.ml.utils.TestData;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+
+public class MLCommonsIntegTestCase extends OpenSearchIntegTestCase {
+    private Gson gson = new Gson();
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(MachineLearningPlugin.class);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+        return Collections.singletonList(MachineLearningPlugin.class);
+    }
+
+    public void loadIrisData(String indexName) {
+        BulkRequest bulkRequest = new BulkRequest();
+        String[] rows = TestData.IRIS_DATA.split("\n");
+        for (int i = 1; i < rows.length; i += 2) {
+            IndexRequest indexRequest = new IndexRequest(indexName).id(i + "");
+            indexRequest.source(rows[i], XContentType.JSON);
+            bulkRequest.add(indexRequest);
+        }
+        bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client().bulk(bulkRequest).actionGet(5000);
+    }
+
+    public DataFrame irisDataFrame() {
+        DataFrame dataFrame = new DefaultDataFrame(
+            new ColumnMeta[] {
+                new ColumnMeta("petal_length_in_cm", ColumnType.DOUBLE),
+                new ColumnMeta("petal_width_in_cm", ColumnType.DOUBLE) }
+        );
+        String[] rows = TestData.IRIS_DATA.split("\n");
+
+        for (int i = 1; i < rows.length; i += 2) {
+            Map<String, Object> map = gson.fromJson(rows[i], Map.class);
+            dataFrame.appendRow(new Object[] { map.get("petal_length_in_cm"), map.get("petal_width_in_cm") });
+        }
+        return dataFrame;
+    }
+
+    public SearchSourceBuilder irisDataQuery() {
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.size(1000);
+        searchSourceBuilder.fetchSource(new String[] { "petal_length_in_cm", "petal_width_in_cm" }, null);
+        searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+        return searchSourceBuilder;
+    }
+
+    public MLInputDataset emptyQueryInputDataSet(String indexName) {
+        SearchSourceBuilder searchSourceBuilder = irisDataQuery();
+        searchSourceBuilder.query(QueryBuilders.matchQuery("class", "wrong_value"));
+        return new SearchQueryInputDataset(Collections.singletonList(indexName), searchSourceBuilder);
+    }
+
+    public MLPredictionOutput trainAndPredictKmeansWithIrisData(String irisIndexName) {
+        MLInputDataset inputDataset = new SearchQueryInputDataset(ImmutableList.of(irisIndexName), irisDataQuery());
+        return trainAndPredict(FunctionName.KMEANS, KMeansParams.builder().centroids(3).build(), inputDataset);
+    }
+
+    public MLPredictionOutput trainAndPredict(FunctionName functionName, MLAlgoParams params, MLInputDataset inputDataset) {
+        MLInput mlInput = MLInput.builder().algorithm(functionName).parameters(params).inputDataset(inputDataset).build();
+        MLTrainingTaskRequest trainingRequest = MLTrainingTaskRequest.builder().mlInput(mlInput).build();
+        ActionFuture<MLTaskResponse> trainingFuture = client().execute(MLTrainAndPredictionTaskAction.INSTANCE, trainingRequest);
+        MLTaskResponse trainingResponse = trainingFuture.actionGet();
+        assertNotNull(trainingResponse);
+
+        MLPredictionOutput mlPredictionOutput = (MLPredictionOutput) trainingResponse.getOutput();
+        return mlPredictionOutput;
+    }
+
+    public String trainKmeansWithIrisData(String irisIndexName, boolean async) {
+        MLInputDataset inputDataset = new SearchQueryInputDataset(ImmutableList.of(irisIndexName), irisDataQuery());
+        return trainModel(FunctionName.KMEANS, KMeansParams.builder().centroids(3).build(), inputDataset, async);
+    }
+
+    public String trainModel(FunctionName functionName, KMeansParams params, MLInputDataset inputDataset, boolean async) {
+        MLInput mlInput = MLInput.builder().algorithm(functionName).parameters(params).inputDataset(inputDataset).build();
+        MLTrainingTaskRequest trainingRequest = new MLTrainingTaskRequest(mlInput, async);
+        ActionFuture<MLTaskResponse> trainingFuture = client().execute(MLTrainingTaskAction.INSTANCE, trainingRequest);
+        MLTaskResponse trainingResponse = trainingFuture.actionGet();
+        assertNotNull(trainingResponse);
+
+        MLTrainingOutput modelTrainingOutput = (MLTrainingOutput) trainingResponse.getOutput();
+        String id = async ? modelTrainingOutput.getTaskId() : modelTrainingOutput.getModelId();
+        String status = modelTrainingOutput.getStatus();
+        assertNotNull(id);
+        assertFalse(id.isEmpty());
+        if (async) {
+            assertEquals("CREATED", status);
+        } else {
+            assertEquals("COMPLETED", status);
+        }
+        return id;
+    }
+
+    public MLTask getTask(String taskId) {
+        MLTaskGetRequest getRequest = new MLTaskGetRequest(taskId);
+        MLTaskGetResponse response = client().execute(MLTaskGetAction.INSTANCE, getRequest).actionGet(5000);
+        return response.getMlTask();
+    }
+
+    public MLModel getModel(String modelId) {
+        MLTaskGetRequest getRequest = new MLTaskGetRequest(modelId);
+        MLModelGetResponse response = client().execute(MLModelGetAction.INSTANCE, getRequest).actionGet(5000);
+        return response.getMlModel();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/prediction/PredictionITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prediction/PredictionITTests.java
@@ -5,107 +5,84 @@
 
 package org.opensearch.ml.action.prediction;
 
-import static org.opensearch.ml.utils.IntegTestUtils.DATA_FRAME_INPUT_DATASET;
-import static org.opensearch.ml.utils.IntegTestUtils.TESTING_DATA;
-import static org.opensearch.ml.utils.IntegTestUtils.TESTING_INDEX_NAME;
-import static org.opensearch.ml.utils.IntegTestUtils.generateEmptyDataset;
-import static org.opensearch.ml.utils.IntegTestUtils.generateMLTestingData;
-import static org.opensearch.ml.utils.IntegTestUtils.generateSearchSourceBuilder;
-import static org.opensearch.ml.utils.IntegTestUtils.predictAndVerifyResult;
-import static org.opensearch.ml.utils.IntegTestUtils.trainModel;
-import static org.opensearch.ml.utils.IntegTestUtils.verifyGeneratedTestingData;
-import static org.opensearch.ml.utils.IntegTestUtils.waitModelAvailable;
-
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.ExecutionException;
+import static org.opensearch.ml.utils.TestData.IRIS_DATA_SIZE;
 
 import org.junit.Before;
-import org.junit.Ignore;
-import org.opensearch.ResourceNotFoundException;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 import org.opensearch.action.ActionFuture;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ml.action.MLCommonsIntegTestCase;
+import org.opensearch.ml.common.dataframe.DataFrame;
+import org.opensearch.ml.common.dataset.DataFrameInputDataset;
 import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.SearchQueryInputDataset;
 import org.opensearch.ml.common.parameter.FunctionName;
 import org.opensearch.ml.common.parameter.MLInput;
+import org.opensearch.ml.common.parameter.MLModel;
+import org.opensearch.ml.common.parameter.MLPredictionOutput;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
-import org.opensearch.ml.plugin.MachineLearningPlugin;
-import org.opensearch.plugins.Plugin;
-import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
-@OpenSearchIntegTestCase.ClusterScope(transportClientRatio = 0.9)
-@Ignore("Test cases in this class are flaky, something is off with waitModelAvailable(taskId) method."
-    + " This issue will be tracked in an issue and will be fixed later")
-public class PredictionITTests extends OpenSearchIntegTestCase {
-    private String taskId;
+import com.google.common.collect.ImmutableList;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
+public class PredictionITTests extends MLCommonsIntegTestCase {
+    private String irisIndexName;
+    private String modelId;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
-    public void initTestingData() throws ExecutionException, InterruptedException {
-        generateMLTestingData();
+    public void setUp() throws Exception {
+        super.setUp();
+        irisIndexName = "iris_data_for_prediction_it";
+        loadIrisData(irisIndexName);
 
-        SearchSourceBuilder searchSourceBuilder = generateSearchSourceBuilder();
-        MLInputDataset inputDataset = new SearchQueryInputDataset(Collections.singletonList(TESTING_INDEX_NAME), searchSourceBuilder);
-        taskId = trainModel(inputDataset);
-        waitModelAvailable(taskId);
+        modelId = trainKmeansWithIrisData(irisIndexName, false);
+        MLModel model = getModel(modelId);
+        assertNotNull(model);
     }
 
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Collections.singletonList(MachineLearningPlugin.class);
+    public void testPredictionWithSearchInput() {
+        MLInputDataset inputDataset = new SearchQueryInputDataset(ImmutableList.of(irisIndexName), irisDataQuery());
+        predictAndVerify(inputDataset);
     }
 
-    @Override
-    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
-        return Collections.singletonList(MachineLearningPlugin.class);
+    public void testPredictionWithDataInput() {
+        MLInputDataset inputDataset = new DataFrameInputDataset(irisDataFrame());
+        predictAndVerify(inputDataset);
     }
 
-    public void testTestingData() throws ExecutionException, InterruptedException {
-        verifyGeneratedTestingData(TESTING_DATA);
-        waitModelAvailable(taskId);
-    }
-
-    public void testPredictionWithSearchInput() throws IOException {
-        SearchSourceBuilder searchSourceBuilder = generateSearchSourceBuilder();
-        MLInputDataset inputDataset = new SearchQueryInputDataset(Collections.singletonList(TESTING_INDEX_NAME), searchSourceBuilder);
-
-        predictAndVerifyResult(taskId, inputDataset);
-    }
-
-    public void testPredictionWithDataInput() throws IOException {
-        predictAndVerifyResult(taskId, DATA_FRAME_INPUT_DATASET);
-    }
-
-    public void testPredictionWithoutAlgorithm() throws IOException {
-        MLInput mlInput = MLInput.builder().inputDataset(DATA_FRAME_INPUT_DATASET).build();
-        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest(taskId, mlInput);
-        ActionFuture<MLTaskResponse> predictionFuture = client().execute(MLPredictionTaskAction.INSTANCE, predictionRequest);
-        expectThrows(ActionRequestValidationException.class, () -> predictionFuture.actionGet());
-    }
-
-    public void testPredictionWithoutModelId() throws IOException {
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.KMEANS).inputDataset(DATA_FRAME_INPUT_DATASET).build();
-        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest("", mlInput);
-        ActionFuture<MLTaskResponse> predictionFuture = client().execute(MLPredictionTaskAction.INSTANCE, predictionRequest);
-        expectThrows(ResourceNotFoundException.class, () -> predictionFuture.actionGet());
-    }
-
-    public void testPredictionWithoutDataset() throws IOException {
+    public void testPredictionWithoutDataset() {
+        exceptionRule.expect(ActionRequestValidationException.class);
+        exceptionRule.expectMessage("input data can't be null");
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.KMEANS).build();
-        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest(taskId, mlInput);
+        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest(modelId, mlInput);
         ActionFuture<MLTaskResponse> predictionFuture = client().execute(MLPredictionTaskAction.INSTANCE, predictionRequest);
-        expectThrows(ActionRequestValidationException.class, () -> predictionFuture.actionGet());
+        predictionFuture.actionGet();
     }
 
-    public void testPredictionWithEmptyDataset() throws IOException {
-        MLInputDataset emptySearchInputDataset = generateEmptyDataset();
+    public void testPredictionWithEmptyDataset() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("No document found");
+        MLInputDataset emptySearchInputDataset = emptyQueryInputDataSet(irisIndexName);
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.KMEANS).inputDataset(emptySearchInputDataset).build();
-        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest(taskId, mlInput);
+        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest(modelId, mlInput);
         ActionFuture<MLTaskResponse> predictionFuture = client().execute(MLPredictionTaskAction.INSTANCE, predictionRequest);
-        expectThrows(IllegalArgumentException.class, () -> predictionFuture.actionGet());
+        predictionFuture.actionGet();
+    }
+
+    private void predictAndVerify(MLInputDataset inputDataset) {
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.KMEANS).inputDataset(inputDataset).build();
+        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest(modelId, mlInput);
+        ActionFuture<MLTaskResponse> predictionFuture = client().execute(MLPredictionTaskAction.INSTANCE, predictionRequest);
+        MLTaskResponse predictionResponse = predictionFuture.actionGet();
+        MLPredictionOutput mlPredictionOutput = (MLPredictionOutput) predictionResponse.getOutput();
+        DataFrame predictionResult = mlPredictionOutput.getPredictionResult();
+        assertEquals(IRIS_DATA_SIZE, predictionResult.size());
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/prediction/PredictionITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prediction/PredictionITTests.java
@@ -7,23 +7,23 @@ package org.opensearch.ml.action.prediction;
 
 import static org.opensearch.ml.utils.TestData.IRIS_DATA_SIZE;
 
+import org.apache.lucene.util.LuceneTestCase;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.action.ActionFuture;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.ml.action.MLCommonsIntegTestCase;
-import org.opensearch.ml.common.dataframe.DataFrame;
 import org.opensearch.ml.common.dataset.DataFrameInputDataset;
 import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.SearchQueryInputDataset;
 import org.opensearch.ml.common.parameter.FunctionName;
 import org.opensearch.ml.common.parameter.MLInput;
 import org.opensearch.ml.common.parameter.MLModel;
-import org.opensearch.ml.common.parameter.MLPredictionOutput;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
+import org.opensearch.ml.utils.TestData;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import com.google.common.collect.ImmutableList;
@@ -31,7 +31,9 @@ import com.google.common.collect.ImmutableList;
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
 public class PredictionITTests extends MLCommonsIntegTestCase {
     private String irisIndexName;
-    private String modelId;
+    private String kMeansModelId;
+    private String batchRcfModelId;
+    private int batchRcfDataSize = 100;
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
@@ -42,47 +44,51 @@ public class PredictionITTests extends MLCommonsIntegTestCase {
         irisIndexName = "iris_data_for_prediction_it";
         loadIrisData(irisIndexName);
 
-        modelId = trainKmeansWithIrisData(irisIndexName, false);
-        MLModel model = getModel(modelId);
-        assertNotNull(model);
+        // TODO: open these lines when this bug fix merged https://github.com/oracle/tribuo/issues/223
+        // modelId = trainKmeansWithIrisData(irisIndexName, false);
+        // MLModel kMeansModel = getModel(kMeansModelId);
+        // assertNotNull(kMeansModel);
+
+        batchRcfModelId = trainBatchRCFWithDataFrame(500, false);
+        MLModel batchRcfModel = getModel(batchRcfModelId);
+        assertNotNull(batchRcfModel);
     }
 
-    public void testPredictionWithSearchInput() {
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/oracle/tribuo/issues/223")
+    public void testPredictionWithSearchInput_KMeans() {
         MLInputDataset inputDataset = new SearchQueryInputDataset(ImmutableList.of(irisIndexName), irisDataQuery());
-        predictAndVerify(inputDataset);
+        predictAndVerify(kMeansModelId, inputDataset, FunctionName.KMEANS, IRIS_DATA_SIZE);
     }
 
-    public void testPredictionWithDataInput() {
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/oracle/tribuo/issues/223")
+    public void testPredictionWithDataInput_KMeans() {
         MLInputDataset inputDataset = new DataFrameInputDataset(irisDataFrame());
-        predictAndVerify(inputDataset);
+        predictAndVerify(kMeansModelId, inputDataset, FunctionName.KMEANS, IRIS_DATA_SIZE);
     }
 
-    public void testPredictionWithoutDataset() {
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/oracle/tribuo/issues/223")
+    public void testPredictionWithoutDataset_KMeans() {
         exceptionRule.expect(ActionRequestValidationException.class);
         exceptionRule.expectMessage("input data can't be null");
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.KMEANS).build();
-        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest(modelId, mlInput);
+        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest(kMeansModelId, mlInput);
         ActionFuture<MLTaskResponse> predictionFuture = client().execute(MLPredictionTaskAction.INSTANCE, predictionRequest);
         predictionFuture.actionGet();
     }
 
-    public void testPredictionWithEmptyDataset() {
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/oracle/tribuo/issues/223")
+    public void testPredictionWithEmptyDataset_KMeans() {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("No document found");
         MLInputDataset emptySearchInputDataset = emptyQueryInputDataSet(irisIndexName);
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.KMEANS).inputDataset(emptySearchInputDataset).build();
-        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest(modelId, mlInput);
+        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest(kMeansModelId, mlInput);
         ActionFuture<MLTaskResponse> predictionFuture = client().execute(MLPredictionTaskAction.INSTANCE, predictionRequest);
         predictionFuture.actionGet();
     }
 
-    private void predictAndVerify(MLInputDataset inputDataset) {
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.KMEANS).inputDataset(inputDataset).build();
-        MLPredictionTaskRequest predictionRequest = new MLPredictionTaskRequest(modelId, mlInput);
-        ActionFuture<MLTaskResponse> predictionFuture = client().execute(MLPredictionTaskAction.INSTANCE, predictionRequest);
-        MLTaskResponse predictionResponse = predictionFuture.actionGet();
-        MLPredictionOutput mlPredictionOutput = (MLPredictionOutput) predictionResponse.getOutput();
-        DataFrame predictionResult = mlPredictionOutput.getPredictionResult();
-        assertEquals(IRIS_DATA_SIZE, predictionResult.size());
+    public void testPredictionWithDataFrame_BatchRCF() {
+        MLInputDataset inputDataset = new DataFrameInputDataset(TestData.constructTestDataFrame(batchRcfDataSize));
+        predictAndVerify(batchRcfModelId, inputDataset, FunctionName.BATCH_RCF, batchRcfDataSize);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeResponseTests.java
@@ -10,12 +10,27 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.ml.stats.StatNames;
+import org.opensearch.ml.utils.TestHelper;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class MLStatsNodeResponseTests extends OpenSearchTestCase {
+    private MLStatsNodeResponse response;
+
+    @Before
+    public void setup() {
+        DiscoveryNode node = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
+        Map<String, Object> statsToValues = new HashMap<>();
+        statsToValues.put(StatNames.ML_TOTAL_REQUEST_COUNT, 100);
+        response = new MLStatsNodeResponse(node, statsToValues);
+    }
 
     public void testSerializationDeserialization() throws IOException {
         DiscoveryNode localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
@@ -29,5 +44,22 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         for (String stat : newResponse.getStatsMap().keySet()) {
             Assert.assertEquals(response.getStatsMap().get(stat), newResponse.getStatsMap().get(stat));
         }
+    }
+
+    public void testToXContent() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        String taskContent = TestHelper.xContentBuilderToString(builder);
+        assertEquals("{\"ml_total_request_count\":100}", taskContent);
+    }
+
+    public void testReadStats() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        MLStatsNodeResponse mlStatsNodeResponse = MLStatsNodeResponse.readStats(output.bytes().streamInput());
+        Integer expectedValue = (Integer) response.getStatsMap().get(StatNames.ML_TOTAL_REQUEST_COUNT);
+        assertEquals(expectedValue, mlStatsNodeResponse.getStatsMap().get(StatNames.ML_TOTAL_REQUEST_COUNT));
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesResponseTests.java
@@ -7,12 +7,21 @@ package org.opensearch.ml.action.stats;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
+import org.opensearch.Version;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.ml.stats.StatNames;
+import org.opensearch.ml.utils.TestHelper;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class MLStatsNodesResponseTests extends OpenSearchTestCase {
@@ -26,5 +35,20 @@ public class MLStatsNodesResponseTests extends OpenSearchTestCase {
         response.writeTo(output);
         MLStatsNodesResponse newResponse = new MLStatsNodesResponse(output.bytes().streamInput());
         Assert.assertEquals(newResponse.getNodes().size(), response.getNodes().size());
+    }
+
+    public void testToXContent() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        ClusterName clusterName = new ClusterName("test");
+        List<MLStatsNodeResponse> nodes = new ArrayList<>();
+        DiscoveryNode node = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
+        Map<String, Object> statsToValues = new HashMap<>();
+        statsToValues.put(StatNames.ML_TOTAL_REQUEST_COUNT, 100);
+        nodes.add(new MLStatsNodeResponse(node, statsToValues));
+        List<FailedNodeException> failures = new ArrayList<>();
+        MLStatsNodesResponse response = new MLStatsNodesResponse(clusterName, nodes, failures);
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String taskContent = TestHelper.xContentBuilderToString(builder);
+        assertEquals("{\"node0\":{\"ml_total_request_count\":100}}", taskContent);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/training/TrainingITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/training/TrainingITTests.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.action.training;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.lucene.util.LuceneTestCase;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -33,7 +34,8 @@ public class TrainingITTests extends MLCommonsIntegTestCase {
         loadIrisData(irisIndexName);
     }
 
-    public void testTrainingWithSearchInput_Async() throws InterruptedException {
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/oracle/tribuo/issues/223")
+    public void testTrainingWithSearchInput_Async_KMenas() throws InterruptedException {
         String taskId = trainKmeansWithIrisData(irisIndexName, true);
         assertNotNull(taskId);
 
@@ -47,20 +49,42 @@ public class TrainingITTests extends MLCommonsIntegTestCase {
         assertNotNull(model);
     }
 
-    public void testTrainingWithSearchInput_Sync() {
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/oracle/tribuo/issues/223")
+    public void testTrainingWithSearchInput_Sync_KMenas() {
         String modelId = trainKmeansWithIrisData(irisIndexName, false);
         assertNotNull(modelId);
         MLModel model = getModel(modelId);
         assertNotNull(model);
     }
 
-    public void testTrainingWithoutDataset() {
+    public void testTrainingWithDataFrame_Async_BatchRCF() throws InterruptedException {
+        String taskId = trainBatchRCFWithDataFrame(500, true);
+        assertNotNull(taskId);
+
+        AtomicReference<String> modelId = new AtomicReference<>();
+        waitUntil(() -> {
+            String id = getTask(taskId).getModelId();
+            modelId.set(id);
+            return id != null;
+        }, 10, TimeUnit.SECONDS);
+        MLModel model = getModel(modelId.get());
+        assertNotNull(model);
+    }
+
+    public void testTrainingWithDataFrame_Sync_BatchRCF() {
+        String modelId = trainBatchRCFWithDataFrame(500, false);
+        assertNotNull(modelId);
+        MLModel model = getModel(modelId);
+        assertNotNull(model);
+    }
+
+    public void testTrainingWithoutDataset_KMenas() {
         exceptionRule.expect(ActionRequestValidationException.class);
         exceptionRule.expectMessage("input data can't be null");
         trainModel(FunctionName.KMEANS, KMeansParams.builder().centroids(3).build(), null, false);
     }
 
-    public void testTrainingWithEmptyDataset() {
+    public void testTrainingWithEmptyDataset_KMenas() {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("No document found");
         MLInputDataset emptySearchInputDataset = emptyQueryInputDataSet(irisIndexName);

--- a/plugin/src/test/java/org/opensearch/ml/action/trainpredict/TrainAndPredictITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/trainpredict/TrainAndPredictITTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.trainpredict;
+
+import static org.opensearch.ml.utils.TestData.IRIS_DATA_SIZE;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ml.action.MLCommonsIntegTestCase;
+import org.opensearch.ml.common.dataframe.DataFrame;
+import org.opensearch.ml.common.dataset.MLInputDataset;
+import org.opensearch.ml.common.parameter.FunctionName;
+import org.opensearch.ml.common.parameter.KMeansParams;
+import org.opensearch.ml.common.parameter.MLPredictionOutput;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
+public class TrainAndPredictITTests extends MLCommonsIntegTestCase {
+    private String irisIndexName;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        irisIndexName = "iris_data_for_train_and_predict_it";
+        loadIrisData(irisIndexName);
+    }
+
+    public void testTrainAndPredict() {
+        MLPredictionOutput mlPredictionOutput = trainAndPredictKmeansWithIrisData(irisIndexName);
+        assertNotNull(mlPredictionOutput);
+        DataFrame predictionResult = mlPredictionOutput.getPredictionResult();
+        assertNotNull(predictionResult);
+        assertEquals(IRIS_DATA_SIZE, predictionResult.size());
+    }
+
+    public void testTrainAndPredictWithoutDataset() {
+        exceptionRule.expect(ActionRequestValidationException.class);
+        exceptionRule.expectMessage("input data can't be null");
+        trainAndPredict(FunctionName.KMEANS, KMeansParams.builder().centroids(3).build(), null);
+    }
+
+    public void testTrainAndPredictWithEmptyDataset() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("No document found");
+        MLInputDataset emptySearchInputDataset = emptyQueryInputDataSet(irisIndexName);
+        trainAndPredict(FunctionName.KMEANS, KMeansParams.builder().centroids(3).build(), emptySearchInputDataset);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/trainpredict/TrainAndPredictITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/trainpredict/TrainAndPredictITTests.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.action.trainpredict;
 
 import static org.opensearch.ml.utils.TestData.IRIS_DATA_SIZE;
 
+import org.apache.lucene.util.LuceneTestCase;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -33,7 +34,8 @@ public class TrainAndPredictITTests extends MLCommonsIntegTestCase {
         loadIrisData(irisIndexName);
     }
 
-    public void testTrainAndPredict() {
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/oracle/tribuo/issues/223")
+    public void testTrainAndPredict_KMeans() {
         MLPredictionOutput mlPredictionOutput = trainAndPredictKmeansWithIrisData(irisIndexName);
         assertNotNull(mlPredictionOutput);
         DataFrame predictionResult = mlPredictionOutput.getPredictionResult();
@@ -41,13 +43,22 @@ public class TrainAndPredictITTests extends MLCommonsIntegTestCase {
         assertEquals(IRIS_DATA_SIZE, predictionResult.size());
     }
 
-    public void testTrainAndPredictWithoutDataset() {
+    public void testTrainAndPredict_BatchRCF() {
+        int size = 1000;
+        MLPredictionOutput mlPredictionOutput = trainAndPredictBatchRCFWithDataFrame(size);
+        assertNotNull(mlPredictionOutput);
+        DataFrame predictionResult = mlPredictionOutput.getPredictionResult();
+        assertNotNull(predictionResult);
+        assertEquals(size, predictionResult.size());
+    }
+
+    public void testTrainAndPredictWithoutDataset_KMeans() {
         exceptionRule.expect(ActionRequestValidationException.class);
         exceptionRule.expectMessage("input data can't be null");
         trainAndPredict(FunctionName.KMEANS, KMeansParams.builder().centroids(3).build(), null);
     }
 
-    public void testTrainAndPredictWithEmptyDataset() {
+    public void testTrainAndPredictWithEmptyDataset_KMeans() {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("No document found");
         MLInputDataset emptySearchInputDataset = emptyQueryInputDataSet(irisIndexName);

--- a/plugin/src/test/java/org/opensearch/ml/params/MLInputTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/params/MLInputTests.java
@@ -9,6 +9,8 @@ import static org.opensearch.ml.utils.TestHelper.parser;
 
 import java.io.IOException;
 
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.ml.common.dataframe.ColumnType;
 import org.opensearch.ml.common.dataframe.DataFrame;
@@ -16,9 +18,12 @@ import org.opensearch.ml.common.dataset.DataFrameInputDataset;
 import org.opensearch.ml.common.dataset.SearchQueryInputDataset;
 import org.opensearch.ml.common.parameter.FunctionName;
 import org.opensearch.ml.common.parameter.MLInput;
+import org.opensearch.ml.utils.TestData;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class MLInputTests extends OpenSearchTestCase {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
 
     public void testParseKmeansInputQuery() throws IOException {
         String query =
@@ -51,6 +56,12 @@ public class MLInputTests extends OpenSearchTestCase {
         assertEquals(ColumnType.BOOLEAN, dataFrame.getRow(0).getValue(1).columnType());
         assertEquals(15.0, dataFrame.getRow(0).getValue(0).getValue());
         assertEquals(false, dataFrame.getRow(0).getValue(1).getValue());
+    }
+
+    public void testWithoutAlgorithm() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("algorithm can't be null");
+        MLInput.builder().inputDataset(new DataFrameInputDataset(TestData.constructTestDataFrame(10))).build();
     }
 
 }

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestData.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestData.java
@@ -38,7 +38,7 @@ public class TestData {
         MultivariateNormalDistribution[] normalDistributions = new MultivariateNormalDistribution[] { g1, g2 };
         for (int i = 0; i < size; ++i) {
             int id = 0;
-            if (Math.random() < 0.5) {
+            if (random.nextDouble() < 0.5) {
                 id = 1;
             }
             double[] sample = normalDistributions[id].sample();
@@ -48,6 +48,7 @@ public class TestData {
         return dataFrame;
     }
 
+    public static final int IRIS_DATA_SIZE = 150;
     public static final String IRIS_DATA = "{ \"index\" : { \"_index\" : \"iris_data\" } }\n"
         + "{\"sepal_length_in_cm\":5.1,\"sepal_width_in_cm\":3.5,\"petal_length_in_cm\":1.4,\"petal_width_in_cm\":0.2,\"class\":\"Iris-setosa\"}\n"
         + "{ \"index\" : { \"_index\" : \"iris_data\" } }\n"


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
add more IT for train/predict and train&predict action
 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
