### PR TITLE
Use custom plugin to publish zips to maven

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -24,6 +24,7 @@ ext {
 
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.testclusters'
+apply plugin: 'opensearch.pluginzip'
 ext {
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.txt')
@@ -53,6 +54,28 @@ dependencies {
     checkstyle "com.puppycrawl.tools:checkstyle:${project.checkstyle.toolVersion}"
 }
 
+publishing {
+    publications {
+        pluginZip(MavenPublication) { publication ->
+            pom {
+                name = opensearchplugin.name
+                description = opensearchplugin.description
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        name = "OpenSearch"
+                        url = "https://github.com/opensearch-project/ml-commons"
+                    }
+                }
+            }
+        }
+    }
+}
 
 compileJava {
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
@@ -238,6 +261,7 @@ configurations.all {
     resolutionStrategy.force 'junit:junit:4.12'
     resolutionStrategy.force 'org.apache.commons:commons-lang3:3.10'
     resolutionStrategy.force 'commons-logging:commons-logging:1.2'
+    resolutionStrategy.force 'org.objenesis:objenesis:3.2'
 }
 
 apply plugin: 'nebula.ospackage'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -69,6 +69,7 @@ fi
 
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishAllPublicationsToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 mkdir -p $OUTPUT/maven/org/opensearch
 cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch
 


### PR DESCRIPTION
Signed-off-by: Xun Zhang <xunzh@amazon.com>

### Description
Follow https://github.com/opensearch-project/opensearch-build/issues/1916 and use custom plugin to publish zips to maven.
 
### Issues Resolved
[306](https://github.com/opensearch-project/ml-commons/issues/306)
 
### Check List
Run ./gradlew publishPluginZipPublicationToZipStagingRepository, and identified the local-staging-repo directory created.

tree ./
./
├── libs
│   ├── opensearch-ml-2.0.0.0-SNAPSHOT.jar
│   └── opensearch-ml-2.0.0.0-rc1-SNAPSHOT.jar
├── local-staging-repo
│   └── org
│       └── opensearch
│           └── plugin
│               └── opensearch-ml-plugin
│                   ├── 2.0.0.0-SNAPSHOT
│                   │   ├── maven-metadata.xml
│                   │   ├── maven-metadata.xml.md5
│                   │   ├── maven-metadata.xml.sha1
│                   │   ├── maven-metadata.xml.sha256
│                   │   ├── maven-metadata.xml.sha512
│                   │   ├── opensearch-ml-plugin-2.0.0.0-20220609.235643-1.pom
│                   │   ├── opensearch-ml-plugin-2.0.0.0-20220609.235643-1.pom.md5
│                   │   ├── opensearch-ml-plugin-2.0.0.0-20220609.235643-1.pom.sha1
│                   │   ├── opensearch-ml-plugin-2.0.0.0-20220609.235643-1.pom.sha256
│                   │   ├── opensearch-ml-plugin-2.0.0.0-20220609.235643-1.pom.sha512
│                   │   ├── opensearch-ml-plugin-2.0.0.0-20220609.235643-1.zip
│                   │   ├── opensearch-ml-plugin-2.0.0.0-20220609.235643-1.zip.md5
│                   │   ├── opensearch-ml-plugin-2.0.0.0-20220609.235643-1.zip.sha1
│                   │   ├── opensearch-ml-plugin-2.0.0.0-20220609.235643-1.zip.sha256
│                   │   └── opensearch-ml-plugin-2.0.0.0-20220609.235643-1.zip.sha512
│                   ├── maven-metadata.xml
│                   ├── maven-metadata.xml.md5
│                   ├── maven-metadata.xml.sha1
│                   ├── maven-metadata.xml.sha256
│                   └── maven-metadata.xml.sha512
├── lombok
│   └── effective-config
│       ├── lombok-main.config
│       └── lombok-test.config
├── private
│   └── opensearch_tmp
└── tmp
    └── jar
        └── MANIFEST.MF


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
