### PR TITLE
allow input null for text docs input

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/input/nlp/TextDocsMLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/nlp/TextDocsMLInput.java
@@ -114,7 +114,11 @@ public class TextDocsMLInput extends MLInput {
                 case TEXT_DOCS_FIELD:
                     ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                        docs.add(parser.text());
+                        if (parser.currentToken() == null || parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                            docs.add(null);
+                        } else {
+                            docs.add(parser.text());
+                        }
                     }
                     break;
                 case RESULT_FILTER_FIELD:

--- a/common/src/test/java/org/opensearch/ml/common/input/nlp/TextDocsMLInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/nlp/TextDocsMLInputTest.java
@@ -4,9 +4,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.opensearch.core.common.Strings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -26,6 +24,7 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class TextDocsMLInputTest {
@@ -52,22 +51,22 @@ public class TextDocsMLInputTest {
         input.toXContent(builder, ToXContent.EMPTY_PARAMS);
         String jsonStr = builder.toString();
         System.out.println(jsonStr);
-        parseMLInput(jsonStr);
+        parseMLInput(jsonStr, 2);
     }
 
     @Test
     public void parseTextDocsMLInput_OldWay() throws IOException {
-        String jsonStr = "{\"text_docs\": [ \"doc1\", \"doc2\" ],\"return_number\": true, \"return_bytes\": true,\"target_response\": [ \"field1\" ], \"target_response_positions\": [2]}";
-        parseMLInput(jsonStr);
+        String jsonStr = "{\"text_docs\": [ \"doc1\", \"doc2\", null ],\"return_number\": true, \"return_bytes\": true,\"target_response\": [ \"field1\" ], \"target_response_positions\": [2]}";
+        parseMLInput(jsonStr, 3);
     }
 
     @Test
     public void parseTextDocsMLInput_NewWay() throws IOException {
         String jsonStr = "{\"text_docs\":[\"doc1\",\"doc2\"],\"result_filter\":{\"return_bytes\":true,\"return_number\":true,\"target_response\":[\"field1\"], \"target_response_positions\": [2]}}";
-        parseMLInput(jsonStr);
+        parseMLInput(jsonStr, 2);
     }
 
-    private void parseMLInput(String jsonStr) throws IOException {
+    private void parseMLInput(String jsonStr, int docSize) throws IOException {
         XContentParser parser = XContentType.JSON.xContent()
                 .createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
                         Collections.emptyList()).getNamedXContents()), null, jsonStr);
@@ -78,9 +77,12 @@ public class TextDocsMLInputTest {
         assertEquals(input.getFunctionName(), parsedInput.getFunctionName());
         assertEquals(input.getInputDataset().getInputDataType(), parsedInput.getInputDataset().getInputDataType());
         TextDocsInputDataSet inputDataset = (TextDocsInputDataSet) parsedInput.getInputDataset();
-        assertEquals(2, inputDataset.getDocs().size());
+        assertEquals(docSize, inputDataset.getDocs().size());
         assertEquals("doc1", inputDataset.getDocs().get(0));
         assertEquals("doc2", inputDataset.getDocs().get(1));
+        if (inputDataset.getDocs().size() > 2) {
+            assertNull(inputDataset.getDocs().get(2));
+        }
         assertNotNull(inputDataset.getResultFilter());
         assertTrue(inputDataset.getResultFilter().isReturnBytes());
         assertTrue(inputDataset.getResultFilter().isReturnNumber());


### PR DESCRIPTION
### Description
We need to support null value for some use case, for example multi-modal model needs text and image input. User who use TextDocsInputDataSet can use such format `[text, image]`, the first item is text and second is image, but they could be null, for example user may only input image, the input will be `[null, image]`

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
