### PR TITLE
Conversation memory client

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -14,6 +14,7 @@ plugins {
 
 dependencies {
     implementation project(':opensearch-ml-common')
+    implementation project(':opensearch-ml-memory')
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'

--- a/client/src/main/java/org/opensearch/ml/client/MachineLearningClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MachineLearningClient.java
@@ -226,4 +226,10 @@ public interface MachineLearningClient {
      * @param listener action listener
      */
     void searchTask(SearchRequest searchRequest, ActionListener<SearchResponse> listener);
+
+    /**
+     * Get the memory client
+     * @return A Memory client for accessing conversation memory
+     */
+    MemoryClient memory();
 }

--- a/client/src/main/java/org/opensearch/ml/client/MachineLearningNodeClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MachineLearningNodeClient.java
@@ -53,10 +53,16 @@ import static org.opensearch.ml.common.input.InputHelper.getAction;
 import static org.opensearch.ml.common.input.InputHelper.getFunctionName;
 
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
-@RequiredArgsConstructor
 public class MachineLearningNodeClient implements MachineLearningClient {
 
     Client client;
+    MemoryClient memoryClient;
+
+    public MachineLearningNodeClient(Client client) {
+        this.client = client;
+        this.memoryClient = new MemoryNodeClient(client);
+    }
+
 
     @Override
     public void predict(String modelId, MLInput mlInput, ActionListener<MLOutput> listener) {
@@ -217,5 +223,10 @@ public class MachineLearningNodeClient implements MachineLearningClient {
         if(requireInput && mlInput.getInputDataset() == null) {
             throw new IllegalArgumentException("input data set can't be null");
         }
+    }
+
+    @Override
+    public MemoryClient memory() {
+        return memoryClient;
     }
 }

--- a/client/src/main/java/org/opensearch/ml/client/MemoryClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MemoryClient.java
@@ -15,23 +15,73 @@ import org.opensearch.ml.memory.action.conversation.GetInteractionsResponse;
 
 public interface MemoryClient {
 
+    /**
+     * Create a conversation using the transport-layer CreateConversation Action
+     * @param request Request containing (optional) conversation name
+     * @param listener Gets the CreateConversationResponse (contains new conversation id)
+     */
     void createConversation(CreateConversationRequest request, ActionListener<CreateConversationResponse> listener);
 
+    /**
+     * Create a conversation using the transport-layer CreateConversation Action
+     * @param request Request containing (optional) conversation name
+     * @return ActionFuture for the CreateConversationResponse (contains new conversation id)
+     */
     ActionFuture<CreateConversationResponse> createConversation(CreateConversationRequest request);
 
+    /**
+     * Create an interaction using the transport-layer CreateInteraction Action
+     * @param request Request containing interaction fields
+     * @param listener Gets the CreateInteractionResponse containing the id of the new interaction
+     */
     void createInteraction(CreateInteractionRequest request, ActionListener<CreateInteractionResponse> listener);
 
+    /**
+     * Create an interaction using the transport-layer CreateInteraction Action
+     * @param request Request containing interaction fields
+     * @return ActionFuture for the CreateInteractionResponse containing the id of the new interaction
+     */
     ActionFuture<CreateInteractionResponse> createInteraction(CreateInteractionRequest request);
 
+    /**
+     * Get a list of conversations using the transport-layer GetConversations Action
+     * @param request Request containing number of interactions to get and what page to get them from
+     * @param listener Gets the GetConversationsResponse containing the list of conversations
+     */
     void getConversations(GetConversationsRequest request, ActionListener<GetConversationsResponse> listener);
 
+    /**
+     * Get a list of conversations using the transport-layer GetConversations Action
+     * @param request Request containing number of interactions to get and what page to get them from
+     * @return ActionFuture for the GetConversationsResponse containing the list of conversations
+     */
     ActionFuture<GetConversationsResponse> getConversations(GetConversationsRequest request);
 
+    /**
+     * Get a list of interactions belonging to a conversation using the transport-layer GetInteractions Action
+     * @param request Request containing the conversationId, number of interactions to get, and page to get them from
+     * @param listener Gets the GetInteractionsResponse containing the list of interactions
+     */
     void getInteractions(GetInteractionsRequest request, ActionListener<GetInteractionsResponse> listener);
 
+    /**
+     * Get a list of interactions belonging to a conversation using the transport-layer GetInteractions Action
+     * @param request Request containing the conversationId, number of interactions to get, and page to get them from
+     * @return ActionFuture for the GetInteractionsResponse containing the list of interactions
+     */
     ActionFuture<GetInteractionsResponse> getInteractions(GetInteractionsRequest request);
 
+    /**
+     * Delete a conversation and all of its interactions
+     * @param request Request containing the id of the conversation to delete
+     * @param listener Gets the DeleteConversationsResponse containing whether the deletion was successful
+     */
     void deleteConversation(DeleteConversationRequest request, ActionListener<DeleteConversationResponse> listener);
 
+    /**
+     * Delete a conversation and all of its interactions
+     * @param request Request containing the id of the conversation to delete
+     * @return ActionFuture for the DeleteConversationsResponse containing whether the deletion was successful
+     */
     ActionFuture<DeleteConversationResponse> deleteConversation(DeleteConversationRequest request);
 }

--- a/client/src/main/java/org/opensearch/ml/client/MemoryClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MemoryClient.java
@@ -1,0 +1,37 @@
+package org.opensearch.ml.client;
+
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.memory.action.conversation.CreateConversationRequest;
+import org.opensearch.ml.memory.action.conversation.CreateConversationResponse;
+import org.opensearch.ml.memory.action.conversation.CreateInteractionRequest;
+import org.opensearch.ml.memory.action.conversation.CreateInteractionResponse;
+import org.opensearch.ml.memory.action.conversation.DeleteConversationRequest;
+import org.opensearch.ml.memory.action.conversation.DeleteConversationResponse;
+import org.opensearch.ml.memory.action.conversation.GetConversationsRequest;
+import org.opensearch.ml.memory.action.conversation.GetConversationsResponse;
+import org.opensearch.ml.memory.action.conversation.GetInteractionsRequest;
+import org.opensearch.ml.memory.action.conversation.GetInteractionsResponse;
+
+public interface MemoryClient {
+
+    void createConversation(CreateConversationRequest request, ActionListener<CreateConversationResponse> listener);
+
+    ActionFuture<CreateConversationResponse> createConversation(CreateConversationRequest request);
+
+    void createInteraction(CreateInteractionRequest request, ActionListener<CreateInteractionResponse> listener);
+
+    ActionFuture<CreateInteractionResponse> createInteraction(CreateInteractionRequest request);
+
+    void getConversations(GetConversationsRequest request, ActionListener<GetConversationsResponse> listener);
+
+    ActionFuture<GetConversationsResponse> getConversations(GetConversationsRequest request);
+
+    void getInteractions(GetInteractionsRequest request, ActionListener<GetInteractionsResponse> listener);
+
+    ActionFuture<GetInteractionsResponse> getInteractions(GetInteractionsRequest request);
+
+    void deleteConversation(DeleteConversationRequest request, ActionListener<DeleteConversationResponse> listener);
+
+    ActionFuture<DeleteConversationResponse> deleteConversation(DeleteConversationRequest request);
+}

--- a/client/src/main/java/org/opensearch/ml/client/MemoryClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MemoryClient.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2023 Aryn
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.opensearch.ml.client;
 
 import org.opensearch.common.action.ActionFuture;

--- a/client/src/main/java/org/opensearch/ml/client/MemoryNodeClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MemoryNodeClient.java
@@ -1,0 +1,82 @@
+package org.opensearch.ml.client;
+
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.client.Client;
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.memory.action.conversation.CreateConversationAction;
+import org.opensearch.ml.memory.action.conversation.CreateConversationRequest;
+import org.opensearch.ml.memory.action.conversation.CreateConversationResponse;
+import org.opensearch.ml.memory.action.conversation.CreateInteractionAction;
+import org.opensearch.ml.memory.action.conversation.CreateInteractionRequest;
+import org.opensearch.ml.memory.action.conversation.CreateInteractionResponse;
+import org.opensearch.ml.memory.action.conversation.DeleteConversationAction;
+import org.opensearch.ml.memory.action.conversation.DeleteConversationRequest;
+import org.opensearch.ml.memory.action.conversation.DeleteConversationResponse;
+import org.opensearch.ml.memory.action.conversation.GetConversationsAction;
+import org.opensearch.ml.memory.action.conversation.GetConversationsRequest;
+import org.opensearch.ml.memory.action.conversation.GetConversationsResponse;
+import org.opensearch.ml.memory.action.conversation.GetInteractionsAction;
+import org.opensearch.ml.memory.action.conversation.GetInteractionsRequest;
+import org.opensearch.ml.memory.action.conversation.GetInteractionsResponse;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@AllArgsConstructor
+public class MemoryNodeClient implements MemoryClient {
+    
+    Client client;
+    
+    public void createConversation(CreateConversationRequest request, ActionListener<CreateConversationResponse> listener) {
+        client.execute(CreateConversationAction.INSTANCE, request, listener);
+    }
+
+    
+    public ActionFuture<CreateConversationResponse> createConversation(CreateConversationRequest request) {
+        PlainActionFuture<CreateConversationResponse> fut = PlainActionFuture.newFuture();
+        createConversation(request, fut);
+        return fut;
+    }
+
+    
+    public void createInteraction(CreateInteractionRequest request, ActionListener<CreateInteractionResponse> listener) {
+        client.execute(CreateInteractionAction.INSTANCE, request, listener);
+    }
+
+    public ActionFuture<CreateInteractionResponse> createInteraction(CreateInteractionRequest request) {
+        PlainActionFuture<CreateInteractionResponse> fut = PlainActionFuture.newFuture();
+        createInteraction(request, fut);
+        return fut;
+    }
+
+    public void getConversations(GetConversationsRequest request, ActionListener<GetConversationsResponse> listener) {
+        client.execute(GetConversationsAction.INSTANCE, request, listener);
+    }
+
+    public ActionFuture<GetConversationsResponse> getConversations(GetConversationsRequest request) {
+        PlainActionFuture<GetConversationsResponse> fut = PlainActionFuture.newFuture();
+        getConversations(request, fut);
+        return fut;
+    }
+
+    public void getInteractions(GetInteractionsRequest request, ActionListener<GetInteractionsResponse> listener) {
+        client.execute(GetInteractionsAction.INSTANCE, request, listener);
+    }
+
+    public ActionFuture<GetInteractionsResponse> getInteractions(GetInteractionsRequest request) {
+        PlainActionFuture<GetInteractionsResponse> fut = PlainActionFuture.newFuture();
+        getInteractions(request, fut);
+        return fut;
+    }
+
+    public void deleteConversation(DeleteConversationRequest request, ActionListener<DeleteConversationResponse> listener) {
+        client.execute(DeleteConversationAction.INSTANCE, request, listener);
+    }
+
+    public ActionFuture<DeleteConversationResponse> deleteConversation(DeleteConversationRequest request) {
+        PlainActionFuture<DeleteConversationResponse> fut = PlainActionFuture.newFuture();
+        deleteConversation(request, fut);
+        return fut;
+    }
+}

--- a/client/src/main/java/org/opensearch/ml/client/MemoryNodeClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MemoryNodeClient.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2023 Aryn
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.opensearch.ml.client;
 
 import org.opensearch.action.support.PlainActionFuture;
@@ -21,7 +38,6 @@ import org.opensearch.ml.memory.action.conversation.GetInteractionsRequest;
 import org.opensearch.ml.memory.action.conversation.GetInteractionsResponse;
 
 import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @AllArgsConstructor
 public class MemoryNodeClient implements MemoryClient {

--- a/client/src/test/java/org/opensearch/ml/client/MachineLearningClientTest.java
+++ b/client/src/test/java/org/opensearch/ml/client/MachineLearningClientTest.java
@@ -58,6 +58,9 @@ public class MachineLearningClientTest {
     @Mock
     SearchResponse searchResponse;
 
+    @Mock
+    MemoryClient memoryClient;
+
     private String modekId = "test_model_id";
     private MLModel mlModel;
     private MLTask mlTask;
@@ -131,6 +134,11 @@ public class MachineLearningClientTest {
             @Override
             public void searchTask(SearchRequest searchRequest, ActionListener<SearchResponse> listener) {
                 listener.onResponse(searchResponse);
+            }
+
+            @Override
+            public MemoryClient memory() {
+                return memoryClient;
             }
         };
     }
@@ -250,5 +258,10 @@ public class MachineLearningClientTest {
     @Test
     public void searchTask() {
         assertEquals(searchResponse, machineLearningClient.searchTask(new SearchRequest()).actionGet());
+    }
+
+    @Test
+    public void memory() {
+        assertEquals(memoryClient, machineLearningClient.memory());
     }
 }

--- a/client/src/test/java/org/opensearch/ml/client/MachineLearningNodeClientTest.java
+++ b/client/src/test/java/org/opensearch/ml/client/MachineLearningNodeClientTest.java
@@ -36,8 +36,6 @@ import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.output.MLPredictionOutput;
-import org.opensearch.ml.common.MLTask;
-import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.output.MLTrainingOutput;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.model.MLModelDeleteAction;
@@ -57,6 +55,9 @@ import org.opensearch.ml.common.transport.task.MLTaskSearchAction;
 import org.opensearch.ml.common.transport.training.MLTrainingTaskAction;
 import org.opensearch.ml.common.transport.training.MLTrainingTaskRequest;
 import org.opensearch.ml.common.transport.trainpredict.MLTrainAndPredictionTaskAction;
+import org.opensearch.ml.memory.action.conversation.CreateConversationAction;
+import org.opensearch.ml.memory.action.conversation.CreateConversationRequest;
+import org.opensearch.ml.memory.action.conversation.CreateConversationResponse;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.InternalAggregations;
@@ -64,17 +65,22 @@ import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.profile.SearchProfileShardResults;
 import org.opensearch.search.suggest.Suggest;
 
+import lombok.extern.log4j.Log4j2;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.opensearch.ml.common.input.Constants.ACTION;
 import static org.opensearch.ml.common.input.Constants.ALGORITHM;
@@ -85,6 +91,7 @@ import static org.opensearch.ml.common.input.Constants.RCF;
 import static org.opensearch.ml.common.input.Constants.TRAIN;
 import static org.opensearch.ml.common.input.Constants.TRAINANDPREDICT;
 
+@Log4j2
 public class MachineLearningNodeClientTest {
 
     @Mock(answer = RETURNS_DEEP_STUBS)
@@ -589,5 +596,11 @@ public class MachineLearningNodeClientTest {
                 ShardSearchFailure.EMPTY_ARRAY,
                 SearchResponse.Clusters.EMPTY
         );
+    }
+
+    @Test
+    public void memory() {
+        MemoryClient memoryClient = machineLearningNodeClient.memory();
+        assertNotNull(memoryClient);
     }
 }

--- a/client/src/test/java/org/opensearch/ml/client/MemoryNodeClientTest.java
+++ b/client/src/test/java/org/opensearch/ml/client/MemoryNodeClientTest.java
@@ -1,0 +1,294 @@
+package org.opensearch.ml.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.memory.action.conversation.CreateConversationAction;
+import org.opensearch.ml.memory.action.conversation.CreateConversationRequest;
+import org.opensearch.ml.memory.action.conversation.CreateConversationResponse;
+import org.opensearch.ml.memory.action.conversation.CreateInteractionAction;
+import org.opensearch.ml.memory.action.conversation.CreateInteractionRequest;
+import org.opensearch.ml.memory.action.conversation.CreateInteractionResponse;
+import org.opensearch.ml.memory.action.conversation.DeleteConversationAction;
+import org.opensearch.ml.memory.action.conversation.DeleteConversationRequest;
+import org.opensearch.ml.memory.action.conversation.DeleteConversationResponse;
+import org.opensearch.ml.memory.action.conversation.GetConversationsAction;
+import org.opensearch.ml.memory.action.conversation.GetConversationsRequest;
+import org.opensearch.ml.memory.action.conversation.GetConversationsResponse;
+import org.opensearch.ml.memory.action.conversation.GetInteractionsAction;
+import org.opensearch.ml.memory.action.conversation.GetInteractionsRequest;
+import org.opensearch.ml.memory.action.conversation.GetInteractionsResponse;
+
+public class MemoryNodeClientTest {
+    
+    @Mock
+    Client client;
+
+    @Mock
+    ActionListener<CreateConversationResponse> createConversationListener;
+
+    @Mock
+    ActionListener<CreateInteractionResponse> createInteractionListener;
+
+    @Mock
+    ActionListener<GetConversationsResponse> getConversationsListener;
+
+    @Mock
+    ActionListener<GetInteractionsResponse> getInteractionsListener;
+
+    @Mock
+    ActionListener<DeleteConversationResponse> deleteConversationListener;
+
+    @InjectMocks
+    MemoryNodeClient memoryClient;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void createConversation_Success() {
+        CreateConversationResponse response = new CreateConversationResponse("Test id");
+        doAnswer(invocation -> {
+            ActionListener<CreateConversationResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(CreateConversationAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<CreateConversationResponse> argCaptor = ArgumentCaptor.forClass(CreateConversationResponse.class);
+        CreateConversationRequest request = new CreateConversationRequest();
+        memoryClient.createConversation(request, createConversationListener);
+
+        verify(createConversationListener, times(1)).onResponse(argCaptor.capture());
+        assertEquals(response, argCaptor.getValue());
+    }
+
+    @Test
+    public void createConversation_Fails() {
+        doAnswer(invocation -> {
+            ActionListener<CreateConversationResponse> listener = invocation.getArgument(2);
+            listener.onFailure(new Exception("CC Fail"));
+            return null;
+        }).when(client).execute(eq(CreateConversationAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
+        CreateConversationRequest request = new CreateConversationRequest();
+        memoryClient.createConversation(request, createConversationListener);
+
+        verify(createConversationListener, times(1)).onFailure(argCaptor.capture());
+        assertEquals("CC Fail", argCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void createConversation_Future() {
+        CreateConversationResponse response = new CreateConversationResponse("Test id");
+        doAnswer(invocation -> {
+            ActionListener<CreateConversationResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(CreateConversationAction.INSTANCE), any(), any());
+
+        CreateConversationRequest request = new CreateConversationRequest();
+        assertEquals(memoryClient.createConversation(request).actionGet(), response);
+    }
+
+    @Test
+    public void createInteraction_Success() {
+        CreateInteractionResponse response = new CreateInteractionResponse("Test IID");
+        doAnswer(invocation -> {
+            ActionListener<CreateInteractionResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(CreateInteractionAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<CreateInteractionResponse> argCaptor = ArgumentCaptor.forClass(CreateInteractionResponse.class);
+        CreateInteractionRequest request = new CreateInteractionRequest("cid", "inp", "pt", "rsp", "ogn", "add");
+        memoryClient.createInteraction(request, createInteractionListener);
+
+        verify(createInteractionListener, times(1)).onResponse(argCaptor.capture());
+        assertEquals(response, argCaptor.getValue());
+    }
+
+    @Test
+    public void createInteraction_Fails() {
+        doAnswer(invocation -> {
+            ActionListener<CreateInteractionResponse> listener = invocation.getArgument(2);
+            listener.onFailure(new Exception("CI Fail"));
+            return null;
+        }).when(client).execute(eq(CreateInteractionAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
+        CreateInteractionRequest request = new CreateInteractionRequest("cid", "inp", "pt", "rsp", "ogn", "add");
+        memoryClient.createInteraction(request, createInteractionListener);
+
+        verify(createInteractionListener, times(1)).onFailure(argCaptor.capture());
+        assertEquals("CI Fail", argCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void createInteraction_Future() {
+        CreateInteractionResponse response = new CreateInteractionResponse("Test IID");
+        doAnswer(invocation -> {
+            ActionListener<CreateInteractionResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(CreateInteractionAction.INSTANCE), any(), any());
+
+        CreateInteractionRequest request = new CreateInteractionRequest("cid", "inp", "pt", "rsp", "ogn", "add");
+        assertEquals(memoryClient.createInteraction(request).actionGet(), response);
+    }
+
+    @Test
+    public void getConversations_Success() {
+        GetConversationsResponse response = new GetConversationsResponse(List.of(), 4, false);
+        doAnswer(invocation -> {
+            ActionListener<GetConversationsResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(GetConversationsAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<GetConversationsResponse> argCaptor = ArgumentCaptor.forClass(GetConversationsResponse.class);
+        GetConversationsRequest request = new GetConversationsRequest();
+        memoryClient.getConversations(request, getConversationsListener);
+
+        verify(getConversationsListener, times(1)).onResponse(argCaptor.capture());
+        assertEquals(response, argCaptor.getValue());
+    }
+
+    @Test
+    public void getConversations_Fails() {
+        doAnswer(invocation -> {
+            ActionListener<GetConversationsResponse> listener = invocation.getArgument(2);
+            listener.onFailure(new Exception("GC Fail"));
+            return null;
+        }).when(client).execute(eq(GetConversationsAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
+        GetConversationsRequest request = new GetConversationsRequest();
+        memoryClient.getConversations(request, getConversationsListener);
+
+        verify(getConversationsListener, times(1)).onFailure(argCaptor.capture());
+        assertEquals("GC Fail", argCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void getConversations_Future() {
+        GetConversationsResponse response = new GetConversationsResponse(List.of(), 4, false);
+        doAnswer(invocation -> {
+            ActionListener<GetConversationsResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(GetConversationsAction.INSTANCE), any(), any());
+
+        GetConversationsRequest request = new GetConversationsRequest();
+        assertEquals(memoryClient.getConversations(request).actionGet(), response);
+    }
+
+    @Test
+    public void getInteractions_Success() {
+        GetInteractionsResponse response = new GetInteractionsResponse(List.of(), 4, false);
+        doAnswer(invocation -> {
+            ActionListener<GetInteractionsResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(GetInteractionsAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<GetInteractionsResponse> argCaptor = ArgumentCaptor.forClass(GetInteractionsResponse.class);
+        GetInteractionsRequest request = new GetInteractionsRequest("Test CID");
+        memoryClient.getInteractions(request, getInteractionsListener);
+
+        verify(getInteractionsListener, times(1)).onResponse(argCaptor.capture());
+        assertEquals(response, argCaptor.getValue());
+    }
+
+    @Test
+    public void getInteractions_Fails() {
+        doAnswer(invocation -> {
+            ActionListener<GetInteractionsResponse> listener = invocation.getArgument(2);
+            listener.onFailure(new Exception("GI Fail"));
+            return null;
+        }).when(client).execute(eq(GetInteractionsAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
+        GetInteractionsRequest request = new GetInteractionsRequest("Test CID");
+        memoryClient.getInteractions(request, getInteractionsListener);
+
+        verify(getInteractionsListener, times(1)).onFailure(argCaptor.capture());
+        assertEquals("GI Fail", argCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void getInteractions_Future() {
+        GetInteractionsResponse response = new GetInteractionsResponse(List.of(), 4, false);
+        doAnswer(invocation -> {
+            ActionListener<GetInteractionsResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(GetInteractionsAction.INSTANCE), any(), any());
+
+        GetInteractionsRequest request = new GetInteractionsRequest("Test CID");
+        assertEquals(memoryClient.getInteractions(request).actionGet(), response);
+    }
+
+    @Test
+    public void deleteConversation_Success() {
+        DeleteConversationResponse response = new DeleteConversationResponse(true);
+        doAnswer(invocation -> {
+            ActionListener<DeleteConversationResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(DeleteConversationAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<DeleteConversationResponse> argCaptor = ArgumentCaptor.forClass(DeleteConversationResponse.class);
+        DeleteConversationRequest request = new DeleteConversationRequest("Test CID");
+        memoryClient.deleteConversation(request, deleteConversationListener);
+
+        verify(deleteConversationListener, times(1)).onResponse(argCaptor.capture());
+        assertEquals(response, argCaptor.getValue());
+    }
+
+    @Test
+    public void deleteConversation_Fails() {
+        doAnswer(invocation -> {
+            ActionListener<DeleteConversationResponse> listener = invocation.getArgument(2);
+            listener.onFailure(new Exception("DC Fail"));
+            return null;
+        }).when(client).execute(eq(DeleteConversationAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
+        DeleteConversationRequest request = new DeleteConversationRequest("Test CID");
+        memoryClient.deleteConversation(request, deleteConversationListener);
+
+        verify(deleteConversationListener, times(1)).onFailure(argCaptor.capture());
+        assertEquals("DC Fail", argCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void deleteConversation_Future() {
+        DeleteConversationResponse response = new DeleteConversationResponse(true);
+        doAnswer(invocation -> {
+            ActionListener<DeleteConversationResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(DeleteConversationAction.INSTANCE), any(), any());
+
+        DeleteConversationRequest request = new DeleteConversationRequest("Test CID");
+        assertEquals(memoryClient.deleteConversation(request).actionGet(), response);
+    }
+
+}

--- a/client/src/test/java/org/opensearch/ml/client/MemoryNodeClientTest.java
+++ b/client/src/test/java/org/opensearch/ml/client/MemoryNodeClientTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2023 Aryn
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.opensearch.ml.client;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
### Description
Add a client for accessing conversation memory to the MLClient; similar pattern to the admin clients, e.g.
```
CreateConversationResponse response = machineLearningClient
                                       .memory()
                                       .createConversation(new CreateConversationRequest())
                                       .actionGet();
```

 
### Issues Resolved
#1282 
 
### Check List
- [ x] New functionality includes testing.
  - [ x] All tests pass
- [ x] New functionality has been documented.
  - [ x] New functionality has javadoc added
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
