### PR TITLE
Baselines the MAINTAINERS.md and CODEOWNERS files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
 *   @opensearch-project/machine-learning
-@rbhavna
-@jngz-es
 @b4sjoo
-@Zhangxunmt
-@ylwu-amzn
 @dhrubo-os
-@zane-neo
-@wujunshen
+@jngz-es
 @model-collapse
+@rbhavna
+@wujunshen
+@ylwu-amzn
+@zane-neo
+@Zhangxunmt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,1 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/machine-learning
-@b4sjoo
-@dhrubo-os
-@jngz-es
-@model-collapse
-@rbhavna
-@wujunshen
-@ylwu-amzn
-@zane-neo
-@Zhangxunmt
+*   @b4sjoo @dhrubo-os @jngz-es @model-collapse @rbhavna @wujunshen @ylwu-amzn @zane-neo @Zhangxunmt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,11 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
 *   @opensearch-project/machine-learning
+@rbhavna
+@jngz-es
+@b4sjoo
+@Zhangxunmt
+@ylwu-amzn
+@dhrubo-os
+@zane-neo
+@wujunshen
+@model-collapse

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,8 +6,21 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer           | GitHub ID                                   | Affiliation |
 |----------------------|---------------------------------------------|-------------|
-| Bhavana Goud Ramaram | [rbhavna](https://github.com/rbhavna)       | Amazon      |
-| Jing Zhang           | [jngz-es](https://github.com/jngz-es)       | Amazon      |
-| Sicheng Song         | [b4sjoo](https://github.com/b4sjoo)         | Amazon      |
-| Xun Zhang            | [Zhangxunmt](https://github.com/Zhangxunmt) | Amazon      |
-| Yaliang Wu           | [ylwu-amzn](https://github.com/ylwu-amzn)   | Amazon      |
+| Bhavana Goud Ramaram | [rbhavna](https://github.com/rbhavna)                   | Amazon      |
+| Jing Zhang           | [jngz-es](https://github.com/jngz-es)                   | Amazon      |
+| Sicheng Song         | [b4sjoo](https://github.com/b4sjoo)                    | Amazon      |
+| Xun Zhang            | [Zhangxunmt](https://github.com/Zhangxunmt)            | Amazon      |
+| Yaliang Wu           | [ylwu-amzn](https://github.com/ylwu-amzn)             | Amazon      |
+| Dhrubo Saha          | [dhrubo-os](https://github.com/dhrubo-os)             | Amazon      |
+| Zan Niu              | [zane-neo](https://github.com/
+zane-neo)                  | Amazon      |
+| Junshen Wu           | [wujunshen](https://github.com/wujunshen)             | Amazon      |
+| Charlie Yang         | [model-collapse](https://github.com/model-collapse) | Amazon      |
+
+
+## Emeritus
+
+| Maintainer             | GitHub ID                                   | Affiliation |
+|----------------------|---------------------------------------------|-------------|
+| Mingshi Liu       | [mingshl](https://github.com/mingshl)           | Amazon      |
+| Jackie Han        | [jackiehanyang](https://github.com/jackiehanyang) | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,20 +7,20 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer           | GitHub ID                                   | Affiliation |
 |----------------------|---------------------------------------------|-------------|
 | Bhavana Goud Ramaram | [rbhavna](https://github.com/rbhavna)                   | Amazon      |
+| Charlie Yang         | [model-collapse](https://github.com/model-collapse) | Amazon      |
+| Dhrubo Saha          | [dhrubo-os](https://github.com/dhrubo-os)             | Amazon      |
 | Jing Zhang           | [jngz-es](https://github.com/jngz-es)                   | Amazon      |
+| Junshen Wu           | [wujunshen](https://github.com/wujunshen)             | Amazon      |
 | Sicheng Song         | [b4sjoo](https://github.com/b4sjoo)                    | Amazon      |
 | Xun Zhang            | [Zhangxunmt](https://github.com/Zhangxunmt)            | Amazon      |
 | Yaliang Wu           | [ylwu-amzn](https://github.com/ylwu-amzn)             | Amazon      |
-| Dhrubo Saha          | [dhrubo-os](https://github.com/dhrubo-os)             | Amazon      |
 | Zan Niu              | [zane-neo](https://github.com/
 zane-neo)                  | Amazon      |
-| Junshen Wu           | [wujunshen](https://github.com/wujunshen)             | Amazon      |
-| Charlie Yang         | [model-collapse](https://github.com/model-collapse) | Amazon      |
 
 
 ## Emeritus
 
 | Maintainer             | GitHub ID                                   | Affiliation |
 |----------------------|---------------------------------------------|-------------|
-| Mingshi Liu       | [mingshl](https://github.com/mingshl)           | Amazon      |
 | Jackie Han        | [jackiehanyang](https://github.com/jackiehanyang) | Amazon      |
+| Mingshi Liu       | [mingshl](https://github.com/mingshl)           | Amazon      |


### PR DESCRIPTION
### Description
Baselines the MAINTAINERS.md and CODEOWNERS files to specify active and inactive maintainers of ml-commons repo.
 
### Issues Resolved
This should resolve issue #727 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
