### PR TITLE
Forwarding port changes in 2.4 to main branch (Support the generic ml ppl command) 

### DIFF
--- a/client/src/main/java/org/opensearch/ml/client/MachineLearningClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MachineLearningClient.java
@@ -17,6 +17,8 @@ import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.MLTask;
 
+import java.util.Map;
+
 /**
  * A client to provide interfaces for machine learning jobs. This will be used by other plugins.
  */
@@ -86,6 +88,26 @@ public interface MachineLearningClient {
      * @param listener a listener to be notified of the result
      */
     void train(MLInput mlInput, boolean asyncTask, ActionListener<MLOutput> listener);
+
+    /**
+     * Execute train/predict/trainandpredict.
+     * @param mlInput ML input
+     * @param args algorithm parameters
+     * @return ActionFuture of MLOutput
+     */
+    default ActionFuture<MLOutput> run(MLInput mlInput, Map<String, Object> args) {
+        PlainActionFuture<MLOutput> actionFuture = PlainActionFuture.newFuture();
+        run(mlInput, args, actionFuture);
+        return actionFuture;
+    }
+
+    /**
+     * Execute train/predict/trainandpredict.
+     * @param mlInput ML input
+     * @param args algorithm parameters
+     * @param listener a listener to be notified of the result
+     */
+    void run(MLInput mlInput, Map<String, Object> args, ActionListener<MLOutput> listener);
 
     /**
      * Get MLModel and return ActionFuture.

--- a/client/src/test/java/org/opensearch/ml/client/MachineLearningClientTest.java
+++ b/client/src/test/java/org/opensearch/ml/client/MachineLearningClientTest.java
@@ -25,8 +25,15 @@ import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.output.MLTrainingOutput;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
+import static org.opensearch.ml.common.input.Constants.ACTION;
+import static org.opensearch.ml.common.input.Constants.ALGORITHM;
+import static org.opensearch.ml.common.input.Constants.KMEANS;
+import static org.opensearch.ml.common.input.Constants.TRAIN;
 
 public class MachineLearningClientTest {
 
@@ -89,6 +96,11 @@ public class MachineLearningClientTest {
             @Override
             public void train(MLInput mlInput, boolean asyncTask, ActionListener<MLOutput> listener) {
                 listener.onResponse(MLTrainingOutput.builder().modelId(modekId).build());
+            }
+
+            @Override
+            public void run(MLInput mlInput, Map<String, Object> args, ActionListener<MLOutput> listener) {
+                listener.onResponse(output);
             }
 
             @Override
@@ -195,6 +207,19 @@ public class MachineLearningClientTest {
                 .inputDataset(new DataFrameInputDataset(input))
                 .build();
         assertEquals(output, machineLearningClient.trainAndPredict(mlInput).actionGet());
+    }
+
+    @Test
+    public void execute() {
+        MLInput mlInput = MLInput.builder()
+                .algorithm(FunctionName.SAMPLE_ALGO)
+                .parameters(mlParameters)
+                .inputDataset(new DataFrameInputDataset(input))
+                .build();
+        Map<String, Object> args = new HashMap<>();
+        args.put(ACTION, TRAIN);
+        args.put(ALGORITHM, KMEANS);
+        assertEquals(output, machineLearningClient.run(mlInput, args).actionGet());
     }
 
     @Test

--- a/client/src/test/java/org/opensearch/ml/client/MachineLearningNodeClientTest.java
+++ b/client/src/test/java/org/opensearch/ml/client/MachineLearningNodeClientTest.java
@@ -64,6 +64,7 @@ import org.opensearch.search.suggest.Suggest;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -73,6 +74,14 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
+import static org.opensearch.ml.common.input.Constants.ACTION;
+import static org.opensearch.ml.common.input.Constants.ALGORITHM;
+import static org.opensearch.ml.common.input.Constants.KMEANS;
+import static org.opensearch.ml.common.input.Constants.MODELID;
+import static org.opensearch.ml.common.input.Constants.PREDICT;
+import static org.opensearch.ml.common.input.Constants.RCF;
+import static org.opensearch.ml.common.input.Constants.TRAIN;
+import static org.opensearch.ml.common.input.Constants.TRAINANDPREDICT;
 
 public class MachineLearningNodeClientTest {
 
@@ -234,6 +243,174 @@ public class MachineLearningNodeClientTest {
                 .inputDataset(input)
                 .build();
         machineLearningNodeClient.trainAndPredict(mlInput, trainingActionListener);
+
+        verify(client).execute(eq(MLTrainAndPredictionTaskAction.INSTANCE), isA(MLTrainingTaskRequest.class), any());
+        verify(trainingActionListener).onResponse(argumentCaptor.capture());
+        assertEquals(MLTaskState.COMPLETED.name(), ((MLPredictionOutput)argumentCaptor.getValue()).getStatus());
+        assertEquals(output, ((MLPredictionOutput)argumentCaptor.getValue()).getPredictionResult());
+    }
+
+    @Test
+    public void execute_predict() {
+        Map<String, Object> args = new HashMap<>();
+        args.put(ACTION, PREDICT);
+        args.put(ALGORITHM, KMEANS);
+        args.put(MODELID, "123");
+        execute_predict(args);
+    }
+
+    @Test
+    public void execute_predict_null_model_id() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("The model ID is required for prediction.");
+        Map<String, Object> args = new HashMap<>();
+        args.put(ACTION, PREDICT);
+        args.put(ALGORITHM, KMEANS);
+        execute_predict(args);
+    }
+
+    private void execute_predict(Map<String, Object> args) {
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            MLPredictionOutput predictionOutput = MLPredictionOutput.builder()
+                    .status("Success")
+                    .predictionResult(output)
+                    .taskId("taskId")
+                    .build();
+            actionListener.onResponse(MLTaskResponse.builder()
+                    .output(predictionOutput)
+                    .build());
+            return null;
+        }).when(client).execute(eq(MLPredictionTaskAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<MLOutput> dataFrameArgumentCaptor = ArgumentCaptor.forClass(MLOutput.class);
+        MLInput mlInput = MLInput.builder()
+                .algorithm(FunctionName.SAMPLE_ALGO)
+                .inputDataset(input)
+                .build();
+        machineLearningNodeClient.run(mlInput, args, dataFrameActionListener);
+
+        verify(client).execute(eq(MLPredictionTaskAction.INSTANCE), isA(MLPredictionTaskRequest.class), any());
+        verify(dataFrameActionListener).onResponse(dataFrameArgumentCaptor.capture());
+        assertEquals(output, ((MLPredictionOutput)dataFrameArgumentCaptor.getValue()).getPredictionResult());
+    }
+
+    @Test
+    public void execute_train() {
+        String modelId = "test_model_id";
+        String status = "InProgress";
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            MLTrainingOutput output = MLTrainingOutput.builder()
+                    .status(status)
+                    .modelId(modelId)
+                    .build();
+            actionListener.onResponse(MLTaskResponse.builder()
+                    .output(output)
+                    .build());
+            return null;
+        }).when(client).execute(eq(MLTrainingTaskAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<MLOutput> argumentCaptor = ArgumentCaptor.forClass(MLOutput.class);
+        Map<String, Object> args = new HashMap<>();
+        args.put(ACTION, TRAIN);
+        args.put(ALGORITHM, KMEANS);
+        MLInput mlInput = MLInput.builder()
+                .algorithm(FunctionName.SAMPLE_ALGO)
+                .inputDataset(input)
+                .build();
+        machineLearningNodeClient.run(mlInput, args, trainingActionListener);
+
+        verify(client).execute(eq(MLTrainingTaskAction.INSTANCE), isA(MLTrainingTaskRequest.class), any());
+        verify(trainingActionListener).onResponse(argumentCaptor.capture());
+        assertEquals(modelId, ((MLTrainingOutput)argumentCaptor.getValue()).getModelId());
+        assertEquals(status, ((MLTrainingOutput)argumentCaptor.getValue()).getStatus());
+    }
+
+    @Test
+    public void execute_null_action() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("The parameter action is required.");
+        Map<String, Object> args = new HashMap<>();
+        args.put(ALGORITHM, KMEANS);
+        execute_trainandpredict(args);
+    }
+
+    @Test
+    public void execute_unsupported_action() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Unsupported action.");
+        Map<String, Object> args = new HashMap<>();
+        args.put(ACTION, "unsupported");
+        args.put(ALGORITHM, KMEANS);
+        execute_trainandpredict(args);
+    }
+
+    @Test
+    public void execute_null_algorithm() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("The parameter algorithm is required.");
+        Map<String, Object> args = new HashMap<>();
+        args.put(ACTION, TRAINANDPREDICT);
+        execute_trainandpredict(args);
+    }
+
+    @Test
+    public void execute_unsupported_algorithm() {
+        String algo = "dummyAlgo";
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage(String.format("unsupported algorithm: %s.", algo));
+        Map<String, Object> args = new HashMap<>();
+        args.put(ACTION, TRAINANDPREDICT);
+        args.put(ALGORITHM, algo);
+        execute_trainandpredict(args);
+    }
+
+    @Test
+    public void execute_trainandpredict_kmeans() {
+        Map<String, Object> args = new HashMap<>();
+        args.put(ACTION, TRAINANDPREDICT);
+        args.put(ALGORITHM, KMEANS);
+        execute_trainandpredict(args);
+    }
+
+    @Test
+    public void execute_trainandpredict_batch_rcf() {
+        Map<String, Object> args = new HashMap<>();
+        args.put(ACTION, TRAINANDPREDICT);
+        args.put(ALGORITHM, RCF);
+        execute_trainandpredict(args);
+    }
+
+    @Test
+    public void execute_trainandpredict_fit_rcf() {
+        Map<String, Object> args = new HashMap<>();
+        args.put(ACTION, TRAINANDPREDICT);
+        args.put(ALGORITHM, RCF);
+        args.put("timeField", "ts");
+        execute_trainandpredict(args);
+    }
+
+    private void execute_trainandpredict(Map<String, Object> args) {
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            MLPredictionOutput predictionOutput = MLPredictionOutput.builder()
+                    .status(MLTaskState.COMPLETED.name())
+                    .predictionResult(output)
+                    .taskId("taskId")
+                    .build();
+            actionListener.onResponse(MLTaskResponse.builder()
+                    .output(predictionOutput)
+                    .build());
+            return null;
+        }).when(client).execute(eq(MLTrainAndPredictionTaskAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<MLOutput> argumentCaptor = ArgumentCaptor.forClass(MLOutput.class);
+        MLInput mlInput = MLInput.builder()
+                .algorithm(FunctionName.SAMPLE_ALGO)
+                .inputDataset(input)
+                .build();
+        machineLearningNodeClient.run(mlInput, args, trainingActionListener);
 
         verify(client).execute(eq(MLTrainAndPredictionTaskAction.INSTANCE), isA(MLTrainingTaskRequest.class), any());
         verify(trainingActionListener).onResponse(argumentCaptor.capture());

--- a/common/src/main/java/org/opensearch/ml/common/input/Constants.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/Constants.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.input;
+
+public class Constants {
+    // train, predict, trainandpredict
+    public static final String ACTION = "action";
+    public static final String TRAIN = "train";
+    public static final String PREDICT = "predict";
+    public static final String TRAINANDPREDICT = "trainandpredict";
+    // algorithm
+    public static final String ALGORITHM = "algorithm";
+    public static final String KMEANS = "kmeans";
+    public static final String RCF = "rcf";
+    // common parameters
+    public static final String ASYNC = "async";
+    public static final String MODELID = "modelid";
+    // Only need to define the below key strings for KMEANS and AD, as
+    // these strings are set to keywords in ast of PPL.
+    // KMEANS constants
+    public static final String KM_CENTROIDS = "centroid";
+    public static final String KM_ITERATIONS = "iteration";
+    public static final String KM_DISTANCE_TYPE = "distType";
+    // AD constants
+    public static final String AD_NUMBER_OF_TREES = "numberTrees";
+    public static final String AD_SHINGLE_SIZE = "shingleSize";
+    public static final String AD_SAMPLE_SIZE = "sampleSize";
+    public static final String AD_OUTPUT_AFTER = "outputAfter";
+    public static final String AD_TIME_DECAY = "timeDecay";
+    public static final String AD_ANOMALY_RATE = "anomalyRate";
+    public static final String AD_TIME_FIELD = "timeField";
+    public static final String AD_TIME_ZONE = "timeZone";
+    public static final String AD_TRAINING_DATA_SIZE = "trainingDataSize";
+    public static final String AD_ANOMALY_SCORE_THRESHOLD = "anomalyScoreThreshold";
+    public static final String AD_DATE_FORMAT = "dateFormat";
+}

--- a/common/src/main/java/org/opensearch/ml/common/input/InputHelper.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/InputHelper.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.input;
+
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.input.parameter.MLAlgoParams;
+import org.opensearch.ml.common.input.parameter.clustering.KMeansParams;
+import org.opensearch.ml.common.input.parameter.rcf.BatchRCFParams;
+import org.opensearch.ml.common.input.parameter.rcf.FitRCFParams;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.opensearch.ml.common.FunctionName.BATCH_RCF;
+import static org.opensearch.ml.common.FunctionName.FIT_RCF;
+import static org.opensearch.ml.common.FunctionName.KMEANS;
+import static org.opensearch.ml.common.input.Constants.ACTION;
+import static org.opensearch.ml.common.input.Constants.AD_ANOMALY_RATE;
+import static org.opensearch.ml.common.input.Constants.AD_ANOMALY_SCORE_THRESHOLD;
+import static org.opensearch.ml.common.input.Constants.AD_DATE_FORMAT;
+import static org.opensearch.ml.common.input.Constants.AD_NUMBER_OF_TREES;
+import static org.opensearch.ml.common.input.Constants.AD_OUTPUT_AFTER;
+import static org.opensearch.ml.common.input.Constants.AD_SAMPLE_SIZE;
+import static org.opensearch.ml.common.input.Constants.AD_SHINGLE_SIZE;
+import static org.opensearch.ml.common.input.Constants.AD_TIME_DECAY;
+import static org.opensearch.ml.common.input.Constants.AD_TIME_FIELD;
+import static org.opensearch.ml.common.input.Constants.AD_TIME_ZONE;
+import static org.opensearch.ml.common.input.Constants.AD_TRAINING_DATA_SIZE;
+import static org.opensearch.ml.common.input.Constants.ALGORITHM;
+import static org.opensearch.ml.common.input.Constants.KM_CENTROIDS;
+import static org.opensearch.ml.common.input.Constants.KM_DISTANCE_TYPE;
+import static org.opensearch.ml.common.input.Constants.KM_ITERATIONS;
+
+public class InputHelper {
+    public static String getAction(Map<String, Object> arguments) {
+        return (String) arguments.get(ACTION);
+    }
+
+    public static FunctionName getFunctionName(Map<String, Object> arguments) {
+        String algo = (String) arguments.get(ALGORITHM);
+        if (algo == null) {
+            throw new  IllegalArgumentException("The parameter algorithm is required.");
+        }
+        switch (algo.toLowerCase(Locale.ROOT)) {
+            case Constants.KMEANS:
+                return KMEANS;
+            case Constants.RCF:
+                return arguments.get(AD_TIME_FIELD) == null ?
+                        BATCH_RCF : FIT_RCF;
+            default:
+                throw new IllegalArgumentException(
+                        String.format("unsupported algorithm: %s.", algo));
+        }
+    }
+
+    public static MLAlgoParams convertArgumentToMLParameter(Map<String, Object> arguments,
+                                                      FunctionName func) {
+        switch (func) {
+            case KMEANS:
+                return buildKMeansParameters(arguments);
+            case BATCH_RCF:
+                return buildBatchRCFParameters(arguments);
+            case FIT_RCF:
+                return buildFitRCFParameters(arguments);
+            default:
+                throw new IllegalArgumentException(
+                        String.format("unsupported algorithm: %s.", func));
+        }
+    }
+
+    private static MLAlgoParams buildKMeansParameters(Map<String, Object> arguments) {
+        return KMeansParams.builder()
+                .centroids((Integer) arguments.get(KM_CENTROIDS))
+                .iterations((Integer) arguments.get(KM_ITERATIONS))
+                .distanceType(arguments.containsKey(KM_DISTANCE_TYPE)
+                        ? KMeansParams.DistanceType.valueOf((
+                        (String) arguments.get(KM_DISTANCE_TYPE)).toUpperCase(Locale.ROOT))
+                        : null)
+                .build();
+    }
+
+    private static MLAlgoParams buildBatchRCFParameters(Map<String, Object> arguments) {
+        return BatchRCFParams.builder()
+                .numberOfTrees((Integer) arguments.get(AD_NUMBER_OF_TREES))
+                .sampleSize((Integer) arguments.get(AD_SAMPLE_SIZE))
+                .outputAfter((Integer) arguments.get(AD_OUTPUT_AFTER))
+                .trainingDataSize((Integer) arguments.get(AD_TRAINING_DATA_SIZE))
+                .anomalyScoreThreshold((Double) arguments.get(AD_ANOMALY_SCORE_THRESHOLD))
+                .build();
+    }
+
+    private static MLAlgoParams buildFitRCFParameters(Map<String, Object> arguments) {
+        return FitRCFParams.builder()
+                .numberOfTrees((Integer) arguments.get(AD_NUMBER_OF_TREES))
+                .shingleSize((Integer) arguments.get(AD_SHINGLE_SIZE))
+                .sampleSize((Integer) arguments.get(AD_SAMPLE_SIZE))
+                .outputAfter((Integer) arguments.get(AD_OUTPUT_AFTER))
+                .timeDecay((Double) arguments.get(AD_TIME_DECAY))
+                .anomalyRate((Double) arguments.get(AD_ANOMALY_RATE))
+                .timeField((String) arguments.get(AD_TIME_FIELD))
+                .dateFormat(arguments.containsKey(AD_DATE_FORMAT)
+                        ? ((String) arguments.get(AD_DATE_FORMAT))
+                        : "yyyy-MM-dd HH:mm:ss")
+                .timeZone((String) arguments.get(AD_TIME_ZONE))
+                .build();
+    }
+}


### PR DESCRIPTION
* Support the generic ml ppl command.

Signed-off-by: Jing Zhang <jngz@amazon.com>

* Change algorithm name ad to rcf.

Signed-off-by: Jing Zhang <jngz@amazon.com>

* Rename the method from execute to run. Add InputHelper to handle arguments.

Signed-off-by: Jing Zhang <jngz@amazon.com>

* Add header for InputHelper.

Signed-off-by: Jing Zhang <jngz@amazon.com>

* Move all constants to the common.

Signed-off-by: Jing Zhang <jngz@amazon.com>

Signed-off-by: Jing Zhang <jngz@amazon.com>
Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

### Description
This PR is a partial forwarding of port changes in branch 2.x ([commit #484](https://github.com/opensearch-project/ml-commons/commit/d5f51ae3a7d46af469ee373812bd6d6147e47d49)) to main branch.
 
### Issues Resolved
This PR partially resolves [#553](https://github.com/opensearch-project/ml-commons/issues/553) and [OpenSearch-SQL #1065](https://github.com/opensearch-project/sql/issues/1065)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
