### PR TITLE
throw exception when masterKey is not provided

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/remote/TransportCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/remote/TransportCreateConnectorAction.java
@@ -97,7 +97,7 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
         String connectorName = mlCreateConnectorInput.getName();
         try {
             if (mlCreateConnectorInput.getConnectorTemplate() == null) {
-                throw new IllegalArgumentException("Invalid Connector template, APIs are missing");
+                throw new IllegalArgumentException("Invalid Connector template, Actions are missing");
             }
             validateConnectorURL(mlCreateConnectorInput);
             User user = RestActionUtils.getUserContext(client);


### PR DESCRIPTION
### Description
throw meta data exception if the master key is not provided for encryption/decryption.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
