### PR TITLE
add text docs ML input

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/annotation/MLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/annotation/MLInput.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.annotation;
+
+import org.opensearch.ml.common.FunctionName;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MLInput {
+    // supported algorithms
+    FunctionName[] functionNames();
+}

--- a/common/src/main/java/org/opensearch/ml/common/input/nlp/TextDocsMLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/nlp/TextDocsMLInput.java
@@ -1,0 +1,133 @@
+package org.opensearch.ml.common.input.nlp;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.dataset.MLInputDataset;
+import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.output.model.ModelResultFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+/**
+ * ML input class which supports a list fo text docs.
+ * This class can be used for TEXT_EMBEDDING model.
+ */
+@org.opensearch.ml.common.annotation.MLInput(functionNames = {FunctionName.TEXT_EMBEDDING})
+public class TextDocsMLInput extends MLInput {
+    public static final String TEXT_DOCS_FIELD = "text_docs";
+    public static final String RESULT_FILTER_FIELD = "result_filter";
+
+    public TextDocsMLInput(FunctionName algorithm, MLInputDataset inputDataset) {
+        super(algorithm, null, inputDataset);
+    }
+
+    public TextDocsMLInput(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(ALGORITHM_FIELD, algorithm.name());
+        if (parameters != null) {
+            builder.field(ML_PARAMETERS_FIELD, parameters);
+        }
+        if (inputDataset != null) {
+            TextDocsInputDataSet textInputDataSet = (TextDocsInputDataSet) this.inputDataset;
+            List<String> docs = textInputDataSet.getDocs();
+            ModelResultFilter resultFilter = textInputDataSet.getResultFilter();
+            if (docs != null && docs.size() > 0) {
+                builder.field(TEXT_DOCS_FIELD, docs.toArray(new String[0]));
+            }
+            if (resultFilter != null) {
+                builder.startObject(RESULT_FILTER_FIELD);
+                builder.field(RETURN_BYTES_FIELD, resultFilter.isReturnBytes());
+                builder.field(RETURN_NUMBER_FIELD, resultFilter.isReturnNumber());
+                List<String> targetResponse = resultFilter.getTargetResponse();
+                if (targetResponse != null && targetResponse.size() > 0) {
+                    builder.field(TARGET_RESPONSE_FIELD, targetResponse.toArray(new String[0]));
+                }
+                List<Integer> targetPositions = resultFilter.getTargetResponsePositions();
+                if (targetPositions != null && targetPositions.size() > 0) {
+                    builder.field(TARGET_RESPONSE_POSITIONS_FIELD, targetPositions.toArray(new Integer[0]));
+                }
+                builder.endObject();
+            }
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public TextDocsMLInput(XContentParser parser, FunctionName functionName) throws IOException {
+        super();
+        this.algorithm = functionName;
+        List<String> docs = new ArrayList<>();
+        ModelResultFilter resultFilter = null;
+
+        boolean returnBytes = false;
+        boolean returnNumber = true;
+        List<String> targetResponse = new ArrayList<>();
+        List<Integer> targetResponsePositions = new ArrayList<>();
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case RETURN_BYTES_FIELD:
+                    returnBytes = parser.booleanValue();
+                    break;
+                case RETURN_NUMBER_FIELD:
+                    returnNumber = parser.booleanValue();
+                    break;
+                case TARGET_RESPONSE_FIELD:
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        targetResponse.add(parser.text());
+                    }
+                    break;
+                case TARGET_RESPONSE_POSITIONS_FIELD:
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        targetResponsePositions.add(parser.intValue());
+                    }
+                    break;
+                case TEXT_DOCS_FIELD:
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        docs.add(parser.text());
+                    }
+                    break;
+                case RESULT_FILTER_FIELD:
+                    resultFilter = ModelResultFilter.parse(parser);
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        ModelResultFilter filter = resultFilter != null ? resultFilter : ModelResultFilter.builder().returnBytes(returnBytes)
+                .returnNumber(returnNumber).targetResponse(targetResponse).targetResponsePositions(targetResponsePositions)
+                .build();
+
+        if (docs.size() == 0) {
+            throw new IllegalArgumentException("Empty text docs");
+        }
+        inputDataset = new TextDocsInputDataSet(docs, filter);
+    }
+
+}

--- a/common/src/test/java/org/opensearch/ml/common/input/nlp/TextDocsMLInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/nlp/TextDocsMLInputTest.java
@@ -1,0 +1,85 @@
+package org.opensearch.ml.common.input.nlp;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.opensearch.common.Strings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.dataset.MLInputDataset;
+import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.output.model.ModelResultFilter;
+import org.opensearch.search.SearchModule;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class TextDocsMLInputTest {
+
+    MLInput input;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    private final FunctionName algorithm = FunctionName.TEXT_EMBEDDING;
+
+    @Before
+    public void setUp() throws Exception {
+        ModelResultFilter resultFilter = ModelResultFilter.builder().returnBytes(true).returnNumber(true).targetResponse(Arrays.asList("field1")).targetResponsePositions(Arrays.asList(2)).build();
+        MLInputDataset inputDataset = TextDocsInputDataSet.builder().docs(Arrays.asList("doc1", "doc2")).resultFilter(resultFilter).build();
+        input = new TextDocsMLInput(algorithm, inputDataset);
+    }
+
+    @Test
+    public void parseTextDocsMLInput() throws IOException {
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        input.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String jsonStr = Strings.toString(builder);
+        System.out.println(jsonStr);
+        parseMLInput(jsonStr);
+    }
+
+    @Test
+    public void parseTextDocsMLInput_OldWay() throws IOException {
+        String jsonStr = "{\"text_docs\": [ \"doc1\", \"doc2\" ],\"return_number\": true, \"return_bytes\": true,\"target_response\": [ \"field1\" ], \"target_response_positions\": [2]}";
+        parseMLInput(jsonStr);
+    }
+
+    @Test
+    public void parseTextDocsMLInput_NewWay() throws IOException {
+        String jsonStr = "{\"text_docs\":[\"doc1\",\"doc2\"],\"result_filter\":{\"return_bytes\":true,\"return_number\":true,\"target_response\":[\"field1\"], \"target_response_positions\": [2]}}";
+        parseMLInput(jsonStr);
+    }
+
+    private void parseMLInput(String jsonStr) throws IOException {
+        XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                Collections.emptyList()).getNamedXContents()), null, jsonStr);
+        parser.nextToken();
+
+        MLInput parsedInput = MLInput.parse(parser, input.getFunctionName().name());
+        assertTrue(parsedInput instanceof TextDocsMLInput);
+        assertEquals(input.getFunctionName(), parsedInput.getFunctionName());
+        assertEquals(input.getInputDataset().getInputDataType(), parsedInput.getInputDataset().getInputDataType());
+        TextDocsInputDataSet inputDataset = (TextDocsInputDataSet) parsedInput.getInputDataset();
+        assertEquals(2, inputDataset.getDocs().size());
+        assertEquals("doc1", inputDataset.getDocs().get(0));
+        assertEquals("doc2", inputDataset.getDocs().get(1));
+        assertNotNull(inputDataset.getResultFilter());
+        assertTrue(inputDataset.getResultFilter().isReturnBytes());
+        assertTrue(inputDataset.getResultFilter().isReturnNumber());
+    }
+
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms;
 
 import ai.djl.Application;


### PR DESCRIPTION
### Description
Add text docs ML input.

Before this PR

```
POST /_plugins/_ml/models/<model_id>/_predict
{
    "text_docs": ["today is sunny"],
    "return_number": true,
    "target_response": ["sentence_embedding"]
}
```
After
```
POST /_plugins/_ml/models/<model_id>/_predict
{
    "text_docs": ["today is sunny"],
    "result_filter": {
        "return_number": true,
        "target_response": ["sentence_embedding"]
    }
}
```
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
