### PR TITLE
Forwarding port changes in 2.4 to main branch (Add test coverage to common package)

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/forward/MLForwardResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/forward/MLForwardResponse.java
@@ -45,7 +45,7 @@ public class MLForwardResponse extends ActionResponse implements ToXContentObjec
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException{
+    public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalString(status);
         if (mlOutput != null) {
             out.writeBoolean(true);

--- a/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpResponse.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.common.transport.sync;
 
+import lombok.Getter;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -13,6 +14,7 @@ import org.opensearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
+@Getter
 public class MLSyncUpResponse extends ActionResponse implements ToXContentObject {
     public static final String STATUS_FIELD = "status";
 

--- a/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardInputTest.java
@@ -1,0 +1,127 @@
+package org.opensearch.ml.common.transport.forward;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.MLTaskType;
+import org.opensearch.ml.common.dataframe.DataFrame;
+import org.opensearch.ml.common.dataframe.DataFrameBuilder;
+import org.opensearch.ml.common.dataset.DataFrameInputDataset;
+import org.opensearch.ml.common.dataset.MLInputDataType;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.input.parameter.clustering.KMeansParams;
+import org.opensearch.ml.common.model.MLModelConfig;
+import org.opensearch.ml.common.model.MLModelFormat;
+import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
+import org.opensearch.ml.common.transport.upload.MLUploadInput;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.*;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class MLForwardInputTest {
+
+    private MLForwardInput forwardInput;
+    private final FunctionName functionName = FunctionName.KMEANS;
+
+
+    @Before
+    public void setUp() throws Exception {
+        Instant time = Instant.now();
+        MLTask mlTask = MLTask.builder()
+                .taskId("mlTaskTaskId")
+                .modelId("mlTaskModelId")
+                .taskType(MLTaskType.PREDICTION)
+                .functionName(functionName)
+                .state(MLTaskState.RUNNING)
+                .inputType(MLInputDataType.DATA_FRAME)
+                .workerNode("mlTaskNode1")
+                .progress(0.0f)
+                .outputIndex("test_index")
+                .error("test_error")
+                .createTime(time.minus(1, ChronoUnit.MINUTES))
+                .lastUpdateTime(time)
+                .build();
+
+        DataFrame dataFrame = DataFrameBuilder.load(Collections.singletonList(new HashMap<String, Object>() {{
+            put("key1", 2.0D);
+        }}));
+        MLInput modelInput = MLInput.builder()
+                .algorithm(FunctionName.KMEANS)
+                .parameters(KMeansParams.builder().centroids(1).build())
+                .inputDataset(DataFrameInputDataset.builder().dataFrame(dataFrame).build())
+                .build();
+        MLModelConfig config = TextEmbeddingModelConfig.builder()
+                .modelType("uploadInputModelType")
+                .allConfig("{\"field1\":\"value1\",\"field2\":\"value2\"}")
+                .frameworkType(TextEmbeddingModelConfig.FrameworkType.SENTENCE_TRANSFORMERS)
+                .embeddingDimension(100)
+                .build();
+        MLUploadInput uploadInput = MLUploadInput.builder()
+                .functionName(functionName)
+                .modelName("uploadInputModelName")
+                .version("uploadInputVersion")
+                .url("url")
+                .modelFormat(MLModelFormat.ONNX)
+                .modelConfig(config)
+                .loadModel(true)
+                .modelNodeIds(new String[]{"modelNodeIds"})
+                .build();
+
+        forwardInput = MLForwardInput.builder()
+                .taskId("forwardInputTaskId")
+                .modelId("forwardInputModelId")
+                .workerNodeId("forwardInputWorkerNodeId")
+                .requestType(MLForwardRequestType.LOAD_MODEL_DONE)
+                .mlTask(mlTask)
+                .modelInput(modelInput)
+                .error("forwardInputError")
+                .workerNodes(new String [] {"forwardInputNodeId1", "forwardInputNodeId2", "forwardInputNodeId3"})
+                .uploadInput(uploadInput)
+                .build();
+    }
+
+    @Test
+    public void readInputStream_Success() throws IOException {
+        readInputStream(forwardInput, parsedInput -> {
+            assertEquals(forwardInput.getTaskId(), parsedInput.getTaskId());
+            assertEquals(forwardInput.getModelId(), parsedInput.getModelId());
+        });
+    }
+
+
+    @Test
+    public void readInputStream_SuccessWithNullFields() throws IOException {
+        forwardInput.setMlTask(null);
+        forwardInput.setModelInput(null);
+        forwardInput.setUploadInput(null);
+        readInputStream(forwardInput, parsedInput -> {
+            assertNull(parsedInput.getMlTask());
+            assertNull(parsedInput.getModelInput());
+            assertNull(parsedInput.getUploadInput());
+        });
+    }
+
+
+    private void readInputStream(MLForwardInput input, Consumer<MLForwardInput> verify) throws IOException {
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        input.writeTo(bytesStreamOutput);
+
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        MLForwardInput parsedInput = new MLForwardInput(streamInput);
+        verify.accept(parsedInput);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardRequestTest.java
@@ -1,0 +1,200 @@
+package org.opensearch.ml.common.transport.forward;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.MLTaskType;
+import org.opensearch.ml.common.dataframe.DataFrame;
+import org.opensearch.ml.common.dataframe.DataFrameBuilder;
+import org.opensearch.ml.common.dataset.DataFrameInputDataset;
+import org.opensearch.ml.common.dataset.MLInputDataType;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.input.parameter.clustering.KMeansParams;
+import org.opensearch.ml.common.model.MLModelConfig;
+import org.opensearch.ml.common.model.MLModelFormat;
+import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
+import org.opensearch.ml.common.transport.upload.MLUploadInput;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MLForwardRequestTest {
+
+    private MLForwardInput forwardInput;
+    private MLTask mlTask;
+    private MLInput modelInput;
+    private MLUploadInput uploadInput;
+    private final FunctionName functionName = FunctionName.KMEANS;
+
+
+    @Before
+    public void setUp() throws Exception {
+        Instant time = Instant.now();
+        mlTask = MLTask.builder()
+                .taskId("mlTaskTaskId")
+                .modelId("mlTaskModelId")
+                .taskType(MLTaskType.PREDICTION)
+                .functionName(functionName)
+                .state(MLTaskState.RUNNING)
+                .inputType(MLInputDataType.DATA_FRAME)
+                .workerNode("mlTaskNode1")
+                .progress(0.0f)
+                .outputIndex("test_index")
+                .error("test_error")
+                .createTime(time.minus(1, ChronoUnit.MINUTES))
+                .lastUpdateTime(time)
+                .build();
+
+        DataFrame dataFrame = DataFrameBuilder.load(Collections.singletonList(new HashMap<String, Object>() {{
+            put("key1", 2.0D);
+        }}));
+        modelInput = MLInput.builder()
+                .algorithm(FunctionName.KMEANS)
+                .parameters(KMeansParams.builder().centroids(1).build())
+                .inputDataset(DataFrameInputDataset.builder().dataFrame(dataFrame).build())
+                .build();
+        MLModelConfig config = TextEmbeddingModelConfig.builder()
+                .modelType("uploadInputModelType")
+                .allConfig("{\"field1\":\"value1\",\"field2\":\"value2\"}")
+                .frameworkType(TextEmbeddingModelConfig.FrameworkType.SENTENCE_TRANSFORMERS)
+                .embeddingDimension(100)
+                .build();
+        uploadInput = MLUploadInput.builder()
+                .functionName(functionName)
+                .modelName("uploadInputModelName")
+                .version("uploadInputVersion")
+                .url("url")
+                .modelFormat(MLModelFormat.ONNX)
+                .modelConfig(config)
+                .loadModel(true)
+                .modelNodeIds(new String[]{"modelNodeIds" })
+                .build();
+
+        forwardInput = MLForwardInput.builder()
+                .taskId("forwardInputTaskId")
+                .modelId("forwardInputModelId")
+                .workerNodeId("forwardInputWorkerNodeId")
+                .requestType(MLForwardRequestType.LOAD_MODEL_DONE)
+                .mlTask(mlTask)
+                .modelInput(modelInput)
+                .error("forwardInputError")
+                .workerNodes(new String [] {"forwardInputNodeId1", "forwardInputNodeId2", "forwardInputNodeId3"})
+                .uploadInput(uploadInput)
+                .build();
+    }
+
+    @Test
+    public void writeTo_Success() throws IOException {
+
+        MLForwardRequest request = MLForwardRequest.builder()
+                .forwardInput(forwardInput)
+                .build();
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        request.writeTo(bytesStreamOutput);
+        request = new MLForwardRequest(bytesStreamOutput.bytes().streamInput());
+        assertEquals("forwardInputTaskId", request.getForwardInput().getTaskId());
+        assertEquals("forwardInputModelId", request.getForwardInput().getModelId());
+        assertEquals("forwardInputWorkerNodeId", request.getForwardInput().getWorkerNodeId());
+        assertEquals(MLForwardRequestType.LOAD_MODEL_DONE, request.getForwardInput().getRequestType());
+        assertEquals("forwardInputError", request.getForwardInput().getError());
+        assertArrayEquals(new String [] {"forwardInputNodeId1", "forwardInputNodeId2", "forwardInputNodeId3"}, request.getForwardInput().getWorkerNodes());
+        assertEquals(mlTask.getTaskId(), request.getForwardInput().getMlTask().getTaskId());
+        assertEquals(modelInput.getAlgorithm().toString(), request.getForwardInput().getModelInput().getAlgorithm().toString());
+        assertEquals(uploadInput.getModelName(), request.getForwardInput().getUploadInput().getModelName());
+    }
+
+    @Test
+    public void validate_Success() {
+        MLForwardRequest request = MLForwardRequest.builder()
+                .forwardInput(forwardInput)
+                .build();
+
+        assertNull(request.validate());
+    }
+
+    @Test
+    public void validate_Exception_NullMLUploadInput() {
+        MLForwardRequest request = MLForwardRequest.builder()
+                .build();
+        ActionRequestValidationException exception = request.validate();
+        assertEquals("Validation Failed: 1: ML input can't be null;", exception.getMessage());
+    }
+
+    @Test
+    // MLForwardInput check its parameters when created, so exception is not thrown here
+    public void validate_Exception_NullMLModelName() {
+        forwardInput.setTaskId(null);
+        MLForwardRequest request = MLForwardRequest.builder()
+                .forwardInput(forwardInput)
+                .build();
+
+        assertNull(request.validate());
+        assertNull(request.getForwardInput().getTaskId());
+    }
+
+    @Test
+    public void fromActionRequest_Success_WithMLForwardRequest() {
+        MLForwardRequest request = MLForwardRequest.builder()
+                .forwardInput(forwardInput)
+                .build();
+
+        assertSame(MLForwardRequest.fromActionRequest(request), request);
+    }
+
+
+    @Test
+    public void fromActionRequest_Success_WithNonMLForwardRequest() {
+        MLForwardRequest request = MLForwardRequest.builder()
+                .forwardInput(forwardInput)
+                .build();
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                request.writeTo(out);
+            }
+        };
+        MLForwardRequest result = MLForwardRequest.fromActionRequest(actionRequest);
+        assertNotSame(result, request);
+        assertEquals(request.getForwardInput().getTaskId(), result.getForwardInput().getTaskId());
+        assertEquals(request.getForwardInput().getMlTask().getTaskId(), result.getForwardInput().getMlTask().getTaskId());
+        assertEquals(request.getForwardInput().getModelInput().getAlgorithm().toString(), result.getForwardInput().getModelInput().getAlgorithm().toString());
+        assertEquals(request.getForwardInput().getUploadInput().getModelName(), result.getForwardInput().getUploadInput().getModelName());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void fromActionRequest_IOException() {
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException("test");
+            }
+        };
+        MLForwardRequest.fromActionRequest(actionRequest);
+    }
+
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardResponseTest.java
@@ -1,0 +1,120 @@
+package org.opensearch.ml.common.transport.forward;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.action.ActionResponse;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.ml.common.dataframe.DataFrame;
+import org.opensearch.ml.common.dataframe.DataFrameBuilder;
+import org.opensearch.ml.common.output.MLPredictionOutput;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MLForwardResponseTest {
+
+    private MLPredictionOutput predictionOutput;
+    private String status;
+
+    @Before
+    public void setUp() throws Exception {
+        status = "test";
+        DataFrame dataFrame = DataFrameBuilder.load(Collections.singletonList(new HashMap<String, Object>() {{
+            put("key1", 2.0D);
+        }}));
+        predictionOutput = MLPredictionOutput.builder()
+                .status("Success")
+                .predictionResult(dataFrame)
+                .taskId("taskId")
+                .build();
+    }
+
+    @Test
+    public void writeTo_Success() throws IOException {
+        // Setup
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        MLForwardResponse response = new MLForwardResponse(status, predictionOutput);
+        // Run the test
+        response.writeTo(bytesStreamOutput);
+        MLForwardResponse parsedResponse = new MLForwardResponse(bytesStreamOutput.bytes().streamInput());
+        // Verify the results
+        assertEquals(response.getStatus(), parsedResponse.getStatus());
+        assertEquals(response.getMlOutput().toString(), parsedResponse.getMlOutput().toString());
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        // Setup
+        MLForwardResponse response = new MLForwardResponse(status, predictionOutput);
+        // Run the test
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(builder);
+        String jsonStr = Strings.toString(builder);
+        // Verify the results
+        assertEquals("{\"result\":{\"task_id\":\"taskId\",\"status\":\"Success\",\"prediction_result\":{\"column_metas\":[{\"name\":\"key1\",\"column_type\":\"DOUBLE\"}],\"rows\":[{\"values\":[{\"column_type\":\"DOUBLE\",\"value\":2.0}]}]}}}", jsonStr);
+    }
+
+    @Test
+    public void fromActionResponse_Success() {
+        MLForwardResponse response = new MLForwardResponse(status, predictionOutput);
+
+        assertSame(MLForwardResponse.fromActionResponse(response), response);
+    }
+
+    @Test
+    // Maybe there's a better way to test the branch in the writeTo method(L50-54)
+    public void writeTo_WithNullMLOutput() {
+        MLForwardResponse response = new MLForwardResponse(status, null);
+        ActionResponse actionResponse = new ActionResponse() {
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                response.writeTo(out);
+            }
+        };
+        assertNull(MLForwardResponse.fromActionResponse(actionResponse).getMlOutput());
+    }
+
+    @Test
+    public void fromActionResponse_Success_WithNonMLUploadModelRequest() {
+        MLForwardResponse response = new MLForwardResponse(status, predictionOutput);
+        ActionResponse actionResponse = new ActionResponse() {
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                response.writeTo(out);
+            }
+        };
+        MLForwardResponse result = MLForwardResponse.fromActionResponse(actionResponse);
+        assertNotSame(result, response);
+        assertEquals(response.getStatus(), result.getStatus());
+        assertEquals(response.getMlOutput().toString(), result.getMlOutput().toString());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void fromActionResponse_IOException() {
+        ActionResponse actionResponse = new ActionResponse() {
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException("test");
+            }
+        };
+        MLForwardResponse.fromActionResponse(actionResponse);
+    }
+
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelInputTest.java
@@ -1,0 +1,74 @@
+package org.opensearch.ml.common.transport.load;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.MLTaskType;
+import org.opensearch.ml.common.dataframe.DataFrame;
+import org.opensearch.ml.common.dataframe.DataFrameBuilder;
+import org.opensearch.ml.common.dataset.MLInputDataType;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static javax.swing.UIManager.put;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoadModelInputTest {
+
+    private MLTask mlTask;
+    private LoadModelInput loadModelInput;
+
+    @Before
+    public void setUp() throws Exception {
+        Instant time = Instant.now();
+        mlTask = MLTask.builder()
+                .taskId("mlTaskTaskId")
+                .modelId("mlTaskModelId")
+                .taskType(MLTaskType.PREDICTION)
+                .functionName(FunctionName.LINEAR_REGRESSION)
+                .state(MLTaskState.RUNNING)
+                .inputType(MLInputDataType.DATA_FRAME)
+                .workerNode("node1")
+                .progress(0.0f)
+                .outputIndex("test_index")
+                .error("test_error")
+                .createTime(time.minus(1, ChronoUnit.MINUTES))
+                .lastUpdateTime(time)
+                .build();
+
+        loadModelInput = LoadModelInput.builder()
+                .modelId("loadModelInputModelId")
+                .taskId("loadModelInputTaskId")
+                .modelContentHash("modelContentHash")
+                .nodeCount(3)
+                .coordinatingNodeId("coordinatingNodeId")
+                .mlTask(mlTask)
+                .build();
+    }
+
+    @Test
+    public void readInputStream() throws IOException {
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        loadModelInput.writeTo(bytesStreamOutput);
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        LoadModelInput parsedInput = new LoadModelInput(streamInput);
+        assertEquals(loadModelInput.getModelId(), parsedInput.getModelId());
+        assertEquals(loadModelInput.getTaskId(), parsedInput.getTaskId());
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelNodeResponseTest.java
@@ -1,0 +1,69 @@
+package org.opensearch.ml.common.transport.load;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.transport.TransportAddress;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoadModelNodeResponseTest {
+
+    @Mock
+    private DiscoveryNode localNode;
+
+    @Before
+    public void setUp() throws Exception {
+        localNode = new DiscoveryNode(
+                "foo0",
+                "foo0",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+    }
+
+    @Test
+    public void testSerializationDeserialization() throws IOException {
+        Map<String, String> modelToLoadStatus = new HashMap<>();
+        modelToLoadStatus.put("modelName:version", "response");
+        LoadModelNodeResponse response = new LoadModelNodeResponse(localNode, modelToLoadStatus);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        LoadModelNodeResponse newResponse = new LoadModelNodeResponse(output.bytes().streamInput());
+        assertEquals(newResponse.getNode().getId(), response.getNode().getId());
+    }
+
+    @Test
+    public void testSerializationDeserialization_NullModelLoadStatus() throws IOException {
+        LoadModelNodeResponse response = new LoadModelNodeResponse(localNode, null);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        LoadModelNodeResponse newResponse = new LoadModelNodeResponse(output.bytes().streamInput());
+        assertEquals(newResponse.getNode().getId(), response.getNode().getId());
+    }
+
+    @Test
+    public void testReadProfile() throws IOException {
+        LoadModelNodeResponse response = new LoadModelNodeResponse(localNode, new HashMap<>());
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        LoadModelNodeResponse newResponse = LoadModelNodeResponse.readStats(output.bytes().streamInput());
+        assertNotEquals(newResponse, response);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelNodesRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelNodesRequestTest.java
@@ -1,0 +1,156 @@
+package org.opensearch.ml.common.transport.load;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.MLTaskType;
+import org.opensearch.ml.common.dataset.MLInputDataType;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoadModelNodesRequestTest {
+
+    private DiscoveryNode localNode1;
+    private DiscoveryNode localNode2;
+    private DiscoveryNode localNode3;
+
+    @Mock
+    private MLTask mlTask;
+
+    @Before
+    public void setUp() throws Exception {
+        localNode1 = new DiscoveryNode(
+                "foo1",
+                "foo1",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+        localNode2 = new DiscoveryNode(
+                "foo2",
+                "foo2",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+        localNode3 = new DiscoveryNode(
+                "foo3",
+                "foo3",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+
+        Instant time = Instant.now();
+        mlTask = MLTask.builder()
+                .taskId("mlTaskTaskId")
+                .modelId("mlTaskModelId")
+                .taskType(MLTaskType.PREDICTION)
+                .functionName(FunctionName.LINEAR_REGRESSION)
+                .state(MLTaskState.RUNNING)
+                .inputType(MLInputDataType.DATA_FRAME)
+                .workerNode("node1")
+                .progress(0.0f)
+                .outputIndex("test_index")
+                .error("test_error")
+                .createTime(time.minus(1, ChronoUnit.MINUTES))
+                .lastUpdateTime(time)
+                .build();
+
+    }
+
+    @Test
+    public void testConstructorSerialization1() throws IOException {
+        String [] nodeIds = {"id1", "id2", "id3"};
+        LoadModelInput loadModelInput = new LoadModelInput("modelId", "taskId", "modelContentHash", 3, "coordinatingNodeId", mlTask);
+        LoadModelNodeRequest loadModelNodeRequest = new LoadModelNodeRequest(
+                new LoadModelNodesRequest(nodeIds, loadModelInput)
+        );
+        BytesStreamOutput output = new BytesStreamOutput();
+
+        loadModelNodeRequest.writeTo(output);
+
+        assertNotNull(loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput());
+        assertEquals("modelId", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getModelId());
+        assertEquals("taskId", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getTaskId());
+        assertEquals("modelContentHash", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getModelContentHash());
+        assertEquals(3, loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getNodeCount().intValue());
+        assertEquals("coordinatingNodeId", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getCoordinatingNodeId());
+        assertEquals(mlTask.getTaskId(), loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getMlTask().getTaskId());
+    }
+
+    @Test
+    public void testConstructorSerialization2() throws IOException {
+        DiscoveryNode [] nodeIds = {localNode1, localNode2, localNode3};
+        LoadModelInput loadModelInput = new LoadModelInput("modelId", "taskId", "modelContentHash", 3, "coordinatingNodeId", mlTask);
+        LoadModelNodeRequest loadModelNodeRequest = new LoadModelNodeRequest(
+                new LoadModelNodesRequest(nodeIds, loadModelInput)
+        );
+        assertNotNull(loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput());
+        assertEquals("modelId", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getModelId());
+        assertEquals("taskId", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getTaskId());
+        assertEquals("modelContentHash", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getModelContentHash());
+        assertEquals(3, loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getNodeCount().intValue());
+        assertEquals("coordinatingNodeId", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getCoordinatingNodeId());
+        assertEquals(mlTask.getTaskId(), loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getMlTask().getTaskId());
+    }
+
+    @Test
+    public void testConstructorSerialization3() throws IOException {
+        LoadModelNodeRequest loadModelNodeRequest = new LoadModelNodeRequest(
+                new LoadModelNodesRequest(localNode1, localNode2, localNode3)
+        );
+        loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().setModelId("modelIdSetDuringTest");
+        loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().setTaskId("taskIdSetDuringTest");
+        loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().setModelContentHash("modelContentHashSetDuringTest");
+        loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().setNodeCount(2);
+        loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().setCoordinatingNodeId("coordinatingNodeIdSetDuringTest");
+        loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().setMlTask(mlTask);
+        assertNotNull(loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput());
+        assertEquals("modelIdSetDuringTest", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getModelId());
+        assertEquals("taskIdSetDuringTest", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getTaskId());
+        assertEquals("modelContentHashSetDuringTest", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getModelContentHash());
+        assertEquals(2, loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getNodeCount().intValue());
+        assertEquals("coordinatingNodeIdSetDuringTest", loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getCoordinatingNodeId());
+        assertEquals(mlTask.getTaskId(), loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getMlTask().getTaskId());
+    }
+
+    @Test
+    public void testConstructorFromInputStream() throws IOException {
+        String [] nodeIds = {"id1", "id2", "id3"};
+        LoadModelInput loadModelInput = new LoadModelInput("modelId", "taskId", "modelContentHash", 3, "coordinatingNodeId", mlTask);
+        LoadModelNodeRequest loadModelNodeRequest = new LoadModelNodeRequest(
+                new LoadModelNodesRequest(nodeIds, loadModelInput)
+        );
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        loadModelNodeRequest.writeTo(bytesStreamOutput);
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        LoadModelNodeRequest parsedNodeRequest = new LoadModelNodeRequest(streamInput);
+
+        assertNotNull(parsedNodeRequest.getLoadModelNodesRequest().getLoadModelInput());
+        assertEquals(loadModelNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getModelId(),
+                parsedNodeRequest.getLoadModelNodesRequest().getLoadModelInput().getModelId());
+    }
+
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelNodesResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelNodesResponseTest.java
@@ -1,0 +1,91 @@
+package org.opensearch.ml.common.transport.load;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.Version;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.ml.common.TestHelper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoadModelNodesResponseTest {
+
+    @Mock
+    private ClusterName clusterName;
+
+    @Before
+    public void setUp() throws Exception {
+        clusterName = new ClusterName("clusterName");
+    }
+
+
+    @Test
+    public void testSerializationDeserialization() throws IOException {
+        List<LoadModelNodeResponse> responseList = new ArrayList<>();
+        List<FailedNodeException> failuresList = new ArrayList<>();
+        LoadModelNodesResponse response = new LoadModelNodesResponse(clusterName, responseList, failuresList);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        LoadModelNodesResponse newResponse = new LoadModelNodesResponse(output.bytes().streamInput());
+        assertEquals(newResponse.getNodes().size(), response.getNodes().size());
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        List<LoadModelNodeResponse> nodes = new ArrayList<>();
+        DiscoveryNode node1 = new DiscoveryNode(
+                "foo1",
+                "foo1",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+        Map<String, String> modelToLoadStatus1 = new HashMap<>();
+        modelToLoadStatus1.put("modelName:version1", "response");
+        nodes.add(new LoadModelNodeResponse(node1, modelToLoadStatus1));
+
+        DiscoveryNode node2 = new DiscoveryNode(
+                "foo2",
+                "foo2",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+        Map<String, String> modelToLoadStatus2 = new HashMap<>();
+        modelToLoadStatus2.put("modelName:version2", "response");
+        nodes.add(new LoadModelNodeResponse(node2, modelToLoadStatus2));
+
+        List<FailedNodeException> failures = new ArrayList<>();
+        LoadModelNodesResponse response = new LoadModelNodesResponse(clusterName, nodes, failures);
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String jsonStr = Strings.toString(builder);
+        assertEquals(
+                "{\"foo1\":{\"stats\":{\"modelName:version1\":\"response\"}},\"foo2\":{\"stats\":{\"modelName:version2\":\"response\"}}}",
+                jsonStr
+        );
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelResponseTest.java
@@ -1,0 +1,56 @@
+package org.opensearch.ml.common.transport.load;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class LoadModelResponseTest {
+
+    private String taskId;
+    private String status;
+
+    @Before
+    public void setUp() throws Exception {
+        taskId = "test_id";
+        status = "test";
+    }
+
+    @Test
+    public void writeTo_Success() throws IOException {
+        // Setup
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        LoadModelResponse response = new LoadModelResponse(taskId, status);
+        // Run the test
+        response.writeTo(bytesStreamOutput);
+        LoadModelResponse parsedResponse = new LoadModelResponse(bytesStreamOutput.bytes().streamInput());
+        // Verify the results
+        assertEquals(response.getTaskId(), parsedResponse.getTaskId());
+        assertEquals(response.getStatus(), parsedResponse.getStatus());
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        // Setup
+        LoadModelResponse response = new LoadModelResponse(taskId, status);
+        // Run the test
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(builder);
+        String jsonStr = Strings.toString(builder);
+        // Verify the results
+        assertEquals("{\"task_id\":\"test_id\"," +
+                "\"status\":\"test\"}", jsonStr);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/load/MLLoadModelRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/load/MLLoadModelRequestTest.java
@@ -1,0 +1,158 @@
+package org.opensearch.ml.common.transport.load;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.common.xcontent.*;
+import org.opensearch.ml.common.TestHelper;
+import org.opensearch.search.SearchModule;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskId;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.junit.Assert.*;
+
+public class MLLoadModelRequestTest {
+
+    private MLLoadModelRequest mlLoadModelRequest;
+
+    @Before
+    public void setUp() throws Exception {
+        mlLoadModelRequest = MLLoadModelRequest.builder().
+                modelId("modelId").
+                modelNodeIds(new String[]{"modelNodeIds"}).
+                async(true).
+                dispatchTask(true).
+                build();
+
+    }
+
+    @Test
+    public void testValidateWithBuilder() {
+         MLLoadModelRequest request = MLLoadModelRequest.builder().
+                 modelId("modelId").
+                 build();
+        assertNull(request.validate());
+    }
+
+    @Test
+    public void testValidateWithoutBuilder() {
+        MLLoadModelRequest request = new MLLoadModelRequest("modelId", true);
+        assertNull(request.validate());
+    }
+
+    @Test
+    public void validate_Exception_WithNullModelId() {
+        MLLoadModelRequest request = MLLoadModelRequest.builder().
+                modelId(null).
+                modelNodeIds(new String[]{"modelNodeIds"}).
+                async(true).
+                dispatchTask(true).
+                build();
+        ActionRequestValidationException exception = request.validate();
+        assertEquals("Validation Failed: 1: ML model id can't be null;", exception.getMessage());
+    }
+
+    @Test
+    public void writeTo_Success() throws IOException {
+
+        MLLoadModelRequest request = mlLoadModelRequest;
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        request.writeTo(bytesStreamOutput);
+        request = new MLLoadModelRequest(bytesStreamOutput.bytes().streamInput());
+
+        assertEquals("modelId", request.getModelId());
+        assertArrayEquals(new String[]{"modelNodeIds"}, request.getModelNodeIds());
+        assertTrue(request.isAsync());
+        assertTrue(request.isDispatchTask());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void fromActionRequest_IOException() {
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException("test");
+            }
+        };
+        MLLoadModelRequest.fromActionRequest(actionRequest);
+    }
+
+    @Test
+    public void fromActionRequest_Success_WithMLLoadModelRequest() {
+        MLLoadModelRequest request = MLLoadModelRequest.builder().
+                modelId("modelId").
+                build();
+        assertSame(MLLoadModelRequest.fromActionRequest(request), request);
+    }
+
+    @Test
+    public void fromActionRequest_Success_WithNonMLLoadModelRequest() {
+        MLLoadModelRequest request = mlLoadModelRequest;
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                request.writeTo(out);
+            }
+        };
+        MLLoadModelRequest result = MLLoadModelRequest.fromActionRequest(actionRequest);
+        assertNotSame(result, request);
+        assertEquals(request.isAsync(), result.isAsync());
+        assertEquals(request.isDispatchTask(), result.isDispatchTask());
+    }
+
+    @Test
+    public void testParse() throws Exception {
+        String modelId = "modelId";
+        String expectedInputStr = "{\"node_ids\":[\"modelNodeIds\"]}";
+        parseFromJsonString(modelId, expectedInputStr, parsedInput -> {
+            assertEquals("modelId", parsedInput.getModelId());
+            assertArrayEquals(new String [] {"modelNodeIds"}, parsedInput.getModelNodeIds());
+            assertFalse(parsedInput.isAsync());
+            assertTrue(parsedInput.isDispatchTask());}
+        );
+    }
+
+    @Test
+    public void testParseWithInvalidField() throws Exception {
+        String modelId = "modelId";
+        String withInvalidFieldInputStr = "{\"void\":\"void\", \"dispatchTask\":\"false\", \"async\":\"true\", \"node_ids\":[\"modelNodeIds\"]}";
+        parseFromJsonString(modelId, withInvalidFieldInputStr, parsedInput -> {
+            assertEquals("modelId", parsedInput.getModelId());
+            assertArrayEquals(new String [] {"modelNodeIds"}, parsedInput.getModelNodeIds());
+            assertFalse(parsedInput.isAsync());
+            assertTrue(parsedInput.isDispatchTask());}
+        );
+    }
+
+    private void parseFromJsonString(String modelId, String expectedInputStr, Consumer<MLLoadModelRequest> verify) throws Exception {
+        XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                Collections.emptyList()).getNamedXContents()), LoggingDeprecationHandler.INSTANCE, expectedInputStr);
+        parser.nextToken();
+        MLLoadModelRequest parsedInput = MLLoadModelRequest.parse(parser, modelId);
+        verify.accept(parsedInput);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpInputTest.java
@@ -1,0 +1,75 @@
+package org.opensearch.ml.common.transport.sync;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class MLSyncUpInputTest {
+
+
+    @Test
+    public void testConstructorSerialization_SuccessWithNullFields() throws IOException {
+        MLSyncUpInput syncUpInputWithNullFields = MLSyncUpInput.builder()
+                .getLoadedModels(true)
+                .clearRoutingTable(true)
+                .syncRunningLoadModelTasks(true)
+                .build();
+
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        syncUpInputWithNullFields.writeTo(bytesStreamOutput);
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        MLSyncUpInput parsedInput = new MLSyncUpInput(streamInput);
+
+        assertNull(parsedInput.getAddedWorkerNodes());
+        assertNull(parsedInput.getRemovedWorkerNodes());
+        assertNull(parsedInput.getModelRoutingTable());
+        assertNull(parsedInput.getAddedWorkerNodes());
+    }
+
+    @Test
+    public void testConstructorSerialization_SuccessWithFullFields() throws IOException {
+        Map<String, String[]> addedWorkerNodes = new HashMap<>();
+        Map<String, String[]> removedWorkerNodes = new HashMap<>();
+        Map<String, Set<String>> modelRoutingTable = new HashMap<>();
+        Map<String, Set<String>> runningLoadModelTasks = new HashMap<>();
+
+        MLSyncUpInput syncUpInput = MLSyncUpInput.builder()
+                .getLoadedModels(true)
+                .addedWorkerNodes(addedWorkerNodes)
+                .removedWorkerNodes(removedWorkerNodes)
+                .modelRoutingTable(modelRoutingTable)
+                .runningLoadModelTasks(runningLoadModelTasks)
+                .clearRoutingTable(true)
+                .syncRunningLoadModelTasks(true)
+                .build();
+
+        Set<String> modelRoutingTableSet = new HashSet<>();
+        Set<String> runningLoadModelTaskSet = new HashSet<>();
+        modelRoutingTableSet.add("modelRoutingTable1");
+        runningLoadModelTaskSet.add("runningLoadModelTask1");
+        addedWorkerNodes.put("addedWorkerNodesKey1", new String [] {"addedWorkerNode1"});
+        removedWorkerNodes.put("removedWorkerNodesKey1", new String [] {"removedWorkerNode1"});
+        modelRoutingTable.put("modelRoutingTableKey1",modelRoutingTableSet);
+        runningLoadModelTasks.put("runningLoadModelTaskKey1",runningLoadModelTaskSet);
+
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        syncUpInput.writeTo(bytesStreamOutput);
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        MLSyncUpInput parsedInput = new MLSyncUpInput(streamInput);
+
+        assertArrayEquals(syncUpInput.getAddedWorkerNodes().get("addedWorkerNodesKey1"), parsedInput.getAddedWorkerNodes().get("addedWorkerNodesKey1"));
+        assertArrayEquals(syncUpInput.getRemovedWorkerNodes().get("removedWorkerNodesKey1"), parsedInput.getRemovedWorkerNodes().get("removedWorkerNodesKey1"));
+        assertEquals(syncUpInput.getModelRoutingTable().get("modelRoutingTableKey1"), parsedInput.getModelRoutingTable().get("modelRoutingTableKey1"));
+        assertEquals(syncUpInput.getRunningLoadModelTasks().get("runningLoadModelTaskKey1"), parsedInput.getRunningLoadModelTasks().get("runningLoadModelTaskKey1"));
+
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeRequestTest.java
@@ -1,0 +1,140 @@
+package org.opensearch.ml.common.transport.sync;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.transport.TransportAddress;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class MLSyncUpNodeRequestTest {
+
+    private DiscoveryNode localNode1;
+    private DiscoveryNode localNode2;
+    private DiscoveryNode localNode3;
+
+    @Mock
+    private MLSyncUpInput syncUpInput;
+
+    @Before
+    public void setUp() throws Exception {
+        localNode1 = new DiscoveryNode(
+                "foo1",
+                "foo1",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+        localNode2 = new DiscoveryNode(
+                "foo2",
+                "foo2",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+        localNode3 = new DiscoveryNode(
+                "foo3",
+                "foo3",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+
+        Map<String, String[]> addedWorkerNodes = new HashMap<>();
+        Map<String, String[]> removedWorkerNodes = new HashMap<>();
+        Map<String, Set<String>> modelRoutingTable = new HashMap<>();
+        Map<String, Set<String>> runningLoadModelTasks = new HashMap<>();
+
+        syncUpInput = MLSyncUpInput.builder()
+                .getLoadedModels(true)
+                .addedWorkerNodes(addedWorkerNodes)
+                .removedWorkerNodes(removedWorkerNodes)
+                .modelRoutingTable(modelRoutingTable)
+                .runningLoadModelTasks(runningLoadModelTasks)
+                .clearRoutingTable(true)
+                .syncRunningLoadModelTasks(true)
+                .build();
+    }
+
+    @Test
+    public void testConstructorSerialization1() throws IOException {
+        String [] nodeIds = {"id1", "id2", "id3"};
+        MLSyncUpNodeRequest syncUpNodeRequest = new MLSyncUpNodeRequest(
+                new MLSyncUpNodesRequest(nodeIds, syncUpInput)
+        );
+        BytesStreamOutput output = new BytesStreamOutput();
+
+        syncUpNodeRequest.writeTo(output);
+
+        assertEquals(3, syncUpNodeRequest.getSyncUpNodesRequest().nodesIds().length);
+        assertTrue(syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isClearRoutingTable());
+        assertTrue(syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isSyncRunningLoadModelTasks());
+        assertTrue(syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isClearRoutingTable());
+
+    }
+
+    @Test
+    public void testConstructorSerialization2() {
+        DiscoveryNode [] nodeIds = {localNode1, localNode2, localNode3};
+        MLSyncUpNodeRequest syncUpNodeRequest = new MLSyncUpNodeRequest(
+                new MLSyncUpNodesRequest(nodeIds, syncUpInput)
+        );
+
+        assertEquals(3, syncUpNodeRequest.getSyncUpNodesRequest().concreteNodes().length);
+        assertTrue(syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isClearRoutingTable());
+        assertTrue(syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isSyncRunningLoadModelTasks());
+        assertTrue(syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isClearRoutingTable());
+    }
+
+    @Test
+    public void testConstructorSerialization3() {
+        MLSyncUpNodeRequest syncUpNodeRequest = new MLSyncUpNodeRequest(
+                new MLSyncUpNodesRequest(localNode1, localNode2, localNode3)
+        );
+        syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().setClearRoutingTable(true);
+        syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().setSyncRunningLoadModelTasks(true);
+        syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().setClearRoutingTable(true);
+
+        assertEquals(3, syncUpNodeRequest.getSyncUpNodesRequest().concreteNodes().length);
+        assertTrue(syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isClearRoutingTable());
+        assertTrue(syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isSyncRunningLoadModelTasks());
+        assertTrue(syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isClearRoutingTable());
+    }
+
+    @Test
+    public void testConstructorFromInputStream() throws IOException {
+        String [] nodeIds = {"id1", "id2", "id3"};
+        MLSyncUpNodeRequest syncUpNodeRequest = new MLSyncUpNodeRequest(
+                new MLSyncUpNodesRequest(nodeIds, syncUpInput)
+        );
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        syncUpNodeRequest.writeTo(bytesStreamOutput);
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        MLSyncUpNodeRequest parsedNodeRequest = new MLSyncUpNodeRequest(streamInput);
+
+        assertEquals(3, parsedNodeRequest.getSyncUpNodesRequest().nodesIds().length);
+        assertEquals(parsedNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isClearRoutingTable(), syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isClearRoutingTable());
+        assertEquals(parsedNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isClearRoutingTable(), syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isSyncRunningLoadModelTasks());
+        assertEquals(parsedNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isClearRoutingTable(), syncUpNodeRequest.getSyncUpNodesRequest().getSyncUpInput().isClearRoutingTable());
+    }
+
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponseTest.java
@@ -1,0 +1,64 @@
+package org.opensearch.ml.common.transport.sync;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.transport.TransportAddress;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MLSyncUpNodeResponseTest {
+
+    private DiscoveryNode localNode;
+    private final String modelStatus = "modelStatus";
+    private final String[] loadedModelIds = {"loadedModelIds"};
+    private final String[] runningLoadModelTaskIds = {"runningLoadModelTaskIds"};
+    @Before
+    public void setUp() throws Exception {
+        localNode = new DiscoveryNode(
+                "foo0",
+                "foo0",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+    }
+
+    @Test
+    public void testSerializationDeserialization() throws IOException {
+        MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(localNode, modelStatus, loadedModelIds, runningLoadModelTaskIds);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        MLSyncUpNodeResponse newResponse = new MLSyncUpNodeResponse(output.bytes().streamInput());
+        assertNotEquals(newResponse, response);
+        assertEquals(newResponse.getNode().getName(), response.getNode().getName());
+        assertEquals(newResponse.getModelStatus(), response.getModelStatus());
+        assertArrayEquals(newResponse.getLoadedModelIds(), response.getLoadedModelIds());
+        assertArrayEquals(newResponse.getRunningLoadModelTaskIds(), response.getRunningLoadModelTaskIds());
+    }
+
+    @Test
+    public void testReadProfile() throws IOException {
+        MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(localNode, modelStatus, loadedModelIds, runningLoadModelTaskIds);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        MLSyncUpNodeResponse newResponse = MLSyncUpNodeResponse.readStats(output.bytes().streamInput());
+        assertNotEquals(newResponse, response);
+        assertEquals(newResponse.getNode().getName(), response.getNode().getName());
+        assertEquals(newResponse.getModelStatus(), response.getModelStatus());
+        assertArrayEquals(newResponse.getLoadedModelIds(), response.getLoadedModelIds());
+        assertArrayEquals(newResponse.getRunningLoadModelTaskIds(), response.getRunningLoadModelTaskIds());
+
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodesResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodesResponseTest.java
@@ -1,0 +1,39 @@
+package org.opensearch.ml.common.transport.sync;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MLSyncUpNodesResponseTest {
+
+    private ClusterName clusterName;
+
+    @Before
+    public void setUp() throws Exception {
+        clusterName = new ClusterName("clusterName");
+    }
+
+    @Test
+    public void testSerializationDeserialization1() throws IOException {
+        List<MLSyncUpNodeResponse> responseList = new ArrayList<>();
+        List<FailedNodeException> failuresList = new ArrayList<>();
+        MLSyncUpNodesResponse response = new MLSyncUpNodesResponse(clusterName, responseList, failuresList);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        MLSyncUpNodesResponse newResponse = new MLSyncUpNodesResponse(output.bytes().streamInput());
+        assertEquals(newResponse.getNodes().size(), response.getNodes().size());
+    }
+
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpResponseTest.java
@@ -1,0 +1,52 @@
+package org.opensearch.ml.common.transport.sync;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MLSyncUpResponseTest {
+    private String status;
+
+    @Before
+    public void setUp() throws Exception {
+        status = "test";
+    }
+
+    @Test
+    public void writeTo_Success() throws IOException {
+        // Setup
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        MLSyncUpResponse response = new MLSyncUpResponse(status);
+        // Run the test
+        response.writeTo(bytesStreamOutput);
+        MLSyncUpResponse parsedResponse = new MLSyncUpResponse(bytesStreamOutput.bytes().streamInput());
+        // Verify the results
+        assertEquals(response.getStatus(), parsedResponse.getStatus());
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        // Setup
+        MLSyncUpResponse response = new MLSyncUpResponse(status);
+        // Run the test
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(builder);
+        String jsonStr = Strings.toString(builder);
+        // Verify the results
+        assertEquals("{\"status\":\"test\"}", jsonStr);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/training/MLTrainingTaskRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/training/MLTrainingTaskRequestTest.java
@@ -47,10 +47,34 @@ public class MLTrainingTaskRequestTest {
 
     @Test
     public void validate_Success() {
+        MLTrainingTaskRequest request = new MLTrainingTaskRequest(mlInput, true);
+        assertNull(request.validate());
+    }
+
+    @Test
+    public void validate_SuccessWithBuilder() {
         MLTrainingTaskRequest request = MLTrainingTaskRequest.builder()
                 .mlInput(mlInput)
                 .build();
         assertNull(request.validate());
+    }
+
+    @Test
+    public void validate_Exception_NullMLInput() {
+        MLTrainingTaskRequest request = MLTrainingTaskRequest.builder()
+                .build();
+        ActionRequestValidationException exception = request.validate();
+        assertEquals("Validation Failed: 1: ML input can't be null;", exception.getMessage());
+    }
+
+    @Test
+    public void validate_Exception_NullInputDataInMLInput() {
+        mlInput.setInputDataset(null);
+        MLTrainingTaskRequest request = MLTrainingTaskRequest.builder()
+                .mlInput(mlInput)
+                .build();
+        ActionRequestValidationException exception = request.validate();
+        assertEquals("Validation Failed: 1: input data can't be null;", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelInputTest.java
@@ -1,0 +1,76 @@
+package org.opensearch.ml.common.transport.unload;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.*;
+import org.opensearch.search.SearchModule;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+public class UnloadModelInputTest {
+    private UnloadModelInput input;
+    private final String [] modelIds = new String [] {"modelId1","modelId2","modelId3"};
+    private final String [] nodeIds = new String [] {"nodeId1","nodeId2","nodeId3"};
+    private final String expectedInputStr =  "{\"model_ids\":[\"modelId1\",\"modelId2\",\"modelId3\"]," +
+            "\"node_ids\":[\"nodeId1\",\"nodeId2\",\"nodeId3\"]}";
+
+    @Before
+    public void setUp() throws Exception {
+        input = UnloadModelInput.builder()
+                .modelIds(modelIds)
+                .nodeIds(nodeIds)
+                .build();
+    }
+
+    @Test
+    public void testToXContent() throws Exception {
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        input.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(builder);
+        String jsonStr = Strings.toString(builder);
+        assertEquals(expectedInputStr, jsonStr);
+    }
+
+    @Test
+    public void testParse() throws Exception {
+        XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                Collections.emptyList()).getNamedXContents()), LoggingDeprecationHandler.INSTANCE, expectedInputStr);
+        parser.nextToken();
+        UnloadModelInput parsedInput = UnloadModelInput.parse(parser);
+        assertArrayEquals(new String [] {"modelId1","modelId2","modelId3"}, parsedInput.getModelIds());
+        assertArrayEquals(new String [] {"nodeId1","nodeId2","nodeId3"}, parsedInput.getNodeIds());
+    }
+
+    @Test
+    public void testParseWithInvalidField() throws Exception {
+        String withInvalidFieldInputStr =  "{\"void\":\"void\"," +
+                "\"model_ids\":[\"modelId1\",\"modelId2\",\"modelId3\"]," +
+                "\"node_ids\":[\"nodeId1\",\"nodeId2\",\"nodeId3\"]}";
+        XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                Collections.emptyList()).getNamedXContents()), LoggingDeprecationHandler.INSTANCE, withInvalidFieldInputStr);
+        parser.nextToken();
+        UnloadModelInput parsedInput = UnloadModelInput.parse(parser);
+        assertArrayEquals(new String [] {"modelId1","modelId2","modelId3"}, parsedInput.getModelIds());
+        assertArrayEquals(new String [] {"nodeId1","nodeId2","nodeId3"}, parsedInput.getNodeIds());
+    }
+
+    @Test
+    public void readInputStream() throws IOException {
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        input.writeTo(bytesStreamOutput);
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        UnloadModelInput parsedInput = new UnloadModelInput(streamInput);
+        assertArrayEquals(input.getModelIds(), parsedInput.getModelIds());
+        assertArrayEquals(input.getNodeIds(), parsedInput.getNodeIds());
+    }
+ }
+

--- a/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelNodeResponseTest.java
@@ -1,0 +1,72 @@
+package org.opensearch.ml.common.transport.unload;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnloadModelNodeResponseTest {
+
+    @Mock
+    private DiscoveryNode localNode;
+
+    @Before
+    public void setUp() throws Exception {
+        localNode = new DiscoveryNode(
+                "foo0",
+                "foo0",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+    }
+
+    @Test
+    public void testSerializationDeserialization() throws IOException {
+        Map<String, String> modelToLoadStatus = new HashMap<>();
+        modelToLoadStatus.put("modelName:version", "response");
+        UnloadModelNodeResponse response = new UnloadModelNodeResponse(localNode, modelToLoadStatus);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        UnloadModelNodeResponse newResponse = new UnloadModelNodeResponse(output.bytes().streamInput());
+        assertEquals(newResponse.getNode().getId(), response.getNode().getId());
+    }
+
+    @Test
+    public void testSerializationDeserialization_NullModelLoadStatus() throws IOException {
+        UnloadModelNodeResponse response = new UnloadModelNodeResponse(localNode, null);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        UnloadModelNodeResponse newResponse = new UnloadModelNodeResponse(output.bytes().streamInput());
+        assertEquals(newResponse.getNode().getId(), response.getNode().getId());
+    }
+
+    @Test
+    public void testReadProfile() throws IOException {
+        UnloadModelNodeResponse response = new UnloadModelNodeResponse(localNode, new HashMap<>());
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        UnloadModelNodeResponse newResponse = UnloadModelNodeResponse.readStats(output.bytes().streamInput());
+        assertNotEquals(newResponse, response);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelNodesRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelNodesRequestTest.java
@@ -1,0 +1,87 @@
+package org.opensearch.ml.common.transport.unload;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.transport.TransportAddress;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collections;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnloadModelNodesRequestTest {
+
+    private DiscoveryNode localNode1;
+    private DiscoveryNode localNode2;
+
+    @Test
+    public void testConstructorSerialization1() throws IOException {
+
+        String[] modelIds = {"modelId1", "modelId2", "modelId3"};
+        String[] nodeIds = {"nodeId1", "nodeId2", "nodeId3"};
+
+        UnloadModelNodeRequest unloadModelNodeRequest = new UnloadModelNodeRequest(
+                new UnloadModelNodesRequest(nodeIds, modelIds)
+        );
+        BytesStreamOutput output = new BytesStreamOutput();
+
+        unloadModelNodeRequest.writeTo(output);
+        assertArrayEquals(new String[] {"modelId1", "modelId2", "modelId3"}, unloadModelNodeRequest.getUnloadModelNodesRequest().getModelIds());
+
+    }
+
+    @Test
+    public void testConstructorSerialization2() throws IOException {
+
+        localNode1 = new DiscoveryNode(
+                "foo1",
+                "foo1",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+        localNode2 = new DiscoveryNode(
+                "foo2",
+                "foo2",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+
+        UnloadModelNodeRequest unloadModelNodeRequest = new UnloadModelNodeRequest(
+                new UnloadModelNodesRequest(localNode1,localNode2)
+        );
+        assertEquals(2, unloadModelNodeRequest.getUnloadModelNodesRequest().concreteNodes().length);
+
+    }
+
+    @Test
+    public void testConstructorFromInputStream() throws IOException {
+
+        String[] modelIds = {"modelId1", "modelId2", "modelId3"};
+        String[] nodeIds = {"nodeId1", "nodeId2", "nodeId3"};
+
+        UnloadModelNodeRequest unloadModelNodeRequest = new UnloadModelNodeRequest(
+                new UnloadModelNodesRequest(nodeIds, modelIds)
+        );
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        unloadModelNodeRequest.writeTo(bytesStreamOutput);
+
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        UnloadModelNodeRequest parsedNodeRequest = new UnloadModelNodeRequest(streamInput);
+
+        assertArrayEquals(unloadModelNodeRequest.getUnloadModelNodesRequest().getModelIds(), parsedNodeRequest.getUnloadModelNodesRequest().getModelIds());
+
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelNodesResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelNodesResponseTest.java
@@ -1,0 +1,89 @@
+package org.opensearch.ml.common.transport.unload;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.Version;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnloadModelNodesResponseTest {
+
+    @Mock
+    private ClusterName clusterName;
+    private DiscoveryNode node1;
+    private DiscoveryNode node2;
+
+    @Before
+    public void setUp() throws Exception {
+        clusterName = new ClusterName("clusterName");
+        node1 = new DiscoveryNode(
+                "foo1",
+                "foo1",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+        node2 = new DiscoveryNode(
+                "foo2",
+                "foo2",
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                Collections.emptyMap(),
+                Collections.singleton(CLUSTER_MANAGER_ROLE),
+                Version.CURRENT
+        );
+    }
+
+    @Test
+    public void testSerializationDeserialization1() throws IOException {
+        List<UnloadModelNodeResponse> responseList = new ArrayList<>();
+        List<FailedNodeException> failuresList = new ArrayList<>();
+        UnloadModelNodesResponse response = new UnloadModelNodesResponse(clusterName, responseList, failuresList);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        UnloadModelNodesResponse newResponse = new UnloadModelNodesResponse(output.bytes().streamInput());
+        assertEquals(newResponse.getNodes().size(), response.getNodes().size());
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        List<UnloadModelNodeResponse> nodes = new ArrayList<>();
+
+        Map<String, String> modelToUnloadStatus1 = new HashMap<>();
+        modelToUnloadStatus1.put("modelName:version1", "response");
+        nodes.add(new UnloadModelNodeResponse(node1, modelToUnloadStatus1));
+
+        Map<String, String> modelToUnloadStatus2 = new HashMap<>();
+        modelToUnloadStatus2.put("modelName:version2", "response");
+        nodes.add(new UnloadModelNodeResponse(node2, modelToUnloadStatus2));
+
+        List<FailedNodeException> failures = new ArrayList<>();
+        UnloadModelNodesResponse response = new UnloadModelNodesResponse(clusterName, nodes, failures);
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String jsonStr = Strings.toString(builder);
+        assertEquals(
+                "{\"foo1\":{\"stats\":{\"modelName:version1\":\"response\"}},\"foo2\":{\"stats\":{\"modelName:version2\":\"response\"}}}",
+                jsonStr
+        );
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/upload/MLUploadInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/upload/MLUploadInputTest.java
@@ -1,0 +1,244 @@
+package org.opensearch.ml.common.transport.upload;
+
+import org.hamcrest.Matcher;
+import org.junit.Rule;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.*;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.TestHelper;
+import org.opensearch.ml.common.model.MLModelConfig;
+import org.opensearch.ml.common.model.MLModelFormat;
+import org.opensearch.search.SearchModule;
+import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
+
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MLUploadInputTest {
+
+    @Mock
+    MLModelConfig config;
+    MLUploadInput input;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+    private final String expectedInputStr = "{\"function_name\":\"LINEAR_REGRESSION\",\"name\":\"modelName\",\"version\":\"version\",\"url\":\"url\",\"model_format\":\"ONNX\"," +
+            "\"model_config\":{\"model_type\":\"testModelType\",\"embedding_dimension\":100,\"framework_type\":\"SENTENCE_TRANSFORMERS\"," +
+            "\"all_config\":\"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\"}\"}," +
+            "\"load_model\":true,\"model_node_ids\":[\"modelNodeIds\"]}";
+    private final FunctionName functionName = FunctionName.LINEAR_REGRESSION;
+    private final String modelName = "modelName";
+    private final String version = "version";
+    private final String url = "url";
+
+    @Before
+    public void setUp() throws Exception {
+        config = TextEmbeddingModelConfig.builder()
+                .modelType("testModelType")
+                .allConfig("{\"field1\":\"value1\",\"field2\":\"value2\"}")
+                .frameworkType(TextEmbeddingModelConfig.FrameworkType.SENTENCE_TRANSFORMERS)
+                .embeddingDimension(100)
+                .build();
+
+        input = MLUploadInput.builder()
+                .functionName(functionName)
+                .modelName(modelName)
+                .version(version)
+                .url(url)
+                .modelFormat(MLModelFormat.ONNX)
+                .modelConfig(config)
+                .loadModel(true)
+                .modelNodeIds(new String[]{"modelNodeIds" })
+                .build();
+
+    }
+
+    @Test
+    public void constructor_NullModel() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("model name is null");
+        MLUploadInput.builder().build();
+    }
+
+    @Test
+    public void constructor_NullModelName() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("model name is null");
+        MLUploadInput.builder()
+                .functionName(functionName)
+                .modelName(null)
+                .build();
+    }
+
+    @Test
+    public void constructor_NullModelVersion() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("model version is null");
+        MLUploadInput.builder()
+                .functionName(functionName)
+                .modelName(modelName)
+                .version(null)
+                .build();
+    }
+
+    @Test
+    public void constructor_NullModelFormat() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("model format is null");
+        MLUploadInput.builder()
+                .functionName(functionName)
+                .modelName(modelName)
+                .version(version)
+                .modelFormat(null)
+                .build();
+    }
+
+    @Test
+    public void constructor_NullModelConfig() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("model config is null");
+        MLUploadInput.builder()
+                .functionName(functionName)
+                .modelName(modelName)
+                .version(version)
+                .modelFormat(MLModelFormat.ONNX)
+                .modelConfig(null)
+                .build();
+    }
+
+    @Test
+    public void constructor_NullModelFileUrl() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("model file url is null");
+        MLUploadInput.builder()
+                .functionName(functionName)
+                .modelName(modelName)
+                .version(version)
+                .modelFormat(MLModelFormat.ONNX)
+                .modelConfig(config)
+                .url(null)
+                .build();
+    }
+
+    @Test
+    public void constructor_SuccessWithMinimalSetup() {
+        MLUploadInput input = MLUploadInput.builder()
+                .modelName(modelName)
+                .version(version)
+                .modelFormat(MLModelFormat.ONNX)
+                .modelConfig(config)
+                .url(url)
+                .build();
+        // MLUploadInput.functionName is set to FunctionName.TEXT_EMBEDDING if not explicitly passed, with no exception thrown
+        assertEquals(FunctionName.TEXT_EMBEDDING, input.getFunctionName());
+        // MLUploadInput.loadModel is set to false if not explicitly passed, with no exception thrown
+        assertFalse(input.isLoadModel());
+        // MLUploadInput.loadModel is set to null if not explicitly passed, with no exception thrown
+        assertNull(input.getModelNodeIds());
+    }
+
+    @Test
+    public void testToXContent() throws Exception {
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        input.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(builder);
+        String jsonStr = Strings.toString(builder);
+        assertEquals(expectedInputStr, jsonStr);
+    }
+
+    @Test
+    public void testToXContent_Incomplete() throws Exception {
+        String expectedIncompleteInputStr =
+                "{\"function_name\":\"LINEAR_REGRESSION\",\"name\":\"modelName\"," +
+                "\"version\":\"version\",\"load_model\":true}";
+        input.setUrl(null);
+        input.setModelConfig(null);
+        input.setModelFormat(null);
+        input.setModelNodeIds(null);
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        input.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(builder);
+        String jsonStr = Strings.toString(builder);
+        assertEquals(expectedIncompleteInputStr, jsonStr);
+    }
+
+    @Test
+    public void parse_WithModel() throws Exception {
+        testParseFromJsonString("modelNameInsideTest", "versionInsideTest", true, expectedInputStr, parsedInput -> {
+            assertEquals(FunctionName.LINEAR_REGRESSION, parsedInput.getFunctionName());
+            assertEquals("modelNameInsideTest", parsedInput.getModelName());
+            assertEquals("versionInsideTest", parsedInput.getVersion());
+        });
+    }
+
+    @Test
+    public void parse_WithoutModel() throws Exception {
+        testParseFromJsonString( false, expectedInputStr, parsedInput -> {
+            assertFalse(parsedInput.isLoadModel());
+            assertEquals("modelName", parsedInput.getModelName());
+            assertEquals("version", parsedInput.getVersion());
+        });
+    }
+
+    private void testParseFromJsonString(String modelName, String version, Boolean loadModel, String expectedInputStr, Consumer<MLUploadInput> verify) throws Exception {
+        XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                Collections.emptyList()).getNamedXContents()), LoggingDeprecationHandler.INSTANCE, expectedInputStr);
+        parser.nextToken();
+        MLUploadInput parsedInput = MLUploadInput.parse(parser, modelName, version, loadModel);
+        verify.accept(parsedInput);
+    }
+
+    private void testParseFromJsonString(Boolean loadModel,String expectedInputStr, Consumer<MLUploadInput> verify) throws Exception {
+        XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                Collections.emptyList()).getNamedXContents()), LoggingDeprecationHandler.INSTANCE, expectedInputStr);
+        parser.nextToken();
+        MLUploadInput parsedInput = MLUploadInput.parse(parser, loadModel);
+        verify.accept(parsedInput);
+    }
+
+    @Test
+    public void readInputStream_Success() throws IOException {
+        readInputStream(input, parsedInput -> {
+            assertEquals(input.getFunctionName(), parsedInput.getFunctionName());
+            assertEquals(input.getModelName(), parsedInput.getModelName());
+        });
+    }
+
+
+    @Test
+    public void readInputStream_SuccessWithNullFields() throws IOException {
+        input.setModelFormat(null);
+        input.setModelConfig(null);
+        readInputStream(input, parsedInput -> {
+            assertNull(parsedInput.getModelConfig());
+            assertNull(parsedInput.getModelFormat());
+        });
+    }
+
+
+    private void readInputStream(MLUploadInput input, Consumer<MLUploadInput> verify) throws IOException {
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        input.writeTo(bytesStreamOutput);
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        MLUploadInput parsedInput = new MLUploadInput(streamInput);
+        verify.accept(parsedInput);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/upload/MLUploadModelRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/upload/MLUploadModelRequestTest.java
@@ -1,0 +1,143 @@
+package org.opensearch.ml.common.transport.upload;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.model.MLModelFormat;
+import org.opensearch.ml.common.model.MLModelConfig;
+
+import static org.junit.Assert.*;
+
+public class MLUploadModelRequestTest {
+
+    private MLUploadInput mlUploadInput;
+
+    @Before
+    public void setUp(){
+
+        TextEmbeddingModelConfig config = TextEmbeddingModelConfig.builder()
+                .modelType("testModelType")
+                .allConfig("{\"field1\":\"value1\",\"field2\":\"value2\"}")
+                .frameworkType(TextEmbeddingModelConfig.FrameworkType.SENTENCE_TRANSFORMERS)
+                .embeddingDimension(100)
+                .build();
+
+
+        mlUploadInput = MLUploadInput.builder()
+                .functionName(FunctionName.KMEANS)
+                .modelName("modelName")
+                .version("version")
+                .url("url")
+                .modelFormat(MLModelFormat.ONNX)
+                .modelConfig(config)
+                .loadModel(true)
+                .modelNodeIds(new String[]{"modelNodeIds" })
+                .build();
+    }
+
+    @Test
+    public void writeTo_Success() throws IOException {
+
+        MLUploadModelRequest request = MLUploadModelRequest.builder()
+                .mlUploadInput(mlUploadInput)
+                .build();
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        request.writeTo(bytesStreamOutput);
+        request = new MLUploadModelRequest(bytesStreamOutput.bytes().streamInput());
+        assertEquals(FunctionName.KMEANS, request.getMlUploadInput().getFunctionName());
+        assertEquals("modelName", request.getMlUploadInput().getModelName());
+        assertEquals("version", request.getMlUploadInput().getVersion());
+        assertEquals("url", request.getMlUploadInput().getUrl());
+        assertEquals(MLModelFormat.ONNX, request.getMlUploadInput().getModelFormat());
+        MLModelConfig config1 = request.getMlUploadInput().getModelConfig();
+        assertEquals("testModelType", config1.getModelType());
+        assertEquals("{\"field1\":\"value1\",\"field2\":\"value2\"}", config1.getAllConfig());
+        assertTrue(request.getMlUploadInput().isLoadModel());
+        String[] modelNodeIds = request.getMlUploadInput().getModelNodeIds();
+        assertEquals("modelNodeIds", modelNodeIds[0]);
+        assertEquals("TEXT_EMBEDDING", config1.getWriteableName());
+    }
+
+    @Test
+    public void validate_Success() {
+        MLUploadModelRequest request = MLUploadModelRequest.builder()
+                .mlUploadInput(mlUploadInput)
+                .build();
+
+        assertNull(request.validate());
+    }
+
+    @Test
+    public void validate_Exception_NullMLUploadInput() {
+        MLUploadModelRequest request = MLUploadModelRequest.builder()
+                .build();
+        ActionRequestValidationException exception = request.validate();
+        assertEquals("Validation Failed: 1: ML input can't be null;", exception.getMessage());
+    }
+
+    @Test
+    // MLUploadInput check its parameters when created, so exception is not thrown here
+    public void validate_Exception_NullMLModelName() {
+        mlUploadInput.setModelName(null);
+        MLUploadModelRequest request = MLUploadModelRequest.builder()
+                .mlUploadInput(mlUploadInput)
+                .build();
+
+        assertNull(request.validate());
+        assertNull(request.getMlUploadInput().getModelName());
+    }
+
+    @Test
+    public void fromActionRequest_Success_WithMLUploadModelRequest() {
+        MLUploadModelRequest request = MLUploadModelRequest.builder()
+                .mlUploadInput(mlUploadInput)
+                .build();
+        assertSame(MLUploadModelRequest.fromActionRequest(request), request);
+    }
+
+    @Test
+    public void fromActionRequest_Success_WithNonMLUploadModelRequest() {
+        MLUploadModelRequest request = MLUploadModelRequest.builder()
+                .mlUploadInput(mlUploadInput)
+                .build();
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                request.writeTo(out);
+            }
+        };
+        MLUploadModelRequest result = MLUploadModelRequest.fromActionRequest(actionRequest);
+        assertNotSame(result, request);
+        assertEquals(request.getMlUploadInput().getModelName(), result.getMlUploadInput().getModelName());
+        assertEquals(request.getMlUploadInput().getModelConfig().getModelType(), result.getMlUploadInput().getModelConfig().getModelType());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void fromActionRequest_IOException() {
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException("test");
+            }
+        };
+        MLUploadModelRequest.fromActionRequest(actionRequest);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/upload/UploadModelResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/upload/UploadModelResponseTest.java
@@ -1,0 +1,54 @@
+package org.opensearch.ml.common.transport.upload;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+public class UploadModelResponseTest {
+
+    private String taskId;
+    private String status;
+
+    @Before
+    public void setUp() throws Exception {
+        taskId = "test_id";
+        status = "test";
+    }
+
+    @Test
+    public void writeTo_Success() throws IOException {
+        // Setup
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        UploadModelResponse response = new UploadModelResponse(taskId, status);
+        // Run the test
+        response.writeTo(bytesStreamOutput);
+        UploadModelResponse parsedResponse = new UploadModelResponse(bytesStreamOutput.bytes().streamInput());
+        // Verify the results
+        assertEquals(response.getTaskId(), parsedResponse.getTaskId());
+        assertEquals(response.getStatus(), parsedResponse.getStatus());
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        // Setup
+        UploadModelResponse response = new UploadModelResponse(taskId, status);
+        // Run the test
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(builder);
+        String jsonStr = Strings.toString(builder);
+        // Verify the results
+        assertEquals("{\"task_id\":\"test_id\"," +
+                "\"status\":\"test\"}", jsonStr);
+    }
+}


### PR DESCRIPTION
* add test coverage to common package

Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

* improve unit test coverage for forward, load, unload and upload class

Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

* improve unit test coverage for sync, training, unload and load class

Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

* code improvement after review

Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>
Signed-off-by: Sicheng Song <sicheng.song@outlook.com>

### Description
This PR is a partial forwarding of port changes in branch 2.x ([commit #514](https://github.com/opensearch-project/ml-commons/commit/6f47975b098aa65a78a5aff90caf1e478babab32)) to main branch.
 
### Issues Resolved
This PR partially resolves [#553](https://github.com/opensearch-project/ml-commons/issues/553) and [OpenSearch-SQL #1065](https://github.com/opensearch-project/sql/issues/1065)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
