### PR TITLE
include deployment status in deploy API response

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/deploy/MLDeployModelResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/deploy/MLDeployModelResponse.java
@@ -12,31 +12,37 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.MLTaskType;
 
 import java.io.IOException;
 
 @Getter
 public class MLDeployModelResponse extends ActionResponse implements ToXContentObject {
     public static final String TASK_ID_FIELD = "task_id";
+    public static final String TASK_TYPE_FIELD = "task_type";
     public static final String STATUS_FIELD = "status";
 
     private String taskId;
+    private MLTaskType taskType;
     private String status;
 
     public MLDeployModelResponse(StreamInput in) throws IOException {
         super(in);
         this.taskId = in.readString();
+        this.taskType = in.readEnum(MLTaskType.class);
         this.status = in.readString();
     }
 
-    public MLDeployModelResponse(String taskId, String status) {
+    public MLDeployModelResponse(String taskId, MLTaskType mlTaskType, String status) {
         this.taskId = taskId;
+        this.taskType = mlTaskType;
         this.status= status;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(taskId);
+        out.writeEnum(taskType);
         out.writeString(status);
     }
 
@@ -44,6 +50,9 @@ public class MLDeployModelResponse extends ActionResponse implements ToXContentO
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject();
         builder.field(TASK_ID_FIELD, taskId);
+        if (taskType != null) {
+            builder.field(TASK_TYPE_FIELD, taskType);
+        }
         builder.field(STATUS_FIELD, status);
         builder.endObject();
         return builder;

--- a/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelResponseTest.java
@@ -6,6 +6,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.MLTaskType;
 
 import java.io.IOException;
 
@@ -16,37 +17,40 @@ public class MLDeployModelResponseTest {
 
     private String taskId;
     private String status;
+    private MLTaskType taskType;
 
     @Before
     public void setUp() throws Exception {
         taskId = "test_id";
         status = "test";
+        taskType = MLTaskType.DEPLOY_MODEL;
     }
 
     @Test
     public void writeTo_Success() throws IOException {
         // Setup
         BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
-        MLDeployModelResponse response = new MLDeployModelResponse(taskId, status);
+        MLDeployModelResponse response = new MLDeployModelResponse(taskId, taskType, status);
         // Run the test
         response.writeTo(bytesStreamOutput);
         MLDeployModelResponse parsedResponse = new MLDeployModelResponse(bytesStreamOutput.bytes().streamInput());
         // Verify the results
         assertEquals(response.getTaskId(), parsedResponse.getTaskId());
+        assertEquals(response.getTaskType(), parsedResponse.getTaskType());
         assertEquals(response.getStatus(), parsedResponse.getStatus());
     }
 
     @Test
     public void testToXContent() throws IOException {
         // Setup
-        MLDeployModelResponse response = new MLDeployModelResponse(taskId, status);
+        MLDeployModelResponse response = new MLDeployModelResponse(taskId, taskType, status);
         // Run the test
         XContentBuilder builder = XContentFactory.jsonBuilder();
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertNotNull(builder);
         String jsonStr = builder.toString();
         // Verify the results
-        assertEquals("{\"task_id\":\"test_id\"," +
+        assertEquals("{\"task_id\":\"test_id\"," + "\"task_type\":\"DEPLOY_MODEL\"," +
                 "\"status\":\"test\"}", jsonStr);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -233,7 +233,6 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
                 throw new IllegalArgumentException("URL can't match trusted url regex");
             }
         }
-        System.out.println("registering the model");
         boolean isAsync = registerModelInput.getFunctionName() != FunctionName.REMOTE;
         MLTask mlTask = MLTask
             .builder()
@@ -250,7 +249,6 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
             mlTaskManager.createMLTask(mlTask, ActionListener.wrap(response -> {
                 String taskId = response.getId();
                 mlTask.setTaskId(taskId);
-                System.out.println("mlModelManager calls registerMLRemoteModel");
                 mlModelManager.registerMLRemoteModel(registerModelInput, mlTask, listener);
             }, e -> {
                 logException("Failed to register model", e, log);

--- a/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileModelResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/profile/MLProfileModelResponseTests.java
@@ -106,7 +106,6 @@ public class MLProfileModelResponseTests extends OpenSearchTestCase {
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         String xContentString = TestHelper.xContentBuilderToString(builder);
-        System.out.println(xContentString);
     }
 
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
@@ -129,7 +129,7 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         String modelId = (String) responseMap.get("model_id");
         response = deployRemoteModel(modelId);
         responseMap = parseResponseToMap(response);
-        assertEquals("CREATED", (String) responseMap.get("status"));
+        assertEquals("COMPLETED", (String) responseMap.get("status"));
         taskId = (String) responseMap.get("task_id");
         waitForTask(taskId, MLTaskState.COMPLETED);
     }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchConnectorActionTests.java
@@ -137,7 +137,6 @@ public class RestMLSearchConnectorActionTests extends OpenSearchTestCase {
         SearchRequest searchRequest = argumentCaptor.getValue();
         String[] indices = searchRequest.indices();
         assertArrayEquals(new String[] { ML_CONNECTOR_INDEX }, indices);
-        System.out.println(searchRequest);
         assertEquals(
             "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
             searchRequest.source().toString()


### PR DESCRIPTION
### Description
This is to add deployment status with minimum impact to the current code and API workflows. Verified it works with local environment. 

# Before this change: 
POST /_plugins/_ml/models/mUFIL4kB4ubqQRzeKvr1/_deploy

sample response for remote model
{
  "task_id": "OP5JL4kB28KP1SGMupr3",
  "status": "CREATED"
}

This is ridiculous - deploying a remote model doesn't need to be asyncrhonize. I need to see the deployment status right away without sending another API request to query the Task Id!

# After this change: 
POST /_plugins/_ml/models/mUFIL4kB4ubqQRzeKvr1/_deploy

sample response for remote model
{
  "task_id": "OP5JL4kB28KP1SGMupr3",
  "task_type" : "DEPLOY_MODEL"
  "status": "COMPLETED"
}

For non remote models, the response will be 
{
  "task_id": "OP5JL4kB28KP1SGMupr3",
  "task_type" : "DEPLOY_MODEL"
  "status": "CREATED"
}

If the deployment fails, the response will send back the error message right away. 
