### PR TITLE
Forwarding port changes in 2.4 to main branch (add more test coverage to ModelHelper and FileUtils)

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -54,11 +54,11 @@ jacocoTestCoverageVerification {
         rule {
             limit {
                 counter = 'LINE'
-                minimum = 0.85 //TODO: increase coverage to 0.90
+                minimum = 0.90 //TODO: increase coverage to 0.90
             }
             limit {
                 counter = 'BRANCH'
-                minimum = 0.75 //TODO: increase coverage to 0.85
+                minimum = 0.80 //TODO: increase coverage to 0.85
             }
         }
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/rcf/FixedInTimeRandomCutForest.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/rcf/FixedInTimeRandomCutForest.java
@@ -21,7 +21,6 @@ import org.opensearch.ml.common.dataframe.DataFrame;
 import org.opensearch.ml.common.dataframe.DataFrameBuilder;
 import org.opensearch.ml.common.dataframe.Row;
 import org.opensearch.ml.common.dataset.DataFrameInputDataset;
-import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.exception.MLValidationException;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.input.parameter.MLAlgoParams;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.text_embedding;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.ActionListener;
+import org.opensearch.ml.engine.MLEngine;
+import org.opensearch.ml.engine.ModelHelper;
+
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.security.PrivilegedActionException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.verify;
+
+public class ModelHelperTest {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    private ModelHelper modelHelper;
+    private String modelId;
+
+    @Mock
+    ActionListener<Map<String, Object>> actionListener;
+
+    @Before
+    public void setup() throws URISyntaxException {
+        MockitoAnnotations.openMocks(this);
+        modelHelper = new ModelHelper();
+        modelId = "model_id";
+        MLEngine.setDjlCachePath(Path.of("/tmp/test" + modelId));
+    }
+
+    @Test
+    public void testDownloadAndSplit_UrlFailure() {
+        modelHelper.downloadAndSplit(modelId, "model_name", "1", "http://testurl", actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(PrivilegedActionException.class, argumentCaptor.getValue().getClass());
+    }
+
+    @Test
+    public void testDownloadAndSplit() throws URISyntaxException {
+        String modelUrl = getClass().getResource("traced_small_model.zip").toURI().toString();
+        modelHelper.downloadAndSplit(modelId, "model_name", "1", modelUrl, actionListener);
+        ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(actionListener).onResponse(argumentCaptor.capture());
+        assertNotNull(argumentCaptor.getValue());
+        assertNotEquals(0, argumentCaptor.getValue().size());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Xun Zhang <xunzh@amazon.com>
Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

### Description
This PR is a partial forwarding of port changes in branch 2.x ([commit #510](https://github.com/opensearch-project/ml-commons/commit/fb07dcb679b080bba9cd3c386bee2c4835d6e36e)) to main branch.
 
### Issues Resolved
This PR partially resolves [#553](https://github.com/opensearch-project/ml-commons/issues/553) and [OpenSearch-SQL #1065](https://github.com/opensearch-project/sql/issues/1065)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
