### PR TITLE
Changing messaging for ILlegalArgumentException on duplicate model gr…

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -75,11 +75,7 @@ public class MLModelGroupManager {
                             listener
                                 .onFailure(
                                     new IllegalArgumentException(
-                                        "The name you provided is already being used by another model with ID: "
-                                            + id
-                                            + ". Please provide a different name or add \"model_group_id\": \""
-                                            + id
-                                            + "\" to request body"
+                                        "The name you provided is already being used by a model group with ID: " + id + "."
                                     )
                                 );
                         }

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelGroupManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelGroupManagerTests.java
@@ -143,7 +143,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
-            "The name you provided is already being used by another model with ID: model_group_ID. Please provide a different name or add \"model_group_id\": \"model_group_ID\" to request body",
+            "The name you provided is already being used by a model group with ID: model_group_ID.",
             argumentCaptor.getValue().getMessage()
         );
 


### PR DESCRIPTION
…oup creation.

### Description
Updating the error message shown when attempting to create a non-unique model group. 
 
### Issues Resolved
#1290 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
