### PR TITLE
Migrate client transports to Apache HttpClient / Core 5.x

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileNodeRequest.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileNodeRequest.java
@@ -9,11 +9,11 @@ import java.io.IOException;
 
 import lombok.Getter;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
-public class MLProfileNodeRequest extends BaseNodeRequest {
+public class MLProfileNodeRequest extends TransportRequest {
     @Getter
     private MLProfileRequest mlProfileRequest;
 

--- a/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeRequest.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeRequest.java
@@ -9,11 +9,11 @@ import java.io.IOException;
 
 import lombok.Getter;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
-public class MLStatsNodeRequest extends BaseNodeRequest {
+public class MLStatsNodeRequest extends TransportRequest {
     @Getter
     private MLStatsNodesRequest mlStatsNodesRequest;
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.rest;
 
+import static org.opensearch.client.RestClientBuilder.DEFAULT_MAX_CONN_PER_ROUTE;
+import static org.opensearch.client.RestClientBuilder.DEFAULT_MAX_CONN_TOTAL;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_ENABLED;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
@@ -29,18 +31,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.message.BasicHeader;
-import org.apache.http.ssl.SSLContextBuilder;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.core5.http.*;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.apache.hc.core5.util.Timeout;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.junit.After;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -156,7 +159,7 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
     @After
     protected void wipeAllODFEIndices() throws IOException {
         Response response = adminClient().performRequest(new Request("GET", "/_cat/indices?format=json&expand_wildcards=all"));
-        XContentType xContentType = XContentType.fromMediaType(response.getEntity().getContentType().getValue());
+        XContentType xContentType = XContentType.fromMediaType(response.getEntity().getContentType());
         try (
             XContentParser parser = xContentType
                 .xContent()
@@ -198,15 +201,19 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
             String password = Optional
                 .ofNullable(System.getProperty("password"))
                 .orElseThrow(() -> new RuntimeException("password is missing"));
-            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(userName, password));
+            BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(new AuthScope(new HttpHost("localhost", 9200)), new UsernamePasswordCredentials(userName, password.toCharArray()));
             try {
-                return httpClientBuilder
-                    .setDefaultCredentialsProvider(credentialsProvider)
-                    // disable the certificate since our testing cluster just uses the default security configuration
-                    .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-                    .setSSLContext(SSLContextBuilder.create().loadTrustMaterial(null, (chains, authType) -> true).build());
-            } catch (Exception e) {
+                final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
+                        .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                        .setSslContext(SSLContextBuilder.create().loadTrustMaterial(null, (chains, authType) -> true).build())
+                        .build();
+                final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
+                        .setMaxConnPerRoute(DEFAULT_MAX_CONN_PER_ROUTE)
+                        .setMaxConnTotal(DEFAULT_MAX_CONN_TOTAL)
+                        .setTlsStrategy(tlsStrategy)
+                        .build();
+                return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider).setConnectionManager(connectionManager);            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
@@ -214,7 +221,7 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
         final String socketTimeoutString = settings.get(CLIENT_SOCKET_TIMEOUT);
         final TimeValue socketTimeout = TimeValue
             .parseTimeValue(socketTimeoutString == null ? "60s" : socketTimeoutString, CLIENT_SOCKET_TIMEOUT);
-        builder.setRequestConfigCallback(conf -> conf.setSocketTimeout(Math.toIntExact(socketTimeout.getMillis())));
+        builder.setRequestConfigCallback(conf -> conf.setResponseTimeout(Timeout.ofMilliseconds(Math.toIntExact(socketTimeout.getMillis()))));
         if (settings.hasValue(CLIENT_PATH_PREFIX)) {
             builder.setPathPrefix(settings.get(CLIENT_PATH_PREFIX));
         }
@@ -228,7 +235,7 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
         return true;
     }
 
-    protected Response ingestIrisData(String indexName) throws IOException {
+    protected Response ingestIrisData(String indexName) throws IOException, ParseException {
         String irisDataIndexMapping = "";
         TestHelper
             .makeRequest(

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteModelActionIT.java
@@ -8,7 +8,7 @@ package org.opensearch.ml.rest;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.http.HttpEntity;
+import org.apache.hc.core5.http.HttpEntity;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.client.Response;

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelActionIT.java
@@ -8,7 +8,7 @@ package org.opensearch.ml.rest;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.http.HttpEntity;
+import org.apache.hc.core5.http.HttpEntity;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.client.Response;

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelActionIT.java
@@ -10,7 +10,7 @@ import static org.opensearch.ml.utils.TestData.matchAllSearchQuery;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.http.HttpEntity;
+import org.apache.hc.core5.http.HttpEntity;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.client.Response;

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLTrainAndPredictIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLTrainAndPredictIT.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import org.apache.http.HttpEntity;
+import org.apache.hc.core5.http.HttpEntity;
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.client.Response;

--- a/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
@@ -10,7 +10,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 
-import org.apache.http.HttpHost;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.ParseException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,7 +47,7 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
-    public void setup() throws IOException {
+    public void setup() throws IOException, ParseException {
         if (!isHttps()) {
             throw new IllegalArgumentException("Secure Tests are running but HTTPS is not set");
         }

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.ml.utils;
 
-import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.junit.Assert.assertEquals;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.DATA_ROLE;
@@ -26,11 +25,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.nio.entity.NStringEntity;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.Version;
 import org.opensearch.client.Request;
@@ -119,7 +117,7 @@ public class TestHelper {
         String jsonEntity,
         List<Header> headers
     ) throws IOException {
-        HttpEntity httpEntity = Strings.isBlank(jsonEntity) ? null : new NStringEntity(jsonEntity, ContentType.APPLICATION_JSON);
+        HttpEntity httpEntity = Strings.isBlank(jsonEntity) ? null : new StringEntity(jsonEntity, ContentType.APPLICATION_JSON);
         return makeRequest(client, method, endpoint, params, httpEntity, headers);
     }
 
@@ -162,11 +160,11 @@ public class TestHelper {
     }
 
     public static HttpEntity toHttpEntity(ToXContentObject object) throws IOException {
-        return new StringEntity(toJsonString(object), APPLICATION_JSON);
+        return new StringEntity(toJsonString(object), ContentType.APPLICATION_JSON);
     }
 
     public static HttpEntity toHttpEntity(String jsonString) throws IOException {
-        return new StringEntity(jsonString, APPLICATION_JSON);
+        return new StringEntity(jsonString, ContentType.APPLICATION_JSON);
     }
 
     public static RestStatus restStatus(Response response) {


### PR DESCRIPTION
Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

### Description
Migrate client transports to Apache HttpClient / Core 5.x. Removed deprecation packages and migrated them to active substitutes.
 
### Issues Resolved
Previously ml-commons will fail in CI workflow because OpenSearch 3.0 has many breaking changes, especially in Apache HttpClient related packages. So we did this fix to unblock infra team's CI workflow.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
