### PR TITLE
add allow custom deployment plan setting; add deploy to all nodes field in model index

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -30,7 +30,7 @@ public class CommonValue {
 
     public static final String ML_MODEL_INDEX = ".plugins-ml-model";
     public static final String ML_TASK_INDEX = ".plugins-ml-task";
-    public static final Integer ML_MODEL_INDEX_SCHEMA_VERSION = 3;
+    public static final Integer ML_MODEL_INDEX_SCHEMA_VERSION = 4;
     public static final Integer ML_TASK_INDEX_SCHEMA_VERSION = 1;
     public static final String USER_FIELD_MAPPING = "      \""
             + CommonValue.USER
@@ -93,6 +93,9 @@ public class CommonValue {
             + "      \""
             + MLModel.PLANNING_WORKER_NODES_FIELD
             + "\": {\"type\": \"keyword\"},\n"
+            + "      \""
+            + MLModel.DEPLOY_TO_ALL_NODES_FIELD
+            + "\": {\"type\": \"boolean\"},\n"
             + "      \""
             + MLModel.MODEL_CONFIG_FIELD
             + "\" : {\"properties\":{\""

--- a/common/src/main/java/org/opensearch/ml/common/MLModel.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModel.java
@@ -57,6 +57,7 @@ public class MLModel implements ToXContentObject {
     public static final String PLANNING_WORKER_NODE_COUNT_FIELD = "planning_worker_node_count";
     public static final String CURRENT_WORKER_NODE_COUNT_FIELD = "current_worker_node_count";
     public static final String PLANNING_WORKER_NODES_FIELD = "planning_worker_nodes";
+    public static final String DEPLOY_TO_ALL_NODES_FIELD = "deploy_to_all_nodes";
 
     private String name;
     private FunctionName algorithm;
@@ -85,6 +86,7 @@ public class MLModel implements ToXContentObject {
     private Integer currentWorkerNodeCount; // model is deployed to how many nodes
 
     private String[] planningWorkerNodes; // plan to deploy model to these nodes
+    private boolean deployToAllNodes;
     @Builder(toBuilder = true)
     public MLModel(String name,
                    FunctionName algorithm,
@@ -106,7 +108,8 @@ public class MLModel implements ToXContentObject {
                    Integer totalChunks,
                    Integer planningWorkerNodeCount,
                    Integer currentWorkerNodeCount,
-                   String[] planningWorkerNodes) {
+                   String[] planningWorkerNodes,
+                   boolean deployToAllNodes) {
         this.name = name;
         this.algorithm = algorithm;
         this.version = version;
@@ -129,6 +132,7 @@ public class MLModel implements ToXContentObject {
         this.planningWorkerNodeCount = planningWorkerNodeCount;
         this.currentWorkerNodeCount = currentWorkerNodeCount;
         this.planningWorkerNodes = planningWorkerNodes;
+        this.deployToAllNodes = deployToAllNodes;
     }
 
     public MLModel(StreamInput input) throws IOException{
@@ -165,6 +169,7 @@ public class MLModel implements ToXContentObject {
             planningWorkerNodeCount = input.readOptionalInt();
             currentWorkerNodeCount = input.readOptionalInt();
             planningWorkerNodes = input.readOptionalStringArray();
+            deployToAllNodes = input.readBoolean();
         }
     }
 
@@ -211,6 +216,7 @@ public class MLModel implements ToXContentObject {
         out.writeOptionalInt(planningWorkerNodeCount);
         out.writeOptionalInt(currentWorkerNodeCount);
         out.writeOptionalStringArray(planningWorkerNodes);
+        out.writeBoolean(deployToAllNodes);
     }
 
     @Override
@@ -282,6 +288,9 @@ public class MLModel implements ToXContentObject {
         if (planningWorkerNodes != null && planningWorkerNodes.length > 0) {
             builder.field(PLANNING_WORKER_NODES_FIELD, planningWorkerNodes);
         }
+        if (deployToAllNodes) {
+            builder.field(DEPLOY_TO_ALL_NODES_FIELD, deployToAllNodes);
+        }
         builder.endObject();
         return builder;
     }
@@ -312,6 +321,7 @@ public class MLModel implements ToXContentObject {
         Integer planningWorkerNodeCount = null;
         Integer currentWorkerNodeCount = null;
         List<String> planningWorkerNodes = new ArrayList<>();
+        boolean deployToAllNodes = false;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -379,6 +389,9 @@ public class MLModel implements ToXContentObject {
                         planningWorkerNodes.add(parser.text());
                     }
                     break;
+                case DEPLOY_TO_ALL_NODES_FIELD:
+                    deployToAllNodes = parser.booleanValue();
+                    break;
                 case CREATED_TIME_FIELD:
                     createdTime = Instant.ofEpochMilli(parser.longValue());
                     break;
@@ -422,6 +435,7 @@ public class MLModel implements ToXContentObject {
                 .planningWorkerNodeCount(planningWorkerNodeCount)
                 .currentWorkerNodeCount(currentWorkerNodeCount)
                 .planningWorkerNodes(planningWorkerNodes.toArray(new String[0]))
+                .deployToAllNodes(deployToAllNodes)
                 .build();
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/load/TransportLoadModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/load/TransportLoadModelAction.java
@@ -9,6 +9,7 @@ import static org.opensearch.ml.common.MLTask.ERROR_FIELD;
 import static org.opensearch.ml.common.MLTask.STATE_FIELD;
 import static org.opensearch.ml.common.MLTaskState.FAILED;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.LOAD_THREAD_POOL;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN;
 import static org.opensearch.ml.task.MLTaskManager.TASK_SEMAPHORE_TIMEOUT;
 
 import java.time.Instant;
@@ -31,6 +32,7 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
@@ -75,6 +77,8 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
     MLModelManager mlModelManager;
     MLStats mlStats;
 
+    private volatile boolean allowCustomDeploymentPlan;
+
     @Inject
     public TransportLoadModelAction(
         TransportService transportService,
@@ -88,7 +92,8 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
         DiscoveryNodeHelper nodeFilter,
         MLTaskDispatcher mlTaskDispatcher,
         MLModelManager mlModelManager,
-        MLStats mlStats
+        MLStats mlStats,
+        Settings settings
     ) {
         super(MLLoadModelAction.NAME, transportService, actionFilters, MLLoadModelRequest::new);
         this.transportService = transportService;
@@ -102,6 +107,10 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
         this.mlTaskDispatcher = mlTaskDispatcher;
         this.mlModelManager = mlModelManager;
         this.mlStats = mlStats;
+        allowCustomDeploymentPlan = ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN.get(settings);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN, it -> allowCustomDeploymentPlan = it);
     }
 
     @Override
@@ -109,6 +118,11 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
         MLLoadModelRequest deployModelRequest = MLLoadModelRequest.fromActionRequest(request);
         String modelId = deployModelRequest.getModelId();
         String[] targetNodeIds = deployModelRequest.getModelNodeIds();
+        boolean deployToAllNodes = targetNodeIds == null || targetNodeIds.length == 0;
+        if (!allowCustomDeploymentPlan && !deployToAllNodes) {
+            throw new IllegalArgumentException("Don't allow custom deployment plan");
+        }
+
         // mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
         mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
         DiscoveryNode[] allEligibleNodes = nodeFilter.getEligibleNodes();
@@ -121,7 +135,7 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
 
         List<DiscoveryNode> eligibleNodes = new ArrayList<>();
         List<String> nodeIds = new ArrayList<>();
-        if (targetNodeIds != null && targetNodeIds.length > 0) {
+        if (!deployToAllNodes) {
             for (String nodeId : targetNodeIds) {
                 if (allEligibleNodeIds.contains(nodeId)) {
                     eligibleNodes.add(nodeMapping.get(nodeId));
@@ -189,7 +203,7 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
                                     localNodeId,
                                     mlTask,
                                     eligibleNodes,
-                                    algorithm
+                                    deployToAllNodes
                                 )
                             );
                     } catch (Exception ex) {
@@ -226,7 +240,7 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
         String localNodeId,
         MLTask mlTask,
         List<DiscoveryNode> eligibleNodes,
-        FunctionName algorithm
+        boolean deployToAllNodes
     ) {
         LoadModelInput loadModelInput = new LoadModelInput(
             modelId,
@@ -264,7 +278,9 @@ public class TransportLoadModelAction extends HandledTransportAction<ActionReque
                         MLModel.PLANNING_WORKER_NODE_COUNT_FIELD,
                         eligibleNodes.size(),
                         MLModel.PLANNING_WORKER_NODES_FIELD,
-                        workerNodes
+                        workerNodes,
+                        MLModel.DEPLOY_TO_ALL_NODES_FIELD,
+                        deployToAllNodes
                     ),
                 ActionListener
                     .wrap(

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -515,7 +515,8 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
                 MLCommonsSettings.ML_COMMONS_MAX_LOAD_MODEL_TASKS_PER_NODE,
                 MLCommonsSettings.ML_COMMONS_TRUSTED_URL_REGEX,
                 MLCommonsSettings.ML_COMMONS_NATIVE_MEM_THRESHOLD,
-                MLCommonsSettings.ML_COMMONS_EXCLUDE_NODE_NAMES
+                MLCommonsSettings.ML_COMMONS_EXCLUDE_NODE_NAMES,
+                MLCommonsSettings.ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -59,4 +59,6 @@ public final class MLCommonsSettings {
 
     public static final Setting<String> ML_COMMONS_EXCLUDE_NODE_NAMES = Setting
         .simpleString("plugins.ml_commons.exclude_nodes._name", Setting.Property.NodeScope, Setting.Property.Dynamic);
+    public static final Setting<Boolean> ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN = Setting
+        .boolSetting("plugins.ml_commons.allow_custom_deployment_plan", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/load/TransportLoadModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/load/TransportLoadModelActionTests.java
@@ -7,17 +7,20 @@ package org.opensearch.ml.action.load;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN;
 
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -31,6 +34,7 @@ import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
@@ -87,13 +91,18 @@ public class TransportLoadModelActionTests extends OpenSearchTestCase {
     @Mock
     private MLLoadModelRequest mlLoadModelRequest;
 
-    @InjectMocks
     private TransportLoadModelAction transportLoadModelAction;
     @Mock
     private ExecutorService executorService;
 
     @Mock
     MLTask mlTask;
+    @Mock
+    MLTaskDispatcher mlTaskDispatcher;
+    @Mock
+    NamedXContentRegistry namedXContentRegistry;
+    private Settings settings;
+    private ClusterSettings clusterSettings;
     private final String modelId = "mock_model_id";
     private final MLModel mlModel = mock(MLModel.class);
     private final String localNodeId = "mockNodeId";
@@ -102,9 +111,16 @@ public class TransportLoadModelActionTests extends OpenSearchTestCase {
 
     private final List<DiscoveryNode> eligibleNodes = mock(List.class);
 
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
+        settings = Settings.builder().put(ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN.getKey(), true).build();
+        clusterSettings = new ClusterSettings(settings, new HashSet<>(Arrays.asList(ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN)));
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
         mlEngine = new MLEngine(Path.of("/tmp/test" + randomAlphaOfLength(10)));
         modelHelper = new ModelHelper(mlEngine);
         when(mlLoadModelRequest.getModelId()).thenReturn("mockModelId");
@@ -125,6 +141,21 @@ public class TransportLoadModelActionTests extends OpenSearchTestCase {
 
         MLStat mlStat = mock(MLStat.class);
         when(mlStats.getStat(eq(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT))).thenReturn(mlStat);
+        transportLoadModelAction = new TransportLoadModelAction(
+            transportService,
+            actionFilters,
+            modelHelper,
+            mlTaskManager,
+            clusterService,
+            threadPool,
+            client,
+            namedXContentRegistry,
+            nodeFilter,
+            mlTaskDispatcher,
+            mlModelManager,
+            mlStats,
+            settings
+        );
     }
 
     public void testDoExecute_success() {
@@ -149,6 +180,34 @@ public class TransportLoadModelActionTests extends OpenSearchTestCase {
         verify(loadModelResponseListener).onResponse(any(LoadModelResponse.class));
     }
 
+    public void testDoExecute_DoNotAllowCustomDeploymentPlan() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Don't allow custom deployment plan");
+        Settings settings = Settings.builder().put(ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN.getKey(), false).build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            new HashSet<>(Arrays.asList(ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN))
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        TransportLoadModelAction transportLoadModelAction = new TransportLoadModelAction(
+            transportService,
+            actionFilters,
+            modelHelper,
+            mlTaskManager,
+            clusterService,
+            threadPool,
+            client,
+            namedXContentRegistry,
+            nodeFilter,
+            mlTaskDispatcher,
+            mlModelManager,
+            mlStats,
+            settings
+        );
+
+        transportLoadModelAction.doExecute(mock(Task.class), mlLoadModelRequest, mock(ActionListener.class));
+    }
+
     public void testDoExecute_whenLoadModelRequestNodeIdsEmpty_thenMLResourceNotFoundException() {
         DiscoveryNodeHelper nodeHelper = mock(DiscoveryNodeHelper.class);
         when(nodeHelper.getEligibleNodes()).thenReturn(new DiscoveryNode[] {});
@@ -161,11 +220,12 @@ public class TransportLoadModelActionTests extends OpenSearchTestCase {
                 clusterService,
                 threadPool,
                 client,
-                mock(NamedXContentRegistry.class),
+                namedXContentRegistry,
                 nodeHelper,
-                mock(MLTaskDispatcher.class),
+                mlTaskDispatcher,
                 mlModelManager,
-                mlStats
+                mlStats,
+                settings
             )
         );
         MLLoadModelRequest mlLoadModelRequest1 = mock(MLLoadModelRequest.class);
@@ -243,7 +303,7 @@ public class TransportLoadModelActionTests extends OpenSearchTestCase {
                 localNodeId,
                 mlTask,
                 Arrays.asList(discoveryNode),
-                FunctionName.ANOMALY_LOCALIZATION
+                true
             );
         verify(mlTaskManager).updateMLTask(anyString(), anyMap(), anyLong(), anyBoolean());
 
@@ -257,15 +317,7 @@ public class TransportLoadModelActionTests extends OpenSearchTestCase {
     public void testUpdateModelLoadStatusAndTriggerOnNodesAction_whenMLTaskManagerThrowException_ListenerOnFailureExecuted() {
         doCallRealMethod().when(mlModelManager).updateModel(anyString(), any(ImmutableMap.class), isA(ActionListener.class));
         transportLoadModelAction
-            .updateModelLoadStatusAndTriggerOnNodesAction(
-                modelId,
-                "mock_task_id",
-                mlModel,
-                localNodeId,
-                mlTask,
-                eligibleNodes,
-                FunctionName.TEXT_EMBEDDING
-            );
+            .updateModelLoadStatusAndTriggerOnNodesAction(modelId, "mock_task_id", mlModel, localNodeId, mlTask, eligibleNodes, false);
         verify(mlTaskManager).updateMLTask(anyString(), anyMap(), anyLong(), anyBoolean());
     }
 


### PR DESCRIPTION
### Description
1. Add allow custom deployment plan setting, set default value as `false`, which means by default user can't deploy model to specified node ids. 
2. Add deploy to all nodes field in model index.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
