### PR TITLE
Keep model document even register fail

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/model/MLModelState.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/MLModelState.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.common.model;
 
+import java.util.function.Function;
+
 public enum MLModelState {
     TRAINED,
     @Deprecated
@@ -23,6 +25,7 @@ public enum MLModelState {
     LOAD_FAILED,
 
     REGISTERING,
+    REGISTER_FAILED,
     REGISTERED,
     DEPLOYING,
     DEPLOYED,

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -123,7 +123,7 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
         MLTask mlTask = MLTask
             .builder()
             .async(true)
-            .taskType(MLTaskType.DEPLOY_MODEL)
+            .taskType(MLTaskType.REGISTER_MODEL)
             .functionName(registerModelInput.getFunctionName())
             .createTime(Instant.now())
             .lastUpdateTime(Instant.now())

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
@@ -9,6 +9,7 @@ import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.common.CommonValue.UNDEPLOYED;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -160,6 +161,7 @@ public class TransportUndeployModelAction extends
                             updateDocument.put(MLModel.CURRENT_WORKER_NODE_COUNT_FIELD, newPlanningWorkerNodes.size());
                             deployToAllNodes.put(modelId, false);
                         }
+                        updateDocument.put(MLModel.LAST_UNDEPLOYED_TIME_FIELD, Instant.now().toEpochMilli());
                         updateRequest.index(ML_MODEL_INDEX).id(modelId).doc(updateDocument);
                         bulkRequest.add(updateRequest);
                     }

--- a/plugin/src/main/java/org/opensearch/ml/action/upload_chunk/MLModelChunkUploader.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/upload_chunk/MLModelChunkUploader.java
@@ -9,6 +9,7 @@ import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
 import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
 
+import java.time.Instant;
 import java.util.Base64;
 import java.util.concurrent.Semaphore;
 
@@ -113,6 +114,7 @@ public class MLModelChunkUploader {
                                         .totalChunks(existingModel.getTotalChunks())
                                         .modelContentHash(existingModel.getModelContentHash())
                                         .modelContentSizeInBytes(existingModel.getModelContentSizeInBytes())
+                                        .lastRegisteredTime(Instant.now())
                                         .createdTime(existingModel.getCreatedTime())
                                         .build();
                                     IndexRequest indexReq = new IndexRequest(ML_MODEL_INDEX);

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -53,17 +53,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import javax.management.modelmbean.ModelMBeanInfo;
-
 import lombok.extern.log4j.Log4j2;
 
 import org.opensearch.action.ActionListener;
-import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
-import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.ThreadedActionListener;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
@@ -76,9 +72,6 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.query.TermQueryBuilder;
-import org.opensearch.index.reindex.DeleteByQueryAction;
-import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.ml.breaker.MLCircuitBreakerService;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
 import org.opensearch.ml.common.FunctionName;
@@ -478,11 +471,12 @@ public class MLModelManager {
         Map<String, Object> updated = ImmutableMap.of(ERROR_FIELD, MLExceptionUtils.getRootCauseMessage(e), STATE_FIELD, FAILED);
         mlTaskManager.updateMLTask(taskId, updated, TIMEOUT_IN_MILLIS, true);
     }
-    
+
     private void handleExceptionUpdateModelState(FunctionName functionName, String taskId, String modelId, Exception e) {
         mlStats.createCounterStatIfAbsent(functionName, REGISTER, MLActionLevelStat.ML_ACTION_FAILURE_COUNT).increment();
-        Map<String, Object> updated = ImmutableMap.of(ERROR_FIELD, MLExceptionUtils.getRootCauseMessage(e), STATE_FIELD, FAILED, MODEL_ID_FIELD, modelId);
-        mlTaskManager.updateMLTask(taskId, updated, TIMEOUT_IN_MILLIS, true); 
+        Map<String, Object> updated = ImmutableMap
+            .of(ERROR_FIELD, MLExceptionUtils.getRootCauseMessage(e), STATE_FIELD, FAILED, MODEL_ID_FIELD, modelId);
+        mlTaskManager.updateMLTask(taskId, updated, TIMEOUT_IN_MILLIS, true);
         updateModel(modelId, ImmutableMap.of(MLModel.MODEL_STATE_FIELD, MLModelState.REGISTER_FAILED));
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -53,6 +53,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import javax.management.modelmbean.ModelMBeanInfo;
+
 import lombok.extern.log4j.Log4j2;
 
 import org.opensearch.action.ActionListener;
@@ -386,10 +388,10 @@ public class MLModelManager {
                         }, e -> {
                             log.error("Failed to index model chunk " + chunkId, e);
                             failedToUploadChunk.set(true);
-                            handleException(functionName, taskId, e);
+                            handleExceptionUpdateModelState(functionName, taskId, modelId, e);
                             deleteFileQuietly(file);
                             // remove model doc as failed to upload model
-                            deleteModel(modelId);
+                            // deleteModel(modelId);
                             semaphore.release();
                             deleteFileQuietly(mlEngine.getRegisterModelPath(modelId));
                         }));
@@ -397,8 +399,8 @@ public class MLModelManager {
                 }, e -> {
                     log.error("Failed to index chunk file", e);
                     deleteFileQuietly(mlEngine.getRegisterModelPath(modelId));
-                    deleteModel(modelId);
-                    handleException(functionName, taskId, e);
+                    // deleteModel(modelId);
+                    handleExceptionUpdateModelState(functionName, taskId, modelId, e);
                 })
             );
     }
@@ -462,7 +464,7 @@ public class MLModelManager {
         }, e -> {
             log.error("Failed to update model", e);
             handleException(functionName, taskId, e);
-            deleteModel(modelId);
+            // deleteModel(modelId);
         }));
     }
 
@@ -490,6 +492,13 @@ public class MLModelManager {
         mlStats.createCounterStatIfAbsent(functionName, REGISTER, MLActionLevelStat.ML_ACTION_FAILURE_COUNT).increment();
         Map<String, Object> updated = ImmutableMap.of(ERROR_FIELD, MLExceptionUtils.getRootCauseMessage(e), STATE_FIELD, FAILED);
         mlTaskManager.updateMLTask(taskId, updated, TIMEOUT_IN_MILLIS, true);
+    }
+    
+    private void handleExceptionUpdateModelState(FunctionName functionName, String taskId, String modelId, Exception e) {
+        mlStats.createCounterStatIfAbsent(functionName, REGISTER, MLActionLevelStat.ML_ACTION_FAILURE_COUNT).increment();
+        Map<String, Object> updated = ImmutableMap.of(ERROR_FIELD, MLExceptionUtils.getRootCauseMessage(e), STATE_FIELD, FAILED, MODEL_ID_FIELD, modelId);
+        mlTaskManager.updateMLTask(taskId, updated, TIMEOUT_IN_MILLIS, true); 
+        updateModel(modelId, ImmutableMap.of(MLModel.MODEL_STATE_FIELD, MLModelState.REGISTER_FAILED));
     }
 
     /**

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -70,6 +68,8 @@ import org.opensearch.search.profile.SearchProfileShardResults;
 import org.opensearch.search.suggest.Suggest;
 import org.opensearch.test.OpenSearchTestCase;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 public class MLSyncUpCronTests extends OpenSearchTestCase {
@@ -99,7 +99,7 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
 
         testState = setupTestClusterState();
         when(clusterService.state()).thenReturn(testState);
-        when(nodeHelper.getEligibleNodes()).thenReturn(new DiscoveryNode[]{mlNode1, mlNode2});
+        when(nodeHelper.getEligibleNodes()).thenReturn(new DiscoveryNode[] { mlNode1, mlNode2 });
     }
 
     public void testRun_NoMLModelIndex() {
@@ -222,7 +222,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         Map<String, Set<String>> deployingModels = new HashMap<>();
         doAnswer(invocation -> {
             ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYED, 2, null, Instant.now().toEpochMilli(), false));
+            actionListener
+                .onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYED, 2, null, Instant.now().toEpochMilli(), false));
             return null;
         }).when(client).search(any(), any());
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
@@ -245,7 +246,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         Map<String, Set<String>> deployingModels = new HashMap<>();
         doAnswer(invocation -> {
             ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYED, 2, 0, Instant.now().toEpochMilli(), false));
+            actionListener
+                .onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYED, 2, 0, Instant.now().toEpochMilli(), false));
             return null;
         }).when(client).search(any(), any());
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
@@ -269,7 +271,9 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         doAnswer(invocation -> {
             ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
             actionListener
-                .onResponse(createSearchModelResponse("modelId", MLModelState.PARTIALLY_DEPLOYED, 3, 2, Instant.now().toEpochMilli(), false));
+                .onResponse(
+                    createSearchModelResponse("modelId", MLModelState.PARTIALLY_DEPLOYED, 3, 2, Instant.now().toEpochMilli(), false)
+                );
             return null;
         }).when(client).search(any(), any());
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
@@ -293,7 +297,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         deployingModels.put("modelId", ImmutableSet.of("node2"));
         doAnswer(invocation -> {
             ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOY_FAILED, 2, 0, Instant.now().toEpochMilli(), false));
+            actionListener
+                .onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOY_FAILED, 2, 0, Instant.now().toEpochMilli(), false));
             return null;
         }).when(client).search(any(), any());
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
@@ -316,7 +321,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         deployingModels.put("modelId", ImmutableSet.of("node2"));
         doAnswer(invocation -> {
             ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli(), false));
+            actionListener
+                .onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli(), false));
             return null;
         }).when(client).search(any(), any());
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
@@ -329,7 +335,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         Map<String, Set<String>> deployingModels = new HashMap<>();
         doAnswer(invocation -> {
             ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli(), false));
+            actionListener
+                .onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli(), false));
             return null;
         }).when(client).search(any(), any());
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
@@ -342,7 +349,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         Map<String, Set<String>> deployingModels = new HashMap<>();
         doAnswer(invocation -> {
             ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli(), true));
+            actionListener
+                .onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli(), true));
             return null;
         }).when(client).search(any(), any());
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
@@ -355,7 +363,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         Map<String, Set<String>> deployingModels = new HashMap<>();
         doAnswer(invocation -> {
             ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 1, 1, Instant.now().toEpochMilli(), false));
+            actionListener
+                .onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 1, 1, Instant.now().toEpochMilli(), false));
             return null;
         }).when(client).search(any(), any());
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);


### PR DESCRIPTION
### Description
1. Keep model document even register failed, so user can edit the failed document on frontend page.
2. Add a new model status: REGISTER_FAILED to identify register failed state.
3. Fix incorrect model register task action type from DEPLOY_MODEL to REGISTER_MODEL.
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/895
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
