### PR TITLE
set model state as partially loaded if unload model from partial nodes

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/unload/UnloadModelNodeResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/unload/UnloadModelNodeResponse.java
@@ -20,16 +20,23 @@ import java.util.Map;
 public class UnloadModelNodeResponse extends BaseNodeResponse implements ToXContentFragment {
 
     private Map<String, String> modelUnloadStatus;
+    private Map<String, Integer> modelWorkerNodeCounts;
 
-    public UnloadModelNodeResponse(DiscoveryNode node, Map<String, String> modelUnloadStatus) {
+    public UnloadModelNodeResponse(DiscoveryNode node,
+                                   Map<String, String> modelUnloadStatus,
+                                   Map<String, Integer> modelWorkerNodeCounts) {
         super(node);
         this.modelUnloadStatus = modelUnloadStatus;
+        this.modelWorkerNodeCounts = modelWorkerNodeCounts;
     }
 
     public UnloadModelNodeResponse(StreamInput in) throws IOException {
         super(in);
         if (in.readBoolean()) {
             this.modelUnloadStatus = in.readMap(s -> s.readString(), s-> s.readString());
+        }
+        if (in.readBoolean()) {
+            this.modelWorkerNodeCounts = in.readMap(s -> s.readString(), s-> s.readInt());
         }
     }
 
@@ -44,6 +51,12 @@ public class UnloadModelNodeResponse extends BaseNodeResponse implements ToXCont
         if (modelUnloadStatus != null) {
             out.writeBoolean(true);
             out.writeMap(modelUnloadStatus, StreamOutput::writeString, StreamOutput::writeString);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (modelWorkerNodeCounts != null) {
+            out.writeBoolean(true);
+            out.writeMap(modelWorkerNodeCounts, StreamOutput::writeString, StreamOutput::writeInt);
         } else {
             out.writeBoolean(false);
         }

--- a/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelNodeResponseTest.java
@@ -8,12 +8,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.BytesStreamOutput;
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.transport.TransportAddress;
-import org.opensearch.common.xcontent.XContentBuilder;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Collections;
@@ -29,6 +25,8 @@ public class UnloadModelNodeResponseTest {
     @Mock
     private DiscoveryNode localNode;
 
+    private Map<String, Integer> modelWorkerNodeCounts;
+
     @Before
     public void setUp() throws Exception {
         localNode = new DiscoveryNode(
@@ -39,13 +37,15 @@ public class UnloadModelNodeResponseTest {
                 Collections.singleton(CLUSTER_MANAGER_ROLE),
                 Version.CURRENT
         );
+        modelWorkerNodeCounts = new HashMap<>();
+        modelWorkerNodeCounts.put("modelId1", 1);
     }
 
     @Test
     public void testSerializationDeserialization() throws IOException {
         Map<String, String> modelToLoadStatus = new HashMap<>();
-        modelToLoadStatus.put("modelName:version", "response");
-        UnloadModelNodeResponse response = new UnloadModelNodeResponse(localNode, modelToLoadStatus);
+        modelToLoadStatus.put("modelId1", "response");
+        UnloadModelNodeResponse response = new UnloadModelNodeResponse(localNode, modelToLoadStatus, modelWorkerNodeCounts);
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
         UnloadModelNodeResponse newResponse = new UnloadModelNodeResponse(output.bytes().streamInput());
@@ -54,7 +54,7 @@ public class UnloadModelNodeResponseTest {
 
     @Test
     public void testSerializationDeserialization_NullModelLoadStatus() throws IOException {
-        UnloadModelNodeResponse response = new UnloadModelNodeResponse(localNode, null);
+        UnloadModelNodeResponse response = new UnloadModelNodeResponse(localNode, null, null);
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
         UnloadModelNodeResponse newResponse = new UnloadModelNodeResponse(output.bytes().streamInput());
@@ -63,7 +63,7 @@ public class UnloadModelNodeResponseTest {
 
     @Test
     public void testReadProfile() throws IOException {
-        UnloadModelNodeResponse response = new UnloadModelNodeResponse(localNode, new HashMap<>());
+        UnloadModelNodeResponse response = new UnloadModelNodeResponse(localNode, new HashMap<>(), new HashMap<>());
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
         UnloadModelNodeResponse newResponse = UnloadModelNodeResponse.readStats(output.bytes().streamInput());

--- a/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelNodesResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/unload/UnloadModelNodesResponseTest.java
@@ -31,6 +31,7 @@ public class UnloadModelNodesResponseTest {
     private ClusterName clusterName;
     private DiscoveryNode node1;
     private DiscoveryNode node2;
+    private Map<String, Integer> modelWorkerNodeCounts;
 
     @Before
     public void setUp() throws Exception {
@@ -51,6 +52,8 @@ public class UnloadModelNodesResponseTest {
                 Collections.singleton(CLUSTER_MANAGER_ROLE),
                 Version.CURRENT
         );
+        modelWorkerNodeCounts = new HashMap<>();
+        modelWorkerNodeCounts.put("modelId1", 1);
     }
 
     @Test
@@ -69,12 +72,16 @@ public class UnloadModelNodesResponseTest {
         List<UnloadModelNodeResponse> nodes = new ArrayList<>();
 
         Map<String, String> modelToUnloadStatus1 = new HashMap<>();
-        modelToUnloadStatus1.put("modelName:version1", "response");
-        nodes.add(new UnloadModelNodeResponse(node1, modelToUnloadStatus1));
+        modelToUnloadStatus1.put("modelId1", "response");
+        Map<String, Integer> modelWorkerNodeCounts1 = new HashMap<>();
+        modelWorkerNodeCounts1.put("modelId1", 1);
+        nodes.add(new UnloadModelNodeResponse(node1, modelToUnloadStatus1, modelWorkerNodeCounts1));
 
         Map<String, String> modelToUnloadStatus2 = new HashMap<>();
-        modelToUnloadStatus2.put("modelName:version2", "response");
-        nodes.add(new UnloadModelNodeResponse(node2, modelToUnloadStatus2));
+        modelToUnloadStatus2.put("modelId2", "response");
+        Map<String, Integer> modelWorkerNodeCounts2 = new HashMap<>();
+        modelWorkerNodeCounts2.put("modelId2", 2);
+        nodes.add(new UnloadModelNodeResponse(node2, modelToUnloadStatus2, modelWorkerNodeCounts2));
 
         List<FailedNodeException> failures = new ArrayList<>();
         UnloadModelNodesResponse response = new UnloadModelNodesResponse(clusterName, nodes, failures);
@@ -82,7 +89,7 @@ public class UnloadModelNodesResponseTest {
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         String jsonStr = Strings.toString(builder);
         assertEquals(
-                "{\"foo1\":{\"stats\":{\"modelName:version1\":\"response\"}},\"foo2\":{\"stats\":{\"modelName:version2\":\"response\"}}}",
+                "{\"foo1\":{\"stats\":{\"modelId1\":\"response\"}},\"foo2\":{\"stats\":{\"modelId2\":\"response\"}}}",
                 jsonStr
         );
     }


### PR DESCRIPTION
### Description
If user deploy model to multiple ML nodes, then unload model from one ML node, the model state will become `UNLOADED`. This is not correct. We should set the model state as `PARTIALLY_LOADED`. This PR fixed this bug.
 
### Issues Resolved
[[List any issues this PR will resolve]](https://github.com/opensearch-project/ml-commons/issues/805)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
