### PR TITLE
add pre-trained model list

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/MLEngine.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/MLEngine.java
@@ -40,6 +40,10 @@ public class MLEngine {
         mlModelsCachePath = mlCachePath.resolve("models_cache");
     }
 
+    public String getPrebuiltModelMetaListPath() {
+        return "https://artifacts.opensearch.org/models/ml-models/model_listing/pre_trained_models.json";
+    }
+
     public String getPrebuiltModelConfigPath(String modelName, String version, MLModelFormat modelFormat) {
         String format = modelFormat.name().toLowerCase(Locale.ROOT);
         return String.format("%s/%s/%s/%s/config.json", MODEL_REPO, modelName, version, format, Locale.ROOT);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
@@ -171,8 +171,6 @@ public class ModelHelper {
 
                 return config;
             });
-        } catch (Exception e) {
-            throw e;
         } finally {
             deleteFileQuietly(mlEngine.getRegisterModelPath(taskId));
         }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
@@ -22,6 +22,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.security.AccessController;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -132,6 +133,46 @@ public class ModelHelper {
             });
         } catch (Exception e) {
             listener.onFailure(e);
+        } finally {
+            deleteFileQuietly(mlEngine.getRegisterModelPath(taskId));
+        }
+    }
+
+    public boolean isModelAllowed(MLRegisterModelInput registerModelInput, List modelMetaList) {
+        String modelName = registerModelInput.getModelName();
+        String version = registerModelInput.getVersion();
+        MLModelFormat modelFormat = registerModelInput.getModelFormat();
+        for (Object meta: modelMetaList) {
+            String name = (String) ((Map<String, Object>)meta).get("name");
+            List<String> versions = (List) ((Map<String, Object>)meta).get("version");
+            List<String> formats = (List) ((Map<String, Object>)meta).get("format");
+            if (name.equals(modelName) && versions.contains(version.toLowerCase(Locale.ROOT)) && formats.contains(modelFormat.toString().toLowerCase(Locale.ROOT))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List downloadPrebuiltModelMetaList(String taskId, MLRegisterModelInput registerModelInput) throws PrivilegedActionException {
+        String modelName = registerModelInput.getModelName();
+        String version = registerModelInput.getVersion();
+        try {
+            return AccessController.doPrivileged((PrivilegedExceptionAction<List>) () -> {
+
+                Path registerModelPath = mlEngine.getRegisterModelPath(taskId, modelName, version);
+                String cacheFilePath = registerModelPath.resolve("model_meta_list.json").toString();
+                String modelMetaListUrl = mlEngine.getPrebuiltModelMetaListPath();
+                DownloadUtils.download(modelMetaListUrl, cacheFilePath, new ProgressBar());
+
+                List<?> config = null;
+                try (JsonReader reader = new JsonReader(new FileReader(cacheFilePath))) {
+                    config = gson.fromJson(reader, List.class);
+                }
+
+                return config;
+            });
+        } catch (Exception e) {
+            throw e;
         } finally {
             deleteFileQuietly(mlEngine.getRegisterModelPath(taskId));
         }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
@@ -24,11 +24,14 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.security.PrivilegedActionException;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 
 public class ModelHelperTest {
@@ -165,5 +168,61 @@ public class ModelHelperTest {
         MLModelConfig modelConfig = argumentCaptor.getValue().getModelConfig();
         assertNotNull(modelConfig);
         assertEquals("mpnet", modelConfig.getModelType());
+    }
+
+    @Test
+    public void testDownloadPrebuiltModelMetaList() throws PrivilegedActionException {
+        String taskId = "test_task_id";
+        MLRegisterModelInput registerModelInput = MLRegisterModelInput.builder()
+                .modelName("huggingface/sentence-transformers/all-mpnet-base-v2")
+                .version("1.0.1")
+                .modelFormat(modelFormat)
+                .deployModel(false)
+                .modelNodeIds(new String[]{"node_id1"})
+                .build();
+        List modelMetaList = modelHelper.downloadPrebuiltModelMetaList(taskId, registerModelInput);
+        assertEquals("huggingface/sentence-transformers/all-distilroberta-v1", ((Map<String, String>)modelMetaList.get(0)).get("name"));
+    }
+
+    @Test
+    public void testIsModelAllowed_true() throws PrivilegedActionException {
+        String taskId = "test_task_id";
+        MLRegisterModelInput registerModelInput = MLRegisterModelInput.builder()
+                .modelName("huggingface/sentence-transformers/all-mpnet-base-v2")
+                .version("1.0.1")
+                .modelFormat(modelFormat)
+                .deployModel(false)
+                .modelNodeIds(new String[]{"node_id1"})
+                .build();
+        List modelMetaList = modelHelper.downloadPrebuiltModelMetaList(taskId, registerModelInput);
+        assertTrue(modelHelper.isModelAllowed(registerModelInput, modelMetaList));
+    }
+
+    @Test
+    public void testIsModelAllowed_WrongModelName() throws PrivilegedActionException {
+        String taskId = "test_task_id";
+        MLRegisterModelInput registerModelInput = MLRegisterModelInput.builder()
+                .modelName("huggingface/sentence-transformers/all-mpnet-base-v2-wrong")
+                .version("1.0.1")
+                .modelFormat(modelFormat)
+                .deployModel(false)
+                .modelNodeIds(new String[]{"node_id1"})
+                .build();
+        List modelMetaList = modelHelper.downloadPrebuiltModelMetaList(taskId, registerModelInput);
+        assertFalse(modelHelper.isModelAllowed(registerModelInput, modelMetaList));
+    }
+
+    @Test
+    public void testIsModelAllowed_WrongModelVersion() throws PrivilegedActionException {
+        String taskId = "test_task_id";
+        MLRegisterModelInput registerModelInput = MLRegisterModelInput.builder()
+                .modelName("huggingface/sentence-transformers/all-mpnet-base-v2")
+                .version("000")
+                .modelFormat(modelFormat)
+                .deployModel(false)
+                .modelNodeIds(new String[]{"node_id1"})
+                .build();
+        List modelMetaList = modelHelper.downloadPrebuiltModelMetaList(taskId, registerModelInput);
+        assertFalse(modelHelper.isModelAllowed(registerModelInput, modelMetaList));
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -38,6 +38,7 @@ import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegist
 
 import java.io.File;
 import java.nio.file.Path;
+import java.security.PrivilegedActionException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
@@ -404,8 +405,12 @@ public class MLModelManager {
             );
     }
 
-    private void registerPrebuiltModel(MLRegisterModelInput registerModelInput, MLTask mlTask) {
+    private void registerPrebuiltModel(MLRegisterModelInput registerModelInput, MLTask mlTask) throws PrivilegedActionException {
         String taskId = mlTask.getTaskId();
+        List modelMetaList = modelHelper.downloadPrebuiltModelMetaList(taskId, registerModelInput);
+        if (!modelHelper.isModelAllowed(registerModelInput, modelMetaList)) {
+            throw new IllegalArgumentException("This model is not in the pre-trained model list, please check your parameters.");
+        }
         modelHelper
             .downloadPrebuiltModelConfig(
                 taskId,


### PR DESCRIPTION
### Description
Add pre-trained model list in register api to restrict the model parameters input.
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
