### PR TITLE
fix model group auto-deletion when last version is deleted

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -5,10 +5,13 @@
 
 package org.opensearch.ml.action.models;
 
-import com.google.common.annotations.VisibleForTesting;
-import lombok.AccessLevel;
-import lombok.experimental.FieldDefaults;
-import lombok.extern.log4j.Log4j2;
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
+import static org.opensearch.ml.common.MLModel.MODEL_ID_FIELD;
+import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
+import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
+
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.ActionRequest;
@@ -43,12 +46,11 @@ import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
-import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
-import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
-import static org.opensearch.ml.common.MLModel.MODEL_ID_FIELD;
-import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
-import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
+import com.google.common.annotations.VisibleForTesting;
+
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 @FieldDefaults(level = AccessLevel.PRIVATE)

--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -6,14 +6,12 @@
 package org.opensearch.ml.action.models;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
 import static org.opensearch.ml.common.MLModel.MODEL_ID_FIELD;
 import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
 import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
 
-import org.apache.commons.lang3.StringUtils;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.ActionRequest;
@@ -21,8 +19,6 @@ import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.client.Client;
@@ -34,8 +30,6 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryAction;
@@ -48,7 +42,6 @@ import org.opensearch.ml.common.transport.model.MLModelDeleteRequest;
 import org.opensearch.ml.common.transport.model.MLModelGetRequest;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.utils.RestActionUtils;
-import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -110,6 +103,7 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
                             algorithmName = getResponse.getSource().get(ALGORITHM_FIELD).toString();
                         }
                         MLModel mlModel = MLModel.parse(parser, algorithmName);
+                        MLModelState mlModelState = mlModel.getModelState();
 
                         modelAccessControlHelper
                             .validateModelGroupAccess(user, mlModel.getModelGroupId(), client, ActionListener.wrap(access -> {
@@ -118,37 +112,20 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
                                         .onFailure(
                                             new MLValidationException("User doesn't have privilege to perform this operation on this model")
                                         );
+                                } else if (mlModelState.equals(MLModelState.LOADED)
+                                    || mlModelState.equals(MLModelState.LOADING)
+                                    || mlModelState.equals(MLModelState.PARTIALLY_LOADED)
+                                    || mlModelState.equals(MLModelState.DEPLOYED)
+                                    || mlModelState.equals(MLModelState.DEPLOYING)
+                                    || mlModelState.equals(MLModelState.PARTIALLY_DEPLOYED)) {
+                                    actionListener
+                                        .onFailure(
+                                            new Exception(
+                                                "Model cannot be deleted in deploying or deployed state. Try undeploy model first then delete"
+                                            )
+                                        );
                                 } else {
-                                    MLModelState mlModelState = mlModel.getModelState();
-                                    if (mlModelState.equals(MLModelState.LOADED)
-                                        || mlModelState.equals(MLModelState.LOADING)
-                                        || mlModelState.equals(MLModelState.PARTIALLY_LOADED)
-                                        || mlModelState.equals(MLModelState.DEPLOYED)
-                                        || mlModelState.equals(MLModelState.DEPLOYING)
-                                        || mlModelState.equals(MLModelState.PARTIALLY_DEPLOYED)) {
-                                        wrappedListener
-                                            .onFailure(
-                                                new Exception(
-                                                    "Model cannot be deleted in deploying or deployed state. Try undeploy model first then delete"
-                                                )
-                                            );
-                                    } else if (StringUtils.isNotEmpty(mlModel.getModelGroupId())) {
-                                        searchModel(mlModel.getModelGroupId(), ActionListener.wrap(response -> {
-                                            boolean isLastModelOfGroup = false;
-                                            if (response != null
-                                                && response.getHits() != null
-                                                && response.getHits().getTotalHits() != null
-                                                && response.getHits().getTotalHits().value == 1) {
-                                                isLastModelOfGroup = true;
-                                            }
-                                            deleteModel(modelId, mlModel.getModelGroupId(), isLastModelOfGroup, wrappedListener);
-                                        }, e -> {
-                                            log.error("Failed to Search Model index " + modelId, e);
-                                            wrappedListener.onFailure(e);
-                                        }));
-                                    } else {
-                                        deleteModel(modelId, mlModel.getModelGroupId(), false, wrappedListener);
-                                    }
+                                    deleteModel(modelId, actionListener);
                                 }
                             }, e -> {
                                 log.error("Failed to validate Access for Model Id " + modelId, e);
@@ -166,18 +143,6 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
             log.error("Failed to delete ML model " + modelId, e);
             actionListener.onFailure(e);
         }
-    }
-
-    private void searchModel(String modelGroupId, ActionListener<SearchResponse> listener) {
-        BoolQueryBuilder query = new BoolQueryBuilder();
-        query.filter(new TermQueryBuilder(MLModel.MODEL_GROUP_ID_FIELD, modelGroupId));
-
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(query);
-        SearchRequest searchRequest = new SearchRequest(ML_MODEL_INDEX).source(searchSourceBuilder);
-        client.search(searchRequest, ActionListener.wrap(response -> { listener.onResponse(response); }, e -> {
-            log.error("Failed to search Model index", e);
-            listener.onFailure(e);
-        }));
     }
 
     @VisibleForTesting
@@ -218,19 +183,11 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
         actionListener.onFailure(new OpenSearchStatusException(errorMessage, RestStatus.INTERNAL_SERVER_ERROR));
     }
 
-    private void deleteModel(
-        String modelId,
-        String modelGroupId,
-        boolean isLastModelOfGroup,
-        ActionListener<DeleteResponse> actionListener
-    ) {
+    private void deleteModel(String modelId, ActionListener<DeleteResponse> actionListener) {
         DeleteRequest deleteRequest = new DeleteRequest(ML_MODEL_INDEX, modelId);
         client.delete(deleteRequest, new ActionListener<DeleteResponse>() {
             @Override
             public void onResponse(DeleteResponse deleteResponse) {
-                if (isLastModelOfGroup) {
-                    deleteModelGroup(modelGroupId);
-                }
                 deleteModelChunks(modelId, deleteResponse, actionListener);
             }
 
@@ -241,21 +198,6 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
                     deleteModelChunks(modelId, null, actionListener);
                 }
                 actionListener.onFailure(e);
-            }
-        });
-    }
-
-    private void deleteModelGroup(String modelGroupId) {
-        DeleteRequest deleteRequest = new DeleteRequest(ML_MODEL_GROUP_INDEX, modelGroupId);
-        client.delete(deleteRequest, new ActionListener<DeleteResponse>() {
-            @Override
-            public void onResponse(DeleteResponse deleteResponse) {
-                log.debug("Completed Delete Model Group for modelGroupId:{}", modelGroupId);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                log.error("Failed to delete ML Model Group with Id:{} " + modelGroupId, e);
             }
         });
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -5,13 +5,10 @@
 
 package org.opensearch.ml.action.models;
 
-import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
-import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
-import static org.opensearch.ml.common.MLModel.MODEL_ID_FIELD;
-import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
-import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
-
+import com.google.common.annotations.VisibleForTesting;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.log4j.Log4j2;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.ActionRequest;
@@ -46,11 +43,12 @@ import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
-import com.google.common.annotations.VisibleForTesting;
-
-import lombok.AccessLevel;
-import lombok.experimental.FieldDefaults;
-import lombok.extern.log4j.Log4j2;
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
+import static org.opensearch.ml.common.MLModel.MODEL_ID_FIELD;
+import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
+import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
 
 @Log4j2
 @FieldDefaults(level = AccessLevel.PRIVATE)
@@ -118,7 +116,7 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
                                     || mlModelState.equals(MLModelState.DEPLOYED)
                                     || mlModelState.equals(MLModelState.DEPLOYING)
                                     || mlModelState.equals(MLModelState.PARTIALLY_DEPLOYED)) {
-                                    actionListener
+                                    wrappedListener
                                         .onFailure(
                                             new Exception(
                                                 "Model cannot be deleted in deploying or deployed state. Try undeploy model first then delete"

--- a/plugin/src/test/java/org/opensearch/ml/action/models/DeleteModelTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/DeleteModelTransportActionTests.java
@@ -6,9 +6,7 @@
 package org.opensearch.ml.action.models;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -35,7 +32,6 @@ import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetResponse;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
@@ -50,15 +46,11 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.ScrollableHitSource;
-import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.common.transport.model.MLModelDeleteRequest;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelManager;
-import org.opensearch.ml.utils.TestHelper;
-import org.opensearch.search.SearchHit;
-import org.opensearch.search.SearchHits;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -182,115 +174,6 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         verify(actionListener).onResponse(deleteResponse);
-    }
-
-    public void test_Success_ModelGroupIDNotNull_LastModelOfGroup() throws IOException {
-        doAnswer(invocation -> {
-            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
-            listener.onResponse(deleteResponse);
-            return null;
-        }).when(client).delete(any(), any());
-
-        doAnswer(invocation -> {
-            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
-            BulkByScrollResponse response = new BulkByScrollResponse(new ArrayList<>(), null);
-            listener.onResponse(response);
-            return null;
-        }).when(client).execute(any(), any(), any());
-
-        SearchResponse searchResponse = createModelGroupSearchResponse(1);
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), isA(ActionListener.class));
-
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, "modelGroupID");
-
-        doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
-            return null;
-        }).when(client).get(any(), any());
-
-        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
-        verify(actionListener).onResponse(deleteResponse);
-    }
-
-    public void test_Success_ModelGroupIDNotNull_NotLastModelOfGroup() throws IOException {
-        doAnswer(invocation -> {
-            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
-            listener.onResponse(deleteResponse);
-            return null;
-        }).when(client).delete(any(), any());
-
-        doAnswer(invocation -> {
-            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
-            BulkByScrollResponse response = new BulkByScrollResponse(new ArrayList<>(), null);
-            listener.onResponse(response);
-            return null;
-        }).when(client).execute(any(), any(), any());
-
-        SearchResponse searchResponse = createModelGroupSearchResponse(2);
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), isA(ActionListener.class));
-
-        MLModel mlModel = MLModel
-            .builder()
-            .modelId("test_id")
-            .modelGroupId("modelGroupID")
-            .modelState(MLModelState.REGISTERED)
-            .algorithm(FunctionName.TEXT_EMBEDDING)
-            .build();
-        XContentBuilder content = mlModel.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
-        BytesReference bytesReference = BytesReference.bytes(content);
-        GetResult getResult = new GetResult("indexName", "111", 111l, 111l, 111l, true, bytesReference, null, null);
-        GetResponse getResponse = new GetResponse(getResult);
-        doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
-            return null;
-        }).when(client).get(any(), any());
-
-        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
-        verify(actionListener).onResponse(deleteResponse);
-    }
-
-    public void test_Failure_FailedToSearchLastModel() throws IOException {
-        doAnswer(invocation -> {
-            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
-            listener.onResponse(deleteResponse);
-            return null;
-        }).when(client).delete(any(), any());
-
-        doAnswer(invocation -> {
-            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
-            BulkByScrollResponse response = new BulkByScrollResponse(new ArrayList<>(), null);
-            listener.onResponse(response);
-            return null;
-        }).when(client).execute(any(), any(), any());
-
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new Exception("Failed to search Model index"));
-            return null;
-        }).when(client).search(any(), isA(ActionListener.class));
-
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, "modelGroupID");
-
-        doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
-            return null;
-        }).when(client).get(any(), any());
-
-        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
-        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals("Failed to search Model index", argumentCaptor.getValue().getMessage());
     }
 
     public void test_UserHasNoAccessException() throws IOException {
@@ -516,21 +399,5 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
         GetResult getResult = new GetResult("indexName", "111", 111l, 111l, 111l, true, bytesReference, null, null);
         GetResponse getResponse = new GetResponse(getResult);
         return getResponse;
-    }
-
-    private SearchResponse createModelGroupSearchResponse(long totalHits) throws IOException {
-        SearchResponse searchResponse = mock(SearchResponse.class);
-        String modelContent = "{\n"
-            + "                    \"created_time\": 1684981986069,\n"
-            + "                    \"access\": \"public\",\n"
-            + "                    \"latest_version\": 0,\n"
-            + "                    \"last_updated_time\": 1684981986069,\n"
-            + "                    \"name\": \"model_group_IT\",\n"
-            + "                    \"description\": \"This is an example description\"\n"
-            + "                }";
-        SearchHit modelGroup = SearchHit.fromXContent(TestHelper.parser(modelContent));
-        SearchHits hits = new SearchHits(new SearchHit[] { modelGroup }, new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), Float.NaN);
-        when(searchResponse.getHits()).thenReturn(hits);
-        return searchResponse;
     }
 }


### PR DESCRIPTION
### Description
Currently, when the last version of a model group is being deleted, the model group also gets deleted automatically along with the version. Due to this, the access control information stored in model group is getting deleted without user's knowledge and user is required to create a new model group which is undesirable. With this PR, we ensure even if the last existing version of a model group is deleted, the model group still remains without getting deleted.
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
