### PR TITLE
[Backport to 1.3] force protobuf-java version as 3.21.9

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -33,6 +33,10 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 }
 
+configurations.all {
+    resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.21.9'
+}
+
 jacocoTestReport {
     reports {
         xml.enabled false

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -255,6 +255,7 @@ configurations.all {
     resolutionStrategy.force 'org.apache.commons:commons-lang3:3.10'
     resolutionStrategy.force 'commons-logging:commons-logging:1.2'
     resolutionStrategy.force 'org.apache.commons:commons-text:1.10.0'
+    resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.21.9'
     // Resolve conflict with org.opensearch:opensearch:1.3.4-SNAPSHOT which using 2.13.2
     // resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
 }


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
