### PR TITLE
add feature flag for remote inference

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLCreateConnectorAction.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.rest;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.MLExceptionUtils.REMOTE_INFERENCE_DISABLED_ERR_MSG;
 
 import java.io.IOException;
 import java.util.List;
@@ -17,6 +18,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorAction;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestToXContentListener;
@@ -26,11 +28,15 @@ import com.google.common.collect.ImmutableList;
 
 public class RestMLCreateConnectorAction extends BaseRestHandler {
     private static final String ML_CREATE_CONNECTOR_ACTION = "ml_create_connector_action";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     /**
-     * Constructor *
+     * Constructor
+     * @param mlFeatureEnabledSetting
      */
-    public RestMLCreateConnectorAction() {}
+    public RestMLCreateConnectorAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
 
     @Override
     public String getName() {
@@ -56,6 +62,9 @@ public class RestMLCreateConnectorAction extends BaseRestHandler {
      */
     @VisibleForTesting
     MLCreateConnectorRequest getRequest(RestRequest request) throws IOException {
+        if (!mlFeatureEnabledSetting.isRemoteInferenceEnabled()) {
+            throw new IllegalStateException(REMOTE_INFERENCE_DISABLED_ERR_MSG);
+        }
         if (!request.hasContent()) {
             throw new IOException("Create Connector request has empty body");
         }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.rest;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.MLExceptionUtils.REMOTE_INFERENCE_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_ALGORITHM;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
 import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
@@ -29,6 +30,7 @@ import org.opensearch.ml.common.transport.model.MLModelGetResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
@@ -45,11 +47,14 @@ public class RestMLPredictionAction extends BaseRestHandler {
 
     private MLModelManager modelManager;
 
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
     /**
      * Constructor
      */
-    public RestMLPredictionAction(MLModelManager modelManager) {
+    public RestMLPredictionAction(MLModelManager modelManager, MLFeatureEnabledSetting mlFeatureEnabledSetting) {
         this.modelManager = modelManager;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
     }
 
     @Override
@@ -117,6 +122,9 @@ public class RestMLPredictionAction extends BaseRestHandler {
      */
     @VisibleForTesting
     MLPredictionTaskRequest getRequest(String modelId, String algorithm, RestRequest request) throws IOException {
+        if (algorithm.equals("REMOTE") && !mlFeatureEnabledSetting.isRemoteInferenceEnabled()) {
+            throw new IllegalStateException(REMOTE_INFERENCE_DISABLED_ERR_MSG);
+        }
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         MLInput mlInput = MLInput.parse(parser, algorithm);

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -108,6 +108,9 @@ public final class MLCommonsSettings {
             Setting.Property.Dynamic
         );
 
+    public static final Setting<Boolean> ML_COMMONS_REMOTE_INFERENCE_ENABLED = Setting
+        .boolSetting("plugins.ml_commons.remote_inference_enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
     public static final Setting<Boolean> ML_COMMONS_MODEL_ACCESS_CONTROL_ENABLED = Setting
         .boolSetting("plugins.ml_commons.model_access_control_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.ml.settings;
+
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED;
+
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+
+public class MLFeatureEnabledSetting {
+
+    private volatile Boolean isRemoteInferenceEnabled;
+
+    public MLFeatureEnabledSetting(ClusterService clusterService, Settings settings) {
+        isRemoteInferenceEnabled = ML_COMMONS_REMOTE_INFERENCE_ENABLED.get(settings);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_REMOTE_INFERENCE_ENABLED, it -> isRemoteInferenceEnabled = it);
+    }
+
+    /**
+     * Whether the remote inference feature is enabled.  If disabled, time series plugin rejects RESTful requests for this feature.
+     * @return whether Remote Inference is enabled.
+     */
+    public boolean isRemoteInferenceEnabled() {
+        return isRemoteInferenceEnabled;
+    }
+
+}

--- a/plugin/src/main/java/org/opensearch/ml/utils/MLExceptionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/MLExceptionUtils.java
@@ -18,6 +18,8 @@ import org.opensearch.ml.common.exception.MLResourceNotFoundException;
 public class MLExceptionUtils {
 
     public static final String NOT_SERIALIZABLE_EXCEPTION_WRAPPER = "NotSerializableExceptionWrapper: ";
+    public static final String REMOTE_INFERENCE_DISABLED_ERR_MSG =
+        "Remote Inference is disabled. To enable update the setting plugins.ml_commons.remote_inference_enabled to true";
 
     public static String getRootCauseMessage(final Throwable throwable) {
         String message = ExceptionUtils.getRootCauseMessage(throwable);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRegisterModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRegisterModelActionTests.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ALLOW_MODEL_URL;
+import static org.opensearch.ml.utils.MLExceptionUtils.REMOTE_INFERENCE_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.TestHelper.clusterSetting;
 
 import java.util.List;
@@ -34,10 +35,12 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.transport.model.MLModelGetResponse;
 import org.opensearch.ml.common.transport.register.MLRegisterModelAction;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
@@ -62,6 +65,9 @@ public class RestMLRegisterModelActionTests extends OpenSearchTestCase {
     @Mock
     private ClusterService clusterService;
 
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
     private Settings settings;
 
     @Before
@@ -70,7 +76,8 @@ public class RestMLRegisterModelActionTests extends OpenSearchTestCase {
         settings = Settings.builder().put(ML_COMMONS_ALLOW_MODEL_URL.getKey(), true).build();
         ClusterSettings clusterSettings = clusterSetting(settings, ML_COMMONS_ALLOW_MODEL_URL);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-        restMLRegisterModelAction = new RestMLRegisterModelAction(clusterService, settings);
+        when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(true);
+        restMLRegisterModelAction = new RestMLRegisterModelAction(clusterService, settings, mlFeatureEnabledSetting);
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
         client = spy(new NodeClient(Settings.EMPTY, threadPool));
         doAnswer(invocation -> {
@@ -87,7 +94,7 @@ public class RestMLRegisterModelActionTests extends OpenSearchTestCase {
     }
 
     public void testConstructor() {
-        RestMLRegisterModelAction registerModelAction = new RestMLRegisterModelAction();
+        RestMLRegisterModelAction registerModelAction = new RestMLRegisterModelAction(mlFeatureEnabledSetting);
         assertNotNull(registerModelAction);
     }
 
@@ -130,11 +137,20 @@ public class RestMLRegisterModelActionTests extends OpenSearchTestCase {
         assertEquals("TORCH_SCRIPT", registerModelInput.getModelFormat().toString());
     }
 
+    public void testRegisterModelRequestRemoteInferenceDisabled() throws Exception {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage(REMOTE_INFERENCE_DISABLED_ERR_MSG);
+
+        when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(false);
+        RestRequest request = getRestRequestWithNullModelId();
+        restMLRegisterModelAction.handleRequest(request, channel, client);
+    }
+
     public void testRegisterModelUrlNotAllowed() throws Exception {
         settings = Settings.builder().put(ML_COMMONS_ALLOW_MODEL_URL.getKey(), false).build();
         ClusterSettings clusterSettings = clusterSetting(settings, ML_COMMONS_ALLOW_MODEL_URL);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-        restMLRegisterModelAction = new RestMLRegisterModelAction(clusterService, settings);
+        restMLRegisterModelAction = new RestMLRegisterModelAction(clusterService, settings, mlFeatureEnabledSetting);
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule
             .expectMessage(
@@ -226,7 +242,9 @@ public class RestMLRegisterModelActionTests extends OpenSearchTestCase {
                 "model_format",
                 "TORCH_SCRIPT",
                 "model_config",
-                modelConfig
+                modelConfig,
+                "function_name",
+                FunctionName.REMOTE
             );
         String requestContent = new Gson().toJson(model).toString();
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)


### PR DESCRIPTION
### Description
Add a new class for feature flags in ml-commons. It has remote inference feature flag for now which has setting to block APIs for connector creation, model registration, model deploy and model predictions.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
