### PR TITLE
wait for upload task to complete in security tests

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -616,8 +616,10 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
         return parseTaskIdFromResponse(response);
     }
 
-    public void loadModel(RestClient client, MLUploadInput uploadInput, Consumer<Map<String, Object>> function) throws IOException {
+    public void loadModel(RestClient client, MLUploadInput uploadInput, Consumer<Map<String, Object>> function) throws IOException,
+        InterruptedException {
         String taskId = uploadModel(TestHelper.toJsonString(uploadInput));
+        waitForTask(taskId, MLTaskState.COMPLETED);
         getTask(client(), taskId, response -> {
             String algorithm = (String) response.get(FUNCTION_NAME_FIELD);
             assertEquals(uploadInput.getFunctionName().name(), algorithm);

--- a/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
@@ -150,12 +150,6 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
         uploadModel(mlReadOnlyClient, TestHelper.toJsonString(mlUploadInput), null);
     }
 
-    public void testUploadModelWithFullMLAccessNoIndexAccess() throws IOException {
-        exceptionRule.expect(ResponseException.class);
-        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/upload_model]");
-        uploadModel(mlFullAccessNoIndexAccessClient, TestHelper.toJsonString(mlUploadInput), null);
-    }
-
     public void testUploadModelWithFullAccess() throws IOException {
         uploadModel(mlFullAccessClient, TestHelper.toJsonString(mlUploadInput), uploadModelResult -> {
             assertFalse(uploadModelResult.containsKey("model_id"));
@@ -174,25 +168,19 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
         });
     }
 
-    public void testLoadModelWithNoAccess() throws IOException {
+    public void testLoadModelWithNoAccess() throws IOException, InterruptedException {
         exceptionRule.expect(RuntimeException.class);
         exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/load_model]");
         loadModel(mlNoAccessClient, mlUploadInput, null);
     }
 
-    public void testLoadModelWithReadOnlyMLAccess() throws IOException {
-        exceptionRule.expect(ResponseException.class);
+    public void testLoadModelWithReadOnlyMLAccess() throws IOException, InterruptedException {
+        exceptionRule.expect(RuntimeException.class);
         exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/load_model]");
         loadModel(mlReadOnlyClient, mlUploadInput, null);
     }
 
-    public void testLoadModelWithFullMLAccessNoIndexAccess() throws IOException {
-        exceptionRule.expect(ResponseException.class);
-        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/load_model]");
-        loadModel(mlFullAccessNoIndexAccessClient, mlUploadInput, null);
-    }
-
-    public void testLoadModelWithFullAccess() throws IOException {
+    public void testLoadModelWithFullAccess() throws IOException, InterruptedException {
         loadModel(mlFullAccessClient, mlUploadInput, loadModelResult -> {
             assertFalse(loadModelResult.containsKey("model_id"));
             String taskId = (String) loadModelResult.get("task_id");


### PR DESCRIPTION
Signed-off-by: Xun Zhang <xunzh@amazon.com>

### Description
Need to wait for upload task to complete before running load model in security tests.
The tests are running successful against the 2.4 release candidate. Launched all integration tests against a local cluster and run tests with security. 

./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=admin

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
