### PR TITLE
Updated MAINTAINERS.md to match recommended opensearch-project format…

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,11 @@
-# OpenSearch Machine Learning Maintainers
+## Overview
 
-## Maintainers
-| Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Hanguang Zhang | [zhanghg08](https://github.com/zhanghg08) | Amazon |
-| Jing Zhang | [jngz-es](https://github.com/jngz-es) | Amazon |
-| Weicong Sun | [weicongs-amazon](https://github.com/weicongs-amazon) | Amazon |
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
+| Maintainer     | GitHub ID                                             | Affiliation |
+| -------------- | ----------------------------------------------------- | ----------- |
+| Hanguang Zhang | [zhanghg08](https://github.com/zhanghg08)             | Amazon      |
+| Jing Zhang     | [jngz-es](https://github.com/jngz-es)                 | Amazon      |
+| Weicong Sun    | [weicongs-amazon](https://github.com/weicongs-amazon) | Amazon      |


### PR DESCRIPTION
…. (#659)

Signed-off-by: dblock <dblock@amazon.com>
(cherry picked from commit 098de57b8e1b8194171146aa926c888ab359fb05)

### Description
Updated MAINTAINERS.md to match recommended opensearch-project format.
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
