### PR TITLE
fix running tasks when circuit breaker is open

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -168,16 +168,16 @@ public class MLModelManager {
      * @param mlTask      ML task
      */
     public void uploadMLModel(MLUploadInput uploadInput, MLTask mlTask) {
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
-        String errorMsg = checkAndAddRunningTask(mlTask, maxUploadTasksPerNode);
-        if (errorMsg != null) {
-            mlTaskManager.updateMLTaskDirectly(mlTask.getTaskId(), ImmutableMap.of(STATE_FIELD, FAILED, ERROR_FIELD, errorMsg));
-            throw new MLLimitExceededException(errorMsg);
-        }
         String taskId = mlTask.getTaskId();
         FunctionName functionName = mlTask.getFunctionName();
-
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+            String errorMsg = checkAndAddRunningTask(mlTask, maxUploadTasksPerNode);
+            if (errorMsg != null) {
+                mlTaskManager.updateMLTaskDirectly(mlTask.getTaskId(), ImmutableMap.of(STATE_FIELD, FAILED, ERROR_FIELD, errorMsg));
+                throw new MLLimitExceededException(errorMsg);
+            }
+
             mlStats.createCounterStatIfAbsent(functionName, UPLOAD, ML_ACTION_REQUEST_COUNT).increment();
             mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
             String modelName = uploadInput.getModelName();

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -501,7 +501,7 @@ public class MLModelManager {
             }, e -> {
                 stopNow.set(true);
                 semaphore.release();
-                log.error("Failed to model and chunks", e);
+                log.error("Failed to retrieve model chunk " + modelChunkId, e);
                 if (retrievedChunks.get() == totalChunks - 1) {
                     listener.onFailure(new MLResourceNotFoundException("Fail to find model chunk " + modelChunkId));
                 }

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -75,7 +75,6 @@ import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.MLTaskType;
 import org.opensearch.ml.common.breaker.MLCircuitBreakerService;
 import org.opensearch.ml.common.dataset.MLInputDataType;
-import org.opensearch.ml.common.exception.MLLimitExceededException;
 import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.MLModelState;
@@ -248,20 +247,16 @@ public class MLModelManagerTests extends OpenSearchTestCase {
 
     public void testUploadMLModel_ExceedMaxRunningTask() {
         String error = "exceed max running task limit";
-        expectedEx.expect(MLLimitExceededException.class);
-        expectedEx.expectMessage(error);
         when(mlTaskManager.checkLimitAndAddRunningTask(any(), any())).thenReturn(error);
         modelManager.uploadMLModel(uploadInput, mlTask);
-        verify(mlTaskManager, never()).updateMLTaskDirectly(eq(mlTask.getTaskId()), any());
+        verify(mlTaskManager).updateMLTask(anyString(), anyMap(), anyLong(), anyBoolean());
     }
 
     public void testUploadMLModel_CircuitBreakerOpen() {
-        expectedEx.expect(MLLimitExceededException.class);
-        expectedEx.expectMessage("Disk Circuit Breaker is open, please check your resources!");
         when(mlTaskManager.checkLimitAndAddRunningTask(any(), any())).thenReturn(null);
         when(mlCircuitBreakerService.checkOpenCB()).thenReturn("Disk Circuit Breaker");
         modelManager.uploadMLModel(uploadInput, mlTask);
-        verify(mlTaskManager, never()).updateMLTaskDirectly(eq(mlTask.getTaskId()), any());
+        verify(mlTaskManager).updateMLTask(anyString(), anyMap(), anyLong(), anyBoolean());
     }
 
     public void testUploadMLModel_InitModelIndexFailure() {


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
When disk circuit breaker is open, the upload model task will never completed/failed.

The original design of `String errorMsg = checkAndAddRunningTask(mlTask, maxUploadTasksPerNode);` will never throw exceptions, will throw exception by checking `errorMsg`. Now circuit breaker will throw limit exceed exception inside `checkAndAddRunningTask`, so we should move this method inside the try block.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
