### PR TITLE
bump tribuo version to 4.2.1

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -17,9 +17,9 @@ dependencies {
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation project(':opensearch-ml-common')
     implementation group: 'org.reflections', name: 'reflections', version: '0.9.12'
-    implementation group: 'org.tribuo', name: 'tribuo-clustering-kmeans', version: '4.2.0'
-    implementation group: 'org.tribuo', name: 'tribuo-regression-sgd', version: '4.2.0'
-    implementation group: 'org.tribuo', name: 'tribuo-anomaly-libsvm', version: '4.2.0'
+    implementation group: 'org.tribuo', name: 'tribuo-clustering-kmeans', version: '4.2.1'
+    implementation group: 'org.tribuo', name: 'tribuo-regression-sgd', version: '4.2.1'
+    implementation group: 'org.tribuo', name: 'tribuo-anomaly-libsvm', version: '4.2.1'
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
     implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:3.0-rc2.1'
     implementation 'software.amazon.randomcutforest:randomcutforest-core:3.0-rc2.1'


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
We fixed a bug in tribuo `4.2.0` https://github.com/oracle/tribuo/pull/224. Need to bump version to `4.2.1`.

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
