### PR TITLE
model auto-reload

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -26,129 +26,134 @@ public class CommonValue {
     public static String WARM_BOX_TYPE = "warm";
 
     public static final String ML_MODEL_INDEX = ".plugins-ml-model";
+    public static final String ML_MODEL_RELOAD_INDEX = ".plugins-ml-model-reload";
+    public static final Integer ML_MODEL_RELOAD_MAX_RETRY_TIMES = 2;
     public static final String ML_TASK_INDEX = ".plugins-ml-task";
     public static final Integer ML_MODEL_INDEX_SCHEMA_VERSION = 2;
     public static final Integer ML_TASK_INDEX_SCHEMA_VERSION = 1;
     public static final String USER_FIELD_MAPPING = "      \""
-            + CommonValue.USER
-            + "\": {\n"
-            + "        \"type\": \"nested\",\n"
-            + "        \"properties\": {\n"
-            + "          \"name\": {\"type\":\"text\", \"fields\":{\"keyword\":{\"type\":\"keyword\", \"ignore_above\":256}}},\n"
-            + "          \"backend_roles\": {\"type\":\"text\", \"fields\":{\"keyword\":{\"type\":\"keyword\"}}},\n"
-            + "          \"roles\": {\"type\":\"text\", \"fields\":{\"keyword\":{\"type\":\"keyword\"}}},\n"
-            + "          \"custom_attribute_names\": {\"type\":\"text\", \"fields\":{\"keyword\":{\"type\":\"keyword\"}}}\n"
-            + "        }\n"
-            + "      }\n";
+        + CommonValue.USER
+        + "\": {\n"
+        + "        \"type\": \"nested\",\n"
+        + "        \"properties\": {\n"
+        + "          \"name\": {\"type\":\"text\", \"fields\":{\"keyword\":{\"type\":\"keyword\", \"ignore_above\":256}}},\n"
+        + "          \"backend_roles\": {\"type\":\"text\", \"fields\":{\"keyword\":{\"type\":\"keyword\"}}},\n"
+        + "          \"roles\": {\"type\":\"text\", \"fields\":{\"keyword\":{\"type\":\"keyword\"}}},\n"
+        + "          \"custom_attribute_names\": {\"type\":\"text\", \"fields\":{\"keyword\":{\"type\":\"keyword\"}}}\n"
+        + "        }\n"
+        + "      }\n";
+    public static final String NODE_ID_FIELD = "node_id";
+    public static final String MODEL_LOAD_RETRY_TIMES_FIELD = "retry_times";
+
     public static final String ML_MODEL_INDEX_MAPPING = "{\n"
-            + "    \"_meta\": {\"schema_version\": "
-            + ML_MODEL_INDEX_SCHEMA_VERSION
-            + "},\n"
-            + "    \"properties\": {\n"
-            + "      \""
-            + MLModel.ALGORITHM_FIELD
-            + "\": {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLModel.MODEL_NAME_FIELD
-            + "\" : {\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\n"
-            + "      \""
-            + MLModel.OLD_MODEL_VERSION_FIELD
-            + "\" : {\"type\": \"long\"},\n"
-            + "      \""
-            + MLModel.MODEL_VERSION_FIELD
-            + "\" : {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLModel.MODEL_CONTENT_FIELD
-            + "\" : {\"type\": \"binary\"},\n"
-            + "      \""
-            + MLModel.CHUNK_NUMBER_FIELD
-            + "\" : {\"type\": \"long\"},\n"
-            + "      \""
-            + MLModel.TOTAL_CHUNKS_FIELD
-            + "\" : {\"type\": \"long\"},\n"
-            + "      \""
-            + MLModel.MODEL_ID_FIELD
-            + "\" : {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLModel.DESCRIPTION_FIELD
-            + "\" : {\"type\": \"text\"},\n"
-            + "      \""
-            + MLModel.MODEL_FORMAT_FIELD
-            + "\" : {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLModel.MODEL_STATE_FIELD
-            + "\" : {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLModel.MODEL_CONTENT_SIZE_IN_BYTES_FIELD
-            + "\" : {\"type\": \"long\"},\n"
-            + "      \""
-            + MLModel.MODEL_CONFIG_FIELD
-            + "\" : {\"properties\":{\""
-            + MODEL_TYPE_FIELD + "\":{\"type\":\"keyword\"},\""
-            + EMBEDDING_DIMENSION_FIELD + "\":{\"type\":\"integer\"},\""
-            + FRAMEWORK_TYPE_FIELD + "\":{\"type\":\"keyword\"},\""
-            + ALL_CONFIG_FIELD + "\":{\"type\":\"text\"}}},\n"
-            + "      \""
-            + MLModel.MODEL_CONTENT_HASH_VALUE_FIELD
-            + "\" : {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLModel.CREATED_TIME_FIELD
-            + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
-            + "      \""
-            + MLModel.LAST_UPLOADED_TIME_FIELD
-            + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
-            + "      \""
-            + MLModel.LAST_LOADED_TIME_FIELD
-            + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
-            + "      \""
-            + MLModel.LAST_UNLOADED_TIME_FIELD
-            + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
-            + USER_FIELD_MAPPING
-            + "    }\n"
-            + "}";
+        + "    \"_meta\": {\"schema_version\": "
+        + ML_MODEL_INDEX_SCHEMA_VERSION
+        + "},\n"
+        + "    \"properties\": {\n"
+        + "      \""
+        + MLModel.ALGORITHM_FIELD
+        + "\": {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLModel.MODEL_NAME_FIELD
+        + "\" : {\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\n"
+        + "      \""
+        + MLModel.OLD_MODEL_VERSION_FIELD
+        + "\" : {\"type\": \"long\"},\n"
+        + "      \""
+        + MLModel.MODEL_VERSION_FIELD
+        + "\" : {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLModel.MODEL_CONTENT_FIELD
+        + "\" : {\"type\": \"binary\"},\n"
+        + "      \""
+        + MLModel.CHUNK_NUMBER_FIELD
+        + "\" : {\"type\": \"long\"},\n"
+        + "      \""
+        + MLModel.TOTAL_CHUNKS_FIELD
+        + "\" : {\"type\": \"long\"},\n"
+        + "      \""
+        + MLModel.MODEL_ID_FIELD
+        + "\" : {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLModel.DESCRIPTION_FIELD
+        + "\" : {\"type\": \"text\"},\n"
+        + "      \""
+        + MLModel.MODEL_FORMAT_FIELD
+        + "\" : {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLModel.MODEL_STATE_FIELD
+        + "\" : {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLModel.MODEL_CONTENT_SIZE_IN_BYTES_FIELD
+        + "\" : {\"type\": \"long\"},\n"
+        + "      \""
+        + MLModel.MODEL_CONFIG_FIELD
+        + "\" : {\"properties\":{\""
+        + MODEL_TYPE_FIELD + "\":{\"type\":\"keyword\"},\""
+        + EMBEDDING_DIMENSION_FIELD + "\":{\"type\":\"integer\"},\""
+        + FRAMEWORK_TYPE_FIELD + "\":{\"type\":\"keyword\"},\""
+        + ALL_CONFIG_FIELD + "\":{\"type\":\"text\"}}},\n"
+        + "      \""
+        + MLModel.MODEL_CONTENT_HASH_VALUE_FIELD
+        + "\" : {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLModel.CREATED_TIME_FIELD
+        + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
+        + "      \""
+        + MLModel.LAST_UPLOADED_TIME_FIELD
+        + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
+        + "      \""
+        + MLModel.LAST_LOADED_TIME_FIELD
+        + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
+        + "      \""
+        + MLModel.LAST_UNLOADED_TIME_FIELD
+        + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
+        + USER_FIELD_MAPPING
+        + "    }\n"
+        + "}";
 
     public static final String ML_TASK_INDEX_MAPPING = "{\n"
-            + "    \"_meta\": {\"schema_version\": "
-            + ML_TASK_INDEX_SCHEMA_VERSION
-            + "},\n"
-            + "    \"properties\": {\n"
-            + "      \""
-            + MLTask.MODEL_ID_FIELD
-            + "\": {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLTask.TASK_TYPE_FIELD
-            + "\": {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLTask.FUNCTION_NAME_FIELD
-            + "\": {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLTask.STATE_FIELD
-            + "\": {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLTask.INPUT_TYPE_FIELD
-            + "\": {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLTask.PROGRESS_FIELD
-            + "\": {\"type\": \"float\"},\n"
-            + "      \""
-            + MLTask.OUTPUT_INDEX_FIELD
-            + "\": {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLTask.WORKER_NODE_FIELD
-            + "\": {\"type\": \"keyword\"},\n"
-            + "      \""
-            + MLTask.CREATE_TIME_FIELD
-            + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
-            + "      \""
-            + MLTask.LAST_UPDATE_TIME_FIELD
-            + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
-            + "      \""
-            + MLTask.ERROR_FIELD
-            + "\": {\"type\": \"text\"},\n"
-            + "      \""
-            + MLTask.IS_ASYNC_TASK_FIELD
-            + "\" : {\"type\" : \"boolean\"}, \n"
-            + USER_FIELD_MAPPING
-            + "    }\n"
-            + "}";
+        + "    \"_meta\": {\"schema_version\": "
+        + ML_TASK_INDEX_SCHEMA_VERSION
+        + "},\n"
+        + "    \"properties\": {\n"
+        + "      \""
+        + MLTask.MODEL_ID_FIELD
+        + "\": {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLTask.TASK_TYPE_FIELD
+        + "\": {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLTask.FUNCTION_NAME_FIELD
+        + "\": {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLTask.STATE_FIELD
+        + "\": {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLTask.INPUT_TYPE_FIELD
+        + "\": {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLTask.PROGRESS_FIELD
+        + "\": {\"type\": \"float\"},\n"
+        + "      \""
+        + MLTask.OUTPUT_INDEX_FIELD
+        + "\": {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLTask.WORKER_NODE_FIELD
+        + "\": {\"type\": \"keyword\"},\n"
+        + "      \""
+        + MLTask.CREATE_TIME_FIELD
+        + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
+        + "      \""
+        + MLTask.LAST_UPDATE_TIME_FIELD
+        + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
+        + "      \""
+        + MLTask.ERROR_FIELD
+        + "\": {\"type\": \"text\"},\n"
+        + "      \""
+        + MLTask.IS_ASYNC_TASK_FIELD
+        + "\" : {\"type\" : \"boolean\"}, \n"
+        + USER_FIELD_MAPPING
+        + "    }\n"
+        + "}";
 }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelAutoReLoader.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelAutoReLoader.java
@@ -203,14 +203,15 @@ public class MLModelAutoReLoader {
                 return 0;
             }
 
-            for (SearchHit hit : hits) {
-                Map<String, Object> sourceAsMap = hit.getSourceAsMap();
-                return (Integer) sourceAsMap.get(MODEL_LOAD_RETRY_TIMES_FIELD);
+            if (hits.length != 1) {
+                throw new RuntimeException("can't get retry times by " + nodeId);
             }
+
+            Map<String, Object> sourceAsMap = hits[0].getSourceAsMap();
+            return (Integer) sourceAsMap.get(MODEL_LOAD_RETRY_TIMES_FIELD);
         } catch (IndexNotFoundException e) {
             throw new IndexNotFoundException("index " + ML_MODEL_RELOAD_INDEX + " not found");
         }
-        throw new RuntimeException("can't get retry times by " + nodeId);
     }
 
     /**

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelAutoReLoader.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelAutoReLoader.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.ml.model;
+
+import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_RELOAD_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_RELOAD_MAX_RETRY_TIMES;
+import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
+import static org.opensearch.ml.common.CommonValue.MODEL_LOAD_RETRY_TIMES_FIELD;
+import static org.opensearch.ml.common.CommonValue.NODE_ID_FIELD;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MODEL_AUTO_RELOAD_ENABLE;
+import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.opensearch.action.admin.indices.exists.indices.IndicesExistsAction;
+import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest;
+import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse;
+import org.opensearch.action.index.IndexAction;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchAction;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.CollectionUtils;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.ml.cluster.DiscoveryNodeHelper;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.MLTaskType;
+import org.opensearch.ml.common.transport.load.MLLoadModelAction;
+import org.opensearch.ml.common.transport.load.MLLoadModelRequest;
+import org.opensearch.ml.utils.MLNodeUtils;
+import org.opensearch.rest.RestStatus;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Manager class for ML models and nodes. It contains ML model auto reload operations etc.
+ */
+@Log4j2
+public class MLModelAutoReLoader {
+    private final Client client;
+    private final ClusterService clusterService;
+    private final NamedXContentRegistry xContentRegistry;
+    private final DiscoveryNodeHelper nodeHelper;
+    private volatile Boolean enableAutoReLoadModel;
+
+    /**
+     * constructor method， init all the params necessary for model auto reloading
+     * @param clusterService
+     * @param client
+     * @param xContentRegistry
+     * @param nodeHelper
+     * @param settings
+     */
+    public MLModelAutoReLoader(
+        ClusterService clusterService,
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        DiscoveryNodeHelper nodeHelper,
+        Settings settings
+    ) {
+        this.clusterService = clusterService;
+        this.client = client;
+        this.xContentRegistry = xContentRegistry;
+        this.nodeHelper = nodeHelper;
+
+        enableAutoReLoadModel = ML_COMMONS_MODEL_AUTO_RELOAD_ENABLE.get(settings);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_MODEL_AUTO_RELOAD_ENABLE, it -> enableAutoReLoadModel = it);
+    }
+
+    /**
+     * the main method: model auto reloading
+     */
+    public void autoReLoadModel() {
+        log.debug("enableAutoReLoadModel {} ", enableAutoReLoadModel);
+
+        // if we don't need to reload automatically, just return without doing anything
+        if (!enableAutoReLoadModel) {
+            return;
+        }
+
+        // At opensearch startup, get local node id, if not ml node,we ignored, just return without doing anything
+        String localNodeId = clusterService.localNode().getId();
+        if (!MLNodeUtils.isMLNode(nodeHelper.getNode(localNodeId))) {
+            return;
+        }
+
+        // According to the node id to get retry times, if more than the maxi retry times, don't need to retry
+        // that the number of unsuccessful reload has reached the maximum number of times, do not need to reload
+        Integer reTryTimes = getReTryTimes(localNodeId);
+        if (reTryTimes > ML_MODEL_RELOAD_MAX_RETRY_TIMES) {
+            log.debug("have exceeded max retry times, always failure");
+        }
+
+        // auto reload all models of this local node, if it fails, reTryTimes+1, if it succeeds, reTryTimes is cleared to 0
+        CompletableFuture<Void> completableFuture = CompletableFuture.runAsync(() -> autoReLoadModelByNodeId(localNodeId));
+
+        try {
+            completableFuture.get();
+        } catch (Exception e) {
+            throw new RuntimeException("Can't auto reload model");
+        }
+    }
+
+    /**
+     * auto reload all the models under the node id
+     * the node must be a ml node
+     * @param nodeId node id
+     */
+    @VisibleForTesting
+    void autoReLoadModelByNodeId(String nodeId) {
+        if (!isExistedIndex(ML_TASK_INDEX)) {
+            return;
+        }
+
+        SearchRequest searchRequest = new SearchRequest(ML_TASK_INDEX);
+        SearchResponse response = client.execute(SearchAction.INSTANCE, searchRequest).actionGet(5000);
+
+        SearchHit[] hits = response.getHits().getHits();
+        if (CollectionUtils.isEmpty(hits)) {
+            return;
+        }
+
+        Integer reTryTimes = 0;
+        for (SearchHit hit : hits) {
+            try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, hit.getSourceRef())) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                MLTask mlTask = MLTask.parse(parser);
+
+                String workerNode = mlTask.getWorkerNode();
+                MLTaskType mlTaskType = mlTask.getTaskType();
+                MLTaskState mlTaskState = mlTask.getState();
+
+                if (workerNode.contains(nodeId) && mlTaskType == MLTaskType.LOAD_MODEL && mlTaskState == MLTaskState.COMPLETED) {
+                    autoReLoadModelByNodeAndModelId(nodeId, mlTask.getModelId());
+                }
+            } catch (RuntimeException | IOException e) {
+                reTryTimes++;
+                // Store the latest value of the reTryTimes and node id under the index ".plugins-ml-model-reload"
+                saveLatestReTryTimes(nodeId, reTryTimes);
+                log.error("Can't auto reload model in node id {} ,has try {} times\nThe reason is:{}", nodeId, reTryTimes, e.getMessage());
+            }
+        }
+
+        // Store the latest value of the reTryTimes and node id under the index ".plugins-ml-model-reload"
+        saveLatestReTryTimes(nodeId, reTryTimes);
+    }
+
+    /**
+     *  auto reload 1 model under the node id
+     * @param nodeId node id
+     * @param modelId model id
+     */
+    @VisibleForTesting
+    void autoReLoadModelByNodeAndModelId(String nodeId, String modelId) {
+        MLLoadModelRequest mlLoadModelRequest = new MLLoadModelRequest(modelId, new String[] { nodeId }, false, false);
+        client.execute(MLLoadModelAction.INSTANCE, mlLoadModelRequest).actionGet(5000);
+    }
+
+    /**
+     * get retry times from the index ".plugins-ml-model-reload" by 1 ml node
+     * @param nodeId the filter condition to query
+     * @return retry times
+     */
+    @VisibleForTesting
+    Integer getReTryTimes(String nodeId) {
+        if (!isExistedIndex(ML_MODEL_RELOAD_INDEX)) {
+            return 0;
+        }
+
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.fetchSource(new String[] { MODEL_LOAD_RETRY_TIMES_FIELD }, null);
+        QueryBuilder queryBuilder = QueryBuilders.idsQuery().addIds(nodeId);
+        searchSourceBuilder.query(queryBuilder);
+        SearchRequest searchRequest = new SearchRequest().source(searchSourceBuilder).indices(ML_MODEL_RELOAD_INDEX);
+
+        try {
+            SearchResponse response = client.execute(SearchAction.INSTANCE, searchRequest).actionGet(5000);
+
+            SearchHit[] hits = response.getHits().getHits();
+            if (CollectionUtils.isEmpty(hits)) {
+                return 0;
+            }
+
+            for (SearchHit hit : hits) {
+                Map<String, Object> sourceAsMap = hit.getSourceAsMap();
+                return (Integer) sourceAsMap.get(MODEL_LOAD_RETRY_TIMES_FIELD);
+            }
+        } catch (IndexNotFoundException e) {
+            throw new IndexNotFoundException("index " + ML_MODEL_RELOAD_INDEX + " not found");
+        }
+        throw new RuntimeException("can't get retry times by " + nodeId);
+    }
+
+    /**
+     * judge whether the index ".plugins-ml-model-reload" existed
+     * @param indexName index name
+     * @return true: existed. false: not existed
+     */
+    @VisibleForTesting
+    boolean isExistedIndex(String indexName) {
+        IndicesExistsRequest existsRequest = new IndicesExistsRequest(indexName);
+        IndicesExistsResponse exists = client.execute(IndicesExistsAction.INSTANCE, existsRequest).actionGet(5000);
+
+        return exists.isExists();
+    }
+
+    /**
+     * save retry times
+     * @param nodeId node id
+     * @param reTryTimes actual retry times
+     */
+    @VisibleForTesting
+    void saveLatestReTryTimes(String nodeId, Integer reTryTimes) {
+        Map<String, Object> content = new HashMap<>();
+        content.put(NODE_ID_FIELD, nodeId);
+        content.put(MODEL_LOAD_RETRY_TIMES_FIELD, reTryTimes);
+
+        IndexRequest indexRequest = new IndexRequest(ML_MODEL_RELOAD_INDEX);
+        indexRequest.id(nodeId);
+        indexRequest.source(content);
+        indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        IndexResponse indexResponse = client.execute(IndexAction.INSTANCE, indexRequest).actionGet(5000);
+
+        if (indexResponse.status() == RestStatus.CREATED || indexResponse.status() == RestStatus.OK) {
+            log.debug("node id:{} insert retry times successfully", nodeId);
+        } else {
+            throw new RuntimeException("can't insert retry times by " + nodeId);
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -97,6 +97,7 @@ import org.opensearch.ml.engine.algorithms.anomalylocalization.AnomalyLocalizerI
 import org.opensearch.ml.engine.algorithms.sample.LocalSampleCalculator;
 import org.opensearch.ml.indices.MLIndicesHandler;
 import org.opensearch.ml.indices.MLInputDatasetHandler;
+import org.opensearch.ml.model.MLModelAutoReLoader;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.ml.rest.RestMLCreateModelMetaAction;
@@ -158,6 +159,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
     private MLModelCacheHelper modelCacheHelper;
     private MLTaskManager mlTaskManager;
     private MLModelManager mlModelManager;
+    private MLModelAutoReLoader mlModelAutoReLoader;
     private MLIndicesHandler mlIndicesHandler;
     private MLInputDatasetHandler mlInputDatasetHandler;
     private MLTrainingTaskRunner mlTrainingTaskRunner;
@@ -264,6 +266,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
             modelCacheHelper,
             mlEngine
         );
+        mlModelAutoReLoader = new MLModelAutoReLoader(clusterService, client, xContentRegistry, nodeHelper, settings);
         mlInputDatasetHandler = new MLInputDatasetHandler(client);
 
         mlModelMetaCreate = new MLModelMetaCreate(mlIndicesHandler, threadPool, client);
@@ -345,6 +348,8 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
             nodeHelper
         );
 
+        mlModelAutoReLoader.autoReLoadModel();
+
         return ImmutableList
             .of(
                 mlEngine,
@@ -353,6 +358,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
                 mlStats,
                 mlTaskManager,
                 mlModelManager,
+                mlModelAutoReLoader,
                 mlIndicesHandler,
                 mlInputDatasetHandler,
                 mlTrainingTaskRunner,
@@ -504,7 +510,8 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
                 MLCommonsSettings.ML_COMMONS_MAX_UPLOAD_TASKS_PER_NODE,
                 MLCommonsSettings.ML_COMMONS_MAX_ML_TASK_PER_NODE,
                 MLCommonsSettings.ML_COMMONS_MAX_LOAD_MODEL_TASKS_PER_NODE,
-                MLCommonsSettings.ML_COMMONS_TRUSTED_URL_REGEX
+                MLCommonsSettings.ML_COMMONS_TRUSTED_URL_REGEX,
+                MLCommonsSettings.ML_COMMONS_MODEL_AUTO_RELOAD_ENABLE
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -52,4 +52,7 @@ public final class MLCommonsSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
+
+    public static final Setting<Boolean> ML_COMMONS_MODEL_AUTO_RELOAD_ENABLE = Setting
+        .boolSetting("plugins.ml_commons.model.autoreload.enable", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelAutoReLoaderITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelAutoReLoaderITTests.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.model;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_RELOAD_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MAX_MODELS_PER_NODE;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MAX_UPLOAD_TASKS_PER_NODE;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MODEL_AUTO_RELOAD_ENABLE;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MONITORING_REQUEST_COUNT;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ONLY_RUN_ON_ML_NODE;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.index.IndexAction;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.ml.action.MLCommonsIntegTestCase;
+import org.opensearch.ml.cluster.DiscoveryNodeHelper;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.MLTaskType;
+import org.opensearch.ml.common.model.MLModelConfig;
+import org.opensearch.ml.common.model.MLModelFormat;
+import org.opensearch.ml.common.model.MLModelState;
+import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 3)
+public class MLModelAutoReLoaderITTests extends MLCommonsIntegTestCase {
+    private final Instant time = Instant.now();
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Mock
+    private DiscoveryNodeHelper nodeHelper;
+    private Settings settings;
+    private MLModelAutoReLoader mlModelAutoReLoader;
+    private String modelId;
+    private String localNodeId;
+    @Mock
+    private MLModelManager modelManager;
+    private MLModel modelChunk0;
+    private MLModel modelChunk1;
+
+    @Before
+    public void setup() throws Exception {
+        super.setUp();
+
+        settings = Settings.builder().put(ML_COMMONS_ONLY_RUN_ON_ML_NODE.getKey(), true).build();
+        settings = Settings.builder().put(ML_COMMONS_MAX_MODELS_PER_NODE.getKey(), 10).build();
+        settings = Settings.builder().put(ML_COMMONS_MAX_UPLOAD_TASKS_PER_NODE.getKey(), 10).build();
+        settings = Settings.builder().put(ML_COMMONS_MONITORING_REQUEST_COUNT.getKey(), 10).build();
+        settings = Settings.builder().put(ML_COMMONS_MODEL_AUTO_RELOAD_ENABLE.getKey(), true).build();
+
+        nodeHelper = spy(new DiscoveryNodeHelper(clusterService(), settings));
+
+        mlModelAutoReLoader = spy(new MLModelAutoReLoader(clusterService(), client(), xContentRegistry(), nodeHelper, settings));
+        modelId = "modelId1";
+        localNodeId = clusterService().localNode().getId();
+        modelManager = mock(MLModelManager.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        settings = null;
+        nodeHelper = null;
+        mlModelAutoReLoader = null;
+        modelId = null;
+        localNodeId = null;
+        modelManager = null;
+    }
+
+    public void testIsExistedIndex() {
+        assertFalse(mlModelAutoReLoader.isExistedIndex(ML_MODEL_RELOAD_INDEX));
+
+        createIndex(ML_MODEL_RELOAD_INDEX);
+
+        assertTrue(mlModelAutoReLoader.isExistedIndex(ML_MODEL_RELOAD_INDEX));
+    }
+
+    public void testSaveLatestReTryTimes_getReTryTimes() {
+        assertFalse(mlModelAutoReLoader.isExistedIndex(ML_MODEL_RELOAD_INDEX));
+
+        mlModelAutoReLoader.saveLatestReTryTimes(localNodeId, 0);
+        assertTrue(mlModelAutoReLoader.isExistedIndex(ML_MODEL_RELOAD_INDEX));
+        Integer retryTimes = mlModelAutoReLoader.getReTryTimes(localNodeId);
+        assertThat(retryTimes, is(0));
+
+        mlModelAutoReLoader.saveLatestReTryTimes(localNodeId, 1);
+        retryTimes = mlModelAutoReLoader.getReTryTimes(localNodeId);
+        assertThat(retryTimes, is(1));
+    }
+
+    public void testGetReTryTimes_IndexNotExisted() {
+        Integer retryTimes = mlModelAutoReLoader.getReTryTimes(localNodeId);
+        assertThat(retryTimes, is(0));
+    }
+
+    public void testGetReTryTimes_EmptyHits() {
+        assertFalse(mlModelAutoReLoader.isExistedIndex(ML_MODEL_RELOAD_INDEX));
+
+        createIndex(ML_MODEL_RELOAD_INDEX);
+
+        Integer retryTimes = mlModelAutoReLoader.getReTryTimes(localNodeId);
+        assertThat(retryTimes, is(0));
+    }
+
+    public void testAutoReLoadModelByNodeAndModelId_Exception() {
+        exceptionRule.expect(Exception.class);
+        mlModelAutoReLoader.autoReLoadModelByNodeAndModelId(localNodeId, modelId);
+    }
+
+    public void testAutoReLoadModelByNodeId() throws IOException, URISyntaxException {
+        initDataOfMlTask(localNodeId, modelId, MLTaskType.LOAD_MODEL, MLTaskState.COMPLETED);
+        initDataOfMlModel(modelId, MLModelState.LOADED);
+
+        mlModelAutoReLoader.autoReLoadModelByNodeId(localNodeId);
+
+        assertTrue(mlModelAutoReLoader.isExistedIndex(ML_TASK_INDEX));
+        assertTrue(mlModelAutoReLoader.isExistedIndex(ML_MODEL_INDEX));
+        assertTrue(mlModelAutoReLoader.isExistedIndex(ML_MODEL_RELOAD_INDEX));
+    }
+
+    public void testAutoReLoadModelByNodeId_IndexNotFound() {
+        mlModelAutoReLoader.autoReLoadModelByNodeId(localNodeId);
+
+        assertFalse(mlModelAutoReLoader.isExistedIndex(ML_MODEL_INDEX));
+        assertFalse(mlModelAutoReLoader.isExistedIndex(ML_MODEL_RELOAD_INDEX));
+    }
+
+    public void testAutoReLoadModelByNodeId_EmptyHits() {
+        assertFalse(mlModelAutoReLoader.isExistedIndex(ML_TASK_INDEX));
+
+        createIndex(ML_TASK_INDEX);
+
+        mlModelAutoReLoader.autoReLoadModelByNodeId(localNodeId);
+
+        assertTrue(mlModelAutoReLoader.isExistedIndex(ML_TASK_INDEX));
+        assertFalse(mlModelAutoReLoader.isExistedIndex(ML_MODEL_INDEX));
+        assertFalse(mlModelAutoReLoader.isExistedIndex(ML_MODEL_RELOAD_INDEX));
+    }
+
+    public void testAutoReLoadModel() {
+        mlModelAutoReLoader.autoReLoadModel();
+
+        assertFalse(mlModelAutoReLoader.isExistedIndex(ML_TASK_INDEX));
+        assertFalse(mlModelAutoReLoader.isExistedIndex(ML_MODEL_INDEX));
+        assertFalse(mlModelAutoReLoader.isExistedIndex(ML_MODEL_RELOAD_INDEX));
+    }
+
+    private void initDataOfMlTask(String nodeId, String modelId, MLTaskType mlTaskType, MLTaskState mlTaskState) throws IOException {
+        MLTask mlTask = MLTask
+            .builder()
+            .taskId("taskId1")
+            .modelId(modelId)
+            .taskType(mlTaskType)
+            .state(mlTaskState)
+            .workerNode(nodeId)
+            .progress(0.0f)
+            .outputIndex("test_index")
+            .error("test_error")
+            .createTime(time.minus(1, ChronoUnit.MINUTES))
+            .lastUpdateTime(time)
+            .build();
+
+        IndexRequest indexRequest = new IndexRequest(ML_TASK_INDEX);
+        indexRequest.id("taskId1");
+        indexRequest.source(mlTask.toXContent(XContentBuilder.builder(XContentType.JSON.xContent()), ToXContent.EMPTY_PARAMS));
+        indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        client().execute(IndexAction.INSTANCE, indexRequest).actionGet(5000);
+    }
+
+    private void initDataOfMlModel(String modelId, MLModelState modelState) throws IOException, URISyntaxException {
+        MLModelConfig modelConfig = TextEmbeddingModelConfig
+            .builder()
+            .modelType("bert")
+            .frameworkType(TextEmbeddingModelConfig.FrameworkType.SENTENCE_TRANSFORMERS)
+            .embeddingDimension(384)
+            .build();
+
+        MLModel mlModel = MLModel
+            .builder()
+            .name("model_name")
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .version("1.0.0")
+            .modelFormat(MLModelFormat.TORCH_SCRIPT)
+            .modelState(modelState)
+            .modelConfig(modelConfig)
+            .totalChunks(2)
+            .modelContentHash("c446f747520bcc6af053813cb1e8d34944a7c4686bbb405aeaa23883b5a806c8")
+            .modelContentSizeInBytes(1000L)
+            .createdTime(time.minus(1, ChronoUnit.MINUTES))
+            .build();
+        modelChunk0 = mlModel
+            .toBuilder()
+            .content(Base64.getEncoder().encodeToString("test chunk1".getBytes(StandardCharsets.UTF_8)))
+            .build();
+        modelChunk1 = mlModel
+            .toBuilder()
+            .content(Base64.getEncoder().encodeToString("test chunk2".getBytes(StandardCharsets.UTF_8)))
+            .build();
+
+        setUpMock_GetModelChunks(mlModel);
+
+        IndexRequest indexRequest = new IndexRequest(ML_MODEL_INDEX);
+        indexRequest.id(modelId);
+        indexRequest.source(mlModel.toXContent(XContentBuilder.builder(XContentType.JSON.xContent()), ToXContent.EMPTY_PARAMS));
+        indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        client().execute(IndexAction.INSTANCE, indexRequest).actionGet(5000);
+    }
+
+    private void setUpMock_GetModelChunks(MLModel model) {
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(1);
+            listener.onResponse(model);
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(1);
+            listener.onResponse(modelChunk0);
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(1);
+            listener.onResponse(modelChunk1);
+            return null;
+        }).when(modelManager).getModel(any(), any());
+    }
+}


### PR DESCRIPTION
Description

the new feature:
Model auto reloading
Issues Resolved

please see:
https://github.com/opensearch-project/ml-commons/issues/577

When a ml node under the opensearch cluster halt down with some unknown reasons. The models under this node will be broken and impact the process of the inference or reduced performance. So we add a new feature: When a ml node halt down, we reboot this ml node, the opensearch on this node will auto reload all the models under this node,and user will not reload the model manually. Even in extreme cases, if the reload operation is still unsuccessful, opensearch will also tell the user via logs that the reload was unsuccessful.
Check List

New functionality includes testing.

    All tests pass

New functionality has been documented.

    New functionality has javadoc added

    Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).