### PR TITLE
change only run on ml node setting default value to true

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -23,7 +23,7 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MAX_ML_TASK_PER_NODE = Setting
         .intSetting("plugins.ml_commons.max_ml_task_per_node", 10, 0, 10000, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Boolean> ML_COMMONS_ONLY_RUN_ON_ML_NODE = Setting
-        .boolSetting("plugins.ml_commons.only_run_on_ml_node", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .boolSetting("plugins.ml_commons.only_run_on_ml_node", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Integer> ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS = Setting
         .intSetting(
             "plugins.ml_commons.sync_up_job_interval_in_seconds",

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
@@ -26,6 +26,7 @@ import org.opensearch.ml.action.stats.MLStatsNodeResponse;
 import org.opensearch.ml.action.stats.MLStatsNodesAction;
 import org.opensearch.ml.action.stats.MLStatsNodesRequest;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
+import org.opensearch.ml.common.exception.MLResourceNotFoundException;
 import org.opensearch.ml.stats.MLNodeLevelStat;
 
 import com.google.common.collect.ImmutableSet;
@@ -165,6 +166,9 @@ public class MLTaskDispatcher {
 
     private void dispatchTaskWithRoundRobin(ActionListener<DiscoveryNode> listener) {
         DiscoveryNode[] eligibleNodes = nodeHelper.getEligibleNodes();
+        if (eligibleNodes == null || eligibleNodes.length == 0) {
+            throw new MLResourceNotFoundException("no eligible node found, ml node is required to run this request");
+        }
         dispatchTaskWithRoundRobin(eligibleNodes, listener);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
@@ -414,10 +414,6 @@ public class MLCommonsIntegTestCase extends OpenSearchIntegTestCase {
 
     @Override
     protected Settings nodeSettings(int ordinal) {
-        return Settings
-            .builder()
-            .put(super.nodeSettings(ordinal))
-            .put(ML_COMMONS_ONLY_RUN_ON_ML_NODE.getKey(), false)
-            .build();
+        return Settings.builder().put(super.nodeSettings(ordinal)).put(ML_COMMONS_ONLY_RUN_ON_ML_NODE.getKey(), false).build();
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.action;
 
 import static org.opensearch.ml.common.input.parameter.regression.LogisticRegressionParams.ObjectiveType.LOGMULTICLASS;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ONLY_RUN_ON_ML_NODE;
 import static org.opensearch.ml.utils.RestActionUtils.getAllNodes;
 import static org.opensearch.ml.utils.TestData.TARGET_FIELD;
 import static org.opensearch.ml.utils.TestData.TIME_FIELD;
@@ -24,6 +25,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -408,5 +410,14 @@ public class MLCommonsIntegTestCase extends OpenSearchIntegTestCase {
         MLSyncUpNodesRequest syncUpRequest = new MLSyncUpNodesRequest(allNodes, syncUpInput);
         MLSyncUpNodesResponse syncUpResponse = client().execute(MLSyncUpAction.INSTANCE, syncUpRequest).actionGet(5000);
         return syncUpResponse;
+    }
+
+    @Override
+    protected Settings nodeSettings(int ordinal) {
+        return Settings
+            .builder()
+            .put(super.nodeSettings(ordinal))
+            .put(ML_COMMONS_ONLY_RUN_ON_ML_NODE.getKey(), false)
+            .build();
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -49,6 +49,7 @@ import org.apache.http.message.BasicHeader;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
+import org.junit.Before;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
@@ -101,6 +102,20 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
         }
 
         return isHttps;
+    }
+
+    @Before
+    public void setupSettings() throws IOException {
+        Response response = TestHelper
+            .makeRequest(
+                client(),
+                "PUT",
+                "_cluster/settings",
+                null,
+                "{\"persistent\":{\"plugins.ml_commons.only_run_on_ml_node\":false}}",
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+            );
+        assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
It's not recommended to run ML tasks on data node. This PR changes only run on ml node setting default value to true. So ML tasks will only run on ML node by default. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
