### PR TITLE
Remove oss flavor

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -265,7 +265,7 @@ afterEvaluate {
         fileMode 0644
         dirMode 0755
 
-        requires('opensearch-oss', versions.opensearch, EQUAL)
+        requires('opensearch', versions.opensearch, EQUAL)
         packager = 'Amazon'
         vendor = 'Amazon'
         os = 'LINUX'


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Removes unnecessary `-oss` flavor from `build.gradle`. OpenSearch exported `oss` flavor flag until now (all versions up to 1.3.0) and will remove it after. https://github.com/opensearch-project/OpenSearch/pull/1751

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
