### PR TITLE
create model/task index with correct mapping

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
@@ -100,7 +100,7 @@ public class MLIndicesHandler {
                     log.error("Failed to create index " + indexName, e);
                     listener.onFailure(e);
                 });
-                CreateIndexRequest request = new CreateIndexRequest(indexName);
+                CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping);
                 client.admin().indices().create(request, ActionListener.runBefore(actionListener, () -> threadContext.restore()));
             } catch (Exception e) {
                 log.error("Failed to init index " + indexName, e);


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
We found security test `testReadOnlyUser_CanSearchModels` failed. Debug locally and found ML model index mapping is wrong: filed `algorithm` was set as `text` type
So when search with this query, will return empty result.
```
POST /_plugins/_ml/models/_search
{
  "query": {
    "bool": {
      "filter": [
        {
          "term": {
            "algorithm": "KMEANS"
          }
        }
      ]
    }
  }
}
```

This PR fix this bug by setting mapping in create index request. Will backport this to 1.x .
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
