### PR TITLE
Forwarding port changes in 2.4 to main branch (unit tests coverage for load/unload/syncup)

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -240,11 +240,7 @@ List<String> jacocoExclusions = [
         'org.opensearch.ml.profile.MLModelProfile',
         'org.opensearch.ml.profile.MLPredictRequestStats',
         'org.opensearch.ml.action.load.TransportLoadModelAction',
-        'org.opensearch.ml.action.load.TransportLoadModelOnNodeAction',
         'org.opensearch.ml.model.MLModelManager',
-        'org.opensearch.ml.action.unload.TransportUnloadModelAction',
-        'org.opensearch.ml.action.forward.TransportForwardAction',
-        'org.opensearch.ml.action.syncup.TransportSyncUpOnNodeAction',
         'org.opensearch.ml.stats.MLClusterLevelStat',
         'org.opensearch.ml.stats.MLStatLevel',
         'org.opensearch.ml.utils.IndexUtils',
@@ -258,7 +254,6 @@ List<String> jacocoExclusions = [
         'org.opensearch.ml.task.MLTrainAndPredictTaskRunner',
         'org.opensearch.ml.task.MLExecuteTaskRunner',
         'org.opensearch.ml.action.profile.MLProfileTransportAction',
-        'org.opensearch.ml.action.syncup.TransportSyncUpOnNodeAction',
         'org.opensearch.ml.action.models.DeleteModelTransportAction.1',
         'org.opensearch.ml.rest.RestMLPredictionAction'
 ]

--- a/plugin/src/test/java/org/opensearch/ml/action/load/TransportLoadModelOnNodeActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/load/TransportLoadModelOnNodeActionTests.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.load;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MAX_LOAD_MODEL_TASKS_PER_NODE;
+import static org.opensearch.ml.utils.TestHelper.clusterSetting;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.Version;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.ActionListenerResponseHandler;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.MLTaskType;
+import org.opensearch.ml.common.breaker.MLCircuitBreakerService;
+import org.opensearch.ml.common.dataset.MLInputDataType;
+import org.opensearch.ml.common.exception.MLLimitExceededException;
+import org.opensearch.ml.common.transport.forward.MLForwardResponse;
+import org.opensearch.ml.common.transport.load.LoadModelInput;
+import org.opensearch.ml.common.transport.load.LoadModelNodeRequest;
+import org.opensearch.ml.common.transport.load.LoadModelNodeResponse;
+import org.opensearch.ml.common.transport.load.LoadModelNodesRequest;
+import org.opensearch.ml.common.transport.load.LoadModelNodesResponse;
+import org.opensearch.ml.engine.ModelHelper;
+import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.stats.MLStats;
+import org.opensearch.ml.task.MLTaskManager;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+public class TransportLoadModelOnNodeActionTests extends OpenSearchTestCase {
+
+    @Mock
+    private TransportService transportService;
+
+    @Mock
+    private ModelHelper modelHelper;
+
+    @Mock
+    private MLTaskManager mlTaskManager;
+
+    @Mock
+    private MLModelManager mlModelManager;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private NamedXContentRegistry xContentRegistry;
+
+    @Mock
+    private MLCircuitBreakerService mlCircuitBreakerService;
+
+    @Mock
+    private MLStats mlStats;
+
+    @Mock
+    private ExecutorService executorService;
+
+    @Mock
+    private ActionFilters actionFilters;
+
+    private TransportLoadModelOnNodeAction action;
+
+    private ThreadContext threadContext;
+
+    private Settings settings;
+
+    private DiscoveryNode localNode;
+    private DiscoveryNode localNode1;
+    private DiscoveryNode localNode2;
+    private DiscoveryNode localNode3;
+    private DiscoveryNode clusterManagerNode;
+    private final String clusterManagerNodeId = "clusterManagerNode";
+
+    private MLTask mlTask;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.openMocks(this);
+        settings = Settings.builder().put(ML_COMMONS_MAX_LOAD_MODEL_TASKS_PER_NODE.getKey(), 1).build();
+        ClusterSettings clusterSettings = clusterSetting(settings, ML_COMMONS_MAX_LOAD_MODEL_TASKS_PER_NODE);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        threadContext = new ThreadContext(settings);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(threadPool.executor(anyString())).thenReturn(executorService);
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
+        action = new TransportLoadModelOnNodeAction(
+            transportService,
+            actionFilters,
+            modelHelper,
+            mlTaskManager,
+            mlModelManager,
+            clusterService,
+            threadPool,
+            client,
+            xContentRegistry,
+            mlCircuitBreakerService,
+            mlStats,
+            settings
+        );
+
+        clusterManagerNode = new DiscoveryNode(
+            clusterManagerNodeId,
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            Version.CURRENT
+        );
+
+        localNode = new DiscoveryNode(
+            "foo0",
+            "foo0",
+            new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+            Collections.emptyMap(),
+            Collections.singleton(CLUSTER_MANAGER_ROLE),
+            Version.CURRENT
+        );
+        localNode1 = new DiscoveryNode(
+            "foo1",
+            "foo1",
+            new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+            Collections.emptyMap(),
+            Collections.singleton(CLUSTER_MANAGER_ROLE),
+            Version.CURRENT
+        );
+        localNode2 = new DiscoveryNode(
+            "foo2",
+            "foo2",
+            new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+            Collections.emptyMap(),
+            Collections.singleton(CLUSTER_MANAGER_ROLE),
+            Version.CURRENT
+        );
+        localNode3 = new DiscoveryNode(
+            "foo3",
+            "foo3",
+            new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+            Collections.emptyMap(),
+            Collections.singleton(CLUSTER_MANAGER_ROLE),
+            Version.CURRENT
+        );
+
+        when(clusterService.getClusterName()).thenReturn(new ClusterName("Local Cluster"));
+        when(clusterService.localNode()).thenReturn(localNode);
+
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(3);
+            listener.onResponse("successful");
+            return null;
+        }).when(mlModelManager).loadModel(any(), any(), any(), any());
+        MLForwardResponse forwardResponse = Mockito.mock(MLForwardResponse.class);
+        doAnswer(invocation -> {
+            ActionListenerResponseHandler<MLForwardResponse> handler = invocation.getArgument(3);
+            handler.handleResponse(forwardResponse);
+            return null;
+        }).when(transportService).sendRequest(any(), any(), any(), any());
+
+        DiscoveryNodes nodes = DiscoveryNodes.builder().add(clusterManagerNode).add(localNode1).add(localNode1).add(localNode1).build();
+        ClusterState clusterState = new ClusterState(
+            new ClusterName("Local Cluster"),
+            123l,
+            "111111",
+            null,
+            null,
+            nodes,
+            null,
+            null,
+            0,
+            false
+        );
+        when(clusterService.state()).thenReturn(clusterState);
+
+        Instant time = Instant.now();
+        mlTask = MLTask
+            .builder()
+            .taskId("mlTaskTaskId")
+            .modelId("mlTaskModelId")
+            .taskType(MLTaskType.PREDICTION)
+            .functionName(FunctionName.LINEAR_REGRESSION)
+            .state(MLTaskState.RUNNING)
+            .inputType(MLInputDataType.DATA_FRAME)
+            .workerNode("node1")
+            .progress(0.0f)
+            .outputIndex("test_index")
+            .error("test_error")
+            .createTime(time.minus(1, ChronoUnit.MINUTES))
+            .lastUpdateTime(time)
+            .build();
+
+    }
+
+    public void testConstructor() {
+        assertNotNull(action);
+    }
+
+    public void testNewResponses() {
+        final LoadModelNodesRequest nodesRequest = prepareRequest();
+        Map<String, String> modelToLoadStatus = new HashMap<>();
+        modelToLoadStatus.put("modelName:version", "response");
+        LoadModelNodeResponse response = new LoadModelNodeResponse(localNode, modelToLoadStatus);
+        final List<LoadModelNodeResponse> responses = Arrays.asList(new LoadModelNodeResponse[] { response });
+        final List<FailedNodeException> failures = new ArrayList<FailedNodeException>();
+        LoadModelNodesResponse response1 = action.newResponse(nodesRequest, responses, failures);
+        assertNotNull(response1);
+    }
+
+    public void testNewRequest() {
+        final LoadModelNodesRequest nodesRequest = prepareRequest();
+        final LoadModelNodeRequest request = action.newNodeRequest(nodesRequest);
+        assertNotNull(request);
+    }
+
+    public void testNewNodeResponse() throws IOException {
+        Map<String, String> modelToLoadStatus = new HashMap<>();
+        modelToLoadStatus.put("modelName:version", "response");
+        LoadModelNodeResponse response = new LoadModelNodeResponse(localNode, modelToLoadStatus);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        final LoadModelNodeResponse response1 = action.newNodeResponse(output.bytes().streamInput());
+        assertNotNull(response1);
+    }
+
+    public void testNodeOperation_Success() {
+        final LoadModelNodesRequest nodesRequest = prepareRequest();
+        final LoadModelNodeRequest request = action.newNodeRequest(nodesRequest);
+        final LoadModelNodeResponse response = action.nodeOperation(request);
+        assertNotNull(response);
+    }
+
+    public void testNodeOperation_LoadModelException() {
+        when(mlModelManager.checkAndAddRunningTask(any(), any())).thenThrow(NullPointerException.class);
+        final LoadModelNodesRequest nodesRequest = prepareRequest();
+        final LoadModelNodeRequest request = action.newNodeRequest(nodesRequest);
+        final LoadModelNodeResponse response = action.nodeOperation(request);
+        assertNotNull(response);
+    }
+
+    public void testNodeOperation_Exception() {
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(3);
+            listener.onFailure(new RuntimeException("Something went wrong"));
+            return null;
+        }).when(mlModelManager).loadModel(any(), any(), any(), any());
+        final LoadModelNodesRequest nodesRequest = prepareRequest();
+        final LoadModelNodeRequest request = action.newNodeRequest(nodesRequest);
+        final LoadModelNodeResponse response = action.nodeOperation(request);
+        assertNotNull(response);
+    }
+
+    public void testNodeOperation_MLLimitExceededException() {
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(3);
+            listener.onFailure(new MLLimitExceededException("Limit exceeded exception"));
+            return null;
+        }).when(mlModelManager).loadModel(any(), any(), any(), any());
+        final LoadModelNodesRequest nodesRequest = prepareRequest();
+        final LoadModelNodeRequest request = action.newNodeRequest(nodesRequest);
+        final LoadModelNodeResponse response = action.nodeOperation(request);
+        assertNotNull(response);
+    }
+
+    public void testNodeOperation_ErrorMessageNotNull() {
+        when(mlModelManager.checkAndAddRunningTask(any(), any())).thenReturn("Error message");
+        final LoadModelNodesRequest nodesRequest = prepareRequest();
+        final LoadModelNodeRequest request = action.newNodeRequest(nodesRequest);
+        final LoadModelNodeResponse response = action.nodeOperation(request);
+        assertNotNull(response);
+    }
+
+    private LoadModelNodesRequest prepareRequest() {
+        DiscoveryNode[] nodeIds = { localNode1, localNode2, localNode3 };
+        LoadModelInput loadModelInput = new LoadModelInput("modelId", "taskId", "modelContentHash", 3, "coordinatingNodeId", mlTask);
+        return new LoadModelNodesRequest(nodeIds, loadModelInput);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeActionTests.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.syncup;
+
+import static java.util.Collections.emptyMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ONLY_RUN_ON_ML_NODE;
+import static org.opensearch.ml.utils.TestHelper.ML_ROLE;
+import static org.opensearch.ml.utils.TestHelper.clusterSetting;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.Version;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.sync.MLSyncUpInput;
+import org.opensearch.ml.common.transport.sync.MLSyncUpNodeRequest;
+import org.opensearch.ml.common.transport.sync.MLSyncUpNodeResponse;
+import org.opensearch.ml.common.transport.sync.MLSyncUpNodesRequest;
+import org.opensearch.ml.common.transport.sync.MLSyncUpNodesResponse;
+import org.opensearch.ml.engine.MLEngine;
+import org.opensearch.ml.engine.ModelHelper;
+import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.task.MLTaskManager;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import com.google.common.collect.ImmutableSet;
+
+public class TransportSyncUpOnNodeActionTests extends OpenSearchTestCase {
+
+    @Mock
+    private TransportService transportService;
+
+    @Mock
+    private ActionFilters actionFilters;
+
+    @Mock
+    private ModelHelper modelHelper;
+
+    @Mock
+    private MLTaskManager mlTaskManager;
+
+    @Mock
+    private MLModelManager mlModelManager;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private NamedXContentRegistry xContentRegistry;
+
+    @Mock
+    private MLEngine mlEngine;
+
+    private Settings settings;
+
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    private TransportSyncUpOnNodeAction action;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.openMocks(this);
+        mockSettings(true);
+        when(clusterService.getClusterName()).thenReturn(new ClusterName("Local Cluster"));
+        action = new TransportSyncUpOnNodeAction(
+            transportService,
+            actionFilters,
+            modelHelper,
+            mlTaskManager,
+            mlModelManager,
+            clusterService,
+            threadPool,
+            client,
+            xContentRegistry,
+            mlEngine
+        );
+    }
+
+    public void testConstructor() {
+        assertNotNull(action);
+    }
+
+    public void testNewResponse() {
+        final MLSyncUpNodesRequest nodesRequest = Mockito.mock(MLSyncUpNodesRequest.class);
+        final List<MLSyncUpNodeResponse> responses = new ArrayList<MLSyncUpNodeResponse>();
+        final List<FailedNodeException> failures = new ArrayList<FailedNodeException>();
+        final MLSyncUpNodesResponse response = action.newResponse(nodesRequest, responses, failures);
+        assertNotNull(response);
+    }
+
+    public void testNewRequest() {
+        final MLSyncUpNodeRequest request = action.newNodeRequest(new MLSyncUpNodesRequest(new String[] {}, prepareRequest()));
+        assertNotNull(request);
+    }
+
+    public void testNewNodeResponse() throws IOException {
+        final DiscoveryNode mlNode1 = new DiscoveryNode(
+            "123",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            ImmutableSet.of(ML_ROLE),
+            Version.CURRENT
+        );
+        String[] loadedModelIds = new String[] { "123" };
+        String[] runningLoadModelTaskIds = new String[] { "1" };
+        MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(mlNode1, "LOADED", loadedModelIds, runningLoadModelTaskIds);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        final MLSyncUpNodeResponse response1 = action.newNodeResponse(output.bytes().streamInput());
+        assertNotNull(response1);
+    }
+
+    public void testNodeOperation_AddedWorkerNodes() throws IOException {
+        testFolder.create();
+        File file1 = testFolder.newFolder();
+        File file2 = testFolder.newFolder();
+        File file3 = testFolder.newFolder();
+        for (int i = 0; i < 5; i++) {
+            File.createTempFile("Hello" + i, "1.txt", file1);
+            File.createTempFile("Hello" + i, "1.txt", file2);
+            File.createTempFile("Hello" + i, "1.txt", file3);
+        }
+        when(mlEngine.getModelCachePath(any())).thenReturn(Paths.get(file3.getCanonicalPath()));
+        when(mlEngine.getLoadModelPath(any())).thenReturn(Paths.get(file2.getCanonicalPath()));
+        when(mlEngine.getUploadModelPath(any())).thenReturn(Paths.get(file1.getCanonicalPath()));
+        DiscoveryNode localNode = new DiscoveryNode(
+            "foo0",
+            "foo0",
+            new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+            Collections.emptyMap(),
+            Collections.singleton(CLUSTER_MANAGER_ROLE),
+            Version.CURRENT
+        );
+        when(clusterService.localNode()).thenReturn(localNode);
+        when(mlEngine.getUploadModelRootPath()).thenReturn(Paths.get(file1.getCanonicalPath()));
+        when(mlEngine.getLoadModelRootPath()).thenReturn(Paths.get(file2.getCanonicalPath()));
+        when(mlEngine.getModelCacheRootPath()).thenReturn(Paths.get(file3.getCanonicalPath()));
+        final MLSyncUpNodeRequest request = action.newNodeRequest(new MLSyncUpNodesRequest(new String[] {}, prepareRequest()));
+        final MLSyncUpNodeResponse response = action.nodeOperation(request);
+        assertNotNull(response);
+        file1.deleteOnExit();
+        file2.deleteOnExit();
+        file3.deleteOnExit();
+        testFolder.delete();
+    }
+
+    public void testNodeOperation_RemovedWorkerNodes() throws IOException {
+        testFolder.create();
+        File file1 = testFolder.newFolder();
+        File file2 = testFolder.newFolder();
+        File file3 = testFolder.newFolder();
+        for (int i = 0; i < 5; i++) {
+            File.createTempFile("Hello" + i, "1.txt", file1);
+            File.createTempFile("Hello" + i, "1.txt", file2);
+            File.createTempFile("Hello" + i, "1.txt", file3);
+        }
+        when(mlEngine.getModelCachePath(any())).thenReturn(Paths.get(file3.getCanonicalPath()));
+        when(mlEngine.getLoadModelPath(any())).thenReturn(Paths.get(file2.getCanonicalPath()));
+        when(mlEngine.getUploadModelPath(any())).thenReturn(Paths.get(file1.getCanonicalPath()));
+        DiscoveryNode localNode = new DiscoveryNode(
+            "foo0",
+            "foo0",
+            new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+            Collections.emptyMap(),
+            Collections.singleton(CLUSTER_MANAGER_ROLE),
+            Version.CURRENT
+        );
+        when(clusterService.localNode()).thenReturn(localNode);
+        when(mlEngine.getUploadModelRootPath()).thenReturn(Paths.get(file1.getCanonicalPath()));
+        when(mlEngine.getLoadModelRootPath()).thenReturn(Paths.get(file2.getCanonicalPath()));
+        when(mlEngine.getModelCacheRootPath()).thenReturn(Paths.get(file3.getCanonicalPath()));
+        when(mlTaskManager.contains(any())).thenReturn(true);
+        when(mlTaskManager.containsModel(any())).thenReturn(true);
+        when(mlModelManager.isModelRunningOnNode(anyString())).thenReturn(true);
+        final MLSyncUpNodeRequest request = action.newNodeRequest(new MLSyncUpNodesRequest(new String[] {}, prepareRequest2()));
+        final MLSyncUpNodeResponse response = action.nodeOperation(request);
+        assertNotNull(response);
+        file1.deleteOnExit();
+        file2.deleteOnExit();
+        file3.deleteOnExit();
+        testFolder.delete();
+    }
+
+    private MLSyncUpInput prepareRequest() {
+        Map<String, String[]> addedWorkerNodes = new HashMap<>();
+        addedWorkerNodes.put("modelId1", new String[] { "nodeId1", "nodeId2", "nodeId3" });
+        Map<String, Set<String>> modelRoutingTable = new HashMap<>();
+        Map<String, Set<String>> runningLoadModelTasks = new HashMap<>();
+        final HashSet<String> set = new HashSet<>();
+        set.addAll(Arrays.asList(new String[] { "nodeId3", "nodeId4", "nodeId5" }));
+        modelRoutingTable.put("modelId2", set);
+        MLSyncUpInput syncUpInput = MLSyncUpInput
+            .builder()
+            .getLoadedModels(true)
+            .addedWorkerNodes(addedWorkerNodes)
+            .modelRoutingTable(modelRoutingTable)
+            .runningLoadModelTasks(runningLoadModelTasks)
+            .clearRoutingTable(true)
+            .syncRunningLoadModelTasks(true)
+            .build();
+        return syncUpInput;
+    }
+
+    private MLSyncUpInput prepareRequest2() {
+        Map<String, String[]> removedWorkerNodes = new HashMap<>();
+        removedWorkerNodes.put("modelId2", new String[] { "nodeId3", "nodeId4", "nodeId5" });
+        Map<String, Set<String>> modelRoutingTable = new HashMap<>();
+        Map<String, Set<String>> runningLoadModelTasks = new HashMap<>();
+        final HashSet<String> set = new HashSet<>();
+        set.addAll(Arrays.asList(new String[] { "nodeId3", "nodeId4", "nodeId5" }));
+        modelRoutingTable.put("modelId2", set);
+        MLSyncUpInput syncUpInput = MLSyncUpInput
+            .builder()
+            .getLoadedModels(true)
+            .removedWorkerNodes(removedWorkerNodes)
+            .modelRoutingTable(modelRoutingTable)
+            .runningLoadModelTasks(runningLoadModelTasks)
+            .clearRoutingTable(false)
+            .syncRunningLoadModelTasks(true)
+            .build();
+        return syncUpInput;
+    }
+
+    private void mockSettings(boolean onlyRunOnMLNode) {
+        settings = Settings.builder().put(ML_COMMONS_ONLY_RUN_ON_ML_NODE.getKey(), onlyRunOnMLNode).build();
+        ClusterSettings clusterSettings = clusterSetting(settings, ML_COMMONS_ONLY_RUN_ON_ML_NODE);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/unload/TransportUnloadModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/unload/TransportUnloadModelActionTests.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.unload;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.Version;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.ml.cluster.DiscoveryNodeHelper;
+import org.opensearch.ml.common.transport.unload.UnloadModelNodeRequest;
+import org.opensearch.ml.common.transport.unload.UnloadModelNodeResponse;
+import org.opensearch.ml.common.transport.unload.UnloadModelNodesRequest;
+import org.opensearch.ml.common.transport.unload.UnloadModelNodesResponse;
+import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.stats.MLStat;
+import org.opensearch.ml.stats.MLStats;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+public class TransportUnloadModelActionTests extends OpenSearchTestCase {
+
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private TransportService transportService;
+
+    @Mock
+    private ActionFilters actionFilters;
+
+    @Mock
+    private MLModelManager mlModelManager;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private DiscoveryNodeHelper nodeFilter;
+
+    @Mock
+    private MLStats mlStats;
+
+    private ThreadContext threadContext;
+
+    @Mock
+    private ExecutorService executorService;
+
+    private TransportUnloadModelAction action;
+
+    private DiscoveryNode localNode;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.openMocks(this);
+        Settings settings = Settings.builder().build();
+        threadContext = new ThreadContext(settings);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(threadPool.executor(anyString())).thenReturn(executorService);
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
+        action = new TransportUnloadModelAction(
+            transportService,
+            actionFilters,
+            mlModelManager,
+            clusterService,
+            null,
+            client,
+            nodeFilter,
+            mlStats
+        );
+        localNode = new DiscoveryNode(
+            "foo0",
+            "foo0",
+            new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+            Collections.emptyMap(),
+            Collections.singleton(CLUSTER_MANAGER_ROLE),
+            Version.CURRENT
+        );
+        when(clusterService.getClusterName()).thenReturn(new ClusterName("Local Cluster"));
+        when(clusterService.localNode()).thenReturn(localNode);
+    }
+
+    public void testConstructor() {
+        assertNotNull(action);
+    }
+
+    public void testNewNodeRequest() {
+        final UnloadModelNodesRequest request = new UnloadModelNodesRequest(
+            new String[] { "nodeId1", "nodeId2" },
+            new String[] { "modelId1", "modelId2" }
+        );
+        final UnloadModelNodeRequest unLoadrequest = action.newNodeRequest(request);
+        assertNotNull(unLoadrequest);
+    }
+
+    public void testNewNodeStreamRequest() throws IOException {
+        java.util.Map<String, String> modelToLoadStatus = new HashMap<>();
+        modelToLoadStatus.put("modelName:version", "response");
+        UnloadModelNodeResponse response = new UnloadModelNodeResponse(localNode, modelToLoadStatus);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        final UnloadModelNodeResponse unLoadResponse = action.newNodeResponse(output.bytes().streamInput());
+        assertNotNull(unLoadResponse);
+    }
+
+    public void testNodeOperation() {
+        MLStat mlStat = mock(MLStat.class);
+        when(mlStats.getStat(any())).thenReturn(mlStat);
+        final UnloadModelNodesRequest request = new UnloadModelNodesRequest(
+            new String[] { "nodeId1", "nodeId2" },
+            new String[] { "modelId1", "modelId2" }
+        );
+        final UnloadModelNodeResponse response = action.nodeOperation(new UnloadModelNodeRequest(request));
+        assertNotNull(response);
+    }
+
+    public void testNewResponseWithUnloadedModelStatus() {
+        final UnloadModelNodesRequest nodesRequest = new UnloadModelNodesRequest(
+            new String[] { "nodeId1", "nodeId2" },
+            new String[] { "modelId1", "modelId2" }
+        );
+        final List<UnloadModelNodeResponse> responses = new ArrayList<>();
+        java.util.Map<String, String> modelToLoadStatus = new HashMap<>();
+        modelToLoadStatus.put("modelName:version", "unloaded");
+        UnloadModelNodeResponse response1 = new UnloadModelNodeResponse(localNode, modelToLoadStatus);
+        modelToLoadStatus.put("modelName:version", "unloaded");
+        UnloadModelNodeResponse response2 = new UnloadModelNodeResponse(localNode, modelToLoadStatus);
+        responses.add(response1);
+        responses.add(response2);
+        final List<FailedNodeException> failures = new ArrayList<>();
+        final UnloadModelNodesResponse response = action.newResponse(nodesRequest, responses, failures);
+        assertNotNull(response);
+
+    }
+
+    public void testNewResponseWithNotFoundModelStatus() {
+        final UnloadModelNodesRequest nodesRequest = new UnloadModelNodesRequest(
+            new String[] { "nodeId1", "nodeId2" },
+            new String[] { "modelId1", "modelId2" }
+        );
+        final List<UnloadModelNodeResponse> responses = new ArrayList<>();
+        java.util.Map<String, String> modelToLoadStatus = new HashMap<>();
+        modelToLoadStatus.put("modelName:version", "not_found");
+        UnloadModelNodeResponse response1 = new UnloadModelNodeResponse(localNode, modelToLoadStatus);
+        modelToLoadStatus.put("modelName:version", "not_found");
+        UnloadModelNodeResponse response2 = new UnloadModelNodeResponse(localNode, modelToLoadStatus);
+        responses.add(response1);
+        responses.add(response2);
+        final List<FailedNodeException> failures = new ArrayList<>();
+        final UnloadModelNodesResponse response = action.newResponse(nodesRequest, responses, failures);
+        assertNotNull(response);
+    }
+}


### PR DESCRIPTION
* unit tests coverage for load/unload/syncup

Signed-off-by: Bhavana Ramaram <rbhavna@amazon.com>
Signed-off-by: Sicheng Song <sicheng.song@outlook.com>

### Description
This PR is a partial forwarding of port changes in branch 2.x ([commit #592](https://github.com/opensearch-project/ml-commons/commit/231499d2a2050c2a80c93929339d7a83adbecab4)) to main branch.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
