### PR TITLE
[Backport to 2.x] allow input null for text docs input (#1401)

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/input/nlp/TextDocsMLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/nlp/TextDocsMLInput.java
@@ -114,7 +114,11 @@ public class TextDocsMLInput extends MLInput {
                 case TEXT_DOCS_FIELD:
                     ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                        docs.add(parser.text());
+                        if (parser.currentToken() == null || parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                            docs.add(null);
+                        } else {
+                            docs.add(parser.text());
+                        }
                     }
                     break;
                 case RESULT_FILTER_FIELD:


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/ml-commons/pull/1401 to 2.x
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
