### PR TITLE
[backport 1.3]Staging for version increment automation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,3 +69,20 @@ ext {
 dependencies {
     implementation 'junit:junit:4.12'
 }
+
+// updateVersion: Task to auto increment to the next development iteration
+task updateVersion {
+    onlyIf { System.getProperty('newVersion') }
+    doLast {
+        ext.newVersion = System.getProperty('newVersion')
+        println "Setting version to ${newVersion}."
+        // String tokenization to support -SNAPSHOT
+        ant.replaceregexp(match: opensearch_version.tokenize('-')[0], replace: newVersion.tokenize('-')[0], flags:'g', byline:true) {
+            fileset(dir: projectDir) {
+                // Include the required files that needs to be updated with new Version
+                include(name: "build.gradle")
+                include(name: ".github/workflows/CI-workflow.yml")
+            }
+        }
+    }
+}  


### PR DESCRIPTION
Signed-off-by: prudhvigodithi <pgodithi@amazon.com>

### Description
This is the staging PR for to execute workflows that auto raise the version increment PR's
Example: https://github.com/prudhvigodithi/ml-commons/pull/2
 
### Issues Resolved
Part of: https://github.com/opensearch-project/opensearch-build/issues/1375
From solution: https://github.com/opensearch-project/opensearch-build/issues/1375#issuecomment-1159476686
Related issue: https://github.com/opensearch-project/ml-commons/issues/357
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
