### PR TITLE
fix checkstyle version

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -31,6 +31,10 @@ ext {
     noticeFile = rootProject.file('NOTICE')
 }
 
+checkstyle {
+    toolVersion = '8.38'
+}
+
 opensearchplugin {
     name 'opensearch-ml'
     description 'machine learning plugin for opensearch'
@@ -381,6 +385,3 @@ tasks.withType(licenseHeaders.class) {
     additionalLicense 'AL   ', 'Apache', 'Licensed under the Apache License, Version 2.0 (the "License")'
 }
 
-checkstyle {
-    toolVersion = '8.38'
-}


### PR DESCRIPTION
### Description
Guava has one CVE , we need to bump to 30.0. https://nvd.nist.gov/vuln/detail/cve-2020-8908
For ml-commons, the CVE is from Checkstyle

Before this PR
```
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:8.37
     ...
     +--- com.google.guava:guava:29.0-jre
     ...
```

After this PR
```
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:8.38
    ...
     +--- com.google.guava:guava:30.0-jre
     ...
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
