### PR TITLE
Remove jackson-databind and jackson-annotations dependencies now coming from core

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -44,8 +44,6 @@ dependencies {
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     implementation "org.opensearch:common-utils:${common_utils_version}"
-    implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
-    implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'


### PR DESCRIPTION
Signed-off-by: Sicheng Song <sicheng.song@outlook.com>

### Description
jackson-databind and jackson-annotations were added as api dependencies in server of opensearch core. The security plugin now gets these dependencies transitively and does not need direct dependencies on the jars.

PR in core where the dependencies are added: https://github.com/opensearch-project/OpenSearch/pull/5366

Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Maintenance
 
### Issues Resolved
This PR will resolve https://github.com/opensearch-project/ml-commons/issues/634 and complete campaign https://github.com/opensearch-project/opensearch-plugins/issues/191
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
