### PR TITLE
fixing some error message handeling

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/MLCommonsClassLoader.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLCommonsClassLoader.java
@@ -259,6 +259,8 @@ public class MLCommonsClassLoader {
             Throwable cause = e.getCause();
             if (cause instanceof MLException) {
                 throw (MLException)cause;
+	    } else if (cause instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) cause;
             } else {
                 log.error("Failed to init instance for type " + type, e);
                 return null;

--- a/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
@@ -89,13 +89,21 @@ public interface Connector extends ToXContentObject, Writeable {
     }
 
     static Connector fromStream(StreamInput in) throws IOException {
-        String connectorProtocol = in.readString();
-        return MLCommonsClassLoader.initConnector(connectorProtocol, new Object[]{connectorProtocol, in}, String.class, StreamInput.class);
+        try {
+            String connectorProtocol = in.readString();
+            return MLCommonsClassLoader.initConnector(connectorProtocol, new Object[]{connectorProtocol, in}, String.class, StreamInput.class);
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw illegalArgumentException;
+        }
     }
 
     static Connector createConnector(XContentBuilder builder, String connectorProtocol) throws IOException {
-        String jsonStr = Strings.toString(builder);
-        return createConnector(jsonStr, connectorProtocol);
+        try {
+            String jsonStr = Strings.toString(builder);
+            return createConnector(jsonStr, connectorProtocol);
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw illegalArgumentException;
+        }
     }
 
     static Connector createConnector(XContentParser parser) throws IOException {
@@ -119,7 +127,12 @@ public interface Connector extends ToXContentObject, Writeable {
                 throw new IllegalArgumentException("connector protocol is null");
             }
             return MLCommonsClassLoader.initConnector(connectorProtocol, new Object[]{connectorProtocol, connectorParser}, String.class, XContentParser.class);
-        }
+        } catch (Exception ex) {
+            if (ex instanceof IllegalArgumentException) {
+                throw ex;
+            }
+            return null;
+	    }
     }
 
     default void validateConnectorURL(List<String> urlRegexes) {

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
@@ -23,7 +23,6 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.ml.common.connector.Connector;
-import org.opensearch.ml.common.exception.MLResourceNotFoundException;
 import org.opensearch.ml.common.exception.MLValidationException;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetAction;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetRequest;
@@ -92,7 +91,8 @@ public class GetConnectorTransportAction extends HandledTransportAction<ActionRe
                 }
             }, e -> {
                 if (e instanceof IndexNotFoundException) {
-                    actionListener.onFailure(new MLResourceNotFoundException("Fail to find connector"));
+                    log.error("Failed to get connector index", e);
+                    actionListener.onFailure(new IllegalArgumentException("Fail to find connector"));
                 } else {
                     log.error("Failed to get ML connector " + connectorId, e);
                     actionListener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLCreateConnectorAction.java
@@ -56,9 +56,6 @@ public class RestMLCreateConnectorAction extends BaseRestHandler {
      */
     @VisibleForTesting
     MLCreateConnectorRequest getRequest(RestRequest request) throws IOException {
-        if (!request.hasContent()) {
-            throw new IOException("Create Connector request has empty body");
-        }
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         MLCreateConnectorInput mlCreateConnectorInput = MLCreateConnectorInput.parse(parser);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLCreateConnectorActionTests.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.settings.Settings;
@@ -113,8 +114,8 @@ public class RestMLCreateConnectorActionTests extends OpenSearchTestCase {
     }
 
     public void testPrepareRequest_EmptyContent() throws Exception {
-        thrown.expect(IOException.class);
-        thrown.expectMessage("Create Connector request has empty body");
+        thrown.expect(OpenSearchParseException.class);
+        thrown.expectMessage("request body is required");
         Map<String, String> params = new HashMap<>();
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).build();
 


### PR DESCRIPTION
### Description
Made changes so we propagate the right exception up to the response level, for example we didn't return the `missing credentials` exception message to the user but only some generic 500 error. 
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
