### PR TITLE
Typo fix and minor improvement in `maven-publish` GHA workflow.

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,11 +3,10 @@ name: Publish snapshots to maven
 on:
   workflow_dispatch:
   push:
-    branches: [
-        main
-          1.*
-          2.*
-    ]
+    branches:
+      - main
+      - 1.*
+      - 2.*
 
 jobs:
   build-and-publish-snapshots:
@@ -26,7 +25,7 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 17
       - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
           aws-region: us-east-1


### PR DESCRIPTION
### Description
Typo fix in `maven-publish` GHA workflow - branch list has to be a comma-separate list or list of entries.
I also updated `aws-actions/configure-aws-credentials` used to avoid coming deprecation.
 
### Issues Resolved
#755 
#754

(Please, label as `backport 2.x`)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
