### PR TITLE
fix parameter parsing bug for create connector input

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.utils.StringUtils.getParameterMap;
 
 @Data
 public class MLCreateConnectorInput implements ToXContentObject, Writeable {
@@ -125,7 +126,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
                     protocol = parser.text();
                     break;
                 case CONNECTOR_PARAMETERS_FIELD:
-                    parameters = parser.mapStrings();
+                    parameters = getParameterMap(parser.map());
                     break;
                 case CONNECTOR_CREDENTIAL_FIELD:
                     credential = parser.mapStrings();

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -172,6 +172,25 @@ public class MLCreateConnectorInputTests {
     }
 
     @Test
+    public void testParse_ArrayParameter() throws Exception {
+        String expectedInputStr = "{\"name\":\"test_connector_name\"," +
+                "\"description\":\"this is a test connector\",\"version\":\"1\",\"protocol\":\"http\"," +
+                "\"parameters\":{\"input\":[\"test input value\"]},\"credential\":{\"key\":\"test_key_value\"}," +
+                "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\"," +
+                "\"headers\":{\"api_key\":\"${credential.key}\"}," +
+                "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\"," +
+                "\"pre_process_function\":\"connector.pre_process.openai.embedding\"," +
+                "\"post_process_function\":\"connector.post_process.openai.embedding\"}]," +
+                "\"backend_roles\":[\"role1\",\"role2\"],\"add_all_backend_roles\":false," +
+                "\"access_mode\":\"PUBLIC\"}";
+        testParseFromJsonString(expectedInputStr, parsedInput -> {
+            assertEquals("test_connector_name", parsedInput.getName());
+            assertEquals(1, parsedInput.getParameters().size());
+            assertEquals("[\"test input value\"]", parsedInput.getParameters().get("input"));
+        });
+    }
+
+    @Test
     public void testParseWithDryRun() throws Exception {
         String expectedInputStrWithDryRun = "{\"dry_run\":true}";
         testParseFromJsonString(expectedInputStrWithDryRun, parsedInput -> {


### PR DESCRIPTION
### Description
If user input array parameter, the `MLCreateConnectorInput` will fail to parse. This PR fixed that bug.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
