### PR TITLE
force protobuf-java version as 3.21.9

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -40,6 +40,10 @@ dependencies {
     implementation group: 'ai.djl.huggingface', name: 'tokenizers'
 }
 
+configurations.all {
+    resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.21.9'
+}
+
 jacocoTestReport {
     reports {
         xml.enabled false

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -293,6 +293,7 @@ configurations.all {
     resolutionStrategy.force 'org.objenesis:objenesis:3.2'
     resolutionStrategy.force 'net.java.dev.jna:jna:5.11.0'
     resolutionStrategy.force 'org.apache.commons:commons-text:1.10.0'
+    resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.21.9'
 }
 
 apply plugin: 'nebula.ospackage'


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
force protobuf-java version as 3.21.9
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
