### PR TITLE
2.x consistent get interactions

### DIFF
--- a/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
@@ -270,16 +270,16 @@ public class ConversationMetaIndex {
         String userstr = client.threadPool().getThreadContext().getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
         try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());
-            // If security is off - User doesn't exist - you have permission
-            if (userstr == null || User.parse(userstr) == null) {
-                internalListener.onResponse(true);
-                return;
-            }
             GetRequest getRequest = Requests.getRequest(indexName).id(conversationId);
             ActionListener<GetResponse> al = ActionListener.wrap(getResponse -> {
                 // If the conversation doesn't exist, fail
                 if (!(getResponse.isExists() && getResponse.getId().equals(conversationId))) {
                     throw new ResourceNotFoundException("Conversation [" + conversationId + "] not found");
+                }
+                // If security is off - User doesn't exist - you have permission
+                if (userstr == null || User.parse(userstr) == null) {
+                    internalListener.onResponse(true);
+                    return;
                 }
                 ConversationMeta conversation = ConversationMeta.fromMap(conversationId, getResponse.getSourceAsMap());
                 String user = User.parse(userstr).getName();
@@ -290,7 +290,14 @@ public class ConversationMetaIndex {
                 }
                 internalListener.onResponse(true);
             }, e -> { internalListener.onFailure(e); });
-            client.get(getRequest, al);
+            client
+                .admin()
+                .indices()
+                .refresh(Requests.refreshRequest(indexName), ActionListener.wrap(refreshResponse -> { client.get(getRequest, al); }, e -> {
+                    log.error("Failed to refresh conversations index during check access ", e);
+                    internalListener.onFailure(e);
+                }));
+            // client.get(getRequest, al);
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
@@ -297,7 +297,6 @@ public class ConversationMetaIndex {
                     log.error("Failed to refresh conversations index during check access ", e);
                     internalListener.onFailure(e);
                 }));
-            // client.get(getRequest, al);
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/memory/src/main/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandler.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandler.java
@@ -250,7 +250,7 @@ public class OpenSearchConversationalMemoryHandler implements ConversationalMemo
     public void deleteConversation(String conversationId, ActionListener<Boolean> listener) {
         StepListener<Boolean> accessListener = new StepListener<>();
         conversationMetaIndex.checkAccess(conversationId, accessListener);
-        log.info("DELETING CID " + conversationId);
+        log.info("DELETING CONVERSATION " + conversationId);
         accessListener.whenComplete(access -> {
             if (access) {
                 StepListener<Boolean> metaDeleteListener = new StepListener<>();
@@ -265,7 +265,7 @@ public class OpenSearchConversationalMemoryHandler implements ConversationalMemo
                     );
 
                 metaDeleteListener.whenComplete(metaDeleteResult -> {
-                    log.info("SUCCESSFUL DELETION OF CID " + conversationId);
+                    log.info("SUCCESSFUL DELETION OF CONVERSATION " + conversationId);
                     listener.onResponse(metaDeleteResult && interactionsListener.result());
                 }, listener::onFailure);
 

--- a/memory/src/test/java/org/opensearch/ml/memory/ConversationalMemoryHandlerITTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/ConversationalMemoryHandlerITTests.java
@@ -249,16 +249,18 @@ public class ConversationalMemoryHandlerITTests extends OpenSearchIntegTestCase 
         });
 
         StepListener<List<Interaction>> inters2 = new StepListener<>();
-        inters1.whenComplete(ints -> { cmHandler.getInteractions(cid2.result(), 0, 10, inters2); }, e -> {
+        inters1.whenComplete(ints -> {
             cdl.countDown();
             assert (false);
+        }, e -> {
+            assert (e.getMessage().startsWith("Conversation ["));
+            cmHandler.getInteractions(cid2.result(), 0, 10, inters2);
         });
 
         LatchedActionListener<List<Interaction>> finishAndAssert = new LatchedActionListener<>(ActionListener.wrap(r -> {
             assert (del.result());
             assert (conversations.result().size() == 1);
             assert (conversations.result().get(0).getId().equals(cid2.result()));
-            assert (inters1.result().size() == 0);
             assert (inters2.result().size() == 1);
             assert (inters2.result().get(0).getId().equals(iid3.result()));
         }, e -> { assert (false); }), cdl);

--- a/memory/src/test/java/org/opensearch/ml/memory/index/ConversationMetaIndexTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/index/ConversationMetaIndexTests.java
@@ -404,6 +404,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
 
     public void testCheckAccess_DoesNotExist_ThenFail() {
         setupUser("user");
+        setupRefreshSuccess();
         doReturn(true).when(metadata).hasIndex(anyString());
         GetResponse response = mock(GetResponse.class);
         doReturn(false).when(response).isExists();
@@ -423,6 +424,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
 
     public void testCheckAccess_WrongId_ThenFail() {
         setupUser("user");
+        setupRefreshSuccess();
         doReturn(true).when(metadata).hasIndex(anyString());
         GetResponse response = mock(GetResponse.class);
         doReturn(true).when(response).isExists();
@@ -443,6 +445,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
 
     public void testCheckAccess_GetFails_ThenFail() {
         setupUser("user");
+        setupRefreshSuccess();
         doReturn(true).when(metadata).hasIndex(anyString());
         doAnswer(invocation -> {
             ActionListener<GetResponse> al = invocation.getArgument(1);
@@ -459,6 +462,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
 
     public void testCheckAccess_ClientFails_ThenFail() {
         setupUser("user");
+        setupRefreshSuccess();
         doReturn(true).when(metadata).hasIndex(anyString());
         doThrow(new RuntimeException("Client Test Fail")).when(client).get(any(), any());
         @SuppressWarnings("unchecked")

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryDeleteConversationActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryDeleteConversationActionIT.java
@@ -26,6 +26,7 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.message.BasicHeader;
 import org.junit.Before;
 import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.conversation.ActionConstants;
 import org.opensearch.ml.settings.MLCommonsSettings;
@@ -163,15 +164,20 @@ public class RestMemoryDeleteConversationActionIT extends MLCommonsRestTestCase 
         assert (!gcmap.containsKey("next_token"));
         assert (((ArrayList) gcmap.get("conversations")).size() == 0);
 
-        Response giresponse = TestHelper
-            .makeRequest(client(), "GET", ActionConstants.GET_INTERACTIONS_REST_PATH.replace("{conversation_id}", cid), null, "", null);
-        assert (giresponse != null);
-        assert (TestHelper.restStatus(giresponse) == RestStatus.OK);
-        HttpEntity gihttpEntity = giresponse.getEntity();
-        String gientityString = TestHelper.httpEntityToString(gihttpEntity);
-        Map gimap = gson.fromJson(gientityString, Map.class);
-        assert (gimap.containsKey("interactions"));
-        assert (!gimap.containsKey("next_token"));
-        assert (((ArrayList) gimap.get("interactions")).size() == 0);
+        try {
+            Response giresponse = TestHelper
+                .makeRequest(client(), "GET", ActionConstants.GET_INTERACTIONS_REST_PATH.replace("{conversation_id}", cid), null, "", null);
+            assert (giresponse != null);
+            assert (TestHelper.restStatus(giresponse) == RestStatus.OK);
+            HttpEntity gihttpEntity = giresponse.getEntity();
+            String gientityString = TestHelper.httpEntityToString(gihttpEntity);
+            Map gimap = gson.fromJson(gientityString, Map.class);
+            assert (gimap.containsKey("interactions"));
+            assert (!gimap.containsKey("next_token"));
+            assert (((ArrayList) gimap.get("interactions")).size() == 0);
+            assert (false);
+        } catch (ResponseException e) {
+            assert (TestHelper.restStatus(e.getResponse()) == RestStatus.NOT_FOUND);
+        }
     }
 }


### PR DESCRIPTION
### Description
Fix issue where getInteractions returned different results in security-enabled and -disabled settings. Also fix a data race in deleteConversation that made that test flaky.
 
### Issues Resolved
#1272 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
