### PR TITLE
bump version to 1.3.2 in CI workflow

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -28,10 +28,10 @@ jobs:
 
       - name: Build and Run Tests
         run: |
-          ./gradlew build -Dopensearch.version=1.3.0-SNAPSHOT
+          ./gradlew build
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.3.0-SNAPSHOT
+          ./gradlew publishToMavenLocal
       - name: Multi Nodes Integration Testing
         run: |
           ./gradlew integTest -PnumNodes=3
@@ -39,8 +39,8 @@ jobs:
         run: |
           plugin=`ls plugin/build/distributions/*.zip`
           echo MLCommons plugin $plugin
-          version=1.3.0
-          plugin_version=1.3.0.0-SNAPSHOT
+          version=1.3.2
+          plugin_version=1.3.2.0-SNAPSHOT
           echo Using OpenSearch $version with MLCommons $plugin_version
           cd ..
           if docker pull opensearchstaging/opensearch:$version


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
bump version to 1.3.2 in CI workflow

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
