### PR TITLE
change aws-actions/configure-aws-credentials version from 1.7.0 to 1

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 17
       - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1.7.0
+      - uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
           aws-region: us-east-1


### PR DESCRIPTION
### Description
change aws-actions/configure-aws-credentials version from 1.7.0 to 1
 
### Issues Resolved
maven publish failure
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
