### PR TITLE
Add publication of jars workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -35,4 +35,4 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
-          ./gradlew publishPluginZipPublicationToSnapshotsRepository
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository publishJarsPublicationToSnapshotsRepository

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -68,6 +68,14 @@ publishing {
             name = 'staging'
             url = "${rootProject.buildDir}/local-staging-repo"
         }
+        maven {
+            name = "Snapshots"
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
     }
     publications {
         shadow(MavenPublication) { publication ->
@@ -99,6 +107,34 @@ publishing {
                 }
             }
         }
+        jars(MavenPublication) { publication ->
+            from components.java
+
+            pom {
+                name = "OpenSearch Machine Learning Client"
+                packaging = "jar"
+                url = "https://github.com/opensearch-project/ml-commons"
+                description = "OpenSearch Machine Learning Client"
+                scm {
+                    connection = "scm:git@github.com:opensearch-project/ml-commons.git"
+                    developerConnection = "scm:git@github.com:opensearch-project/ml-commons.git"
+                    url = "git@github.com:opensearch-project/ml-commons.git"
+                }
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        name = "OpenSearch"
+                        url = "https://github.com/opensearch-project/ml-commons"
+                    }
+                }
+            }
+        }
+
     }
 
 }


### PR DESCRIPTION
### Description
There are new gradle task `publishJarsPublicationToSnapshotsRepository` which is called in GHA. It publishes client snapshot jars to the [corresponding repository](https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/opensearch-ml-client/3.0.0.0-SNAPSHOT/).

Tested with `publishPluginZipPublicationToMavenLocal`, it produced
```
$ ls -1 ~/.m2/repository/org/opensearch/opensearch-ml-client/3.0.0.0-SNAPSHOT/
maven-metadata-local.xml
opensearch-ml-client-3.0.0.0-SNAPSHOT.jar
opensearch-ml-client-3.0.0.0-SNAPSHOT.module
opensearch-ml-client-3.0.0.0-SNAPSHOT.pom
```
jar contains
```
$ tree opensearch-ml-client-3.0.0.0-SNAPSHOT/ | grep -v class
opensearch-ml-client-3.0.0.0-SNAPSHOT/
├── META-INF
│   ├── MANIFEST.MF
│   └── maven
│       ├── org.javassist
│       │   └── javassist
│       │       ├── pom.properties
│       │       └── pom.xml
│       └── org.reflections
│           └── reflections
│               ├── pom.properties
│               └── pom.xml
├── javassist
│   ├── bytecode
│   │   ├── analysis
│   │   ├── annotation
│   │   └── stackmap
│   ├── compiler
│   │   └── ast
│   ├── convert
│   ├── expr
│   ├── runtime
│   ├── scopedpool
│   ├── tools
│   │   ├── reflect
│   │   ├── rmi
│   │   └── web
│   └── util
│       └── proxy
└── org
    ├── opensearch
    │   └── ml
    │       ├── client
    │       └── common
    │         .....
    └── reflections
        ├── adapters
        ├── scanners
        ├── serializers
        ├── util
        └── vfs

69 directories, 697 files
```


```
$ ./gradlew --dry-run publishJarsPublicationToMavenLocal
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.4.2
  OS Info               : Linux 5.15.79.1-microsoft-standard-WSL2 (amd64)
  JDK Version           : 11 (Ubuntu JDK)
  JAVA_HOME             : /usr/lib/jvm/java-11-openjdk-amd64
  Random Testing Seed   : E602FED0661BB7B2
  In FIPS 140 mode      : false
=======================================
:opensearch-ml-client:generateEffectiveLombokConfig SKIPPED
:opensearch-ml-common:generateEffectiveLombokConfig SKIPPED
:opensearch-ml-common:compileJava SKIPPED
:opensearch-ml-common:processResources SKIPPED
:opensearch-ml-common:classes SKIPPED
:opensearch-ml-common:jar SKIPPED
:opensearch-ml-client:compileJava SKIPPED
:opensearch-ml-client:processResources SKIPPED
:opensearch-ml-client:classes SKIPPED
:opensearch-ml-client:jar SKIPPED
:opensearch-ml-client:shadowJar SKIPPED
:opensearch-ml-client:generateMetadataFileForJarsPublication SKIPPED
:opensearch-ml-client:generatePomFileForJarsPublication SKIPPED
:opensearch-ml-client:publishJarsPublicationToMavenLocal SKIPPED
```
 
### Issues Resolved
Fixes #763
Discussed in #755, #754
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
