### PR TITLE
delete connector successfully if model index is missing

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
@@ -20,6 +20,7 @@ import org.opensearch.client.Client;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.exception.MLValidationException;
@@ -85,6 +86,10 @@ public class DeleteConnectorTransportAction extends HandledTransportAction<Actio
                                 );
                         }
                     }, e -> {
+                        if (e instanceof IndexNotFoundException) {
+                            deleteConnector(deleteRequest, connectorId, actionListener);
+                            return;
+                        }
                         log.error("Failed to delete ML connector: " + connectorId, e);
                         actionListener.onFailure(e);
                     }));


### PR DESCRIPTION
### Description
Currently in deleting a connector, an IndexNotFound exception is throw when the ml_model index does not exist. But actually this deletion should be successful because there will be no models associated with the connector.
 
Verified the fix using local cluster.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
