### PR TITLE
Neural search default process support

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
 
     compileOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
-    compileOnly group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     compileOnly group: 'org.json', name: 'json', version: '20230227'
 }
 

--- a/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.ml.common.connector;
 
-import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.utils.StringUtils.gson;
 
 import java.io.IOException;
 import java.security.AccessController;
@@ -32,6 +30,8 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.MLCommonsClassLoader;
 import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.utils.GsonUtil;
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
  * Connector defines how to connect to a remote service.
@@ -108,7 +108,7 @@ public interface Connector extends ToXContentObject, Writeable {
         Map<String, Object> connectorMap = parser.map();
         String jsonStr;
         try {
-            jsonStr = AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> gson.toJson(connectorMap));
+            jsonStr = AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> GsonUtil.toJson(connectorMap));
         } catch (PrivilegedActionException e) {
             throw new IllegalArgumentException("wrong connector");
         }

--- a/common/src/main/java/org/opensearch/ml/common/connector/MLPreProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/MLPreProcessFunction.java
@@ -6,44 +6,37 @@
 package org.opensearch.ml.common.connector;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public class MLPreProcessFunction {
 
-    private static Map<String, String> PRE_PROCESS_FUNCTIONS;
+    private static final Map<String, Function<List<String>, Map<String, Object>>> PRE_PROCESS_FUNCTIONS = new HashMap<>();
     public static final String TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT = "connector.pre_process.cohere.embedding";
     public static final String TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT = "connector.pre_process.openai.embedding";
 
-    static {
-        PRE_PROCESS_FUNCTIONS = new HashMap<>();
-        //TODO: change to java for openAI, embedding and Titan
-        PRE_PROCESS_FUNCTIONS.put(TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT, "\n    StringBuilder builder = new StringBuilder();\n" +
-                "    builder.append(\"[\");\n" +
-                "    for (int i=0; i< params.text_docs.length; i++) {\n" +
-                "        builder.append(\"\\\"\");\n" +
-                "        builder.append(params.text_docs[i]);\n" +
-                "        builder.append(\"\\\"\");\n" +
-                "        if (i < params.text_docs.length - 1) {\n" +
-                "          builder.append(\",\")\n" +
-                "        }\n" +
-                "    }\n" +
-                "    builder.append(\"]\");\n" +
-                "    def parameters = \"{\" +\"\\\"prompt\\\":\" + builder + \"}\";\n" +
-                "    return  \"{\" +\"\\\"parameters\\\":\" + parameters + \"}\";");
+    public static final String NEURAL_SEARCH_EMBEDDING_INPUT = "connector.pre_process.neural_search.text_embedding";
 
-        PRE_PROCESS_FUNCTIONS.put(TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT, "\n    StringBuilder builder = new StringBuilder();\n" +
-                        "    builder.append(\"\\\"\");\n" +
-                        "    builder.append(params.text_docs[0]);\n" +
-                        "    builder.append(\"\\\"\");\n" +
-                        "    def parameters = \"{\" +\"\\\"input\\\":\" + builder + \"}\";\n" +
-                        "    return  \"{\" +\"\\\"parameters\\\":\" + parameters + \"}\";");
+    private static Function<List<String>, Map<String, Object>> cohereTextEmbeddingPreProcess() {
+        return inputs -> Map.of("parameters", Map.of("texts", inputs));
+    }
+
+    private static Function<List<String>, Map<String, Object>> openAiTextEmbeddingPreProcess() {
+        return inputs -> Map.of("parameters", Map.of("input", inputs));
+    }
+
+    static {
+        PRE_PROCESS_FUNCTIONS.put(TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT, cohereTextEmbeddingPreProcess());
+        PRE_PROCESS_FUNCTIONS.put(TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT, openAiTextEmbeddingPreProcess());
+        PRE_PROCESS_FUNCTIONS.put(NEURAL_SEARCH_EMBEDDING_INPUT, openAiTextEmbeddingPreProcess());
     }
 
     public static boolean contains(String functionName) {
         return PRE_PROCESS_FUNCTIONS.containsKey(functionName);
     }
 
-    public static String get(String postProcessFunction) {
+    public static Function<List<String>, Map<String, Object>> get(String postProcessFunction) {
         return PRE_PROCESS_FUNCTIONS.get(postProcessFunction);
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/output/model/ModelTensor.java
+++ b/common/src/main/java/org/opensearch/ml/common/output/model/ModelTensor.java
@@ -6,7 +6,6 @@
 package org.opensearch.ml.common.output.model;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.utils.StringUtils.gson;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -26,6 +25,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.utils.GsonUtil;
 
 @Data
 public class ModelTensor implements Writeable, ToXContentObject {
@@ -224,7 +224,7 @@ public class ModelTensor implements Writeable, ToXContentObject {
         this.result = in.readOptionalString();
         if (in.readBoolean()) {
             String mapStr = in.readString();
-            this.dataAsMap = gson.fromJson(mapStr, Map.class);
+            this.dataAsMap = GsonUtil.fromJson(mapStr, Map.class);
         }
     }
 
@@ -270,7 +270,7 @@ public class ModelTensor implements Writeable, ToXContentObject {
             out.writeBoolean(true);
             try {
                 AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                    out.writeString(gson.toJson(dataAsMap));
+                    out.writeString(GsonUtil.toJson(dataAsMap));
                     return null;
                 });
             } catch (PrivilegedActionException e) {

--- a/common/src/main/java/org/opensearch/ml/common/utils/GsonUtil.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/GsonUtil.java
@@ -1,0 +1,30 @@
+package org.opensearch.ml.common.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.stream.JsonReader;
+
+public class GsonUtil {
+
+    private static final Gson gson;
+
+    static {
+        gson = new Gson();
+    }
+
+    public static String toJson(Object obj) {
+        return gson.toJson(obj);
+    }
+
+    public static <T> T fromJson(String json, Class<T> clazz) {
+        return gson.fromJson(json, clazz);
+    }
+
+    public static <T> T fromJson(JsonElement jsonElement, Class<T> clazz) {
+        return gson.fromJson(jsonElement, clazz);
+    }
+
+    public static <T> T fromJson(JsonReader jsonReader, Class<T> clazz) {
+        return gson.fromJson(jsonReader, clazz);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,9 +45,12 @@ public class StringUtils {
         return utf8EncodedString;
     }
 
-    public static Map<String, Object> fromJson(String jsonStr, String defaultKey) {
+    public static Map<String, Object> fromJson(String input, String defaultKey) {
+        if (!isJson(input)) {
+            return Collections.singletonMap(defaultKey, input);
+        }
         Map<String, Object> result;
-        JsonElement jsonElement = JsonParser.parseString(jsonStr);
+        JsonElement jsonElement = JsonParser.parseString(input);
         if (jsonElement.isJsonObject()) {
             result = GsonUtil.fromJson(jsonElement, Map.class);
         } else if (jsonElement.isJsonArray()) {

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.ml.common.utils;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import org.json.JSONArray;
@@ -24,11 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 public class StringUtils {
-
-    public static final Gson gson;
-    static {
-        gson = new Gson();
-    }
 
     public static boolean isJson(String Json) {
         try {
@@ -54,9 +48,9 @@ public class StringUtils {
         Map<String, Object> result;
         JsonElement jsonElement = JsonParser.parseString(jsonStr);
         if (jsonElement.isJsonObject()) {
-            result = gson.fromJson(jsonElement, Map.class);
+            result = GsonUtil.fromJson(jsonElement, Map.class);
         } else if (jsonElement.isJsonArray()) {
-            List<Object> list = gson.fromJson(jsonElement, List.class);
+            List<Object> list = GsonUtil.fromJson(jsonElement, List.class);
             result = new HashMap<>();
             result.put(defaultKey, list);
         } else {
@@ -74,7 +68,7 @@ public class StringUtils {
                     if (value instanceof String) {
                         parameters.put(key, (String)value);
                     } else {
-                        parameters.put(key, gson.toJson(value));
+                        parameters.put(key, GsonUtil.toJson(value));
                     }
                     return null;
                 });

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -11,6 +11,8 @@ import com.google.gson.JsonParser;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.XContentBuilder;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -81,5 +83,9 @@ public class StringUtils {
             }
         }
         return parameters;
+    }
+
+    public static String xContentBuilderToString(XContentBuilder builder) {
+        return BytesReference.bytes(builder).utf8ToString();
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/connector/MLPostProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/MLPostProcessFunctionTest.java
@@ -6,11 +6,20 @@
 package org.opensearch.ml.common.connector;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static org.opensearch.ml.common.connector.MLPostProcessFunction.OPENAI_EMBEDDING;
 
 public class MLPostProcessFunctionTest {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void contains() {
@@ -22,5 +31,25 @@ public class MLPostProcessFunctionTest {
     public void get() {
         Assert.assertNotNull(MLPostProcessFunction.get(OPENAI_EMBEDDING));
         Assert.assertNull(MLPostProcessFunction.get("wrong value"));
+    }
+
+    @Test
+    public void test_getResponseFilter() {
+        assert null != MLPostProcessFunction.getResponseFilter(OPENAI_EMBEDDING);
+        assert null == MLPostProcessFunction.getResponseFilter("wrong value");
+    }
+
+    @Test
+    public void test_buildModelTensorList() {
+        Assert.assertNotNull(MLPostProcessFunction.buildModelTensorList());
+        List<List<Float>> numbersList = new ArrayList<>();
+        numbersList.add(Collections.singletonList(1.0f));
+        Assert.assertNotNull(MLPostProcessFunction.buildModelTensorList().apply(numbersList));
+    }
+
+    @Test
+    public void test_buildModelTensorList_exception() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        MLPostProcessFunction.buildModelTensorList().apply(null);
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/utils/GsonUtilsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/GsonUtilsTest.java
@@ -1,0 +1,47 @@
+package org.opensearch.ml.common.utils;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GsonUtilsTest {
+    @Test
+    public void test_toJson() {
+        Map<String, String> map = new HashMap<>();
+        map.put("key", "value");
+        String mapString = GsonUtil.toJson(map);
+        assert mapString.equals("{\"key\":\"value\"}");
+    }
+
+    @Test
+    public void test_fromJsonString() {
+        Map<String, String> map = GsonUtil.fromJson("{\"key\": \"value\"}", Map.class);
+        Assert.assertEquals(1, map.size());
+        Assert.assertEquals("value", map.get("key"));
+    }
+
+    @Test
+    public void test_fromJsonJsonElement() {
+        JsonElement jsonElement = JsonParser.parseString("{\"key\": \"value\"}");
+        Map<String, String> map = GsonUtil.fromJson(jsonElement, Map.class);
+        Assert.assertEquals(1, map.size());
+        Assert.assertEquals("value", map.get("key"));
+    }
+
+    @Test
+    public void test_fromJsonJsonReader() {
+        JsonReader reader = new JsonReader(new StringReader("{\"key\": \"value\"}"));
+        Map<String, String> map = GsonUtil.fromJson(reader, Map.class);
+        Assert.assertEquals(1, map.size());
+        Assert.assertEquals("value", map.get("key"));
+    }
+
+
+
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
@@ -7,7 +7,6 @@ package org.opensearch.ml.engine;
 
 import ai.djl.training.util.DownloadUtils;
 import ai.djl.training.util.ProgressBar;
-import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.core.action.ActionListener;
@@ -16,6 +15,7 @@ import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
+import org.opensearch.ml.common.utils.GsonUtil;
 
 import java.io.File;
 import java.io.FileReader;
@@ -48,11 +48,9 @@ public class ModelHelper {
     public static final String PYTORCH_ENGINE = "PyTorch";
     public static final String ONNX_ENGINE = "OnnxRuntime";
     private final MLEngine mlEngine;
-    private Gson gson;
 
     public ModelHelper(MLEngine mlEngine) {
         this.mlEngine = mlEngine;
-        gson = new Gson();
     }
 
     public void downloadPrebuiltModelConfig(String taskId, MLRegisterModelInput registerModelInput, ActionListener<MLRegisterModelInput> listener) {
@@ -74,7 +72,7 @@ public class ModelHelper {
 
                 Map<?, ?> config = null;
                 try (JsonReader reader = new JsonReader(new FileReader(configCacheFilePath))) {
-                    config = gson.fromJson(reader, Map.class);
+                    config = GsonUtil.fromJson(reader, Map.class);
                 }
 
                 if (config == null) {
@@ -172,7 +170,7 @@ public class ModelHelper {
 
                 List<?> config = null;
                 try (JsonReader reader = new JsonReader(new FileReader(cacheFilePath))) {
-                    config = gson.fromJson(reader, List.class);
+                    config = GsonUtil.fromJson(reader, List.class);
                 }
 
                 return config;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
@@ -67,7 +67,9 @@ public class ConnectorUtils {
         if (inputData.getParameters() != null) {
             Map<String, String> newParameters = new HashMap<>();
             inputData.getParameters().forEach((key, value) -> {
-                if (org.opensearch.ml.common.utils.StringUtils.isJson(value)) {
+                if (value == null) {
+                    newParameters.put(key, null);
+                } else if (org.opensearch.ml.common.utils.StringUtils.isJson(value)) {
                     // no need to escape if it's already valid json
                     newParameters.put(key, value);
                 } else {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
@@ -5,17 +5,20 @@
 
 package org.opensearch.ml.engine.algorithms.remote;
 
-import com.google.common.collect.ImmutableMap;
 import com.jayway.jsonpath.JsonPath;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
+import org.opensearch.ml.common.connector.MLPostProcessFunction;
+import org.opensearch.ml.common.connector.MLPreProcessFunction;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensors;
-import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.common.utils.GsonUtil;
 import org.opensearch.script.ScriptService;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
@@ -37,10 +40,11 @@ import java.util.Optional;
 
 import static org.apache.commons.text.StringEscapeUtils.escapeJson;
 import static org.opensearch.ml.common.connector.HttpConnector.RESPONSE_FILTER_FIELD;
-import static org.opensearch.ml.engine.utils.ScriptUtils.executePostprocessFunction;
+import static org.opensearch.ml.engine.utils.ScriptUtils.executeBuildInPostProcessFunction;
+import static org.opensearch.ml.engine.utils.ScriptUtils.executePostProcessFunction;
 import static org.opensearch.ml.engine.utils.ScriptUtils.executePreprocessFunction;
-import static org.opensearch.ml.engine.utils.ScriptUtils.gson;
 
+@Log4j2
 public class ConnectorUtils {
 
     private static final Aws4Signer signer;
@@ -54,43 +58,7 @@ public class ConnectorUtils {
         }
         RemoteInferenceInputDataSet inputData;
         if (mlInput.getInputDataset() instanceof TextDocsInputDataSet) {
-            TextDocsInputDataSet inputDataSet = (TextDocsInputDataSet)mlInput.getInputDataset();
-            List<String> docs = new ArrayList<>(inputDataSet.getDocs());
-            Map<String, Object> params = ImmutableMap.of("text_docs", docs);
-            Optional<ConnectorAction> predictAction = connector.findPredictAction();
-            if (!predictAction.isPresent()) {
-                throw new IllegalArgumentException("no predict action found");
-            }
-            String preProcessFunction = predictAction.get().getPreProcessFunction();
-            if (preProcessFunction == null) {
-                throw new IllegalArgumentException("Must provide pre_process_function for predict action to process text docs input.");
-            }
-            if (preProcessFunction != null && preProcessFunction.contains("${parameters")) {
-                StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
-                preProcessFunction = substitutor.replace(preProcessFunction);
-            }
-            Optional<String> processedResponse = executePreprocessFunction(scriptService, preProcessFunction, params);
-            if (!processedResponse.isPresent()) {
-                throw new IllegalArgumentException("Wrong input");
-            }
-            Map<String, Object> map = gson.fromJson(processedResponse.get(), Map.class);
-            Map<String, Object> parametersMap = (Map<String, Object>) map.get("parameters");
-            Map<String, String> processedParameters = new HashMap<>();
-            for (String key : parametersMap.keySet()) {
-                try {
-                    AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                        if (parametersMap.get(key) instanceof String) {
-                            processedParameters.put(key, (String) parametersMap.get(key));
-                        } else {
-                            processedParameters.put(key, gson.toJson(parametersMap.get(key)));
-                        }
-                        return null;
-                    });
-                } catch (PrivilegedActionException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-            inputData = RemoteInferenceInputDataSet.builder().parameters(processedParameters).build();
+            inputData = processTextDocsInput((TextDocsInputDataSet) mlInput.getInputDataset(), connector, parameters, scriptService);
         } else if (mlInput.getInputDataset() instanceof RemoteInferenceInputDataSet) {
             inputData = (RemoteInferenceInputDataSet)mlInput.getInputDataset();
         } else {
@@ -98,19 +66,64 @@ public class ConnectorUtils {
         }
         if (inputData.getParameters() != null) {
             Map<String, String> newParameters = new HashMap<>();
-            inputData.getParameters().entrySet().forEach(entry -> {
-                if (entry.getValue() == null) {
-                    newParameters.put(entry.getKey(), entry.getValue());
-                } else if (StringUtils.isJson(entry.getValue())) {
+            inputData.getParameters().forEach((key, value) -> {
+                if (org.opensearch.ml.common.utils.StringUtils.isJson(value)) {
                     // no need to escape if it's already valid json
-                    newParameters.put(entry.getKey(), entry.getValue());
+                    newParameters.put(key, value);
                 } else {
-                    newParameters.put(entry.getKey(), escapeJson(entry.getValue()));
+                    newParameters.put(key, escapeJson(value));
                 }
             });
             inputData.setParameters(newParameters);
         }
         return inputData;
+    }
+    private static RemoteInferenceInputDataSet processTextDocsInput(TextDocsInputDataSet inputDataSet, Connector connector, Map<String, String> parameters, ScriptService scriptService) {
+        List<String> docs = new ArrayList<>(inputDataSet.getDocs());
+        Optional<ConnectorAction> predictAction = connector.findPredictAction();
+        if (predictAction.isEmpty()) {
+            throw new IllegalArgumentException("no predict action found");
+        }
+        String preProcessFunction = predictAction.get().getPreProcessFunction();
+        if (preProcessFunction == null) {
+            throw new IllegalArgumentException("Must provide pre_process_function for predict action to process text docs input.");
+        }
+        if (MLPreProcessFunction.contains(preProcessFunction)) {
+            Map<String, Object> buildInFunctionResult = MLPreProcessFunction.get(preProcessFunction).apply(docs);
+            return RemoteInferenceInputDataSet.builder().parameters(convertScriptStringToJsonString(buildInFunctionResult)).build();
+        } else {
+            if (preProcessFunction.contains("${parameters")) {
+                StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
+                preProcessFunction = substitutor.replace(preProcessFunction);
+            }
+            Optional<String> processedInput = executePreprocessFunction(scriptService, preProcessFunction, docs);
+            if (processedInput.isEmpty()) {
+                throw new IllegalArgumentException("Wrong input");
+            }
+            Map<String, Object> map = GsonUtil.fromJson(processedInput.get(), Map.class);
+            return RemoteInferenceInputDataSet.builder().parameters(convertScriptStringToJsonString(map)).build();
+        }
+    }
+
+    private static Map<String, String> convertScriptStringToJsonString(Map<String, Object> processedInput) {
+        Map<String, String> parameterStringMap = new HashMap<>();
+        try {
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                Map<String, Object> parametersMap = (Map<String, Object>) processedInput.get("parameters");
+                for (String key : parametersMap.keySet()) {
+                    if (parametersMap.get(key) instanceof String) {
+                        parameterStringMap.put(key, (String) parametersMap.get(key));
+                    } else {
+                        parameterStringMap.put(key, GsonUtil.toJson(parametersMap.get(key)));
+                    }
+                }
+                return null;
+            });
+        } catch (PrivilegedActionException e) {
+            log.error("Error processing parameters", e);
+            throw new RuntimeException(e);
+        }
+        return parameterStringMap;
     }
 
     public static ModelTensors processOutput(String modelResponse, Connector connector, ScriptService scriptService, Map<String, String> parameters) throws IOException {
@@ -119,26 +132,36 @@ public class ConnectorUtils {
         }
         List<ModelTensor> modelTensors = new ArrayList<>();
         Optional<ConnectorAction> predictAction = connector.findPredictAction();
-        if (!predictAction.isPresent()) {
+        if (predictAction.isEmpty()) {
             throw new IllegalArgumentException("no predict action found");
         }
-        String postProcessFunction = predictAction.get().getPostProcessFunction();
+        ConnectorAction connectorAction = predictAction.get();
+        String postProcessFunction = connectorAction.getPostProcessFunction();
         if (postProcessFunction != null && postProcessFunction.contains("${parameters")) {
             StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
             postProcessFunction = substitutor.replace(postProcessFunction);
         }
-        Optional<String> processedResponse = executePostprocessFunction(scriptService, postProcessFunction, modelResponse);
 
-        String response = processedResponse.orElse(modelResponse);
-        if (parameters.get(RESPONSE_FILTER_FIELD) == null) {
-            connector.parseResponse(response, modelTensors, postProcessFunction != null && processedResponse.isPresent());
-        } else {
-            Object filteredResponse = JsonPath.parse(response).read(parameters.get(RESPONSE_FILTER_FIELD));
-            connector.parseResponse(filteredResponse, modelTensors, postProcessFunction != null && processedResponse.isPresent());
+        String responseFilter = parameters.get(RESPONSE_FILTER_FIELD);
+        if (MLPostProcessFunction.contains(postProcessFunction)) {
+            // in this case, we can use jsonpath to build a List<List<Float>> result from model response.
+            if (StringUtils.isBlank(responseFilter)) responseFilter = MLPostProcessFunction.getResponseFilter(postProcessFunction);
+            List<List<Float>> vectors = JsonPath.read(modelResponse, responseFilter);
+            List<ModelTensor> processedResponse = executeBuildInPostProcessFunction(vectors, MLPostProcessFunction.get(postProcessFunction));
+            return ModelTensors.builder().mlModelTensors(processedResponse).build();
         }
 
-        ModelTensors tensors = ModelTensors.builder().mlModelTensors(modelTensors).build();
-        return tensors;
+        // execute user defined painless script.
+        Optional<String> processedResponse = executePostProcessFunction(scriptService, postProcessFunction, modelResponse);
+        String response = processedResponse.orElse(modelResponse);
+        boolean scriptReturnModelTensor = postProcessFunction != null && processedResponse.isPresent();
+        if (responseFilter == null) {
+            connector.parseResponse(response, modelTensors, scriptReturnModelTensor);
+        } else {
+            Object filteredResponse = JsonPath.parse(response).read(parameters.get(RESPONSE_FILTER_FIELD));
+            connector.parseResponse(filteredResponse, modelTensors, scriptReturnModelTensor);
+        }
+        return ModelTensors.builder().mlModelTensors(modelTensors).build();
     }
 
     public static SdkHttpFullRequest signRequest(SdkHttpFullRequest request, String accessKey, String secretKey, String sessionToken, String signingName, String region) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -32,14 +32,8 @@ public interface RemoteConnectorExecutor {
 
         if (mlInput.getInputDataset() instanceof TextDocsInputDataSet) {
             TextDocsInputDataSet textDocsInputDataSet = (TextDocsInputDataSet) mlInput.getInputDataset();
-            List textDocs = new ArrayList(textDocsInputDataSet.getDocs());
-            for (int i = 0; i < textDocsInputDataSet.getDocs().size(); i++) {
-                preparePayloadAndInvokeRemoteModel(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(TextDocsInputDataSet.builder().docs(textDocs).build()).build(), tensorOutputs);
-                if (tensorOutputs.size() >= textDocsInputDataSet.getDocs().size()) {
-                    break;
-                }
-                textDocs.remove(0);
-            }
+            List<String> textDocs = new ArrayList<>(textDocsInputDataSet.getDocs());
+            preparePayloadAndInvokeRemoteModel(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(TextDocsInputDataSet.builder().docs(textDocs).build()).build(), tensorOutputs);
         } else {
             preparePayloadAndInvokeRemoteModel(mlInput, tensorOutputs);
         }
@@ -65,7 +59,7 @@ public interface RemoteConnectorExecutor {
         }
 
         RemoteInferenceInputDataSet inputData = processInput(mlInput, connector, parameters, getScriptService());
-        if (inputData != null && inputData.getParameters() != null) {
+        if (inputData.getParameters() != null) {
             parameters.putAll(inputData.getParameters());
         }
         String payload = connector.createPredictPayload(parameters);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/ScriptUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/ScriptUtils.java
@@ -5,52 +5,36 @@
 
 package org.opensearch.ml.engine.utils;
 
-import com.google.gson.Gson;
-import org.opensearch.ml.common.connector.MLPostProcessFunction;
-import org.opensearch.ml.common.connector.MLPreProcessFunction;
-import org.opensearch.ml.common.utils.StringUtils;
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptService;
 import org.opensearch.script.ScriptType;
 import org.opensearch.script.TemplateScript;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 public class ScriptUtils {
 
-    public static final Gson gson;
-
-    static {
-        gson = new Gson();
+    public static Optional<String> executePreprocessFunction(ScriptService scriptService, String preProcessFunction, List<String> inputSentences) {
+        return Optional.ofNullable(executeScript(scriptService, preProcessFunction, ImmutableMap.of("text_docs", inputSentences)));
     }
 
-    public static Optional<String> executePreprocessFunction(ScriptService scriptService,
-                                                             String preProcessFunction,
-                                                             Map<String, Object> params) {
-        if (MLPreProcessFunction.contains(preProcessFunction)) {
-            preProcessFunction = MLPreProcessFunction.get(preProcessFunction);
-        }
-        if (preProcessFunction != null) {
-            return Optional.ofNullable(executeScript(scriptService, preProcessFunction, params));
-        }
-        return Optional.empty();
+    public static List<ModelTensor> executeBuildInPostProcessFunction(List<List<Float>> vectors, Function<List<List<Float>>, List<ModelTensor>> function) {
+        return function.apply(vectors);
     }
 
-    public static Optional<String> executePostprocessFunction(ScriptService scriptService,
-                                                              String postProcessFunction,
-                                                              String resultJson) {
-        Map<String, Object> result = StringUtils.fromJson(resultJson, "result");
-        if (MLPostProcessFunction.contains(postProcessFunction)) {
-            postProcessFunction = MLPostProcessFunction.get(postProcessFunction);
-        }
+    public static Optional<String> executePostProcessFunction(ScriptService scriptService, String postProcessFunction, String resultJson) {
+        Map<String, Object> result = org.opensearch.ml.common.utils.StringUtils.fromJson(resultJson, "result");
         if (postProcessFunction != null) {
             return Optional.ofNullable(executeScript(scriptService, postProcessFunction, result));
         }
         return Optional.empty();
     }
-
     public static String executeScript(ScriptService scriptService, String painlessScript, Map<String, Object> params) {
         Script script = new Script(ScriptType.INLINE, "painless", painlessScript, Collections.emptyMap());
         TemplateScript templateScript = scriptService.compile(script, TemplateScript.CONTEXT).newInstance(params);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.engine.algorithms.remote;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Before;
@@ -18,7 +19,9 @@ import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.connector.AwsConnector;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
+import org.opensearch.ml.common.connector.MLPreProcessFunction;
 import org.opensearch.ml.common.dataset.MLInputDataset;
+import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
@@ -130,6 +133,37 @@ public class AwsConnectorExecutorTest {
 
         MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
         ModelTensorOutput modelTensorOutput = executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
+        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());
+        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().size());
+        Assert.assertEquals("response", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getName());
+        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap().size());
+        Assert.assertEquals("value", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap().get("key"));
+    }
+
+    @Test
+    public void executePredict_TextDocsInferenceInput() throws IOException {
+        String jsonString = "{\"key\":\"value\"}";
+        InputStream inputStream = new ByteArrayInputStream(jsonString.getBytes());
+        AbortableInputStream abortableInputStream = AbortableInputStream.create(inputStream);
+        when(response.responseBody()).thenReturn(Optional.of(abortableInputStream));
+        when(httpRequest.call()).thenReturn(response);
+        when(httpClient.prepareRequest(any())).thenReturn(httpRequest);
+
+        ConnectorAction predictAction = ConnectorAction.builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("http://test.com/mock")
+            .requestBody("{\"input\": ${parameters.input}}")
+            .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
+            .build();
+        Map<String, String> credential = ImmutableMap.of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key"), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key"));
+        Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
+        Connector connector = AwsConnector.awsConnectorBuilder().name("test connector").version("1").protocol("http").parameters(parameters).credential(credential).actions(Arrays.asList(predictAction)).build();
+        connector.decrypt((c) -> encryptor.decrypt(c));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
+
+        MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(ImmutableList.of("input", "test input data")).build();
+        ModelTensorOutput modelTensorOutput = executor.executePredict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build());
         Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());
         Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().size());
         Assert.assertEquals("response", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getName());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
@@ -175,9 +175,9 @@ public class ConnectorUtilsTest {
             .requestBody("{\"input\": \"${parameters.input}\"}")
             .build();
         Map<String, String> parameters = new HashMap<>();
-        parameters.put("key1", "value1");
+        parameters.put("input", "value1");
         Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").parameters(parameters).actions(Arrays.asList(predictAction)).build();
-        ModelTensors tensors = ConnectorUtils.processOutput("test response", connector, scriptService, ImmutableMap.of());
+        ModelTensors tensors = ConnectorUtils.processOutput("test response", connector, scriptService, parameters);
         Assert.assertEquals(1, tensors.getMlModelTensors().size());
         Assert.assertEquals("response", tensors.getMlModelTensors().get(0).getName());
         Assert.assertEquals(1, tensors.getMlModelTensors().get(0).getDataAsMap().size());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
@@ -24,11 +24,15 @@ import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.utils.GsonUtil;
 import org.opensearch.script.ScriptService;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -121,18 +125,20 @@ public class ConnectorUtilsTest {
 
     @Test
     public void processInput_TextDocsInputDataSet_PreprocessFunction_OneTextDoc() {
+        List<String> input = Collections.singletonList("test_value");
+        String inputJson = GsonUtil.toJson(input);
         processInput_TextDocsInputDataSet_PreprocessFunction(
-                "{\"input\": \"${parameters.input}\"}",
-                "{\"parameters\": { \"input\": \"test_value\" } }",
-                "test_value");
+                "{\"input\": \"${parameters.input}\"}", input, inputJson, MLPreProcessFunction.TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT, "texts");
     }
 
     @Test
     public void processInput_TextDocsInputDataSet_PreprocessFunction_MultiTextDoc() {
+        List<String> input = new ArrayList<>();
+        input.add("test_value1");
+        input.add("test_value2");
+        String inputJson = GsonUtil.toJson(input);
         processInput_TextDocsInputDataSet_PreprocessFunction(
-                "{\"input\": ${parameters.input}}",
-                "{\"parameters\": { \"input\": [\"test_value1\", \"test_value2\"] } }",
-                "[\"test_value1\",\"test_value2\"]");
+                "{\"input\": ${parameters.input}}", input, inputJson, MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT, "input");
     }
 
     @Test
@@ -143,7 +149,7 @@ public class ConnectorUtilsTest {
     }
 
     @Test
-    public void processOutput_NoPostprocessFunction() throws IOException {
+    public void processOutput_NoPostprocessFunction_jsonResponse() throws IOException {
         ConnectorAction predictAction = ConnectorAction.builder()
                 .actionType(ConnectorAction.ActionType.PREDICT)
                 .method("POST")
@@ -154,6 +160,24 @@ public class ConnectorUtilsTest {
         parameters.put("key1", "value1");
         Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").parameters(parameters).actions(Arrays.asList(predictAction)).build();
         ModelTensors tensors = ConnectorUtils.processOutput("{\"response\": \"test response\"}", connector, scriptService, ImmutableMap.of());
+        Assert.assertEquals(1, tensors.getMlModelTensors().size());
+        Assert.assertEquals("response", tensors.getMlModelTensors().get(0).getName());
+        Assert.assertEquals(1, tensors.getMlModelTensors().get(0).getDataAsMap().size());
+        Assert.assertEquals("test response", tensors.getMlModelTensors().get(0).getDataAsMap().get("response"));
+    }
+
+    @Test
+    public void processOutput_noPostProcessFunction_nonJsonResponse() throws IOException {
+        ConnectorAction predictAction = ConnectorAction.builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("http://test.com/mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("key1", "value1");
+        Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").parameters(parameters).actions(Arrays.asList(predictAction)).build();
+        ModelTensors tensors = ConnectorUtils.processOutput("test response", connector, scriptService, ImmutableMap.of());
         Assert.assertEquals(1, tensors.getMlModelTensors().size());
         Assert.assertEquals("response", tensors.getMlModelTensors().get(0).getName());
         Assert.assertEquals(1, tensors.getMlModelTensors().get(0).getDataAsMap().size());
@@ -186,10 +210,8 @@ public class ConnectorUtilsTest {
         Assert.assertEquals(0.0035105038, tensors.getMlModelTensors().get(0).getData()[2]);
     }
 
-    private void processInput_TextDocsInputDataSet_PreprocessFunction(String requestBody, String preprocessResult, String expectedProcessedInput) {
-        when(scriptService.compile(any(), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult));
-
-        TextDocsInputDataSet dataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test1", "test2")).build();
+    private void processInput_TextDocsInputDataSet_PreprocessFunction(String requestBody, List<String> inputs, String expectedProcessedInput, String preProcessName, String resultKey) {
+        TextDocsInputDataSet dataSet = TextDocsInputDataSet.builder().docs(inputs).build();
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(dataSet).build();
 
         ConnectorAction predictAction = ConnectorAction.builder()
@@ -197,7 +219,7 @@ public class ConnectorUtilsTest {
                 .method("POST")
                 .url("http://test.com/mock")
                 .requestBody(requestBody)
-                .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT)
+                .preProcessFunction(preProcessName)
                 .build();
         Map<String, String> parameters = new HashMap<>();
         parameters.put("key1", "value1");
@@ -205,6 +227,6 @@ public class ConnectorUtilsTest {
         RemoteInferenceInputDataSet remoteInferenceInputDataSet = ConnectorUtils.processInput(mlInput, connector, new HashMap<>(), scriptService);
         Assert.assertNotNull(remoteInferenceInputDataSet.getParameters());
         Assert.assertEquals(1, remoteInferenceInputDataSet.getParameters().size());
-        Assert.assertEquals(expectedProcessedInput, remoteInferenceInputDataSet.getParameters().get("input"));
+        Assert.assertEquals(expectedProcessedInput, remoteInferenceInputDataSet.getParameters().get(resultKey));
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
@@ -112,14 +112,10 @@ public class HttpJsonConnectorExecutorTest {
     @Test
     public void executePredict_TextDocsInput() throws IOException {
         String preprocessResult1 = "{\"parameters\": { \"input\": \"test doc1\" } }";
-        String postprocessResult1 = "{\"name\":\"sentence_embedding\",\"data_type\":\"FLOAT32\",\"shape\":[3],\"data\":[1, 2, 3]}";
         String preprocessResult2 = "{\"parameters\": { \"input\": \"test doc2\" } }";
-        String postprocessResult2 = "{\"name\":\"sentence_embedding\",\"data_type\":\"FLOAT32\",\"shape\":[3],\"data\":[4, 5, 6]}";
         when(scriptService.compile(any(), any()))
                 .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult1))
-                .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(postprocessResult1))
-                .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult2))
-                .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(postprocessResult2));
+                .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult2));
 
         ConnectorAction predictAction = ConnectorAction.builder()
                 .actionType(ConnectorAction.ActionType.PREDICT)
@@ -127,21 +123,28 @@ public class HttpJsonConnectorExecutorTest {
                 .url("http://test.com/mock")
                 .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
                 .postProcessFunction(MLPostProcessFunction.OPENAI_EMBEDDING)
-                .requestBody("{\"input\": \"${parameters.input}\"}")
+                .requestBody("{\"input\": ${parameters.input}}")
                 .build();
         Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").actions(Arrays.asList(predictAction)).build();
         HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
         executor.setScriptService(scriptService);
         when(httpClient.execute(any())).thenReturn(response);
-        String modelResponse = "{\"object\":\"list\",\"data\":[{\"object\":\"embedding\",\"index\":0,\"embedding\":[-0.014555434,-0.0002135904,0.0035105038]}],\"model\":\"text-embedding-ada-002-v2\",\"usage\":{\"prompt_tokens\":5,\"total_tokens\":5}}";
+        String modelResponse = "{\n" + "    \"object\": \"list\",\n" + "    \"data\": [\n" + "        {\n"
+            + "            \"object\": \"embedding\",\n" + "            \"index\": 0,\n" + "            \"embedding\": [\n"
+            + "                -0.014555434,\n" + "                -0.002135904,\n" + "                0.0035105038\n" + "            ]\n"
+            + "        },\n" + "        {\n" + "            \"object\": \"embedding\",\n" + "            \"index\": 1,\n"
+            + "            \"embedding\": [\n" + "                -0.014555434,\n" + "                -0.002135904,\n"
+            + "                0.0035105038\n" + "            ]\n" + "        }\n" + "    ],\n"
+            + "    \"model\": \"text-embedding-ada-002-v2\",\n" + "    \"usage\": {\n" + "        \"prompt_tokens\": 5,\n"
+            + "        \"total_tokens\": 5\n" + "    }\n" + "}";
         HttpEntity entity = new StringEntity(modelResponse);
         when(response.getEntity()).thenReturn(entity);
         when(executor.getHttpClient()).thenReturn(httpClient);
         MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test doc1", "test doc2")).build();
         ModelTensorOutput modelTensorOutput = executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
-        Assert.assertEquals(2, modelTensorOutput.getMlModelOutputs().size());
+        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());
         Assert.assertEquals("sentence_embedding", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getName());
-        Assert.assertArrayEquals(new Number[] {1, 2, 3}, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getData());
-        Assert.assertArrayEquals(new Number[] {4, 5, 6}, modelTensorOutput.getMlModelOutputs().get(1).getMlModelTensors().get(0).getData());
+        Assert.assertArrayEquals(new Number[] {-0.014555434, -0.002135904, 0.0035105038}, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getData());
+        Assert.assertArrayEquals(new Number[] {-0.014555434, -0.002135904, 0.0035105038}, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(1).getData());
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/utils/ScriptUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/utils/ScriptUtilsTest.java
@@ -1,0 +1,59 @@
+package org.opensearch.ml.engine.utils;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.ingest.TestTemplateService;
+import org.opensearch.ml.common.connector.MLPostProcessFunction;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.script.ScriptService;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class ScriptUtilsTest {
+
+    @Mock
+    ScriptService scriptService;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(scriptService.compile(any(), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory("test result"));
+    }
+
+    @Test
+    public void test_executePreprocessFunction() {
+        Optional<String> resultOpt = ScriptUtils.executePreprocessFunction(scriptService, "any function", Collections.singletonList("any input"));
+        assertEquals("test result", resultOpt.get());
+    }
+
+    @Test
+    public void test_executeBuildInPostProcessFunction() {
+        List<List<Float>> input = Arrays.asList(Arrays.asList(1.0f, 2.0f), Arrays.asList(3.0f, 4.0f));
+        List<ModelTensor> modelTensors = ScriptUtils.executeBuildInPostProcessFunction(input, MLPostProcessFunction.get(MLPostProcessFunction.NEURAL_SEARCH_EMBEDDING));
+        assertNotNull(modelTensors);
+        assertEquals(2, modelTensors.size());
+    }
+
+    @Test
+    public void test_executePostProcessFunction() {
+        when(scriptService.compile(any(), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory("{\"result\": \"test result\"}"));
+        Optional<String> resultOpt = ScriptUtils.executePostProcessFunction(scriptService, "any function", "{\"result\": \"test result\"}");
+        assertEquals("{\"result\": \"test result\"}", resultOpt.get());
+    }
+
+    @Test
+    public void test_executeScript() {
+        String result = ScriptUtils.executeScript(scriptService, "any function", Collections.singletonMap("key", "value"));
+        assertEquals("test result", result);
+    }
+}


### PR DESCRIPTION
### Description
ml-commons has two default pre/post process function which are for OpenAI and Cohere and written in painless script. There's no default pre/post process function for neural search plugin, and if user want to use neural search with remote model, user has to write complex painless script which is a heavy burden. This PR do two things: 
1. Add default pre/post process function for neural search plugin and user only need to define a simple string like: `connector.pre_process.neural_search.text_embedding` or `connector.post_process.neural_search.text_embedding` to use neural search plugin easily.
2. Change default painless script to java code to make them more readable to both coder and user.
 
### Issues Resolved
NA
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
