### PR TITLE
renaming metrics

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
@@ -148,8 +148,6 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
                         if (!allowCustomDeploymentPlan && !deployToAllNodes) {
                             throw new IllegalArgumentException("Don't allow custom deployment plan");
                         }
-                        // mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
-                        mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
                         DiscoveryNode[] allEligibleNodes = nodeFilter.getEligibleNodes(functionName);
                         Map<String, DiscoveryNode> nodeMapping = new HashMap<>();
                         for (DiscoveryNode node : allEligibleNodes) {

--- a/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
@@ -54,7 +54,6 @@ import org.opensearch.ml.engine.ModelHelper;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.ml.settings.MLFeatureEnabledSetting;
-import org.opensearch.ml.stats.MLNodeLevelStat;
 import org.opensearch.ml.stats.MLStats;
 import org.opensearch.ml.task.MLTaskDispatcher;
 import org.opensearch.ml.task.MLTaskManager;

--- a/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
@@ -149,7 +149,7 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
                             throw new IllegalArgumentException("Don't allow custom deployment plan");
                         }
                         // mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
-                        mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+                        mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
                         DiscoveryNode[] allEligibleNodes = nodeFilter.getEligibleNodes(functionName);
                         Map<String, DiscoveryNode> nodeMapping = new HashMap<>();
                         for (DiscoveryNode node : allEligibleNodes) {

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -234,8 +234,8 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
                 throw new IllegalArgumentException("URL can't match trusted url regex");
             }
         }
-        // mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+        // mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
         // //TODO: track executing task; track register failures
         // mlStats.createCounterStatIfAbsent(FunctionName.TEXT_EMBEDDING,
         // ActionName.REGISTER,

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -234,12 +234,6 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
                 throw new IllegalArgumentException("URL can't match trusted url regex");
             }
         }
-        // mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
-        mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
-        // //TODO: track executing task; track register failures
-        // mlStats.createCounterStatIfAbsent(FunctionName.TEXT_EMBEDDING,
-        // ActionName.REGISTER,
-        // MLActionLevelStat.ML_ACTION_REQUEST_COUNT).increment();
         boolean isAsync = registerModelInput.getFunctionName() != FunctionName.REMOTE;
         MLTask mlTask = MLTask
             .builder()

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -54,7 +54,6 @@ import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.indices.MLIndicesHandler;
 import org.opensearch.ml.model.MLModelGroupManager;
 import org.opensearch.ml.model.MLModelManager;
-import org.opensearch.ml.stats.MLNodeLevelStat;
 import org.opensearch.ml.stats.MLStats;
 import org.opensearch.ml.task.MLTaskDispatcher;
 import org.opensearch.ml.task.MLTaskManager;

--- a/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodesTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodesTransportAction.java
@@ -97,9 +97,9 @@ public class MLStatsNodesTransportAction extends
         MLStatsInput mlStatsInput = mlStatsNodesRequest.getMlStatsInput();
         // return node level stats
         if (mlStatsInput.getTargetStatLevels().contains(MLStatLevel.NODE)) {
-            if (mlStatsInput.retrieveStat(MLNodeLevelStat.ML_NODE_JVM_HEAP_USAGE)) {
+            if (mlStatsInput.retrieveStat(MLNodeLevelStat.ML_JVM_HEAP_USAGE)) {
                 long heapUsedPercent = jvmService.stats().getMem().getHeapUsedPercent();
-                statValues.put(MLNodeLevelStat.ML_NODE_JVM_HEAP_USAGE, heapUsedPercent);
+                statValues.put(MLNodeLevelStat.ML_JVM_HEAP_USAGE, heapUsedPercent);
             }
 
             for (Enum statName : mlStats.getNodeStats().keySet()) {

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
@@ -229,7 +229,6 @@ public class TransportUndeployModelAction extends
 
     private MLUndeployModelNodeResponse createUndeployModelNodeResponse(MLUndeployModelNodesRequest MLUndeployModelNodesRequest) {
         mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
-        mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
 
         String[] modelIds = MLUndeployModelNodesRequest.getModelIds();
 
@@ -246,7 +245,6 @@ public class TransportUndeployModelAction extends
         }
 
         Map<String, String> modelUndeployStatus = mlModelManager.undeployModel(modelIds);
-        mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).decrement();
         return new MLUndeployModelNodeResponse(clusterService.localNode(), modelUndeployStatus, modelWorkerNodesMap);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
@@ -245,6 +245,7 @@ public class TransportUndeployModelAction extends
         }
 
         Map<String, String> modelUndeployStatus = mlModelManager.undeployModel(modelIds);
+        mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).decrement();
         return new MLUndeployModelNodeResponse(clusterService.localNode(), modelUndeployStatus, modelWorkerNodesMap);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
@@ -228,8 +228,8 @@ public class TransportUndeployModelAction extends
     }
 
     private MLUndeployModelNodeResponse createUndeployModelNodeResponse(MLUndeployModelNodesRequest MLUndeployModelNodesRequest) {
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
 
         String[] modelIds = MLUndeployModelNodesRequest.getModelIds();
 
@@ -246,7 +246,7 @@ public class TransportUndeployModelAction extends
         }
 
         Map<String, String> modelUndeployStatus = mlModelManager.undeployModel(modelIds);
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).decrement();
+        mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).decrement();
         return new MLUndeployModelNodeResponse(clusterService.localNode(), modelUndeployStatus, modelWorkerNodesMap);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -323,7 +323,6 @@ public class MLModelManager {
         checkAndAddRunningTask(mlTask, maxRegisterTasksPerNode);
         try {
             mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
-            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
             mlStats.createCounterStatIfAbsent(mlTask.getFunctionName(), REGISTER, ML_ACTION_REQUEST_COUNT).increment();
 
             String modelGroupId = registerModelInput.getModelGroupId();
@@ -392,9 +391,6 @@ public class MLModelManager {
         String taskId = mlTask.getTaskId();
         FunctionName functionName = mlTask.getFunctionName();
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
-            mlStats.createCounterStatIfAbsent(functionName, REGISTER, ML_ACTION_REQUEST_COUNT).increment();
-            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
 
             String modelName = registerModelInput.getModelName();
             String version = modelVersion == null ? registerModelInput.getVersion() : modelVersion;
@@ -443,8 +439,6 @@ public class MLModelManager {
         } catch (Exception e) {
             logException("Failed to upload model", e, log);
             handleException(functionName, taskId, e);
-        } finally {
-            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
         }
     }
 
@@ -462,9 +456,6 @@ public class MLModelManager {
         String taskId = mlTask.getTaskId();
         FunctionName functionName = mlTask.getFunctionName();
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
-            mlStats.createCounterStatIfAbsent(functionName, REGISTER, ML_ACTION_REQUEST_COUNT).increment();
-            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
             String modelName = registerModelInput.getModelName();
             String version = modelVersion == null ? registerModelInput.getVersion() : modelVersion;
             String modelGroupId = registerModelInput.getModelGroupId();
@@ -509,8 +500,6 @@ public class MLModelManager {
         } catch (Exception e) {
             logException("Failed to register model", e, log);
             handleException(functionName, taskId, e);
-        } finally {
-            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
         }
     }
 
@@ -718,6 +707,7 @@ public class MLModelManager {
         ActionListener<String> listener
     ) {
         mlStats.createCounterStatIfAbsent(functionName, ActionName.DEPLOY, ML_ACTION_REQUEST_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
         mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
         List<String> workerNodes = mlTask.getWorkerNodes();
         if (modelCacheHelper.isModelDeployed(modelId)) {

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -212,7 +212,7 @@ public class MLModelManager {
     public void registerModelMeta(MLRegisterModelMetaInput mlRegisterModelMetaInput, ActionListener<String> listener) {
         try {
             FunctionName functionName = mlRegisterModelMetaInput.getFunctionName();
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
             mlStats.createCounterStatIfAbsent(functionName, REGISTER, ML_ACTION_REQUEST_COUNT).increment();
             String modelGroupId = mlRegisterModelMetaInput.getModelGroupId();
             if (Strings.isBlank(modelGroupId)) {
@@ -322,8 +322,8 @@ public class MLModelManager {
 
         checkAndAddRunningTask(mlTask, maxRegisterTasksPerNode);
         try {
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
             mlStats.createCounterStatIfAbsent(mlTask.getFunctionName(), REGISTER, ML_ACTION_REQUEST_COUNT).increment();
 
             String modelGroupId = registerModelInput.getModelGroupId();
@@ -384,7 +384,7 @@ public class MLModelManager {
         } catch (Exception e) {
             handleException(registerModelInput.getFunctionName(), mlTask.getTaskId(), e);
         } finally {
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
         }
     }
 
@@ -392,9 +392,9 @@ public class MLModelManager {
         String taskId = mlTask.getTaskId();
         FunctionName functionName = mlTask.getFunctionName();
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
             mlStats.createCounterStatIfAbsent(functionName, REGISTER, ML_ACTION_REQUEST_COUNT).increment();
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
 
             String modelName = registerModelInput.getModelName();
             String version = modelVersion == null ? registerModelInput.getVersion() : modelVersion;
@@ -444,7 +444,7 @@ public class MLModelManager {
             logException("Failed to upload model", e, log);
             handleException(functionName, taskId, e);
         } finally {
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
         }
     }
 
@@ -462,9 +462,9 @@ public class MLModelManager {
         String taskId = mlTask.getTaskId();
         FunctionName functionName = mlTask.getFunctionName();
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
             mlStats.createCounterStatIfAbsent(functionName, REGISTER, ML_ACTION_REQUEST_COUNT).increment();
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
             String modelName = registerModelInput.getModelName();
             String version = modelVersion == null ? registerModelInput.getVersion() : modelVersion;
             String modelGroupId = registerModelInput.getModelGroupId();
@@ -510,7 +510,7 @@ public class MLModelManager {
             logException("Failed to register model", e, log);
             handleException(functionName, taskId, e);
         } finally {
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
         }
     }
 
@@ -693,7 +693,7 @@ public class MLModelManager {
             && !(e instanceof MLResourceNotFoundException)
             && !(e instanceof IllegalArgumentException)) {
             mlStats.createCounterStatIfAbsent(functionName, REGISTER, MLActionLevelStat.ML_ACTION_FAILURE_COUNT).increment();
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_FAILURE_COUNT).increment();
         }
         Map<String, Object> updated = ImmutableMap.of(ERROR_FIELD, MLExceptionUtils.getRootCauseMessage(e), STATE_FIELD, FAILED);
         mlTaskManager.updateMLTask(taskId, updated, TIMEOUT_IN_MILLIS, true);
@@ -718,7 +718,7 @@ public class MLModelManager {
         ActionListener<String> listener
     ) {
         mlStats.createCounterStatIfAbsent(functionName, ActionName.DEPLOY, ML_ACTION_REQUEST_COUNT).increment();
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
         List<String> workerNodes = mlTask.getWorkerNodes();
         if (modelCacheHelper.isModelDeployed(modelId)) {
             if (workerNodes != null && workerNodes.size() > 0) {
@@ -800,7 +800,7 @@ public class MLModelManager {
                         MLExecutable mlExecutable = mlEngine.deployExecute(mlModel, params);
                         try {
                             modelCacheHelper.setMLExecutor(modelId, mlExecutable);
-                            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT).increment();
+                            mlStats.getStat(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT).increment();
                             modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
                             listener.onResponse("successful");
                         } catch (Exception e) {
@@ -813,7 +813,7 @@ public class MLModelManager {
                         Predictable predictable = mlEngine.deploy(mlModel, params);
                         try {
                             modelCacheHelper.setPredictor(modelId, predictable);
-                            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT).increment();
+                            mlStats.getStat(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT).increment();
                             modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
                             Long modelContentSizeInBytes = mlModel.getModelContentSizeInBytes();
                             long contentSize = modelContentSizeInBytes == null
@@ -846,7 +846,7 @@ public class MLModelManager {
             && !(e instanceof MLResourceNotFoundException)
             && !(e instanceof IllegalArgumentException)) {
             mlStats.createCounterStatIfAbsent(functionName, ActionName.DEPLOY, MLActionLevelStat.ML_ACTION_FAILURE_COUNT).increment();
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_FAILURE_COUNT).increment();
         }
         removeModel(modelId);
         listener.onFailure(e);
@@ -855,7 +855,7 @@ public class MLModelManager {
     private void setupPredictable(String modelId, MLModel mlModel, Map<String, Object> params) {
         Predictable predictable = mlEngine.deploy(mlModel, params);
         modelCacheHelper.setPredictor(modelId, predictable);
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT).increment();
         modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
     }
 
@@ -1056,8 +1056,8 @@ public class MLModelManager {
             for (String modelId : modelIds) {
                 if (modelCacheHelper.isModelDeployed(modelId)) {
                     modelUndeployStatus.put(modelId, UNDEPLOYED);
-                    mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT).decrement();
-                    mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+                    mlStats.getStat(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT).decrement();
+                    mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
                     mlStats
                         .createCounterStatIfAbsent(getModelFunctionName(modelId), ActionName.UNDEPLOY, ML_ACTION_REQUEST_COUNT)
                         .increment();
@@ -1070,7 +1070,7 @@ public class MLModelManager {
             log.debug("undeploy all models {}", Arrays.toString(getLocalDeployedModels()));
             for (String modelId : getLocalDeployedModels()) {
                 modelUndeployStatus.put(modelId, UNDEPLOYED);
-                mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT).decrement();
+                mlStats.getStat(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT).decrement();
                 mlStats.createCounterStatIfAbsent(getModelFunctionName(modelId), ActionName.UNDEPLOY, ML_ACTION_REQUEST_COUNT).increment();
                 removeModel(modelId);
             }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -800,7 +800,7 @@ public class MLModelManager {
                         MLExecutable mlExecutable = mlEngine.deployExecute(mlModel, params);
                         try {
                             modelCacheHelper.setMLExecutor(modelId, mlExecutable);
-                            mlStats.getStat(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT).increment();
+                            mlStats.getStat(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT).increment();
                             modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
                             listener.onResponse("successful");
                         } catch (Exception e) {
@@ -813,7 +813,7 @@ public class MLModelManager {
                         Predictable predictable = mlEngine.deploy(mlModel, params);
                         try {
                             modelCacheHelper.setPredictor(modelId, predictable);
-                            mlStats.getStat(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT).increment();
+                            mlStats.getStat(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT).increment();
                             modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
                             Long modelContentSizeInBytes = mlModel.getModelContentSizeInBytes();
                             long contentSize = modelContentSizeInBytes == null
@@ -855,7 +855,7 @@ public class MLModelManager {
     private void setupPredictable(String modelId, MLModel mlModel, Map<String, Object> params) {
         Predictable predictable = mlEngine.deploy(mlModel, params);
         modelCacheHelper.setPredictor(modelId, predictable);
-        mlStats.getStat(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT).increment();
         modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
     }
 
@@ -1056,7 +1056,7 @@ public class MLModelManager {
             for (String modelId : modelIds) {
                 if (modelCacheHelper.isModelDeployed(modelId)) {
                     modelUndeployStatus.put(modelId, UNDEPLOYED);
-                    mlStats.getStat(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT).decrement();
+                    mlStats.getStat(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT).decrement();
                     mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
                     mlStats
                         .createCounterStatIfAbsent(getModelFunctionName(modelId), ActionName.UNDEPLOY, ML_ACTION_REQUEST_COUNT)
@@ -1070,7 +1070,7 @@ public class MLModelManager {
             log.debug("undeploy all models {}", Arrays.toString(getLocalDeployedModels()));
             for (String modelId : getLocalDeployedModels()) {
                 modelUndeployStatus.put(modelId, UNDEPLOYED);
-                mlStats.getStat(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT).decrement();
+                mlStats.getStat(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT).decrement();
                 mlStats.createCounterStatIfAbsent(getModelFunctionName(modelId), ActionName.UNDEPLOY, ML_ACTION_REQUEST_COUNT).increment();
                 removeModel(modelId);
             }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -324,6 +324,7 @@ public class MLModelManager {
         try {
             mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
             mlStats.createCounterStatIfAbsent(mlTask.getFunctionName(), REGISTER, ML_ACTION_REQUEST_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
 
             String modelGroupId = registerModelInput.getModelGroupId();
             GetRequest getModelGroupRequest = new GetRequest(ML_MODEL_GROUP_INDEX).id(modelGroupId);
@@ -383,7 +384,7 @@ public class MLModelManager {
         } catch (Exception e) {
             handleException(registerModelInput.getFunctionName(), mlTask.getTaskId(), e);
         } finally {
-            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).decrement();
         }
     }
 
@@ -827,6 +828,8 @@ public class MLModelManager {
             })));
         } catch (Exception e) {
             handleDeployModelException(modelId, functionName, listener, e);
+        } finally {
+            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).decrement();
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -308,7 +308,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
         stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_CIRCUIT_BREAKER_TRIGGER_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = new MLStats(stats);
 

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -305,11 +305,11 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
         stats.put(MLClusterLevelStat.ML_MODEL_COUNT, new MLStat<>(true, new CounterSupplier()));
         stats.put(MLClusterLevelStat.ML_CONNECTOR_COUNT, new MLStat<>(true, new CounterSupplier()));
         // node level stats
-        stats.put(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_CIRCUIT_BREAKER_TRIGGER_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_CIRCUIT_BREAKER_TRIGGER_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = new MLStats(stats);
 
         mlIndicesHandler = new MLIndicesHandler(clusterService, client);

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLStatsAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLStatsAction.java
@@ -61,6 +61,9 @@ public class RestMLStatsAction extends BaseRestHandler {
     private static final String QUERY_ALL_MODEL_META_DOC =
         "{\"query\":{\"bool\":{\"must_not\":{\"exists\":{\"field\":\"chunk_number\"}}}}}";
 
+    private static final Set<String> ML_NODE_STAT_NAMES = EnumSet.allOf(MLNodeLevelStat.class).stream().
+            map(stat -> stat.name()).collect(Collectors.toSet());
+
     /**
      * Constructor
      * @param mlStats MLStats object
@@ -150,9 +153,6 @@ public class RestMLStatsAction extends BaseRestHandler {
 
     MLStatsInput createMlStatsInputFromRequestParams(RestRequest request) {
 
-        Set<String> mlNodeStatNames = EnumSet.allOf(MLNodeLevelStat.class).stream()
-                .map(stat -> stat.name())
-                .collect(Collectors.toSet());
         MLStatsInput mlStatsInput = new MLStatsInput();
         Optional<String[]> nodeIds = splitCommaSeparatedParam(request, "nodeId");
         if (nodeIds.isPresent()) {
@@ -163,7 +163,7 @@ public class RestMLStatsAction extends BaseRestHandler {
             for (String state : stats.get()) {
                 state = state.toUpperCase(Locale.ROOT);
                 // only support cluster and node level stats for bwc
-                if (mlNodeStatNames.contains(state)) {
+                if (ML_NODE_STAT_NAMES.contains(state)) {
                     mlStatsInput.getNodeLevelStats().add(MLNodeLevelStat.from(state));
                 } else {
                     mlStatsInput.getClusterLevelStats().add(MLClusterLevelStat.from(state));

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLStatsAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLStatsAction.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.opensearch.client.node.NodeClient;
@@ -148,6 +149,10 @@ public class RestMLStatsAction extends BaseRestHandler {
     }
 
     MLStatsInput createMlStatsInputFromRequestParams(RestRequest request) {
+
+        Set<String> mlNodeStatNames = EnumSet.allOf(MLNodeLevelStat.class).stream()
+                .map(stat -> stat.name())
+                .collect(Collectors.toSet());
         MLStatsInput mlStatsInput = new MLStatsInput();
         Optional<String[]> nodeIds = splitCommaSeparatedParam(request, "nodeId");
         if (nodeIds.isPresent()) {
@@ -158,7 +163,7 @@ public class RestMLStatsAction extends BaseRestHandler {
             for (String state : stats.get()) {
                 state = state.toUpperCase(Locale.ROOT);
                 // only support cluster and node level stats for bwc
-                if (state.startsWith("ML_NODE")) {
+                if (mlNodeStatNames.contains(state)) {
                     mlStatsInput.getNodeLevelStats().add(MLNodeLevelStat.from(state));
                 } else {
                     mlStatsInput.getClusterLevelStats().add(MLClusterLevelStat.from(state));

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLStatsAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLStatsAction.java
@@ -61,8 +61,11 @@ public class RestMLStatsAction extends BaseRestHandler {
     private static final String QUERY_ALL_MODEL_META_DOC =
         "{\"query\":{\"bool\":{\"must_not\":{\"exists\":{\"field\":\"chunk_number\"}}}}}";
 
-    private static final Set<String> ML_NODE_STAT_NAMES = EnumSet.allOf(MLNodeLevelStat.class).stream().
-            map(stat -> stat.name()).collect(Collectors.toSet());
+    private static final Set<String> ML_NODE_STAT_NAMES = EnumSet
+        .allOf(MLNodeLevelStat.class)
+        .stream()
+        .map(stat -> stat.name())
+        .collect(Collectors.toSet());
 
     /**
      * Constructor

--- a/plugin/src/main/java/org/opensearch/ml/stats/MLNodeLevelStat.java
+++ b/plugin/src/main/java/org/opensearch/ml/stats/MLNodeLevelStat.java
@@ -11,8 +11,8 @@ package org.opensearch.ml.stats;
  */
 public enum MLNodeLevelStat {
     ML_JVM_HEAP_USAGE,
-    ML_EXECUTING_TASK_COUNT, // How many tasks are executing currently. If any task starts, then it will be 1, if the task finished then it
-                             // will get back to 0.
+    ML_EXECUTING_TASK_COUNT, // How many tasks are executing currently. If any task starts, then it will increase by 1,
+                             // if the task finished then it will decrease by 0.
     ML_REQUEST_COUNT,
     ML_FAILURE_COUNT,
     ML_DEPLOYED_MODEL_COUNT,

--- a/plugin/src/main/java/org/opensearch/ml/stats/MLNodeLevelStat.java
+++ b/plugin/src/main/java/org/opensearch/ml/stats/MLNodeLevelStat.java
@@ -11,7 +11,8 @@ package org.opensearch.ml.stats;
  */
 public enum MLNodeLevelStat {
     ML_JVM_HEAP_USAGE,
-    ML_EXECUTING_TASK_COUNT,
+    ML_EXECUTING_TASK_COUNT, // How many tasks are executing currently. If any task starts, then it will be 1, if the task finished then it
+                             // will get back to 0.
     ML_REQUEST_COUNT,
     ML_FAILURE_COUNT,
     ML_DEPLOYED_MODEL_COUNT,

--- a/plugin/src/main/java/org/opensearch/ml/stats/MLNodeLevelStat.java
+++ b/plugin/src/main/java/org/opensearch/ml/stats/MLNodeLevelStat.java
@@ -10,12 +10,12 @@ package org.opensearch.ml.stats;
  * This enum represents node level stats.
  */
 public enum MLNodeLevelStat {
-    ML_NODE_JVM_HEAP_USAGE,
-    ML_NODE_EXECUTING_TASK_COUNT,
-    ML_NODE_TOTAL_REQUEST_COUNT,
-    ML_NODE_TOTAL_FAILURE_COUNT,
-    ML_NODE_TOTAL_MODEL_COUNT,
-    ML_NODE_TOTAL_CIRCUIT_BREAKER_TRIGGER_COUNT;
+    ML_JVM_HEAP_USAGE,
+    ML_EXECUTING_TASK_COUNT,
+    ML_REQUEST_COUNT,
+    ML_FAILURE_COUNT,
+    ML_TOTAL_MODEL_COUNT,
+    ML_CIRCUIT_BREAKER_TRIGGER_COUNT;
 
     public static MLNodeLevelStat from(String value) {
         try {

--- a/plugin/src/main/java/org/opensearch/ml/stats/MLNodeLevelStat.java
+++ b/plugin/src/main/java/org/opensearch/ml/stats/MLNodeLevelStat.java
@@ -14,7 +14,7 @@ public enum MLNodeLevelStat {
     ML_EXECUTING_TASK_COUNT,
     ML_REQUEST_COUNT,
     ML_FAILURE_COUNT,
-    ML_TOTAL_MODEL_COUNT,
+    ML_DEPLOYED_MODEL_COUNT,
     ML_CIRCUIT_BREAKER_TRIGGER_COUNT;
 
     public static MLNodeLevelStat from(String value) {

--- a/plugin/src/main/java/org/opensearch/ml/task/MLExecuteTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLExecuteTaskRunner.java
@@ -88,8 +88,8 @@ public class MLExecuteTaskRunner extends MLTaskRunner<MLExecuteTaskRequest, MLEx
     protected void executeTask(MLExecuteTaskRequest request, ActionListener<MLExecuteTaskResponse> listener) {
         threadPool.executor(EXECUTE_THREAD_POOL).execute(() -> {
             try {
-                mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
-                mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+                mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
+                mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
                 mlStats
                     .createCounterStatIfAbsent(request.getFunctionName(), ActionName.EXECUTE, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
                     .increment();
@@ -113,7 +113,7 @@ public class MLExecuteTaskRunner extends MLTaskRunner<MLExecuteTaskRequest, MLEx
                     .increment();
                 listener.onFailure(e);
             } finally {
-                mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).decrement();
+                mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).decrement();
             }
         });
     }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -201,8 +201,8 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
     private void predict(String modelId, MLTask mlTask, MLInput mlInput, ActionListener<MLTaskResponse> listener) {
         ActionListener<MLTaskResponse> internalListener = wrappedCleanupListener(listener, mlTask.getTaskId());
         // track ML task count and add ML task into cache
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
         mlStats
             .createCounterStatIfAbsent(mlTask.getFunctionName(), ActionName.PREDICT, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
             .increment();
@@ -303,7 +303,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
             mlStats
                 .createCounterStatIfAbsent(mlTask.getFunctionName(), ActionName.PREDICT, MLActionLevelStat.ML_ACTION_FAILURE_COUNT)
                 .increment();
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_FAILURE_COUNT).increment();
         }
         handleAsyncMLTaskFailure(mlTask, e);
         listener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
@@ -106,8 +106,7 @@ public class MLTaskDispatcher {
 
     private void dispatchTaskWithLeastLoad(DiscoveryNode[] nodes, ActionListener<DiscoveryNode> listener) {
         MLStatsNodesRequest MLStatsNodesRequest = new MLStatsNodesRequest(nodes);
-        MLStatsNodesRequest
-            .addNodeLevelStats(ImmutableSet.of(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, MLNodeLevelStat.ML_JVM_HEAP_USAGE));
+        MLStatsNodesRequest.addNodeLevelStats(ImmutableSet.of(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, MLNodeLevelStat.ML_JVM_HEAP_USAGE));
 
         client.execute(MLStatsNodesAction.INSTANCE, MLStatsNodesRequest, ActionListener.wrap(mlStatsResponse -> {
             // Check JVM pressure

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskRunner.java
@@ -96,7 +96,7 @@ public abstract class MLTaskRunner<Request extends MLTaskRequest, Response exten
 
     protected ActionListener<MLTaskResponse> wrappedCleanupListener(ActionListener<MLTaskResponse> listener, String taskId) {
         ActionListener<MLTaskResponse> internalListener = ActionListener.runAfter(listener, () -> {
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).decrement();
+            mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).decrement();
             mlTaskManager.remove(taskId);
         });
         return internalListener;

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunner.java
@@ -128,8 +128,8 @@ public class MLTrainAndPredictTaskRunner extends MLTaskRunner<MLTrainingTaskRequ
     private void trainAndPredict(MLTask mlTask, MLInput mlInput, ActionListener<MLTaskResponse> listener) {
         ActionListener<MLTaskResponse> internalListener = wrappedCleanupListener(listener, mlTask.getTaskId());
         // track ML task count and add ML task into cache
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
         mlStats
             .createCounterStatIfAbsent(mlTask.getFunctionName(), ActionName.TRAIN_PREDICT, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
             .increment();
@@ -161,7 +161,7 @@ public class MLTrainAndPredictTaskRunner extends MLTaskRunner<MLTrainingTaskRequ
             mlStats
                 .createCounterStatIfAbsent(mlTask.getFunctionName(), ActionName.TRAIN_PREDICT, MLActionLevelStat.ML_ACTION_FAILURE_COUNT)
                 .increment();
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_FAILURE_COUNT).increment();
         }
         handleAsyncMLTaskFailure(mlTask, e);
         listener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
@@ -146,8 +146,8 @@ public class MLTrainingTaskRunner extends MLTaskRunner<MLTrainingTaskRequest, ML
     private void startTrainingTask(MLTask mlTask, MLInput mlInput, ActionListener<MLTaskResponse> listener) {
         ActionListener<MLTaskResponse> internalListener = wrappedCleanupListener(listener, mlTask.getTaskId());
         // track ML task count and add ML task into cache
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT).increment();
-        mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
+        mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
         mlStats
             .createCounterStatIfAbsent(mlTask.getFunctionName(), ActionName.TRAIN, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
             .increment();
@@ -180,7 +180,7 @@ public class MLTrainingTaskRunner extends MLTaskRunner<MLTrainingTaskRequest, ML
             mlStats
                 .createCounterStatIfAbsent(mlTask.getFunctionName(), ActionName.TRAIN, MLActionLevelStat.ML_ACTION_FAILURE_COUNT)
                 .increment();
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_FAILURE_COUNT).increment();
             actionListener.onFailure(e);
         });
         try {

--- a/plugin/src/main/java/org/opensearch/ml/utils/MLNodeUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/MLNodeUtils.java
@@ -59,7 +59,7 @@ public class MLNodeUtils {
     public static void checkOpenCircuitBreaker(MLCircuitBreakerService mlCircuitBreakerService, MLStats mlStats) {
         ThresholdCircuitBreaker openCircuitBreaker = mlCircuitBreakerService.checkOpenCB();
         if (openCircuitBreaker != null) {
-            mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_CIRCUIT_BREAKER_TRIGGER_COUNT).increment();
+            mlStats.getStat(MLNodeLevelStat.ML_CIRCUIT_BREAKER_TRIGGER_COUNT).increment();
             throw new MLLimitExceededException(openCircuitBreaker.getName() + " is open, please check your resources!");
         }
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/deploy/TransportDeployModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/deploy/TransportDeployModelActionTests.java
@@ -175,7 +175,7 @@ public class TransportDeployModelActionTests extends OpenSearchTestCase {
         when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(true);
 
         MLStat mlStat = mock(MLStat.class);
-        when(mlStats.getStat(eq(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT))).thenReturn(mlStat);
+        when(mlStats.getStat(eq(MLNodeLevelStat.ML_REQUEST_COUNT))).thenReturn(mlStat);
         transportDeployModelAction = new TransportDeployModelAction(
             transportService,
             actionFilters,

--- a/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
@@ -184,7 +184,7 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
         }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any());
 
         MLStat mlStat = mock(MLStat.class);
-        when(mlStats.getStat(eq(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT))).thenReturn(mlStat);
+        when(mlStats.getStat(eq(MLNodeLevelStat.ML_REQUEST_COUNT))).thenReturn(mlStat);
 
         doAnswer(invocation -> {
             ActionListener<IndexResponse> listener = invocation.getArgument(1);

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeITTests.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.ml.action.stats;
 
-import static org.opensearch.ml.stats.MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT;
+import static org.opensearch.ml.stats.MLNodeLevelStat.ML_EXECUTING_TASK_COUNT;
 import static org.opensearch.ml.utils.IntegTestUtils.TESTING_DATA;
 import static org.opensearch.ml.utils.IntegTestUtils.generateMLTestingData;
 import static org.opensearch.ml.utils.IntegTestUtils.verifyGeneratedTestingData;
@@ -45,7 +45,7 @@ public class MLStatsNodeITTests extends OpenSearchIntegTestCase {
 
     public void testNormalCase() throws ExecutionException, InterruptedException {
         MLStatsNodesRequest request = new MLStatsNodesRequest(new String[0], new MLStatsInput());
-        request.addNodeLevelStats(ImmutableSet.of(ML_NODE_EXECUTING_TASK_COUNT));
+        request.addNodeLevelStats(ImmutableSet.of(ML_EXECUTING_TASK_COUNT));
 
         ActionFuture<MLStatsNodesResponse> future = client().execute(MLStatsNodesAction.INSTANCE, request);
         MLStatsNodesResponse response = future.get();
@@ -58,6 +58,6 @@ public class MLStatsNodeITTests extends OpenSearchIntegTestCase {
 
         MLStatsNodeResponse nodeResponse = responseList.get(0);
         assertEquals(1, nodeResponse.getNodeLevelStatSize());
-        assertEquals(0l, nodeResponse.getNodeLevelStat(ML_NODE_EXECUTING_TASK_COUNT));
+        assertEquals(0l, nodeResponse.getNodeLevelStat(ML_EXECUTING_TASK_COUNT));
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeResponseTests.java
@@ -60,7 +60,7 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         String taskContent = TestHelper.xContentBuilderToString(builder);
-        assertEquals("{\"ML_REQUEST_COUNT\":100}", taskContent);
+        assertEquals("{\"ml_request_count\":100}", taskContent);
     }
 
     public void testToXContent_AlgorithmStats() throws IOException {
@@ -114,8 +114,8 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         String taskContent = TestHelper.xContentBuilderToString(builder);
         Set<String> validResult = ImmutableSet
             .of(
-                "{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_failure_count\":22,\"ml_action_request_count\":111}}}}",
-                "{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":111,\"ml_action_failure_count\":22}}}}"
+                "{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_failure_count\":22,\"ml_action_request_count\":111}}}}",
+                "{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":111,\"ml_action_failure_count\":22}}}}"
             );
         assertTrue(validResult.contains(taskContent));
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeResponseTests.java
@@ -39,14 +39,14 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
     public void setup() {
         node = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
         Map<MLNodeLevelStat, Object> statsToValues = new HashMap<>();
-        statsToValues.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, 100);
+        statsToValues.put(MLNodeLevelStat.ML_REQUEST_COUNT, 100);
         response = new MLStatsNodeResponse(node, statsToValues);
     }
 
     public void testSerializationDeserialization() throws IOException {
         DiscoveryNode localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
         Map<MLNodeLevelStat, Object> statsToValues = new HashMap<>();
-        statsToValues.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, 10l);
+        statsToValues.put(MLNodeLevelStat.ML_REQUEST_COUNT, 10l);
         MLStatsNodeResponse response = new MLStatsNodeResponse(localNode, statsToValues);
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
@@ -60,7 +60,7 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         String taskContent = TestHelper.xContentBuilderToString(builder);
-        assertEquals("{\"ml_node_total_request_count\":100}", taskContent);
+        assertEquals("{\"ML_REQUEST_COUNT\":100}", taskContent);
     }
 
     public void testToXContent_AlgorithmStats() throws IOException {
@@ -100,7 +100,7 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         builder.startObject();
         DiscoveryNode node = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
         Map<MLNodeLevelStat, Object> statsToValues = new HashMap<>();
-        statsToValues.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, 100);
+        statsToValues.put(MLNodeLevelStat.ML_REQUEST_COUNT, 100);
         Map<FunctionName, MLAlgoStats> algoStats = new HashMap<>();
         Map<ActionName, MLActionStats> algoActionStats = new HashMap<>();
         Map<MLActionLevelStat, Object> algoActionStatMap = new HashMap<>();
@@ -114,8 +114,8 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         String taskContent = TestHelper.xContentBuilderToString(builder);
         Set<String> validResult = ImmutableSet
             .of(
-                "{\"ml_node_total_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_failure_count\":22,\"ml_action_request_count\":111}}}}",
-                "{\"ml_node_total_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":111,\"ml_action_failure_count\":22}}}}"
+                "{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_failure_count\":22,\"ml_action_request_count\":111}}}}",
+                "{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":111,\"ml_action_failure_count\":22}}}}"
             );
         assertTrue(validResult.contains(taskContent));
     }
@@ -124,8 +124,8 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
         MLStatsNodeResponse mlStatsNodeResponse = MLStatsNodeResponse.readStats(output.bytes().streamInput());
-        Integer expectedValue = (Integer) response.getNodeLevelStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT);
-        assertEquals(expectedValue, mlStatsNodeResponse.getNodeLevelStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT));
+        Integer expectedValue = (Integer) response.getNodeLevelStat(MLNodeLevelStat.ML_REQUEST_COUNT);
+        assertEquals(expectedValue, mlStatsNodeResponse.getNodeLevelStat(MLNodeLevelStat.ML_REQUEST_COUNT));
     }
 
     public void testIsEmpty_NullNodeStats() {
@@ -150,23 +150,23 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
 
     public void testIsEmpty_NonEmptyNodeAndAlgoStats() {
         MLStatsNodeResponse response = createResponseWithDefaultAlgoStats(
-            ImmutableMap.of(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, totalRequestCount)
+            ImmutableMap.of(MLNodeLevelStat.ML_REQUEST_COUNT, totalRequestCount)
         );
         assertFalse(response.isEmpty());
     }
 
     public void testGetNodeLevelStat_NonExistingStat() {
-        assertNull(response.getNodeLevelStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT));
+        assertNull(response.getNodeLevelStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT));
         assertEquals(1, response.getNodeLevelStatSize());
     }
 
     public void testGetNodeLevelStat_NullOrEmptyNodeStats() {
         MLStatsNodeResponse response = new MLStatsNodeResponse(node, null);
-        assertNull(response.getNodeLevelStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT));
+        assertNull(response.getNodeLevelStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT));
         assertEquals(0, response.getNodeLevelStatSize());
 
         response = new MLStatsNodeResponse(node, ImmutableMap.of());
-        assertNull(response.getNodeLevelStat(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT));
+        assertNull(response.getNodeLevelStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT));
         assertEquals(0, response.getNodeLevelStatSize());
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesRequestTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesRequestTests.java
@@ -20,7 +20,7 @@ public class MLStatsNodesRequestTests extends OpenSearchTestCase {
     public void testSerializationDeserialization() throws IOException {
         MLStatsNodesRequest mlStatsNodesRequest = new MLStatsNodesRequest(new String[] { "testNodeId" }, new MLStatsInput());
 
-        mlStatsNodesRequest.addNodeLevelStats(ImmutableSet.of(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT));
+        mlStatsNodesRequest.addNodeLevelStats(ImmutableSet.of(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT));
         BytesStreamOutput output = new BytesStreamOutput();
         MLStatsNodeRequest request = new MLStatsNodeRequest(mlStatsNodesRequest);
         request.writeTo(output);

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesResponseTests.java
@@ -58,6 +58,6 @@ public class MLStatsNodesResponseTests extends OpenSearchTestCase {
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         String taskContent = TestHelper.xContentBuilderToString(builder);
-        assertEquals("{\"nodes\":{\"node1\":{\"ML_REQUEST_COUNT\":100},\"node2\":{\"ML_REQUEST_COUNT\":200}}}", taskContent);
+        assertEquals("{\"nodes\":{\"node1\":{\"ml_request_count\":100},\"node2\":{\"ml_request_count\":200}}}", taskContent);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesResponseTests.java
@@ -44,12 +44,12 @@ public class MLStatsNodesResponseTests extends OpenSearchTestCase {
 
         DiscoveryNode node1 = new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT);
         Map<MLNodeLevelStat, Object> nodeLevelStats1 = new HashMap<>();
-        nodeLevelStats1.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, 100);
+        nodeLevelStats1.put(MLNodeLevelStat.ML_REQUEST_COUNT, 100);
         nodes.add(new MLStatsNodeResponse(node1, nodeLevelStats1));
 
         DiscoveryNode node2 = new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT);
         Map<MLNodeLevelStat, Object> nodeLevelStats2 = new HashMap<>();
-        nodeLevelStats2.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, 200);
+        nodeLevelStats2.put(MLNodeLevelStat.ML_REQUEST_COUNT, 200);
         nodes.add(new MLStatsNodeResponse(node2, nodeLevelStats2));
 
         List<FailedNodeException> failures = new ArrayList<>();
@@ -58,9 +58,6 @@ public class MLStatsNodesResponseTests extends OpenSearchTestCase {
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         String taskContent = TestHelper.xContentBuilderToString(builder);
-        assertEquals(
-            "{\"nodes\":{\"node1\":{\"ml_node_total_request_count\":100},\"node2\":{\"ml_node_total_request_count\":200}}}",
-            taskContent
-        );
+        assertEquals("{\"nodes\":{\"node1\":{\"ML_REQUEST_COUNT\":100},\"node2\":{\"ML_REQUEST_COUNT\":200}}}", taskContent);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesTransportActionTests.java
@@ -7,7 +7,7 @@ package org.opensearch.ml.action.stats;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ml.stats.MLNodeLevelStat.ML_NODE_JVM_HEAP_USAGE;
+import static org.opensearch.ml.stats.MLNodeLevelStat.ML_JVM_HEAP_USAGE;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -56,13 +56,13 @@ public class MLStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
         super.setUp();
 
         clusterStatName1 = MLClusterLevelStat.ML_MODEL_COUNT;
-        nodeStatName1 = MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT;
+        nodeStatName1 = MLNodeLevelStat.ML_EXECUTING_TASK_COUNT;
 
         statsMap = new HashMap<>() {
             {
                 put(nodeStatName1, new MLStat<>(false, new CounterSupplier()));
                 put(clusterStatName1, new MLStat<>(true, new CounterSupplier()));
-                put(ML_NODE_JVM_HEAP_USAGE, new MLStat<>(true, new SettableSupplier()));
+                put(ML_JVM_HEAP_USAGE, new MLStat<>(true, new SettableSupplier()));
             }
         };
 
@@ -119,14 +119,14 @@ public class MLStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
         String nodeId = clusterService().localNode().getId();
         MLStatsNodesRequest mlStatsNodesRequest = new MLStatsNodesRequest(new String[] { nodeId }, new MLStatsInput());
 
-        Set<MLNodeLevelStat> statsToBeRetrieved = ImmutableSet.of(ML_NODE_JVM_HEAP_USAGE);
+        Set<MLNodeLevelStat> statsToBeRetrieved = ImmutableSet.of(ML_JVM_HEAP_USAGE);
 
         mlStatsNodesRequest.addNodeLevelStats(statsToBeRetrieved);
 
         MLStatsNodeResponse response = action.nodeOperation(new MLStatsNodeRequest(mlStatsNodesRequest));
 
         Assert.assertEquals(statsToBeRetrieved.size(), response.getNodeLevelStatSize());
-        assertNotNull(response.getNodeLevelStat(ML_NODE_JVM_HEAP_USAGE));
+        assertNotNull(response.getNodeLevelStat(ML_JVM_HEAP_USAGE));
     }
 
     public void testNodeOperation_NoNodeLevelStat() {

--- a/plugin/src/test/java/org/opensearch/ml/bwc/MLCommonsBackwardsCompatibilityRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/bwc/MLCommonsBackwardsCompatibilityRestTestCase.java
@@ -14,8 +14,8 @@ import static org.opensearch.ml.common.MLTask.FUNCTION_NAME_FIELD;
 import static org.opensearch.ml.common.MLTask.MODEL_ID_FIELD;
 import static org.opensearch.ml.common.MLTask.STATE_FIELD;
 import static org.opensearch.ml.common.MLTask.TASK_ID_FIELD;
-import static org.opensearch.ml.stats.MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT;
-import static org.opensearch.ml.stats.MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT;
+import static org.opensearch.ml.stats.MLNodeLevelStat.ML_FAILURE_COUNT;
+import static org.opensearch.ml.stats.MLNodeLevelStat.ML_REQUEST_COUNT;
 import static org.opensearch.ml.utils.TestData.SENTENCE_TRANSFORMER_MODEL_URL;
 import static org.opensearch.ml.utils.TestData.trainModelDataJson;
 
@@ -292,11 +292,11 @@ public class MLCommonsBackwardsCompatibilityRestTestCase extends OpenSearchRestT
         Map<String, Object> allNodeStats = (Map<String, Object>) map.get("nodes");
         for (String key : allNodeStats.keySet()) {
             Map<String, Object> nodeStatsMap = (Map<String, Object>) allNodeStats.get(key);
-            String statKey = ML_NODE_TOTAL_FAILURE_COUNT.name().toLowerCase(Locale.ROOT);
+            String statKey = ML_FAILURE_COUNT.name().toLowerCase(Locale.ROOT);
             if (nodeStatsMap.containsKey(statKey)) {
                 totalFailureCount += (Double) nodeStatsMap.get(statKey);
             }
-            statKey = ML_NODE_TOTAL_REQUEST_COUNT.name().toLowerCase(Locale.ROOT);
+            statKey = ML_REQUEST_COUNT.name().toLowerCase(Locale.ROOT);
             if (nodeStatsMap.containsKey(statKey)) {
                 totalRequestCount += (Double) nodeStatsMap.get(statKey);
             }

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -213,11 +213,11 @@ public class MLModelManagerTests extends OpenSearchTestCase {
 
         Map<Enum, MLStat<?>> stats = new ConcurrentHashMap<>();
         // node level stats
-        stats.put(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_CIRCUIT_BREAKER_TRIGGER_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_CIRCUIT_BREAKER_TRIGGER_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = spy(new MLStats(stats));
 
         mlTask = MLTask
@@ -734,7 +734,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         modelManager.deployModel(modelId, modelContentHashValue, functionName, true, mlTask, listener);
         verify(modelCacheHelper).removeModel(eq(modelId));
         verify(mlStats).createCounterStatIfAbsent(eq(functionName), eq(ActionName.DEPLOY), eq(MLActionLevelStat.ML_ACTION_REQUEST_COUNT));
-        verify(mlStats).getStat(eq(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT));
+        verify(mlStats).getStat(eq(MLNodeLevelStat.ML_REQUEST_COUNT));
     }
 
     private void mock_client_index_ModelChunkFailure(Client client, String modelId) {

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -216,7 +216,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_CIRCUIT_BREAKER_TRIGGER_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = spy(new MLStats(stats));
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -14,8 +14,8 @@ import static org.opensearch.ml.common.MLTask.FUNCTION_NAME_FIELD;
 import static org.opensearch.ml.common.MLTask.MODEL_ID_FIELD;
 import static org.opensearch.ml.common.MLTask.STATE_FIELD;
 import static org.opensearch.ml.common.MLTask.TASK_ID_FIELD;
-import static org.opensearch.ml.stats.MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT;
-import static org.opensearch.ml.stats.MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT;
+import static org.opensearch.ml.stats.MLNodeLevelStat.ML_FAILURE_COUNT;
+import static org.opensearch.ml.stats.MLNodeLevelStat.ML_REQUEST_COUNT;
 import static org.opensearch.ml.utils.TestData.SENTENCE_TRANSFORMER_MODEL_URL;
 import static org.opensearch.ml.utils.TestData.trainModelDataJson;
 
@@ -338,11 +338,11 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
         Map<String, Object> allNodeStats = (Map<String, Object>) map.get("nodes");
         for (String key : allNodeStats.keySet()) {
             Map<String, Object> nodeStatsMap = (Map<String, Object>) allNodeStats.get(key);
-            String statKey = ML_NODE_TOTAL_FAILURE_COUNT.name().toLowerCase(Locale.ROOT);
+            String statKey = ML_FAILURE_COUNT.name().toLowerCase(Locale.ROOT);
             if (nodeStatsMap.containsKey(statKey)) {
                 totalFailureCount += (Double) nodeStatsMap.get(statKey);
             }
-            statKey = ML_NODE_TOTAL_REQUEST_COUNT.name().toLowerCase(Locale.ROOT);
+            statKey = ML_REQUEST_COUNT.name().toLowerCase(Locale.ROOT);
             if (nodeStatsMap.containsKey(statKey)) {
                 totalRequestCount += (Double) nodeStatsMap.get(statKey);
             }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
@@ -113,7 +113,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         MockitoAnnotations.openMocks(this);
         Map<Enum, MLStat<?>> statMap = ImmutableMap
             .<Enum, MLStat<?>>builder()
-            .put(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()))
+            .put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()))
             .build();
         mlStats = new MLStats(statMap);
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
@@ -209,7 +209,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             content
                 .utf8ToString()
                 .contains(
-                    "\"nodes\":{\"node\":{\"ml_node_total_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
+                    "\"nodes\":{\"node\":{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
                 )
         );
     }
@@ -218,7 +218,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         doAnswer(invocation -> {
             ActionListener<MLStatsNodesResponse> actionListener = invocation.getArgument(2);
             List<MLStatsNodeResponse> nodes = new ArrayList<>();
-            Map<MLNodeLevelStat, Object> nodeStats = ImmutableMap.of(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, nodeTotalRequestCount);
+            Map<MLNodeLevelStat, Object> nodeStats = ImmutableMap.of(MLNodeLevelStat.ML_REQUEST_COUNT, nodeTotalRequestCount);
             Map<FunctionName, MLAlgoStats> algoStats = new HashMap<>();
             Map<ActionName, MLActionStats> actionStats = ImmutableMap
                 .of(
@@ -299,7 +299,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             content
                 .utf8ToString()
                 .contains(
-                    "\"nodes\":{\"node\":{\"ml_node_total_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
+                    "\"nodes\":{\"node\":{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
                 )
         );
     }
@@ -309,7 +309,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
 
         RestRequest request = getStatsRestRequest(
             node.getId(),
-            MLClusterLevelStat.ML_MODEL_COUNT + "," + MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT
+            MLClusterLevelStat.ML_MODEL_COUNT + "," + MLNodeLevelStat.ML_TOTAL_MODEL_COUNT
         );
         restAction.handleRequest(request, channel, client);
 
@@ -321,7 +321,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         assertTrue(input.getTargetStatLevels().contains(MLStatLevel.NODE));
         assertEquals(1, input.getClusterLevelStats().size());
         assertTrue(input.getClusterLevelStats().contains(MLClusterLevelStat.ML_MODEL_COUNT));
-        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT));
+        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT));
 
         ArgumentCaptor<BytesRestResponse> argumentCaptor = ArgumentCaptor.forClass(BytesRestResponse.class);
         verify(channel, times(1)).sendResponse(argumentCaptor.capture());
@@ -334,7 +334,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             content
                 .utf8ToString()
                 .contains(
-                    "\"nodes\":{\"node\":{\"ml_node_total_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
+                    "\"nodes\":{\"node\":{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
                 )
         );
     }
@@ -342,7 +342,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
     public void testPrepareRequest_ClusterAndNodeLevelStates_RequestParams_NodeLevelStat() throws Exception {
         prepareResponse();
 
-        RestRequest request = getStatsRestRequest(node.getId(), MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT.name());
+        RestRequest request = getStatsRestRequest(node.getId(), MLNodeLevelStat.ML_TOTAL_MODEL_COUNT.name());
         restAction.handleRequest(request, channel, client);
 
         ArgumentCaptor<MLStatsNodesRequest> inputArgumentCaptor = ArgumentCaptor.forClass(MLStatsNodesRequest.class);
@@ -352,7 +352,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         assertTrue(input.getTargetStatLevels().contains(MLStatLevel.NODE));
         assertEquals(0, input.getClusterLevelStats().size());
         assertEquals(1, input.getNodeLevelStats().size());
-        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT));
+        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT));
 
         ArgumentCaptor<BytesRestResponse> argumentCaptor = ArgumentCaptor.forClass(BytesRestResponse.class);
         verify(channel, times(1)).sendResponse(argumentCaptor.capture());
@@ -360,17 +360,17 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         assertEquals(RestStatus.OK, restResponse.status());
         BytesReference content = restResponse.content();
         assertEquals(
-            "{\"nodes\":{\"node\":{\"ml_node_total_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}",
+            "{\"nodes\":{\"node\":{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}",
             content.utf8ToString()
         );
     }
 
     public void testCreateMlStatsInputFromRequestParams_NodeStat() {
-        RestRequest request = getStatsRestRequest(node.getId(), MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT.name().toLowerCase(Locale.ROOT));
+        RestRequest request = getStatsRestRequest(node.getId(), MLNodeLevelStat.ML_TOTAL_MODEL_COUNT.name().toLowerCase(Locale.ROOT));
         MLStatsInput input = restAction.createMlStatsInputFromRequestParams(request);
         assertEquals(1, input.getTargetStatLevels().size());
         assertTrue(input.getTargetStatLevels().contains(MLStatLevel.NODE));
-        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT));
+        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT));
         assertEquals(0, input.getClusterLevelStats().size());
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
@@ -309,7 +309,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
 
         RestRequest request = getStatsRestRequest(
             node.getId(),
-            MLClusterLevelStat.ML_MODEL_COUNT + "," + MLNodeLevelStat.ML_TOTAL_MODEL_COUNT
+            MLClusterLevelStat.ML_MODEL_COUNT + "," + MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT
         );
         restAction.handleRequest(request, channel, client);
 
@@ -321,7 +321,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         assertTrue(input.getTargetStatLevels().contains(MLStatLevel.NODE));
         assertEquals(1, input.getClusterLevelStats().size());
         assertTrue(input.getClusterLevelStats().contains(MLClusterLevelStat.ML_MODEL_COUNT));
-        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT));
+        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT));
 
         ArgumentCaptor<BytesRestResponse> argumentCaptor = ArgumentCaptor.forClass(BytesRestResponse.class);
         verify(channel, times(1)).sendResponse(argumentCaptor.capture());
@@ -342,7 +342,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
     public void testPrepareRequest_ClusterAndNodeLevelStates_RequestParams_NodeLevelStat() throws Exception {
         prepareResponse();
 
-        RestRequest request = getStatsRestRequest(node.getId(), MLNodeLevelStat.ML_TOTAL_MODEL_COUNT.name());
+        RestRequest request = getStatsRestRequest(node.getId(), MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT.name());
         restAction.handleRequest(request, channel, client);
 
         ArgumentCaptor<MLStatsNodesRequest> inputArgumentCaptor = ArgumentCaptor.forClass(MLStatsNodesRequest.class);
@@ -352,7 +352,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         assertTrue(input.getTargetStatLevels().contains(MLStatLevel.NODE));
         assertEquals(0, input.getClusterLevelStats().size());
         assertEquals(1, input.getNodeLevelStats().size());
-        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT));
+        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT));
 
         ArgumentCaptor<BytesRestResponse> argumentCaptor = ArgumentCaptor.forClass(BytesRestResponse.class);
         verify(channel, times(1)).sendResponse(argumentCaptor.capture());
@@ -366,11 +366,11 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
     }
 
     public void testCreateMlStatsInputFromRequestParams_NodeStat() {
-        RestRequest request = getStatsRestRequest(node.getId(), MLNodeLevelStat.ML_TOTAL_MODEL_COUNT.name().toLowerCase(Locale.ROOT));
+        RestRequest request = getStatsRestRequest(node.getId(), MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT.name().toLowerCase(Locale.ROOT));
         MLStatsInput input = restAction.createMlStatsInputFromRequestParams(request);
         assertEquals(1, input.getTargetStatLevels().size());
         assertTrue(input.getTargetStatLevels().contains(MLStatLevel.NODE));
-        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT));
+        assertTrue(input.getNodeLevelStats().contains(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT));
         assertEquals(0, input.getClusterLevelStats().size());
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
@@ -209,7 +209,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             content
                 .utf8ToString()
                 .contains(
-                    "\"nodes\":{\"node\":{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
+                    "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
                 )
         );
     }
@@ -299,7 +299,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             content
                 .utf8ToString()
                 .contains(
-                    "\"nodes\":{\"node\":{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
+                    "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
                 )
         );
     }
@@ -334,7 +334,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             content
                 .utf8ToString()
                 .contains(
-                    "\"nodes\":{\"node\":{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
+                    "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
                 )
         );
     }
@@ -360,7 +360,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         assertEquals(RestStatus.OK, restResponse.status());
         BytesReference content = restResponse.content();
         assertEquals(
-            "{\"nodes\":{\"node\":{\"ML_REQUEST_COUNT\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}",
+            "{\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}",
             content.utf8ToString()
         );
     }

--- a/plugin/src/test/java/org/opensearch/ml/stats/MLStatsInputTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/stats/MLStatsInputTests.java
@@ -84,27 +84,27 @@ public class MLStatsInputTests extends OpenSearchTestCase {
 
     public void testShouldRetrieveStat() {
         assertTrue(mlStatsInput.retrieveStat(MLClusterLevelStat.ML_MODEL_COUNT));
-        assertTrue(mlStatsInput.retrieveStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT));
+        assertTrue(mlStatsInput.retrieveStat(MLNodeLevelStat.ML_REQUEST_COUNT));
         assertTrue(mlStatsInput.retrieveStat(MLActionLevelStat.ML_ACTION_REQUEST_COUNT));
 
         MLStatsInput mlStatsInput = MLStatsInput.builder().build();
         assertTrue(mlStatsInput.retrieveStat(MLClusterLevelStat.ML_MODEL_COUNT));
-        assertTrue(mlStatsInput.retrieveStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT));
+        assertTrue(mlStatsInput.retrieveStat(MLNodeLevelStat.ML_REQUEST_COUNT));
         assertTrue(mlStatsInput.retrieveStat(MLActionLevelStat.ML_ACTION_REQUEST_COUNT));
 
         mlStatsInput = new MLStatsInput();
         assertTrue(mlStatsInput.retrieveStat(MLClusterLevelStat.ML_MODEL_COUNT));
-        assertTrue(mlStatsInput.retrieveStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT));
+        assertTrue(mlStatsInput.retrieveStat(MLNodeLevelStat.ML_REQUEST_COUNT));
         assertTrue(mlStatsInput.retrieveStat(MLActionLevelStat.ML_ACTION_REQUEST_COUNT));
 
         mlStatsInput = MLStatsInput
             .builder()
             .clusterLevelStats(EnumSet.of(MLClusterLevelStat.ML_TASK_INDEX_STATUS))
-            .nodeLevelStats(EnumSet.of(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT))
+            .nodeLevelStats(EnumSet.of(MLNodeLevelStat.ML_FAILURE_COUNT))
             .actionLevelStats(EnumSet.of(MLActionLevelStat.ML_ACTION_FAILURE_COUNT))
             .build();
         assertFalse(mlStatsInput.retrieveStat(MLClusterLevelStat.ML_MODEL_COUNT));
-        assertFalse(mlStatsInput.retrieveStat(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT));
+        assertFalse(mlStatsInput.retrieveStat(MLNodeLevelStat.ML_REQUEST_COUNT));
         assertFalse(mlStatsInput.retrieveStat(MLActionLevelStat.ML_ACTION_REQUEST_COUNT));
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/stats/MLStatsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/stats/MLStatsTests.java
@@ -33,7 +33,7 @@ public class MLStatsTests extends OpenSearchTestCase {
     public void setup() {
         clusterStatName1 = MLClusterLevelStat.ML_MODEL_COUNT;
 
-        nodeStatName1 = MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT;
+        nodeStatName1 = MLNodeLevelStat.ML_EXECUTING_TASK_COUNT;
 
         statsMap = new HashMap<Enum, MLStat<?>>() {
             {
@@ -70,14 +70,14 @@ public class MLStatsTests extends OpenSearchTestCase {
     }
 
     public void testGetStatNoExisting() {
-        MLNodeLevelStat wrongStat = MLNodeLevelStat.ML_NODE_JVM_HEAP_USAGE;
+        MLNodeLevelStat wrongStat = MLNodeLevelStat.ML_JVM_HEAP_USAGE;
         expectedEx.expect(IllegalArgumentException.class);
         expectedEx.expectMessage("Stat \"" + wrongStat + "\" does not exist");
         mlStats.getStat(wrongStat);
     }
 
     public void testCreateCounterStatIfAbsent() {
-        MLStat<?> stat = mlStats.createCounterStatIfAbsent(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT);
+        MLStat<?> stat = mlStats.createCounterStatIfAbsent(MLNodeLevelStat.ML_FAILURE_COUNT);
         stat.increment();
         assertEquals(1L, stat.getValue());
     }

--- a/plugin/src/test/java/org/opensearch/ml/task/MLExecuteTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLExecuteTaskRunnerTests.java
@@ -119,10 +119,10 @@ public class MLExecuteTaskRunnerTests extends OpenSearchTestCase {
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         Map<Enum, MLStat<?>> stats = new ConcurrentHashMap<>();
-        stats.put(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = new MLStats(stats);
 
         mlInputDatasetHandler = spy(new MLInputDatasetHandler(client));

--- a/plugin/src/test/java/org/opensearch/ml/task/MLExecuteTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLExecuteTaskRunnerTests.java
@@ -122,7 +122,7 @@ public class MLExecuteTaskRunnerTests extends OpenSearchTestCase {
         stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = new MLStats(stats);
 
         mlInputDatasetHandler = spy(new MLInputDatasetHandler(client));

--- a/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
@@ -144,7 +144,7 @@ public class MLPredictTaskRunnerTests extends OpenSearchTestCase {
         stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = new MLStats(stats);
         mlInputDatasetHandler = spy(new MLInputDatasetHandler(client));
         taskRunner = spy(

--- a/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
@@ -141,10 +141,10 @@ public class MLPredictTaskRunnerTests extends OpenSearchTestCase {
         }).when(executorService).execute(any(Runnable.class));
 
         Map<Enum, MLStat<?>> stats = new ConcurrentHashMap<>();
-        stats.put(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = new MLStats(stats);
         mlInputDatasetHandler = spy(new MLInputDatasetHandler(client));
         taskRunner = spy(

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTaskDispatcherTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTaskDispatcherTests.java
@@ -160,8 +160,8 @@ public class MLTaskDispatcherTests extends OpenSearchTestCase {
 
     private MLStatsNodesResponse getMlStatsNodesResponse() {
         Map<MLNodeLevelStat, Object> nodeStats = new HashMap<>();
-        nodeStats.put(MLNodeLevelStat.ML_NODE_JVM_HEAP_USAGE, 50l);
-        nodeStats.put(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT, 5l);
+        nodeStats.put(MLNodeLevelStat.ML_JVM_HEAP_USAGE, 50l);
+        nodeStats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, 5l);
         MLStatsNodeResponse mlStatsNodeResponse1 = new MLStatsNodeResponse(dataNode1, nodeStats);
         MLStatsNodeResponse mlStatsNodeResponse2 = new MLStatsNodeResponse(dataNode1, nodeStats);
         return new MLStatsNodesResponse(
@@ -173,7 +173,7 @@ public class MLTaskDispatcherTests extends OpenSearchTestCase {
 
     private MLStatsNodesResponse getNodesResponse_NoTaskCounts() {
         Map<MLNodeLevelStat, Object> nodeStats = new HashMap<>();
-        nodeStats.put(MLNodeLevelStat.ML_NODE_JVM_HEAP_USAGE, 50l);
+        nodeStats.put(MLNodeLevelStat.ML_JVM_HEAP_USAGE, 50l);
         MLStatsNodeResponse mlStatsNodeResponse1 = new MLStatsNodeResponse(dataNode1, nodeStats);
         MLStatsNodeResponse mlStatsNodeResponse2 = new MLStatsNodeResponse(dataNode1, nodeStats);
         return new MLStatsNodesResponse(
@@ -185,8 +185,8 @@ public class MLTaskDispatcherTests extends OpenSearchTestCase {
 
     private MLStatsNodesResponse getNodesResponse_MemoryExceedLimits() {
         Map<MLNodeLevelStat, Object> nodeStats = new HashMap<>();
-        nodeStats.put(MLNodeLevelStat.ML_NODE_JVM_HEAP_USAGE, 90l);
-        nodeStats.put(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT, 5l);
+        nodeStats.put(MLNodeLevelStat.ML_JVM_HEAP_USAGE, 90l);
+        nodeStats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, 5l);
         MLStatsNodeResponse mlStatsNodeResponse1 = new MLStatsNodeResponse(dataNode1, nodeStats);
         MLStatsNodeResponse mlStatsNodeResponse2 = new MLStatsNodeResponse(dataNode1, nodeStats);
         return new MLStatsNodesResponse(
@@ -198,8 +198,8 @@ public class MLTaskDispatcherTests extends OpenSearchTestCase {
 
     private MLStatsNodesResponse getNodesResponse_TaskCountExceedLimits() {
         Map<MLNodeLevelStat, Object> nodeStats = new HashMap<>();
-        nodeStats.put(MLNodeLevelStat.ML_NODE_JVM_HEAP_USAGE, 50l);
-        nodeStats.put(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT, 15l);
+        nodeStats.put(MLNodeLevelStat.ML_JVM_HEAP_USAGE, 50l);
+        nodeStats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, 15l);
         MLStatsNodeResponse mlStatsNodeResponse1 = new MLStatsNodeResponse(dataNode1, nodeStats);
         MLStatsNodeResponse mlStatsNodeResponse2 = new MLStatsNodeResponse(dataNode1, nodeStats);
         return new MLStatsNodesResponse(

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunnerTests.java
@@ -120,7 +120,7 @@ public class MLTrainAndPredictTaskRunnerTests extends OpenSearchTestCase {
         stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = new MLStats(stats);
 
         mlInputDatasetHandler = spy(new MLInputDatasetHandler(client));

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunnerTests.java
@@ -117,10 +117,10 @@ public class MLTrainAndPredictTaskRunnerTests extends OpenSearchTestCase {
         }).when(executorService).execute(any(Runnable.class));
 
         Map<Enum, MLStat<?>> stats = new ConcurrentHashMap<>();
-        stats.put(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = new MLStats(stats);
 
         mlInputDatasetHandler = spy(new MLInputDatasetHandler(client));

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTrainingTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTrainingTaskRunnerTests.java
@@ -125,10 +125,10 @@ public class MLTrainingTaskRunnerTests extends OpenSearchTestCase {
         }).when(executorService).execute(any(Runnable.class));
 
         Map<Enum, MLStat<?>> stats = new ConcurrentHashMap<>();
-        stats.put(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = new MLStats(stats);
 
         mlInputDatasetHandler = spy(new MLInputDatasetHandler(client));

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTrainingTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTrainingTaskRunnerTests.java
@@ -128,7 +128,7 @@ public class MLTrainingTaskRunnerTests extends OpenSearchTestCase {
         stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = new MLStats(stats);
 
         mlInputDatasetHandler = spy(new MLInputDatasetHandler(client));

--- a/plugin/src/test/java/org/opensearch/ml/task/TaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/TaskRunnerTests.java
@@ -72,7 +72,7 @@ public class TaskRunnerTests extends OpenSearchTestCase {
         stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
         stats.put(MLNodeLevelStat.ML_CIRCUIT_BREAKER_TRIGGER_COUNT, new MLStat<>(false, new CounterSupplier()));
         mlStats = new MLStats(stats);
 

--- a/plugin/src/test/java/org/opensearch/ml/task/TaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/TaskRunnerTests.java
@@ -69,11 +69,11 @@ public class TaskRunnerTests extends OpenSearchTestCase {
     @Before
     public void setup() {
         Map<Enum, MLStat<?>> stats = new ConcurrentHashMap<>();
-        stats.put(MLNodeLevelStat.ML_NODE_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
-        stats.put(MLNodeLevelStat.ML_NODE_TOTAL_CIRCUIT_BREAKER_TRIGGER_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_REQUEST_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_FAILURE_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_TOTAL_MODEL_COUNT, new MLStat<>(false, new CounterSupplier()));
+        stats.put(MLNodeLevelStat.ML_CIRCUIT_BREAKER_TRIGGER_COUNT, new MLStat<>(false, new CounterSupplier()));
         mlStats = new MLStats(stats);
 
         MockitoAnnotations.openMocks(this);
@@ -140,7 +140,7 @@ public class TaskRunnerTests extends OpenSearchTestCase {
         ActionListener listener = mock(ActionListener.class);
         MLTaskRequest request = new MLTaskRequest(false);
         expectThrows(MLLimitExceededException.class, () -> mlTaskRunner.run(FunctionName.REMOTE, request, transportService, listener));
-        Long value = (Long) mlStats.getStat(MLNodeLevelStat.ML_NODE_TOTAL_CIRCUIT_BREAKER_TRIGGER_COUNT).getValue();
+        Long value = (Long) mlStats.getStat(MLNodeLevelStat.ML_CIRCUIT_BREAKER_TRIGGER_COUNT).getValue();
         assertEquals(1L, value.longValue());
     }
 }


### PR DESCRIPTION
### Description
[We renamed the node level metrics:

ml_node_executing_task_count -->  ml_executing_task_count
ml_node_total_model_count        -->   ml_deployed_model_count
ml_node_total_failure_count.       -->   ml_failure_count
ml_node_total_circuit_breaker_trigger_count        -->    ml_circuit_breaker_trigger_count
ml_node_total_request_count    -->   ml_request_count
ml_node_jvm_heap_usage          --> ml_jvm_heap_usage
]
 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
