### PR TITLE
Enhance profile API to add model centric result controlled by view parameter

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileModelResponse.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileModelResponse.java
@@ -7,9 +7,14 @@
 
 package org.opensearch.ml.action.profile;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -17,10 +22,6 @@ import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.profile.MLModelProfile;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 @Getter
 @NoArgsConstructor
@@ -55,27 +56,27 @@ public class MLProfileModelResponse implements ToXContentFragment, Writeable {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         if (targetWorkerNodes != null) {
-           builder.field("target_worker_nodes", targetWorkerNodes);
+            builder.field("target_worker_nodes", targetWorkerNodes);
         }
         if (workerNodes != null) {
             builder.field("worker_nodes", workerNodes);
         }
         if (mlModelProfileMap.size() > 0) {
-           builder.startObject("nodes");
-           for (Map.Entry<String, MLModelProfile> entry : mlModelProfileMap.entrySet()) {
-               builder.field(entry.getKey(), entry.getValue());
-           }
-           builder.endObject();
+            builder.startObject("nodes");
+            for (Map.Entry<String, MLModelProfile> entry : mlModelProfileMap.entrySet()) {
+                builder.field(entry.getKey(), entry.getValue());
+            }
+            builder.endObject();
         }
         if (mlTaskMap.size() > 0) {
-           builder.startObject("tasks");
-           for (Map.Entry<String, MLTask> entry : mlTaskMap.entrySet()) {
-               builder.field(entry.getKey(), entry.getValue());
-           }
-           builder.endObject();
+            builder.startObject("tasks");
+            for (Map.Entry<String, MLTask> entry : mlTaskMap.entrySet()) {
+                builder.field(entry.getKey(), entry.getValue());
+            }
+            builder.endObject();
         }
-       builder.endObject();
-       return builder;
+        builder.endObject();
+        return builder;
     }
 
     @Override

--- a/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileModelResponse.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileModelResponse.java
@@ -16,7 +16,6 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.ml.common.MLTask;
-import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.profile.MLModelProfile;
 
 import java.io.IOException;
@@ -36,7 +35,7 @@ public class MLProfileModelResponse implements ToXContentFragment, Writeable {
 
     private Map<String, MLTask> mlTaskMap = new HashMap<>();
 
-    public MLProfileModelResponse(MLModelState modelState, String[] targetWorkerNodes, String[] workerNodes) {
+    public MLProfileModelResponse(String[] targetWorkerNodes, String[] workerNodes) {
         this.targetWorkerNodes = targetWorkerNodes;
         this.workerNodes = workerNodes;
     }
@@ -54,27 +53,27 @@ public class MLProfileModelResponse implements ToXContentFragment, Writeable {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-       builder.startObject();
-       if (targetWorkerNodes != null) {
+        builder.startObject();
+        if (targetWorkerNodes != null) {
            builder.field("target_worker_nodes", targetWorkerNodes);
-       }
-       if (workerNodes != null) {
-           builder.field("worker_nodes", workerNodes);
-       }
-       if (mlModelProfileMap.size() > 0) {
+        }
+        if (workerNodes != null) {
+            builder.field("worker_nodes", workerNodes);
+        }
+        if (mlModelProfileMap.size() > 0) {
            builder.startObject("nodes");
            for (Map.Entry<String, MLModelProfile> entry : mlModelProfileMap.entrySet()) {
                builder.field(entry.getKey(), entry.getValue());
            }
            builder.endObject();
-       }
-       if (mlTaskMap.size() > 0) {
+        }
+        if (mlTaskMap.size() > 0) {
            builder.startObject("tasks");
            for (Map.Entry<String, MLTask> entry : mlTaskMap.entrySet()) {
                builder.field(entry.getKey(), entry.getValue());
            }
            builder.endObject();
-       }
+        }
        builder.endObject();
        return builder;
     }
@@ -83,17 +82,18 @@ public class MLProfileModelResponse implements ToXContentFragment, Writeable {
     public void writeTo(StreamOutput streamOutput) throws IOException {
         streamOutput.writeOptionalStringArray(workerNodes);
         streamOutput.writeOptionalStringArray(targetWorkerNodes);
-        if (mlTaskMap.size() > 0) {
-            streamOutput.writeBoolean(true);
-            streamOutput.writeMap(mlTaskMap, StreamOutput::writeString, (o, r) -> r.writeTo(o));
-        } else {
-            streamOutput.writeBoolean(false);
-        }
         if (mlModelProfileMap.size() > 0) {
             streamOutput.writeBoolean(true);
             streamOutput.writeMap(mlModelProfileMap, StreamOutput::writeString, (o, r) -> r.writeTo(o));
         } else {
             streamOutput.writeBoolean(false);
         }
+        if (mlTaskMap.size() > 0) {
+            streamOutput.writeBoolean(true);
+            streamOutput.writeMap(mlTaskMap, StreamOutput::writeString, (o, r) -> r.writeTo(o));
+        } else {
+            streamOutput.writeBoolean(false);
+        }
+
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileModelResponse.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/profile/MLProfileModelResponse.java
@@ -1,0 +1,99 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.ml.action.profile;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.ToXContentFragment;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.common.model.MLModelState;
+import org.opensearch.ml.profile.MLModelProfile;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+public class MLProfileModelResponse implements ToXContentFragment, Writeable {
+    @Setter
+    private String[] targetWorkerNodes;
+
+    @Setter
+    private String[] workerNodes;
+
+    private Map<String, MLModelProfile> mlModelProfileMap = new HashMap<>();
+
+    private Map<String, MLTask> mlTaskMap = new HashMap<>();
+
+    public MLProfileModelResponse(MLModelState modelState, String[] targetWorkerNodes, String[] workerNodes) {
+        this.targetWorkerNodes = targetWorkerNodes;
+        this.workerNodes = workerNodes;
+    }
+
+    public MLProfileModelResponse(StreamInput in) throws IOException {
+        this.workerNodes = in.readOptionalStringArray();
+        this.targetWorkerNodes = in.readOptionalStringArray();
+        if (in.readBoolean()) {
+            this.mlModelProfileMap = in.readMap(StreamInput::readString, MLModelProfile::new);
+        }
+        if (in.readBoolean()) {
+            this.mlTaskMap = in.readMap(StreamInput::readString, MLTask::new);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+       builder.startObject();
+       if (targetWorkerNodes != null) {
+           builder.field("target_worker_nodes", targetWorkerNodes);
+       }
+       if (workerNodes != null) {
+           builder.field("worker_nodes", workerNodes);
+       }
+       if (mlModelProfileMap.size() > 0) {
+           builder.startObject("nodes");
+           for (Map.Entry<String, MLModelProfile> entry : mlModelProfileMap.entrySet()) {
+               builder.field(entry.getKey(), entry.getValue());
+           }
+           builder.endObject();
+       }
+       if (mlTaskMap.size() > 0) {
+           builder.startObject("tasks");
+           for (Map.Entry<String, MLTask> entry : mlTaskMap.entrySet()) {
+               builder.field(entry.getKey(), entry.getValue());
+           }
+           builder.endObject();
+       }
+       builder.endObject();
+       return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput streamOutput) throws IOException {
+        streamOutput.writeOptionalStringArray(workerNodes);
+        streamOutput.writeOptionalStringArray(targetWorkerNodes);
+        if (mlTaskMap.size() > 0) {
+            streamOutput.writeBoolean(true);
+            streamOutput.writeMap(mlTaskMap, StreamOutput::writeString, (o, r) -> r.writeTo(o));
+        } else {
+            streamOutput.writeBoolean(false);
+        }
+        if (mlModelProfileMap.size() > 0) {
+            streamOutput.writeBoolean(true);
+            streamOutput.writeMap(mlModelProfileMap, StreamOutput::writeString, (o, r) -> r.writeTo(o));
+        } else {
+            streamOutput.writeBoolean(false);
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLProfileAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLProfileAction.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableMap;
 import lombok.extern.log4j.Log4j2;
 
 import org.opensearch.action.ActionListener;
@@ -44,6 +43,7 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 @Log4j2
 public class RestMLProfileAction extends BaseRestHandler {
@@ -144,8 +144,10 @@ public class RestMLProfileAction extends BaseRestHandler {
             for (Map.Entry<String, MLModelProfile> entry : modelProfileMap.entrySet()) {
                 MLProfileModelResponse mlProfileModelResponse = modelCentricMap.get(entry.getKey());
                 if (mlProfileModelResponse == null) {
-                    mlProfileModelResponse = new MLProfileModelResponse(entry.getValue().getTargetWorkerNodes(),
-                        entry.getValue().getWorkerNodes());
+                    mlProfileModelResponse = new MLProfileModelResponse(
+                        entry.getValue().getTargetWorkerNodes(),
+                        entry.getValue().getWorkerNodes()
+                    );
                     modelCentricMap.put(entry.getKey(), mlProfileModelResponse);
                 }
                 if (mlProfileModelResponse.getTargetWorkerNodes() == null || mlProfileModelResponse.getWorkerNodes() == null) {
@@ -153,9 +155,14 @@ public class RestMLProfileAction extends BaseRestHandler {
                     mlProfileModelResponse.setWorkerNodes(entry.getValue().getWorkerNodes());
                 }
                 // Create a new object and remove targetWorkerNodes and workerNodes.
-                MLModelProfile modelProfile = new MLModelProfile(entry.getValue().getModelState(),
-                    entry.getValue().getPredictor(), null, null, entry.getValue().getModelInferenceStats(),
-                    entry.getValue().getPredictRequestStats());
+                MLModelProfile modelProfile = new MLModelProfile(
+                    entry.getValue().getModelState(),
+                    entry.getValue().getPredictor(),
+                    null,
+                    null,
+                    entry.getValue().getModelInferenceStats(),
+                    entry.getValue().getPredictRequestStats()
+                );
                 mlProfileModelResponse.getMlModelProfileMap().putAll(ImmutableMap.of(nodeId, modelProfile));
             }
 

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLProfileAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLProfileAction.java
@@ -144,8 +144,8 @@ public class RestMLProfileAction extends BaseRestHandler {
             for (Map.Entry<String, MLModelProfile> entry : modelProfileMap.entrySet()) {
                 MLProfileModelResponse mlProfileModelResponse = modelCentricMap.get(entry.getKey());
                 if (mlProfileModelResponse == null) {
-                    mlProfileModelResponse = new MLProfileModelResponse(entry.getValue().getModelState(), entry.getValue()
-                        .getTargetWorkerNodes(), entry.getValue().getWorkerNodes());
+                    mlProfileModelResponse = new MLProfileModelResponse(entry.getValue().getTargetWorkerNodes(),
+                        entry.getValue().getWorkerNodes());
                     modelCentricMap.put(entry.getKey(), mlProfileModelResponse);
                 }
                 if (mlProfileModelResponse.getTargetWorkerNodes() == null || mlProfileModelResponse.getWorkerNodes() == null) {

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLProfileAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLProfileAction.java
@@ -15,10 +15,13 @@ import static org.opensearch.ml.utils.RestActionUtils.splitCommaSeparatedParam;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableMap;
 import lombok.extern.log4j.Log4j2;
 
 import org.opensearch.action.ActionListener;
@@ -28,9 +31,13 @@ import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.ml.action.profile.MLProfileAction;
+import org.opensearch.ml.action.profile.MLProfileModelResponse;
 import org.opensearch.ml.action.profile.MLProfileNodeResponse;
 import org.opensearch.ml.action.profile.MLProfileRequest;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.profile.MLModelProfile;
 import org.opensearch.ml.profile.MLProfileInput;
+import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
@@ -41,6 +48,10 @@ import com.google.common.collect.ImmutableList;
 @Log4j2
 public class RestMLProfileAction extends BaseRestHandler {
     private static final String PROFILE_ML_ACTION = "profile_ml";
+
+    private static final String VIEW = "view";
+    private static final String MODEL_VIEW = "model";
+    private static final String NODE_VIEW = "node";
 
     private ClusterService clusterService;
 
@@ -80,6 +91,7 @@ public class RestMLProfileAction extends BaseRestHandler {
         } else {
             mlProfileInput = createMLProfileInputFromRequestParams(request);
         }
+        String view = RestActionUtils.getStringParam(request, VIEW).orElse(NODE_VIEW);
         String[] nodeIds = mlProfileInput.retrieveProfileOnAllNodes()
             ? getAllNodes(clusterService)
             : mlProfileInput.getNodeIds().toArray(new String[0]);
@@ -93,7 +105,16 @@ public class RestMLProfileAction extends BaseRestHandler {
                 List<MLProfileNodeResponse> nodeProfiles = r.getNodes().stream().filter(s -> !s.isEmpty()).collect(Collectors.toList());
                 log.debug("Build MLProfileNodeResponse for size of {}", nodeProfiles.size());
                 if (nodeProfiles.size() > 0) {
-                    r.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                    if (NODE_VIEW.equals(view)) {
+                        r.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                    } else if (MODEL_VIEW.equals(view)) {
+                        Map<String, MLProfileModelResponse> modelCentricProfileMap = buildModelCentricResult(nodeProfiles);
+                        builder.startObject("models");
+                        for (Map.Entry<String, MLProfileModelResponse> entry : modelCentricProfileMap.entrySet()) {
+                            builder.field(entry.getKey(), entry.getValue());
+                        }
+                        builder.endObject();
+                    }
                 }
                 builder.endObject();
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
@@ -103,6 +124,52 @@ public class RestMLProfileAction extends BaseRestHandler {
                 onFailure(channel, RestStatus.INTERNAL_SERVER_ERROR, errorMessage, e);
             }));
         };
+    }
+
+    /**
+     * The data structure for node centric is:
+     *  MLProfileNodeResponse:
+     *      taskMap: Map<String, MLTask>
+     *      modelMap: Map<String, MLModelProfile> model_id, MLModelProfile
+     *  And we need to convert to format like this:
+     *  modelMap: Map<String, Map<String, MLModelProfile>>
+     */
+    private Map<String, MLProfileModelResponse> buildModelCentricResult(List<MLProfileNodeResponse> nodeResponses) {
+        // aggregate model information into one final map.
+        Map<String, MLProfileModelResponse> modelCentricMap = new HashMap<>();
+        for (MLProfileNodeResponse mlProfileNodeResponse : nodeResponses) {
+            String nodeId = mlProfileNodeResponse.getNode().getId();
+            Map<String, MLModelProfile> modelProfileMap = mlProfileNodeResponse.getMlNodeModels();
+            Map<String, MLTask> taskProfileMap = mlProfileNodeResponse.getMlNodeTasks();
+            for (Map.Entry<String, MLModelProfile> entry : modelProfileMap.entrySet()) {
+                MLProfileModelResponse mlProfileModelResponse = modelCentricMap.get(entry.getKey());
+                if (mlProfileModelResponse == null) {
+                    mlProfileModelResponse = new MLProfileModelResponse(entry.getValue().getModelState(), entry.getValue()
+                        .getTargetWorkerNodes(), entry.getValue().getWorkerNodes());
+                    modelCentricMap.put(entry.getKey(), mlProfileModelResponse);
+                }
+                if (mlProfileModelResponse.getTargetWorkerNodes() == null || mlProfileModelResponse.getWorkerNodes() == null) {
+                    mlProfileModelResponse.setTargetWorkerNodes(entry.getValue().getTargetWorkerNodes());
+                    mlProfileModelResponse.setWorkerNodes(entry.getValue().getWorkerNodes());
+                }
+                // Create a new object and remove targetWorkerNodes and workerNodes.
+                MLModelProfile modelProfile = new MLModelProfile(entry.getValue().getModelState(),
+                    entry.getValue().getPredictor(), null, null, entry.getValue().getModelInferenceStats(),
+                    entry.getValue().getPredictRequestStats());
+                mlProfileModelResponse.getMlModelProfileMap().putAll(ImmutableMap.of(nodeId, modelProfile));
+            }
+
+            for (Map.Entry<String, MLTask> entry : taskProfileMap.entrySet()) {
+                String modelId = entry.getValue().getModelId();
+                MLProfileModelResponse mlProfileModelResponse = modelCentricMap.get(modelId);
+                if (mlProfileModelResponse == null) {
+                    mlProfileModelResponse = new MLProfileModelResponse();
+                    modelCentricMap.put(modelId, mlProfileModelResponse);
+                }
+                mlProfileModelResponse.getMlTaskMap().putAll(ImmutableMap.of(entry.getKey(), entry.getValue()));
+            }
+        }
+        return modelCentricMap;
     }
 
     MLProfileInput createMLProfileInputFromRequestParams(RestRequest request) {

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -161,4 +161,8 @@ public class RestActionUtils {
         return Optional.ofNullable(request.param(paramName)).map(s -> s.split(","));
     }
 
+    public static Optional<String> getStringParam(RestRequest request, String paramName) {
+        return Optional.ofNullable(request.param(paramName));
+    }
+
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileModelResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileModelResponseTests.java
@@ -7,6 +7,12 @@
 
 package org.opensearch.ml.action.profile;
 
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Before;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.ToXContent;
@@ -23,12 +29,6 @@ import org.opensearch.ml.profile.MLModelProfile;
 import org.opensearch.ml.profile.MLPredictRequestStats;
 import org.opensearch.ml.utils.TestHelper;
 import org.opensearch.test.OpenSearchTestCase;
-
-import java.io.IOException;
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 public class MLProfileModelResponseTests extends OpenSearchTestCase {
 
@@ -64,8 +64,8 @@ public class MLProfileModelResponseTests extends OpenSearchTestCase {
     }
 
     public void test_create_MLProfileModelResponse_withArgs() throws IOException {
-        String[] targetWorkerNodes = new String[]{"node1", "node2"};
-        String[] workerNodes = new String[]{"node1"};
+        String[] targetWorkerNodes = new String[] { "node1", "node2" };
+        String[] workerNodes = new String[] { "node1" };
         Map<String, MLModelProfile> profileMap = new HashMap<>();
         Map<String, MLTask> taskMap = new HashMap<>();
         profileMap.put("node1", mlModelProfile);
@@ -93,8 +93,8 @@ public class MLProfileModelResponseTests extends OpenSearchTestCase {
     }
 
     public void test_toXContent() throws IOException {
-        String[] targetWorkerNodes = new String[]{"node1", "node2"};
-        String[] workerNodes = new String[]{"node1"};
+        String[] targetWorkerNodes = new String[] { "node1", "node2" };
+        String[] workerNodes = new String[] { "node1" };
         Map<String, MLModelProfile> profileMap = new HashMap<>();
         Map<String, MLTask> taskMap = new HashMap<>();
         profileMap.put("node1", mlModelProfile);

--- a/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileModelResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileModelResponseTests.java
@@ -1,0 +1,112 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.ml.action.profile;
+
+import org.junit.Before;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.MLTaskType;
+import org.opensearch.ml.common.dataset.MLInputDataType;
+import org.opensearch.ml.common.model.MLModelState;
+import org.opensearch.ml.profile.MLModelProfile;
+import org.opensearch.ml.profile.MLPredictRequestStats;
+import org.opensearch.ml.utils.TestHelper;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MLProfileModelResponseTests extends OpenSearchTestCase {
+
+    MLTask mlTask;
+    MLModelProfile mlModelProfile;
+
+    @Before
+    public void setup() {
+        mlTask = MLTask
+            .builder()
+            .taskId("test_id")
+            .modelId("model_id")
+            .taskType(MLTaskType.TRAINING)
+            .functionName(FunctionName.AD_LIBSVM)
+            .state(MLTaskState.CREATED)
+            .inputType(MLInputDataType.DATA_FRAME)
+            .progress(0.4f)
+            .outputIndex("test_index")
+            .workerNodes(Arrays.asList("test_node"))
+            .createTime(Instant.ofEpochMilli(123))
+            .lastUpdateTime(Instant.ofEpochMilli(123))
+            .error("error")
+            .user(new User())
+            .async(false)
+            .build();
+        mlModelProfile = MLModelProfile
+            .builder()
+            .predictor("test_predictor")
+            .workerNodes(new String[] { "node1", "node2" })
+            .modelState(MLModelState.LOADED)
+            .modelInferenceStats(MLPredictRequestStats.builder().count(10L).average(11.0).max(20.0).min(5.0).build())
+            .build();
+    }
+
+    public void test_create_MLProfileModelResponse_withArgs() throws IOException {
+        String[] targetWorkerNodes = new String[]{"node1", "node2"};
+        String[] workerNodes = new String[]{"node1"};
+        Map<String, MLModelProfile> profileMap = new HashMap<>();
+        Map<String, MLTask> taskMap = new HashMap<>();
+        profileMap.put("node1", mlModelProfile);
+        taskMap.put("node1", mlTask);
+        MLProfileModelResponse response = new MLProfileModelResponse(targetWorkerNodes, workerNodes);
+        response.getMlModelProfileMap().putAll(profileMap);
+        response.getMlTaskMap().putAll(taskMap);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        MLProfileModelResponse newResponse = new MLProfileModelResponse(output.bytes().streamInput());
+        assertNotNull(newResponse.getTargetWorkerNodes());
+        assertNotNull(response.getTargetWorkerNodes());
+        assertEquals(newResponse.getTargetWorkerNodes().length, response.getTargetWorkerNodes().length);
+        assertEquals(newResponse.getMlModelProfileMap().size(), response.getMlModelProfileMap().size());
+        assertEquals(newResponse.getMlTaskMap().size(), response.getMlTaskMap().size());
+    }
+
+    public void test_create_MLProfileModelResponse_NoArgs() throws IOException {
+        MLProfileModelResponse response = new MLProfileModelResponse();
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        MLProfileModelResponse newResponse = new MLProfileModelResponse(output.bytes().streamInput());
+        assertNull(response.getWorkerNodes());
+        assertNull(newResponse.getWorkerNodes());
+    }
+
+    public void test_toXContent() throws IOException {
+        String[] targetWorkerNodes = new String[]{"node1", "node2"};
+        String[] workerNodes = new String[]{"node1"};
+        Map<String, MLModelProfile> profileMap = new HashMap<>();
+        Map<String, MLTask> taskMap = new HashMap<>();
+        profileMap.put("node1", mlModelProfile);
+        taskMap.put("node1", mlTask);
+        MLProfileModelResponse response = new MLProfileModelResponse(targetWorkerNodes, workerNodes);
+        response.getMlModelProfileMap().putAll(profileMap);
+        response.getMlTaskMap().putAll(taskMap);
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String xContentString = TestHelper.xContentBuilderToString(builder);
+        System.out.println(xContentString);
+    }
+
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLProfileActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLProfileActionTests.java
@@ -12,8 +12,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ml.utils.TestHelper.getProfileRestRequest;
-import static org.opensearch.ml.utils.TestHelper.setupTestClusterState;
+import static org.opensearch.ml.utils.TestHelper.*;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -26,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -41,6 +41,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Strings;
+import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
@@ -281,6 +282,14 @@ public class RestMLProfileActionTests extends OpenSearchTestCase {
         }).when(client).execute(eq(MLProfileAction.INSTANCE), any(), any());
 
         RestRequest request = getRestRequest();
+        profileAction.handleRequest(request, channel, client);
+        ArgumentCaptor<MLProfileRequest> argumentCaptor = ArgumentCaptor.forClass(MLProfileRequest.class);
+        verify(client, times(1)).execute(eq(MLProfileAction.INSTANCE), argumentCaptor.capture(), any());
+    }
+
+    public void test_WhenViewIsModel_ReturnModelViewResult() throws Exception {
+        MLProfileInput mlProfileInput = new MLProfileInput();
+        RestRequest request = getProfileRestRequestWithQueryParams(mlProfileInput, ImmutableMap.of("view", "model"));
         profileAction.handleRequest(request, channel, client);
         ArgumentCaptor<MLProfileRequest> argumentCaptor = ArgumentCaptor.forClass(MLProfileRequest.class);
         verify(client, times(1)).execute(eq(MLProfileAction.INSTANCE), argumentCaptor.capture(), any());

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLProfileActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLProfileActionTests.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -41,7 +40,6 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Strings;
-import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
@@ -69,6 +67,7 @@ import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class RestMLProfileActionTests extends OpenSearchTestCase {
     @Rule

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -215,7 +215,7 @@ public class TestHelper {
     }
 
     public static RestRequest getProfileRestRequest(MLProfileInput input) throws IOException {
-       return new FakeRestRequest.Builder(getXContentRegistry())
+        return new FakeRestRequest.Builder(getXContentRegistry())
             .withContent(new BytesArray(buildRequestContent(input)), XContentType.JSON)
             .build();
     }

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -215,14 +215,22 @@ public class TestHelper {
     }
 
     public static RestRequest getProfileRestRequest(MLProfileInput input) throws IOException {
+       return new FakeRestRequest.Builder(getXContentRegistry())
+            .withContent(new BytesArray(buildRequestContent(input)), XContentType.JSON)
+            .build();
+    }
+
+    public static RestRequest getProfileRestRequestWithQueryParams(MLProfileInput input, Map<String, String> params) throws IOException {
+        return new FakeRestRequest.Builder(getXContentRegistry())
+            .withContent(new BytesArray(buildRequestContent(input)), XContentType.JSON)
+            .withParams(params)
+            .build();
+    }
+
+    private static String buildRequestContent(MLProfileInput input) throws IOException {
         XContentBuilder builder = XContentFactory.jsonBuilder();
         input.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        String requestContent = TestHelper.xContentBuilderToString(builder);
-
-        RestRequest request = new FakeRestRequest.Builder(getXContentRegistry())
-            .withContent(new BytesArray(requestContent), XContentType.JSON)
-            .build();
-        return request;
+        return TestHelper.xContentBuilderToString(builder);
     }
 
     public static RestRequest getStatsRestRequest() {


### PR DESCRIPTION
### Description
This change is to add model centric result for profile API, so that user can fetch either node centric result or model centric result or both.
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/646
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
