### PR TITLE
Replace references to deprecated BaseNodeRequest with TransportRequest

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileNodeRequest.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileNodeRequest.java
@@ -9,9 +9,9 @@ import java.io.IOException;
 
 import lombok.Getter;
 
-import org.opensearch.transport.TransportRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
 public class MLProfileNodeRequest extends TransportRequest {
     @Getter

--- a/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileNodeRequest.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileNodeRequest.java
@@ -9,11 +9,11 @@ import java.io.IOException;
 
 import lombok.Getter;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
+import org.opensearch.transport.TransportRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 
-public class MLProfileNodeRequest extends BaseNodeRequest {
+public class MLProfileNodeRequest extends TransportRequest {
     @Getter
     private MLProfileRequest mlProfileRequest;
 

--- a/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeRequest.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeRequest.java
@@ -9,9 +9,9 @@ import java.io.IOException;
 
 import lombok.Getter;
 
-import org.opensearch.transport.TransportRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
 public class MLStatsNodeRequest extends TransportRequest {
     @Getter

--- a/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeRequest.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeRequest.java
@@ -9,11 +9,11 @@ import java.io.IOException;
 
 import lombok.Getter;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
+import org.opensearch.transport.TransportRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 
-public class MLStatsNodeRequest extends BaseNodeRequest {
+public class MLStatsNodeRequest extends TransportRequest {
     @Getter
     private MLStatsNodesRequest mlStatsNodesRequest;
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
@@ -254,7 +254,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         assertEquals(RestStatus.INTERNAL_SERVER_ERROR, restResponse.status());
         content = restResponse.content();
         // Return exception directly in normal case
-        assertEquals("{\"error\":\"No OpenSearchException found\",\"status\":500}", content.utf8ToString());
+        assertEquals("{\"error\":\"Internal failure\",\"status\":500}", content.utf8ToString());
     }
 
     public void testPrepareRequest_ClusterAndNodeLevelStates_NoRequestContent() throws Exception {


### PR DESCRIPTION
Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

### Description
Removed the BaseNodeRequest class due to deprecation. Subclasses should extend TransportRequest directly.
 
### Issues Resolved
Previously ml-commons will fail in CI workflow because OpenSearch 3.0 removed BaseNodeRequest class. So we did this fix to unblock infra team's CI workflow.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
