### PR TITLE
Make 2.10 release notes up to date

### DIFF
--- a/release-notes/opensearch-ml-common.release-notes-2.10.0.0.md
+++ b/release-notes/opensearch-ml-common.release-notes-2.10.0.0.md
@@ -3,7 +3,7 @@
 Compatible with OpenSearch 2.10.0
 
 
-### Features
+### Experimental Features
 * Conversations and Generative AI in OpenSearch ([#1150](https://github.com/opensearch-project/ml-commons/issues/1150))
 
 ### Enhancements
@@ -23,6 +23,10 @@ Compatible with OpenSearch 2.10.0
 * Handle escaping string parameters explicitly ([#1174](https://github.com/opensearch-project/ml-commons/pull/1174))
 * Fix model count bug ([#1180](https://github.com/opensearch-project/ml-commons/pull/1180))
 * Fix core package name to address compilation errors ([#1157](https://github.com/opensearch-project/ml-commons/pull/1157))
+* Fix system index access bug ([#1320](https://github.com/opensearch-project/ml-commons/pull/1320))
+* Fix unassigned ml system shard replicas ([#1315](https://github.com/opensearch-project/ml-commons/pull/1315))
+* Adjust index replicas settings to keep consistent with AOS 2.9 ([#1325](https://github.com/opensearch-project/ml-commons/pull/1325))
+* Fix GetInteractions returned different results in security-enabled and -disabled settings ([#1334](https://github.com/opensearch-project/ml-commons/pull/1334))
 
 ### Documentation
 * Updating cohere blueprint doc ([#1213](https://github.com/opensearch-project/ml-commons/pull/1213))


### PR DESCRIPTION
### Description
This PR make 2.10 release notes up to date to catch up with latest OpenSearch 2.10 build, meanwhile fix an experimental feature previously classified to feature
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
