### PR TITLE
Forwarding port changes in 2.4 to main branch (Adds security IT for new upload and load APIs)

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -12,6 +12,9 @@ import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTT
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH;
+import static org.opensearch.ml.common.MLTask.FUNCTION_NAME_FIELD;
+import static org.opensearch.ml.common.MLTask.MODEL_ID_FIELD;
+import static org.opensearch.ml.common.MLTask.STATE_FIELD;
 import static org.opensearch.ml.common.MLTask.TASK_ID_FIELD;
 import static org.opensearch.ml.stats.MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT;
 import static org.opensearch.ml.stats.MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT;
@@ -614,9 +617,36 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
             .build();
     }
 
+    public void uploadModel(RestClient client, String input, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "POST", "/_plugins/_ml/models/_upload", null, input, null);
+        verifyResponse(function, response);
+    }
+
     public String uploadModel(String input) throws IOException {
         Response response = TestHelper.makeRequest(client(), "POST", "/_plugins/_ml/models/_upload", null, input, null);
         return parseTaskIdFromResponse(response);
+    }
+
+    public void loadModel(RestClient client, MLUploadInput uploadInput, Consumer<Map<String, Object>> function) throws IOException {
+        String taskId = uploadModel(TestHelper.toJsonString(uploadInput));
+        getTask(client(), taskId, response -> {
+            String algorithm = (String) response.get(FUNCTION_NAME_FIELD);
+            assertEquals(uploadInput.getFunctionName().name(), algorithm);
+            assertNotNull(response.get(MODEL_ID_FIELD));
+            assertEquals(MLTaskState.COMPLETED.name(), response.get(STATE_FIELD));
+            String modelId = (String) response.get(MODEL_ID_FIELD);
+            try {
+                // load model
+                loadModel(client, modelId, function);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public void loadModel(RestClient client, String modelId, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "POST", "/_plugins/_ml/models/" + modelId + "/_load", null, (String) null, null);
+        verifyResponse(function, response);
     }
 
     public String loadModel(String modelId) throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
@@ -23,6 +23,8 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.input.parameter.clustering.KMeansParams;
+import org.opensearch.ml.common.transport.upload.MLUploadInput;
+import org.opensearch.ml.utils.TestHelper;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 import com.google.common.base.Throwables;
@@ -42,6 +44,7 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
 
     private String opensearchBackendRole = "opensearch";
     private SearchSourceBuilder searchSourceBuilder;
+    private MLUploadInput mlUploadInput;
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
@@ -94,6 +97,8 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
         searchSourceBuilder.query(new MatchAllQueryBuilder());
         searchSourceBuilder.size(1000);
         searchSourceBuilder.fetchSource(new String[] { "petal_length_in_cm", "petal_width_in_cm" }, null);
+
+        mlUploadInput = createUploadModelInput();
     }
 
     @After
@@ -132,6 +137,70 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
             searchSourceBuilder,
             null
         );
+    }
+
+    public void testUploadModelWithNoAccess() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/upload_model]");
+        uploadModel(mlNoAccessClient, TestHelper.toJsonString(mlUploadInput), null);
+    }
+
+    public void testUploadModelWithReadOnlyMLAccess() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/upload_model]");
+        uploadModel(mlReadOnlyClient, TestHelper.toJsonString(mlUploadInput), null);
+    }
+
+    public void testUploadModelWithFullMLAccessNoIndexAccess() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/upload_model]");
+        uploadModel(mlFullAccessNoIndexAccessClient, TestHelper.toJsonString(mlUploadInput), null);
+    }
+
+    public void testUploadModelWithFullAccess() throws IOException {
+        uploadModel(mlFullAccessClient, TestHelper.toJsonString(mlUploadInput), uploadModelResult -> {
+            assertFalse(uploadModelResult.containsKey("model_id"));
+            String taskId = (String) uploadModelResult.get("task_id");
+            assertNotNull(taskId);
+            String status = (String) uploadModelResult.get("status");
+            assertEquals(MLTaskState.CREATED.name(), status);
+            try {
+                getTask(mlFullAccessClient, taskId, task -> {
+                    String algorithm = (String) task.get("function_name");
+                    assertEquals(FunctionName.TEXT_EMBEDDING.name(), algorithm);
+                });
+            } catch (IOException e) {
+                assertNull(e);
+            }
+        });
+    }
+
+    public void testLoadModelWithNoAccess() throws IOException {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/load_model]");
+        loadModel(mlNoAccessClient, mlUploadInput, null);
+    }
+
+    public void testLoadModelWithReadOnlyMLAccess() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/load_model]");
+        loadModel(mlReadOnlyClient, mlUploadInput, null);
+    }
+
+    public void testLoadModelWithFullMLAccessNoIndexAccess() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/load_model]");
+        loadModel(mlFullAccessNoIndexAccessClient, mlUploadInput, null);
+    }
+
+    public void testLoadModelWithFullAccess() throws IOException {
+        loadModel(mlFullAccessClient, mlUploadInput, loadModelResult -> {
+            assertFalse(loadModelResult.containsKey("model_id"));
+            String taskId = (String) loadModelResult.get("task_id");
+            assertNotNull(taskId);
+            String status = (String) loadModelResult.get("status");
+            assertEquals(MLTaskState.CREATED.name(), status);
+        });
     }
 
     public void testTrainWithReadOnlyMLAccess() throws IOException {


### PR DESCRIPTION
Signed-off-by: Xun Zhang <xunzh@amazon.com>
Signed-off-by: Sicheng Song <sicheng.song@outlook.com>

### Description
This PR is a partial forwarding of port changes in branch 2.x ([commit #529](https://github.com/opensearch-project/ml-commons/commit/f0cf53f8f9c8e91a7e423817e7b879410ca536fb)) to main branch.
 
### Issues Resolved
This PR partially resolves [#553](https://github.com/opensearch-project/ml-commons/issues/553) and [OpenSearch-SQL #1065](https://github.com/opensearch-project/sql/issues/1065)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
