### PR TITLE
Bug fix: filter _source field in search model api

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/rest/AbstractMLSearchAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/AbstractMLSearchAction.java
@@ -44,7 +44,7 @@ public abstract class AbstractMLSearchAction<T extends ToXContentObject> extends
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.parseXContent(request.contentOrSourceParamParser());
-        searchSourceBuilder.fetchSource(getSourceContext(request));
+        searchSourceBuilder.fetchSource(getSourceContext(request, searchSourceBuilder));
         searchSourceBuilder.seqNoAndPrimaryTerm(true).version(true);
         SearchRequest searchRequest = new SearchRequest().source(searchSourceBuilder).indices(index);
         return channel -> client.execute(actionType, searchRequest, search(channel));

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -74,6 +74,7 @@ public class RestActionUtils {
                 return new FetchSourceContext(true, includes, excludes);
             }
         } else {
+            // When user does not set the _source field in search model api request, searchSourceBuilder.fetchSource becomes null
             if (!userAgent.contains(OPENSEARCH_DASHBOARDS_USER_AGENT)) {
                 return new FetchSourceContext(true, Strings.EMPTY_ARRAY, UI_METADATA_EXCLUDE);
             } else {

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -37,7 +37,7 @@ public class RestActionUtils {
      * Get the Model or Task id from a RestRequest
      *
      * @param request RestRequest
-     * @param idName ID name for example "model_id"
+     * @param idName  ID name for example "model_id"
      * @return id for model or task
      */
     public static String getParameterId(RestRequest request, String idName) {
@@ -72,7 +72,12 @@ public class RestActionUtils {
             } else {
                 return new FetchSourceContext(true, includes, excludes);
             }
+        } else {
+            if (!userAgent.contains(OPENSEARCH_DASHBOARDS_USER_AGENT)) {
+                return new FetchSourceContext(true, Strings.EMPTY_ARRAY, UI_METADATA_EXCLUDE);
+            } else {
+                return null;
+            }
         }
-        return new FetchSourceContext(true, Strings.EMPTY_ARRAY, UI_METADATA_EXCLUDE);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -53,13 +53,14 @@ public class RestActionUtils {
      * If the request came from the client then we exclude the UI Metadata from the search result.
      *
      * @param request rest request
+     * @param searchSourceBuilder instance of searchSourceBuilder to fetch includes and excludes
      * @return instance of {@link org.opensearch.search.fetch.subphase.FetchSourceContext}
      */
     public static FetchSourceContext getSourceContext(RestRequest request, SearchSourceBuilder searchSourceBuilder) {
         String userAgent = Strings.coalesceToEmpty(request.header("User-Agent"));
         if (searchSourceBuilder.fetchSource() != null) {
-            String[] includes = searchSourceBuilder.fetchSource().includes();
-            String[] excludes = searchSourceBuilder.fetchSource().excludes();
+            final String[] includes = searchSourceBuilder.fetchSource().includes();
+            final String[] excludes = searchSourceBuilder.fetchSource().excludes();
             String[] metadataExcludes = new String[excludes.length + 1];
             if (!userAgent.contains(OPENSEARCH_DASHBOARDS_USER_AGENT)) {
                 if (excludes.length == 0) {

--- a/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
@@ -22,6 +22,7 @@ import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.plugin.MachineLearningPlugin;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.rest.FakeRestRequest;
@@ -95,17 +96,33 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
             .withParams(param)
             .withHeaders(headers)
             .build();
-        FetchSourceContext sourceContext = RestActionUtils.getSourceContext(request);
-        assertNull(sourceContext);
+        SearchSourceBuilder testSearchSourceBuilder = new SearchSourceBuilder();
+        testSearchSourceBuilder.fetchSource(new String[] { "a" }, new String[] { "b" });
+        FetchSourceContext sourceContext = RestActionUtils.getSourceContext(request, testSearchSourceBuilder);
+        assertNotNull(sourceContext);
     }
 
-    public void testGetSourceContext_FromClient() {
+    public void testGetSourceContext_FromClient_EmptyExcludes() {
         FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(RestRequest.Method.POST)
             .withPath(urlPath)
             .withParams(param)
             .build();
-        FetchSourceContext sourceContext = RestActionUtils.getSourceContext(request);
+        SearchSourceBuilder testSearchSourceBuilder = new SearchSourceBuilder();
+        testSearchSourceBuilder.fetchSource(new String[] { "a" }, new String[0]);
+        FetchSourceContext sourceContext = RestActionUtils.getSourceContext(request, testSearchSourceBuilder);
         assertArrayEquals(UI_METADATA_EXCLUDE, sourceContext.excludes());
+    }
+
+    public void testGetSourceContext_FromClient_WithExcludes() {
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.POST)
+            .withPath(urlPath)
+            .withParams(param)
+            .build();
+        SearchSourceBuilder testSearchSourceBuilder = new SearchSourceBuilder();
+        testSearchSourceBuilder.fetchSource(new String[] { "a" }, new String[] { "b" });
+        FetchSourceContext sourceContext = RestActionUtils.getSourceContext(request, testSearchSourceBuilder);
+        assertEquals(sourceContext.excludes().length, 2);
     }
 }


### PR DESCRIPTION

"_source field" to be recognized in search model api.
This PR fixes the bug reported in the issue https://github.com/opensearch-project/ml-commons/issues/419


Test api request and response with '_source' field:
<img width="1082" alt="Screen Shot 2022-09-19 at 11 27 24 AM" src="https://user-images.githubusercontent.com/110800195/191094989-6a4a787b-682d-47b0-8268-96be3808c71b.png">


<img width="1086" alt="Screen Shot 2022-09-19 at 11 28 33 AM" src="https://user-images.githubusercontent.com/110800195/191094996-befcf872-a6d6-40e5-8ac6-c16f1673cb21.png">
Signed-off-by: Bhavana Ramaram <rbhavna@amazon.com>

Without specifying '_source' field:
<img width="1097" alt="Screen Shot 2022-09-19 at 11 29 12 AM" src="https://user-images.githubusercontent.com/110800195/191095217-78fe929f-69b4-4f7c-84d1-ecb020b3da45.png">

 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/419
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
