### PR TITLE
add eligible node role settings

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
@@ -129,6 +129,7 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
 
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             mlModelManager.getModel(modelId, null, excludes, ActionListener.wrap(mlModel -> {
+                FunctionName functionName = mlModel.getAlgorithm();
                 modelAccessControlHelper.validateModelGroupAccess(user, mlModel.getModelGroupId(), client, ActionListener.wrap(access -> {
                     if (!access) {
                         listener
@@ -141,7 +142,7 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
                         }
                         // mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
                         mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
-                        DiscoveryNode[] allEligibleNodes = nodeFilter.getEligibleNodes();
+                        DiscoveryNode[] allEligibleNodes = nodeFilter.getEligibleNodes(functionName);
                         Map<String, DiscoveryNode> nodeMapping = new HashMap<>();
                         for (DiscoveryNode node : allEligibleNodes) {
                             nodeMapping.put(node.getId(), node);
@@ -161,7 +162,7 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
                                     nodeIds.add(nodeId);
                                 }
                             }
-                            String[] workerNodes = mlModelManager.getWorkerNodes(modelId);
+                            String[] workerNodes = mlModelManager.getWorkerNodes(modelId, functionName);
                             if (workerNodes != null && workerNodes.length > 0) {
                                 Set<String> difference = new HashSet<String>(Arrays.asList(workerNodes));
                                 difference.removeAll(Arrays.asList(targetNodeIds));

--- a/plugin/src/main/java/org/opensearch/ml/action/execute/TransportExecuteTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/execute/TransportExecuteTaskAction.java
@@ -10,6 +10,7 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskAction;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskRequest;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskResponse;
@@ -42,6 +43,7 @@ public class TransportExecuteTaskAction extends HandledTransportAction<ActionReq
     @Override
     protected void doExecute(Task task, ActionRequest request, ActionListener<MLExecuteTaskResponse> listener) {
         MLExecuteTaskRequest mlPredictionTaskRequest = MLExecuteTaskRequest.fromActionRequest(request);
-        mlExecuteTaskRunner.run(mlPredictionTaskRequest, transportService, listener);
+        FunctionName functionName = mlPredictionTaskRequest.getFunctionName();
+        mlExecuteTaskRunner.run(functionName, mlPredictionTaskRequest, transportService, listener);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
@@ -15,6 +15,7 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.exception.MLValidationException;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
@@ -86,6 +87,7 @@ public class TransportPredictionTaskAction extends HandledTransportAction<Action
 
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             mlModelManager.getModel(modelId, ActionListener.wrap(mlModel -> {
+                FunctionName functionName = mlModel.getAlgorithm();
                 modelAccessControlHelper
                     .validateModelGroupAccess(userInfo, mlModel.getModelGroupId(), client, ActionListener.wrap(access -> {
                         if (!access) {
@@ -97,12 +99,13 @@ public class TransportPredictionTaskAction extends HandledTransportAction<Action
                             String requestId = mlPredictionTaskRequest.getRequestID();
                             log.debug("receive predict request " + requestId + " for model " + mlPredictionTaskRequest.getModelId());
                             long startTime = System.nanoTime();
-                            mlPredictTaskRunner.run(mlPredictionTaskRequest, transportService, ActionListener.runAfter(listener, () -> {
-                                long endTime = System.nanoTime();
-                                double durationInMs = (endTime - startTime) / 1e6;
-                                modelCacheHelper.addPredictRequestDuration(modelId, durationInMs);
-                                log.debug("completed predict request " + requestId + " for model " + modelId);
-                            }));
+                            mlPredictTaskRunner
+                                .run(functionName, mlPredictionTaskRequest, transportService, ActionListener.runAfter(listener, () -> {
+                                    long endTime = System.nanoTime();
+                                    double durationInMs = (endTime - startTime) / 1e6;
+                                    modelCacheHelper.addPredictRequestDuration(modelId, durationInMs);
+                                    log.debug("completed predict request " + requestId + " for model " + modelId);
+                                }));
                         }
                     }, e -> {
                         log.error("Failed to Validate Access for ModelId " + modelId, e);

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -264,7 +264,7 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
             }));
             return;
         }
-        mlTaskDispatcher.dispatch(ActionListener.wrap(node -> {
+        mlTaskDispatcher.dispatch(registerModelInput.getFunctionName(), ActionListener.wrap(node -> {
             String nodeId = node.getId();
             mlTask.setWorkerNodes(ImmutableList.of(nodeId));
 

--- a/plugin/src/main/java/org/opensearch/ml/action/training/TransportTrainingTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/training/TransportTrainingTaskAction.java
@@ -39,6 +39,6 @@ public class TransportTrainingTaskAction extends HandledTransportAction<ActionRe
     @Override
     protected void doExecute(Task task, ActionRequest request, ActionListener<MLTaskResponse> listener) {
         MLTrainingTaskRequest trainingRequest = MLTrainingTaskRequest.fromActionRequest(request);
-        mlTrainingTaskRunner.run(trainingRequest, transportService, listener);
+        mlTrainingTaskRunner.run(trainingRequest.getMlInput().getFunctionName(), trainingRequest, transportService, listener);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/trainpredict/TransportTrainAndPredictionTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/trainpredict/TransportTrainAndPredictionTaskAction.java
@@ -35,6 +35,6 @@ public class TransportTrainAndPredictionTaskAction extends HandledTransportActio
     @Override
     protected void doExecute(Task task, ActionRequest request, ActionListener<MLTaskResponse> listener) {
         MLTrainingTaskRequest trainingRequest = MLTrainingTaskRequest.fromActionRequest(request);
-        mlTrainAndPredictTaskRunner.run(trainingRequest, transportService, listener);
+        mlTrainAndPredictTaskRunner.run(trainingRequest.getMlInput().getFunctionName(), trainingRequest, transportService, listener);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
@@ -30,6 +30,7 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.common.transport.sync.MLSyncUpAction;
@@ -238,7 +239,8 @@ public class TransportUndeployModelAction extends
         String[] removedModelIds = specifiedModelIds ? modelIds : mlModelManager.getAllModelIds();
         if (removedModelIds != null) {
             for (String modelId : removedModelIds) {
-                String[] workerNodes = mlModelManager.getWorkerNodes(modelId);
+                FunctionName functionName = mlModelManager.getModelFunctionName(modelId);
+                String[] workerNodes = mlModelManager.getWorkerNodes(modelId, functionName);
                 modelWorkerNodesMap.put(modelId, workerNodes);
             }
         }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -1074,10 +1074,11 @@ public class MLModelManager {
      * Get worker nodes of specific model.
      *
      * @param modelId model id
+     * @param functionName function name
      * @param onlyEligibleNode return only eligible node
      * @return list of worker node ids
      */
-    public String[] getWorkerNodes(String modelId, boolean onlyEligibleNode) {
+    public String[] getWorkerNodes(String modelId, FunctionName functionName, boolean onlyEligibleNode) {
         String[] workerNodeIds = modelCacheHelper.getWorkerNodes(modelId);
         if (!onlyEligibleNode) {
             return workerNodeIds;
@@ -1086,7 +1087,7 @@ public class MLModelManager {
             return workerNodeIds;
         }
 
-        String[] eligibleNodeIds = nodeHelper.filterEligibleNodes(workerNodeIds);
+        String[] eligibleNodeIds = nodeHelper.filterEligibleNodes(functionName, workerNodeIds);
         if (eligibleNodeIds == null || eligibleNodeIds.length == 0) {
             throw new IllegalArgumentException("No eligible worker node found");
         }
@@ -1097,10 +1098,11 @@ public class MLModelManager {
      * Get worker node of specific model without filtering eligible node.
      *
      * @param modelId model id
+     * @param functionName function name
      * @return list of worker node ids
      */
-    public String[] getWorkerNodes(String modelId) {
-        return getWorkerNodes(modelId, false);
+    public String[] getWorkerNodes(String modelId, FunctionName functionName) {
+        return getWorkerNodes(modelId, functionName, false);
     }
 
     /**

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -612,7 +612,9 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
                 MLCommonsSettings.ML_COMMONS_ALLOW_LOCAL_FILE_UPLOAD,
                 MLCommonsSettings.ML_COMMONS_MODEL_ACCESS_CONTROL_ENABLED,
                 MLCommonsSettings.ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED,
-                MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX
+                MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX,
+                MLCommonsSettings.ML_COMMONS_REMOTE_MODEL_ELIGIBLE_NODE_ROLES,
+                MLCommonsSettings.ML_COMMONS_LOCAL_MODEL_ELIGIBLE_NODE_ROLES
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -128,6 +128,22 @@ public final class MLCommonsSettings {
             Setting.Property.Dynamic
         );
 
+    /**
+     * Per PM's suggestion, remote model should be able to run on data or ML node by default.
+     * But we should also keep local model run on ML node by default. So we still keep
+     * "plugins.ml_commons.only_run_on_ml_node" as true, but only control local model.
+     * Add more setting to provide granular level control on remote and local model.
+     *
+     * 1. Add "plugins.ml_commons.task_dispatcher.eligible_node_role.remote_model" which controls
+     * only remote model can run on which node. Default value is ["data", "ml"] which means the
+     * remote model can run on data node and ML node by default.
+     * 2. Add "plugins.ml_commons.task_dispatcher.eligible_node_role.local_model" which controls
+     * only remote model can run on which node. But we have "plugins.ml_commons.only_run_on_ml_node"
+     * which controls the model can only run on ML node or not.
+     * To provide BWC, for local model, 1/ if plugins.ml_commons.only_run_on_ml_node is true, we
+     * will always run it on ML node. 2/ if plugins.ml_commons.only_run_on_ml_node is false, will
+     * run model on nodes defined in plugins.ml_commons.task_dispatcher.eligible_node_role.local_model.
+     */
     public static final Setting<List<String>> ML_COMMONS_REMOTE_MODEL_ELIGIBLE_NODE_ROLES = Setting
         .listSetting(
             "plugins.ml_commons.task_dispatcher.eligible_node_role.remote_model",

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -127,4 +127,22 @@ public final class MLCommonsSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
+
+    public static final Setting<List<String>> ML_COMMONS_REMOTE_MODEL_ELIGIBLE_NODE_ROLES = Setting
+        .listSetting(
+            "plugins.ml_commons.task_dispatcher.eligible_node_role.remote_model",
+            ImmutableList.of("data", "ml"),
+            Function.identity(),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<List<String>> ML_COMMONS_LOCAL_MODEL_ELIGIBLE_NODE_ROLES = Setting
+        .listSetting(
+            "plugins.ml_commons.task_dispatcher.eligible_node_role.local_model",
+            ImmutableList.of("data", "ml"),
+            Function.identity(),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
 }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
@@ -24,6 +24,7 @@ import org.opensearch.ml.action.stats.MLStatsNodeResponse;
 import org.opensearch.ml.action.stats.MLStatsNodesAction;
 import org.opensearch.ml.action.stats.MLStatsNodesRequest;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.stats.MLNodeLevelStat;
 
 import com.google.common.collect.ImmutableSet;
@@ -60,13 +61,14 @@ public class MLTaskDispatcher {
 
     /**
      * Dispatch task to target node.
+     * @param functionName function name
      * @param actionListener action listener
      */
-    public void dispatch(ActionListener<DiscoveryNode> actionListener) {
+    public void dispatch(FunctionName functionName, ActionListener<DiscoveryNode> actionListener) {
         if (ROUND_ROBIN.equals(dispatchPolicy)) {
-            dispatchTaskWithRoundRobin(actionListener);
+            dispatchTaskWithRoundRobin(functionName, actionListener);
         } else if (LEAST_LOAD.equals(dispatchPolicy)) {
-            dispatchTaskWithLeastLoad(actionListener);
+            dispatchTaskWithLeastLoad(functionName, actionListener);
         } else {
             throw new IllegalArgumentException("Unknown policy");
         }
@@ -158,13 +160,13 @@ public class MLTaskDispatcher {
         }));
     }
 
-    private void dispatchTaskWithLeastLoad(ActionListener<DiscoveryNode> listener) {
-        DiscoveryNode[] eligibleNodes = nodeHelper.getEligibleNodes();
+    private void dispatchTaskWithLeastLoad(FunctionName functionName, ActionListener<DiscoveryNode> listener) {
+        DiscoveryNode[] eligibleNodes = nodeHelper.getEligibleNodes(functionName);
         dispatchTaskWithLeastLoad(eligibleNodes, listener);
     }
 
-    private void dispatchTaskWithRoundRobin(ActionListener<DiscoveryNode> listener) {
-        DiscoveryNode[] eligibleNodes = nodeHelper.getEligibleNodes();
+    private void dispatchTaskWithRoundRobin(FunctionName functionName, ActionListener<DiscoveryNode> listener) {
+        DiscoveryNode[] eligibleNodes = nodeHelper.getEligibleNodes(functionName);
         if (eligibleNodes == null || eligibleNodes.length == 0) {
             throw new IllegalArgumentException(
                 "No eligible node found to execute this request. It's best practice to"

--- a/plugin/src/test/java/org/opensearch/ml/action/deploy/TransportDeployModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/deploy/TransportDeployModelActionTests.java
@@ -149,7 +149,7 @@ public class TransportDeployModelActionTests extends OpenSearchTestCase {
         when(mlDeployModelRequest.getModelNodeIds()).thenReturn(new String[] { "node1" });
         DiscoveryNode discoveryNode = mock(DiscoveryNode.class);
         DiscoveryNode[] discoveryNodes = new DiscoveryNode[] { discoveryNode };
-        when(nodeFilter.getEligibleNodes()).thenReturn(discoveryNodes);
+        when(nodeFilter.getEligibleNodes(any())).thenReturn(discoveryNodes);
         when(discoveryNode.getId()).thenReturn("node1");
 
         when(clusterService.localNode()).thenReturn(discoveryNode);
@@ -286,7 +286,7 @@ public class TransportDeployModelActionTests extends OpenSearchTestCase {
     @Ignore
     public void testDoExecute_whenDeployModelRequestNodeIdsEmpty_thenMLResourceNotFoundException() {
         DiscoveryNodeHelper nodeHelper = mock(DiscoveryNodeHelper.class);
-        when(nodeHelper.getEligibleNodes()).thenReturn(new DiscoveryNode[] {});
+        when(nodeHelper.getEligibleNodes(FunctionName.REMOTE)).thenReturn(new DiscoveryNode[] {});
         TransportDeployModelAction deployModelAction = spy(
             new TransportDeployModelAction(
                 transportService,

--- a/plugin/src/test/java/org/opensearch/ml/action/forward/TransportForwardActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/forward/TransportForwardActionTests.java
@@ -178,7 +178,12 @@ public class TransportForwardActionTests extends OpenSearchTestCase {
         workerNodes.add(nodeId1);
         workerNodes.add(nodeId2);
         when(mlTaskManager.getWorkNodes(anyString())).thenReturn(workerNodes);
-        when(mlModelManager.getWorkerNodes(anyString())).thenReturn(new String[] { nodeId1, nodeId2 });
+        when(mlModelManager.getWorkerNodes(anyString(), any())).thenReturn(new String[] { nodeId1, nodeId2 });
+        MLTaskCache mlTaskCache = mock(MLTaskCache.class);
+        MLTask mlTask = mock(MLTask.class);
+        when(mlTaskCache.getMlTask()).thenReturn(mlTask);
+        when(mlTask.getFunctionName()).thenReturn(FunctionName.TEXT_EMBEDDING);
+        when(mlTaskManager.getMLTaskCache(anyString())).thenReturn(mlTaskCache);
 
         MLForwardInput forwardInput = MLForwardInput
             .builder()
@@ -200,12 +205,15 @@ public class TransportForwardActionTests extends OpenSearchTestCase {
         Set<String> workerNodes = new HashSet<>();
         workerNodes.add(nodeId1);
         when(mlTaskManager.getWorkNodes(anyString())).thenReturn(workerNodes);
-        when(mlModelManager.getWorkerNodes(anyString())).thenReturn(new String[] { nodeId1 });
+        when(mlModelManager.getWorkerNodes(anyString(), any())).thenReturn(new String[] { nodeId1 });
         MLTaskCache mlTaskCache = mock(MLTaskCache.class);
         when(mlTaskCache.getErrors()).thenReturn(ImmutableMap.of());
         when(mlTaskCache.hasError()).thenReturn(false);
         when(mlTaskCache.getWorkerNodeSize()).thenReturn(1);
         when(mlTaskCache.errorNodesCount()).thenReturn(0);
+        MLTask mlTask = mock(MLTask.class);
+        when(mlTask.getFunctionName()).thenReturn(FunctionName.REMOTE);
+        when(mlTaskCache.getMlTask()).thenReturn(mlTask);
         when(mlTaskManager.getMLTaskCache(anyString())).thenReturn(mlTaskCache);
         MLForwardInput forwardInput = MLForwardInput
             .builder()
@@ -229,7 +237,7 @@ public class TransportForwardActionTests extends OpenSearchTestCase {
         MLTaskCache mlTaskCache = MLTaskCache.builder().mlTask(createMlTask(MLTaskType.REGISTER_MODEL)).workerNodes(workerNodes).build();
         mlTaskCache.addError(nodeId1, error);
         doReturn(mlTaskCache).when(mlTaskManager).getMLTaskCache(anyString());
-        when(mlModelManager.getWorkerNodes(anyString())).thenReturn(new String[] { nodeId1, nodeId2 });
+        when(mlModelManager.getWorkerNodes(anyString(), any())).thenReturn(new String[] { nodeId1, nodeId2 });
 
         MLForwardInput forwardInput = MLForwardInput
             .builder()
@@ -261,7 +269,7 @@ public class TransportForwardActionTests extends OpenSearchTestCase {
             .build();
         mlTaskCache.addError(nodeId1, error);
         doReturn(mlTaskCache).when(mlTaskManager).getMLTaskCache(anyString());
-        when(mlModelManager.getWorkerNodes(anyString())).thenReturn(new String[] { nodeId1, nodeId2 });
+        when(mlModelManager.getWorkerNodes(anyString(), any())).thenReturn(new String[] { nodeId1, nodeId2 });
 
         MLForwardInput forwardInput = MLForwardInput
             .builder()

--- a/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
@@ -193,10 +193,10 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
         }).when(mlTaskManager).createMLTask(any(), any());
 
         doAnswer(invocation -> {
-            ActionListener<DiscoveryNode> listener = invocation.getArgument(0);
+            ActionListener<DiscoveryNode> listener = invocation.getArgument(1);
             listener.onResponse(node1);
             return null;
-        }).when(mlTaskDispatcher).dispatch(any());
+        }).when(mlTaskDispatcher).dispatch(any(), any());
 
         when(clusterService.localNode()).thenReturn(node2);
         when(node2.getId()).thenReturn("node2Id");
@@ -305,10 +305,10 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
 
     public void testTransportRegisterModelActionDoExecuteWithDispatchException() {
         doAnswer(invocation -> {
-            ActionListener<Exception> listener = invocation.getArgument(0);
+            ActionListener<Exception> listener = invocation.getArgument(1);
             listener.onFailure(new Exception("Failed to dispatch register model task "));
             return null;
-        }).when(mlTaskDispatcher).dispatch(any());
+        }).when(mlTaskDispatcher).dispatch(any(), any());
         when(node1.getId()).thenReturn("NodeId1");
         when(clusterService.localNode()).thenReturn(node1);
         transportRegisterModelAction.doExecute(task, prepareRequest("http://test_url", "modelGroupID"), actionListener);

--- a/plugin/src/test/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeActionTests.java
@@ -53,6 +53,7 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskType;
 import org.opensearch.ml.common.model.MLModelState;
@@ -317,7 +318,7 @@ public class TransportSyncUpOnNodeActionTests extends OpenSearchTestCase {
         MLTask mlTask = mlTaskBuilder.build();
         MLTaskCache taskCache = MLTaskCache.builder().mlTask(mlTask).build();
         if (MLModelState.DEPLOY_FAILED != modelState) {
-            when(mlModelManager.getWorkerNodes(modelId)).thenReturn(new String[] { "node1" });
+            when(mlModelManager.getWorkerNodes(modelId, FunctionName.REMOTE)).thenReturn(new String[] { "node1" });
         }
         when(mlTaskManager.getMLTaskCache(taskId)).thenReturn(taskCache);
         action.cleanUpLocalCache(runningDeployModelTasks);

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
@@ -62,6 +62,7 @@ import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.common.transport.sync.MLSyncUpAction;
@@ -439,6 +440,7 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         XContentBuilder content = TestHelper.builder();
         content.startObject();
         content.field(MLModel.MODEL_STATE_FIELD, state);
+        content.field(MLModel.ALGORITHM_FIELD, FunctionName.KMEANS);
         content.field(MLModel.PLANNING_WORKER_NODE_COUNT_FIELD, planningWorkerNodeCount);
         if (currentWorkerNodeCount != null) {
             content.field(MLModel.CURRENT_WORKER_NODE_COUNT_FIELD, currentWorkerNodeCount);

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -662,19 +662,19 @@ public class MLModelManagerTests extends OpenSearchTestCase {
     public void testGetWorkerNodes() {
         String[] nodes = new String[] { "node1", "node2" };
         when(modelCacheHelper.getWorkerNodes(anyString())).thenReturn(nodes);
-        String[] workerNodes = modelManager.getWorkerNodes(modelId);
+        String[] workerNodes = modelManager.getWorkerNodes(modelId, FunctionName.REMOTE);
         assertArrayEquals(nodes, workerNodes);
     }
 
     public void testGetWorkerNodes_Null() {
         when(modelCacheHelper.getWorkerNodes(anyString())).thenReturn(null);
-        String[] workerNodes = modelManager.getWorkerNodes(modelId);
+        String[] workerNodes = modelManager.getWorkerNodes(modelId, FunctionName.REMOTE);
         assertNull(workerNodes);
     }
 
     public void testGetWorkerNodes_EmptyNodes() {
         when(modelCacheHelper.getWorkerNodes(anyString())).thenReturn(new String[] {});
-        String[] workerNodes = modelManager.getWorkerNodes(modelId);
+        String[] workerNodes = modelManager.getWorkerNodes(modelId, FunctionName.REMOTE);
         assertEquals(0, workerNodes.length);
     }
 
@@ -683,8 +683,8 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         when(modelCacheHelper.getWorkerNodes(anyString())).thenReturn(nodes);
 
         String[] eligibleNodes = new String[] { "node1" };
-        when(nodeHelper.filterEligibleNodes(any())).thenReturn(eligibleNodes);
-        String[] workerNodes = modelManager.getWorkerNodes(modelId, true);
+        when(nodeHelper.filterEligibleNodes(any(), any())).thenReturn(eligibleNodes);
+        String[] workerNodes = modelManager.getWorkerNodes(modelId, FunctionName.REMOTE, true);
         assertArrayEquals(eligibleNodes, workerNodes);
     }
 
@@ -694,8 +694,8 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         String[] nodes = new String[] { "node1", "node2" };
         when(modelCacheHelper.getWorkerNodes(anyString())).thenReturn(nodes);
 
-        when(nodeHelper.filterEligibleNodes(any())).thenReturn(null);
-        modelManager.getWorkerNodes(modelId, true);
+        when(nodeHelper.filterEligibleNodes(any(), any())).thenReturn(null);
+        modelManager.getWorkerNodes(modelId, FunctionName.REMOTE, true);
     }
 
     public void testGetWorkerNodes_FilterEligibleNodes_Empty() {
@@ -704,8 +704,8 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         String[] nodes = new String[] { "node1", "node2" };
         when(modelCacheHelper.getWorkerNodes(anyString())).thenReturn(nodes);
 
-        when(nodeHelper.filterEligibleNodes(any())).thenReturn(new String[] {});
-        modelManager.getWorkerNodes(modelId, true);
+        when(nodeHelper.filterEligibleNodes(any(), any())).thenReturn(new String[] {});
+        modelManager.getWorkerNodes(modelId, FunctionName.REMOTE, true);
     }
 
     public void test_addModelWorkerNodes_success() {

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTaskDispatcherTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTaskDispatcherTests.java
@@ -41,6 +41,7 @@ import org.opensearch.ml.action.stats.MLStatsNodesAction;
 import org.opensearch.ml.action.stats.MLStatsNodesRequest;
 import org.opensearch.ml.action.stats.MLStatsNodesResponse;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.stats.MLNodeLevelStat;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -96,7 +97,7 @@ public class MLTaskDispatcherTests extends OpenSearchTestCase {
 
     @Ignore
     public void testDispatchTask_Success() {
-        taskDispatcher.dispatch(listener);
+        taskDispatcher.dispatch(FunctionName.REMOTE, listener);
         verify(client).execute(any(MLStatsNodesAction.class), any(MLStatsNodesRequest.class), any());
         verify(listener).onResponse(any());
     }
@@ -104,7 +105,7 @@ public class MLTaskDispatcherTests extends OpenSearchTestCase {
     @Ignore
     public void testDispatchTask_NullPointerException() {
         mlStatsNodesResponse = getNodesResponse_NoTaskCounts();
-        taskDispatcher.dispatch(listener);
+        taskDispatcher.dispatch(FunctionName.REMOTE, listener);
         verify(client).execute(any(MLStatsNodesAction.class), any(MLStatsNodesRequest.class), any());
         verify(listener).onFailure(any(NullPointerException.class));
     }
@@ -112,7 +113,7 @@ public class MLTaskDispatcherTests extends OpenSearchTestCase {
     @Ignore
     public void testDispatchTask_MemoryExceedLimit() {
         mlStatsNodesResponse = getNodesResponse_MemoryExceedLimits();
-        taskDispatcher.dispatch(listener);
+        taskDispatcher.dispatch(FunctionName.REMOTE, listener);
         verify(client).execute(any(MLStatsNodesAction.class), any(MLStatsNodesRequest.class), any());
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(argumentCaptor.capture());
@@ -125,7 +126,7 @@ public class MLTaskDispatcherTests extends OpenSearchTestCase {
     @Ignore
     public void testDispatchTask_TaskCountExceedLimit() {
         mlStatsNodesResponse = getNodesResponse_TaskCountExceedLimits();
-        taskDispatcher.dispatch(listener);
+        taskDispatcher.dispatch(FunctionName.REMOTE, listener);
         verify(client).execute(any(MLStatsNodesAction.class), any(MLStatsNodesRequest.class), any());
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(argumentCaptor.capture());
@@ -135,7 +136,7 @@ public class MLTaskDispatcherTests extends OpenSearchTestCase {
 
     @Ignore
     public void testGetEligibleNodes_DataNodeOnly() {
-        DiscoveryNode[] eligibleNodes = nodeHelper.getEligibleNodes();
+        DiscoveryNode[] eligibleNodes = nodeHelper.getEligibleNodes(FunctionName.REMOTE);
         assertEquals(2, eligibleNodes.length);
         for (DiscoveryNode node : eligibleNodes) {
             assertTrue(node.isDataNode());
@@ -148,7 +149,7 @@ public class MLTaskDispatcherTests extends OpenSearchTestCase {
         testState = new ClusterState(new ClusterName(clusterName), 123l, "111111", null, null, nodes, null, Map.of(), 0, false);
         when(clusterService.state()).thenReturn(testState);
 
-        DiscoveryNode[] eligibleNodes = nodeHelper.getEligibleNodes();
+        DiscoveryNode[] eligibleNodes = nodeHelper.getEligibleNodes(FunctionName.REMOTE);
         assertEquals(1, eligibleNodes.length);
         for (DiscoveryNode node : eligibleNodes) {
             assertFalse(node.isDataNode());

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunnerTests.java
@@ -165,11 +165,11 @@ public class MLTrainAndPredictTaskRunnerTests extends OpenSearchTestCase {
     @Ignore
     public void testExecuteTask_OnLocalNode() {
         doAnswer(invocation -> {
-            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(0);
+            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(1);
             actionListener.onResponse(localNode);
             return null;
-        }).when(mlTaskDispatcher).dispatch(any());
-        taskRunner.dispatchTask(requestWithDataFrame, transportService, listener);
+        }).when(mlTaskDispatcher).dispatch(any(), any());
+        taskRunner.dispatchTask(FunctionName.REMOTE, requestWithDataFrame, transportService, listener);
         verify(listener).onResponse(any());
         verify(taskRunner).handleAsyncMLTaskComplete(any(MLTask.class));
     }
@@ -177,10 +177,10 @@ public class MLTrainAndPredictTaskRunnerTests extends OpenSearchTestCase {
     @Ignore
     public void testExecuteTask_OnLocalNode_QueryInput() {
         doAnswer(invocation -> {
-            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(0);
+            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(1);
             actionListener.onResponse(localNode);
             return null;
-        }).when(mlTaskDispatcher).dispatch(any());
+        }).when(mlTaskDispatcher).dispatch(any(), any());
 
         doAnswer(invocation -> {
             ActionListener<MLInputDataset> actionListener = invocation.getArgument(1);
@@ -188,7 +188,7 @@ public class MLTrainAndPredictTaskRunnerTests extends OpenSearchTestCase {
             return null;
         }).when(mlInputDatasetHandler).parseSearchQueryInput(any(), any());
 
-        taskRunner.dispatchTask(requestWithQuery, transportService, listener);
+        taskRunner.dispatchTask(FunctionName.REMOTE, requestWithQuery, transportService, listener);
         verify(listener).onResponse(any());
         verify(taskRunner).handleAsyncMLTaskComplete(any(MLTask.class));
     }
@@ -196,10 +196,10 @@ public class MLTrainAndPredictTaskRunnerTests extends OpenSearchTestCase {
     @Ignore
     public void testExecuteTask_OnLocalNode_QueryInput_Failure() {
         doAnswer(invocation -> {
-            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(0);
+            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(1);
             actionListener.onResponse(localNode);
             return null;
-        }).when(mlTaskDispatcher).dispatch(any());
+        }).when(mlTaskDispatcher).dispatch(any(), any());
 
         doAnswer(invocation -> {
             ActionListener<MLInputDataset> actionListener = invocation.getArgument(1);
@@ -207,7 +207,7 @@ public class MLTrainAndPredictTaskRunnerTests extends OpenSearchTestCase {
             return null;
         }).when(mlInputDatasetHandler).parseSearchQueryInput(any(), any());
 
-        taskRunner.dispatchTask(requestWithQuery, transportService, listener);
+        taskRunner.dispatchTask(FunctionName.REMOTE, requestWithQuery, transportService, listener);
         verify(listener, never()).onResponse(any());
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(argumentCaptor.capture());
@@ -218,12 +218,12 @@ public class MLTrainAndPredictTaskRunnerTests extends OpenSearchTestCase {
     @Ignore
     public void testExecuteTask_OnLocalNode_FailedToUpdateTask() {
         doAnswer(invocation -> {
-            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(0);
+            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(1);
             actionListener.onResponse(localNode);
             return null;
-        }).when(mlTaskDispatcher).dispatch(any());
+        }).when(mlTaskDispatcher).dispatch(any(), any());
         doThrow(new RuntimeException(errorMessage)).when(mlTaskManager).updateTaskStateAsRunning(anyString(), anyBoolean());
-        taskRunner.dispatchTask(requestWithDataFrame, transportService, listener);
+        taskRunner.dispatchTask(FunctionName.REMOTE, requestWithDataFrame, transportService, listener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(argumentCaptor.capture());
         assertEquals(errorMessage, argumentCaptor.getValue().getMessage());
@@ -233,21 +233,21 @@ public class MLTrainAndPredictTaskRunnerTests extends OpenSearchTestCase {
     @Ignore
     public void testExecuteTask_OnRemoteNode() {
         doAnswer(invocation -> {
-            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(0);
+            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(1);
             actionListener.onResponse(remoteNode);
             return null;
-        }).when(mlTaskDispatcher).dispatch(any());
-        taskRunner.dispatchTask(requestWithDataFrame, transportService, listener);
+        }).when(mlTaskDispatcher).dispatch(any(), any());
+        taskRunner.dispatchTask(FunctionName.REMOTE, requestWithDataFrame, transportService, listener);
         verify(transportService).sendRequest(eq(remoteNode), eq(MLTrainAndPredictionTaskAction.NAME), eq(requestWithDataFrame), any());
     }
 
     public void testExecuteTask_FailedToDispatch() {
         doAnswer(invocation -> {
-            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(0);
+            ActionListener<DiscoveryNode> actionListener = invocation.getArgument(1);
             actionListener.onFailure(new RuntimeException(errorMessage));
             return null;
-        }).when(mlTaskDispatcher).dispatch(any());
-        taskRunner.dispatchTask(requestWithDataFrame, transportService, listener);
+        }).when(mlTaskDispatcher).dispatch(any(), any());
+        taskRunner.dispatchTask(FunctionName.REMOTE, requestWithDataFrame, transportService, listener);
         verify(listener, never()).onResponse(any());
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/task/TaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/TaskRunnerTests.java
@@ -30,6 +30,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.ml.breaker.MLCircuitBreakerService;
 import org.opensearch.ml.breaker.ThresholdCircuitBreaker;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.MLTaskType;
@@ -138,7 +139,7 @@ public class TaskRunnerTests extends OpenSearchTestCase {
         TransportService transportService = mock(TransportService.class);
         ActionListener listener = mock(ActionListener.class);
         MLTaskRequest request = new MLTaskRequest(false);
-        expectThrows(MLLimitExceededException.class, () -> mlTaskRunner.run(request, transportService, listener));
+        expectThrows(MLLimitExceededException.class, () -> mlTaskRunner.run(FunctionName.REMOTE, request, transportService, listener));
         Long value = (Long) mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_CIRCUIT_BREAKER_TRIGGER_COUNT).getValue();
         assertEquals(1L, value.longValue());
     }


### PR DESCRIPTION
### Description
Per PM's suggestion, remote model should be able to run on data or ML node by default. But we should also keep local model run on ML node by default. So we still keep `plugins.ml_commons.only_run_on_ml_node` as true, but only control local model. Add more setting to provide granular level control on remote and local model.

1. Add `plugins.ml_commons.task_dispatcher.eligible_node_role.remote_model` which controls only remote model can run on which node. Default value is `["data", "ml"]` which means the remote model can run on data node and ML node by default.
2. Add `plugins.ml_commons.task_dispatcher.eligible_node_role.local_model` which controls only remote model can run on which node. But we have `plugins.ml_commons.only_run_on_ml_node` which controls the model can only run on ML node or not. This is to provide BWC, For local model, 1/ if `plugins.ml_commons.only_run_on_ml_node` is `true`, we will always run it on ML node. 2/ if `plugins.ml_commons.only_run_on_ml_node` is `false`, will run model on nodes defined in `plugins.ml_commons.task_dispatcher.eligible_node_role.local_model`.  
 
 

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
