### PR TITLE
[Backport to 1.x] bump tribuo version to 4.2.1

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -17,9 +17,9 @@ dependencies {
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     compile project(':opensearch-ml-common')
     compile group: 'org.reflections', name: 'reflections', version: '0.9.12'
-    compile group: 'org.tribuo', name: 'tribuo-clustering-kmeans', version: '4.2.0'
-    compile group: 'org.tribuo', name: 'tribuo-regression-sgd', version: '4.2.0'
-    compile group: 'org.tribuo', name: 'tribuo-anomaly-libsvm', version: '4.2.0'
+    compile group: 'org.tribuo', name: 'tribuo-clustering-kmeans', version: '4.2.1'
+    compile group: 'org.tribuo', name: 'tribuo-regression-sgd', version: '4.2.1'
+    compile group: 'org.tribuo', name: 'tribuo-anomaly-libsvm', version: '4.2.1'
     compile group: 'commons-io', name: 'commons-io', version: '2.11.0'
     compile files('lib/randomcutforest-parkservices-2.0.1.jar')
     compile files('lib/randomcutforest-core-2.0.1.jar')


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Backport PR #312 to 1.x
 

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
