### PR TITLE
return model id in registering remote model

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelResponse.java
@@ -18,15 +18,18 @@ import java.io.IOException;
 @Getter
 public class MLRegisterModelResponse extends ActionResponse implements ToXContentObject {
     public static final String TASK_ID_FIELD = "task_id";
+    public static final String MODEL_ID_FIELD = "model_id";
     public static final String STATUS_FIELD = "status";
 
     private String taskId;
     private String status;
+    private String modelId;
 
     public MLRegisterModelResponse(StreamInput in) throws IOException {
         super(in);
         this.taskId = in.readString();
         this.status = in.readString();
+        this.modelId = in.readOptionalString();
     }
 
     public MLRegisterModelResponse(String taskId, String status) {
@@ -34,10 +37,17 @@ public class MLRegisterModelResponse extends ActionResponse implements ToXConten
         this.status= status;
     }
 
+    public MLRegisterModelResponse(String taskId, String status, String modelId) {
+        this.taskId = taskId;
+        this.status= status;
+        this.modelId = modelId;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(taskId);
         out.writeString(status);
+        out.writeOptionalString(modelId);
     }
 
     @Override
@@ -45,6 +55,9 @@ public class MLRegisterModelResponse extends ActionResponse implements ToXConten
         builder.startObject();
         builder.field(TASK_ID_FIELD, taskId);
         builder.field(STATUS_FIELD, status);
+        if (modelId != null) {
+            builder.field(MODEL_ID_FIELD, modelId);
+        }
         builder.endObject();
         return builder;
     }

--- a/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelResponseTest.java
@@ -16,24 +16,27 @@ public class MLRegisterModelResponseTest {
 
     private String taskId;
     private String status;
+    private String modelId;
 
     @Before
     public void setUp() throws Exception {
         taskId = "test_id";
         status = "test";
+        modelId = "model_id";
     }
 
     @Test
     public void writeTo_Success() throws IOException {
         // Setup
         BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
-        MLRegisterModelResponse response = new MLRegisterModelResponse(taskId, status);
+        MLRegisterModelResponse response = new MLRegisterModelResponse(taskId, status, modelId);
         // Run the test
         response.writeTo(bytesStreamOutput);
         MLRegisterModelResponse parsedResponse = new MLRegisterModelResponse(bytesStreamOutput.bytes().streamInput());
         // Verify the results
         assertEquals(response.getTaskId(), parsedResponse.getTaskId());
         assertEquals(response.getStatus(), parsedResponse.getStatus());
+        assertEquals(response.getModelId(), parsedResponse.getModelId());
     }
 
     @Test
@@ -48,5 +51,19 @@ public class MLRegisterModelResponseTest {
         // Verify the results
         assertEquals("{\"task_id\":\"test_id\"," +
                 "\"status\":\"test\"}", jsonStr);
+    }
+
+    @Test
+    public void testToXContent_withModelId() throws IOException {
+        // Setup
+        MLRegisterModelResponse response = new MLRegisterModelResponse(taskId, status, modelId);
+        // Run the test
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(builder);
+        String jsonStr = builder.toString();
+        // Verify the results
+        assertEquals("{\"task_id\":\"test_id\"," +
+                "\"status\":\"test\"," + "\"model_id\":\"model_id\"}", jsonStr);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -233,6 +233,7 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
                 throw new IllegalArgumentException("URL can't match trusted url regex");
             }
         }
+        System.out.println("registering the model");
         boolean isAsync = registerModelInput.getFunctionName() != FunctionName.REMOTE;
         MLTask mlTask = MLTask
             .builder()
@@ -249,8 +250,8 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
             mlTaskManager.createMLTask(mlTask, ActionListener.wrap(response -> {
                 String taskId = response.getId();
                 mlTask.setTaskId(taskId);
-                mlModelManager.registerMLModel(registerModelInput, mlTask);
-                listener.onResponse(new MLRegisterModelResponse(taskId, MLTaskState.CREATED.name()));
+                System.out.println("mlModelManager calls registerMLRemoteModel");
+                mlModelManager.registerMLRemoteModel(registerModelInput, mlTask, listener);
             }, e -> {
                 logException("Failed to register model", e, log);
                 listener.onFailure(e);

--- a/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
@@ -40,6 +40,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
@@ -202,6 +203,7 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
         when(node2.getId()).thenReturn("node2Id");
 
         doAnswer(invocation -> { return null; }).when(mlModelManager).registerMLModel(any(), any());
+        doAnswer(invocation -> { return null; }).when(mlModelManager).registerMLRemoteModel(any(), any(), any());
 
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -358,7 +360,7 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
         MLRegisterModelResponse response = mock(MLRegisterModelResponse.class);
         transportRegisterModelAction.doExecute(task, request, actionListener);
         ArgumentCaptor<MLRegisterModelResponse> argumentCaptor = ArgumentCaptor.forClass(MLRegisterModelResponse.class);
-        verify(actionListener).onResponse(argumentCaptor.capture());
+        verify(mlModelManager).registerMLRemoteModel(eq(input), isA(MLTask.class), eq(actionListener));
     }
 
     public void test_execute_registerRemoteModel_withConnectorId_noPermissionToConnectorId() {
@@ -424,7 +426,7 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
         MLRegisterModelResponse response = mock(MLRegisterModelResponse.class);
         transportRegisterModelAction.doExecute(task, request, actionListener);
         ArgumentCaptor<MLRegisterModelResponse> argumentCaptor = ArgumentCaptor.forClass(MLRegisterModelResponse.class);
-        verify(actionListener).onResponse(argumentCaptor.capture());
+        verify(mlModelManager).registerMLRemoteModel(eq(input), isA(MLTask.class), eq(actionListener));
     }
 
     public void test_execute_registerRemoteModel_withInternalConnector_connectorIsNull() {


### PR DESCRIPTION
### Description
This change only applies to registering remote models. Registering a remote model doesn't need Asynchronize, it should return model_id right away in the response. 

**Before this change:**
POST /_plugins/_ml/models/_register
{
    "name": "openAI-GPT-3.5 completions",
    "function_name": "remote",
    "description": "test model",
    "connector_id": "kUFFL4kB4ubqQRzeQ_r-"
}
Response:
{
  "task_id": "l0FIL4kB4ubqQRzeKvpV",
  "status": "CREATED"
}

**After this change:**
POST /_plugins/_ml/models/_register
{
    "name": "openAI-GPT-3.5 completions",
    "function_name": "remote",
    "description": "test model",
    "connector_id": "kUFFL4kB4ubqQRzeQ_r-"
}
Response:
{
  "task_id": "l0FIL4kB4ubqQRzeKvpV",
  "status": "CREATED",
  "model_id": "xxxxxxxxxxxxxx",
}
 
