### PR TITLE
bumping checkstyle version for 1.3

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -30,6 +30,10 @@ ext {
     noticeFile = rootProject.file('NOTICE')
 }
 
+checkstyle {
+    toolVersion = '8.38'
+}
+
 opensearchplugin {
     name 'opensearch-ml'
     description 'machine learning plugin for opensearch'
@@ -49,7 +53,7 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 
-    checkstyle "com.puppycrawl.tools:checkstyle:8.29"
+    checkstyle "com.puppycrawl.tools:checkstyle:${project.checkstyle.toolVersion}"
 }
 
 
@@ -337,6 +341,3 @@ tasks.withType(licenseHeaders.class) {
     additionalLicense 'AL   ', 'Apache', 'Licensed under the Apache License, Version 2.0 (the "License")'
 }
 
-checkstyle {
-    toolVersion = '8.29'
-}


### PR DESCRIPTION
### Description
Bumping checkstyle version for 1.3 as was done in main branch to solve CVE: https://github.com/opensearch-project/ml-commons/pull/735
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
