### PR TITLE
dispatch ML task to ML node first

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -19,13 +19,11 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
-import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.IndexScopedSettings;
-import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
@@ -115,14 +113,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
     private ClusterService clusterService;
     private ThreadPool threadPool;
 
-    public static final Setting<Boolean> IS_ML_NODE_SETTING = Setting.boolSetting("node.ml", false, Setting.Property.NodeScope);
-
-    public static final DiscoveryNodeRole ML_ROLE = new DiscoveryNodeRole("ml", "l") {
-        @Override
-        public Setting<Boolean> legacySetting() {
-            return IS_ML_NODE_SETTING;
-        }
-    };
+    public static final String ML_ROLE_NAME = "ml";
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {

--- a/plugin/src/main/java/org/opensearch/ml/utils/MLNodeUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/MLNodeUtils.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.utils;
 
+import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_ROLE_NAME;
+
 import java.io.IOException;
 
 import lombok.experimental.UtilityClass;
@@ -12,12 +14,11 @@ import lombok.experimental.UtilityClass;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.*;
-import org.opensearch.ml.plugin.MachineLearningPlugin;
 
 @UtilityClass
 public class MLNodeUtils {
     public boolean isMLNode(DiscoveryNode node) {
-        return node.getRoles().stream().anyMatch(role -> role.roleName().equalsIgnoreCase(MachineLearningPlugin.ML_ROLE.roleName()));
+        return node.getRoles().stream().anyMatch(role -> role.roleName().equalsIgnoreCase(ML_ROLE_NAME));
     }
 
     public static XContentParser createXContentParserFromRegistry(NamedXContentRegistry xContentRegistry, BytesReference bytesReference)

--- a/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.utils;
 
 import static java.util.Collections.emptyMap;
+import static org.opensearch.ml.utils.TestHelper.ML_ROLE;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -22,7 +23,6 @@ import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.ml.common.MLTask;
-import org.opensearch.ml.plugin.MachineLearningPlugin;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class MLNodeUtilsTests extends OpenSearchTestCase {
@@ -34,7 +34,7 @@ public class MLNodeUtilsTests extends OpenSearchTestCase {
         DiscoveryNode normalNode = new DiscoveryNode("Normal node", buildNewFakeTransportAddress(), emptyMap(), roleSet, Version.CURRENT);
         Assert.assertFalse(MLNodeUtils.isMLNode(normalNode));
 
-        roleSet.add(MachineLearningPlugin.ML_ROLE);
+        roleSet.add(ML_ROLE);
         DiscoveryNode mlNode = new DiscoveryNode("ML node", buildNewFakeTransportAddress(), emptyMap(), roleSet, Version.CURRENT);
         Assert.assertTrue(MLNodeUtils.isMLNode(mlNode));
     }

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -30,8 +30,10 @@ import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.WarningsHandler;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
@@ -56,6 +58,16 @@ import org.opensearch.test.rest.FakeRestRequest;
 import com.google.common.collect.ImmutableMap;
 
 public class TestHelper {
+
+    public static final Setting<Boolean> IS_ML_NODE_SETTING = Setting.boolSetting("node.ml", false, Setting.Property.NodeScope);
+
+    public static final DiscoveryNodeRole ML_ROLE = new DiscoveryNodeRole("ml", "ml") {
+        @Override
+        public Setting<Boolean> legacySetting() {
+            return IS_ML_NODE_SETTING;
+        }
+    };
+
     public static XContentParser parser(String xc) throws IOException {
         return parser(xc, true);
     }


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
We plan to support dynamic role in OpenSearch. Refer to this PR https://github.com/opensearch-project/OpenSearch/pull/3436 and issue https://github.com/opensearch-project/OpenSearch/issues/2877

This PR is to change the task dispatcher to support ML node. Will check if cluster has any node with "ml" role first. If yes, will dispatch ML task to "ml" nodes; otherwise will dispatch to data nodes.

 
### Issues Resolved
close #79
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
