### PR TITLE
[Backport to main]Add a setting to enable/disable model url in register API. (#871)

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -385,7 +385,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
         RestMLDeleteTaskAction restMLDeleteTaskAction = new RestMLDeleteTaskAction();
         RestMLSearchTaskAction restMLSearchTaskAction = new RestMLSearchTaskAction();
         RestMLProfileAction restMLProfileAction = new RestMLProfileAction(clusterService);
-        RestMLRegisterModelAction restMLRegisterModelAction = new RestMLRegisterModelAction();
+        RestMLRegisterModelAction restMLRegisterModelAction = new RestMLRegisterModelAction(clusterService, settings);
         RestMLDeployModelAction restMLDeployModelAction = new RestMLDeployModelAction();
         RestMLUndeployModelAction restMLUndeployModelAction = new RestMLUndeployModelAction(clusterService, settings);
         RestMLRegisterModelMetaAction restMLRegisterModelMetaAction = new RestMLRegisterModelMetaAction();
@@ -506,7 +506,8 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin {
                 MLCommonsSettings.ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN,
                 MLCommonsSettings.ML_COMMONS_ENABLE_INHOUSE_PYTHON_MODEL,
                 MLCommonsSettings.ML_COMMONS_MODEL_AUTO_REDEPLOY_ENABLE,
-                MLCommonsSettings.ML_COMMONS_MODEL_AUTO_REDEPLOY_LIFETIME_RETRY_TIMES
+                MLCommonsSettings.ML_COMMONS_MODEL_AUTO_REDEPLOY_LIFETIME_RETRY_TIMES,
+                MLCommonsSettings.ML_COMMONS_ALLOW_MODEL_URL
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLRegisterModelAction.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.rest;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ALLOW_MODEL_URL;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_DEPLOY_MODEL;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_VERSION;
@@ -16,6 +17,8 @@ import java.util.List;
 import java.util.Locale;
 
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.transport.register.MLRegisterModelAction;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
@@ -29,11 +32,22 @@ import com.google.common.collect.ImmutableList;
 
 public class RestMLRegisterModelAction extends BaseRestHandler {
     private static final String ML_REGISTER_MODEL_ACTION = "ml_register_model_action";
+    private volatile boolean isModelUrlAllowed;
 
     /**
      * Constructor
      */
     public RestMLRegisterModelAction() {}
+
+    /**
+     * Constructor
+     * @param clusterService cluster service
+     * @param settings settings
+     */
+    public RestMLRegisterModelAction(ClusterService clusterService, Settings settings) {
+        isModelUrlAllowed = ML_COMMONS_ALLOW_MODEL_URL.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_ALLOW_MODEL_URL, it -> isModelUrlAllowed = it);
+    }
 
     @Override
     public String getName() {
@@ -93,6 +107,11 @@ public class RestMLRegisterModelAction extends BaseRestHandler {
         MLRegisterModelInput mlInput = modelName == null
             ? MLRegisterModelInput.parse(parser, loadModel)
             : MLRegisterModelInput.parse(parser, modelName, version, loadModel);
+        if (mlInput.getUrl() != null && !isModelUrlAllowed) {
+            throw new IllegalArgumentException(
+                "To upload custom model user needs to enable allow_registering_model_via_url settings. Otherwise please use opensearch pre-trained models."
+            );
+        }
         return new MLRegisterModelRequest(mlInput);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -87,4 +87,8 @@ public final class MLCommonsSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
+
+    // This setting is to enable/disable model url in model register API.
+    public static final Setting<Boolean> ML_COMMONS_ALLOW_MODEL_URL = Setting
+        .boolSetting("plugins.ml_commons.allow_registering_model_via_url", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -120,6 +120,17 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
             );
         assertEquals(200, response.getStatusLine().getStatusCode());
 
+        response = TestHelper
+            .makeRequest(
+                client(),
+                "PUT",
+                "_cluster/settings",
+                null,
+                "{\"persistent\":{\"plugins.ml_commons.allow_registering_model_via_url\":true}}",
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+            );
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
         String jsonEntity = "{\n"
             + "  \"persistent\" : {\n"
             + "    \"plugins.ml_commons.native_memory_threshold\" : 100 \n"

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRegisterModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRegisterModelActionTests.java
@@ -8,6 +8,8 @@ package org.opensearch.ml.rest;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ALLOW_MODEL_URL;
+import static org.opensearch.ml.utils.TestHelper.clusterSetting;
 
 import java.util.HashMap;
 import java.util.List;
@@ -15,9 +17,14 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
@@ -39,6 +46,8 @@ import org.opensearch.threadpool.ThreadPool;
 import com.google.gson.Gson;
 
 public class RestMLRegisterModelActionTests extends OpenSearchTestCase {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
 
     private RestMLRegisterModelAction restMLRegisterModelAction;
     private NodeClient client;
@@ -47,9 +56,18 @@ public class RestMLRegisterModelActionTests extends OpenSearchTestCase {
     @Mock
     RestChannel channel;
 
+    @Mock
+    private ClusterService clusterService;
+
+    private Settings settings;
+
     @Before
     public void setup() {
-        restMLRegisterModelAction = new RestMLRegisterModelAction();
+        MockitoAnnotations.openMocks(this);
+        settings = Settings.builder().put(ML_COMMONS_ALLOW_MODEL_URL.getKey(), true).build();
+        ClusterSettings clusterSettings = clusterSetting(settings, ML_COMMONS_ALLOW_MODEL_URL);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        restMLRegisterModelAction = new RestMLRegisterModelAction(clusterService, settings);
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
         client = spy(new NodeClient(Settings.EMPTY, threadPool));
         doAnswer(invocation -> {
@@ -110,6 +128,20 @@ public class RestMLRegisterModelActionTests extends OpenSearchTestCase {
         assertEquals("test_model_with_modelId", registerModelInput.getModelName());
         assertEquals("1", registerModelInput.getVersion());
         assertEquals("TORCH_SCRIPT", registerModelInput.getModelFormat().toString());
+    }
+
+    public void testRegisterModelUrlNotAllowed() throws Exception {
+        settings = Settings.builder().put(ML_COMMONS_ALLOW_MODEL_URL.getKey(), false).build();
+        ClusterSettings clusterSettings = clusterSetting(settings, ML_COMMONS_ALLOW_MODEL_URL);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        restMLRegisterModelAction = new RestMLRegisterModelAction(clusterService, settings);
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule
+            .expectMessage(
+                "To upload custom model user needs to enable allow_registering_model_via_url settings. Otherwise please use opensearch pre-trained models."
+            );
+        RestRequest request = getRestRequest();
+        restMLRegisterModelAction.handleRequest(request, channel, client);
     }
 
     public void testRegisterModelRequest_NullModelID() throws Exception {


### PR DESCRIPTION
* Add a setting to enable/disable model url in register API.



* move the setting from transport to rest api



* remove transport setting



* Update plugin/src/main/java/org/opensearch/ml/rest/RestMLRegisterModelAction.java




* fix ut



* fix spotless



* address comments



* rename the setting



* fix a UT bug



---------

### Description
Backport https://github.com/opensearch-project/ml-commons/pull/871 to main
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
