### PR TITLE
Forwarding port changes in 2.4 to main branch (add integ tests for new APIs: upload/load/unload)

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/text_embedding/TextEmbeddingModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/text_embedding/TextEmbeddingModel.java
@@ -155,8 +155,11 @@ public class TextEmbeddingModel implements Predictable {
                                 throw new IllegalArgumentException("found multiple models");
                             }
                             findModelFile = true;
-                            String suffix = name.substring(name.lastIndexOf("."));
-                            file.renameTo(new File(modelPath.resolve(modelName + suffix).toUri()));
+                            int dotIndex = name.lastIndexOf(".");
+                            String suffix = name.substring(dotIndex);
+                            if (!modelName.equals(name.substring(0, dotIndex))) {
+                                file.renameTo(new File(modelPath.resolve(modelName + suffix).toUri()));
+                            }
                         }
                     }
                     Map<String, Object> arguments = new HashMap<>();

--- a/plugin/src/main/java/org/opensearch/ml/action/forward/TransportForwardAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/forward/TransportForwardAction.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.action.forward;
 
+import static org.opensearch.ml.task.MLTaskManager.TASK_SEMAPHORE_TIMEOUT;
+
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Set;
@@ -130,7 +132,7 @@ public class TransportForwardAction extends HandledTransportAction<ActionRequest
                         if (mlTaskCache.hasError()) {
                             builder.put(MLTask.ERROR_FIELD, mlTaskCache.getErrors().toString());
                         }
-                        mlTaskManager.updateMLTask(taskId, builder.build(), 5000);
+                        mlTaskManager.updateMLTask(taskId, builder.build(), TASK_SEMAPHORE_TIMEOUT, true);
 
                         if (!mlTaskCache.allNodeFailed()) {
                             MLModelState modelState = mlTaskCache.hasError() ? MLModelState.PARTIALLY_LOADED : MLModelState.LOADED;
@@ -149,8 +151,6 @@ public class TransportForwardAction extends HandledTransportAction<ActionRequest
                         } else {
                             log.debug("load model failed on all nodes, model id: {}", modelId);
                         }
-
-                        mlTaskManager.remove(taskId);
                     }
                     listener.onResponse(new MLForwardResponse("ok", null));
                     break;

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -231,7 +231,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
         this.mlStats = new MLStats(stats);
 
         mlIndicesHandler = new MLIndicesHandler(clusterService, client);
-        mlTaskManager = new MLTaskManager(client, mlIndicesHandler);
+        mlTaskManager = new MLTaskManager(client, threadPool, mlIndicesHandler);
         modelHelper = new ModelHelper();
         mlModelManager = new MLModelManager(
             clusterService,

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -17,14 +17,14 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MAX_MODELS_PER_NODE = Setting
         .intSetting("plugins.ml_commons.max_model_on_node", 10, 0, 1000, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Integer> ML_COMMONS_MAX_LOAD_MODEL_TASKS_PER_NODE = Setting
-        .intSetting("plugins.ml_commons.max_load_model_tasks_per_node", 1, 0, 10, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .intSetting("plugins.ml_commons.max_load_model_tasks_per_node", 10, 0, 10, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Boolean> ML_COMMONS_ONLY_RUN_ON_ML_NODE = Setting
         .boolSetting("plugins.ml_commons.only_run_on_ml_node", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Integer> ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS = Setting
         .intSetting(
             "plugins.ml_commons.sync_up_job_interval_in_seconds",
-            10,
+            60,
             0,
             86400,
             Setting.Property.NodeScope,
@@ -35,5 +35,5 @@ public final class MLCommonsSettings {
         .longSetting("plugins.ml_commons.monitoring_request_count", 100, 0, 100_000, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Integer> ML_COMMONS_MAX_UPLOAD_TASKS_PER_NODE = Setting
-        .intSetting("plugins.ml_commons.max_upload_model_tasks_per_node", 1, 0, 10, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .intSetting("plugins.ml_commons.max_upload_model_tasks_per_node", 10, 0, 10, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -241,7 +241,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
                             return;
                         }
                         // run predict
-                        mlTaskManager.updateTaskState(mlTask.getTaskId(), MLTaskState.RUNNING, mlTask.isAsync());
+                        mlTaskManager.updateTaskStateAsRunning(mlTask.getTaskId(), mlTask.isAsync());
                         MLOutput output = MLEngine.predict(mlInput, mlModel);
                         if (output instanceof MLPredictionOutput) {
                             ((MLPredictionOutput) output).setStatus(MLTaskState.COMPLETED.name());

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskRunner.java
@@ -68,7 +68,7 @@ public abstract class MLTaskRunner<Request extends MLTaskRequest, Response exten
             Map<String, Object> updatedFields = ImmutableMap
                 .of(MLTask.STATE_FIELD, MLTaskState.FAILED.name(), MLTask.ERROR_FIELD, e.getMessage());
             // wait for 2 seconds to make sure failed state persisted
-            mlTaskManager.updateMLTask(mlTask.getTaskId(), updatedFields, TIMEOUT_IN_MILLIS);
+            mlTaskManager.updateMLTask(mlTask.getTaskId(), updatedFields, TIMEOUT_IN_MILLIS, true);
         }
     }
 
@@ -81,7 +81,7 @@ public abstract class MLTaskRunner<Request extends MLTaskRequest, Response exten
                 updatedFields.put(MLTask.MODEL_ID_FIELD, mlTask.getModelId());
             }
             // wait for 2 seconds to make sure completed state persisted
-            mlTaskManager.updateMLTask(mlTask.getTaskId(), updatedFields, TIMEOUT_IN_MILLIS);
+            mlTaskManager.updateMLTask(mlTask.getTaskId(), updatedFields, TIMEOUT_IN_MILLIS, true);
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunner.java
@@ -133,7 +133,7 @@ public class MLTrainAndPredictTaskRunner extends MLTaskRunner<MLTrainingTaskRequ
 
         // run train and predict
         try {
-            mlTaskManager.updateTaskState(mlTask.getTaskId(), MLTaskState.RUNNING, mlTask.isAsync());
+            mlTaskManager.updateTaskStateAsRunning(mlTask.getTaskId(), mlTask.isAsync());
             MLOutput output = MLEngine.trainAndPredict(mlInput);
             handleAsyncMLTaskComplete(mlTask);
             if (output instanceof MLPredictionOutput) {

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
@@ -179,7 +179,7 @@ public class MLTrainingTaskRunner extends MLTaskRunner<MLTrainingTaskRequest, ML
         });
         try {
             // run training
-            mlTaskManager.updateTaskState(mlTask.getTaskId(), MLTaskState.RUNNING, mlTask.isAsync());
+            mlTaskManager.updateTaskStateAsRunning(mlTask.getTaskId(), mlTask.isAsync());
             MLModel mlModel = MLEngine.train(mlInput);
             mlIndicesHandler.initModelIndexIfAbsent(ActionListener.wrap(indexCreated -> {
                 if (!indexCreated) {

--- a/plugin/src/test/java/org/opensearch/ml/action/custom_model/CustomModelITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/custom_model/CustomModelITTests.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.custom_model;
+
+import static org.opensearch.ml.utils.TestData.HUGGINGFACE_TRANSFORMER_MODEL_URL;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Before;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ml.action.MLCommonsIntegTestCase;
+import org.opensearch.ml.action.profile.MLProfileNodeResponse;
+import org.opensearch.ml.action.profile.MLProfileResponse;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
+import org.opensearch.ml.common.model.MLModelFormat;
+import org.opensearch.ml.common.model.MLModelState;
+import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.transport.MLTaskResponse;
+import org.opensearch.ml.common.transport.unload.UnloadModelNodesResponse;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 1)
+public class CustomModelITTests extends MLCommonsIntegTestCase {
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testCustomModelWorkflow() throws InterruptedException {
+        FunctionName functionName = FunctionName.TEXT_EMBEDDING;
+        String modelName = "all-MiniLM-L6-v2";
+        String version = "1.0.0";
+        MLModelFormat modelFormat = MLModelFormat.TORCH_SCRIPT;
+        String modelType = "bert";
+        TextEmbeddingModelConfig.FrameworkType frameworkType = TextEmbeddingModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS;
+        int dimension = 384;
+        String allConfig = null;
+        String taskId = uploadModel(
+            functionName,
+            modelName,
+            version,
+            modelFormat,
+            modelType,
+            frameworkType,
+            dimension,
+            allConfig,
+            HUGGINGFACE_TRANSFORMER_MODEL_URL,
+            false
+        );
+        assertNotNull(taskId);
+
+        AtomicReference<String> modelId = new AtomicReference<>();
+        AtomicReference<MLModel> mlModel = new AtomicReference<>();
+        waitUntil(() -> {
+            String id = getTask(taskId).getModelId();
+            modelId.set(id);
+            MLModel model = null;
+            try {
+                if (id != null) {
+                    model = getModel(id + "_" + 1);
+                    mlModel.set(model);
+                }
+            } catch (Exception e) {
+                logger.error("Failed to get model " + id, e);
+            }
+            return id != null && model != null;
+        }, 20, TimeUnit.SECONDS);
+        assertNotNull(modelId.get());
+        MLModel model = getModel(modelId.get());
+        assertNotNull(model);
+        assertEquals(9, model.getTotalChunks().intValue());
+        assertNotNull(mlModel.get());
+        assertEquals(1, mlModel.get().getChunkNumber().intValue());
+
+        waitUntil(() -> {
+            SearchResponse response = searchModelChunks(modelId.get());
+            AtomicBoolean modelChunksReady = new AtomicBoolean(false);
+            if (response != null) {
+                long totalHits = response.getHits().getTotalHits().value;
+                if (totalHits == 9) {
+                    modelChunksReady.set(true);
+                }
+            }
+            return modelChunksReady.get();
+        }, 20, TimeUnit.SECONDS);
+
+        loadModel(modelId.get());
+
+        AtomicBoolean loaded = new AtomicBoolean(false);
+        waitUntil(() -> {
+            MLProfileResponse modelProfile = getModelProfile(taskId);
+            if (modelProfile != null) {
+                List<MLProfileNodeResponse> nodes = modelProfile.getNodes();
+                if (nodes != null) {
+                    nodes.forEach(node -> {
+                        node.getMlNodeModels().entrySet().forEach(e -> {
+                            if (e.getValue().getModelState() == MLModelState.LOADED) {
+                                loaded.set(true);
+                            }
+                        });
+                    });
+                }
+            }
+            return loaded.get();
+        }, 20, TimeUnit.SECONDS);
+        assertTrue(loaded.get());
+
+        // Predict
+        MLTaskResponse response = predict(
+            modelId.get(),
+            functionName,
+            TextDocsInputDataSet.builder().docs(Arrays.asList("today is sunny")).build(),
+            null
+        );
+        ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
+        assertEquals(1, output.getMlModelOutputs().size());
+        assertEquals(1, output.getMlModelOutputs().get(0).getMlModelTensors().size());
+        assertEquals(dimension, output.getMlModelOutputs().get(0).getMlModelTensors().get(0).getData().length);
+
+        // Unload
+        UnloadModelNodesResponse unloadModelResponse = unloadModel(modelId.get());
+        assertEquals(1, unloadModelResponse.getNodes().size());
+        Map<String, String> unloadStatus = unloadModelResponse.getNodes().get(0).getModelUnloadStatus();
+        assertEquals(1, unloadStatus.size());
+        assertEquals("unloaded", unloadStatus.get(modelId.get()));
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -6,11 +6,14 @@
 package org.opensearch.ml.model;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.UPLOAD_THREAD_POOL;
@@ -188,7 +191,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         setUpMock_InitModelIndexFailure();
 
         modelManager.uploadMLModel(uploadInput, mlTask);
-        verify(mlTaskManager, times(1)).remove(any());
+        verify(mlTaskManager).updateMLTask(anyString(), anyMap(), anyLong(), anyBoolean());
         verify(modelHelper, never()).downloadAndSplit(any(), any(), any(), any(), any());
         verify(client, never()).index(any(), any());
     }

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -12,8 +12,10 @@ import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTT
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH;
+import static org.opensearch.ml.common.MLTask.TASK_ID_FIELD;
 import static org.opensearch.ml.stats.MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT;
 import static org.opensearch.ml.stats.MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT;
+import static org.opensearch.ml.utils.TestData.SENTENCE_TRANSFORMER_MODEL_URL;
 import static org.opensearch.ml.utils.TestData.trainModelDataJson;
 
 import java.io.IOException;
@@ -28,6 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -59,10 +62,16 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.rest.SecureRestClientBuilder;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.SearchQueryInputDataset;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.input.parameter.MLAlgoParams;
+import org.opensearch.ml.common.model.MLModelConfig;
+import org.opensearch.ml.common.model.MLModelFormat;
+import org.opensearch.ml.common.model.MLModelState;
+import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
+import org.opensearch.ml.common.transport.upload.MLUploadInput;
 import org.opensearch.ml.stats.ActionName;
 import org.opensearch.ml.stats.MLActionLevelStat;
 import org.opensearch.ml.utils.TestData;
@@ -78,6 +87,7 @@ import com.google.gson.JsonArray;
 
 public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
     protected Gson gson = new Gson();
+    public static long CUSTOM_MODEL_TIMEOUT = 20_000; // 20 seconds
 
     protected boolean isHttps() {
         boolean isHttps = Optional.ofNullable(System.getProperty("https")).map("true"::equalsIgnoreCase).orElse(false);
@@ -278,10 +288,7 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
         int expectedMinimumTotalAlgoRequestCount
     ) throws IOException {
         Response statsResponse = TestHelper.makeRequest(client(), "GET", "_plugins/_ml/stats", null, "", null);
-        HttpEntity entity = statsResponse.getEntity();
-        assertNotNull(statsResponse);
-        String entityString = TestHelper.httpEntityToString(entity);
-        Map<String, Object> map = gson.fromJson(entityString, Map.class);
+        Map<String, Object> map = parseResponseToMap(statsResponse);
         int totalFailureCount = 0;
         int totalAlgoFailureCount = 0;
         int totalRequestCount = 0;
@@ -489,10 +496,7 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
                 TestHelper.toHttpEntity(kmeansInput),
                 null
             );
-        HttpEntity entity = response.getEntity();
-        assertNotNull(response);
-        String entityString = TestHelper.httpEntityToString(entity);
-        Map map = gson.fromJson(entityString, Map.class);
+        Map map = parseResponseToMap(response);
         Map<String, Object> predictionResult = (Map<String, Object>) map.get("prediction_result");
         if (function != null) {
             function.accept(predictionResult);
@@ -583,12 +587,110 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
     }
 
     private void verifyResponse(Consumer<Map<String, Object>> verificationConsumer, Response response) throws IOException {
-        HttpEntity entity = response.getEntity();
-        assertNotNull(response);
-        String entityString = TestHelper.httpEntityToString(entity);
-        Map<String, Object> map = gson.fromJson(entityString, Map.class);
+        Map<String, Object> map = parseResponseToMap(response);
         if (verificationConsumer != null) {
             verificationConsumer.accept(map);
         }
+    }
+
+    public MLUploadInput createUploadModelInput() {
+        MLModelConfig modelConfig = TextEmbeddingModelConfig
+            .builder()
+            .modelType("bert")
+            .frameworkType(TextEmbeddingModelConfig.FrameworkType.SENTENCE_TRANSFORMERS)
+            .embeddingDimension(384)
+            .build();
+        return MLUploadInput
+            .builder()
+            .modelName("test_model_name")
+            .version("1.0.0")
+            .functionName(FunctionName.TEXT_EMBEDDING)
+            .modelFormat(MLModelFormat.TORCH_SCRIPT)
+            .modelConfig(modelConfig)
+            .url(SENTENCE_TRANSFORMER_MODEL_URL)
+            .loadModel(false)
+            .build();
+    }
+
+    public String uploadModel(String input) throws IOException {
+        Response response = TestHelper.makeRequest(client(), "POST", "/_plugins/_ml/models/_upload", null, input, null);
+        return parseTaskIdFromResponse(response);
+    }
+
+    public String loadModel(String modelId) throws IOException {
+        Response response = TestHelper
+            .makeRequest(client(), "POST", "/_plugins/_ml/models/" + modelId + "/_load", null, (String) null, null);
+        return parseTaskIdFromResponse(response);
+    }
+
+    private String parseTaskIdFromResponse(Response response) throws IOException {
+        Map map = parseResponseToMap(response);
+        String taskId = (String) map.get(TASK_ID_FIELD);
+        return taskId;
+    }
+
+    private Map parseResponseToMap(Response response) throws IOException {
+        HttpEntity entity = response.getEntity();
+        assertNotNull(response);
+        String entityString = TestHelper.httpEntityToString(entity);
+        return gson.fromJson(entityString, Map.class);
+    }
+
+    public Map getModelProfile(String modelId, Consumer verifyFunction) throws IOException {
+        Response response = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/profile/models/" + modelId, null, (String) null, null);
+        Map profile = parseResponseToMap(response);
+        Map<String, Object> nodeProfiles = (Map) profile.get("nodes");
+        for (Map.Entry<String, Object> entry : nodeProfiles.entrySet()) {
+            Map<String, Object> modelProfiles = (Map) entry.getValue();
+            assertNotNull(modelProfiles);
+            assertEquals(1, modelProfiles.size());
+            for (Map.Entry<String, Object> modelProfileEntry : modelProfiles.entrySet()) {
+                Map<String, Object> modelProfile = (Map) ((Map) modelProfileEntry.getValue()).get(modelId);
+                if (verifyFunction != null) {
+                    verifyFunction.accept(modelProfile);
+                }
+            }
+        }
+        return profile;
+    }
+
+    public Consumer<Map<String, Object>> verifyTextEmbeddingModelLoaded() {
+        return (modelProfile) -> {
+            assertEquals(MLModelState.LOADED.name(), modelProfile.get("model_state"));
+            assertTrue(
+                ((String) modelProfile.get("predictor"))
+                    .startsWith("org.opensearch.ml.engine.algorithms.text_embedding.TextEmbeddingModel@")
+            );
+            List<String> workNodes = (List) modelProfile.get("worker_nodes");
+            assertTrue(workNodes.size() > 0);
+        };
+    }
+
+    public Map unloadModel(String modelId) throws IOException {
+        Response response = TestHelper
+            .makeRequest(client(), "POST", "/_plugins/_ml/models/" + modelId + "/_unload", null, (String) null, null);
+        return parseResponseToMap(response);
+    }
+
+    public String getTaskState(String taskId) throws IOException {
+        Response response = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/tasks/" + taskId, null, "", null);
+        Map<String, Object> task = parseResponseToMap(response);
+        return (String) task.get("state");
+    }
+
+    public void waitForTask(String taskId, MLTaskState targetState) throws InterruptedException {
+        AtomicBoolean taskDone = new AtomicBoolean(false);
+        waitUntil(() -> {
+            try {
+                String state = getTaskState(taskId);
+                if (targetState.name().equals(state)) {
+                    taskDone.set(true);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return taskDone.get();
+        }, CUSTOM_MODEL_TIMEOUT, TimeUnit.SECONDS);
+        assertTrue(taskDone.get());
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLCustomModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLCustomModelActionIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.opensearch.ml.common.MLTask.FUNCTION_NAME_FIELD;
+import static org.opensearch.ml.common.MLTask.MODEL_ID_FIELD;
+import static org.opensearch.ml.common.MLTask.STATE_FIELD;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.transport.upload.MLUploadInput;
+import org.opensearch.ml.utils.TestHelper;
+
+public class RestMLCustomModelActionIT extends MLCommonsRestTestCase {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    private MLUploadInput uploadInput;
+
+    @Before
+    public void setup() {
+        uploadInput = createUploadModelInput();
+    }
+
+    public void testUnloadModelAPI_Success() throws IOException, InterruptedException {
+        // upload model
+        String taskId = uploadModel(TestHelper.toJsonString(uploadInput));
+        waitForTask(taskId, MLTaskState.COMPLETED);
+        getTask(client(), taskId, response -> {
+            String algorithm = (String) response.get(FUNCTION_NAME_FIELD);
+            assertEquals(uploadInput.getFunctionName().name(), algorithm);
+            assertNotNull(response.get(MODEL_ID_FIELD));
+            assertEquals(MLTaskState.COMPLETED.name(), response.get(STATE_FIELD));
+            String modelId = (String) response.get(MODEL_ID_FIELD);
+            try {
+                // load model
+                String loadTaskId = loadModel(modelId);
+                waitForTask(loadTaskId, MLTaskState.COMPLETED);
+                getTask(client(), loadTaskId, loadTaskResponse -> {
+                    assertEquals(modelId, loadTaskResponse.get(MODEL_ID_FIELD));
+                    assertEquals(MLTaskState.COMPLETED.name(), response.get(STATE_FIELD));
+                });
+                getModelProfile(modelId, verifyTextEmbeddingModelLoaded());
+                Map<String, Object> result = unloadModel(modelId);
+                for (Map.Entry<String, Object> entry : result.entrySet()) {
+                    Map stats = (Map) ((Map) entry.getValue()).get("stats");
+                    assertEquals("unloaded", stats.get(modelId));
+                }
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunnerTests.java
@@ -35,7 +35,6 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLTask;
-import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.breaker.MLCircuitBreakerService;
 import org.opensearch.ml.common.dataframe.DataFrame;
 import org.opensearch.ml.common.dataset.DataFrameInputDataset;
@@ -214,7 +213,7 @@ public class MLTrainAndPredictTaskRunnerTests extends OpenSearchTestCase {
             actionListener.onResponse(localNode);
             return null;
         }).when(mlTaskDispatcher).dispatch(any());
-        doThrow(new RuntimeException(errorMessage)).when(mlTaskManager).updateTaskState(anyString(), any(MLTaskState.class), anyBoolean());
+        doThrow(new RuntimeException(errorMessage)).when(mlTaskManager).updateTaskStateAsRunning(anyString(), anyBoolean());
         taskRunner.dispatchTask(requestWithDataFrame, transportService, listener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/task/TaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/TaskRunnerTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.task;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -100,14 +101,15 @@ public class TaskRunnerTests extends OpenSearchTestCase {
         String errorMessage = "test error";
         mlTaskRunner.handleAsyncMLTaskFailure(mlTask, new RuntimeException(errorMessage));
         ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(mlTaskManager, times(1)).updateMLTask(eq(mlTask.getTaskId()), argumentCaptor.capture(), anyLong());
+        verify(mlTaskManager, times(1)).updateMLTask(eq(mlTask.getTaskId()), argumentCaptor.capture(), anyLong(), anyBoolean());
         assertEquals(errorMessage, argumentCaptor.getValue().get(MLTask.ERROR_FIELD));
+        assertNull(mlTaskManager.getMLTask(mlTask.getTaskId()));
     }
 
     public void testHandleAsyncMLTaskFailure_SyncTask() {
         MLTask syncMlTask = mlTask.toBuilder().async(false).build();
         mlTaskRunner.handleAsyncMLTaskFailure(syncMlTask, new RuntimeException("error"));
-        verify(mlTaskManager, never()).updateMLTask(eq(syncMlTask.getTaskId()), any(), anyLong());
+        verify(mlTaskManager, never()).updateMLTask(eq(syncMlTask.getTaskId()), any(), anyLong(), anyBoolean());
     }
 
     public void testHandleAsyncMLTaskComplete_AsyncTask() {
@@ -115,7 +117,7 @@ public class TaskRunnerTests extends OpenSearchTestCase {
         MLTask task = mlTask.toBuilder().modelId(modelId).build();
         mlTaskRunner.handleAsyncMLTaskComplete(task);
         ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(mlTaskManager, times(1)).updateMLTask(eq(mlTask.getTaskId()), argumentCaptor.capture(), anyLong());
+        verify(mlTaskManager, times(1)).updateMLTask(eq(mlTask.getTaskId()), argumentCaptor.capture(), anyLong(), anyBoolean());
         assertEquals(modelId, argumentCaptor.getValue().get(MLTask.MODEL_ID_FIELD));
         assertEquals(MLTaskState.COMPLETED, argumentCaptor.getValue().get(MLTask.STATE_FIELD));
     }
@@ -123,7 +125,7 @@ public class TaskRunnerTests extends OpenSearchTestCase {
     public void testHandleAsyncMLTaskComplete_SyncTask() {
         MLTask syncMlTask = mlTask.toBuilder().async(false).build();
         mlTaskRunner.handleAsyncMLTaskComplete(syncMlTask);
-        verify(mlTaskManager, never()).updateMLTask(eq(syncMlTask.getTaskId()), any(), anyLong());
+        verify(mlTaskManager, never()).updateMLTask(eq(syncMlTask.getTaskId()), any(), anyLong(), anyBoolean());
     }
 
     public void testRun_CircuitBreakerOpen() {

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestData.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestData.java
@@ -26,6 +26,10 @@ import com.google.gson.JsonObject;
 
 public class TestData {
 
+    public static final String HUGGINGFACE_TRANSFORMER_MODEL_URL =
+        "https://github.com/opensearch-project/ml-commons/blob/2.x/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/text_embedding/all-MiniLM-L6-v2_torchscript_huggingface.zip?raw=true";
+    public static final String SENTENCE_TRANSFORMER_MODEL_URL =
+        "https://github.com/opensearch-project/ml-commons/blob/2.x/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/text_embedding/all-MiniLM-L6-v2_torchscript_sentence-transformer.zip?raw=true";
     public static final String TIME_FIELD = "timestamp";
     public static final String TARGET_FIELD = "price";
 


### PR DESCRIPTION
* add integ tests for new APIs: upload/load/unload

Signed-off-by: Yaliang Wu <ylwu@amazon.com>

* run custom model actions in one test to mitigate resouce usage

Signed-off-by: Yaliang Wu <ylwu@amazon.com>

* fix disk circuit breaker

Signed-off-by: Yaliang Wu <ylwu@amazon.com>

* add integ test for upload/load/unload actions

Signed-off-by: Yaliang Wu <ylwu@amazon.com>

Signed-off-by: Yaliang Wu <ylwu@amazon.com>
Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

### Description
This PR is a partial forwarding of port changes in branch 2.x ([commit #500](https://github.com/opensearch-project/ml-commons/commit/819418cd9baa5061e128015ade3dc1495497caaf)) to main branch.
 
### Issues Resolved
This PR partially resolves [#553](https://github.com/opensearch-project/ml-commons/issues/553) and [OpenSearch-SQL #1065](https://github.com/opensearch-project/sql/issues/1065)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
