### PR TITLE
Migrate client transports to Apache HttpClient / Core 5.x

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileNodeRequest.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileNodeRequest.java
@@ -9,11 +9,11 @@ import java.io.IOException;
 
 import lombok.Getter;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
-public class MLProfileNodeRequest extends BaseNodeRequest {
+public class MLProfileNodeRequest extends TransportRequest {
     @Getter
     private MLProfileRequest mlProfileRequest;
 

--- a/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeRequest.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeRequest.java
@@ -9,11 +9,11 @@ import java.io.IOException;
 
 import lombok.Getter;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
-public class MLStatsNodeRequest extends BaseNodeRequest {
+public class MLStatsNodeRequest extends TransportRequest {
     @Getter
     private MLStatsNodesRequest mlStatsNodesRequest;
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteModelActionIT.java
@@ -8,7 +8,7 @@ package org.opensearch.ml.rest;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.http.HttpEntity;
+import org.apache.hc.core5.http.HttpEntity;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.client.Response;

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelActionIT.java
@@ -8,7 +8,7 @@ package org.opensearch.ml.rest;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.http.HttpEntity;
+import org.apache.hc.core5.http.HttpEntity;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.client.Response;

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelActionIT.java
@@ -10,7 +10,7 @@ import static org.opensearch.ml.utils.TestData.matchAllSearchQuery;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.http.HttpEntity;
+import org.apache.hc.core5.http.HttpEntity;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.client.Response;

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
@@ -254,7 +254,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         assertEquals(RestStatus.INTERNAL_SERVER_ERROR, restResponse.status());
         content = restResponse.content();
         // Return exception directly in normal case
-        assertEquals("{\"error\":\"No OpenSearchException found\",\"status\":500}", content.utf8ToString());
+        assertEquals("{\"error\":\"Internal failure\",\"status\":500}", content.utf8ToString());
     }
 
     public void testPrepareRequest_ClusterAndNodeLevelStates_NoRequestContent() throws Exception {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLTrainAndPredictIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLTrainAndPredictIT.java
@@ -11,7 +11,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import org.apache.http.HttpEntity;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.ParseException;
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.client.Response;
@@ -32,7 +33,7 @@ public class RestMLTrainAndPredictIT extends MLCommonsRestTestCase {
     private String irisIndex = "iris_data_train_predict_it";
 
     @Before
-    public void setup() throws IOException {
+    public void setup() throws IOException, ParseException {
         ingestIrisData(irisIndex);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
@@ -10,7 +10,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 
-import org.apache.http.HttpHost;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.ParseException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,7 +47,7 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
-    public void setup() throws IOException {
+    public void setup() throws IOException, ParseException {
         if (!isHttps()) {
             throw new IllegalArgumentException("Secure Tests are running but HTTPS is not set");
         }

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.ml.utils;
 
-import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+import static org.apache.hc.core5.http.ContentType.APPLICATION_JSON;
 import static org.junit.Assert.assertEquals;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.DATA_ROLE;
@@ -26,11 +26,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.nio.entity.NStringEntity;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.Version;
 import org.opensearch.client.Request;
@@ -119,7 +117,7 @@ public class TestHelper {
         String jsonEntity,
         List<Header> headers
     ) throws IOException {
-        HttpEntity httpEntity = Strings.isBlank(jsonEntity) ? null : new NStringEntity(jsonEntity, ContentType.APPLICATION_JSON);
+        HttpEntity httpEntity = Strings.isBlank(jsonEntity) ? null : new StringEntity(jsonEntity, APPLICATION_JSON);
         return makeRequest(client, method, endpoint, params, httpEntity, headers);
     }
 


### PR DESCRIPTION
Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

### Description
Migrate client transports to Apache HttpClient / Core 5.x. Also removed deprecated packages and migrated them to active substitutes.
 
### Issues Resolved
1. Closes #460
2. Previously ml-commons will fail in CI workflow because OpenSearch 3.0 has many breaking changes, including migration to the Apache HttpClient / Core 5.x . So we did this fix to unblock infra team's CI workflow.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
