### PR TITLE
backport: Address CVE-2022-42889 by updating commons-text

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.9.0'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 }
 
 jacocoTestReport {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     compile("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 
     checkstyle "com.puppycrawl.tools:checkstyle:${project.checkstyle.toolVersion}"
 }
@@ -253,6 +254,7 @@ configurations.all {
     resolutionStrategy.force 'junit:junit:4.12'
     resolutionStrategy.force 'org.apache.commons:commons-lang3:3.10'
     resolutionStrategy.force 'commons-logging:commons-logging:1.2'
+    resolutionStrategy.force 'org.apache.commons:commons-text:1.10.0'
     // Resolve conflict with org.opensearch:opensearch:1.3.4-SNAPSHOT which using 2.13.2
     // resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
 }


### PR DESCRIPTION
Signed-off-by: Xun Zhang <xunzh@amazon.com>

### Description
Back port the commons-text upgrading to 1.10 to fix the CVE. 
This commit is tested successfully with 1.3.6 artifacts and dependencies. The CI build failure is because of the 1.3.7 dependencies not ready.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
