### PR TITLE
Bump checkstyle version for CVE fix

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -32,7 +32,7 @@ ext {
 }
 
 checkstyle {
-    toolVersion = '10.12.0'
+    toolVersion = '10.12.2'
 }
 
 opensearchplugin {


### PR DESCRIPTION
### Description
We bump checksyle from 10.12.0 to 10.12.2 to fix CVE-2023-2976
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
