### PR TITLE
fix text docs input unescaped error; enable deploy remote model

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
@@ -81,7 +81,6 @@ public class ConnectorUtils {
         return inputData;
     }
     private static RemoteInferenceInputDataSet processTextDocsInput(TextDocsInputDataSet inputDataSet, Connector connector, Map<String, String> parameters, ScriptService scriptService) {
-        List<String> docs = new ArrayList<>(inputDataSet.getDocs());
         Optional<ConnectorAction> predictAction = connector.findPredictAction();
         if (predictAction.isEmpty()) {
             throw new IllegalArgumentException("no predict action found");
@@ -89,9 +88,17 @@ public class ConnectorUtils {
         String preProcessFunction = predictAction.get().getPreProcessFunction();
         preProcessFunction = preProcessFunction == null ? MLPreProcessFunction.TEXT_DOCS_TO_DEFAULT_EMBEDDING_INPUT : preProcessFunction;
         if (MLPreProcessFunction.contains(preProcessFunction)) {
-            Map<String, Object> buildInFunctionResult = MLPreProcessFunction.get(preProcessFunction).apply(docs);
+            Map<String, Object> buildInFunctionResult = MLPreProcessFunction.get(preProcessFunction).apply(inputDataSet.getDocs());
             return RemoteInferenceInputDataSet.builder().parameters(convertScriptStringToJsonString(buildInFunctionResult)).build();
         } else {
+            List<String> docs = new ArrayList<>();
+            for (String doc : inputDataSet.getDocs()) {
+                if (doc != null) {
+                    docs.add(gson.toJson(doc));
+                } else {
+                    docs.add(null);
+                }
+            }
             if (preProcessFunction.contains("${parameters")) {
                 StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
                 preProcessFunction = substitutor.replace(preProcessFunction);

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -519,9 +519,9 @@ public class MLModelManager {
                     mlTask.setModelId(modelId);
                     log.info("create new model meta doc {} for upload task {}", modelId, taskId);
                     mlTaskManager.updateMLTask(taskId, ImmutableMap.of(MODEL_ID_FIELD, modelId, STATE_FIELD, COMPLETED), 5000, true);
-                    // if (registerModelInput.isDeployModel()) {
-                    // deployModelAfterRegistering(registerModelInput, modelId);
-                    // }
+                    if (registerModelInput.isDeployModel()) {
+                        deployModelAfterRegistering(registerModelInput, modelId);
+                    }
                     listener.onResponse(new MLRegisterModelResponse(taskId, MLTaskState.CREATED.name(), modelId));
                 }, e -> {
                     log.error("Failed to index model meta doc", e);


### PR DESCRIPTION
### Description
This PR fixed two bugs
1. When neural search plugin send text docs to remote embedding model with unescaped string, it will throw invalid json error.
2. When user register remote model with `?deploy=true`, the model won't be deployed. This part disabled by https://github.com/opensearch-project/ml-commons/pull/1329/files
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
