### PR TITLE
[Draft] Adding Windows 2019 for CI

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -6,8 +6,8 @@ on:
       - 'backport/**'
       - 'create-pull-request/**'
       - 'dependabot/**'
-  #pull_request_target:
-    #types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   id-token: write
@@ -20,7 +20,7 @@ jobs:
         java: [11, 17]
 
     name: Build and Test MLCommons Plugin
-    #if: github.repository == 'opensearch-project/ml-commons'
+    if: github.repository == 'opensearch-project/ml-commons'
     environment: ml-commons-cicd-env
     runs-on: ubuntu-latest
 
@@ -118,7 +118,7 @@ jobs:
       matrix:
         java: [11, 17]
     name: Build and Test MLCommons Plugin on Windows
-    #if: github.repository == 'opensearch-project/ml-commons'
+    if: github.repository == 'opensearch-project/ml-commons'
     environment: ml-commons-cicd-env
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -120,10 +120,10 @@ jobs:
     name: Build and Test MLCommons Plugin on Windows
     if: github.repository == 'opensearch-project/ml-commons'
     environment: ml-commons-cicd-env
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:  [windows-2019, windows-latest]
+    runs-on: windows-2019
+    #strategy:
+    #  matrix:
+    #    os:  [windows-2019, windows-latest]
 
     steps:
       - name: Setup Java ${{ matrix.java }}

--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -117,13 +117,11 @@ jobs:
     strategy:
       matrix:
         java: [11, 17]
+        os: [windows-2019, windows-latest]
     name: Build and Test MLCommons Plugin on Windows
     if: github.repository == 'opensearch-project/ml-commons'
     environment: ml-commons-cicd-env
-    runs-on: windows-2019
-    #strategy:
-    #  matrix:
-    #    os:  [windows-2019, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Setup Java ${{ matrix.java }}

--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -20,7 +20,7 @@ jobs:
         java: [11, 17]
 
     name: Build and Test MLCommons Plugin
-    if: github.repository == 'opensearch-project/ml-commons'
+    #if: github.repository == 'opensearch-project/ml-commons'
     environment: ml-commons-cicd-env
     runs-on: ubuntu-latest
 
@@ -118,7 +118,7 @@ jobs:
       matrix:
         java: [11, 17]
     name: Build and Test MLCommons Plugin on Windows
-    if: github.repository == 'opensearch-project/ml-commons'
+    #if: github.repository == 'opensearch-project/ml-commons'
     environment: ml-commons-cicd-env
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -6,8 +6,8 @@ on:
       - 'backport/**'
       - 'create-pull-request/**'
       - 'dependabot/**'
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  #pull_request_target:
+    #types: [opened, synchronize, reopened]
 
 permissions:
   id-token: write

--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -120,7 +120,10 @@ jobs:
     name: Build and Test MLCommons Plugin on Windows
     if: github.repository == 'opensearch-project/ml-commons'
     environment: ml-commons-cicd-env
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, windows-2019]
 
     steps:
       - name: Setup Java ${{ matrix.java }}

--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -123,7 +123,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, windows-2019]
+        os:  [windows-2019, windows-latest]
 
     steps:
       - name: Setup Java ${{ matrix.java }}


### PR DESCRIPTION
### Description
Trying to debug: https://github.com/opensearch-project/ml-commons/issues/1149
Redeploy Model Test runs successfully on Windows 2019+, trying to add 2019 Runner which is equivalent to our CI runner in Jenkins. 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
