### PR TITLE
Forwarding port changes in 2.4 to main branch (add windows build in CI workflow)

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -85,3 +85,30 @@ jobs:
         with:
           flags: ml-commons
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  Build-ml-windows:
+    strategy:
+      matrix:
+        java: [11, 17]
+    name: Build and Test MLCommons Plugin on Windows
+    runs-on: windows-latest
+
+    steps:
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      # ml-commons
+      - name: Checkout MLCommons
+        uses: actions/checkout@v2
+
+      - name: Build and Run Tests
+        run: |
+          ./gradlew.bat build
+      - name: Publish to Maven Local
+        run: |
+          ./gradlew publishToMavenLocal
+#      - name: Multi Nodes Integration Testing
+#        run: |
+#          ./gradlew integTest -PnumNodes=3

--- a/plugin/src/test/java/org/opensearch/ml/action/custom_model/CustomModelITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/custom_model/CustomModelITTests.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ml.action.MLCommonsIntegTestCase;
 import org.opensearch.ml.action.profile.MLProfileNodeResponse;
@@ -38,6 +39,7 @@ public class CustomModelITTests extends MLCommonsIntegTestCase {
         super.setUp();
     }
 
+    @Ignore
     public void testCustomModelWorkflow() throws InterruptedException {
         FunctionName functionName = FunctionName.TEXT_EMBEDDING;
         String modelName = "all-MiniLM-L6-v2";

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLCustomModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLCustomModelActionIT.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.MLTaskState;
@@ -30,7 +31,8 @@ public class RestMLCustomModelActionIT extends MLCommonsRestTestCase {
         uploadInput = createUploadModelInput();
     }
 
-    public void testUnloadModelAPI_Success() throws IOException, InterruptedException {
+    @Ignore
+    public void testCustomModelWorkflow() throws IOException, InterruptedException {
         // upload model
         String taskId = uploadModel(TestHelper.toJsonString(uploadInput));
         waitForTask(taskId, MLTaskState.COMPLETED);
@@ -49,6 +51,7 @@ public class RestMLCustomModelActionIT extends MLCommonsRestTestCase {
                     assertEquals(MLTaskState.COMPLETED.name(), response.get(STATE_FIELD));
                 });
                 getModelProfile(modelId, verifyTextEmbeddingModelLoaded());
+                // unload model
                 Map<String, Object> result = unloadModel(modelId);
                 for (Map.Entry<String, Object> entry : result.entrySet()) {
                     Map stats = (Map) ((Map) entry.getValue()).get("stats");


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

Signed-off-by: Yaliang Wu <ylwu@amazon.com>
Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

### Description
This PR is a partial forwarding of port changes in branch 2.x ([commit #504](https://github.com/opensearch-project/ml-commons/commit/9ebd2e6fad884829781342a79157a9eba9ca5a47)) to main branch.
 
### Issues Resolved
This PR partially resolves [#553](https://github.com/opensearch-project/ml-commons/issues/553) and [OpenSearch-SQL #1065](https://github.com/opensearch-project/sql/issues/1065)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
