### PR TITLE
Revert #764 to only use shadowjar publication

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -107,35 +107,6 @@ publishing {
                 }
             }
         }
-        jars(MavenPublication) { publication ->
-            from components.java
-            artifact sourcesJar
-            artifact javadocJar
-
-            pom {
-                name = "OpenSearch Machine Learning Client"
-                packaging = "jar"
-                url = "https://github.com/opensearch-project/ml-commons"
-                description = "OpenSearch Machine Learning Client"
-                scm {
-                    connection = "scm:git@github.com:opensearch-project/ml-commons.git"
-                    developerConnection = "scm:git@github.com:opensearch-project/ml-commons.git"
-                    url = "git@github.com:opensearch-project/ml-commons.git"
-                }
-                licenses {
-                    license {
-                        name = "The Apache License, Version 2.0"
-                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                    }
-                }
-                developers {
-                    developer {
-                        name = "OpenSearch"
-                        url = "https://github.com/opensearch-project/ml-commons"
-                    }
-                }
-            }
-        }
 
     }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -67,8 +67,6 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-#./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
-#./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishAllPublicationsToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -67,6 +67,8 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
+#./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+#./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishAllPublicationsToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,4 +14,3 @@ project(":plugin").name = rootProject.name + "-plugin"
 include 'ml-algorithms'
 project(":ml-algorithms").name = rootProject.name + "-algorithms"
 
-//startParameter.excludedTaskNames=["publishShadowPublicationToStagingRepository", "publishShadowPublicationToMavenLocal"]

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,4 +14,4 @@ project(":plugin").name = rootProject.name + "-plugin"
 include 'ml-algorithms'
 project(":ml-algorithms").name = rootProject.name + "-algorithms"
 
-startParameter.excludedTaskNames=["publishShadowPublicationToStagingRepository", "publishShadowPublicationToMavenLocal"]
+//startParameter.excludedTaskNames=["publishShadowPublicationToStagingRepository", "publishShadowPublicationToMavenLocal"]


### PR DESCRIPTION
### Description
Revert #764 to only use shadowjar publication.

ml used to publish a lot of unrelated content in jar, therefore this PR is created to only publish related classes:
https://github.com/opensearch-project/ml-commons/pull/764

However, the added `jars` publication alongside `shadow` caused some race conditions, so the github actions task was switched back to using `shadow`, without removing `jars` publication in #764.
https://github.com/opensearch-project/ml-commons/pull/779

The above race condition in gradle 7 is not observed clearly when building non-snapshot artifacts with `scripts/build.sh` but showing clear race conditions in gradle 8 after this PR:
https://github.com/opensearch-project/ml-commons/pull/892

The initial fix to this issue in #957 is not correct as it switch from shadow to jars, the exact same error spawns the fix of github actions in #779, causing dependent plugin such as neural-search failed with this error:
```
* What went wrong:
Execution failed for task ':bundlePlugin'.
> Could not resolve all files for configuration ':runtimeClasspath'.
   > Could not find org.opensearch:opensearch-ml-common:2.8.0.0.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/opensearch/opensearch-ml-common/2.8.0.0/opensearch-ml-common-2.8.0.0.pom
       - file:/usr/share/opensearch/.m2/repository/org/opensearch/opensearch-ml-common/2.8.0.0/opensearch-ml-common-2.8.0.0.pom
       - https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/opensearch-ml-common/2.8.0.0/opensearch-ml-common-2.8.0.0.pom
       - https://plugins.gradle.org/m2/org/opensearch/opensearch-ml-common/2.8.0.0/opensearch-ml-common-2.8.0.0.pom
     Required by:
         project : > org.opensearch:opensearch-ml-client:2.8.0.0

* Try:

> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
* Get more help at https://help.gradle.org/
```

Plus, the issue observed in #764 has since been resolved by #796.

Therefore, the final fix to this issue is to remove the `jars` publication all together.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/pull/3434





 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
