### PR TITLE
fix no permission bug when update index mapping

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
@@ -57,61 +57,62 @@ public class MLIndicesHandler {
         String indexName = index.getIndexName();
         String mapping = index.getMapping();
 
-        if (!clusterService.state().metadata().hasIndex(indexName)) {
-            try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
+        try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());
+            if (!clusterService.state().metadata().hasIndex(indexName)) {
                 ActionListener<CreateIndexResponse> actionListener = ActionListener.wrap(r -> {
                     if (r.isAcknowledged()) {
                         log.info("create index:{}", indexName);
-                        listener.onResponse(true);
+                        internalListener.onResponse(true);
                     } else {
-                        listener.onResponse(false);
+                        internalListener.onResponse(false);
                     }
                 }, e -> {
                     log.error("Failed to create index " + indexName, e);
-                    listener.onFailure(e);
+                    internalListener.onFailure(e);
                 });
                 CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping);
-                client.admin().indices().create(request, ActionListener.runBefore(actionListener, () -> threadContext.restore()));
-            } catch (Exception e) {
-                log.error("Failed to init index " + indexName, e);
-                listener.onFailure(e);
-            }
-        } else {
-            log.debug("index:{} is already created", indexName);
-            if (indexMappingUpdated.containsKey(indexName) && !indexMappingUpdated.get(indexName).get()) {
-                shouldUpdateIndex(indexName, index.getVersion(), ActionListener.wrap(r -> {
-                    if (r) {
-                        // return true if should update index
-                        client
-                            .admin()
-                            .indices()
-                            .putMapping(
-                                new PutMappingRequest().indices(indexName).source(mapping, XContentType.JSON),
-                                ActionListener.wrap(response -> {
-                                    if (response.isAcknowledged()) {
-                                        indexMappingUpdated.get(indexName).set(true);
-                                        listener.onResponse(true);
-                                    } else {
-                                        listener.onFailure(new MLException("Failed to update index: " + indexName));
-                                    }
-                                }, exception -> {
-                                    log.error("Failed to update index " + indexName, exception);
-                                    listener.onFailure(exception);
-                                })
-                            );
-                    } else {
-                        // no need to update index if it does not exist or the version is already up-to-date.
-                        indexMappingUpdated.get(indexName).set(true);
-                        listener.onResponse(true);
-                    }
-                }, e -> {
-                    log.error("Failed to update index mapping", e);
-                    listener.onFailure(e);
-                }));
+                client.admin().indices().create(request, actionListener);
             } else {
-                // No need to update index if it's not ML system index or it's already updated.
-                listener.onResponse(true);
+                log.info("index:{} is already created", indexName);
+                if (indexMappingUpdated.containsKey(indexName) && !indexMappingUpdated.get(indexName).get()) {
+                    shouldUpdateIndex(indexName, index.getVersion(), ActionListener.wrap(r -> {
+                        if (r) {
+                            // return true if should update index
+                            client
+                                .admin()
+                                .indices()
+                                .putMapping(
+                                    new PutMappingRequest().indices(indexName).source(mapping, XContentType.JSON),
+                                    ActionListener.wrap(response -> {
+                                        if (response.isAcknowledged()) {
+                                            indexMappingUpdated.get(indexName).set(true);
+                                            internalListener.onResponse(true);
+                                        } else {
+                                            internalListener.onFailure(new MLException("Failed to update index: " + indexName));
+                                        }
+                                    }, exception -> {
+                                        log.error("Failed to update index " + indexName, exception);
+                                        internalListener.onFailure(exception);
+                                    })
+                                );
+                        } else {
+                            // no need to update index if it does not exist or the version is already up-to-date.
+                            indexMappingUpdated.get(indexName).set(true);
+                            internalListener.onResponse(true);
+                        }
+                    }, e -> {
+                        log.error("Failed to update index mapping", e);
+                        internalListener.onFailure(e);
+                    }));
+                } else {
+                    // No need to update index if it's not ML system index or it's already updated.
+                    internalListener.onResponse(true);
+                }
             }
+        } catch (Exception e) {
+            log.error("Failed to init index " + indexName, e);
+            listener.onFailure(e);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
When upgrade from older version, will check if need to upgrade model/task index mapping. As model/task index is system index, so we need to stash thread context first, otherwise it throws no permission exception.

Error log
```
OpenSearchSecurityException[no permissions for [] and User [name=admin123, backend_roles=[], requestedTenant=]]
	at org.opensearch.security.filter.SecurityFilter.apply0(SecurityFilter.java:363)
	at org.opensearch.security.filter.SecurityFilter.apply(SecurityFilter.java:149)
	at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:217)
	at org.opensearch.performanceanalyzer.action.PerformanceAnalyzerActionFilter.apply(PerformanceAnalyzerActionFilter.java:78)
	at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:217)
	at org.opensearch.action.support.TransportAction.execute(TransportAction.java:189)
	at org.opensearch.action.support.TransportAction.execute(TransportAction.java:108)
	at org.opensearch.client.node.NodeClient.executeLocally(NodeClient.java:110)
	at org.opensearch.client.node.NodeClient.doExecute(NodeClient.java:97)
	at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:426)
	at org.opensearch.client.support.AbstractClient$IndicesAdmin.execute(AbstractClient.java:1318)
	at org.opensearch.client.support.AbstractClient$IndicesAdmin.putMapping(AbstractClient.java:1523)
	at org.opensearch.ml.indices.MLIndicesHandler.lambda$initMLIndexIfAbsent$5(MLIndicesHandler.java:88)
	at org.opensearch.action.ActionListener$1.onResponse(ActionListener.java:80)
	at org.opensearch.ml.indices.MLIndicesHandler.shouldUpdateIndex(MLIndicesHandler.java:141)
	at org.opensearch.ml.indices.MLIndicesHandler.initMLIndexIfAbsent(MLIndicesHandler.java:82)
	at org.opensearch.ml.indices.MLIndicesHandler.initModelIndexIfAbsent(MLIndicesHandler.java:49)
	at org.opensearch.ml.task.MLTrainingTaskRunner.train(MLTrainingTaskRunner.java:186)
	at org.opensearch.ml.task.MLTrainingTaskRunner.lambda$startTrainingTask$4(MLTrainingTaskRunner.java:153)
	at org.opensearch.action.ActionListener$1.onResponse(ActionListener.java:80)
	at org.opensearch.action.support.ThreadedActionListener$1.doRun(ThreadedActionListener.java:78)
	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:815)
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
