### PR TITLE
Add a setting to control the update connector API

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -693,6 +693,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
                 MLCommonsSettings.ML_COMMONS_REMOTE_MODEL_ELIGIBLE_NODE_ROLES,
                 MLCommonsSettings.ML_COMMONS_LOCAL_MODEL_ELIGIBLE_NODE_ROLES,
                 MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED,
+                MLCommonsSettings.ML_COMMONS_UPDATE_CONNECTOR_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MEMORY_FEATURE_ENABLED,
                 MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED
             );

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateConnectorAction.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.rest;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
 import static org.opensearch.ml.utils.MLExceptionUtils.REMOTE_INFERENCE_DISABLED_ERR_MSG;
+import static org.opensearch.ml.utils.MLExceptionUtils.UPDATE_CONNECTOR_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_CONNECTOR_ID;
 import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
 
@@ -63,7 +64,9 @@ public class RestMLUpdateConnectorAction extends BaseRestHandler {
         if (!mlFeatureEnabledSetting.isRemoteInferenceEnabled()) {
             throw new IllegalStateException(REMOTE_INFERENCE_DISABLED_ERR_MSG);
         }
-
+        if (!mlFeatureEnabledSetting.isUpdateConnectorEnabled()) {
+            throw new IllegalStateException(UPDATE_CONNECTOR_DISABLED_ERR_MSG);
+        }
         if (!request.hasContent()) {
             throw new IOException("Failed to update connector: Request body is empty");
         }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -114,6 +114,9 @@ public final class MLCommonsSettings {
     public static final Setting<Boolean> ML_COMMONS_REMOTE_INFERENCE_ENABLED = Setting
         .boolSetting("plugins.ml_commons.remote_inference.enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
+    public static final Setting<Boolean> ML_COMMONS_UPDATE_CONNECTOR_ENABLED = Setting
+        .boolSetting("plugins.ml_commons.update_connector.enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
     public static final Setting<Boolean> ML_COMMONS_MODEL_ACCESS_CONTROL_ENABLED = Setting
         .boolSetting("plugins.ml_commons.model_access_control_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
@@ -8,6 +8,7 @@
 package org.opensearch.ml.settings;
 
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_UPDATE_CONNECTOR_ENABLED;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
@@ -15,12 +16,18 @@ import org.opensearch.common.settings.Settings;
 public class MLFeatureEnabledSetting {
 
     private volatile Boolean isRemoteInferenceEnabled;
+    private volatile Boolean isUpdateConnectorEnabled;
 
     public MLFeatureEnabledSetting(ClusterService clusterService, Settings settings) {
         isRemoteInferenceEnabled = ML_COMMONS_REMOTE_INFERENCE_ENABLED.get(settings);
+        isUpdateConnectorEnabled = ML_COMMONS_UPDATE_CONNECTOR_ENABLED.get(settings);
+
         clusterService
             .getClusterSettings()
             .addSettingsUpdateConsumer(ML_COMMONS_REMOTE_INFERENCE_ENABLED, it -> isRemoteInferenceEnabled = it);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_UPDATE_CONNECTOR_ENABLED, it -> isUpdateConnectorEnabled = it);
     }
 
     /**
@@ -29,6 +36,10 @@ public class MLFeatureEnabledSetting {
      */
     public boolean isRemoteInferenceEnabled() {
         return isRemoteInferenceEnabled;
+    }
+
+    public boolean isUpdateConnectorEnabled() {
+        return isUpdateConnectorEnabled;
     }
 
 }

--- a/plugin/src/main/java/org/opensearch/ml/utils/MLExceptionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/MLExceptionUtils.java
@@ -20,6 +20,8 @@ public class MLExceptionUtils {
     public static final String NOT_SERIALIZABLE_EXCEPTION_WRAPPER = "NotSerializableExceptionWrapper: ";
     public static final String REMOTE_INFERENCE_DISABLED_ERR_MSG =
         "Remote Inference is currently disabled. To enable it, update the setting \"plugins.ml_commons.remote_inference_enabled\" to true.";
+    public static final String UPDATE_CONNECTOR_DISABLED_ERR_MSG =
+        "Update connector API is currently disabled. To enable it, update the setting \"plugins.ml_commons.update_connector_enabled\" to true.";
 
     public static String getRootCauseMessage(final Throwable throwable) {
         String message = ExceptionUtils.getRootCauseMessage(throwable);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLCreateConnectorActionTests.java
@@ -64,7 +64,6 @@ public class RestMLCreateConnectorActionTests extends OpenSearchTestCase {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(true);
-        when(mlFeatureEnabledSetting.isUpdateConnectorEnabled()).thenReturn(true);
         restMLCreateConnectorAction = new RestMLCreateConnectorAction(mlFeatureEnabledSetting);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLCreateConnectorActionTests.java
@@ -64,6 +64,7 @@ public class RestMLCreateConnectorActionTests extends OpenSearchTestCase {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isUpdateConnectorEnabled()).thenReturn(true);
         restMLCreateConnectorAction = new RestMLCreateConnectorAction(mlFeatureEnabledSetting);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLUpdateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLUpdateConnectorActionTests.java
@@ -67,6 +67,7 @@ public class RestMLUpdateConnectorActionTests extends OpenSearchTestCase {
         client = spy(new NodeClient(Settings.EMPTY, threadPool));
 
         when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isUpdateConnectorEnabled()).thenReturn(true);
         restMLUpdateConnectorAction = new RestMLUpdateConnectorAction(mlFeatureEnabledSetting);
 
         doAnswer(invocation -> {


### PR DESCRIPTION
### Description
Add a setting to control the update connector API, due to its being experimental feature
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
