### PR TITLE
reenable KMEANS predict IT tests

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/action/prediction/PredictionITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prediction/PredictionITTests.java
@@ -11,7 +11,6 @@ import static org.opensearch.ml.utils.TestData.TIME_FIELD;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -59,10 +58,9 @@ public class PredictionITTests extends MLCommonsIntegTestCase {
         irisIndexName = "iris_data_for_prediction_it";
         loadIrisData(irisIndexName);
 
-        // TODO: open these lines when this bug fix merged https://github.com/oracle/tribuo/issues/223
-        // modelId = trainKmeansWithIrisData(irisIndexName, false);
-        // MLModel kMeansModel = getModel(kMeansModelId);
-        // assertNotNull(kMeansModel);
+        kMeansModelId = trainKmeansWithIrisData(irisIndexName, false);
+        MLModel kMeansModel = getModel(kMeansModelId);
+        assertNotNull(kMeansModel);
 
         batchRcfModelId = trainBatchRCFWithDataFrame(500, false);
         fitRcfModelId = trainFitRCFWithDataFrame(500, false);
@@ -72,19 +70,16 @@ public class PredictionITTests extends MLCommonsIntegTestCase {
         assertNotNull(batchRcfModel);
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/oracle/tribuo/issues/223")
     public void testPredictionWithSearchInput_KMeans() {
         MLInputDataset inputDataset = new SearchQueryInputDataset(ImmutableList.of(irisIndexName), irisDataQuery());
         predictAndVerify(kMeansModelId, inputDataset, FunctionName.KMEANS, null, IRIS_DATA_SIZE);
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/oracle/tribuo/issues/223")
     public void testPredictionWithDataInput_KMeans() {
         MLInputDataset inputDataset = new DataFrameInputDataset(irisDataFrame());
         predictAndVerify(kMeansModelId, inputDataset, FunctionName.KMEANS, null, IRIS_DATA_SIZE);
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/oracle/tribuo/issues/223")
     public void testPredictionWithoutDataset_KMeans() {
         exceptionRule.expect(ActionRequestValidationException.class);
         exceptionRule.expectMessage("input data can't be null");
@@ -94,7 +89,6 @@ public class PredictionITTests extends MLCommonsIntegTestCase {
         predictionFuture.actionGet();
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/oracle/tribuo/issues/223")
     public void testPredictionWithEmptyDataset_KMeans() {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("No document found");


### PR DESCRIPTION
Signed-off-by: Xun Zhang <xunzh@amazon.com>

### Description
ForkJoinPool problem is fixed. Reenabling the prediction tests for KMeans. 
https://github.com/oracle/tribuo/issues/223

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
