### PR TITLE
fix cannot specify model access control parameters error

### DIFF
--- a/common/src/test/java/org/opensearch/ml/common/MLModelGroupTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/MLModelGroupTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.search.SearchModule;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+public class MLModelGroupTest {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void toXContent_NullName() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("model group name is null");
+
+        MLModelGroup.builder().build();
+    }
+
+    @Test
+    public void toXContent_Empty() throws IOException {
+        MLModelGroup modelGroup = MLModelGroup.builder().name("test").build();
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        modelGroup.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+        Assert.assertEquals("{\"name\":\"test\",\"latest_version\":0}", content);
+    }
+
+    @Test
+    public void toXContent() throws IOException {
+        MLModelGroup modelGroup = MLModelGroup.builder()
+                .name("test")
+                .description("this is test group")
+                .latestVersion(1)
+                .backendRoles(Arrays.asList("role1", "role2"))
+                .owner(new User())
+                .access(AccessMode.PUBLIC.name())
+                .build();
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        modelGroup.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+        Assert.assertEquals("{\"name\":\"test\",\"latest_version\":1,\"description\":\"this is test group\"," +
+                "\"backend_roles\":[\"role1\",\"role2\"]," +
+                "\"owner\":{\"name\":\"\",\"backend_roles\":[],\"roles\":[],\"custom_attribute_names\":[],\"user_requested_tenant\":null}," +
+                "\"access\":\"PUBLIC\"}", content);
+    }
+
+    @Test
+    public void parse() throws IOException {
+        String jsonStr = "{\"name\":\"test\",\"latest_version\":1,\"description\":\"this is test group\"," +
+                "\"backend_roles\":[\"role1\",\"role2\"]," +
+                "\"owner\":{\"name\":\"\",\"backend_roles\":[],\"roles\":[],\"custom_attribute_names\":[],\"user_requested_tenant\":null}," +
+                "\"access\":\"PUBLIC\"}";
+        XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                Collections.emptyList()).getNamedXContents()), null, jsonStr);
+        parser.nextToken();
+        MLModelGroup modelGroup = MLModelGroup.parse(parser);
+        Assert.assertEquals("test", modelGroup.getName());
+        Assert.assertEquals("this is test group", modelGroup.getDescription());
+        Assert.assertEquals("PUBLIC", modelGroup.getAccess());
+        Assert.assertEquals(2, modelGroup.getBackendRoles().size());
+        Assert.assertEquals("role1", modelGroup.getBackendRoles().get(0));
+        Assert.assertEquals("role2", modelGroup.getBackendRoles().get(1));
+    }
+
+    @Test
+    public void parse_Empty() throws IOException {
+        String jsonStr = "{\"name\":\"test\"}";
+        XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                Collections.emptyList()).getNamedXContents()), null, jsonStr);
+        parser.nextToken();
+        MLModelGroup modelGroup = MLModelGroup.parse(parser);
+        Assert.assertEquals("test", modelGroup.getName());
+        Assert.assertNull(modelGroup.getBackendRoles());
+        Assert.assertNull(modelGroup.getAccess());
+        Assert.assertNull(modelGroup.getOwner());
+    }
+
+    @Test
+    public void writeTo() throws IOException {
+        MLModelGroup originalModelGroup = MLModelGroup.builder()
+                .name("test")
+                .description("this is test group")
+                .latestVersion(1)
+                .backendRoles(Arrays.asList("role1", "role2"))
+                .owner(new User())
+                .access(AccessMode.PUBLIC.name())
+                .build();
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        originalModelGroup.writeTo(output);
+        MLModelGroup modelGroup = new MLModelGroup(output.bytes().streamInput());
+        Assert.assertEquals("test", modelGroup.getName());
+        Assert.assertEquals("this is test group", modelGroup.getDescription());
+        Assert.assertEquals("PUBLIC", modelGroup.getAccess());
+        Assert.assertEquals(2, modelGroup.getBackendRoles().size());
+        Assert.assertEquals("role1", modelGroup.getBackendRoles().get(0));
+        Assert.assertEquals("role2", modelGroup.getBackendRoles().get(1));
+    }
+
+    @Test
+    public void writeTo_Empty() throws IOException {
+        MLModelGroup originalModelGroup = MLModelGroup.builder().name("test").build();
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        originalModelGroup.writeTo(output);
+        MLModelGroup modelGroup = new MLModelGroup(output.bytes().streamInput());
+        Assert.assertEquals("test", modelGroup.getName());
+        Assert.assertNull(modelGroup.getBackendRoles());
+        Assert.assertNull(modelGroup.getAccess());
+        Assert.assertNull(modelGroup.getOwner());
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -193,7 +193,9 @@ public class MLModelGroupManager {
     }
 
     private void validateSecurityDisabledOrModelAccessControlDisabled(MLRegisterModelGroupInput input) {
-        if (input.getModelAccessMode() != null || input.getIsAddAllBackendRoles() != null || input.getBackendRoles() != null) {
+        if (input.getModelAccessMode() != null
+            || input.getIsAddAllBackendRoles() != null
+            || !CollectionUtils.isEmpty(input.getBackendRoles())) {
             throw new IllegalArgumentException(
                 "You cannot specify model access control parameters because the Security plugin or model access control is disabled on your cluster."
             );

--- a/plugin/src/test/java/org/opensearch/ml/helper/ModelAccessControlHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/ModelAccessControlHelperTests.java
@@ -199,8 +199,12 @@ public class ModelAccessControlHelperTests extends OpenSearchTestCase {
     public void test_IsUserHasBackendRole() {
         User user = User.parse("owner|IT,HR|all_access");
         MLModelGroupBuilder builder = MLModelGroup.builder();
-        assertTrue(modelAccessControlHelper.isUserHasBackendRole(null, builder.access(AccessMode.PUBLIC.getValue()).build()));
-        assertFalse(modelAccessControlHelper.isUserHasBackendRole(null, builder.access(AccessMode.PRIVATE.getValue()).build()));
+        assertTrue(
+            modelAccessControlHelper.isUserHasBackendRole(null, builder.name("test_group").access(AccessMode.PUBLIC.getValue()).build())
+        );
+        assertFalse(
+            modelAccessControlHelper.isUserHasBackendRole(null, builder.name("test_group").access(AccessMode.PRIVATE.getValue()).build())
+        );
         assertTrue(
             modelAccessControlHelper
                 .isUserHasBackendRole(
@@ -218,9 +222,13 @@ public class ModelAccessControlHelperTests extends OpenSearchTestCase {
         User userLostAccess = User.parse("owner|Finance|myTenant");
         assertTrue(modelAccessControlHelper.isOwnerStillHasPermission(null, null));
         MLModelGroupBuilder builder = MLModelGroup.builder();
-        assertTrue(modelAccessControlHelper.isOwnerStillHasPermission(user, builder.access(AccessMode.PUBLIC.getValue()).build()));
         assertTrue(
-            modelAccessControlHelper.isOwnerStillHasPermission(user, builder.access(AccessMode.PRIVATE.getValue()).owner(owner).build())
+            modelAccessControlHelper
+                .isOwnerStillHasPermission(user, builder.name("test_group").access(AccessMode.PUBLIC.getValue()).build())
+        );
+        assertTrue(
+            modelAccessControlHelper
+                .isOwnerStillHasPermission(user, builder.name("test_group").access(AccessMode.PRIVATE.getValue()).owner(owner).build())
         );
         assertFalse(
             modelAccessControlHelper


### PR DESCRIPTION
### Description
See such error when register pretrained model without model group id,
```
{
	"error": {
		"root_cause": [
			{
				"type": "illegal_argument_exception",
				"reason": "You cannot specify model access control parameters because the Security plugin or model access control is disabled on your cluster."
			}
		],
		"type": "illegal_argument_exception",
		"reason": "You cannot specify model access control parameters because the Security plugin or model access control is disabled on your cluster."
	},
	"status": 400
}
```

The reason is `input.getBackendRoles()` is not null, but it's empty.
This PR fixed the bug.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
