### PR TITLE
Bump commons-lang3 version to 3.13.0

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.13.0'
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.19.0"
@@ -322,7 +322,7 @@ jacocoTestCoverageVerification {
 check.dependsOn jacocoTestCoverageVerification
 
 configurations.all {
-    resolutionStrategy.force 'org.apache.commons:commons-lang3:3.10'
+    resolutionStrategy.force 'org.apache.commons:commons-lang3:3.13.0'
     resolutionStrategy.force 'commons-logging:commons-logging:1.2'
     resolutionStrategy.force 'org.objenesis:objenesis:3.2'
     resolutionStrategy.force 'net.java.dev.jna:jna:5.11.0'


### PR DESCRIPTION
### Description
Fixed jarhell errors related to update of commons-lang library, we're seeing those errors in neural-search CI for main branch. Update version to 3.13.0 to match same in core
 
 
### Check List
- [X] All tests pass
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
