### PR TITLE
[Backport to 2.x] fill null parameters in connector body template (#1192)

### DIFF
--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -259,6 +259,14 @@ public class HttpConnectorTest {
         Assert.assertEquals("test output", modelTensors.get(0).getDataAsMap().get("response"));
     }
 
+    @Test
+    public void fillNullParameters() {
+        HttpConnector connector = createHttpConnector();
+        Map<String, String> parameters = new HashMap<>();
+        String output = connector.fillNullParameters(parameters, "{\"input1\": \"${parameters.input1:-null}\"}");
+        Assert.assertEquals("{\"input1\": null}", output);
+    }
+
     public static HttpConnector createHttpConnector() {
         ConnectorAction.ActionType actionType = ConnectorAction.ActionType.PREDICT;
         String method = "POST";

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
@@ -99,7 +99,9 @@ public class ConnectorUtils {
         if (inputData.getParameters() != null) {
             Map<String, String> newParameters = new HashMap<>();
             inputData.getParameters().entrySet().forEach(entry -> {
-                if (StringUtils.isJson(entry.getValue())) {
+                if (entry.getValue() == null) {
+                    newParameters.put(entry.getKey(), entry.getValue());
+                } else if (StringUtils.isJson(entry.getValue())) {
                     // no need to escape if it's already valid json
                     newParameters.put(entry.getKey(), entry.getValue());
                 } else {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
@@ -96,8 +96,16 @@ public class ConnectorUtilsTest {
         processInput_RemoteInferenceInputDataSet(input, input);
     }
 
+    @Test
+    public void processInput_RemoteInferenceInputDataSet_NullParam() {
+        String input = null;
+        processInput_RemoteInferenceInputDataSet(input, input);
+    }
+
     private void processInput_RemoteInferenceInputDataSet(String input, String expectedInput) {
-        RemoteInferenceInputDataSet dataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", input)).build();
+        Map<String, String> params = new HashMap<>();
+        params.put("input", input);
+        RemoteInferenceInputDataSet dataSet = RemoteInferenceInputDataSet.builder().parameters(params).build();
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(dataSet).build();
 
         ConnectorAction predictAction = ConnectorAction.builder()


### PR DESCRIPTION
### Description
Backport PR #1192 to 2.x
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
