### PR TITLE
[Backport 2.9] Reenable OpenAI Remote Inference Tests

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
@@ -131,7 +131,6 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         waitForTask(taskId, MLTaskState.COMPLETED);
     }
 
-    @Ignore
     public void testPredictRemoteModel() throws IOException, InterruptedException {
         Response response = createConnector(completionModelConnectorEntity);
         Map responseMap = parseResponseToMap(response);
@@ -184,7 +183,6 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         assertTrue(responseMap.toString().contains("undeployed"));
     }
 
-    @Ignore
     public void testOpenAIChatCompletionModel() throws IOException, InterruptedException {
         String entity = "{\n"
             + "  \"name\": \"OpenAI chat model Connector\",\n"
@@ -241,7 +239,6 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         assertNotNull(responseMap);
     }
 
-    @Ignore
     public void testOpenAIEditsModel() throws IOException, InterruptedException {
         String entity = "{\n"
             + "  \"name\": \"OpenAI Edit model Connector\",\n"
@@ -307,7 +304,6 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         assertFalse(((String) responseMap.get("text")).isEmpty());
     }
 
-    @Ignore
     public void testOpenAIModerationsModel() throws IOException, InterruptedException {
         String entity = "{\n"
             + "  \"name\": \"OpenAI moderations model Connector\",\n"


### PR DESCRIPTION
### Description
Removes @ignore from OpenAI tests

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
