### PR TITLE
add support for JDK 17

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -11,7 +11,7 @@ jobs:
   Build-ml:
     strategy:
       matrix:
-        java: [11, 14]
+        java: [11, 14, 17]
 
     name: Build and Test MLCommons Plugin
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
 plugins {
     id 'nebula.ospackage' version "8.3.0"
     id 'java'
-    id "io.freefair.lombok" version "5.1.0"
+    id "io.freefair.lombok" version "6.4.1"
     id 'jacoco'
 }
 
@@ -55,7 +55,7 @@ allprojects {
     apply from: "$rootDir/build-tools/repositories.gradle"
 
     plugins.withId('java') {
-        sourceCompatibility = targetCompatibility = "1.8"
+        sourceCompatibility = targetCompatibility = JavaVersion.VERSION_11
     }
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation project(':opensearch-ml-common')
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     testImplementation group: 'junit', name: 'junit', version: '4.12'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
 
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     compileOnly "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     implementation "org.opensearch:common-utils:${common_utils_version}"
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
 }
 
 jacocoTestReport {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     implementation files('lib/randomcutforest-parkservices-2.0.1.jar')
     implementation files('lib/randomcutforest-core-2.0.1.jar')
     testImplementation group: 'junit', name: 'junit', version: '4.12'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
-    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.9.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.4.0'
 }
 
 jacocoTestReport {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -327,5 +327,3 @@ tasks.withType(licenseHeaders.class) {
 checkstyle {
     toolVersion = '8.29'
 }
-sourceCompatibility = JavaVersion.VERSION_1_9
-targetCompatibility = JavaVersion.VERSION_1_9


### PR DESCRIPTION
### Description
To Support build ML-Common using JDK 17, we also need to upgrade the following dependencies.

java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor  -> upgrade to "io.freefair.lombok" version "6.4.1"
opensearch-ml-algorithms:test errors -> upgrade to name: 'mockito-core', version: '4.4.0'
For be consistent with all plugins -> sourceCompatibility = targetCompatibility = JavaVersion.VERSION_11

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
