### PR TITLE
Revert "Remove jackson-databind and jackson-annotations dependencies now coming from core (#652)"

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/upload/MLUploadInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/upload/MLUploadInput.java
@@ -73,13 +73,23 @@ public class MLUploadInput implements ToXContentObject, Writeable {
         if (version == null) {
             throw new IllegalArgumentException("model version is null");
         }
-        if (url != null) {
-            if (modelFormat == null) {
-                throw new IllegalArgumentException("model format is null");
-            }
-            if (modelConfig == null) {
-                throw new IllegalArgumentException("model config is null");
-            }
+        //TODO: enable prebuilt model in 2.6
+//        if (url != null) {
+//            if (modelFormat == null) {
+//                throw new IllegalArgumentException("model format is null");
+//            }
+//            if (modelConfig == null) {
+//                throw new IllegalArgumentException("model config is null");
+//            }
+//        }
+        if (modelFormat == null) {
+            throw new IllegalArgumentException("model format is null");
+        }
+        if (modelConfig == null) {
+            throw new IllegalArgumentException("model config is null");
+        }
+        if (url == null) {
+            throw new IllegalArgumentException("model file url is null");
         }
         this.modelName = modelName;
         this.version = version;

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -61,7 +61,7 @@ jacocoTestCoverageVerification {
         rule {
             limit {
                 counter = 'LINE'
-                minimum = 0.88 //TODO: increase coverage to 0.90
+                minimum = 0.85 //TODO: increase coverage to 0.90
             }
             limit {
                 counter = 'BRANCH'

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.engine.algorithms.text_embedding;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -69,6 +70,7 @@ public class ModelHelperTest {
         assertNotEquals(0, argumentCaptor.getValue().size());
     }
 
+    @Ignore
     @Test
     public void testDownloadPrebuiltModelConfig_WrongModelName() {
         String taskId = "test_task_id";
@@ -84,6 +86,7 @@ public class ModelHelperTest {
         assertEquals(PrivilegedActionException.class, argumentCaptor.getValue().getClass());
     }
 
+    @Ignore
     @Test
     public void testDownloadPrebuiltModelConfig() {
         String taskId = "test_task_id";

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     implementation "org.opensearch:common-utils:${common_utils_version}"
+    implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+    implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'

--- a/plugin/src/main/java/org/opensearch/ml/action/upload/TransportUploadModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/upload/TransportUploadModelAction.java
@@ -68,7 +68,7 @@ public class TransportUploadModelAction extends HandledTransportAction<ActionReq
     DiscoveryNodeHelper nodeFilter;
     MLTaskDispatcher mlTaskDispatcher;
     MLStats mlStats;
-    String trustedUrlRegex;
+    volatile String trustedUrlRegex;
 
     @Inject
     public TransportUploadModelAction(

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -195,7 +195,9 @@ public class MLModelManager {
             if (uploadInput.getUrl() != null) {
                 uploadModelFromUrl(uploadInput, mlTask);
             } else {
-                uploadPrebuiltModel(uploadInput, mlTask);
+                throw new IllegalArgumentException("model file URL is null");
+                // TODO: support prebuilt model later
+                // uploadPrebuiltModel(uploadInput, mlTask);
             }
         } catch (Exception e) {
             mlStats.createCounterStatIfAbsent(mlTask.getFunctionName(), UPLOAD, MLActionLevelStat.ML_ACTION_FAILURE_COUNT).increment();


### PR DESCRIPTION
This reverts commit 26435dee2f5fb21b6c47bdb8d1f1e54312e76225.

### Description
Jackson is no longer in core, so reverting changes made for https://github.com/opensearch-project/ml-commons/issues/634
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
