### PR TITLE
Fix publish shadow publication dependency issue

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -48,6 +48,7 @@ jacocoTestCoverageVerification {
 check.dependsOn jacocoTestCoverageVerification
 
 tasks.named("jar").configure { dependsOn("publishShadowPublicationToMavenLocal") }
+tasks.named("jar").configure { dependsOn("publishShadowPublicationToStagingRepository") }
 
 shadowJar {
     archiveClassifier.set(null)


### PR DESCRIPTION
### Description
Fix `client:publishShadowPublicationToStagingRepository' uses this output of task ':opensearch-ml-client:jar' without declaring an explicit or implicit dependency.` issue.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
