### PR TITLE
increment version to 1.3.6 and remove jackson force version

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -39,8 +39,8 @@ jobs:
         run: |
           plugin=`ls plugin/build/distributions/*.zip`
           echo MLCommons plugin $plugin
-          version=1.3.5
-          plugin_version=1.3.5.0-SNAPSHOT
+          version=1.3.6
+          plugin_version=1.3.6.0-SNAPSHOT
           echo Using OpenSearch $version with MLCommons $plugin_version
           cd ..
           if docker pull opensearchstaging/opensearch:$version

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.3.5-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.3.6-SNAPSHOT")
         // 1.3.0 -> 1.3.0.0, and 1.3.0-SNAPSHOT -> 1.3.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -254,7 +254,7 @@ configurations.all {
     resolutionStrategy.force 'org.apache.commons:commons-lang3:3.10'
     resolutionStrategy.force 'commons-logging:commons-logging:1.2'
     // Resolve conflict with org.opensearch:opensearch:1.3.4-SNAPSHOT which using 2.13.2
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    // resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
 }
 
 apply plugin: 'nebula.ospackage'


### PR DESCRIPTION
Signed-off-by: Xun Zhang <xunzh@amazon.com>

### Description
Increment version to 1.3.6 and remove jackson force version to avoid build Conflicts.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
