### PR TITLE
get 10k model group ids when search model

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/handler/MLSearchHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/handler/MLSearchHandler.java
@@ -74,6 +74,7 @@ public class MLSearchHandler {
             SearchSourceBuilder sourceBuilder = modelAccessControlHelper.createSearchSourceBuilder(user);
             SearchRequest modelGroupSearchRequest = new SearchRequest();
             sourceBuilder.fetchSource(new String[] { MLModelGroup.MODEL_GROUP_ID_FIELD, }, null);
+            sourceBuilder.size(10000);
             modelGroupSearchRequest.source(sourceBuilder);
             modelGroupSearchRequest.indices(CommonValue.ML_MODEL_GROUP_INDEX);
             ActionListener<SearchResponse> modelGroupSearchActionListener = ActionListener.wrap(r -> {


### PR DESCRIPTION
### Description
By default, opensearch return 10 documents. If the target model is not in the top 10 model group, then search model API can't return correct model
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
