### PR TITLE
Fix unassigned ml system shard replicas

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -35,13 +35,13 @@ public class CommonValue {
     public static final String ML_MODEL_GROUP_INDEX = ".plugins-ml-model-group";
     public static final String ML_MODEL_INDEX = ".plugins-ml-model";
     public static final String ML_TASK_INDEX = ".plugins-ml-task";
-    public static final Integer ML_MODEL_GROUP_INDEX_SCHEMA_VERSION = 1;
-    public static final Integer ML_MODEL_INDEX_SCHEMA_VERSION = 6;
+    public static final Integer ML_MODEL_GROUP_INDEX_SCHEMA_VERSION = 2;
+    public static final Integer ML_MODEL_INDEX_SCHEMA_VERSION = 7;
     public static final String ML_CONNECTOR_INDEX = ".plugins-ml-connector";
-    public static final Integer ML_TASK_INDEX_SCHEMA_VERSION = 1;
-    public static final Integer ML_CONNECTOR_SCHEMA_VERSION = 1;
+    public static final Integer ML_TASK_INDEX_SCHEMA_VERSION = 2;
+    public static final Integer ML_CONNECTOR_SCHEMA_VERSION = 2;
     public static final String ML_CONFIG_INDEX = ".plugins-ml-config";
-    public static final Integer ML_CONFIG_INDEX_SCHEMA_VERSION = 1;
+    public static final Integer ML_CONFIG_INDEX_SCHEMA_VERSION = 2;
     public static final String USER_FIELD_MAPPING = "      \""
             + CommonValue.USER
             + "\": {\n"

--- a/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
@@ -117,7 +117,7 @@ public class MLIndicesHandler {
                                                     internalListener.onFailure(exception);
                                                 }));
                                         } else {
-                                            internalListener.onFailure(new MLException("Failed to update index " + indexName));
+                                            internalListener.onFailure(new MLException("Failed to update index: " + indexName));
                                         }
                                     }, exception -> {
                                         log.error("Failed to update index " + indexName, exception);

--- a/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
@@ -68,7 +68,7 @@ public class MLIndicesHandler {
     public void initMLIndexIfAbsent(MLIndex index, ActionListener<Boolean> listener) {
         String indexName = index.getIndexName();
         String mapping = index.getMapping();
-        final Map<String, Object> indexSettings = Map.of("index.auto_expand_replicas", "0-6");
+        final Map<String, Object> indexSettings = Map.of("index.auto_expand_replicas", "0-5");
 
         try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());

--- a/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
@@ -109,10 +109,10 @@ public class MLIndicesHandler {
                                                     internalListener.onResponse(true);
                                                 } else {
                                                     internalListener
-                                                        .onFailure(new MLException("Failed to update index setting: " + indexName));
+                                                        .onFailure(new MLException("Failed to update index setting for: " + indexName));
                                                 }
                                             }, exception -> {
-                                                log.error("Failed to update index setting: " + indexName, exception);
+                                                log.error("Failed to update index setting for: " + indexName, exception);
                                                 internalListener.onFailure(exception);
                                             }));
                                     }, exception -> {

--- a/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
@@ -116,6 +116,8 @@ public class MLIndicesHandler {
                                                     log.error("Failed to update index setting for: " + indexName, exception);
                                                     internalListener.onFailure(exception);
                                                 }));
+                                        } else {
+                                            internalListener.onFailure(new MLException("Failed to update index" + indexName));
                                         }
                                     }, exception -> {
                                         log.error("Failed to update index " + indexName, exception);

--- a/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
@@ -117,10 +117,10 @@ public class MLIndicesHandler {
                                                     internalListener.onFailure(exception);
                                                 }));
                                         } else {
-                                            internalListener.onFailure(new MLException("Failed to update index" + indexName));
+                                            internalListener.onFailure(new MLException("Failed to update index " + indexName));
                                         }
                                     }, exception -> {
-                                        log.error("Failed to update index: " + indexName, exception);
+                                        log.error("Failed to update index " + indexName, exception);
                                         internalListener.onFailure(exception);
                                     })
                                 );

--- a/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
@@ -98,23 +98,25 @@ public class MLIndicesHandler {
                                 .putMapping(
                                     new PutMappingRequest().indices(indexName).source(mapping, XContentType.JSON),
                                     ActionListener.wrap(response -> {
-                                        UpdateSettingsRequest updateSettingRequest = new UpdateSettingsRequest();
-                                        updateSettingRequest.indices(indexName).settings(indexSettings);
-                                        client
-                                            .admin()
-                                            .indices()
-                                            .updateSettings(updateSettingRequest, ActionListener.wrap(updateResponse -> {
-                                                if (response.isAcknowledged()) {
-                                                    indexMappingUpdated.get(indexName).set(true);
-                                                    internalListener.onResponse(true);
-                                                } else {
-                                                    internalListener
-                                                        .onFailure(new MLException("Failed to update index setting for: " + indexName));
-                                                }
-                                            }, exception -> {
-                                                log.error("Failed to update index setting for: " + indexName, exception);
-                                                internalListener.onFailure(exception);
-                                            }));
+                                        if (response.isAcknowledged()) {
+                                            UpdateSettingsRequest updateSettingRequest = new UpdateSettingsRequest();
+                                            updateSettingRequest.indices(indexName).settings(indexSettings);
+                                            client
+                                                .admin()
+                                                .indices()
+                                                .updateSettings(updateSettingRequest, ActionListener.wrap(updateResponse -> {
+                                                    if (response.isAcknowledged()) {
+                                                        indexMappingUpdated.get(indexName).set(true);
+                                                        internalListener.onResponse(true);
+                                                    } else {
+                                                        internalListener
+                                                            .onFailure(new MLException("Failed to update index setting for: " + indexName));
+                                                    }
+                                                }, exception -> {
+                                                    log.error("Failed to update index setting for: " + indexName, exception);
+                                                    internalListener.onFailure(exception);
+                                                }));
+                                        }
                                     }, exception -> {
                                         log.error("Failed to update index " + indexName, exception);
                                         internalListener.onFailure(exception);

--- a/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
@@ -108,7 +108,7 @@ public class MLIndicesHandler {
                                                     indexMappingUpdated.get(indexName).set(true);
                                                     internalListener.onResponse(true);
                                                 } else {
-                                                    internalListener.onFailure(new MLException("Failed to update index: " + indexName));
+                                                    internalListener.onFailure(new MLException("Failed to update index setting: " + indexName));
                                                 }
                                             }, internalListener::onFailure));
                                     }, exception -> {

--- a/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/indices/MLIndicesHandler.java
@@ -120,7 +120,7 @@ public class MLIndicesHandler {
                                             internalListener.onFailure(new MLException("Failed to update index" + indexName));
                                         }
                                     }, exception -> {
-                                        log.error("Failed to update index " + indexName, exception);
+                                        log.error("Failed to update index: " + indexName, exception);
                                         internalListener.onFailure(exception);
                                     })
                                 );


### PR DESCRIPTION
### Description
In previous ml system shard replicas always stays on an arbitrary number and cannot expand automatically, which will cause unassigned shards and yellow cluster problem. This PR can resolve this issue.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
