### PR TITLE
restore thread context before running action listener

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelation.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelation.java
@@ -225,14 +225,14 @@ public class MetricsCorrelation extends DLModelExecute {
             XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
             modelGroup.toXContent(builder, ToXContent.EMPTY_PARAMS);
             createModelGroupRequest.source(builder);
-            client.index(createModelGroupRequest, ActionListener.wrap(r -> {
+            client.index(createModelGroupRequest, ActionListener.runBefore(ActionListener.wrap(r -> {
                 client.execute(MLRegisterModelAction.INSTANCE, registerRequest, ActionListener.wrap(listener::onResponse, e -> {
                     log.error("Failed to Register Model", e);
                     listener.onFailure(e);
                 }));
             }, e-> {
                 listener.onFailure(e);
-            }));
+            }), () -> context.restore()));
         } catch (IOException e) {
             throw new MLException(e);
         }

--- a/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
@@ -86,12 +86,13 @@ public class TransportPredictionTaskAction extends HandledTransportAction<Action
         final User userInfo = user;
 
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<MLTaskResponse> wrappedListener = ActionListener.runBefore(listener, () -> context.restore());
             mlModelManager.getModel(modelId, ActionListener.wrap(mlModel -> {
                 FunctionName functionName = mlModel.getAlgorithm();
                 modelAccessControlHelper
                     .validateModelGroupAccess(userInfo, mlModel.getModelGroupId(), client, ActionListener.wrap(access -> {
                         if (!access) {
-                            listener
+                            wrappedListener
                                 .onFailure(
                                     new MLValidationException("User Doesn't have privilege to perform this operation on this model")
                                 );
@@ -100,20 +101,25 @@ public class TransportPredictionTaskAction extends HandledTransportAction<Action
                             log.debug("receive predict request " + requestId + " for model " + mlPredictionTaskRequest.getModelId());
                             long startTime = System.nanoTime();
                             mlPredictTaskRunner
-                                .run(functionName, mlPredictionTaskRequest, transportService, ActionListener.runAfter(listener, () -> {
-                                    long endTime = System.nanoTime();
-                                    double durationInMs = (endTime - startTime) / 1e6;
-                                    modelCacheHelper.addPredictRequestDuration(modelId, durationInMs);
-                                    log.debug("completed predict request " + requestId + " for model " + modelId);
-                                }));
+                                .run(
+                                    functionName,
+                                    mlPredictionTaskRequest,
+                                    transportService,
+                                    ActionListener.runAfter(wrappedListener, () -> {
+                                        long endTime = System.nanoTime();
+                                        double durationInMs = (endTime - startTime) / 1e6;
+                                        modelCacheHelper.addPredictRequestDuration(modelId, durationInMs);
+                                        log.debug("completed predict request " + requestId + " for model " + modelId);
+                                    })
+                                );
                         }
                     }, e -> {
                         log.error("Failed to Validate Access for ModelId " + modelId, e);
-                        listener.onFailure(e);
+                        wrappedListener.onFailure(e);
                     }));
             }, e -> {
                 log.error("Failed to find model " + modelId, e);
-                listener.onFailure(e);
+                wrappedListener.onFailure(e);
             }));
 
         }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -65,6 +65,7 @@ public class MLModelGroupManager {
             String modelName = input.getName();
             User user = RestActionUtils.getUserContext(client);
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+                ActionListener<String> wrappedListener = ActionListener.runBefore(listener, () -> context.restore());
                 validateUniqueModelGroupName(input.getName(), ActionListener.wrap(modelGroups -> {
                     if (modelGroups != null
                         && modelGroups.getHits().getTotalHits() != null
@@ -72,7 +73,7 @@ public class MLModelGroupManager {
                         Iterator<SearchHit> iterator = modelGroups.getHits().iterator();
                         while (iterator.hasNext()) {
                             String id = iterator.next().getId();
-                            listener
+                            wrappedListener
                                 .onFailure(
                                     new IllegalArgumentException(
                                         "The name you provided is already being used by another model with ID: "
@@ -121,19 +122,19 @@ public class MLModelGroupManager {
 
                             client.index(indexRequest, ActionListener.wrap(r -> {
                                 log.debug("Indexed model group doc successfully {}", modelName);
-                                listener.onResponse(r.getId());
+                                wrappedListener.onResponse(r.getId());
                             }, e -> {
                                 log.error("Failed to index model group doc", e);
-                                listener.onFailure(e);
+                                wrappedListener.onFailure(e);
                             }));
                         }, ex -> {
                             log.error("Failed to init model group index", ex);
-                            listener.onFailure(ex);
+                            wrappedListener.onFailure(ex);
                         }));
                     }
                 }, e -> {
                     log.error("Failed to search model group index", e);
-                    listener.onFailure(e);
+                    wrappedListener.onFailure(e);
                 }));
             } catch (Exception e) {
                 log.error("Failed to create model group doc", e);


### PR DESCRIPTION
### Description
We see reindex will throw error "wrong user in reader context". That's because after stashing thread context, the user info will be gone. Security plugin will recheck user info when reindex, then throw this error.  We should restore thread context before running action listener. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
