### PR TITLE
exclude commons-io and reflections class from ml-commons client jar

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -12,10 +12,10 @@ plugins {
 
 dependencies {
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
-    implementation group: 'org.reflections', name: 'reflections', version: '0.9.12'
+    compileOnly group: 'org.reflections', name: 'reflections', version: '0.9.12'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     compileOnly "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
-    implementation "org.opensearch:common-utils:${common_utils_version}"
+    compileOnly "org.opensearch:common-utils:${common_utils_version}"
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
 }
 


### PR DESCRIPTION
### Description
exclude commons-io and reflections class from ml-commons client jar

Now we are using [GHA](https://github.com/opensearch-project/ml-commons/blob/2.x/.github/workflows/maven-publish.yml#L38) to publish ml-commons jar. 

But the jar built by running `./gradlew publishShadowPublicationToSnapshotsRepository` contains other classes from commons-io and reflection

Before this PR, we can see such classes in `client/build/libs/opensearch-ml-client-2.7.0.0-SNAPSHOT.jar`, that will cause Jarhell issue for SQL plugin as it depends on both commons-utils and ml-commons client .

```
org/opensearch/commons/alerting/model/Alert.class
...
javassist/util/proxy/Proxy.class
```
After this PR, these classes will be removed from ml-commons client jar.
 
### Issues Resolved
#778 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
