### PR TITLE
Ignoring Redeploy test on MacOS due to known failures

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeployModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeployModelActionIT.java
@@ -27,6 +27,8 @@ public class RestMLDeployModelActionIT extends MLCommonsRestTestCase {
 
     @Before
     public void setup() throws IOException {
+        // Skip test if running on Mac OS, https://github.com/opensearch-project/ml-commons/issues/844
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Mac OS X"));
         mlRegisterModelGroupInput = MLRegisterModelGroupInput.builder().name("testGroupID").description("This is test Group").build();
         registerModelGroup(client(), TestHelper.toJsonString(mlRegisterModelGroupInput), registerModelGroupResult -> {
             this.modelGroupId = (String) registerModelGroupResult.get("model_group_id");
@@ -35,9 +37,6 @@ public class RestMLDeployModelActionIT extends MLCommonsRestTestCase {
     }
 
     public void testReDeployModel() throws InterruptedException, IOException {
-        // Skip test if running on Mac OS, https://github.com/opensearch-project/ml-commons/issues/844
-        Assume.assumeFalse(System.getProperty("os.name").startsWith("Mac OS X"));
-
         // Register Model
         String taskId = registerModel(TestHelper.toJsonString(registerModelInput));
         waitForTask(taskId, MLTaskState.COMPLETED);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeployModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeployModelActionIT.java
@@ -9,7 +9,9 @@ import static org.opensearch.ml.common.MLTask.MODEL_ID_FIELD;
 import java.io.IOException;
 import java.util.Map;
 
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.MLTaskState;
@@ -34,6 +36,9 @@ public class RestMLDeployModelActionIT extends MLCommonsRestTestCase {
     }
 
     public void testReDeployModel() throws InterruptedException, IOException {
+        // Skip test if running on Mac OS, https://github.com/opensearch-project/ml-commons/issues/844
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Mac OS X"));
+
         // Register Model
         String taskId = registerModel(TestHelper.toJsonString(registerModelInput));
         waitForTask(taskId, MLTaskState.COMPLETED);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeployModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeployModelActionIT.java
@@ -11,7 +11,6 @@ import java.util.Map;
 
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.MLTaskState;


### PR DESCRIPTION
### Description
Redeploying Model fails on MacOS which we officially don't support for ML-Commons yet. 
 
### Issues Resolved
Part of #844 
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
