### PR TITLE
Add shell bash settings for windows github actions to export credentials

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -140,6 +140,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build and Run Tests
+        shell: bash
         run: |
           export OPENAI_KEY=$(aws secretsmanager get-secret-value --secret-id github_openai_key --query SecretString --output text)
           export COHERE_KEY=$(aws secretsmanager get-secret-value --secret-id github_cohere_key --query SecretString --output text)
@@ -150,6 +151,7 @@ jobs:
         run: |
           ./gradlew publishToMavenLocal
 #      - name: Multi Nodes Integration Testing
+#        shell: bash
 #        run: |
 #          export OPENAI_KEY=$(aws secretsmanager get-secret-value --secret-id github_openai_key --query SecretString --output text)
 #          export COHERE_KEY=$(aws secretsmanager get-secret-value --secret-id github_cohere_key --query SecretString --output text)


### PR DESCRIPTION
### Description
Add shell bash settings for windows github actions to export credentials
 
### Issues Resolved
This is a follow up to https://github.com/opensearch-project/ml-commons/pull/1114
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
