### PR TITLE
change the max_ml_task_per_node into dynamic settings

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -503,6 +503,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
                 MLCommonsSettings.ML_COMMONS_MONITORING_REQUEST_COUNT,
                 MLCommonsSettings.ML_COMMONS_MAX_UPLOAD_TASKS_PER_NODE,
                 MLCommonsSettings.ML_COMMONS_MAX_LOAD_MODEL_TASKS_PER_NODE,
+                MLCommonsSettings.ML_COMMONS_MAX_ML_TASK_PER_NODE,
                 MLCommonsSettings.ML_COMMONS_TRUSTED_URL_REGEX
             );
         return settings;

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -19,7 +19,7 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MAX_LOAD_MODEL_TASKS_PER_NODE = Setting
         .intSetting("plugins.ml_commons.max_load_model_tasks_per_node", 10, 0, 10, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Integer> ML_COMMONS_MAX_ML_TASK_PER_NODE = Setting
-        .intSetting("plugins.ml_commons.max_ml_task_per_node", 10, 0, 10, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .intSetting("plugins.ml_commons.max_ml_task_per_node", 10, 0, 10000, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Boolean> ML_COMMONS_ONLY_RUN_ON_ML_NODE = Setting
         .boolSetting("plugins.ml_commons.only_run_on_ml_node", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Integer> ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS = Setting

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -18,7 +18,8 @@ public final class MLCommonsSettings {
         .intSetting("plugins.ml_commons.max_model_on_node", 10, 0, 1000, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Integer> ML_COMMONS_MAX_LOAD_MODEL_TASKS_PER_NODE = Setting
         .intSetting("plugins.ml_commons.max_load_model_tasks_per_node", 10, 0, 10, Setting.Property.NodeScope, Setting.Property.Dynamic);
-
+    public static final Setting<Integer> ML_COMMONS_MAX_ML_TASK_PER_NODE = Setting
+        .intSetting("plugins.ml_commons.max_ml_task_per_node", 10, 0, 10, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Boolean> ML_COMMONS_ONLY_RUN_ON_ML_NODE = Setting
         .boolSetting("plugins.ml_commons.only_run_on_ml_node", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Integer> ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS = Setting

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
@@ -55,6 +55,7 @@ public class MLTaskDispatcher {
         this.nextNode = new AtomicInteger(0);
         this.dispatchPolicy = ML_COMMONS_TASK_DISPATCH_POLICY.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_TASK_DISPATCH_POLICY, it -> dispatchPolicy = it);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_MAX_ML_TASK_PER_NODE, it -> maxMLBatchTaskPerNode = it);
     }
 
     /**

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.task;
 
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MAX_ML_TASK_PER_NODE;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TASK_DISPATCH_POLICY;
 
 import java.util.List;
@@ -50,7 +51,7 @@ public class MLTaskDispatcher {
         this.clusterService = clusterService;
         this.client = client;
         this.nodeHelper = nodeHelper;
-        this.maxMLBatchTaskPerNode = MLTaskManager.MAX_ML_TASK_PER_NODE;
+        this.maxMLBatchTaskPerNode = ML_COMMONS_MAX_ML_TASK_PER_NODE.get(settings);
         this.nextNode = new AtomicInteger(0);
         this.dispatchPolicy = ML_COMMONS_TASK_DISPATCH_POLICY.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_TASK_DISPATCH_POLICY, it -> dispatchPolicy = it);

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -56,8 +56,6 @@ import com.google.common.collect.ImmutableMap;
 public class MLTaskManager {
     public static int TASK_SEMAPHORE_TIMEOUT = 5000; // 5 seconds
     private final Map<String, MLTaskCache> taskCaches;
-    // TODO: make this value configurable as cluster setting
-    public final static int MAX_ML_TASK_PER_NODE = 10;
     private final Client client;
     private final ThreadPool threadPool;
     private final MLIndicesHandler mlIndicesHandler;


### PR DESCRIPTION
Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

### Description
This PR should change the max_ml_task_per_node into dynamic settings
 
### Issues Resolved
Previously the max_ml_task_per_node is static set in MLTaskManager class, which is hard to change. Now we can easily change this parameter through API.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
