### PR TITLE
[backport 2.5] Revert "Remove jackson-databind and jackson-annotation s dependencies now coming from core"

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     implementation "org.opensearch:common-utils:${common_utils_version}"
+    implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+    implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'


### PR DESCRIPTION
Signed-off-by: Sicheng Song <sicheng.song@outlook.com>

### Description
Backport PR from https://github.com/opensearch-project/ml-commons/pull/652
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
