### PR TITLE
model registry fixes

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
@@ -52,7 +52,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
     public static final String ACCESS_MODE_FIELD = "access_mode";
     public static final String BACKEND_ROLES_FIELD = "backend_roles";
     public static final String ADD_ALL_BACKEND_ROLES_FIELD = "add_all_backend_roles";
-
+    public static final String IS_THIS_VERSION_CREATING_MODEL_GROUP = "is_this_version_creating_model_group";
     private FunctionName functionName;
     private String modelName;
     private String modelGroupId;
@@ -72,6 +72,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
     private List<String> backendRoles;
     private Boolean addAllBackendRoles;
     private AccessMode accessMode;
+    private Boolean isThisVersionCreatingModelGroup;
 
     @Builder(toBuilder = true)
     public MLRegisterModelInput(FunctionName functionName,
@@ -89,7 +90,8 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                                 String connectorId,
                                 List<String> backendRoles,
                                 Boolean addAllBackendRoles,
-                                AccessMode accessMode
+                                AccessMode accessMode,
+                                Boolean isThisVersionCreatingModelGroup
     ) {
         if (functionName == null) {
             this.functionName = FunctionName.TEXT_EMBEDDING;
@@ -122,6 +124,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         this.backendRoles = backendRoles;
         this.addAllBackendRoles = addAllBackendRoles;
         this.accessMode = accessMode;
+        this.isThisVersionCreatingModelGroup = isThisVersionCreatingModelGroup;
     }
 
 
@@ -152,6 +155,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         if (in.readBoolean()) {
             this.accessMode = in.readEnum(AccessMode.class);
         }
+        this.isThisVersionCreatingModelGroup = in.readOptionalBoolean();
     }
 
     @Override
@@ -197,6 +201,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
+        out.writeOptionalBoolean(isThisVersionCreatingModelGroup);
     }
 
     @Override
@@ -244,6 +249,9 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         if (accessMode != null) {
             builder.field(ACCESS_MODE_FIELD, accessMode);
         }
+        if (isThisVersionCreatingModelGroup != null) {
+            builder.field(IS_THIS_VERSION_CREATING_MODEL_GROUP, isThisVersionCreatingModelGroup);
+        }
         builder.endObject();
         return builder;
     }
@@ -262,6 +270,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         List<String> backendRoles = new ArrayList<>();
         Boolean addAllBackendRoles = null;
         AccessMode accessMode = null;
+        Boolean isThisVersionCreatingModelGroup = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -313,12 +322,15 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                 case ACCESS_MODE_FIELD:
                     accessMode = AccessMode.from(parser.text());
                     break;
+                case IS_THIS_VERSION_CREATING_MODEL_GROUP:
+                    isThisVersionCreatingModelGroup = parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
             }
         }
-        return new MLRegisterModelInput(functionName, modelName, modelGroupId, version, description, url, hashValue, modelFormat, modelConfig, deployModel, modelNodeIds.toArray(new String[0]), connector, connectorId, backendRoles, addAllBackendRoles, accessMode);
+        return new MLRegisterModelInput(functionName, modelName, modelGroupId, version, description, url, hashValue, modelFormat, modelConfig, deployModel, modelNodeIds.toArray(new String[0]), connector, connectorId, backendRoles, addAllBackendRoles, accessMode, isThisVersionCreatingModelGroup);
     }
 
     public static MLRegisterModelInput parse(XContentParser parser, boolean deployModel) throws IOException {
@@ -337,6 +349,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         List<String> backendRoles = new ArrayList<>();
         AccessMode accessMode = null;
         Boolean addAllBackendRoles = null;
+        Boolean isThisVersionCreatingModelGroup = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -395,11 +408,14 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                 case ACCESS_MODE_FIELD:
                     accessMode = AccessMode.from(parser.text());
                     break;
+                case IS_THIS_VERSION_CREATING_MODEL_GROUP:
+                    isThisVersionCreatingModelGroup = parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
             }
         }
-        return new MLRegisterModelInput(functionName, name, modelGroupId, version, description, url, hashValue, modelFormat, modelConfig, deployModel, modelNodeIds.toArray(new String[0]), connector, connectorId, backendRoles, addAllBackendRoles, accessMode);
+        return new MLRegisterModelInput(functionName, name, modelGroupId, version, description, url, hashValue, modelFormat, modelConfig, deployModel, modelNodeIds.toArray(new String[0]), connector, connectorId, backendRoles, addAllBackendRoles, accessMode, isThisVersionCreatingModelGroup);
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
@@ -52,7 +52,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
     public static final String ACCESS_MODE_FIELD = "access_mode";
     public static final String BACKEND_ROLES_FIELD = "backend_roles";
     public static final String ADD_ALL_BACKEND_ROLES_FIELD = "add_all_backend_roles";
-    public static final String IS_THIS_VERSION_CREATING_MODEL_GROUP = "is_this_version_creating_model_group";
+    public static final String DOES_VERSION_CREATE_MODEL_GROUP = "does_version_create_model_group";
     private FunctionName functionName;
     private String modelName;
     private String modelGroupId;
@@ -72,7 +72,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
     private List<String> backendRoles;
     private Boolean addAllBackendRoles;
     private AccessMode accessMode;
-    private Boolean isThisVersionCreatingModelGroup;
+    private Boolean doesVersionCreateModelGroup;
 
     @Builder(toBuilder = true)
     public MLRegisterModelInput(FunctionName functionName,
@@ -91,7 +91,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                                 List<String> backendRoles,
                                 Boolean addAllBackendRoles,
                                 AccessMode accessMode,
-                                Boolean isThisVersionCreatingModelGroup
+                                Boolean doesVersionCreateModelGroup
     ) {
         if (functionName == null) {
             this.functionName = FunctionName.TEXT_EMBEDDING;
@@ -124,7 +124,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         this.backendRoles = backendRoles;
         this.addAllBackendRoles = addAllBackendRoles;
         this.accessMode = accessMode;
-        this.isThisVersionCreatingModelGroup = isThisVersionCreatingModelGroup;
+        this.doesVersionCreateModelGroup = doesVersionCreateModelGroup;
     }
 
 
@@ -155,7 +155,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         if (in.readBoolean()) {
             this.accessMode = in.readEnum(AccessMode.class);
         }
-        this.isThisVersionCreatingModelGroup = in.readOptionalBoolean();
+        this.doesVersionCreateModelGroup = in.readOptionalBoolean();
     }
 
     @Override
@@ -201,7 +201,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
-        out.writeOptionalBoolean(isThisVersionCreatingModelGroup);
+        out.writeOptionalBoolean(doesVersionCreateModelGroup);
     }
 
     @Override
@@ -249,8 +249,8 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         if (accessMode != null) {
             builder.field(ACCESS_MODE_FIELD, accessMode);
         }
-        if (isThisVersionCreatingModelGroup != null) {
-            builder.field(IS_THIS_VERSION_CREATING_MODEL_GROUP, isThisVersionCreatingModelGroup);
+        if (doesVersionCreateModelGroup != null) {
+            builder.field(DOES_VERSION_CREATE_MODEL_GROUP, doesVersionCreateModelGroup);
         }
         builder.endObject();
         return builder;
@@ -270,7 +270,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         List<String> backendRoles = new ArrayList<>();
         Boolean addAllBackendRoles = null;
         AccessMode accessMode = null;
-        Boolean isThisVersionCreatingModelGroup = null;
+        Boolean doesVersionCreateModelGroup = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -322,15 +322,15 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                 case ACCESS_MODE_FIELD:
                     accessMode = AccessMode.from(parser.text());
                     break;
-                case IS_THIS_VERSION_CREATING_MODEL_GROUP:
-                    isThisVersionCreatingModelGroup = parser.booleanValue();
+                case DOES_VERSION_CREATE_MODEL_GROUP:
+                    doesVersionCreateModelGroup = parser.booleanValue();
                     break;
                 default:
                     parser.skipChildren();
                     break;
             }
         }
-        return new MLRegisterModelInput(functionName, modelName, modelGroupId, version, description, url, hashValue, modelFormat, modelConfig, deployModel, modelNodeIds.toArray(new String[0]), connector, connectorId, backendRoles, addAllBackendRoles, accessMode, isThisVersionCreatingModelGroup);
+        return new MLRegisterModelInput(functionName, modelName, modelGroupId, version, description, url, hashValue, modelFormat, modelConfig, deployModel, modelNodeIds.toArray(new String[0]), connector, connectorId, backendRoles, addAllBackendRoles, accessMode, doesVersionCreateModelGroup);
     }
 
     public static MLRegisterModelInput parse(XContentParser parser, boolean deployModel) throws IOException {
@@ -349,7 +349,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         List<String> backendRoles = new ArrayList<>();
         AccessMode accessMode = null;
         Boolean addAllBackendRoles = null;
-        Boolean isThisVersionCreatingModelGroup = null;
+        Boolean doesVersionCreateModelGroup = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -408,14 +408,14 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                 case ACCESS_MODE_FIELD:
                     accessMode = AccessMode.from(parser.text());
                     break;
-                case IS_THIS_VERSION_CREATING_MODEL_GROUP:
-                    isThisVersionCreatingModelGroup = parser.booleanValue();
+                case DOES_VERSION_CREATE_MODEL_GROUP:
+                    doesVersionCreateModelGroup = parser.booleanValue();
                     break;
                 default:
                     parser.skipChildren();
                     break;
             }
         }
-        return new MLRegisterModelInput(functionName, name, modelGroupId, version, description, url, hashValue, modelFormat, modelConfig, deployModel, modelNodeIds.toArray(new String[0]), connector, connectorId, backendRoles, addAllBackendRoles, accessMode, isThisVersionCreatingModelGroup);
+        return new MLRegisterModelInput(functionName, name, modelGroupId, version, description, url, hashValue, modelFormat, modelConfig, deployModel, modelNodeIds.toArray(new String[0]), connector, connectorId, backendRoles, addAllBackendRoles, accessMode, doesVersionCreateModelGroup);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupAction.java
@@ -9,7 +9,6 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 import static org.opensearch.ml.utils.MLExceptionUtils.logException;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -90,39 +89,39 @@ public class TransportUpdateModelGroupAction extends HandledTransportAction<Acti
         MLUpdateModelGroupInput updateModelGroupInput = updateModelGroupRequest.getUpdateModelGroupInput();
         String modelGroupId = updateModelGroupInput.getModelGroupID();
         User user = RestActionUtils.getUserContext(client);
-        if (modelAccessControlHelper.isSecurityEnabledAndModelAccessControlEnabled(user)) {
-            GetRequest getModelGroupRequest = new GetRequest(ML_MODEL_GROUP_INDEX).id(modelGroupId);
-            try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-                client.get(getModelGroupRequest, ActionListener.wrap(modelGroup -> {
-                    if (modelGroup.isExists()) {
-                        try (
-                            XContentParser parser = MLNodeUtils
-                                .createXContentParserFromRegistry(NamedXContentRegistry.EMPTY, modelGroup.getSourceAsBytesRef())
-                        ) {
-                            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-                            MLModelGroup mlModelGroup = MLModelGroup.parse(parser);
+        GetRequest getModelGroupRequest = new GetRequest(ML_MODEL_GROUP_INDEX).id(modelGroupId);
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            client.get(getModelGroupRequest, ActionListener.wrap(modelGroup -> {
+                if (modelGroup.isExists()) {
+                    try (
+                        XContentParser parser = MLNodeUtils
+                            .createXContentParserFromRegistry(NamedXContentRegistry.EMPTY, modelGroup.getSourceAsBytesRef())
+                    ) {
+                        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                        MLModelGroup mlModelGroup = MLModelGroup.parse(parser);
+                        if (modelAccessControlHelper.isSecurityEnabledAndModelAccessControlEnabled(user)) {
                             validateRequestForAccessControl(updateModelGroupInput, user, mlModelGroup);
-                            updateModelGroup(modelGroupId, modelGroup.getSource(), updateModelGroupInput, listener, user);
+                        } else {
+                            validateSecurityDisabledOrModelAccessControlDisabled(updateModelGroupInput);
                         }
-                    } else {
-                        listener.onFailure(new OpenSearchStatusException("Failed to find model group", RestStatus.NOT_FOUND));
+                        updateModelGroup(modelGroupId, modelGroup.getSource(), updateModelGroupInput, listener, user);
                     }
-                }, e -> {
-                    if (e instanceof IndexNotFoundException) {
-                        listener.onFailure(new MLResourceNotFoundException("Fail to find model group"));
-                    } else {
-                        logException("Failed to get model group", e, log);
-                        listener.onFailure(e);
-                    }
-                }));
-            } catch (Exception e) {
-                logException("Failed to Update model group", e, log);
-                listener.onFailure(e);
-            }
-        } else {
-            validateSecurityDisabledOrModelAccessControlDisabled(updateModelGroupInput);
-            updateModelGroup(modelGroupId, new HashMap<>(), updateModelGroupInput, listener, user);
+                } else {
+                    listener.onFailure(new OpenSearchStatusException("Failed to find model group", RestStatus.NOT_FOUND));
+                }
+            }, e -> {
+                if (e instanceof IndexNotFoundException) {
+                    listener.onFailure(new MLResourceNotFoundException("Fail to find model group"));
+                } else {
+                    logException("Failed to get model group", e, log);
+                    listener.onFailure(e);
+                }
+            }));
+        } catch (Exception e) {
+            logException("Failed to Update model group", e, log);
+            listener.onFailure(e);
         }
+
     }
 
     private void updateModelGroup(

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupAction.java
@@ -105,6 +105,9 @@ public class TransportUpdateModelGroupAction extends HandledTransportAction<Acti
                             validateSecurityDisabledOrModelAccessControlDisabled(updateModelGroupInput);
                         }
                         updateModelGroup(modelGroupId, modelGroup.getSource(), updateModelGroupInput, listener, user);
+                    } catch (Exception e) {
+                        log.error("Failed to parse ml model group" + modelGroup.getId(), e);
+                        listener.onFailure(e);
                     }
                 } else {
                     listener.onFailure(new OpenSearchStatusException("Failed to find model group", RestStatus.NOT_FOUND));

--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -5,10 +5,13 @@
 
 package org.opensearch.ml.action.models;
 
-import com.google.common.annotations.VisibleForTesting;
-import lombok.AccessLevel;
-import lombok.experimental.FieldDefaults;
-import lombok.extern.log4j.Log4j2;
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
+import static org.opensearch.ml.common.MLModel.MODEL_ID_FIELD;
+import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
+import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
+
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.ActionRequest;
@@ -43,12 +46,11 @@ import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
-import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
-import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
-import static org.opensearch.ml.common.MLModel.MODEL_ID_FIELD;
-import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
-import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
+import com.google.common.annotations.VisibleForTesting;
+
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 @FieldDefaults(level = AccessLevel.PRIVATE)
@@ -113,7 +115,8 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
                                     || mlModelState.equals(MLModelState.LOADING)
                                     || mlModelState.equals(MLModelState.PARTIALLY_LOADED)
                                     || mlModelState.equals(MLModelState.DEPLOYED)
-                                    || mlModelState.equals(MLModelState.DEPLOYING) || mlModelState.equals(MLModelState.PARTIALLY_DEPLOYED)) {
+                                    || mlModelState.equals(MLModelState.DEPLOYING)
+                                    || mlModelState.equals(MLModelState.PARTIALLY_DEPLOYED)) {
                                     actionListener
                                         .onFailure(
                                             new Exception(

--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -6,14 +6,12 @@
 package org.opensearch.ml.action.models;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
 import static org.opensearch.ml.common.MLModel.MODEL_ID_FIELD;
 import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
 import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
 
-import org.apache.commons.lang3.StringUtils;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.ActionRequest;
@@ -21,8 +19,6 @@ import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.client.Client;
@@ -34,8 +30,6 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryAction;
@@ -48,7 +42,6 @@ import org.opensearch.ml.common.transport.model.MLModelDeleteRequest;
 import org.opensearch.ml.common.transport.model.MLModelGetRequest;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.utils.RestActionUtils;
-import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -109,6 +102,7 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
                             algorithmName = getResponse.getSource().get(ALGORITHM_FIELD).toString();
                         }
                         MLModel mlModel = MLModel.parse(parser, algorithmName);
+                        MLModelState mlModelState = mlModel.getModelState();
 
                         modelAccessControlHelper
                             .validateModelGroupAccess(user, mlModel.getModelGroupId(), client, ActionListener.wrap(access -> {
@@ -117,37 +111,19 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
                                         .onFailure(
                                             new MLValidationException("User doesn't have privilege to perform this operation on this model")
                                         );
+                                } else if (mlModelState.equals(MLModelState.LOADED)
+                                    || mlModelState.equals(MLModelState.LOADING)
+                                    || mlModelState.equals(MLModelState.PARTIALLY_LOADED)
+                                    || mlModelState.equals(MLModelState.DEPLOYED)
+                                    || mlModelState.equals(MLModelState.DEPLOYING) | mlModelState.equals(MLModelState.PARTIALLY_DEPLOYED)) {
+                                    actionListener
+                                        .onFailure(
+                                            new Exception(
+                                                "Model cannot be deleted in deploying or deployed state. Try undeploy model first then delete"
+                                            )
+                                        );
                                 } else {
-                                    MLModelState mlModelState = mlModel.getModelState();
-                                    if (mlModelState.equals(MLModelState.LOADED)
-                                        || mlModelState.equals(MLModelState.LOADING)
-                                        || mlModelState.equals(MLModelState.PARTIALLY_LOADED)
-                                        || mlModelState.equals(MLModelState.DEPLOYED)
-                                        || mlModelState.equals(MLModelState.DEPLOYING)
-                                        || mlModelState.equals(MLModelState.PARTIALLY_DEPLOYED)) {
-                                        actionListener
-                                            .onFailure(
-                                                new Exception(
-                                                    "Model cannot be deleted in deploying or deployed state. Try undeploy model first then delete"
-                                                )
-                                            );
-                                    } else if (StringUtils.isNotEmpty(mlModel.getModelGroupId())) {
-                                        searchModel(mlModel.getModelGroupId(), ActionListener.wrap(response -> {
-                                            boolean isLastModelOfGroup = false;
-                                            if (response != null
-                                                && response.getHits() != null
-                                                && response.getHits().getTotalHits() != null
-                                                && response.getHits().getTotalHits().value == 1) {
-                                                isLastModelOfGroup = true;
-                                            }
-                                            deleteModel(modelId, mlModel.getModelGroupId(), isLastModelOfGroup, actionListener);
-                                        }, e -> {
-                                            log.error("Failed to Search Model index " + modelId, e);
-                                            actionListener.onFailure(e);
-                                        }));
-                                    } else {
-                                        deleteModel(modelId, mlModel.getModelGroupId(), false, actionListener);
-                                    }
+                                    deleteModel(modelId, actionListener);
                                 }
                             }, e -> {
                                 log.error("Failed to validate Access for Model Id " + modelId, e);
@@ -165,18 +141,6 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
             log.error("Failed to delete ML model " + modelId, e);
             actionListener.onFailure(e);
         }
-    }
-
-    private void searchModel(String modelGroupId, ActionListener<SearchResponse> listener) {
-        BoolQueryBuilder query = new BoolQueryBuilder();
-        query.filter(new TermQueryBuilder(MLModel.MODEL_GROUP_ID_FIELD, modelGroupId));
-
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(query);
-        SearchRequest searchRequest = new SearchRequest(ML_MODEL_INDEX).source(searchSourceBuilder);
-        client.search(searchRequest, ActionListener.wrap(response -> { listener.onResponse(response); }, e -> {
-            log.error("Failed to search Model index", e);
-            listener.onFailure(e);
-        }));
     }
 
     @VisibleForTesting
@@ -217,19 +181,11 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
         actionListener.onFailure(new OpenSearchStatusException(errorMessage, RestStatus.INTERNAL_SERVER_ERROR));
     }
 
-    private void deleteModel(
-        String modelId,
-        String modelGroupId,
-        boolean isLastModelOfGroup,
-        ActionListener<DeleteResponse> actionListener
-    ) {
+    private void deleteModel(String modelId, ActionListener<DeleteResponse> actionListener) {
         DeleteRequest deleteRequest = new DeleteRequest(ML_MODEL_INDEX, modelId);
         client.delete(deleteRequest, new ActionListener<DeleteResponse>() {
             @Override
             public void onResponse(DeleteResponse deleteResponse) {
-                if (isLastModelOfGroup) {
-                    deleteModelGroup(modelGroupId);
-                }
                 deleteModelChunks(modelId, deleteResponse, actionListener);
             }
 
@@ -240,21 +196,6 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
                     deleteModelChunks(modelId, null, actionListener);
                 }
                 actionListener.onFailure(e);
-            }
-        });
-    }
-
-    private void deleteModelGroup(String modelGroupId) {
-        DeleteRequest deleteRequest = new DeleteRequest(ML_MODEL_GROUP_INDEX, modelGroupId);
-        client.delete(deleteRequest, new ActionListener<DeleteResponse>() {
-            @Override
-            public void onResponse(DeleteResponse deleteResponse) {
-                log.debug("Completed Delete Model Group for modelGroupId:{}", modelGroupId);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                log.error("Failed to delete ML Model Group with Id:{} " + modelGroupId, e);
             }
         });
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -5,13 +5,10 @@
 
 package org.opensearch.ml.action.models;
 
-import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
-import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
-import static org.opensearch.ml.common.MLModel.MODEL_ID_FIELD;
-import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
-import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
-
+import com.google.common.annotations.VisibleForTesting;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.log4j.Log4j2;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.ActionRequest;
@@ -46,11 +43,12 @@ import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
-import com.google.common.annotations.VisibleForTesting;
-
-import lombok.AccessLevel;
-import lombok.experimental.FieldDefaults;
-import lombok.extern.log4j.Log4j2;
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
+import static org.opensearch.ml.common.MLModel.MODEL_ID_FIELD;
+import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
+import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
 
 @Log4j2
 @FieldDefaults(level = AccessLevel.PRIVATE)
@@ -115,7 +113,7 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
                                     || mlModelState.equals(MLModelState.LOADING)
                                     || mlModelState.equals(MLModelState.PARTIALLY_LOADED)
                                     || mlModelState.equals(MLModelState.DEPLOYED)
-                                    || mlModelState.equals(MLModelState.DEPLOYING) | mlModelState.equals(MLModelState.PARTIALLY_DEPLOYED)) {
+                                    || mlModelState.equals(MLModelState.DEPLOYING) || mlModelState.equals(MLModelState.PARTIALLY_DEPLOYED)) {
                                     actionListener
                                         .onFailure(
                                             new Exception(

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -5,18 +5,9 @@
 
 package org.opensearch.ml.action.register;
 
-import static org.opensearch.ml.common.MLTask.STATE_FIELD;
-import static org.opensearch.ml.common.MLTaskState.FAILED;
-import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
-import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_URL_REGEX;
-import static org.opensearch.ml.task.MLTaskManager.TASK_SEMAPHORE_TIMEOUT;
-import static org.opensearch.ml.utils.MLExceptionUtils.logException;
-
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Pattern;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import lombok.extern.log4j.Log4j2;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.action.ActionListenerResponseHandler;
 import org.opensearch.action.ActionRequest;
@@ -63,10 +54,17 @@ import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
 
-import lombok.extern.log4j.Log4j2;
+import static org.opensearch.ml.common.MLTask.STATE_FIELD;
+import static org.opensearch.ml.common.MLTaskState.FAILED;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_URL_REGEX;
+import static org.opensearch.ml.task.MLTaskManager.TASK_SEMAPHORE_TIMEOUT;
+import static org.opensearch.ml.utils.MLExceptionUtils.logException;
 
 @Log4j2
 public class TransportRegisterModelAction extends HandledTransportAction<ActionRequest, MLRegisterModelResponse> {
@@ -176,10 +174,9 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
                 if (isModelNameAlreadyExisting) {
                     // This case handles when user is using the same pre-trained model already registered by another user on the cluster.
                     // The only way here is for the user to first create model group and use its ID in the request
-                    if (registerModelInput.getModelGroupId() != null
-                        && (registerModelInput.getUrl() == null
+                    if (registerModelInput.getUrl() == null
                             && registerModelInput.getFunctionName() != FunctionName.REMOTE
-                            && registerModelInput.getConnectorId() == null)) {
+                            && registerModelInput.getConnectorId() == null) {
                         listener
                             .onFailure(
                                 new IllegalArgumentException(

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -166,24 +166,47 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
         User user = RestActionUtils.getUserContext(client);
         modelAccessControlHelper
             .validateModelGroupAccess(user, registerModelInput.getModelGroupId(), client, ActionListener.wrap(access -> {
-                if (!access) {
-                    if (isModelNameAlreadyExisting) {
+                if (access) {
+                    doRegister(registerModelInput, listener);
+                    return;
+                }
+                // if the user does not have access, we need to check three more conditions before throwing exception.
+                // if we are checking the access based on the name provided in the input, we let user know the name is already used by a
+                // model group they do not have access to.
+                if (isModelNameAlreadyExisting) {
+                    // This case handles when user is using the same pre-trained model already registered by another user on the cluster.
+                    // The only way here is for the user to first create model group and use its ID in the request
+                    if (registerModelInput.getModelGroupId() != null
+                        && (registerModelInput.getUrl() == null
+                            && registerModelInput.getFunctionName() != FunctionName.REMOTE
+                            && registerModelInput.getConnectorId() == null)) {
                         listener
                             .onFailure(
                                 new IllegalArgumentException(
-                                    "The name \""
+                                    "Without a model group ID, the system will use the model name {"
                                         + registerModelInput.getModelName()
-                                        + "\" you provided is already being used by another model group \""
+                                        + "} to create a new model group. However, this name is taken by another group {"
                                         + registerModelInput.getModelGroupId()
-                                        + "\" to which you do not have access. Please provide a different name."
+                                        + "} you can't access. To register this pre-trained model, create a new model group and use its ID in your request."
                                 )
                             );
-                    } else
+                    } else {
                         listener
-                            .onFailure(new IllegalArgumentException("You don't have permissions to perform this operation on this model."));
-                } else {
-                    doRegister(registerModelInput, listener);
+                            .onFailure(
+                                new IllegalArgumentException(
+                                    "The name {"
+                                        + registerModelInput.getModelName()
+                                        + "} you provided is unavailable because it is used by another model group {"
+                                        + registerModelInput.getModelGroupId()
+                                        + "} to which you do not have access. Please provide a different name."
+                                )
+                            );
+                    }
+                    return;
                 }
+                // if user does not have access to the model group ID provided in the input, we let user know they do not have access to the
+                // specified model group
+                listener.onFailure(new IllegalArgumentException("You don't have permissions to perform this operation on this model."));
             }, listener::onFailure));
     }
 
@@ -233,7 +256,7 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
             MLRegisterModelGroupInput mlRegisterModelGroupInput = createRegisterModelGroupRequest(registerModelInput);
             mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, ActionListener.wrap(modelGroupId -> {
                 registerModelInput.setModelGroupId(modelGroupId);
-                registerModelInput.setIsThisVersionCreatingModelGroup(true);
+                registerModelInput.setDoesVersionCreateModelGroup(true);
                 registerModel(registerModelInput, listener);
             }, e -> {
                 logException("Failed to create Model Group", e, log);

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -262,6 +262,7 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
                 listener.onFailure(e);
             }));
         } else {
+            registerModelInput.setDoesVersionCreateModelGroup(false);
             registerModel(registerModelInput, listener);
         }
     }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -145,15 +145,13 @@ public class MLModelGroupManager {
         AccessMode modelAccessMode = input.getModelAccessMode();
         Boolean isAddAllBackendRoles = input.getIsAddAllBackendRoles();
         if (modelAccessMode == null) {
-            if (modelAccessMode == null) {
-                if (!CollectionUtils.isEmpty(input.getBackendRoles()) && Boolean.TRUE.equals(isAddAllBackendRoles)) {
-                    throw new IllegalArgumentException("You cannot specify backend roles and add all backend roles at the same time.");
-                } else if (Boolean.TRUE.equals(isAddAllBackendRoles) || !CollectionUtils.isEmpty(input.getBackendRoles())) {
-                    input.setModelAccessMode(AccessMode.RESTRICTED);
-                    modelAccessMode = AccessMode.RESTRICTED;
-                } else {
-                    input.setModelAccessMode(AccessMode.PRIVATE);
-                }
+            if (!CollectionUtils.isEmpty(input.getBackendRoles()) && Boolean.TRUE.equals(isAddAllBackendRoles)) {
+                throw new IllegalArgumentException("You cannot specify backend roles and add all backend roles at the same time.");
+            } else if (Boolean.TRUE.equals(isAddAllBackendRoles) || !CollectionUtils.isEmpty(input.getBackendRoles())) {
+                input.setModelAccessMode(AccessMode.RESTRICTED);
+                modelAccessMode = AccessMode.RESTRICTED;
+            } else {
+                input.setModelAccessMode(AccessMode.PRIVATE);
             }
         }
         if ((AccessMode.PUBLIC == modelAccessMode || AccessMode.PRIVATE == modelAccessMode)
@@ -183,20 +181,29 @@ public class MLModelGroupManager {
     }
 
     public void validateUniqueModelGroupName(String name, ActionListener<SearchResponse> listener) throws IllegalArgumentException {
-        BoolQueryBuilder query = new BoolQueryBuilder();
-        query.filter(new TermQueryBuilder(MLRegisterModelGroupInput.NAME_FIELD + ".keyword", name));
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            BoolQueryBuilder query = new BoolQueryBuilder();
+            query.filter(new TermQueryBuilder(MLRegisterModelGroupInput.NAME_FIELD + ".keyword", name));
 
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(query);
-        SearchRequest searchRequest = new SearchRequest(ML_MODEL_GROUP_INDEX).source(searchSourceBuilder);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(query);
+            SearchRequest searchRequest = new SearchRequest(ML_MODEL_GROUP_INDEX).source(searchSourceBuilder);
 
-        client.search(searchRequest, ActionListener.wrap(modelGroups -> { listener.onResponse(modelGroups); }, e -> {
-            if (e instanceof IndexNotFoundException) {
-                listener.onResponse(null);
-            } else {
-                log.error("Failed to search model group index", e);
-                listener.onFailure(e);
-            }
-        }));
+            client
+                .search(
+                    searchRequest,
+                    ActionListener.runBefore(ActionListener.wrap(modelGroups -> { listener.onResponse(modelGroups); }, e -> {
+                        if (e instanceof IndexNotFoundException) {
+                            listener.onResponse(null);
+                        } else {
+                            log.error("Failed to search model group index", e);
+                            listener.onFailure(e);
+                        }
+                    }), () -> context.restore())
+                );
+        } catch (Exception e) {
+            log.error("Failed to search model group index", e);
+            listener.onFailure(e);
+        }
     }
 
     private void validateSecurityDisabledOrModelAccessControlDisabled(MLRegisterModelGroupInput input) {

--- a/plugin/src/test/java/org/opensearch/ml/action/models/DeleteModelTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/DeleteModelTransportActionTests.java
@@ -6,9 +6,7 @@
 package org.opensearch.ml.action.models;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -35,7 +32,6 @@ import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetResponse;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
@@ -50,15 +46,11 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.ScrollableHitSource;
-import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.common.transport.model.MLModelDeleteRequest;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelManager;
-import org.opensearch.ml.utils.TestHelper;
-import org.opensearch.search.SearchHit;
-import org.opensearch.search.SearchHits;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -182,115 +174,6 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         verify(actionListener).onResponse(deleteResponse);
-    }
-
-    public void test_Success_ModelGroupIDNotNull_LastModelOfGroup() throws IOException {
-        doAnswer(invocation -> {
-            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
-            listener.onResponse(deleteResponse);
-            return null;
-        }).when(client).delete(any(), any());
-
-        doAnswer(invocation -> {
-            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
-            BulkByScrollResponse response = new BulkByScrollResponse(new ArrayList<>(), null);
-            listener.onResponse(response);
-            return null;
-        }).when(client).execute(any(), any(), any());
-
-        SearchResponse searchResponse = createModelGroupSearchResponse(1);
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), isA(ActionListener.class));
-
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, "modelGroupID");
-
-        doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
-            return null;
-        }).when(client).get(any(), any());
-
-        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
-        verify(actionListener).onResponse(deleteResponse);
-    }
-
-    public void test_Success_ModelGroupIDNotNull_NotLastModelOfGroup() throws IOException {
-        doAnswer(invocation -> {
-            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
-            listener.onResponse(deleteResponse);
-            return null;
-        }).when(client).delete(any(), any());
-
-        doAnswer(invocation -> {
-            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
-            BulkByScrollResponse response = new BulkByScrollResponse(new ArrayList<>(), null);
-            listener.onResponse(response);
-            return null;
-        }).when(client).execute(any(), any(), any());
-
-        SearchResponse searchResponse = createModelGroupSearchResponse(2);
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), isA(ActionListener.class));
-
-        MLModel mlModel = MLModel
-            .builder()
-            .modelId("test_id")
-            .modelGroupId("modelGroupID")
-            .modelState(MLModelState.REGISTERED)
-            .algorithm(FunctionName.TEXT_EMBEDDING)
-            .build();
-        XContentBuilder content = mlModel.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
-        BytesReference bytesReference = BytesReference.bytes(content);
-        GetResult getResult = new GetResult("indexName", "111", 111l, 111l, 111l, true, bytesReference, null, null);
-        GetResponse getResponse = new GetResponse(getResult);
-        doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
-            return null;
-        }).when(client).get(any(), any());
-
-        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
-        verify(actionListener).onResponse(deleteResponse);
-    }
-
-    public void test_Failure_FailedToSearchLastModel() throws IOException {
-        doAnswer(invocation -> {
-            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
-            listener.onResponse(deleteResponse);
-            return null;
-        }).when(client).delete(any(), any());
-
-        doAnswer(invocation -> {
-            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
-            BulkByScrollResponse response = new BulkByScrollResponse(new ArrayList<>(), null);
-            listener.onResponse(response);
-            return null;
-        }).when(client).execute(any(), any(), any());
-
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new Exception("Failed to search Model index"));
-            return null;
-        }).when(client).search(any(), isA(ActionListener.class));
-
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, "modelGroupID");
-
-        doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
-            return null;
-        }).when(client).get(any(), any());
-
-        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
-        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals("Failed to search Model index", argumentCaptor.getValue().getMessage());
     }
 
     public void test_UserHasNoAccessException() throws IOException {
@@ -516,21 +399,5 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
         GetResult getResult = new GetResult("indexName", "111", 111l, 111l, 111l, true, bytesReference, null, null);
         GetResponse getResponse = new GetResponse(getResult);
         return getResponse;
-    }
-
-    private SearchResponse createModelGroupSearchResponse(long totalHits) throws IOException {
-        SearchResponse searchResponse = mock(SearchResponse.class);
-        String modelContent = "{\n"
-            + "                    \"created_time\": 1684981986069,\n"
-            + "                    \"access\": \"public\",\n"
-            + "                    \"latest_version\": 0,\n"
-            + "                    \"last_updated_time\": 1684981986069,\n"
-            + "                    \"name\": \"model_group_IT\",\n"
-            + "                    \"description\": \"This is an example description\"\n"
-            + "                }";
-        SearchHit modelGroup = SearchHit.fromXContent(TestHelper.parser(modelContent));
-        SearchHits hits = new SearchHits(new SearchHit[] { modelGroup }, new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), Float.NaN);
-        when(searchResponse.getHits()).thenReturn(hits);
-        return searchResponse;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
@@ -5,7 +5,23 @@
 
 package org.opensearch.ml.action.register;
 
-import com.google.common.collect.ImmutableList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_URL_REGEX;
+import static org.opensearch.ml.utils.TestHelper.clusterSetting;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,22 +72,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
-import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_URL_REGEX;
-import static org.opensearch.ml.utils.TestHelper.clusterSetting;
+import com.google.common.collect.ImmutableList;
 
 public class TransportRegisterModelActionTests extends OpenSearchTestCase {
     @Rule
@@ -509,18 +510,19 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
         }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any());
 
         MLRegisterModelInput registerModelInput = MLRegisterModelInput
-                .builder()
-                .modelName("huggingface/sentence-transformers/all-MiniLM-L12-v2")
-                .modelFormat(MLModelFormat.TORCH_SCRIPT)
-                .version("1")
-                .build();
+            .builder()
+            .modelName("huggingface/sentence-transformers/all-MiniLM-L12-v2")
+            .modelFormat(MLModelFormat.TORCH_SCRIPT)
+            .version("1")
+            .build();
 
         transportRegisterModelAction.doExecute(task, new MLRegisterModelRequest(registerModelInput), actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
-                "Without a model group ID, the system will use the model name {huggingface/sentence-transformers/all-MiniLM-L12-v2} to create a new model group. However, this name is taken by another group {model_group_ID} you can't access. To register this pre-trained model, create a new model group and use its ID in your request.",
-                argumentCaptor.getValue().getMessage()
+            "Without a model group ID, the system will use the model name {huggingface/sentence-transformers/all-MiniLM-L12-v2} to create a new model group. However, this name is taken by another group {model_group_ID} you can't access. To register this pre-trained model, create a new model group and use its ID in your request.",
+            argumentCaptor.getValue().getMessage()
+
         );
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
@@ -529,7 +529,7 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
-            "The name \"Test Model\" you provided is already being used by another model group \"model_group_ID\" to which you do not have access. Please provide a different name.",
+            "The name {Test Model} you provided is unavailable because it is used by another model group {model_group_ID} to which you do not have access. Please provide a different name.",
             argumentCaptor.getValue().getMessage()
         );
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
@@ -18,9 +18,11 @@ import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CO
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_URL_REGEX;
 import static org.opensearch.ml.utils.TestHelper.clusterSetting;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -30,6 +32,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.ActionListenerResponseHandler;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -61,6 +64,9 @@ import org.opensearch.ml.stats.MLStat;
 import org.opensearch.ml.stats.MLStats;
 import org.opensearch.ml.task.MLTaskDispatcher;
 import org.opensearch.ml.task.MLTaskManager;
+import org.opensearch.ml.utils.TestHelper;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -144,7 +150,7 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
     private ConnectorAccessControlHelper connectorAccessControlHelper;
 
     @Before
-    public void setup() {
+    public void setup() throws IOException {
         MockitoAnnotations.openMocks(this);
         settings = Settings
             .builder()
@@ -198,6 +204,13 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
             listener.onResponse(node1);
             return null;
         }).when(mlTaskDispatcher).dispatch(any(), any());
+
+        SearchResponse searchResponse = createModelGroupSearchResponse(0);
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponse);
+            return null;
+        }).when(mlModelGroupManager).validateUniqueModelGroupName(any(), any());
 
         when(clusterService.localNode()).thenReturn(node2);
         when(node2.getId()).thenReturn("node2Id");
@@ -461,6 +474,66 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
         );
     }
 
+    public void test_ModelNameAlreadyExists() throws IOException {
+        when(node1.getId()).thenReturn("NodeId1");
+        when(node2.getId()).thenReturn("NodeId2");
+        MLForwardResponse forwardResponse = Mockito.mock(MLForwardResponse.class);
+        doAnswer(invocation -> {
+            ActionListenerResponseHandler<MLForwardResponse> handler = invocation.getArgument(3);
+            handler.handleResponse(forwardResponse);
+            return null;
+        }).when(transportService).sendRequest(any(), any(), any(), any());
+        SearchResponse searchResponse = createModelGroupSearchResponse(1);
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponse);
+            return null;
+        }).when(mlModelGroupManager).validateUniqueModelGroupName(any(), any());
+
+        transportRegisterModelAction.doExecute(task, prepareRequest("http://test_url", null), actionListener);
+        ArgumentCaptor<MLRegisterModelResponse> argumentCaptor = ArgumentCaptor.forClass(MLRegisterModelResponse.class);
+        verify(actionListener).onResponse(argumentCaptor.capture());
+    }
+
+    public void test_FailureWhenSearchingModelGroupName() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException("Runtime exception"));
+            return null;
+        }).when(mlModelGroupManager).validateUniqueModelGroupName(any(), any());
+
+        transportRegisterModelAction.doExecute(task, prepareRequest("Test URL", null), actionListener);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Runtime exception", argumentCaptor.getValue().getMessage());
+    }
+
+    public void test_NoAccessWhenModelNameAlreadyExists() throws IOException {
+
+        SearchResponse searchResponse = createModelGroupSearchResponse(1);
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponse);
+            return null;
+        }).when(mlModelGroupManager).validateUniqueModelGroupName(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(3);
+            listener.onResponse(false);
+            return null;
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any());
+
+        transportRegisterModelAction.doExecute(task, prepareRequest("Test URL", null), actionListener);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "The name \"Test Model\" you provided is already being used by another model group \"model_group_ID\" to which you do not have access. Please provide a different name.",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
     private MLRegisterModelRequest prepareRequest(String url, String modelGroupID) {
         MLRegisterModelInput registerModelInput = MLRegisterModelInput
             .builder()
@@ -483,6 +556,24 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
             .url(url)
             .build();
         return new MLRegisterModelRequest(registerModelInput);
+    }
+
+    private SearchResponse createModelGroupSearchResponse(long totalHits) throws IOException {
+
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        String modelContent = "{\n"
+            + "                    \"created_time\": 1684981986069,\n"
+            + "                    \"access\": \"public\",\n"
+            + "                    \"latest_version\": 0,\n"
+            + "                    \"last_updated_time\": 1684981986069,\n"
+            + "                    \"_id\": \"model_group_ID\",\n"
+            + "                    \"name\": \"Test Model\",\n"
+            + "                    \"description\": \"This is an example description\"\n"
+            + "                }";
+        SearchHit modelGroup = SearchHit.fromXContent(TestHelper.parser(modelContent));
+        SearchHits hits = new SearchHits(new SearchHit[] { modelGroup }, new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(searchResponse.getHits()).thenReturn(hits);
+        return searchResponse;
     }
 
 }


### PR DESCRIPTION
### Description
This PR fixes the following issues in Model Registry:

1. **Delete model group if the model version registry fails**: Whenever user registers a first model version, a model group is automatically created. Currently, if the version registration fails for some reason, the model group still remains in the index. This PR ensures the model group is created successfully only if model version registration is successful.
2. **Register new version to the model group based on the name provided**: After this PR, we let user register new version to an existing model group with the name alone even if model group ID is not provided. But if user does not have access to the model group in this case, we throw exception asking user to give a different name since user does not have access to the provided name
3. **Do not delete model group automatically with the last version of the model group**: After this PR, even if the last existing version of a model group is deleted, the model group still remains without getting deleted.
4. **Throw exception during update model group when model group does not exist**

 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
