### PR TITLE
[Backport to 2.6] change to old method to fix missing method createParentDirectories

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/FileUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/FileUtils.java
@@ -85,7 +85,7 @@ public class FileUtils {
      * @throws IOException
      */
     public static void write(byte[] data, File destinationFile, boolean append) throws IOException {
-        org.apache.commons.io.FileUtils.createParentDirectories(destinationFile);
+        org.apache.commons.io.FileUtils.forceMkdir(destinationFile.getParentFile());
         try (FileOutputStream fileOutputStream = new FileOutputStream(destinationFile, append);
              OutputStream output = new BufferedOutputStream(fileOutputStream)){
             output.write(data);


### PR DESCRIPTION
### Description
Backport PR #758 to branch 2.6
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
