### PR TITLE
adding model level metric in node level

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeResponse.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeResponse.java
@@ -33,7 +33,7 @@ public class MLStatsNodeResponse extends BaseNodeResponse implements ToXContentF
      */
     private Map<FunctionName, MLAlgoStats> algorithmStats;
     /**
-     * Model stats which includes stats level stats.
+     * Model stats which includes model level stats.
      *
      * Example: {model_id: { predict: { request_count: 1} }}
      */

--- a/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeResponse.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodeResponse.java
@@ -63,7 +63,12 @@ public class MLStatsNodeResponse extends BaseNodeResponse implements ToXContentF
         this.nodeStats = nodeStats;
     }
 
-    public MLStatsNodeResponse(DiscoveryNode node, Map<MLNodeLevelStat, Object> nodeStats, Map<FunctionName, MLAlgoStats> algorithmStats, Map<String, MLModelStats> modelStats) {
+    public MLStatsNodeResponse(
+        DiscoveryNode node,
+        Map<MLNodeLevelStat, Object> nodeStats,
+        Map<FunctionName, MLAlgoStats> algorithmStats,
+        Map<String, MLModelStats> modelStats
+    ) {
         super(node);
         this.nodeStats = nodeStats;
         this.algorithmStats = algorithmStats;
@@ -158,7 +163,6 @@ public class MLStatsNodeResponse extends BaseNodeResponse implements ToXContentF
     public boolean hasModelStats(String modelId) {
         return modelStats != null && modelStats.containsKey(modelId);
     }
-
 
     public MLAlgoStats getAlgorithmStats(FunctionName algorithm) {
         return algorithmStats == null ? null : algorithmStats.get(algorithm);

--- a/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodesResponse.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/stats/MLStatsNodesResponse.java
@@ -60,7 +60,7 @@ public class MLStatsNodesResponse extends BaseNodesResponse<MLStatsNodeResponse>
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         String nodeId;
         DiscoveryNode node;
-        builder.startObject("nodes");
+        builder.startObject(NODES_KEY);
         for (MLStatsNodeResponse mlStats : getNodes()) {
             node = mlStats.getNode();
             nodeId = node.getId();

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -293,7 +293,6 @@ public class MLModelManager {
 
                 client.index(indexRequest, ActionListener.wrap(response -> {
                     log.debug("Index model meta doc successfully {}", modelName);
-                    mlStats.createModelCounterStatIfAbsent(response.getId(), REGISTER, ML_ACTION_REQUEST_COUNT).increment();
                     wrappedListener.onResponse(response.getId());
                 }, e -> {
                     log.error("Failed to index model meta doc", e);
@@ -579,7 +578,6 @@ public class MLModelManager {
                     String modelId = modelMetaRes.getId();
                     mlTask.setModelId(modelId);
                     log.info("create new model meta doc {} for upload task {}", modelId, taskId);
-                    mlStats.createModelCounterStatIfAbsent(modelId, REGISTER, ML_ACTION_REQUEST_COUNT).increment();
                     mlTaskManager.updateMLTask(taskId, ImmutableMap.of(MODEL_ID_FIELD, modelId, STATE_FIELD, COMPLETED), 5000, true);
                     if (registerModelInput.isDeployModel()) {
                         deployModelAfterRegistering(registerModelInput, modelId);
@@ -642,7 +640,6 @@ public class MLModelManager {
                     String modelId = modelMetaRes.getId();
                     mlTask.setModelId(modelId);
                     log.info("create new model meta doc {} for register model task {}", modelId, taskId);
-                    mlStats.createModelCounterStatIfAbsent(modelId, REGISTER, ML_ACTION_REQUEST_COUNT).increment();
                     // model group id is not present in request body.
                     registerModel(registerModelInput, taskId, functionName, modelName, version, modelId);
                 }, e -> {

--- a/plugin/src/main/java/org/opensearch/ml/stats/MLModelStats.java
+++ b/plugin/src/main/java/org/opensearch/ml/stats/MLModelStats.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.stats;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
+public class MLModelStats implements ToXContentFragment, Writeable {
+
+    /**
+     * Model stats.
+     * Key: Model Id.
+     * Value: MLActionStats which contains action stat/value map.
+     *
+     * Example: {predict: { request_count: 1}}
+     */
+    private Map<ActionName, MLActionStats> modelStats;
+
+    public MLModelStats(StreamInput in) throws IOException {
+        this.modelStats = in.readMap(stream -> stream.readEnum(ActionName.class), MLActionStats::new);
+    }
+
+    public MLModelStats(Map<ActionName, MLActionStats> modelStats) {
+        this.modelStats = modelStats;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeMap(modelStats, (stream, v) -> stream.writeEnum(v), (stream, stats) -> stats.writeTo(stream));
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        if (modelStats != null && modelStats.size() > 0) {
+            for (Map.Entry<ActionName, MLActionStats> entry : modelStats.entrySet()) {
+                builder.startObject(entry.getKey().name().toLowerCase(Locale.ROOT));
+                entry.getValue().toXContent(builder, params);
+                builder.endObject();
+            }
+        }
+        return builder;
+    }
+
+    public MLActionStats getActionStats(ActionName action) {
+        return modelStats == null ? null : modelStats.get(action);
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/stats/MLModelStats.java
+++ b/plugin/src/main/java/org/opensearch/ml/stats/MLModelStats.java
@@ -27,7 +27,9 @@ public class MLModelStats implements ToXContentFragment, Writeable {
     private Map<ActionName, MLActionStats> modelStats;
 
     public MLModelStats(StreamInput in) throws IOException {
-        this.modelStats = in.readMap(stream -> stream.readEnum(ActionName.class), MLActionStats::new);
+        if (in.readBoolean()) {
+            this.modelStats = in.readMap(stream -> stream.readEnum(ActionName.class), MLActionStats::new);
+        }
     }
 
     public MLModelStats(Map<ActionName, MLActionStats> modelStats) {
@@ -37,7 +39,10 @@ public class MLModelStats implements ToXContentFragment, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (modelStats != null && modelStats.size() > 0) {
+            out.writeBoolean(true);
             out.writeMap(modelStats, (stream, v) -> stream.writeEnum(v), (stream, stats) -> stats.writeTo(stream));
+        } else {
+            out.writeBoolean(false);
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/stats/MLModelStats.java
+++ b/plugin/src/main/java/org/opensearch/ml/stats/MLModelStats.java
@@ -5,15 +5,15 @@
 
 package org.opensearch.ml.stats;
 
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
-
-import java.io.IOException;
-import java.util.Locale;
-import java.util.Map;
 
 public class MLModelStats implements ToXContentFragment, Writeable {
 

--- a/plugin/src/main/java/org/opensearch/ml/stats/MLModelStats.java
+++ b/plugin/src/main/java/org/opensearch/ml/stats/MLModelStats.java
@@ -36,7 +36,9 @@ public class MLModelStats implements ToXContentFragment, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(modelStats, (stream, v) -> stream.writeEnum(v), (stream, stats) -> stats.writeTo(stream));
+        if (modelStats != null && modelStats.size() > 0) {
+            out.writeMap(modelStats, (stream, v) -> stream.writeEnum(v), (stream, stats) -> stats.writeTo(stream));
+        }
     }
 
     @Override

--- a/plugin/src/main/java/org/opensearch/ml/stats/MLStatLevel.java
+++ b/plugin/src/main/java/org/opensearch/ml/stats/MLStatLevel.java
@@ -9,6 +9,7 @@ public enum MLStatLevel {
     CLUSTER,
     NODE,
     ALGORITHM,
+    MODEL,
     ACTION;
 
     public static MLStatLevel from(String value) {

--- a/plugin/src/main/java/org/opensearch/ml/stats/MLStatsInput.java
+++ b/plugin/src/main/java/org/opensearch/ml/stats/MLStatsInput.java
@@ -216,7 +216,7 @@ public class MLStatsInput implements ToXContentObject, Writeable {
             .actionLevelStats(actionLevelStats)
             .nodeIds(nodeIds)
             .algorithms(algorithms)
-                .models(models)
+            .models(models)
             .actions(actions)
             .build();
     }
@@ -311,7 +311,7 @@ public class MLStatsInput implements ToXContentObject, Writeable {
         }
         return !targetStatLevels.contains(MLStatLevel.NODE)
             && !targetStatLevels.contains(MLStatLevel.ALGORITHM)
-                && !targetStatLevels.contains(MLStatLevel.MODEL)
+            && !targetStatLevels.contains(MLStatLevel.MODEL)
             && !targetStatLevels.contains(MLStatLevel.ACTION);
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -204,6 +204,9 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
         mlStats
             .createCounterStatIfAbsent(mlTask.getFunctionName(), ActionName.PREDICT, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
             .increment();
+        mlStats
+                .createModelCounterStatIfAbsent(modelId, ActionName.PREDICT, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
+                .increment();
         mlTask.setState(MLTaskState.RUNNING);
         mlTaskManager.add(mlTask);
 
@@ -230,7 +233,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
                     throw new IllegalArgumentException("Model not ready to be used: " + modelId);
                 }
             } catch (Exception e) {
-                handlePredictFailure(mlTask, internalListener, e, false);
+                handlePredictFailure(mlTask, internalListener, e, false, modelId);
             }
 
             // search model by model id.
@@ -256,7 +259,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
                             OpenSearchException e = new OpenSearchException(
                                 "User: " + requestUser.getName() + " does not have permissions to run predict by model: " + modelId
                             );
-                            handlePredictFailure(mlTask, internalListener, e, false);
+                            handlePredictFailure(mlTask, internalListener, e, false, modelId);
                             return;
                         }
                         // run predict
@@ -277,18 +280,18 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
 
                 }, e -> {
                     log.error("Failed to predict " + mlInput.getAlgorithm() + ", modelId: " + mlTask.getModelId(), e);
-                    handlePredictFailure(mlTask, internalListener, e, true);
+                    handlePredictFailure(mlTask, internalListener, e, true, modelId);
                 });
                 GetRequest getRequest = new GetRequest(ML_MODEL_INDEX, mlTask.getModelId());
                 client.get(getRequest, threadedActionListener(ActionListener.runBefore(getModelListener, () -> context.restore())));
             } catch (Exception e) {
                 log.error("Failed to get model " + mlTask.getModelId(), e);
-                handlePredictFailure(mlTask, internalListener, e, true);
+                handlePredictFailure(mlTask, internalListener, e, true, modelId);
             }
         } else {
             IllegalArgumentException e = new IllegalArgumentException("ModelId is invalid");
             log.error("ModelId is invalid", e);
-            handlePredictFailure(mlTask, internalListener, e, false);
+            handlePredictFailure(mlTask, internalListener, e, false, modelId);
         }
     }
 
@@ -296,11 +299,12 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
         return new ThreadedActionListener<>(log, threadPool, PREDICT_THREAD_POOL, listener, false);
     }
 
-    private void handlePredictFailure(MLTask mlTask, ActionListener<MLTaskResponse> listener, Exception e, boolean trackFailure) {
+    private void handlePredictFailure(MLTask mlTask, ActionListener<MLTaskResponse> listener, Exception e, boolean trackFailure, String modelId) {
         if (trackFailure) {
             mlStats
                 .createCounterStatIfAbsent(mlTask.getFunctionName(), ActionName.PREDICT, MLActionLevelStat.ML_ACTION_FAILURE_COUNT)
                 .increment();
+            mlStats.createModelCounterStatIfAbsent(modelId, ActionName.PREDICT, MLActionLevelStat.ML_ACTION_FAILURE_COUNT);
             mlStats.getStat(MLNodeLevelStat.ML_FAILURE_COUNT).increment();
         }
         handleAsyncMLTaskFailure(mlTask, e);

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -204,7 +204,9 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
         mlStats
             .createCounterStatIfAbsent(mlTask.getFunctionName(), ActionName.PREDICT, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
             .increment();
-        mlStats.createModelCounterStatIfAbsent(modelId, ActionName.PREDICT, MLActionLevelStat.ML_ACTION_REQUEST_COUNT).increment();
+        if (modelId != null) {
+            mlStats.createModelCounterStatIfAbsent(modelId, ActionName.PREDICT, MLActionLevelStat.ML_ACTION_REQUEST_COUNT).increment();
+        }
         mlTask.setState(MLTaskState.RUNNING);
         mlTaskManager.add(mlTask);
 

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -204,9 +204,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
         mlStats
             .createCounterStatIfAbsent(mlTask.getFunctionName(), ActionName.PREDICT, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
             .increment();
-        mlStats
-                .createModelCounterStatIfAbsent(modelId, ActionName.PREDICT, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
-                .increment();
+        mlStats.createModelCounterStatIfAbsent(modelId, ActionName.PREDICT, MLActionLevelStat.ML_ACTION_REQUEST_COUNT).increment();
         mlTask.setState(MLTaskState.RUNNING);
         mlTaskManager.add(mlTask);
 
@@ -299,7 +297,13 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
         return new ThreadedActionListener<>(log, threadPool, PREDICT_THREAD_POOL, listener, false);
     }
 
-    private void handlePredictFailure(MLTask mlTask, ActionListener<MLTaskResponse> listener, Exception e, boolean trackFailure, String modelId) {
+    private void handlePredictFailure(
+        MLTask mlTask,
+        ActionListener<MLTaskResponse> listener,
+        Exception e,
+        boolean trackFailure,
+        String modelId
+    ) {
         if (trackFailure) {
             mlStats
                 .createCounterStatIfAbsent(mlTask.getFunctionName(), ActionName.PREDICT, MLActionLevelStat.ML_ACTION_FAILURE_COUNT)

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
@@ -119,6 +119,9 @@ public class MLTrainingTaskRunner extends MLTaskRunner<MLTrainingTaskRequest, ML
                 listener.onResponse(new MLTaskResponse(new MLTrainingOutput(null, taskId, mlTask.getState().name())));
                 ActionListener<MLTaskResponse> internalListener = ActionListener.wrap(res -> {
                     String modelId = ((MLTrainingOutput) res.getOutput()).getModelId();
+                    mlStats
+                            .createModelCounterStatIfAbsent(modelId, ActionName.TRAIN, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
+                            .increment();
                     log.info("ML model trained successfully, task id: {}, model id: {}", taskId, modelId);
                     mlTask.setModelId(modelId);
                     handleAsyncMLTaskComplete(mlTask);

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
@@ -120,8 +120,8 @@ public class MLTrainingTaskRunner extends MLTaskRunner<MLTrainingTaskRequest, ML
                 ActionListener<MLTaskResponse> internalListener = ActionListener.wrap(res -> {
                     String modelId = ((MLTrainingOutput) res.getOutput()).getModelId();
                     mlStats
-                            .createModelCounterStatIfAbsent(modelId, ActionName.TRAIN, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
-                            .increment();
+                        .createModelCounterStatIfAbsent(modelId, ActionName.TRAIN, MLActionLevelStat.ML_ACTION_REQUEST_COUNT)
+                        .increment();
                     log.info("ML model trained successfully, task id: {}, model id: {}", taskId, modelId);
                     mlTask.setModelId(modelId);
                     handleAsyncMLTaskComplete(mlTask);

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeResponseTests.java
@@ -73,7 +73,10 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         String taskContent = TestHelper.xContentBuilderToString(builder);
-        assertEquals("{\"algorithms\":{\"kmeans\":{\"predict\":{\"ml_action_request_count\":100}}},\"models\":{\"model_id\":{\"predict\":{\"ml_action_request_count\":100}}}}", taskContent);
+        assertEquals(
+            "{\"algorithms\":{\"kmeans\":{\"predict\":{\"ml_action_request_count\":100}}},\"models\":{\"model_id\":{\"predict\":{\"ml_action_request_count\":100}}}}",
+            taskContent
+        );
     }
 
     public void testWriteTo_AlgoStats() throws IOException {
@@ -103,7 +106,6 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         MLStatsNodeResponse response = new MLStatsNodeResponse(node, nodeStats, algoStats, modelStats);
         return response;
     }
-
 
     public void testToXContent_WithAlgoAndModelStats() throws IOException {
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
@@ -170,7 +172,6 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         assertEquals(0, response.getAlgorithmStatSize());
         assertEquals(0, response.getModelStatSize());
     }
-
 
     public void testIsEmpty_NonEmptyNodeAndAlgoStats() {
         MLStatsNodeResponse response = createResponseWithDefaultAlgoAndModelStats(

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodeResponseTests.java
@@ -23,6 +23,7 @@ import org.opensearch.ml.stats.ActionName;
 import org.opensearch.ml.stats.MLActionLevelStat;
 import org.opensearch.ml.stats.MLActionStats;
 import org.opensearch.ml.stats.MLAlgoStats;
+import org.opensearch.ml.stats.MLModelStats;
 import org.opensearch.ml.stats.MLNodeLevelStat;
 import org.opensearch.ml.utils.TestHelper;
 import org.opensearch.test.OpenSearchTestCase;
@@ -33,7 +34,9 @@ import com.google.common.collect.ImmutableSet;
 public class MLStatsNodeResponseTests extends OpenSearchTestCase {
     private MLStatsNodeResponse response;
     private DiscoveryNode node;
-    private long totalRequestCount = 100l;
+    private final long totalRequestCount = 100l;
+
+    private final String modelId = "model_id";
 
     @Before
     public void setup() {
@@ -63,39 +66,46 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         assertEquals("{\"ml_request_count\":100}", taskContent);
     }
 
-    public void testToXContent_AlgorithmStats() throws IOException {
+    public void testToXContent_AlgorithmAndModelStats() throws IOException {
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         builder.startObject();
-        MLStatsNodeResponse response = createResponseWithDefaultAlgoStats(null);
+        MLStatsNodeResponse response = createResponseWithDefaultAlgoAndModelStats(null);
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         String taskContent = TestHelper.xContentBuilderToString(builder);
-        assertEquals("{\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":100}}}}", taskContent);
+        assertEquals("{\"algorithms\":{\"kmeans\":{\"predict\":{\"ml_action_request_count\":100}}},\"models\":{\"model_id\":{\"predict\":{\"ml_action_request_count\":100}}}}", taskContent);
     }
 
     public void testWriteTo_AlgoStats() throws IOException {
-        MLStatsNodeResponse response = createResponseWithDefaultAlgoStats(null);
+        MLStatsNodeResponse response = createResponseWithDefaultAlgoAndModelStats(null);
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
         MLStatsNodeResponse newResponse = new MLStatsNodeResponse(output.bytes().streamInput());
         assertEquals(0, newResponse.getNodeLevelStatSize());
         assertEquals(1, newResponse.getAlgorithmStatSize());
         assertTrue(newResponse.hasAlgorithmStats(FunctionName.KMEANS));
-        MLActionStats stats = newResponse.getAlgorithmStats(FunctionName.KMEANS).getActionStats(ActionName.TRAIN);
+        assertTrue(newResponse.hasModelStats(modelId));
+        MLActionStats stats = newResponse.getAlgorithmStats(FunctionName.KMEANS).getActionStats(ActionName.PREDICT);
+        MLActionStats mlStats = newResponse.getModelStats(modelId).getActionStats(ActionName.PREDICT);
         assertEquals(totalRequestCount, stats.getActionStat(MLActionLevelStat.ML_ACTION_REQUEST_COUNT));
+        assertEquals(totalRequestCount, mlStats.getActionStat(MLActionLevelStat.ML_ACTION_REQUEST_COUNT));
     }
 
-    private MLStatsNodeResponse createResponseWithDefaultAlgoStats(Map<MLNodeLevelStat, Object> nodeStats) {
+    private MLStatsNodeResponse createResponseWithDefaultAlgoAndModelStats(Map<MLNodeLevelStat, Object> nodeStats) {
         Map<FunctionName, MLAlgoStats> algoStats = new HashMap<>();
         Map<MLActionLevelStat, Object> actionStats = ImmutableMap.of(MLActionLevelStat.ML_ACTION_REQUEST_COUNT, totalRequestCount);
-        Map<ActionName, MLActionStats> stats = ImmutableMap.of(ActionName.TRAIN, new MLActionStats(actionStats));
+        Map<ActionName, MLActionStats> stats = ImmutableMap.of(ActionName.PREDICT, new MLActionStats(actionStats));
         algoStats.put(FunctionName.KMEANS, new MLAlgoStats(stats));
 
-        MLStatsNodeResponse response = new MLStatsNodeResponse(node, nodeStats, algoStats);
+        Map<String, MLModelStats> modelStats = new HashMap<>();
+        modelStats.put(modelId, new MLModelStats(stats));
+
+        MLStatsNodeResponse response = new MLStatsNodeResponse(node, nodeStats, algoStats, modelStats);
         return response;
     }
 
-    public void testToXContent_WithAlgoStats() throws IOException {
+
+    public void testToXContent_WithAlgoAndModelStats() throws IOException {
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         builder.startObject();
         DiscoveryNode node = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
@@ -108,14 +118,23 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         algoActionStatMap.put(MLActionLevelStat.ML_ACTION_FAILURE_COUNT, 22);
         algoActionStats.put(ActionName.TRAIN, new MLActionStats(algoActionStatMap));
         algoStats.put(FunctionName.KMEANS, new MLAlgoStats(algoActionStats));
-        response = new MLStatsNodeResponse(node, statsToValues, algoStats);
+
+        Map<String, MLModelStats> modelStats = new HashMap<>();
+        Map<ActionName, MLActionStats> modelActionStats = new HashMap<>();
+        Map<MLActionLevelStat, Object> modelActionStatMap = new HashMap<>();
+        modelActionStatMap.put(MLActionLevelStat.ML_ACTION_REQUEST_COUNT, 111);
+        modelActionStatMap.put(MLActionLevelStat.ML_ACTION_FAILURE_COUNT, 22);
+        modelActionStats.put(ActionName.PREDICT, new MLActionStats(modelActionStatMap));
+        modelStats.put(modelId, new MLModelStats(modelActionStats));
+
+        response = new MLStatsNodeResponse(node, statsToValues, algoStats, modelStats);
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         String taskContent = TestHelper.xContentBuilderToString(builder);
         Set<String> validResult = ImmutableSet
             .of(
-                "{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_failure_count\":22,\"ml_action_request_count\":111}}}}",
-                "{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":111,\"ml_action_failure_count\":22}}}}"
+                "{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_failure_count\":22,\"ml_action_request_count\":111}}},\"models\":{\"model_id\":{\"predict\":{\"ml_action_failure_count\":22,\"ml_action_request_count\":111}}}}",
+                "{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":111,\"ml_action_failure_count\":22}}},\"models\":{\"model_id\":{\"predict\":{\"ml_action_request_count\":111,\"ml_action_failure_count\":22}}}}"
             );
         assertTrue(validResult.contains(taskContent));
     }
@@ -129,12 +148,12 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
     }
 
     public void testIsEmpty_NullNodeStats() {
-        MLStatsNodeResponse response = createResponseWithDefaultAlgoStats(null);
+        MLStatsNodeResponse response = createResponseWithDefaultAlgoAndModelStats(null);
         assertFalse(response.isEmpty());
     }
 
     public void testIsEmpty_EmptyNodeStats() {
-        MLStatsNodeResponse response = createResponseWithDefaultAlgoStats(ImmutableMap.of());
+        MLStatsNodeResponse response = createResponseWithDefaultAlgoAndModelStats(ImmutableMap.of());
         assertFalse(response.isEmpty());
     }
 
@@ -142,14 +161,19 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
         assertFalse(response.isEmpty());
     }
 
-    public void testIsEmpty_EmptyAlgoStats() {
-        MLStatsNodeResponse response = createResponseWithDefaultAlgoStats(ImmutableMap.of());
+    public void testIsEmpty_EmptyAlgoAndModelStats() {
+        MLStatsNodeResponse response = createResponseWithDefaultAlgoAndModelStats(ImmutableMap.of());
+        assertEquals(1, response.getAlgorithmStatSize());
+        assertEquals(1, response.getModelStatSize());
         response.removeAlgorithmStats(FunctionName.KMEANS);
-        assertTrue(response.isEmpty());
+        response.removeModelStats(modelId);
+        assertEquals(0, response.getAlgorithmStatSize());
+        assertEquals(0, response.getModelStatSize());
     }
 
+
     public void testIsEmpty_NonEmptyNodeAndAlgoStats() {
-        MLStatsNodeResponse response = createResponseWithDefaultAlgoStats(
+        MLStatsNodeResponse response = createResponseWithDefaultAlgoAndModelStats(
             ImmutableMap.of(MLNodeLevelStat.ML_REQUEST_COUNT, totalRequestCount)
         );
         assertFalse(response.isEmpty());
@@ -176,13 +200,13 @@ public class MLStatsNodeResponseTests extends OpenSearchTestCase {
     }
 
     public void testGetAlgorithmLevelStat_EmptyAlgoStats() {
-        MLStatsNodeResponse response = new MLStatsNodeResponse(node, null, ImmutableMap.of());
+        MLStatsNodeResponse response = new MLStatsNodeResponse(node, null, ImmutableMap.of(), ImmutableMap.of());
         assertNull(response.getAlgorithmStats(FunctionName.BATCH_RCF));
         assertEquals(0, response.getNodeLevelStatSize());
     }
 
     public void testGetAlgorithmLevelStat_NonExistingAlgo() {
-        MLStatsNodeResponse response = createResponseWithDefaultAlgoStats(null);
+        MLStatsNodeResponse response = createResponseWithDefaultAlgoAndModelStats(null);
         assertEquals(0, response.getNodeLevelStatSize());
         assertEquals(1, response.getAlgorithmStatSize());
         assertNotNull(response.getAlgorithmStats(FunctionName.KMEANS));

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesTransportActionTests.java
@@ -146,7 +146,7 @@ public class MLStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
     public void testNodeOperation_NoNodeLevelStat_AlgoStat() {
         MLStats mlStats = new MLStats(statsMap);
         mlStats.createCounterStatIfAbsent(FunctionName.KMEANS, ActionName.TRAIN, MLActionLevelStat.ML_ACTION_REQUEST_COUNT).increment();
-        mlStats.createModelCounterStatIfAbsent(modelId, ActionName.PREDICT,MLActionLevelStat.ML_ACTION_REQUEST_COUNT).increment();
+        mlStats.createModelCounterStatIfAbsent(modelId, ActionName.PREDICT, MLActionLevelStat.ML_ACTION_REQUEST_COUNT).increment();
 
         MLStatsNodesTransportAction action = new MLStatsNodesTransportAction(
             client().threadPool(),

--- a/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/stats/MLStatsNodesTransportActionTests.java
@@ -30,6 +30,7 @@ import org.opensearch.ml.stats.MLActionLevelStat;
 import org.opensearch.ml.stats.MLActionStats;
 import org.opensearch.ml.stats.MLAlgoStats;
 import org.opensearch.ml.stats.MLClusterLevelStat;
+import org.opensearch.ml.stats.MLModelStats;
 import org.opensearch.ml.stats.MLNodeLevelStat;
 import org.opensearch.ml.stats.MLStat;
 import org.opensearch.ml.stats.MLStatLevel;
@@ -49,6 +50,8 @@ public class MLStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
     private MLClusterLevelStat clusterStatName1;
     private MLNodeLevelStat nodeStatName1;
     private Environment environment;
+
+    private final String modelId = "model_id";
 
     @Override
     @Before
@@ -100,6 +103,7 @@ public class MLStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
         StreamInput in = out.bytes().streamInput();
         MLStatsNodeResponse newStatsNodeResponse = action.newNodeResponse(in);
         Assert.assertEquals(statsNodeResponse.getNodeLevelStatSize(), newStatsNodeResponse.getAlgorithmStatSize());
+        Assert.assertEquals(statsNodeResponse.getNodeLevelStatSize(), newStatsNodeResponse.getModelStatSize());
     }
 
     public void testNodeOperation() {
@@ -131,7 +135,7 @@ public class MLStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
 
     public void testNodeOperation_NoNodeLevelStat() {
         String nodeId = clusterService().localNode().getId();
-        MLStatsInput mlStatsInput = MLStatsInput.builder().targetStatLevels(EnumSet.of(MLStatLevel.ALGORITHM)).build();
+        MLStatsInput mlStatsInput = MLStatsInput.builder().targetStatLevels(EnumSet.of(MLStatLevel.ALGORITHM, MLStatLevel.MODEL)).build();
         MLStatsNodesRequest mlStatsNodesRequest = new MLStatsNodesRequest(new String[] { nodeId }, mlStatsInput);
 
         MLStatsNodeResponse response = action.nodeOperation(new MLStatsNodeRequest(mlStatsNodesRequest));
@@ -142,6 +146,7 @@ public class MLStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
     public void testNodeOperation_NoNodeLevelStat_AlgoStat() {
         MLStats mlStats = new MLStats(statsMap);
         mlStats.createCounterStatIfAbsent(FunctionName.KMEANS, ActionName.TRAIN, MLActionLevelStat.ML_ACTION_REQUEST_COUNT).increment();
+        mlStats.createModelCounterStatIfAbsent(modelId, ActionName.PREDICT,MLActionLevelStat.ML_ACTION_REQUEST_COUNT).increment();
 
         MLStatsNodesTransportAction action = new MLStatsNodesTransportAction(
             client().threadPool(),
@@ -153,16 +158,23 @@ public class MLStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
         );
 
         String nodeId = clusterService().localNode().getId();
-        MLStatsInput mlStatsInput = MLStatsInput.builder().targetStatLevels(EnumSet.of(MLStatLevel.ALGORITHM)).build();
+        MLStatsInput mlStatsInput = MLStatsInput.builder().targetStatLevels(EnumSet.of(MLStatLevel.ALGORITHM, MLStatLevel.MODEL)).build();
         MLStatsNodesRequest mlStatsNodesRequest = new MLStatsNodesRequest(new String[] { nodeId }, mlStatsInput);
 
         MLStatsNodeResponse response = action.nodeOperation(new MLStatsNodeRequest(mlStatsNodesRequest));
 
         assertEquals(0, response.getNodeLevelStatSize());
         assertEquals(1, response.getAlgorithmStatSize());
+        assertEquals(1, response.getModelStatSize());
         MLAlgoStats algorithmStats = response.getAlgorithmStats(FunctionName.KMEANS);
         assertNotNull(algorithmStats);
         MLActionStats actionStats = algorithmStats.getActionStats(ActionName.TRAIN);
+        assertNotNull(actionStats);
+        assertEquals(1l, actionStats.getActionStat(MLActionLevelStat.ML_ACTION_REQUEST_COUNT));
+
+        MLModelStats modelStats = response.getModelStats(modelId);
+        assertNotNull(modelStats);
+        actionStats = modelStats.getActionStats(ActionName.PREDICT);
         assertNotNull(actionStats);
         assertEquals(1l, actionStats.getActionStat(MLActionLevelStat.ML_ACTION_REQUEST_COUNT));
     }

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -837,6 +837,8 @@ public class MLModelManagerTests extends OpenSearchTestCase {
 
     public void testRegisterModelMeta() {
         setupForModelMeta();
+        mock_MLIndicesHandler_initModelIndex(mlIndicesHandler, true);
+        mock_client_index(client, modelId);
         MLRegisterModelMetaInput registerModelMetaInput = prepareRequest();
         modelManager.registerModelMeta(registerModelMetaInput, actionListener);
         ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
@@ -212,7 +212,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             content
                 .utf8ToString()
                 .contains(
-                        "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}},\"models\":{\"model_id\":{\"train\":{\"ml_action_request_count\":20}}}}}"
+                    "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}},\"models\":{\"model_id\":{\"train\":{\"ml_action_request_count\":20}}}}}"
                 )
         );
     }
@@ -229,7 +229,6 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
                     new MLActionStats(ImmutableMap.of(MLActionLevelStat.ML_ACTION_REQUEST_COUNT, kmeansTrainRequestCount))
                 );
             algoStats.put(FunctionName.KMEANS, new MLAlgoStats(actionStats));
-
 
             Map<String, MLModelStats> modelStats = new HashMap<>();
 
@@ -343,7 +342,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             content
                 .utf8ToString()
                 .contains(
-                        "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}},\"models\":{\"model_id\":{\"train\":{\"ml_action_request_count\":20}}}}}"
+                    "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}},\"models\":{\"model_id\":{\"train\":{\"ml_action_request_count\":20}}}}}"
                 )
         );
     }
@@ -369,7 +368,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         assertEquals(RestStatus.OK, restResponse.status());
         BytesReference content = restResponse.content();
         assertEquals(
-                "{\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}},\"models\":{\"model_id\":{\"train\":{\"ml_action_request_count\":20}}}}}}",
+            "{\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}},\"models\":{\"model_id\":{\"train\":{\"ml_action_request_count\":20}}}}}}",
             content.utf8ToString()
         );
     }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
@@ -61,6 +61,7 @@ import org.opensearch.ml.stats.MLActionLevelStat;
 import org.opensearch.ml.stats.MLActionStats;
 import org.opensearch.ml.stats.MLAlgoStats;
 import org.opensearch.ml.stats.MLClusterLevelStat;
+import org.opensearch.ml.stats.MLModelStats;
 import org.opensearch.ml.stats.MLNodeLevelStat;
 import org.opensearch.ml.stats.MLStat;
 import org.opensearch.ml.stats.MLStatLevel;
@@ -107,6 +108,8 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
     long mlConnectorCount = 2;
     long nodeTotalRequestCount = 100;
     long kmeansTrainRequestCount = 20;
+
+    String modelId = "model_id";
 
     @Before
     public void setup() throws IOException {
@@ -209,7 +212,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             content
                 .utf8ToString()
                 .contains(
-                    "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
+                        "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}},\"models\":{\"model_id\":{\"train\":{\"ml_action_request_count\":20}}}}}"
                 )
         );
     }
@@ -226,7 +229,13 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
                     new MLActionStats(ImmutableMap.of(MLActionLevelStat.ML_ACTION_REQUEST_COUNT, kmeansTrainRequestCount))
                 );
             algoStats.put(FunctionName.KMEANS, new MLAlgoStats(actionStats));
-            MLStatsNodeResponse nodeResponse = new MLStatsNodeResponse(node, nodeStats, algoStats);
+
+
+            Map<String, MLModelStats> modelStats = new HashMap<>();
+
+            modelStats.put(modelId, new MLModelStats(actionStats));
+
+            MLStatsNodeResponse nodeResponse = new MLStatsNodeResponse(node, nodeStats, algoStats, modelStats);
             nodes.add(nodeResponse);
             MLStatsNodesResponse statsResponse = new MLStatsNodesResponse(clusterName, nodes, ImmutableList.of());
             actionListener.onResponse(statsResponse);
@@ -299,7 +308,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             content
                 .utf8ToString()
                 .contains(
-                    "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
+                    "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}},\"models\":{\"model_id\":{\"train\":{\"ml_action_request_count\":20}}}}}"
                 )
         );
     }
@@ -334,7 +343,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             content
                 .utf8ToString()
                 .contains(
-                    "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}"
+                        "\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}},\"models\":{\"model_id\":{\"train\":{\"ml_action_request_count\":20}}}}}"
                 )
         );
     }
@@ -360,7 +369,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
         assertEquals(RestStatus.OK, restResponse.status());
         BytesReference content = restResponse.content();
         assertEquals(
-            "{\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}}}}}",
+                "{\"nodes\":{\"node\":{\"ml_request_count\":100,\"algorithms\":{\"kmeans\":{\"train\":{\"ml_action_request_count\":20}}},\"models\":{\"model_id\":{\"train\":{\"ml_action_request_count\":20}}}}}}",
             content.utf8ToString()
         );
     }

--- a/plugin/src/test/java/org/opensearch/ml/stats/MLModelStatsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/stats/MLModelStatsTests.java
@@ -51,6 +51,15 @@ public class MLModelStatsTests extends OpenSearchTestCase {
         assertEquals(failureCount, parsedMLActionStats.getActionStat(ML_ACTION_FAILURE_COUNT));
     }
 
+    public void testEmptySerializationDeserialization() throws IOException {
+
+        Map<ActionName, MLActionStats> modelStats = new HashMap<>();
+        MLModelStats mlModelEmptyStats = new MLModelStats(modelStats);
+        BytesStreamOutput output = new BytesStreamOutput();
+        mlModelEmptyStats.writeTo(output);
+        assertEquals(0, output.bytes().length());
+    }
+
     public void testToXContent() throws IOException {
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         builder.startObject();

--- a/plugin/src/test/java/org/opensearch/ml/stats/MLModelStatsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/stats/MLModelStatsTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.stats;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.utils.TestHelper;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.opensearch.ml.stats.MLActionLevelStat.ML_ACTION_FAILURE_COUNT;
+import static org.opensearch.ml.stats.MLActionLevelStat.ML_ACTION_REQUEST_COUNT;
+
+public class MLModelStatsTests extends OpenSearchTestCase {
+    private MLModelStats mlModelStats;
+    private MLActionStats mlActionStats;
+    private long requestCount = 200;
+    private long failureCount = 100;
+
+    @Before
+    public void setup() {
+        Map<MLActionLevelStat, Object> modelActionStats = new HashMap<>();
+        modelActionStats.put(ML_ACTION_REQUEST_COUNT, requestCount);
+        modelActionStats.put(ML_ACTION_FAILURE_COUNT, failureCount);
+        mlActionStats = new MLActionStats(modelActionStats);
+
+        Map<ActionName, MLActionStats> modelStats = new HashMap<>();
+        modelStats.put(ActionName.PREDICT, mlActionStats);
+        mlModelStats = new MLModelStats(modelStats);
+    }
+
+    public void testSerializationDeserialization() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        mlModelStats.writeTo(output);
+        MLModelStats parsedMLModelStats = new MLModelStats(output.bytes().streamInput());
+        MLActionStats parsedMLActionStats = parsedMLModelStats.getActionStats(ActionName.PREDICT);
+        assertEquals(2, parsedMLActionStats.getActionStatSize());
+        assertEquals(requestCount, parsedMLActionStats.getActionStat(ML_ACTION_REQUEST_COUNT));
+        assertEquals(failureCount, parsedMLActionStats.getActionStat(ML_ACTION_FAILURE_COUNT));
+    }
+
+    public void testToXContent() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        mlModelStats.toXContent(builder, EMPTY_PARAMS);
+        builder.endObject();
+        String content = TestHelper.xContentBuilderToString(builder);
+        Set<String> validContents = ImmutableSet
+            .of(
+                "{\"predict\":{\"ml_action_request_count\":200,\"ml_action_failure_count\":100}}",
+                "{\"predict\":{\"ml_action_failure_count\":100,\"ml_action_request_count\":200}}"
+            );
+        assertTrue(validContents.contains(content));
+    }
+
+    public void testToXContent_EmptyStats() throws IOException {
+        Map<ActionName, MLActionStats> statMap = new HashMap<>();
+        MLAlgoStats stats = new MLAlgoStats(statMap);
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        stats.toXContent(builder, EMPTY_PARAMS);
+        builder.endObject();
+        String content = TestHelper.xContentBuilderToString(builder);
+        assertEquals("{}", content);
+    }
+
+    public void testToXContent_NullStats() throws IOException {
+        Map<ActionName, MLActionStats> statMap = null;
+        MLAlgoStats stats = new MLAlgoStats(statMap);
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        stats.toXContent(builder, EMPTY_PARAMS);
+        builder.endObject();
+        String content = TestHelper.xContentBuilderToString(builder);
+        assertEquals("{}", content);
+    }
+
+    public void testGetActionStats() {
+        assertNotNull(mlModelStats.getActionStats(ActionName.PREDICT));
+
+        // null stats
+        Map<ActionName, MLActionStats> statMap = null;
+        MLModelStats stats = new MLModelStats(statMap);
+        assertNull(stats.getActionStats(ActionName.PREDICT));
+
+        // empty stats
+        stats = new MLModelStats(new HashMap<>());
+        assertNull(stats.getActionStats(ActionName.PREDICT));
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/stats/MLModelStatsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/stats/MLModelStatsTests.java
@@ -5,7 +5,15 @@
 
 package org.opensearch.ml.stats;
 
-import com.google.common.collect.ImmutableSet;
+import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.opensearch.ml.stats.MLActionLevelStat.ML_ACTION_FAILURE_COUNT;
+import static org.opensearch.ml.stats.MLActionLevelStat.ML_ACTION_REQUEST_COUNT;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 import org.junit.Before;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
@@ -13,14 +21,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.utils.TestHelper;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
-import static org.opensearch.ml.stats.MLActionLevelStat.ML_ACTION_FAILURE_COUNT;
-import static org.opensearch.ml.stats.MLActionLevelStat.ML_ACTION_REQUEST_COUNT;
+import com.google.common.collect.ImmutableSet;
 
 public class MLModelStatsTests extends OpenSearchTestCase {
     private MLModelStats mlModelStats;

--- a/plugin/src/test/java/org/opensearch/ml/stats/MLModelStatsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/stats/MLModelStatsTests.java
@@ -57,7 +57,10 @@ public class MLModelStatsTests extends OpenSearchTestCase {
         MLModelStats mlModelEmptyStats = new MLModelStats(modelStats);
         BytesStreamOutput output = new BytesStreamOutput();
         mlModelEmptyStats.writeTo(output);
-        assertEquals(0, output.bytes().length());
+        MLModelStats parsedMLModelStats = new MLModelStats(output.bytes().streamInput());
+        MLActionStats parsedMLActionStats = parsedMLModelStats.getActionStats(ActionName.PREDICT);
+        assertNull(parsedMLActionStats);
+        // assertEquals(0, output.bytes().length());
     }
 
     public void testToXContent() throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/stats/MLStatsInputTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/stats/MLStatsInputTests.java
@@ -39,7 +39,7 @@ public class MLStatsInputTests extends OpenSearchTestCase {
             .actionLevelStats(EnumSet.allOf(MLActionLevelStat.class))
             .nodeIds(ImmutableSet.of(node1, node2))
             .algorithms(EnumSet.allOf(FunctionName.class))
-                .models(ImmutableSet.of(modelId))
+            .models(ImmutableSet.of(modelId))
             .actions(EnumSet.allOf(ActionName.class))
             .build();
     }
@@ -157,10 +157,7 @@ public class MLStatsInputTests extends OpenSearchTestCase {
             mlStatsInput.getAlgorithms().toArray(new FunctionName[0]),
             parsedMLStatsInput.getAlgorithms().toArray(new FunctionName[0])
         );
-        assertArrayEquals(
-                mlStatsInput.getModels().toArray(new String[0]),
-                parsedMLStatsInput.getModels().toArray(new String[0])
-        );
+        assertArrayEquals(mlStatsInput.getModels().toArray(new String[0]), parsedMLStatsInput.getModels().toArray(new String[0]));
         assertArrayEquals(mlStatsInput.getActions().toArray(new ActionName[0]), parsedMLStatsInput.getActions().toArray(new ActionName[0]));
         assertEquals(2, parsedMLStatsInput.getNodeIds().size());
         assertTrue(parsedMLStatsInput.getNodeIds().contains(node1));

--- a/plugin/src/test/java/org/opensearch/ml/stats/MLStatsInputTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/stats/MLStatsInputTests.java
@@ -27,6 +27,8 @@ public class MLStatsInputTests extends OpenSearchTestCase {
     private String node1 = "node1";
     private String node2 = "node2";
 
+    private String modelId = "model_id";
+
     @Before
     public void setup() {
         mlStatsInput = MLStatsInput
@@ -37,6 +39,7 @@ public class MLStatsInputTests extends OpenSearchTestCase {
             .actionLevelStats(EnumSet.allOf(MLActionLevelStat.class))
             .nodeIds(ImmutableSet.of(node1, node2))
             .algorithms(EnumSet.allOf(FunctionName.class))
+                .models(ImmutableSet.of(modelId))
             .actions(EnumSet.allOf(ActionName.class))
             .build();
     }
@@ -59,6 +62,7 @@ public class MLStatsInputTests extends OpenSearchTestCase {
 
     public void testRetrieveAll() {
         assertFalse(mlStatsInput.retrieveStatsForAllAlgos());
+        assertFalse(mlStatsInput.retrieveStatsForAllModels());
         assertFalse(mlStatsInput.retrieveAllNodeLevelStats());
         assertFalse(mlStatsInput.retrieveStatsForAllActions());
         assertFalse(mlStatsInput.retrieveAllClusterLevelStats());
@@ -66,6 +70,7 @@ public class MLStatsInputTests extends OpenSearchTestCase {
         assertFalse(mlStatsInput.retrieveAllActionLevelStats());
 
         MLStatsInput mlStatsInput = MLStatsInput.builder().build();
+        assertTrue(mlStatsInput.retrieveStatsForAllModels());
         assertTrue(mlStatsInput.retrieveStatsForAllAlgos());
         assertTrue(mlStatsInput.retrieveAllNodeLevelStats());
         assertTrue(mlStatsInput.retrieveStatsForAllActions());
@@ -75,6 +80,7 @@ public class MLStatsInputTests extends OpenSearchTestCase {
 
         mlStatsInput = new MLStatsInput();
         assertTrue(mlStatsInput.retrieveStatsForAllAlgos());
+        assertTrue(mlStatsInput.retrieveStatsForAllModels());
         assertTrue(mlStatsInput.retrieveAllNodeLevelStats());
         assertTrue(mlStatsInput.retrieveStatsForAllActions());
         assertTrue(mlStatsInput.retrieveAllClusterLevelStats());
@@ -123,6 +129,9 @@ public class MLStatsInputTests extends OpenSearchTestCase {
         mlStatsInput = MLStatsInput.builder().targetStatLevels(EnumSet.of(MLStatLevel.ALGORITHM)).build();
         assertFalse(mlStatsInput.onlyRetrieveClusterLevelStats());
 
+        mlStatsInput = MLStatsInput.builder().targetStatLevels(EnumSet.of(MLStatLevel.MODEL)).build();
+        assertFalse(mlStatsInput.onlyRetrieveClusterLevelStats());
+
         mlStatsInput = MLStatsInput.builder().targetStatLevels(EnumSet.of(MLStatLevel.ACTION)).build();
         assertFalse(mlStatsInput.onlyRetrieveClusterLevelStats());
     }
@@ -147,6 +156,10 @@ public class MLStatsInputTests extends OpenSearchTestCase {
         assertArrayEquals(
             mlStatsInput.getAlgorithms().toArray(new FunctionName[0]),
             parsedMLStatsInput.getAlgorithms().toArray(new FunctionName[0])
+        );
+        assertArrayEquals(
+                mlStatsInput.getModels().toArray(new String[0]),
+                parsedMLStatsInput.getModels().toArray(new String[0])
         );
         assertArrayEquals(mlStatsInput.getActions().toArray(new ActionName[0]), parsedMLStatsInput.getActions().toArray(new ActionName[0]));
         assertEquals(2, parsedMLStatsInput.getNodeIds().size());

--- a/plugin/src/test/java/org/opensearch/ml/stats/MLStatsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/stats/MLStatsTests.java
@@ -26,6 +26,8 @@ public class MLStatsTests extends OpenSearchTestCase {
     private MLClusterLevelStat clusterStatName1;
     private MLNodeLevelStat nodeStatName1;
 
+    private String modelID = "model_id";
+
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
 
@@ -113,6 +115,11 @@ public class MLStatsTests extends OpenSearchTestCase {
         assertNull(algorithmStats);
     }
 
+    public void testGetModelStats_Empty() {
+        Map<ActionName, MLActionStats> modelStats = mlStats.getModelStats(modelID);
+        assertNull(modelStats);
+    }
+
     public void testGetAlgorithmStats() {
         MLStats stats = new MLStats(statsMap);
         MLStat<?> statCounter = stats.createCounterStatIfAbsent(FunctionName.KMEANS, ActionName.TRAIN, ML_ACTION_REQUEST_COUNT);
@@ -122,9 +129,23 @@ public class MLStatsTests extends OpenSearchTestCase {
         assertEquals(1l, algorithmStats.get(ActionName.TRAIN).getActionStat(ML_ACTION_REQUEST_COUNT));
     }
 
+    public void testGetModelStats() {
+        MLStats stats = new MLStats(statsMap);
+        MLStat<?> statCounter = stats.createModelCounterStatIfAbsent(modelID, ActionName.TRAIN, ML_ACTION_REQUEST_COUNT);
+        statCounter.increment();
+        Map<ActionName, MLActionStats> modelStats = stats.getModelStats(modelID);
+        assertNotNull(modelStats);
+        assertEquals(1l, modelStats.get(ActionName.TRAIN).getActionStat(ML_ACTION_REQUEST_COUNT));
+    }
+
     public void testGetAllAlgorithms_Empty() {
         FunctionName[] allAlgorithms = mlStats.getAllAlgorithms();
         assertEquals(0, allAlgorithms.length);
+    }
+
+    public void testGetAllModels_Empty() {
+        String[] allModels = mlStats.getAllModels();
+        assertEquals(0, allModels.length);
     }
 
     public void testGetAllAlgorithms() {
@@ -133,5 +154,13 @@ public class MLStatsTests extends OpenSearchTestCase {
         statCounter.increment();
         FunctionName[] allAlgorithms = stats.getAllAlgorithms();
         assertArrayEquals(new FunctionName[] { FunctionName.KMEANS }, allAlgorithms);
+    }
+
+    public void testGetAllModels() {
+        MLStats stats = new MLStats(statsMap);
+        MLStat<?> statCounter = stats.createModelCounterStatIfAbsent(modelID, ActionName.PREDICT, ML_ACTION_REQUEST_COUNT);
+        statCounter.increment();
+        String[] allModels = stats.getAllModels();
+        assertArrayEquals(new String[] { modelID }, allModels);
     }
 }


### PR DESCRIPTION
### Description
[adding model level metric in node level : https://github.com/opensearch-project/ml-commons/issues/1295

With this change stat api will show metrics like:

```
{
    "nodes": {
        "KKGb_PrDQl2zWWIhifyFdQ": {
            "algorithms": {
                "text_embedding": {
                    "deploy": {
                        "ml_action_request_count": 1
                    },
                    "register": {
                        "ml_action_request_count": 1
                    },
                    "predict": {
                        "ml_action_request_count": 1
                    }
                }
            },
            "models": {
                "FFt4i4oBkVwzPy8kRevJ": {
                    "deploy": {
                        "ml_action_request_count": 1
                    },
                    "predict": {
                        "ml_action_request_count": 1
                    }
                }
            }
        }
    }
}
```
]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
