### PR TITLE
Replace Forum link in ML Commons plugin README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Test Workflow](https://github.com/opensearch-project/ml-commons/workflows/Build%20and%20Test%20ml-commons/badge.svg)](https://github.com/opensearch-project/ml-commons/actions)
 [![codecov](https://codecov.io/gh/opensearch-project/ml-commons/branch/main/graph/badge.svg)](https://codecov.io/gh/opensearch-project/ml-commons)
 [![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://opensearch.org/docs/latest/ml-commons-plugin/api/)
-[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/alerting/)
+[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/c/plugins/ml/46)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 
 <img src="https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg" height="64px"/>


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Replaced the link to the Forum discussion in the README.md file so that it points to the OpenSearch forum rather than the defunct Open Distro forum.
 
### Issues Resolved
This fixes the issue for the ML Commons plugin in [#921](https://github.com/opensearch-project/documentation-website/issues/921).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
