### PR TITLE
Tweak workflow event so ci can retrieve credentails correctly

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -1,12 +1,13 @@
 name: Build and Test ml-commons
 # This workflow is triggered on pull requests and push to any branches
 on:
-  pull_request:
-    branches:
-      - "*"
   push:
-    branches:
-      - "*"
+    branches-ignore:
+      - 'backport/**'
+      - 'create-pull-request/**'
+      - 'dependabot/**'
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   id-token: write


### PR DESCRIPTION
### Description
Tweak workflow event so ci can retrieve credentails correctly

 
### Issues Resolved
This is a follow up to https://github.com/opensearch-project/ml-commons/pull/1099
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
