### PR TITLE
Bug fix: filter _source field in search model api

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/rest/AbstractMLSearchAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/AbstractMLSearchAction.java
@@ -44,7 +44,7 @@ public abstract class AbstractMLSearchAction<T extends ToXContentObject> extends
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.parseXContent(request.contentOrSourceParamParser());
-        searchSourceBuilder.fetchSource(getSourceContext(request));
+        searchSourceBuilder.fetchSource(getSourceContext(request, searchSourceBuilder));
         searchSourceBuilder.seqNoAndPrimaryTerm(true).version(true);
         SearchRequest searchRequest = new SearchRequest().source(searchSourceBuilder).indices(index);
         return channel -> client.execute(actionType, searchRequest, search(channel));

--- a/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
@@ -22,6 +22,7 @@ import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.plugin.MachineLearningPlugin;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.rest.FakeRestRequest;
@@ -95,17 +96,33 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
             .withParams(param)
             .withHeaders(headers)
             .build();
-        FetchSourceContext sourceContext = RestActionUtils.getSourceContext(request);
-        assertNull(sourceContext);
+        SearchSourceBuilder testSearchSourceBuilder = new SearchSourceBuilder();
+        testSearchSourceBuilder.fetchSource(new String[] { "a" }, new String[] { "b" });
+        FetchSourceContext sourceContext = RestActionUtils.getSourceContext(request, testSearchSourceBuilder);
+        assertNotNull(sourceContext);
     }
 
-    public void testGetSourceContext_FromClient() {
+    public void testGetSourceContext_FromClient_EmptyExcludes() {
         FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(RestRequest.Method.POST)
             .withPath(urlPath)
             .withParams(param)
             .build();
-        FetchSourceContext sourceContext = RestActionUtils.getSourceContext(request);
+        SearchSourceBuilder testSearchSourceBuilder = new SearchSourceBuilder();
+        testSearchSourceBuilder.fetchSource(new String[] { "a" }, new String[0]);
+        FetchSourceContext sourceContext = RestActionUtils.getSourceContext(request, testSearchSourceBuilder);
         assertArrayEquals(UI_METADATA_EXCLUDE, sourceContext.excludes());
+    }
+
+    public void testGetSourceContext_FromClient_WithExcludes() {
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.POST)
+            .withPath(urlPath)
+            .withParams(param)
+            .build();
+        SearchSourceBuilder testSearchSourceBuilder = new SearchSourceBuilder();
+        testSearchSourceBuilder.fetchSource(new String[] { "a" }, new String[] { "b" });
+        FetchSourceContext sourceContext = RestActionUtils.getSourceContext(request, testSearchSourceBuilder);
+        assertEquals(sourceContext.excludes().length, 2);
     }
 }


### PR DESCRIPTION
Signed-off-by: Bhavana Ramaram <rbhavna@amazon.com>

### Description
"_source field" to be recognized in search model api.
This PR fixes the bug reported in the issue https://github.com/opensearch-project/ml-commons/issues/419

Test api request and response with '_source' field:

<img width="1082" alt="Screen Shot 2022-09-19 at 11 27 24 AM" src="https://user-images.githubusercontent.com/110800195/191131831-260ac4b8-2c2e-4ed7-9df6-ed9714617f1c.png">
<img width="1086" alt="Screen Shot 2022-09-19 at 11 28 33 AM" src="https://user-images.githubusercontent.com/110800195/191131835-2ef065c0-b130-4a83-9911-d14d37e7b8af.png">

Without specifying '_source' field:

<img width="1097" alt="Screen Shot 2022-09-19 at 11 29 12 AM" src="https://user-images.githubusercontent.com/110800195/191131882-c06f64bc-8f3e-45bd-8ab5-adac55f58489.png">


 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/419
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
