### PR TITLE
add more UT for model/task rest actions, remove support for JDK8

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -11,7 +11,7 @@ jobs:
   Build-ml:
     strategy:
       matrix:
-        java: [8, 11, 14]
+        java: [11, 14]
 
     name: Build and Test MLCommons Plugin
     runs-on: ubuntu-latest

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -214,12 +214,8 @@ List<String> jacocoExclusions = [
         'org.opensearch.ml.task.MLPredictTaskRunner',
         'org.opensearch.ml.rest.RestMLPredictionAction',
         'org.opensearch.ml.rest.AbstractMLSearchAction*',
-        'org.opensearch.ml.rest.RestMLDeleteTaskAction', //0.5
-        'org.opensearch.ml.rest.RestMLGetModelAction', //0.5
         'org.opensearch.ml.rest.RestMLExecuteAction', //0.3
-        'org.opensearch.ml.rest.RestMLDeleteModelAction', //0.5
-        'org.opensearch.ml.rest.RestMLTrainAndPredictAction', //0.3
-        'org.opensearch.ml.rest.RestMLGetTaskAction' //0.5
+        'org.opensearch.ml.rest.RestMLTrainAndPredictAction' //0.3
 ]
 
 jacocoTestCoverageVerification {
@@ -333,3 +329,5 @@ tasks.withType(licenseHeaders.class) {
 checkstyle {
     toolVersion = '8.29'
 }
+sourceCompatibility = JavaVersion.VERSION_1_9
+targetCompatibility = JavaVersion.VERSION_1_9

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteModelActionTests.java
@@ -5,21 +5,64 @@
 
 package org.opensearch.ml.rest;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.Strings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.model.MLModelDeleteAction;
+import org.opensearch.ml.common.transport.model.MLModelDeleteRequest;
+import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
 
 public class RestMLDeleteModelActionTests extends OpenSearchTestCase {
 
     private RestMLDeleteModelAction restMLDeleteModelAction;
 
+    NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
     @Before
     public void setup() {
         restMLDeleteModelAction = new RestMLDeleteModelAction();
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLModelDeleteAction.INSTANCE), any(), any());
+
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
     }
 
     public void testConstructor() {
@@ -40,5 +83,22 @@ public class RestMLDeleteModelActionTests extends OpenSearchTestCase {
         RestHandler.Route route = routes.get(0);
         assertEquals(RestRequest.Method.DELETE, route.getMethod());
         assertEquals("/_plugins/_ml/models/{model_id}", route.getPath());
+    }
+
+    public void test_PrepareRequest() throws Exception {
+        RestRequest request = getRestRequest();
+        restMLDeleteModelAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLModelDeleteRequest> argumentCaptor = ArgumentCaptor.forClass(MLModelDeleteRequest.class);
+        verify(client, times(1)).execute(eq(MLModelDeleteAction.INSTANCE), argumentCaptor.capture(), any());
+        String taskId = argumentCaptor.getValue().getModelId();
+        assertEquals(taskId, "test_id");
+    }
+
+    private RestRequest getRestRequest() {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MODEL_ID, "test_id");
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).build();
+        return request;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteTaskActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteTaskActionTests.java
@@ -5,21 +5,63 @@
 
 package org.opensearch.ml.rest;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_TASK_ID;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.Strings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.task.MLTaskDeleteAction;
+import org.opensearch.ml.common.transport.task.MLTaskDeleteRequest;
+import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
 
 public class RestMLDeleteTaskActionTests extends OpenSearchTestCase {
 
     private RestMLDeleteTaskAction restMLDeleteTaskAction;
 
+    NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
     @Before
     public void setup() {
         restMLDeleteTaskAction = new RestMLDeleteTaskAction();
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLTaskDeleteAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
     }
 
     public void testConstructor() {
@@ -40,5 +82,22 @@ public class RestMLDeleteTaskActionTests extends OpenSearchTestCase {
         RestHandler.Route route = routes.get(0);
         assertEquals(RestRequest.Method.DELETE, route.getMethod());
         assertEquals("/_plugins/_ml/tasks/{task_id}", route.getPath());
+    }
+
+    public void test_PrepareRequest() throws Exception {
+        RestRequest request = getRestRequest();
+        restMLDeleteTaskAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLTaskDeleteRequest> argumentCaptor = ArgumentCaptor.forClass(MLTaskDeleteRequest.class);
+        verify(client, times(1)).execute(eq(MLTaskDeleteAction.INSTANCE), argumentCaptor.capture(), any());
+        String taskId = argumentCaptor.getValue().getTaskId();
+        assertEquals(taskId, "test_id");
+    }
+
+    private RestRequest getRestRequest() {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_TASK_ID, "test_id");
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).build();
+        return request;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelActionTests.java
@@ -5,15 +5,36 @@
 
 package org.opensearch.ml.rest;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.opensearch.action.ActionListener;
+import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.Strings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.model.MLModelGetAction;
+import org.opensearch.ml.common.transport.model.MLModelGetRequest;
+import org.opensearch.ml.common.transport.model.MLModelGetResponse;
+import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
 
 public class RestMLGetModelActionTests extends OpenSearchTestCase {
     @Rule
@@ -21,9 +42,31 @@ public class RestMLGetModelActionTests extends OpenSearchTestCase {
 
     private RestMLGetModelAction restMLGetModelAction;
 
+    NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
     @Before
     public void setup() {
         restMLGetModelAction = new RestMLGetModelAction();
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelGetResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLModelGetAction.INSTANCE), any(), any());
+
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
     }
 
     public void testConstructor() {
@@ -44,5 +87,22 @@ public class RestMLGetModelActionTests extends OpenSearchTestCase {
         RestHandler.Route route = routes.get(0);
         assertEquals(RestRequest.Method.GET, route.getMethod());
         assertEquals("/_plugins/_ml/models/{model_id}", route.getPath());
+    }
+
+    public void test_PrepareRequest() throws Exception {
+        RestRequest request = getRestRequest();
+        restMLGetModelAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLModelGetRequest> argumentCaptor = ArgumentCaptor.forClass(MLModelGetRequest.class);
+        verify(client, times(1)).execute(eq(MLModelGetAction.INSTANCE), argumentCaptor.capture(), any());
+        String taskId = argumentCaptor.getValue().getModelId();
+        assertEquals(taskId, "test_id");
+    }
+
+    private RestRequest getRestRequest() {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MODEL_ID, "test_id");
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).build();
+        return request;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetTaskActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetTaskActionTests.java
@@ -5,21 +5,61 @@
 
 package org.opensearch.ml.rest;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_TASK_ID;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.opensearch.action.ActionListener;
+import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.Strings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.task.*;
+import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
 
 public class RestMLGetTaskActionTests extends OpenSearchTestCase {
 
     private RestMLGetTaskAction restMLGetTaskAction;
 
+    NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
     @Before
     public void setup() {
         restMLGetTaskAction = new RestMLGetTaskAction();
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskGetResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLTaskGetAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
     }
 
     public void testConstructor() {
@@ -40,5 +80,22 @@ public class RestMLGetTaskActionTests extends OpenSearchTestCase {
         RestHandler.Route route = routes.get(0);
         assertEquals(RestRequest.Method.GET, route.getMethod());
         assertEquals("/_plugins/_ml/tasks/{task_id}", route.getPath());
+    }
+
+    public void test_PrepareRequest() throws Exception {
+        RestRequest request = getRestRequest();
+        restMLGetTaskAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLTaskGetRequest> argumentCaptor = ArgumentCaptor.forClass(MLTaskGetRequest.class);
+        verify(client, times(1)).execute(eq(MLTaskGetAction.INSTANCE), argumentCaptor.capture(), any());
+        String taskId = argumentCaptor.getValue().getTaskId();
+        assertEquals(taskId, "test_id");
+    }
+
+    private RestRequest getRestRequest() {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_TASK_ID, "test_id");
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).build();
+        return request;
     }
 }


### PR DESCRIPTION
Signed-off-by: Xun Zhang <xunzh@amazon.com>

### Description
1. Add more unit tests coverage for task/model rest actions. 
2. Remove support for JDK 8 for 2.0 into Main branch.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
