### PR TITLE
refresh model load state in sync up cron job

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -30,7 +30,7 @@ public class CommonValue {
 
     public static final String ML_MODEL_INDEX = ".plugins-ml-model";
     public static final String ML_TASK_INDEX = ".plugins-ml-task";
-    public static final Integer ML_MODEL_INDEX_SCHEMA_VERSION = 2;
+    public static final Integer ML_MODEL_INDEX_SCHEMA_VERSION = 3;
     public static final Integer ML_TASK_INDEX_SCHEMA_VERSION = 1;
     public static final String USER_FIELD_MAPPING = "      \""
             + CommonValue.USER
@@ -85,6 +85,12 @@ public class CommonValue {
             + MLModel.MODEL_CONTENT_SIZE_IN_BYTES_FIELD
             + "\" : {\"type\": \"long\"},\n"
             + "      \""
+            + MLModel.PLANNING_WORKER_NODE_COUNT_FIELD
+            + "\" : {\"type\": \"integer\"},\n"
+            + "      \""
+            + MLModel.CURRENT_WORKER_NODE_COUNT_FIELD
+            + "\" : {\"type\": \"integer\"},\n"
+            + "      \""
             + MLModel.MODEL_CONFIG_FIELD
             + "\" : {\"properties\":{\""
             + MODEL_TYPE_FIELD + "\":{\"type\":\"keyword\"},\""
@@ -99,6 +105,9 @@ public class CommonValue {
             + "\" : {\"type\": \"keyword\"},\n"
             + "      \""
             + MLModel.CREATED_TIME_FIELD
+            + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
+            + "      \""
+            + MLModel.LAST_UPDATE_TIME_FIELD
             + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
             + "      \""
             + MLModel.LAST_UPLOADED_TIME_FIELD

--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -107,7 +107,7 @@ public class CommonValue {
             + MLModel.CREATED_TIME_FIELD
             + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
             + "      \""
-            + MLModel.LAST_UPDATE_TIME_FIELD
+            + MLModel.LAST_UPDATED_TIME_FIELD
             + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
             + "      \""
             + MLModel.LAST_UPLOADED_TIME_FIELD

--- a/common/src/main/java/org/opensearch/ml/common/MLModel.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModel.java
@@ -44,6 +44,7 @@ public class MLModel implements ToXContentObject {
     public static final String MODEL_CONTENT_HASH_VALUE_FIELD = "model_content_hash_value";
     public static final String MODEL_CONFIG_FIELD = "model_config";
     public static final String CREATED_TIME_FIELD = "created_time";
+    public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
     public static final String LAST_UPLOADED_TIME_FIELD = "last_uploaded_time";
     public static final String LAST_LOADED_TIME_FIELD = "last_loaded_time";
     public static final String LAST_UNLOADED_TIME_FIELD = "last_unloaded_time";
@@ -51,6 +52,8 @@ public class MLModel implements ToXContentObject {
     public static final String MODEL_ID_FIELD = "model_id";
     public static final String CHUNK_NUMBER_FIELD = "chunk_number";
     public static final String TOTAL_CHUNKS_FIELD = "total_chunks";
+    public static final String PLANNING_WORKER_NODE_COUNT_FIELD = "planning_worker_node_count";
+    public static final String CURRENT_WORKER_NODE_COUNT_FIELD = "current_worker_node_count";
 
     private String name;
     private FunctionName algorithm;
@@ -66,6 +69,7 @@ public class MLModel implements ToXContentObject {
     private String modelContentHash;
     private MLModelConfig modelConfig;
     private Instant createdTime;
+    private Instant lastUpdateTime;
     private Instant lastUploadedTime;
     private Instant lastLoadedTime;
     private Instant lastUnloadedTime;
@@ -74,9 +78,30 @@ public class MLModel implements ToXContentObject {
     private String modelId; // model chunk doc only
     private Integer chunkNumber; // model chunk doc only
     private Integer totalChunks; // model chunk doc only
+    private Integer planningWorkerNodeCount;
+    private Integer currentWorkerNodeCount;
 
     @Builder(toBuilder = true)
-    public MLModel(String name, FunctionName algorithm, String version, String content, User user, String description, MLModelFormat modelFormat, MLModelState modelState, Long modelContentSizeInBytes, String modelContentHash, MLModelConfig modelConfig, Instant createdTime, Instant lastUploadedTime, Instant lastLoadedTime, Instant lastUnloadedTime, String modelId, Integer chunkNumber, Integer totalChunks) {
+    public MLModel(String name,
+                   FunctionName algorithm,
+                   String version,
+                   String content,
+                   User user,
+                   String description,
+                   MLModelFormat modelFormat,
+                   MLModelState modelState,
+                   Long modelContentSizeInBytes,
+                   String modelContentHash,
+                   MLModelConfig modelConfig,
+                   Instant createdTime,
+                   Instant lastUpdateTime,
+                   Instant lastUploadedTime,
+                   Instant lastLoadedTime,
+                   Instant lastUnloadedTime,
+                   String modelId, Integer chunkNumber,
+                   Integer totalChunks,
+                   Integer planningWorkerNodeCount,
+                   Integer currentWorkerNodeCount) {
         this.name = name;
         this.algorithm = algorithm;
         this.version = version;
@@ -89,12 +114,15 @@ public class MLModel implements ToXContentObject {
         this.modelContentHash = modelContentHash;
         this.modelConfig = modelConfig;
         this.createdTime = createdTime;
+        this.lastUpdateTime = lastUpdateTime;
         this.lastUploadedTime = lastUploadedTime;
         this.lastLoadedTime = lastLoadedTime;
         this.lastUnloadedTime = lastUnloadedTime;
         this.modelId = modelId;
         this.chunkNumber = chunkNumber;
         this.totalChunks = totalChunks;
+        this.planningWorkerNodeCount = planningWorkerNodeCount;
+        this.currentWorkerNodeCount = currentWorkerNodeCount;
     }
 
     public MLModel(StreamInput input) throws IOException{
@@ -121,12 +149,15 @@ public class MLModel implements ToXContentObject {
                 modelConfig = new TextEmbeddingModelConfig(input);
             }
             createdTime = input.readOptionalInstant();
+            lastUpdateTime = input.readOptionalInstant();
             lastUploadedTime = input.readOptionalInstant();
             lastLoadedTime = input.readOptionalInstant();
             lastUnloadedTime = input.readOptionalInstant();
             modelId = input.readOptionalString();
             chunkNumber = input.readOptionalInt();
             totalChunks = input.readOptionalInt();
+            planningWorkerNodeCount = input.readOptionalInt();
+            currentWorkerNodeCount = input.readOptionalInt();
         }
     }
 
@@ -163,12 +194,15 @@ public class MLModel implements ToXContentObject {
             out.writeBoolean(false);
         }
         out.writeOptionalInstant(createdTime);
+        out.writeOptionalInstant(lastUpdateTime);
         out.writeOptionalInstant(lastUploadedTime);
         out.writeOptionalInstant(lastLoadedTime);
         out.writeOptionalInstant(lastUnloadedTime);
         out.writeOptionalString(modelId);
         out.writeOptionalInt(chunkNumber);
         out.writeOptionalInt(totalChunks);
+        out.writeOptionalInt(planningWorkerNodeCount);
+        out.writeOptionalInt(currentWorkerNodeCount);
     }
 
     @Override
@@ -210,6 +244,9 @@ public class MLModel implements ToXContentObject {
         if (createdTime != null) {
             builder.field(CREATED_TIME_FIELD, createdTime.toEpochMilli());
         }
+        if (lastUpdateTime != null) {
+            builder.field(LAST_UPDATE_TIME_FIELD, lastUpdateTime.toEpochMilli());
+        }
         if (lastUploadedTime != null) {
             builder.field(LAST_UPLOADED_TIME_FIELD, lastUploadedTime.toEpochMilli());
         }
@@ -227,6 +264,12 @@ public class MLModel implements ToXContentObject {
         }
         if (totalChunks != null) {
             builder.field(TOTAL_CHUNKS_FIELD, totalChunks);
+        }
+        if (planningWorkerNodeCount != null) {
+            builder.field(PLANNING_WORKER_NODE_COUNT_FIELD, planningWorkerNodeCount);
+        }
+        if (currentWorkerNodeCount != null) {
+            builder.field(CURRENT_WORKER_NODE_COUNT_FIELD, currentWorkerNodeCount);
         }
         builder.endObject();
         return builder;
@@ -248,12 +291,15 @@ public class MLModel implements ToXContentObject {
         String modelContentHash = null;
         MLModelConfig modelConfig = null;
         Instant createdTime = null;
+        Instant lastUpdateTime = null;
         Instant lastUploadedTime = null;
         Instant lastLoadedTime = null;
         Instant lastUnloadedTime = null;
         String modelId = null;
         Integer chunkNumber = null;
         Integer totalChunks = null;
+        Integer planningWorkerNodeCount = null;
+        Integer currentWorkerNodeCount = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -309,8 +355,17 @@ public class MLModel implements ToXContentObject {
                 case MODEL_CONFIG_FIELD:
                     modelConfig = TextEmbeddingModelConfig.parse(parser);
                     break;
+                case PLANNING_WORKER_NODE_COUNT_FIELD:
+                    planningWorkerNodeCount = parser.intValue();
+                    break;
+                case CURRENT_WORKER_NODE_COUNT_FIELD:
+                    currentWorkerNodeCount = parser.intValue();
+                    break;
                 case CREATED_TIME_FIELD:
                     createdTime = Instant.ofEpochMilli(parser.longValue());
+                    break;
+                case LAST_UPDATE_TIME_FIELD:
+                    lastUpdateTime = Instant.ofEpochMilli(parser.longValue());
                     break;
                 case LAST_UPLOADED_TIME_FIELD:
                     lastUploadedTime = Instant.ofEpochMilli(parser.longValue());
@@ -339,12 +394,15 @@ public class MLModel implements ToXContentObject {
                 .modelContentHash(modelContentHash)
                 .modelConfig(modelConfig)
                 .createdTime(createdTime)
+                .lastUpdateTime(lastUpdateTime)
                 .lastUploadedTime(lastUploadedTime)
                 .lastLoadedTime(lastLoadedTime)
                 .lastUnloadedTime(lastUnloadedTime)
                 .modelId(modelId)
                 .chunkNumber(chunkNumber)
                 .totalChunks(totalChunks)
+                .planningWorkerNodeCount(planningWorkerNodeCount)
+                .currentWorkerNodeCount(currentWorkerNodeCount)
                 .build();
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/MLModel.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModel.java
@@ -44,7 +44,7 @@ public class MLModel implements ToXContentObject {
     public static final String MODEL_CONTENT_HASH_VALUE_FIELD = "model_content_hash_value";
     public static final String MODEL_CONFIG_FIELD = "model_config";
     public static final String CREATED_TIME_FIELD = "created_time";
-    public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
+    public static final String LAST_UPDATED_TIME_FIELD = "last_updated_time";
     public static final String LAST_UPLOADED_TIME_FIELD = "last_uploaded_time";
     public static final String LAST_LOADED_TIME_FIELD = "last_loaded_time";
     public static final String LAST_UNLOADED_TIME_FIELD = "last_unloaded_time";
@@ -78,8 +78,8 @@ public class MLModel implements ToXContentObject {
     private String modelId; // model chunk doc only
     private Integer chunkNumber; // model chunk doc only
     private Integer totalChunks; // model chunk doc only
-    private Integer planningWorkerNodeCount;
-    private Integer currentWorkerNodeCount;
+    private Integer planningWorkerNodeCount; // plan to deploy model to how many nodes
+    private Integer currentWorkerNodeCount; // model is deployed to how many nodes
 
     @Builder(toBuilder = true)
     public MLModel(String name,
@@ -245,7 +245,7 @@ public class MLModel implements ToXContentObject {
             builder.field(CREATED_TIME_FIELD, createdTime.toEpochMilli());
         }
         if (lastUpdateTime != null) {
-            builder.field(LAST_UPDATE_TIME_FIELD, lastUpdateTime.toEpochMilli());
+            builder.field(LAST_UPDATED_TIME_FIELD, lastUpdateTime.toEpochMilli());
         }
         if (lastUploadedTime != null) {
             builder.field(LAST_UPLOADED_TIME_FIELD, lastUploadedTime.toEpochMilli());
@@ -364,7 +364,7 @@ public class MLModel implements ToXContentObject {
                 case CREATED_TIME_FIELD:
                     createdTime = Instant.ofEpochMilli(parser.longValue());
                     break;
-                case LAST_UPDATE_TIME_FIELD:
+                case LAST_UPDATED_TIME_FIELD:
                     lastUpdateTime = Instant.ofEpochMilli(parser.longValue());
                     break;
                 case LAST_UPLOADED_TIME_FIELD:

--- a/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponse.java
@@ -21,8 +21,8 @@ public class MLSyncUpNodeResponse extends BaseNodeResponse  {
 
     private String modelStatus;
     private String[] loadedModelIds;
-    private String[] runningLoadModelIds;
-    private String[] runningLoadModelTaskIds;
+    private String[] runningLoadModelIds; // model ids which have loading model task running
+    private String[] runningLoadModelTaskIds; // load model task ids which is running
 
     public MLSyncUpNodeResponse(DiscoveryNode node, String modelStatus, String[] loadedModelIds, String[] runningLoadModelIds,
                                 String[] runningLoadModelTaskIds) {

--- a/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponse.java
@@ -13,6 +13,7 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Map;
 
 @Log4j2
 @Getter
@@ -20,12 +21,15 @@ public class MLSyncUpNodeResponse extends BaseNodeResponse  {
 
     private String modelStatus;
     private String[] loadedModelIds;
+    private String[] runningLoadModelIds;
     private String[] runningLoadModelTaskIds;
 
-    public MLSyncUpNodeResponse(DiscoveryNode node, String modelStatus, String[] loadedModelIds, String[] runningLoadModelTaskIds) {
+    public MLSyncUpNodeResponse(DiscoveryNode node, String modelStatus, String[] loadedModelIds, String[] runningLoadModelIds,
+                                String[] runningLoadModelTaskIds) {
         super(node);
         this.modelStatus = modelStatus;
         this.loadedModelIds = loadedModelIds;
+        this.runningLoadModelIds = runningLoadModelIds;
         this.runningLoadModelTaskIds = runningLoadModelTaskIds;
     }
 
@@ -33,6 +37,7 @@ public class MLSyncUpNodeResponse extends BaseNodeResponse  {
         super(in);
         this.modelStatus = in.readOptionalString();
         this.loadedModelIds = in.readOptionalStringArray();
+        this.runningLoadModelIds = in.readOptionalStringArray();
         this.runningLoadModelTaskIds = in.readOptionalStringArray();
     }
 
@@ -45,6 +50,7 @@ public class MLSyncUpNodeResponse extends BaseNodeResponse  {
         super.writeTo(out);
         out.writeOptionalString(modelStatus);
         out.writeOptionalStringArray(loadedModelIds);
+        out.writeOptionalStringArray(runningLoadModelIds);
         out.writeOptionalStringArray(runningLoadModelTaskIds);
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponseTest.java
@@ -12,6 +12,8 @@ import org.opensearch.common.transport.TransportAddress;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
@@ -23,6 +25,7 @@ public class MLSyncUpNodeResponseTest {
     private final String modelStatus = "modelStatus";
     private final String[] loadedModelIds = {"loadedModelIds"};
     private final String[] runningLoadModelTaskIds = {"runningLoadModelTaskIds"};
+    private final String[] runningLoadModelIds = {"modelid1"};
     @Before
     public void setUp() throws Exception {
         localNode = new DiscoveryNode(
@@ -37,7 +40,7 @@ public class MLSyncUpNodeResponseTest {
 
     @Test
     public void testSerializationDeserialization() throws IOException {
-        MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(localNode, modelStatus, loadedModelIds, runningLoadModelTaskIds);
+        MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(localNode, modelStatus, loadedModelIds, runningLoadModelIds, runningLoadModelTaskIds);
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
         MLSyncUpNodeResponse newResponse = new MLSyncUpNodeResponse(output.bytes().streamInput());
@@ -50,7 +53,7 @@ public class MLSyncUpNodeResponseTest {
 
     @Test
     public void testReadProfile() throws IOException {
-        MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(localNode, modelStatus, loadedModelIds, runningLoadModelTaskIds);
+        MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(localNode, modelStatus, loadedModelIds, runningLoadModelIds, runningLoadModelTaskIds);
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
         MLSyncUpNodeResponse newResponse = MLSyncUpNodeResponse.readStats(output.bytes().streamInput());

--- a/plugin/src/main/java/org/opensearch/ml/action/load/TransportLoadModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/load/TransportLoadModelAction.java
@@ -257,7 +257,8 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
         mlModelManager
             .updateModel(
                 modelId,
-                ImmutableMap.of(MLModel.MODEL_STATE_FIELD, MLModelState.LOADING),
+                ImmutableMap
+                    .of(MLModel.MODEL_STATE_FIELD, MLModelState.LOADING, MLModel.PLANNING_WORKER_NODE_COUNT_FIELD, eligibleNodes.size()),
                 ActionListener
                     .wrap(
                         r -> client.execute(MLLoadModelOnNodeAction.INSTANCE, loadModelRequest, actionListener),

--- a/plugin/src/main/java/org/opensearch/ml/action/upload_chunk/MLModelMetaCreate.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/upload_chunk/MLModelMetaCreate.java
@@ -48,6 +48,7 @@ public class MLModelMetaCreate {
             FunctionName functionName = mlCreateModelMetaInput.getFunctionName();
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
                 mlIndicesHandler.initModelIndexIfAbsent(ActionListener.wrap(res -> {
+                    Instant now = Instant.now();
                     MLModel mlModelMeta = MLModel
                         .builder()
                         .name(modelName)
@@ -60,7 +61,8 @@ public class MLModelMetaCreate {
                         .totalChunks(mlCreateModelMetaInput.getTotalChunks())
                         .modelContentHash(mlCreateModelMetaInput.getModelContentHashValue())
                         .modelContentSizeInBytes(mlCreateModelMetaInput.getModelContentSizeInBytes())
-                        .createdTime(Instant.now())
+                        .createdTime(now)
+                        .lastUpdateTime(now)
                         .build();
                     IndexRequest indexRequest = new IndexRequest(ML_MODEL_INDEX);
                     indexRequest

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
@@ -5,31 +5,58 @@
 
 package org.opensearch.ml.cluster;
 
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+
+import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Semaphore;
 
 import lombok.extern.log4j.Log4j2;
 
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.common.transport.sync.MLSyncUpAction;
 import org.opensearch.ml.common.transport.sync.MLSyncUpInput;
 import org.opensearch.ml.common.transport.sync.MLSyncUpNodeResponse;
 import org.opensearch.ml.common.transport.sync.MLSyncUpNodesRequest;
+import org.opensearch.ml.indices.MLIndicesHandler;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 
 @Log4j2
 public class MLSyncUpCron implements Runnable {
 
+    public static final int LOAD_MODEL_TASK_GRACE_TIME_IN_MS = 20_000;
     private Client client;
+    private ClusterService clusterService;
     private DiscoveryNodeHelper nodeHelper;
+    private MLIndicesHandler mlIndicesHandler;
+    @VisibleForTesting
+    Semaphore updateModelStateSemaphore;
 
-    public MLSyncUpCron(Client client, DiscoveryNodeHelper nodeHelper) {
+    public MLSyncUpCron(Client client, ClusterService clusterService, DiscoveryNodeHelper nodeHelper, MLIndicesHandler mlIndicesHandler) {
         this.client = client;
+        this.clusterService = clusterService;
         this.nodeHelper = nodeHelper;
+        this.mlIndicesHandler = mlIndicesHandler;
+        this.updateModelStateSemaphore = new Semaphore(1);
     }
 
     @Override
@@ -45,6 +72,8 @@ public class MLSyncUpCron implements Runnable {
             Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
             // key is task id, value is set of worker node ids
             Map<String, Set<String>> runningLoadModelTasks = new HashMap<>();
+            // key is model id, value is set of worker node ids
+            Map<String, Set<String>> loadingModels = new HashMap<>();
             for (MLSyncUpNodeResponse response : responses) {
                 String nodeId = response.getNode().getId();
                 String[] loadedModelIds = response.getLoadedModelIds();
@@ -54,6 +83,14 @@ public class MLSyncUpCron implements Runnable {
                         workerNodes.add(nodeId);
                     }
                 }
+                String[] runningModelIds = response.getRunningLoadModelIds();
+                if (runningModelIds != null && runningModelIds.length > 0) {
+                    for (String modelId : runningModelIds) {
+                        Set<String> workerNodes = loadingModels.computeIfAbsent(modelId, it -> new HashSet<>());
+                        workerNodes.add(nodeId);
+                    }
+                }
+
                 String[] runningLoadModelTaskIds = response.getRunningLoadModelTaskIds();
                 if (runningLoadModelTaskIds != null && runningLoadModelTaskIds.length > 0) {
                     for (String taskId : runningLoadModelTaskIds) {
@@ -63,7 +100,8 @@ public class MLSyncUpCron implements Runnable {
                 }
             }
             for (Map.Entry<String, Set<String>> entry : modelWorkerNodes.entrySet()) {
-                log.debug("will sync model worker nodes for model: {}: {}", entry.getKey(), entry.getValue().toArray(new String[0]));
+                String modelId = entry.getKey();
+                log.debug("will sync model worker nodes for model: {}: {}", modelId, entry.getValue().toArray(new String[0]));
             }
             for (Map.Entry<String, Set<String>> entry : runningLoadModelTasks.entrySet()) {
                 log.debug("will sync running task: {}: {}", entry.getKey(), entry.getValue().toArray(new String[0]));
@@ -91,6 +129,139 @@ public class MLSyncUpCron implements Runnable {
                             ex -> { log.error("Failed to sync model routing", ex); }
                         )
                 );
+
+            // refresh model status
+            if (clusterService.state().getRoutingTable().hasIndex(ML_MODEL_INDEX)) {
+                mlIndicesHandler
+                    .initModelIndexIfAbsent(
+                        ActionListener
+                            .wrap(
+                                res -> { refreshModelState(modelWorkerNodes, loadingModels); },
+                                e -> { log.error("Failed to init model index", e); }
+                            )
+                    );
+            }
         }, e -> { log.error("Failed to sync model routing", e); }));
+    }
+
+    @VisibleForTesting
+    void refreshModelState(Map<String, Set<String>> modelWorkerNodes, Map<String, Set<String>> loadingModels) {
+        if (!updateModelStateSemaphore.tryAcquire()) {
+            return;
+        }
+        try {
+            SearchRequest searchRequest = new SearchRequest(ML_MODEL_INDEX);
+            BoolQueryBuilder queryBuilder = new BoolQueryBuilder();
+            queryBuilder
+                .filter(
+                    new TermsQueryBuilder(
+                        MLModel.MODEL_STATE_FIELD,
+                        Arrays
+                            .asList(
+                                MLModelState.LOADING.name(),
+                                MLModelState.PARTIALLY_LOADED.name(),
+                                MLModelState.LOADED.name(),
+                                MLModelState.LOAD_FAILED.name()
+                            )
+                    )
+                );
+            SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+            sourceBuilder.query(queryBuilder);
+            sourceBuilder.size(10_000);
+            sourceBuilder
+                .fetchSource(
+                    new String[] {
+                        MLModel.MODEL_STATE_FIELD,
+                        MLModel.PLANNING_WORKER_NODE_COUNT_FIELD,
+                        MLModel.LAST_UPDATE_TIME_FIELD,
+                        MLModel.CURRENT_WORKER_NODE_COUNT_FIELD },
+                    null
+                );
+            searchRequest.source(sourceBuilder);
+            client.search(searchRequest, ActionListener.wrap(res -> {
+                SearchHit[] hits = res.getHits().getHits();
+                Map<String, MLModelState> newModelStates = new HashMap<>();
+                for (SearchHit hit : hits) {
+                    String modelId = hit.getId();
+                    Map<String, Object> sourceAsMap = hit.getSourceAsMap();
+                    MLModelState state = MLModelState.from((String) sourceAsMap.get(MLModel.MODEL_STATE_FIELD));
+                    Long lastUpdateTime = sourceAsMap.containsKey(MLModel.LAST_UPDATE_TIME_FIELD)
+                        ? (Long) sourceAsMap.get(MLModel.LAST_UPDATE_TIME_FIELD)
+                        : null;
+                    int planningWorkerNodeCount = 0;
+                    if (sourceAsMap.containsKey(MLModel.PLANNING_WORKER_NODE_COUNT_FIELD)) {
+                        planningWorkerNodeCount = (int) sourceAsMap.get(MLModel.PLANNING_WORKER_NODE_COUNT_FIELD);
+                    }
+                    int currentWorkerNodeCountInIndex = 0;
+                    if (sourceAsMap.containsKey(MLModel.CURRENT_WORKER_NODE_COUNT_FIELD)) {
+                        currentWorkerNodeCountInIndex = (int) sourceAsMap.get(MLModel.CURRENT_WORKER_NODE_COUNT_FIELD);
+                    }
+                    Set<String> loadTaskNodes = loadingModels.get(modelId);
+                    if (loadTaskNodes == null || loadTaskNodes.size() == 0) {
+                        int currentWorkerNodeCount = modelWorkerNodes.containsKey(modelId) ? modelWorkerNodes.get(modelId).size() : 0;
+                        if (currentWorkerNodeCount == 0
+                            && state != MLModelState.LOAD_FAILED
+                            && !(state == MLModelState.LOADING
+                                && lastUpdateTime != null
+                                && lastUpdateTime + LOAD_MODEL_TASK_GRACE_TIME_IN_MS > Instant.now().toEpochMilli())) {
+                            newModelStates.put(modelId, MLModelState.LOAD_FAILED);
+                        }
+                        if (currentWorkerNodeCount > 0) {
+                            if (currentWorkerNodeCount < planningWorkerNodeCount
+                                && (state != MLModelState.PARTIALLY_LOADED || currentWorkerNodeCountInIndex != currentWorkerNodeCount)) {
+                                newModelStates.put(modelId, MLModelState.PARTIALLY_LOADED);
+                            } else if (planningWorkerNodeCount > 0
+                                && currentWorkerNodeCount >= planningWorkerNodeCount
+                                && state != MLModelState.LOADED) {
+                                newModelStates.put(modelId, MLModelState.LOADED);
+                                if (currentWorkerNodeCount > planningWorkerNodeCount) {
+                                    log
+                                        .warn(
+                                            "Model {} loaded on more nodes [{}] than planing worker node[{}]",
+                                            modelId,
+                                            currentWorkerNodeCount,
+                                            planningWorkerNodeCount
+                                        );
+                                }
+                            }
+                        }
+                    } else if (state != MLModelState.LOADING) {
+                        newModelStates.put(modelId, MLModelState.LOADING);
+                    }
+                }
+                if (newModelStates.size() > 0) {
+                    BulkRequest bulkUpdateRequest = new BulkRequest();
+                    for (String modelId : newModelStates.keySet()) {
+                        UpdateRequest updateRequest = new UpdateRequest();
+                        Instant now = Instant.now();
+                        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+                        builder
+                            .put(MLModel.MODEL_STATE_FIELD, newModelStates.get(modelId).name())
+                            .put(MLModel.LAST_UPDATE_TIME_FIELD, now.toEpochMilli());
+                        Set<String> workerNodes = modelWorkerNodes.get(modelId);
+                        int currentWorkNodeCount = workerNodes == null ? 0 : workerNodes.size();
+                        builder.put(MLModel.CURRENT_WORKER_NODE_COUNT_FIELD, currentWorkNodeCount);
+                        updateRequest.index(ML_MODEL_INDEX).id(modelId).doc(builder.build());
+                        bulkUpdateRequest.add(updateRequest);
+                    }
+                    log.info("Refresh model state: {}", newModelStates);
+                    client.bulk(bulkUpdateRequest, ActionListener.wrap(br -> {
+                        updateModelStateSemaphore.release();
+                        log.debug("Refresh model state successfully");
+                    }, e -> {
+                        updateModelStateSemaphore.release();
+                        log.error("Failed to bulk update model state", e);
+                    }));
+                } else {
+                    updateModelStateSemaphore.release();
+                }
+            }, e -> {
+                updateModelStateSemaphore.release();
+                log.error("Failed to search models", e);
+            }));
+        } catch (Exception e) {
+            updateModelStateSemaphore.release();
+            log.error("Failed to refresh model state", e);
+        }
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -617,7 +617,7 @@ public class MLModelManager {
         }
         Map<String, Object> newUpdatedFields = new HashMap<>();
         newUpdatedFields.putAll(updatedFields);
-        newUpdatedFields.put(MLModel.LAST_UPDATE_TIME_FIELD, Instant.now().toEpochMilli());
+        newUpdatedFields.put(MLModel.LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli());
         UpdateRequest updateRequest = new UpdateRequest(ML_MODEL_INDEX, modelId);
         updateRequest.doc(newUpdatedFields);
         updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -217,6 +217,7 @@ public class MLModelManager {
             mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
             String modelName = uploadInput.getModelName();
             String version = uploadInput.getVersion();
+            Instant now = Instant.now();
             mlIndicesHandler.initModelIndexIfAbsent(ActionListener.wrap(res -> {
                 MLModel mlModelMeta = MLModel
                     .builder()
@@ -227,7 +228,8 @@ public class MLModelManager {
                     .modelFormat(uploadInput.getModelFormat())
                     .modelState(MLModelState.UPLOADING)
                     .modelConfig(uploadInput.getModelConfig())
-                    .createdTime(Instant.now())
+                    .createdTime(now)
+                    .lastUpdateTime(now)
                     .build();
                 IndexRequest indexModelMetaRequest = new IndexRequest(ML_MODEL_INDEX);
                 indexModelMetaRequest.source(mlModelMeta.toXContent(XContentBuilder.builder(JSON.xContent()), EMPTY_PARAMS));
@@ -284,6 +286,7 @@ public class MLModelManager {
                 File file = new File(name);
                 byte[] bytes = Files.toByteArray(file);
                 int chunkNum = Integer.parseInt(file.getName());
+                Instant now = Instant.now();
                 MLModel mlModel = MLModel
                     .builder()
                     .modelId(modelId)
@@ -294,7 +297,8 @@ public class MLModelManager {
                     .chunkNumber(chunkNum)
                     .totalChunks(chunkFiles.size())
                     .content(Base64.getEncoder().encodeToString(bytes))
-                    .createdTime(Instant.now())
+                    .createdTime(now)
+                    .lastUpdateTime(now)
                     .build();
                 IndexRequest indexRequest = new IndexRequest(ML_MODEL_INDEX);
                 String chunkId = getModelChunkId(modelId, chunkNum);
@@ -611,11 +615,14 @@ public class MLModelManager {
             listener.onFailure(new IllegalArgumentException("Updated fields is null or empty"));
             return;
         }
+        Map<String, Object> newUpdatedFields = new HashMap<>();
+        newUpdatedFields.putAll(updatedFields);
+        newUpdatedFields.put(MLModel.LAST_UPDATE_TIME_FIELD, Instant.now().toEpochMilli());
         UpdateRequest updateRequest = new UpdateRequest(ML_MODEL_INDEX, modelId);
-        updateRequest.doc(updatedFields);
+        updateRequest.doc(newUpdatedFields);
         updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        if (updatedFields.containsKey(MLModel.MODEL_STATE_FIELD)
-            && MODEL_DONE_STATES.contains(updatedFields.get(MLModel.MODEL_STATE_FIELD))) {
+        if (newUpdatedFields.containsKey(MLModel.MODEL_STATE_FIELD)
+            && MODEL_DONE_STATES.contains(newUpdatedFields.get(MLModel.MODEL_STATE_FIELD))) {
             updateRequest.retryOnConflict(3);
         }
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -348,7 +348,8 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
             client,
             settings,
             threadPool,
-            nodeHelper
+            nodeHelper,
+            mlIndicesHandler
         );
 
         return ImmutableList

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -27,7 +27,7 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS = Setting
         .intSetting(
             "plugins.ml_commons.sync_up_job_interval_in_seconds",
-            10,
+            3,
             0,
             86400,
             Setting.Property.NodeScope,

--- a/plugin/src/test/java/org/opensearch/ml/action/forward/TransportForwardActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/forward/TransportForwardActionTests.java
@@ -24,6 +24,7 @@ import static org.opensearch.ml.utils.TestHelper.ML_ROLE;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -154,7 +155,8 @@ public class TransportForwardActionTests extends OpenSearchTestCase {
 
     public void testDoExecute_LoadModelDone_Error_NullTaskWorkerNodes() {
         when(mlTaskManager.getWorkNodes(anyString())).thenReturn(null);
-        MLTaskCache mlTaskCache = MLTaskCache.builder().mlTask(createMlTask(MLTaskType.UPLOAD_MODEL)).build();
+        List<String> workerNodes = Arrays.asList(nodeId1, nodeId2);
+        MLTaskCache mlTaskCache = MLTaskCache.builder().mlTask(createMlTask(MLTaskType.UPLOAD_MODEL)).workerNodes(workerNodes).build();
         mlTaskCache.addError(nodeId1, error);
         doReturn(mlTaskCache).when(mlTaskManager).getMLTaskCache(anyString());
         when(mlModelManager.getWorkerNodes(anyString())).thenReturn(new String[] { nodeId1, nodeId2 });

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
@@ -328,7 +328,7 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         if (currentWorkerNodeCount != null) {
             content.field(MLModel.CURRENT_WORKER_NODE_COUNT_FIELD, currentWorkerNodeCount);
         }
-        content.field(MLModel.LAST_UPDATE_TIME_FIELD, lastUpdateTime);
+        content.field(MLModel.LAST_UPDATED_TIME_FIELD, lastUpdateTime);
         content.endObject();
 
         SearchHit[] hits = new SearchHit[1];

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
@@ -9,27 +9,54 @@ import static java.util.Collections.emptyMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.utils.TestHelper.ML_ROLE;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.common.transport.sync.MLSyncUpAction;
 import org.opensearch.ml.common.transport.sync.MLSyncUpNodeResponse;
 import org.opensearch.ml.common.transport.sync.MLSyncUpNodesResponse;
+import org.opensearch.ml.utils.TestHelper;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.internal.InternalSearchResponse;
+import org.opensearch.search.profile.SearchProfileShardResults;
+import org.opensearch.search.suggest.Suggest;
 import org.opensearch.test.OpenSearchTestCase;
 
 import com.google.common.collect.ImmutableSet;
@@ -38,6 +65,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
 
     @Mock
     private Client client;
+    @Mock
+    private ClusterService clusterService;
     @Mock
     private DiscoveryNodeHelper nodeHelper;
 
@@ -53,7 +82,7 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         MockitoAnnotations.openMocks(this);
         mlNode1 = new DiscoveryNode(mlNode1Id, buildNewFakeTransportAddress(), emptyMap(), ImmutableSet.of(ML_ROLE), Version.CURRENT);
         mlNode2 = new DiscoveryNode(mlNode2Id, buildNewFakeTransportAddress(), emptyMap(), ImmutableSet.of(ML_ROLE), Version.CURRENT);
-        syncUpCron = new MLSyncUpCron(client, nodeHelper);
+        syncUpCron = new MLSyncUpCron(client, clusterService, nodeHelper, null);
     }
 
     public void testRun() {
@@ -83,13 +112,194 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         verify(client, times(1)).execute(eq(MLSyncUpAction.INSTANCE), any(), any());
     }
 
+    public void testRefreshModelState_NoSemaphore() throws InterruptedException {
+        syncUpCron.updateModelStateSemaphore.acquire();
+        syncUpCron.refreshModelState(null, null);
+        verify(client, never()).search(any(), any());
+        syncUpCron.updateModelStateSemaphore.release();
+    }
+
+    public void testRefreshModelState_SearchException() {
+        doThrow(new RuntimeException("test exception")).when(client).search(any(), any());
+        syncUpCron.refreshModelState(null, null);
+        verify(client, times(1)).search(any(), any());
+        assertTrue(syncUpCron.updateModelStateSemaphore.tryAcquire());
+        syncUpCron.updateModelStateSemaphore.release();
+    }
+
+    public void testRefreshModelState_SearchFailed() {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener.onFailure(new RuntimeException("search error"));
+            return null;
+        }).when(client).search(any(), any());
+        syncUpCron.refreshModelState(null, null);
+        verify(client, times(1)).search(any(), any());
+        assertTrue(syncUpCron.updateModelStateSemaphore.tryAcquire());
+        syncUpCron.updateModelStateSemaphore.release();
+    }
+
+    public void testRefreshModelState_EmptySearchResponse() {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            SearchHits hits = new SearchHits(new SearchHit[0], null, Float.NaN);
+            SearchResponseSections searchSections = new SearchResponseSections(
+                hits,
+                InternalAggregations.EMPTY,
+                null,
+                true,
+                false,
+                null,
+                1
+            );
+            SearchResponse searchResponse = new SearchResponse(
+                searchSections,
+                null,
+                1,
+                1,
+                0,
+                11,
+                ShardSearchFailure.EMPTY_ARRAY,
+                SearchResponse.Clusters.EMPTY
+            );
+            actionListener.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(), any());
+        syncUpCron.refreshModelState(new HashMap<>(), new HashMap<>());
+        verify(client, times(1)).search(any(), any());
+        verify(client, never()).bulk(any(), any());
+        assertTrue(syncUpCron.updateModelStateSemaphore.tryAcquire());
+        syncUpCron.updateModelStateSemaphore.release();
+    }
+
+    public void testRefreshModelState_ResetAsLoadFailed() {
+        Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
+        Map<String, Set<String>> loadingModels = new HashMap<>();
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.LOADED, 2, null, Instant.now().toEpochMilli()));
+            return null;
+        }).when(client).search(any(), any());
+        syncUpCron.refreshModelState(modelWorkerNodes, loadingModels);
+        verify(client, times(1)).search(any(), any());
+        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        verify(client, times(1)).bulk(bulkRequestCaptor.capture(), any());
+        BulkRequest bulkRequest = bulkRequestCaptor.getValue();
+        assertEquals(1, bulkRequest.numberOfActions());
+        assertEquals(1, bulkRequest.requests().size());
+        UpdateRequest updateRequest = (UpdateRequest) bulkRequest.requests().get(0);
+        String updateContent = updateRequest.toString();
+        assertTrue(updateContent.contains("\"model_state\":\"LOAD_FAILED\""));
+        assertTrue(updateContent.contains("\"current_worker_node_count\":0"));
+        assertEquals(ML_MODEL_INDEX, updateRequest.index());
+    }
+
+    public void testRefreshModelState_ResetAsPartiallyLoaded() {
+        Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
+        modelWorkerNodes.put("modelId", ImmutableSet.of("node1"));
+        Map<String, Set<String>> loadingModels = new HashMap<>();
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.LOADED, 2, 0, Instant.now().toEpochMilli()));
+            return null;
+        }).when(client).search(any(), any());
+        syncUpCron.refreshModelState(modelWorkerNodes, loadingModels);
+        verify(client, times(1)).search(any(), any());
+        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        verify(client, times(1)).bulk(bulkRequestCaptor.capture(), any());
+        BulkRequest bulkRequest = bulkRequestCaptor.getValue();
+        assertEquals(1, bulkRequest.numberOfActions());
+        assertEquals(1, bulkRequest.requests().size());
+        UpdateRequest updateRequest = (UpdateRequest) bulkRequest.requests().get(0);
+        String updateContent = updateRequest.toString();
+        assertTrue(updateContent.contains("\"model_state\":\"PARTIALLY_LOADED\""));
+        assertTrue(updateContent.contains("\"current_worker_node_count\":1"));
+        assertEquals(ML_MODEL_INDEX, updateRequest.index());
+    }
+
+    public void testRefreshModelState_ResetCurrentWorkerNodeCountForPartiallyLoaded() {
+        Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
+        modelWorkerNodes.put("modelId", ImmutableSet.of("node1"));
+        Map<String, Set<String>> loadingModels = new HashMap<>();
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener
+                .onResponse(createSearchModelResponse("modelId", MLModelState.PARTIALLY_LOADED, 3, 2, Instant.now().toEpochMilli()));
+            return null;
+        }).when(client).search(any(), any());
+        syncUpCron.refreshModelState(modelWorkerNodes, loadingModels);
+        verify(client, times(1)).search(any(), any());
+        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        verify(client, times(1)).bulk(bulkRequestCaptor.capture(), any());
+        BulkRequest bulkRequest = bulkRequestCaptor.getValue();
+        assertEquals(1, bulkRequest.numberOfActions());
+        assertEquals(1, bulkRequest.requests().size());
+        UpdateRequest updateRequest = (UpdateRequest) bulkRequest.requests().get(0);
+        String updateContent = updateRequest.toString();
+        assertTrue(updateContent.contains("\"model_state\":\"PARTIALLY_LOADED\""));
+        assertTrue(updateContent.contains("\"current_worker_node_count\":1"));
+        assertEquals(ML_MODEL_INDEX, updateRequest.index());
+    }
+
+    public void testRefreshModelState_ResetAsLoading() {
+        Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
+        modelWorkerNodes.put("modelId", ImmutableSet.of("node1"));
+        Map<String, Set<String>> loadingModels = new HashMap<>();
+        loadingModels.put("modelId", ImmutableSet.of("node2"));
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.LOAD_FAILED, 2, 0, Instant.now().toEpochMilli()));
+            return null;
+        }).when(client).search(any(), any());
+        syncUpCron.refreshModelState(modelWorkerNodes, loadingModels);
+        verify(client, times(1)).search(any(), any());
+        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        verify(client, times(1)).bulk(bulkRequestCaptor.capture(), any());
+        BulkRequest bulkRequest = bulkRequestCaptor.getValue();
+        assertEquals(1, bulkRequest.numberOfActions());
+        assertEquals(1, bulkRequest.requests().size());
+        UpdateRequest updateRequest = (UpdateRequest) bulkRequest.requests().get(0);
+        String updateContent = updateRequest.toString();
+        assertTrue(updateContent.contains("\"model_state\":\"LOADING\""));
+        assertTrue(updateContent.contains("\"current_worker_node_count\":1"));
+        assertEquals(ML_MODEL_INDEX, updateRequest.index());
+    }
+
+    public void testRefreshModelState_NotResetState_LoadingModelTaskRunning() {
+        Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
+        Map<String, Set<String>> loadingModels = new HashMap<>();
+        loadingModels.put("modelId", ImmutableSet.of("node2"));
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.LOADING, 2, null, Instant.now().toEpochMilli()));
+            return null;
+        }).when(client).search(any(), any());
+        syncUpCron.refreshModelState(modelWorkerNodes, loadingModels);
+        verify(client, times(1)).search(any(), any());
+        verify(client, never()).bulk(any(), any());
+    }
+
+    public void testRefreshModelState_NotResetState_LoadingInGraceTime() {
+        Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
+        Map<String, Set<String>> loadingModels = new HashMap<>();
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.LOADING, 2, null, Instant.now().toEpochMilli()));
+            return null;
+        }).when(client).search(any(), any());
+        syncUpCron.refreshModelState(modelWorkerNodes, loadingModels);
+        verify(client, times(1)).search(any(), any());
+        verify(client, never()).bulk(any(), any());
+    }
+
     private void mockSyncUp_GatherRunningTasks() {
         doAnswer(invocation -> {
             ActionListener<MLSyncUpNodesResponse> listener = invocation.getArgument(2);
             List<MLSyncUpNodeResponse> nodeResponses = new ArrayList<>();
             String[] loadedModelIds = new String[] { randomAlphaOfLength(10) };
+            String[] runningLoadModelIds = new String[] { randomAlphaOfLength(10) };
             String[] runningLoadModelTaskIds = new String[] { randomAlphaOfLength(10) };
-            nodeResponses.add(new MLSyncUpNodeResponse(mlNode1, "ok", loadedModelIds, runningLoadModelTaskIds));
+            nodeResponses.add(new MLSyncUpNodeResponse(mlNode1, "ok", loadedModelIds, runningLoadModelIds, runningLoadModelTaskIds));
             MLSyncUpNodesResponse response = new MLSyncUpNodesResponse(ClusterName.DEFAULT, nodeResponses, Arrays.asList());
             listener.onResponse(response);
             return null;
@@ -102,5 +312,45 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
             listener.onFailure(new RuntimeException("failed to get running tasks"));
             return null;
         }).when(client).execute(eq(MLSyncUpAction.INSTANCE), any(), any());
+    }
+
+    private SearchResponse createSearchModelResponse(
+        String modelId,
+        MLModelState state,
+        Integer planningWorkerNodeCount,
+        Integer currentWorkerNodeCount,
+        Long lastUpdateTime
+    ) throws IOException {
+        XContentBuilder content = TestHelper.builder();
+        content.startObject();
+        content.field(MLModel.MODEL_STATE_FIELD, state);
+        content.field(MLModel.PLANNING_WORKER_NODE_COUNT_FIELD, planningWorkerNodeCount);
+        if (currentWorkerNodeCount != null) {
+            content.field(MLModel.CURRENT_WORKER_NODE_COUNT_FIELD, currentWorkerNodeCount);
+        }
+        content.field(MLModel.LAST_UPDATE_TIME_FIELD, lastUpdateTime);
+        content.endObject();
+
+        SearchHit[] hits = new SearchHit[1];
+        hits[0] = new SearchHit(0, modelId, null, null).sourceRef(BytesReference.bytes(content));
+
+        return new SearchResponse(
+            new InternalSearchResponse(
+                new SearchHits(hits, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f),
+                InternalAggregations.EMPTY,
+                new Suggest(Collections.emptyList()),
+                new SearchProfileShardResults(Collections.emptyMap()),
+                false,
+                false,
+                1
+            ),
+            "",
+            5,
+            5,
+            0,
+            100,
+            ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY
+        );
     }
 }


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
When load model, there are some edge cases the model state is not accurate:

1. Node crashed when loading model, then the model may stay on LOADING state forever. Should change it to LOAD_FAILED.
2. After model loaded, some ML node crashed, then the model will still stay on LOADED state. Should change it to PARTIALLY_LOADED state
3. After model loaded, all ML nodes crashed or cluster restart, then the model will still stay on LOADED state. Should change it to LOAD_FAILED state.

This PR also adds two new fields in model index: 
1. `planning_worker_node_count`: plan to deploy model to how many nodes 
2. `current_worker_node_count`: model is running on how many nodes

### Issues Resolved
close https://github.com/opensearch-project/ml-commons/issues/703
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
