### PR TITLE
Forwarding port changes in 2.4 to main branch (test coverage ratio changes for build.gradlew in plugin package)

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -236,13 +236,31 @@ List<String> jacocoExclusions = [
         'org.opensearch.ml.constant.CommonValue',
         'org.opensearch.ml.plugin.MachineLearningPlugin*',
         'org.opensearch.ml.indices.MLIndicesHandler',
-        'org.opensearch.ml.action.load.TransportLoadModelOnNodeAction',
+        'org.opensearch.ml.rest.RestMLPredictionAction',
+        'org.opensearch.ml.profile.MLModelProfile',
+        'org.opensearch.ml.profile.MLPredictRequestStats',
         'org.opensearch.ml.action.load.TransportLoadModelAction',
-        'org.opensearch.ml.model.MLModelCache',
+        'org.opensearch.ml.action.load.TransportLoadModelOnNodeAction',
         'org.opensearch.ml.model.MLModelManager',
         'org.opensearch.ml.action.unload.TransportUnloadModelAction',
         'org.opensearch.ml.action.forward.TransportForwardAction',
-        'org.opensearch.ml.action.syncup.TransportSyncUpOnNodeAction'
+        'org.opensearch.ml.action.syncup.TransportSyncUpOnNodeAction',
+        'org.opensearch.ml.stats.MLClusterLevelStat',
+        'org.opensearch.ml.stats.MLStatLevel',
+        'org.opensearch.ml.utils.IndexUtils',
+        'org.opensearch.ml.cluster.MLCommonsClusterManagerEventListener',
+        'org.opensearch.ml.cluster.DiscoveryNodeHelper.HotDataNodePredicate',
+        'org.opensearch.ml.cluster.MLCommonsClusterEventListener',
+        'org.opensearch.ml.task.MLTaskManager',
+        'org.opensearch.ml.task.MLTrainingTaskRunner',
+        'org.opensearch.ml.task.MLPredictTaskRunner',
+        'org.opensearch.ml.task.MLTaskDispatcher',
+        'org.opensearch.ml.task.MLTrainAndPredictTaskRunner',
+        'org.opensearch.ml.task.MLExecuteTaskRunner',
+        'org.opensearch.ml.action.profile.MLProfileTransportAction',
+        'org.opensearch.ml.action.syncup.TransportSyncUpOnNodeAction',
+        'org.opensearch.ml.action.models.DeleteModelTransportAction.1',
+        'org.opensearch.ml.rest.RestMLPredictionAction'
 ]
 
 jacocoTestCoverageVerification {
@@ -252,7 +270,7 @@ jacocoTestCoverageVerification {
             excludes = jacocoExclusions
             limit {
                 counter = 'BRANCH'
-                minimum = 0.1
+                minimum = 0.7
             }
         }
         rule {
@@ -261,7 +279,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
-                minimum = 0.1
+                minimum = 0.7
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Bhavana Ramaram <rbhavna@amazon.com>

Signed-off-by: Bhavana Ramaram <rbhavna@amazon.com>
Signed-off-by: Sicheng Song <sicheng.song@outlook.com>

### Description
This PR is a partial forwarding of port changes in branch 2.x ([commit #536](https://github.com/opensearch-project/ml-commons/commit/77666469faa0e8dd9c13e2dc1a927d1086b3dfca)) to main branch.
 
### Issues Resolved
This PR partially resolves [#553](https://github.com/opensearch-project/ml-commons/issues/553) and [OpenSearch-SQL #1065](https://github.com/opensearch-project/sql/issues/1065)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
