### PR TITLE
Bump aws-encryption-sdk-java to fix CVE-2023-33201

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.20.19')
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:apache-client'
-    implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.0'
+    implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
     implementation 'com.jayway.jsonpath:json-path:2.8.0'
     implementation group: 'org.json', name: 'json', version: '20230227'
 }


### PR DESCRIPTION
### Description
Bump aws-encryption-sdk-java version to fix CVE-2023-33201
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
