### PR TITLE
fix:admin with no backend role on AOS unable to create restricted model group

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -167,7 +167,7 @@ public class MLModelGroupManager {
             if (modelAccessControlHelper.isAdmin(user) && Boolean.TRUE.equals(isAddAllBackendRoles)) {
                 throw new IllegalArgumentException("Admin users cannot add all backend roles to a model group.");
             }
-            if (CollectionUtils.isEmpty(user.getBackendRoles())) {
+            if (!modelAccessControlHelper.isAdmin(user) && CollectionUtils.isEmpty(user.getBackendRoles())) {
                 throw new IllegalArgumentException("You must have at least one backend role to register a restricted model group.");
             }
             if (CollectionUtils.isEmpty(input.getBackendRoles()) && !Boolean.TRUE.equals(isAddAllBackendRoles)) {


### PR DESCRIPTION
### Description
fix:admin with no backend role on AOS unable to create restricted model group
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
