### PR TITLE
Publish shadow jar instead of regular one.

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -35,4 +35,4 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
-          ./gradlew publishPluginZipPublicationToSnapshotsRepository publishJarsPublicationToSnapshotsRepository
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository publishShadowPublicationToSnapshotsRepository


### PR DESCRIPTION
### Description
Continue work done in #764 - workaround for #778.
Having `ml-plugin` is not enough to build SQL plugin, it requires `ml-common` too. Having both together produces jar hell described in #778.
As a workaround I propose publishing a shadow jar.

### Issues Resolved
Related to #778, #764, #763, #754, #755
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
