### PR TITLE
change model state to UPLOADED when all chunks uploaded

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/upload_chunk/MLModelChunkUploader.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/upload_chunk/MLModelChunkUploader.java
@@ -55,7 +55,7 @@ public class MLModelChunkUploader {
                         // Use this model to update the chunk count
                         MLModel existingModel = MLModel.parse(parser);
                         existingModel.setModelId(r.getId());
-                        if (existingModel.getTotalChunks() < mlUploadInput.getChunkNumber()) {
+                        if (existingModel.getTotalChunks() <= mlUploadInput.getChunkNumber()) {
                             throw new Exception("Chunk number exceeds total chunks");
                         }
                         byte[] bytes = mlUploadInput.getContent();
@@ -85,7 +85,7 @@ public class MLModelChunkUploader {
                             indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                             client.index(indexRequest, ActionListener.wrap(response -> {
                                 log.info("Index model successful for {} for chunk number {}", mlUploadInput.getModelId(), chunkNum + 1);
-                                if (existingModel.getTotalChunks() == mlUploadInput.getChunkNumber()) {
+                                if (existingModel.getTotalChunks() == (mlUploadInput.getChunkNumber() + 1)) {
                                     Semaphore semaphore = new Semaphore(1);
                                     semaphore.acquire();
                                     MLModel mlModelMeta = MLModel

--- a/plugin/src/test/java/org/opensearch/ml/action/upload_chunk/MLModelChunkUploaderTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/upload_chunk/MLModelChunkUploaderTests.java
@@ -144,14 +144,14 @@ public class MLModelChunkUploaderTests extends OpenSearchTestCase {
 
     private MLUploadModelChunkInput prepareRequest() {
         final byte[] content = new byte[] { 1, 2, 3, 4 };
-        MLUploadModelChunkInput input = MLUploadModelChunkInput.builder().chunkNumber(1).modelId("someModelId").content(content).build();
+        MLUploadModelChunkInput input = MLUploadModelChunkInput.builder().chunkNumber(0).modelId("someModelId").content(content).build();
         return input;
     }
 
     public void testUploadModelChunkNumberEqualsChunkCount() {
         MLModelChunkUploader mlModelChunkUploader = new MLModelChunkUploader(mlIndicesHandler, client, xContentRegistry);
         MLUploadModelChunkInput mlUploadInput = prepareRequest();
-        mlUploadInput.setChunkNumber(2);
+        mlUploadInput.setChunkNumber(1);
         mlModelChunkUploader.uploadModel(mlUploadInput, actionListener);
         ArgumentCaptor<MLUploadModelChunkResponse> argumentCaptor = ArgumentCaptor.forClass(MLUploadModelChunkResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
@@ -162,7 +162,7 @@ public class MLModelChunkUploaderTests extends OpenSearchTestCase {
         final byte[] content = new byte[] {};
         MLUploadModelChunkInput mlUploadInput = MLUploadModelChunkInput
             .builder()
-            .chunkNumber(1)
+            .chunkNumber(0)
             .modelId("someModelId")
             .content(content)
             .build();
@@ -187,7 +187,7 @@ public class MLModelChunkUploaderTests extends OpenSearchTestCase {
         byte[] content = new byte[] { 1, 2, 3, 4 };
         MLModelChunkUploader spy = Mockito.spy(mlModelChunkUploader);
         when(spy.validateChunkSize(content.length)).thenReturn(true);
-        MLUploadModelChunkInput input = MLUploadModelChunkInput.builder().chunkNumber(1).modelId("someModelId").content(content).build();
+        MLUploadModelChunkInput input = MLUploadModelChunkInput.builder().chunkNumber(0).modelId("someModelId").content(content).build();
         spy.uploadModel(input, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLCustomModelChunkActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLCustomModelChunkActionIT.java
@@ -78,12 +78,12 @@ public class RestMLCustomModelChunkActionIT extends MLCommonsRestTestCase {
         Response getModelResponse = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/models/" + modelId, null, "", null);
         assertNotNull(getModelResponse);
 
-        Response chunk1Response = uploadModelChunk(modelId, 1);
+        Response chunk1Response = uploadModelChunk(modelId, 0);
         entity = chunk1Response.getEntity();
         entityString = TestHelper.httpEntityToString(entity);
         assertEquals("Uploaded", gson.fromJson(entityString, Map.class).get("status"));
 
-        Response chunk2Response = uploadModelChunk(modelId, 2);
+        Response chunk2Response = uploadModelChunk(modelId, 1);
         entity = chunk2Response.getEntity();
         entityString = TestHelper.httpEntityToString(entity);
         assertEquals("Uploaded", gson.fromJson(entityString, Map.class).get("status"));
@@ -97,7 +97,7 @@ public class RestMLCustomModelChunkActionIT extends MLCommonsRestTestCase {
 
         exceptionRule.expect(Exception.class);
         exceptionRule.expectMessage("Chunk number exceeds total chunks");
-        Response chunk3Response = uploadModelChunk(modelId, 3);
+        Response chunk3Response = uploadModelChunk(modelId, 2);
         assertNotNull(chunk3Response);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLUploadModelChunkActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLUploadModelChunkActionTests.java
@@ -88,7 +88,7 @@ public class RestMLUploadModelChunkActionTests extends OpenSearchTestCase {
         verify(client, times(1)).execute(eq(MLUploadModelChunkAction.INSTANCE), argumentCaptor.capture(), any());
         MLUploadModelChunkInput chunkRequest = argumentCaptor.getValue().getMlUploadInput();
         assertNotNull(chunkRequest.getContent());
-        assertEquals(Integer.valueOf(1), chunkRequest.getChunkNumber());
+        assertEquals(Integer.valueOf(0), chunkRequest.getChunkNumber());
     }
 
     private RestRequest getRestRequest() {
@@ -96,7 +96,7 @@ public class RestMLUploadModelChunkActionTests extends OpenSearchTestCase {
         BytesArray content = new BytesArray("12345678");
         Map<String, String> params = new HashMap<>();
         params.put("model_id", "r50D4oMBAiM5tNuwVM4C");
-        params.put("chunk_number", "1");
+        params.put("chunk_number", "0");
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withMethod(method)
             .withParams(params)


### PR DESCRIPTION
Signed-off-by: Bhavana Ramaram <rbhavna@amazon.com>

### Description
This PR fixes the bug to change the model state to 'UPLOADED" when all the chunks are successfully uploaded. Previously, the model was still on "UPLOADING" state even when all the chunks are uploaded. 
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
