### PR TITLE
Rollback the SerDeSer filter due to AccessControlException on normal model

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/ModelSerDeSer.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/ModelSerDeSer.java
@@ -89,8 +89,7 @@ public class ModelSerDeSer {
             // Validate the model class type to avoid deserialization attack.
             validatingObjectInputStream
                     .accept(ACCEPT_CLASS_PATTERNS)
-                    .reject(REJECT_CLASS_PATTERNS)
-                    .setObjectInputFilter(ObjectInputFilter.Config.createFilter("maxdepth=20;maxrefs=5000;maxbytes=10000000;maxarray=100000"));
+                    .reject(REJECT_CLASS_PATTERNS);
             return validatingObjectInputStream.readObject();
         } catch (IOException | ClassNotFoundException e) {
             throw new ModelSerDeSerException("Failed to deserialize model.", e.getCause());


### PR DESCRIPTION
### Description
This is an urgent rollback on previous SerDeSer filter because the `ObjectInputFilter.Config.ObjectInputFilter.createFilter​` will cause `java.security.AccessControlException: access denied ("java.io.SerializablePermission" "serialFilter")` on our built-in model when integrating with OpenSearch 2.7
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
