### PR TITLE
change exception type; get function name from cache

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModel.java
@@ -61,13 +61,13 @@ public abstract class DLModel implements Predictable {
 
     @Override
     public MLOutput predict(MLInput mlInput, MLModel model) {
-        throw new MLException("model not loaded");
+        throw new IllegalArgumentException("model not loaded");
     }
 
     @Override
     public MLOutput predict(MLInput mlInput) {
         if (modelHelper == null || modelId == null) {
-            throw new MLException("model not loaded");
+            throw new IllegalArgumentException("model not loaded");
         }
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<ModelTensorOutput>) () -> {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/TextEmbeddingModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/TextEmbeddingModelTest.java
@@ -285,14 +285,14 @@ public class TextEmbeddingModelTest {
 
     @Test
     public void predict_NullModelHelper() {
-        exceptionRule.expect(MLException.class);
+        exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("model not loaded");
         textEmbeddingModel.predict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build());
     }
 
     @Test
     public void predict_NullModelId() {
-        exceptionRule.expect(MLException.class);
+        exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("model not loaded");
         model.setModelId(null);
         try {
@@ -321,7 +321,7 @@ public class TextEmbeddingModelTest {
 
     @Test
     public void predict_BeforeInitingModel() {
-        exceptionRule.expect(MLException.class);
+        exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("model not loaded");
         textEmbeddingModel.predict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build(), model);
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/load/TransportLoadModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/load/TransportLoadModelAction.java
@@ -39,7 +39,6 @@ import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.MLTaskType;
-import org.opensearch.ml.common.exception.MLResourceNotFoundException;
 import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.common.transport.load.LoadModelInput;
 import org.opensearch.ml.common.transport.load.LoadModelNodesRequest;
@@ -150,7 +149,7 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
             eligibleNodes.addAll(Arrays.asList(allEligibleNodes));
         }
         if (nodeIds.size() == 0) {
-            listener.onFailure(new MLResourceNotFoundException("no eligible node found"));
+            listener.onFailure(new IllegalArgumentException("no eligible node found"));
             return;
         }
 

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
@@ -10,6 +10,7 @@ import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MONITORING
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -310,6 +311,12 @@ public class MLModelCacheHelper {
     public FunctionName getFunctionName(String modelId) {
         MLModelCache modelCache = getExistingModelCache(modelId);
         return modelCache.getFunctionName();
+    }
+
+    public Optional<FunctionName> getOptionalFunctionName(String modelId) {
+        MLModelCache modelCache = modelCaches.get(modelId);
+        FunctionName functionName = modelCache == null ? null : modelCache.getFunctionName();
+        return Optional.ofNullable(functionName);
     }
 
     private MLModelCache getExistingModelCache(String modelId) {

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -43,6 +43,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Semaphore;
@@ -525,8 +526,8 @@ public class MLModelManager {
      */
     public void getModel(String modelId, String[] includes, String[] excludes, ActionListener<MLModel> listener) {
         GetRequest getRequest = new GetRequest();
-        FetchSourceContext featchContext = new FetchSourceContext(true, includes, excludes);
-        getRequest.index(ML_MODEL_INDEX).id(modelId).fetchSourceContext(featchContext);
+        FetchSourceContext fetchContext = new FetchSourceContext(true, includes, excludes);
+        getRequest.index(ML_MODEL_INDEX).id(modelId).fetchSourceContext(fetchContext);
         client.get(getRequest, ActionListener.wrap(r -> {
             if (r != null && r.isExists()) {
                 try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, r.getSourceAsBytesRef())) {
@@ -785,6 +786,10 @@ public class MLModelManager {
 
     public FunctionName getModelFunctionName(String modelId) {
         return modelCacheHelper.getFunctionName(modelId);
+    }
+
+    public Optional<FunctionName> getOptionalModelFunctionName(String modelId) {
+        return modelCacheHelper.getOptionalFunctionName(modelId);
     }
 
     public boolean isModelRunningOnNode(String modelId) {

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -390,7 +390,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
         RestMLStatsAction restMLStatsAction = new RestMLStatsAction(mlStats, clusterService, indexUtils);
         RestMLTrainingAction restMLTrainingAction = new RestMLTrainingAction();
         RestMLTrainAndPredictAction restMLTrainAndPredictAction = new RestMLTrainAndPredictAction();
-        RestMLPredictionAction restMLPredictionAction = new RestMLPredictionAction();
+        RestMLPredictionAction restMLPredictionAction = new RestMLPredictionAction(mlModelManager);
         RestMLExecuteAction restMLExecuteAction = new RestMLExecuteAction();
         RestMLGetModelAction restMLGetModelAction = new RestMLGetModelAction();
         RestMLDeleteModelAction restMLDeleteModelAction = new RestMLDeleteModelAction();

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -41,7 +41,6 @@ import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.MLTaskType;
 import org.opensearch.ml.common.dataset.MLInputDataType;
 import org.opensearch.ml.common.dataset.MLInputDataset;
-import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.output.MLPredictionOutput;
@@ -130,7 +129,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
             String[] workerNodes = mlModelManager.getWorkerNodes(modelId);
             if (workerNodes == null || workerNodes.length == 0) {
                 if (algorithm == FunctionName.TEXT_EMBEDDING) {
-                    listener.onFailure(new MLException("model not loaded"));
+                    listener.onFailure(new IllegalArgumentException("model not loaded"));
                     return;
                 } else {
                     workerNodes = nodeHelper.getEligibleNodeIds();
@@ -215,7 +214,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
                     internalListener.onResponse(response);
                     return;
                 } else if (algorithm == FunctionName.TEXT_EMBEDDING) {
-                    throw new MLException("model not loaded");
+                    throw new IllegalArgumentException("model not loaded");
                 }
             } catch (Exception e) {
                 handlePredictFailure(mlTask, internalListener, e, false);

--- a/plugin/src/test/java/org/opensearch/ml/action/load/TransportLoadModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/load/TransportLoadModelActionTests.java
@@ -38,7 +38,6 @@ import org.opensearch.ml.cluster.DiscoveryNodeHelper;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.MLTask;
-import org.opensearch.ml.common.exception.MLResourceNotFoundException;
 import org.opensearch.ml.common.transport.load.LoadModelNodesResponse;
 import org.opensearch.ml.common.transport.load.LoadModelResponse;
 import org.opensearch.ml.common.transport.load.MLLoadModelRequest;
@@ -173,7 +172,7 @@ public class TransportLoadModelActionTests extends OpenSearchTestCase {
         when(mlLoadModelRequest1.getModelNodeIds()).thenReturn(null);
         ActionListener<LoadModelResponse> loadModelResponseListener = mock(ActionListener.class);
         loadModelAction.doExecute(mock(Task.class), mlLoadModelRequest1, loadModelResponseListener);
-        verify(loadModelResponseListener).onFailure(any(MLResourceNotFoundException.class));
+        verify(loadModelResponseListener).onFailure(any(IllegalArgumentException.class));
     }
 
     public void testDoExecute_whenGetModelHasNPE_exception() {

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelCacheHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelCacheHelperTests.java
@@ -280,4 +280,12 @@ public class MLModelCacheHelperTests extends OpenSearchTestCase {
         assertNull(modelProfile.getWorkerNodes());
         assertNull(modelProfile.getModelInferenceStats());
     }
+
+    public void testGetFunctionName() {
+        cacheHelper.initModelState(modelId, MLModelState.LOADING, FunctionName.TEXT_EMBEDDING, targetWorkerNodes);
+        assertEquals(FunctionName.TEXT_EMBEDDING, cacheHelper.getFunctionName(modelId));
+        assertEquals(FunctionName.TEXT_EMBEDDING, cacheHelper.getOptionalFunctionName(modelId).get());
+        assertFalse(cacheHelper.getOptionalFunctionName(randomAlphaOfLength(10)).isPresent());
+    }
+
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLPredictionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLPredictionActionTests.java
@@ -14,6 +14,7 @@ import static org.opensearch.ml.utils.TestHelper.verifyParsedKMeansMLInput;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -21,6 +22,7 @@ import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.opensearch.action.ActionListener;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.Strings;
@@ -33,6 +35,7 @@ import org.opensearch.ml.common.transport.model.MLModelGetAction;
 import org.opensearch.ml.common.transport.model.MLModelGetResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
+import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
@@ -52,10 +55,14 @@ public class RestMLPredictionActionTests extends OpenSearchTestCase {
 
     @Mock
     RestChannel channel;
+    @Mock
+    MLModelManager modelManager;
 
     @Before
     public void setup() {
-        restMLPredictionAction = new RestMLPredictionAction();
+        MockitoAnnotations.openMocks(this);
+        when(modelManager.getOptionalModelFunctionName(anyString())).thenReturn(Optional.empty());
+        restMLPredictionAction = new RestMLPredictionAction(modelManager);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
         client = spy(new NodeClient(Settings.EMPTY, threadPool));
@@ -74,7 +81,7 @@ public class RestMLPredictionActionTests extends OpenSearchTestCase {
     }
 
     public void testConstructor() {
-        RestMLPredictionAction mlPredictionAction = new RestMLPredictionAction();
+        RestMLPredictionAction mlPredictionAction = new RestMLPredictionAction(modelManager);
         assertNotNull(mlPredictionAction);
     }
 


### PR DESCRIPTION
### Description
1. change exception type to return 4xx error code rather than 5xx
2. get function name from cache
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/787
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
