### PR TITLE
add trusted URL regex

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/forward/MLForwardAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/forward/MLForwardAction.java
@@ -9,7 +9,7 @@ import org.opensearch.action.ActionType;
 
 public class MLForwardAction extends ActionType<MLForwardResponse> {
     public static MLForwardAction INSTANCE = new MLForwardAction();
-    public static final String NAME = "cluster:admin/opensearch/ml/forward";
+    public static final String NAME = "cluster:admin/opensearch/mlinternal/forward";
 
     private MLForwardAction() {
         super(NAME, MLForwardResponse::new);

--- a/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpAction.java
@@ -9,7 +9,7 @@ import org.opensearch.action.ActionType;
 
 public class MLSyncUpAction extends ActionType<MLSyncUpNodesResponse> {
     public static MLSyncUpAction INSTANCE = new MLSyncUpAction();
-    public static final String NAME = "cluster:admin/opensearch/ml/syncup";
+    public static final String NAME = "cluster:admin/opensearch/mlinternal/syncup";
 
     private MLSyncUpAction() {
         super(NAME, MLSyncUpNodesResponse::new);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/FileUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/FileUtils.java
@@ -112,7 +112,7 @@ public class FileUtils {
                     write(fileContent, mergedFile, true);
                 }
             } catch (IOException e) {
-                log.error("Failed to merge file " + f.getAbsolutePath() + " to " + mergedFile.getAbsolutePath(), e);
+                log.error("Failed to merge file from " + f.getAbsolutePath() + " to " + mergedFile.getAbsolutePath(), e);
                 failed = true;
             } finally {
                 org.apache.commons.io.FileUtils.deleteQuietly(f);

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -244,7 +244,8 @@ List<String> jacocoExclusions = [
         'org.opensearch.ml.action.forward.TransportForwardAction',
         'org.opensearch.ml.rest.RestMLPredictionAction',
         'org.opensearch.ml.rest.RestMLUploadModelAction',
-        'org.opensearch.ml.rest.RestMLLoadModelAction'
+        'org.opensearch.ml.rest.RestMLLoadModelAction',
+        'org.opensearch.ml.action.syncup.TransportSyncUpOnNodeAction'
 ]
 
 jacocoTestCoverageVerification {

--- a/plugin/src/main/java/org/opensearch/ml/action/forward/TransportForwardAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/forward/TransportForwardAction.java
@@ -59,13 +59,13 @@ public class TransportForwardAction extends HandledTransportAction<ActionRequest
         MLTaskManager mlTaskManager,
         Client client,
         MLModelManager mlModelManager,
-        DiscoveryNodeHelper nodeHel
+        DiscoveryNodeHelper nodeHelper
     ) {
         super(MLForwardAction.NAME, transportService, actionFilters, MLForwardRequest::new);
         this.mlTaskManager = mlTaskManager;
         this.client = client;
         this.mlModelManager = mlModelManager;
-        this.nodeHelper = nodeHel;
+        this.nodeHelper = nodeHelper;
     }
 
     @Override

--- a/plugin/src/main/java/org/opensearch/ml/action/models/GetModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/GetModelTransportAction.java
@@ -61,7 +61,7 @@ public class GetModelTransportAction extends HandledTransportAction<ActionReques
         GetRequest getRequest = new GetRequest(ML_MODEL_INDEX).id(modelId).fetchSourceContext(fetchSourceContext);
 
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            client.get(getRequest, ActionListener.wrap(r -> {
+            client.get(getRequest, ActionListener.runBefore(ActionListener.wrap(r -> {
                 log.info("Completed Get Model Request, id:{}", modelId);
 
                 if (r != null && r.isExists()) {
@@ -83,7 +83,7 @@ public class GetModelTransportAction extends HandledTransportAction<ActionReques
                     log.error("Failed to get ML model " + modelId, e);
                     actionListener.onFailure(e);
                 }
-            }));
+            }), () -> context.restore()));
         } catch (Exception e) {
             log.error("Failed to get ML model " + modelId, e);
             actionListener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -502,7 +502,8 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
                 MLCommonsSettings.ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS,
                 MLCommonsSettings.ML_COMMONS_MONITORING_REQUEST_COUNT,
                 MLCommonsSettings.ML_COMMONS_MAX_UPLOAD_TASKS_PER_NODE,
-                MLCommonsSettings.ML_COMMONS_MAX_LOAD_MODEL_TASKS_PER_NODE
+                MLCommonsSettings.ML_COMMONS_MAX_LOAD_MODEL_TASKS_PER_NODE,
+                MLCommonsSettings.ML_COMMONS_TRUSTED_URL_REGEX
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
@@ -65,13 +65,11 @@ public class RestMLPredictionAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String algorithm = request.param(PARAMETER_ALGORITHM);
         String modelId = getParameterId(request, PARAMETER_MODEL_ID);
-        if (modelId == null) {
-            throw new IllegalArgumentException("model id is null");
-        }
 
         if (algorithm != null) {
+            MLPredictionTaskRequest mlPredictionTaskRequest = getRequest(modelId, algorithm, request);
             return channel -> client
-                .execute(MLPredictionTaskAction.INSTANCE, getRequest(modelId, algorithm, request), new RestToXContentListener<>(channel));
+                .execute(MLPredictionTaskAction.INSTANCE, mlPredictionTaskRequest, new RestToXContentListener<>(channel));
         }
 
         return channel -> {

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -24,7 +24,7 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS = Setting
         .intSetting(
             "plugins.ml_commons.sync_up_job_interval_in_seconds",
-            5,
+            10,
             0,
             86400,
             Setting.Property.NodeScope,
@@ -34,7 +34,7 @@ public final class MLCommonsSettings {
     public static final Setting<Long> ML_COMMONS_MONITORING_REQUEST_COUNT = Setting
         .longSetting(
             "plugins.ml_commons.monitoring_request_count",
-            10000,
+            100,
             0,
             10_000_000,
             Setting.Property.NodeScope,
@@ -43,4 +43,12 @@ public final class MLCommonsSettings {
 
     public static final Setting<Integer> ML_COMMONS_MAX_UPLOAD_TASKS_PER_NODE = Setting
         .intSetting("plugins.ml_commons.max_upload_model_tasks_per_node", 10, 0, 10, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    public static final Setting<String> ML_COMMONS_TRUSTED_URL_REGEX = Setting
+        .simpleString(
+            "plugins.ml_commons.trusted_url_regex",
+            "^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]",
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
 }


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Address security review comments by adding trusted URL regex, so user can set their own trusted URL regex to avoid uploading model from untrusted source.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
