### PR TITLE
[Backport main]Only use shadowjar publication

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -47,9 +47,6 @@ jacocoTestCoverageVerification {
 }
 check.dependsOn jacocoTestCoverageVerification
 
-tasks.named("jar").configure { dependsOn("publishShadowPublicationToMavenLocal") }
-tasks.named("jar").configure { dependsOn("publishShadowPublicationToStagingRepository") }
-
 shadowJar {
     archiveClassifier.set(null)
 }
@@ -110,34 +107,6 @@ publishing {
                 }
             }
         }
-        jars(MavenPublication) { publication ->
-            from components.java
-
-            pom {
-                name = "OpenSearch Machine Learning Client"
-                packaging = "jar"
-                url = "https://github.com/opensearch-project/ml-commons"
-                description = "OpenSearch Machine Learning Client"
-                scm {
-                    connection = "scm:git@github.com:opensearch-project/ml-commons.git"
-                    developerConnection = "scm:git@github.com:opensearch-project/ml-commons.git"
-                    url = "git@github.com:opensearch-project/ml-commons.git"
-                }
-                licenses {
-                    license {
-                        name = "The Apache License, Version 2.0"
-                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                    }
-                }
-                developers {
-                    developer {
-                        name = "OpenSearch"
-                        url = "https://github.com/opensearch-project/ml-commons"
-                    }
-                }
-            }
-        }
-
     }
 
 }


### PR DESCRIPTION
### Description
This is a backport PR combining #957 and #959
 
### Issues Resolved
This should fix the issue on missing ml-commons package when publishing ml-client artifacts. Thanks @ylwu-amzn, @prudhvigodithi, and @peterzhuamazon 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
