### PR TITLE
Add null key check for remote inference integration tests

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
@@ -24,6 +24,9 @@ import com.google.common.collect.ImmutableList;
 
 public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
 
+    private final String OPENAI_KEY = System.getenv("OPENAI_KEY");
+    private final String COHERE_KEY = System.getenv("COHERE_KEY");
+
     private final String completionModelConnectorEntity = "{\n"
         + "\"name\": \"OpenAI Connector\",\n"
         + "\"description\": \"The connector to public OpenAI model service for GPT 3.5\",\n"
@@ -39,7 +42,7 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         + "  },\n"
         + "  \"credential\": {\n"
         + "    \"openAI_key\": \""
-        + System.getenv("OPENAI_KEY")
+        + OPENAI_KEY
         + "\"\n"
         + "  },\n"
         + "  \"actions\": [\n"
@@ -132,6 +135,10 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
     }
 
     public void testPredictRemoteModel() throws IOException, InterruptedException {
+        // Skip test if key is null
+        if (OPENAI_KEY == null) {
+            return;
+        }
         Response response = createConnector(completionModelConnectorEntity);
         Map responseMap = parseResponseToMap(response);
         String connectorId = (String) responseMap.get("connector_id");
@@ -184,6 +191,10 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
     }
 
     public void testOpenAIChatCompletionModel() throws IOException, InterruptedException {
+        // Skip test if key is null
+        if (OPENAI_KEY == null) {
+            return;
+        }
         String entity = "{\n"
             + "  \"name\": \"OpenAI chat model Connector\",\n"
             + "  \"description\": \"The connector to public OpenAI model service for GPT 3.5\",\n"
@@ -199,7 +210,7 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
             + "  },\n"
             + "  \"credential\": {\n"
             + "      \"openAI_key\": \""
-            + System.getenv("OPENAI_KEY")
+            + OPENAI_KEY
             + "\"\n"
             + "  },\n"
             + "  \"actions\": [\n"
@@ -240,6 +251,10 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
     }
 
     public void testOpenAIEditsModel() throws IOException, InterruptedException {
+        // Skip test if key is null
+        if (OPENAI_KEY == null) {
+            return;
+        }
         String entity = "{\n"
             + "  \"name\": \"OpenAI Edit model Connector\",\n"
             + "  \"description\": \"The connector to public OpenAI edit model service\",\n"
@@ -253,7 +268,7 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
             + "  },\n"
             + "  \"credential\": {\n"
             + "      \"openAI_key\": \""
-            + System.getenv("OPENAI_KEY")
+            + OPENAI_KEY
             + "\"\n"
             + "  },\n"
             + "  \"actions\": [\n"
@@ -305,6 +320,10 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
     }
 
     public void testOpenAIModerationsModel() throws IOException, InterruptedException {
+        // Skip test if key is null
+        if (OPENAI_KEY == null) {
+            return;
+        }
         String entity = "{\n"
             + "  \"name\": \"OpenAI moderations model Connector\",\n"
             + "  \"description\": \"The connector to public OpenAI moderations model service\",\n"
@@ -318,7 +337,7 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
             + "  },\n"
             + "  \"credential\": {\n"
             + "      \"openAI_key\": \""
-            + System.getenv("OPENAI_KEY")
+            + OPENAI_KEY
             + "\"\n"
             + "  },\n"
             + "  \"actions\": [\n"
@@ -368,6 +387,10 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
 
     @Ignore
     public void testOpenAITextEmbeddingModel() throws IOException, InterruptedException {
+        // Skip test if key is null
+        if (OPENAI_KEY == null) {
+            return;
+        }
         String entity = "{\n"
             + "  \"name\": \"OpenAI text embedding model Connector\",\n"
             + "  \"description\": \"The connector to public OpenAI text embedding model service\",\n"
@@ -381,7 +404,7 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
             + "  },\n"
             + "  \"credential\": {\n"
             + "      \"openAI_key\": \""
-            + System.getenv("OPENAI_KEY")
+            + OPENAI_KEY
             + "\"\n"
             + "  },\n"
             + "  \"actions\": [\n"
@@ -426,6 +449,10 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
     }
 
     public void testCohereGenerateTextModel() throws IOException, InterruptedException {
+        // Skip test if key is null
+        if (COHERE_KEY == null) {
+            return;
+        }
         String entity = "{\n"
             + "  \"name\": \"Cohere generate text model Connector\",\n"
             + "  \"description\": \"The connector to public Cohere generate text model service\",\n"
@@ -439,7 +466,7 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
             + "  },\n"
             + "  \"credential\": {\n"
             + "      \"cohere_key\": \""
-            + System.getenv("COHERE_KEY")
+            + COHERE_KEY
             + "\"\n"
             + "  },\n"
             + "  \"actions\": [\n"
@@ -487,6 +514,10 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
     }
 
     public void testCohereClassifyModel() throws IOException, InterruptedException {
+        // Skip test if key is null
+        if (COHERE_KEY == null) {
+            return;
+        }
         String entity = "{\n"
             + "  \"name\": \"Cohere classify model Connector\",\n"
             + "  \"description\": \"The connector to public Cohere classify model service\",\n"
@@ -500,7 +531,7 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
             + "  },\n"
             + "  \"credential\": {\n"
             + "      \"cohere_key\": \""
-            + System.getenv("COHERE_KEY")
+            + COHERE_KEY
             + "\"\n"
             + "  },\n"
             + "  \"actions\": [\n"


### PR DESCRIPTION
### Description
Adds a check to skip remote inference integration tests if the API key is null
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
