### PR TITLE
Add back reflections dependency in ml-common

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 dependencies {
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
-    compileOnly group: 'org.reflections', name: 'reflections', version: '0.9.12'
+    implementation group: 'org.reflections', name: 'reflections', version: '0.10.2'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     compileOnly "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     compileOnly "org.opensearch:common-utils:${common_utils_version}"

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation project(':opensearch-ml-common')
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
-    implementation group: 'org.reflections', name: 'reflections', version: '0.9.12'
+    implementation group: 'org.reflections', name: 'reflections', version: '0.10.2'
     implementation group: 'org.tribuo', name: 'tribuo-clustering-kmeans', version: '4.2.1'
     implementation group: 'org.tribuo', name: 'tribuo-regression-sgd', version: '4.2.1'
     implementation group: 'org.tribuo', name: 'tribuo-anomaly-libsvm', version: '4.2.1'


### PR DESCRIPTION
### Description
After PR #796, neural search integration test failed because of lack of refections dependency. Adding back the dependency and also updated dependency version to match it with SQL plugin to avoid Jarhell.
 
### Issues Resolved
https://github.com/opensearch-project/neural-search/actions/runs/4409797848/jobs/7726530275
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
