### PR TITLE
change task worker node to list; add target worker node to cache

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/MLTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLTask.java
@@ -20,6 +20,8 @@ import org.opensearch.ml.common.dataset.MLInputDataType;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.USER;
@@ -54,7 +56,7 @@ public class MLTask implements ToXContentObject, Writeable {
     private Float progress;
     private final String outputIndex;
     @Setter
-    private String workerNode;
+    private List<String> workerNodes;
     private final Instant createTime;
     private Instant lastUpdateTime;
     @Setter
@@ -72,7 +74,7 @@ public class MLTask implements ToXContentObject, Writeable {
         MLInputDataType inputType,
         Float progress,
         String outputIndex,
-        String workerNode,
+        List<String> workerNodes,
         Instant createTime,
         Instant lastUpdateTime,
         String error,
@@ -87,7 +89,7 @@ public class MLTask implements ToXContentObject, Writeable {
         this.inputType = inputType;
         this.progress = progress;
         this.outputIndex = outputIndex;
-        this.workerNode = workerNode;
+        this.workerNodes = workerNodes;
         this.createTime = createTime;
         this.lastUpdateTime = lastUpdateTime;
         this.error = error;
@@ -108,7 +110,7 @@ public class MLTask implements ToXContentObject, Writeable {
         }
         this.progress = input.readOptionalFloat();
         this.outputIndex = input.readOptionalString();
-        this.workerNode = input.readString();
+        this.workerNodes = input.readStringList();
         this.createTime = input.readInstant();
         this.lastUpdateTime = input.readInstant();
         this.error = input.readOptionalString();
@@ -135,7 +137,7 @@ public class MLTask implements ToXContentObject, Writeable {
         }
         out.writeOptionalFloat(progress);
         out.writeOptionalString(outputIndex);
-        out.writeString(workerNode);
+        out.writeStringCollection(workerNodes);
         out.writeInstant(createTime);
         out.writeInstant(lastUpdateTime);
         out.writeOptionalString(error);
@@ -174,8 +176,8 @@ public class MLTask implements ToXContentObject, Writeable {
         if (outputIndex != null) {
             builder.field(OUTPUT_INDEX_FIELD, outputIndex);
         }
-        if (workerNode != null) {
-            builder.field(WORKER_NODE_FIELD, workerNode);
+        if (workerNodes != null) {
+            builder.field(WORKER_NODE_FIELD, workerNodes);
         }
         if (createTime != null) {
             builder.field(CREATE_TIME_FIELD, createTime.toEpochMilli());
@@ -207,7 +209,7 @@ public class MLTask implements ToXContentObject, Writeable {
         MLInputDataType inputType = null;
         Float progress = null;
         String outputIndex = null;
-        String workerNode = null;
+        List<String> workerNodes = null;
         Instant createTime = null;
         Instant lastUpdateTime = null;
         String error = null;
@@ -245,7 +247,11 @@ public class MLTask implements ToXContentObject, Writeable {
                     outputIndex = parser.text();
                     break;
                 case WORKER_NODE_FIELD:
-                    workerNode = parser.text();
+                    workerNodes = new ArrayList<>();
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        workerNodes.add(parser.text());
+                    }
                     break;
                 case CREATE_TIME_FIELD:
                     createTime = Instant.ofEpochMilli(parser.longValue());
@@ -276,7 +282,7 @@ public class MLTask implements ToXContentObject, Writeable {
                 .inputType(inputType)
                 .progress(progress)
                 .outputIndex(outputIndex)
-                .workerNode(workerNode)
+                .workerNodes(workerNodes)
                 .createTime(createTime)
                 .lastUpdateTime(lastUpdateTime)
                 .error(error)

--- a/common/src/main/java/org/opensearch/ml/common/MLTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLTask.java
@@ -21,6 +21,7 @@ import org.opensearch.ml.common.dataset.MLInputDataType;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -247,10 +248,14 @@ public class MLTask implements ToXContentObject, Writeable {
                     outputIndex = parser.text();
                     break;
                 case WORKER_NODE_FIELD:
-                    workerNodes = new ArrayList<>();
-                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
-                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                        workerNodes.add(parser.text());
+                    if (XContentParser.Token.START_ARRAY == parser.currentToken()) {
+                        workerNodes = new ArrayList<>();
+                        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                            workerNodes.add(parser.text());
+                        }
+                    } else {
+                        String[] nodes = parser.text().split(",");
+                        workerNodes = Arrays.asList(nodes);
                     }
                     break;
                 case CREATE_TIME_FIELD:

--- a/common/src/test/java/org/opensearch/ml/common/MLTaskTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/MLTaskTests.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -32,7 +33,7 @@ public class MLTaskTests {
             .functionName(FunctionName.KMEANS)
             .state(MLTaskState.RUNNING)
             .inputType(MLInputDataType.DATA_FRAME)
-            .workerNode("node1")
+            .workerNodes(Arrays.asList("node1"))
             .progress(0.0f)
             .outputIndex("test_index")
             .error("test_error")
@@ -57,7 +58,7 @@ public class MLTaskTests {
         Assert.assertEquals(
             "{\"task_id\":\"dummy taskId\",\"model_id\":\"test_model_id\",\"task_type\":\"PREDICTION\","
                 + "\"function_name\":\"KMEANS\",\"state\":\"RUNNING\",\"input_type\":\"DATA_FRAME\",\"progress\":0.0,"
-                + "\"output_index\":\"test_index\",\"worker_node\":\"node1\",\"create_time\":1641599940000,"
+                + "\"output_index\":\"test_index\",\"worker_node\":[\"node1\"],\"create_time\":1641599940000,"
                 + "\"last_update_time\":1641600000000,\"error\":\"test_error\",\"is_async\":false}",
             taskContent
         );

--- a/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardInputTest.java
@@ -24,6 +24,7 @@ import org.opensearch.ml.common.transport.upload.MLUploadInput;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.function.Consumer;
@@ -48,7 +49,7 @@ public class MLForwardInputTest {
                 .functionName(functionName)
                 .state(MLTaskState.RUNNING)
                 .inputType(MLInputDataType.DATA_FRAME)
-                .workerNode("mlTaskNode1")
+                .workerNodes(Arrays.asList("mlTaskNode1"))
                 .progress(0.0f)
                 .outputIndex("test_index")
                 .error("test_error")

--- a/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardRequestTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -52,7 +53,7 @@ public class MLForwardRequestTest {
                 .functionName(functionName)
                 .state(MLTaskState.RUNNING)
                 .inputType(MLInputDataType.DATA_FRAME)
-                .workerNode("mlTaskNode1")
+                .workerNodes(Arrays.asList("mlTaskNode1"))
                 .progress(0.0f)
                 .outputIndex("test_index")
                 .error("test_error")

--- a/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelInputTest.java
@@ -19,6 +19,7 @@ import org.opensearch.ml.common.dataset.MLInputDataType;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -44,7 +45,7 @@ public class LoadModelInputTest {
                 .functionName(FunctionName.LINEAR_REGRESSION)
                 .state(MLTaskState.RUNNING)
                 .inputType(MLInputDataType.DATA_FRAME)
-                .workerNode("node1")
+                .workerNodes(Arrays.asList("node1"))
                 .progress(0.0f)
                 .outputIndex("test_index")
                 .error("test_error")

--- a/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelNodesRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/load/LoadModelNodesRequestTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.*;
@@ -70,7 +71,7 @@ public class LoadModelNodesRequestTest {
                 .functionName(FunctionName.LINEAR_REGRESSION)
                 .state(MLTaskState.RUNNING)
                 .inputType(MLInputDataType.DATA_FRAME)
-                .workerNode("node1")
+                .workerNodes(Arrays.asList("node1"))
                 .progress(0.0f)
                 .outputIndex("test_index")
                 .error("test_error")

--- a/common/src/test/java/org/opensearch/ml/common/transport/task/MLTaskGetResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/task/MLTaskGetResponseTest.java
@@ -17,6 +17,7 @@ import org.opensearch.ml.common.MLTaskType;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Arrays;
 
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
@@ -35,7 +36,7 @@ public class MLTaskGetResponseTest {
                 .inputType(MLInputDataType.DATA_FRAME)
                 .progress(1.3f)
                 .outputIndex("some index")
-                .workerNode("some node")
+                .workerNodes(Arrays.asList("some node"))
                 .createTime(Instant.ofEpochMilli(123))
                 .lastUpdateTime(Instant.ofEpochMilli(123))
                 .error("error")
@@ -59,7 +60,7 @@ public class MLTaskGetResponseTest {
         assertEquals(response.mlTask.getInputType(), parsedResponse.mlTask.getInputType());
         assertEquals(response.mlTask.getProgress(), parsedResponse.mlTask.getProgress());
         assertEquals(response.mlTask.getOutputIndex(), parsedResponse.mlTask.getOutputIndex());
-        assertEquals(response.mlTask.getWorkerNode(), parsedResponse.mlTask.getWorkerNode());
+        assertEquals(response.mlTask.getWorkerNodes(), parsedResponse.mlTask.getWorkerNodes());
         assertEquals(response.mlTask.getCreateTime(), parsedResponse.mlTask.getCreateTime());
         assertEquals(response.mlTask.getLastUpdateTime(), parsedResponse.mlTask.getLastUpdateTime());
         assertEquals(response.mlTask.getError(), parsedResponse.mlTask.getError());
@@ -80,7 +81,7 @@ public class MLTaskGetResponseTest {
                 "\"input_type\":\"DATA_FRAME\"," +
                 "\"progress\":1.3," +
                 "\"output_index\":\"some index\"," +
-                "\"worker_node\":\"some node\"," +
+                "\"worker_node\":[\"some node\"]," +
                 "\"create_time\":123," +
                 "\"last_update_time\":123," +
                 "\"error\":\"error\"," +

--- a/plugin/src/main/java/org/opensearch/ml/action/load/TransportLoadModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/load/TransportLoadModelAction.java
@@ -137,8 +137,7 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
             return;
         }
 
-        String workerNodes = String.join(",", nodeIds);
-        log.warn("Will load model on these nodes: {}", workerNodes);
+        log.info("Will load model on these nodes: {}", String.join(",", nodeIds));
         String localNodeId = clusterService.localNode().getId();
 
         String[] excludes = new String[] { MLModel.MODEL_CONTENT_FIELD, MLModel.OLD_MODEL_CONTENT_FIELD };
@@ -156,7 +155,7 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
                     .createTime(Instant.now())
                     .lastUpdateTime(Instant.now())
                     .state(MLTaskState.CREATED)
-                    .workerNode(workerNodes)
+                    .workerNodes(nodeIds)
                     .build();
                 mlTaskManager.createMLTask(mlTask, ActionListener.wrap(response -> {
                     String taskId = response.getId();

--- a/plugin/src/main/java/org/opensearch/ml/action/upload/TransportUploadModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/upload/TransportUploadModelAction.java
@@ -52,6 +52,7 @@ import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 @Log4j2
@@ -127,12 +128,12 @@ public class TransportUploadModelAction extends HandledTransportAction<ActionReq
             .createTime(Instant.now())
             .lastUpdateTime(Instant.now())
             .state(MLTaskState.CREATED)
-            .workerNode(clusterService.localNode().getId())
+            .workerNodes(ImmutableList.of(clusterService.localNode().getId()))
             .build();
 
         mlTaskDispatcher.dispatch(ActionListener.wrap(node -> {
             String nodeId = node.getId();
-            mlTask.setWorkerNode(nodeId);
+            mlTask.setWorkerNodes(ImmutableList.of(nodeId));
 
             mlTaskManager.createMLTask(mlTask, ActionListener.wrap(response -> {
                 String taskId = response.getId();

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.model;
 
 import java.util.DoubleSummaryStatistics;
+import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,14 +30,28 @@ public class MLModelCache {
     private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) MLModelState modelState;
     private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) FunctionName functionName;
     private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) Predictable predictor;
+    private @Getter(AccessLevel.PROTECTED) Set<String> targetWorkerNodes;
     private final Set<String> workerNodes;
     private final Queue<Double> modelInferenceDurationQueue;
     private final Queue<Double> predictRequestDurationQueue;
 
     public MLModelCache() {
+        targetWorkerNodes = ConcurrentHashMap.newKeySet();
         workerNodes = ConcurrentHashMap.newKeySet();
         modelInferenceDurationQueue = new ConcurrentLinkedQueue<>();
         predictRequestDurationQueue = new ConcurrentLinkedQueue<>();
+    }
+
+    public void setTargetWorkerNodes(List<String> targetWorkerNodes) {
+        if (targetWorkerNodes == null || targetWorkerNodes.size() == 0) {
+            throw new IllegalArgumentException("Null or empty target worker nodes");
+        }
+        this.targetWorkerNodes.clear();
+        this.targetWorkerNodes.addAll(targetWorkerNodes);
+    }
+
+    public String[] getTargetWorkerNodes() {
+        return targetWorkerNodes.toArray(new String[0]);
     }
 
     public void removeWorkerNode(String nodeId) {

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.model;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MONITORING_REQUEST_COUNT;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,7 +42,7 @@ public class MLModelCacheHelper {
      * @param state model state
      * @param functionName function name
      */
-    public synchronized void initModelState(String modelId, MLModelState state, FunctionName functionName) {
+    public synchronized void initModelState(String modelId, MLModelState state, FunctionName functionName, List<String> targetWorkerNodes) {
         if (isModelRunningOnNode(modelId)) {
             throw new MLLimitExceededException("Duplicate load model task");
         }
@@ -49,6 +50,7 @@ public class MLModelCacheHelper {
         MLModelCache modelCache = new MLModelCache();
         modelCache.setModelState(state);
         modelCache.setFunctionName(functionName);
+        modelCache.setTargetWorkerNodes(targetWorkerNodes);
         modelCaches.put(modelId, modelCache);
     }
 
@@ -253,6 +255,10 @@ public class MLModelCacheHelper {
         builder.modelState(modelCache.getModelState());
         if (modelCache.getPredictor() != null) {
             builder.predictor(modelCache.getPredictor().toString());
+        }
+        String[] targetWorkerNodes = modelCache.getTargetWorkerNodes();
+        if (targetWorkerNodes.length > 0) {
+            builder.targetWorkerNodes(targetWorkerNodes);
         }
         String[] workerNodes = modelCache.getWorkerNodes();
         if (workerNodes.length > 0) {

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -430,7 +430,7 @@ public class MLModelManager {
             listener.onFailure(new IllegalArgumentException("Exceed max model per node limit"));
             return;
         }
-        modelCacheHelper.initModelState(modelId, MLModelState.LOADING, functionName);
+        modelCacheHelper.initModelState(modelId, MLModelState.LOADING, functionName, mlTask.getWorkerNodes());
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             checkAndAddRunningTask(mlTask, maxLoadTasksPerNode);
             this.getModel(modelId, threadedActionListener(LOAD_THREAD_POOL, ActionListener.wrap(mlModel -> {

--- a/plugin/src/main/java/org/opensearch/ml/profile/MLModelProfile.java
+++ b/plugin/src/main/java/org/opensearch/ml/profile/MLModelProfile.java
@@ -56,7 +56,7 @@ public class MLModelProfile implements ToXContentFragment, Writeable {
             builder.field("predictor", predictor);
         }
         if (targetWorkerNodes != null) {
-            builder.field("worker_nodes", targetWorkerNodes);
+            builder.field("target_worker_nodes", targetWorkerNodes);
         }
         if (workerNodes != null) {
             builder.field("worker_nodes", workerNodes);

--- a/plugin/src/main/java/org/opensearch/ml/profile/MLModelProfile.java
+++ b/plugin/src/main/java/org/opensearch/ml/profile/MLModelProfile.java
@@ -24,6 +24,7 @@ public class MLModelProfile implements ToXContentFragment, Writeable {
 
     private final MLModelState modelState;
     private final String predictor;
+    private final String[] targetWorkerNodes;
     private final String[] workerNodes;
     private final MLPredictRequestStats modelInferenceStats;
     private final MLPredictRequestStats predictRequestStats;
@@ -32,12 +33,14 @@ public class MLModelProfile implements ToXContentFragment, Writeable {
     public MLModelProfile(
         MLModelState modelState,
         String predictor,
+        String[] targetWorkerNodes,
         String[] workerNodes,
         MLPredictRequestStats modelInferenceStats,
         MLPredictRequestStats predictRequestStats
     ) {
         this.modelState = modelState;
         this.predictor = predictor;
+        this.targetWorkerNodes = targetWorkerNodes;
         this.workerNodes = workerNodes;
         this.modelInferenceStats = modelInferenceStats;
         this.predictRequestStats = predictRequestStats;
@@ -51,6 +54,9 @@ public class MLModelProfile implements ToXContentFragment, Writeable {
         }
         if (predictor != null) {
             builder.field("predictor", predictor);
+        }
+        if (targetWorkerNodes != null) {
+            builder.field("worker_nodes", targetWorkerNodes);
         }
         if (workerNodes != null) {
             builder.field("worker_nodes", workerNodes);
@@ -72,6 +78,7 @@ public class MLModelProfile implements ToXContentFragment, Writeable {
             this.modelState = null;
         }
         this.predictor = in.readOptionalString();
+        this.targetWorkerNodes = in.readOptionalStringArray();
         this.workerNodes = in.readOptionalStringArray();
         if (in.readBoolean()) {
             this.modelInferenceStats = new MLPredictRequestStats(in);
@@ -94,6 +101,7 @@ public class MLModelProfile implements ToXContentFragment, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(predictor);
+        out.writeOptionalStringArray(targetWorkerNodes);
         out.writeOptionalStringArray(workerNodes);
         if (modelInferenceStats != null) {
             out.writeBoolean(true);

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -60,6 +60,8 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * MLPredictTaskRunner is responsible for running predict tasks.
  */
@@ -159,7 +161,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
             .inputType(inputDataType)
             .functionName(request.getMlInput().getFunctionName())
             .state(MLTaskState.CREATED)
-            .workerNode(clusterService.localNode().getId())
+            .workerNodes(ImmutableList.of(clusterService.localNode().getId()))
             .createTime(now)
             .lastUpdateTime(now)
             .async(false)

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunner.java
@@ -39,6 +39,8 @@ import org.opensearch.ml.stats.MLStats;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportResponseHandler;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * MLPredictTaskRunner is responsible for running predict tasks.
  */
@@ -98,7 +100,7 @@ public class MLTrainAndPredictTaskRunner extends MLTaskRunner<MLTrainingTaskRequ
             .inputType(inputDataType)
             .functionName(request.getMlInput().getFunctionName())
             .state(MLTaskState.CREATED)
-            .workerNode(clusterService.localNode().getId())
+            .workerNodes(ImmutableList.of(clusterService.localNode().getId()))
             .createTime(now)
             .lastUpdateTime(now)
             .async(false)

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
@@ -48,6 +48,8 @@ import org.opensearch.ml.stats.MLStats;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportResponseHandler;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * MLTrainingTaskRunner is responsible for running training tasks.
  */
@@ -104,7 +106,7 @@ public class MLTrainingTaskRunner extends MLTaskRunner<MLTrainingTaskRequest, ML
             .inputType(inputDataType)
             .functionName(request.getMlInput().getFunctionName())
             .state(MLTaskState.CREATED)
-            .workerNode(clusterService.localNode().getId())
+            .workerNodes(ImmutableList.of(clusterService.localNode().getId()))
             .createTime(now)
             .lastUpdateTime(now)
             .async(request.isAsync())

--- a/plugin/src/test/java/org/opensearch/ml/action/load/TransportLoadModelOnNodeActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/load/TransportLoadModelOnNodeActionTests.java
@@ -243,7 +243,7 @@ public class TransportLoadModelOnNodeActionTests extends OpenSearchTestCase {
             .functionName(FunctionName.LINEAR_REGRESSION)
             .state(MLTaskState.RUNNING)
             .inputType(MLInputDataType.DATA_FRAME)
-            .workerNode("node1")
+            .workerNodes(Arrays.asList("node1"))
             .progress(0.0f)
             .outputIndex("test_index")
             .error("test_error")

--- a/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileNodeResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileNodeResponseTests.java
@@ -9,6 +9,7 @@ import static org.opensearch.ml.action.profile.MLProfileNodeResponse.readProfile
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,7 +46,7 @@ public class MLProfileNodeResponseTests extends OpenSearchTestCase {
             .inputType(MLInputDataType.DATA_FRAME)
             .progress(0.4f)
             .outputIndex("test_index")
-            .workerNode("test_node")
+            .workerNodes(Arrays.asList("test_node"))
             .createTime(Instant.ofEpochMilli(123))
             .lastUpdateTime(Instant.ofEpochMilli(123))
             .error("error")

--- a/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileResponseTests.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.action.profile;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,7 @@ public class MLProfileResponseTests extends OpenSearchTestCase {
             .inputType(MLInputDataType.DATA_FRAME)
             .progress(0.4f)
             .outputIndex("test_index")
-            .workerNode("test_node")
+            .workerNodes(Arrays.asList("test_node"))
             .createTime(Instant.ofEpochMilli(123))
             .lastUpdateTime(Instant.ofEpochMilli(123))
             .error("error")
@@ -100,7 +101,7 @@ public class MLProfileResponseTests extends OpenSearchTestCase {
         assertEquals(
             "{\"nodes\":{\"node1\":{\"tasks\":{\"task_1\":{\"task_id\":\"test_id\",\"model_id\":\"model_id\","
                 + "\"task_type\":\"TRAINING\",\"function_name\":\"AD_LIBSVM\",\"state\":\"CREATED\",\"input_type\":"
-                + "\"DATA_FRAME\",\"progress\":0.4,\"output_index\":\"test_index\",\"worker_node\":\"test_node\","
+                + "\"DATA_FRAME\",\"progress\":0.4,\"output_index\":\"test_index\",\"worker_node\":[\"test_node\"],"
                 + "\"create_time\":123,\"last_update_time\":123,\"error\":\"error\",\"user\":{\"name\":\"\","
                 + "\"backend_roles\":[],\"roles\":[],\"custom_attribute_names\":[],\"user_requested_tenant\":null},"
                 + "\"is_async\":false}},\"models\":{\"model1\":{\"model_state\":\"LOADED\",\"predictor\":\"test_predictor\","

--- a/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileTransportActionTests.java
@@ -70,7 +70,7 @@ public class MLProfileTransportActionTests extends OpenSearchIntegTestCase {
             .inputType(MLInputDataType.DATA_FRAME)
             .progress(0.4f)
             .outputIndex("test_index")
-            .workerNode("test_node")
+            .workerNodes(Arrays.asList("test_node"))
             .createTime(Instant.ofEpochMilli(123))
             .lastUpdateTime(Instant.ofEpochMilli(123))
             .error("error")

--- a/plugin/src/test/java/org/opensearch/ml/action/upload/TransportUploadModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/upload/TransportUploadModelActionTests.java
@@ -214,6 +214,8 @@ public class TransportUploadModelActionTests extends OpenSearchTestCase {
             listener.onFailure(new Exception("Failed to dispatch upload model task "));
             return null;
         }).when(mlTaskDispatcher).dispatch(any());
+        when(node1.getId()).thenReturn("NodeId1");
+        when(clusterService.localNode()).thenReturn(node1);
         transportUploadModelAction.doExecute(task, prepareRequest(), actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -225,7 +227,8 @@ public class TransportUploadModelActionTests extends OpenSearchTestCase {
             listener.onFailure(new Exception("Failed to create upload model task"));
             return null;
         }).when(mlTaskManager).createMLTask(any(), any());
-
+        when(node1.getId()).thenReturn("NodeId1");
+        when(clusterService.localNode()).thenReturn(node1);
         transportUploadModelAction.doExecute(task, prepareRequest(), actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLProfileActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLProfileActionTests.java
@@ -67,6 +67,8 @@ import org.opensearch.test.rest.FakeRestRequest;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
+import com.google.common.collect.ImmutableList;
+
 public class RestMLProfileActionTests extends OpenSearchTestCase {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -115,7 +117,7 @@ public class RestMLProfileActionTests extends OpenSearchTestCase {
             .inputType(MLInputDataType.DATA_FRAME)
             .progress(0.4f)
             .outputIndex("test_index")
-            .workerNode("test_node")
+            .workerNodes(ImmutableList.of("test_node"))
             .createTime(Instant.ofEpochMilli(123))
             .lastUpdateTime(Instant.ofEpochMilli(123))
             .error("error")


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
1. ML task may run on multiple nodes. We save all worker nodes as String in ML task doc which is not easy to use. This PR changed worker nodes in MLTask as List<String>
2. Add target worker node to cache
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
