### PR TITLE
drop support for JDK 14

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -11,7 +11,7 @@ jobs:
   Build-ml:
     strategy:
       matrix:
-        java: [11, 14, 17]
+        java: [11, 17]
 
     name: Build and Test MLCommons Plugin
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Xun Zhang <xunzh@amazon.com>

### Description
Remove JDK 14 per request in https://github.com/opensearch-project/ml-commons/issues/266 and https://github.com/opensearch-project/opensearch-plugins/issues/132
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
