### PR TITLE
Performance enhacement for predict action by caching model info

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
@@ -92,6 +92,7 @@ public class TransportPredictionTaskAction extends HandledTransportAction<Action
             ActionListener<MLModel> modelActionListener = new ActionListener<>() {
                 @Override
                 public void onResponse(MLModel mlModel) {
+                    context.restore();
                     modelCacheHelper.setModelInfo(modelId, mlModel);
                     FunctionName functionName = mlModel.getAlgorithm();
                     mlPredictionTaskRequest.getMlInput().setAlgorithm(functionName);

--- a/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
@@ -16,6 +16,7 @@ import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.exception.MLValidationException;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
@@ -87,42 +88,65 @@ public class TransportPredictionTaskAction extends HandledTransportAction<Action
 
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<MLTaskResponse> wrappedListener = ActionListener.runBefore(listener, () -> context.restore());
-            mlModelManager.getModel(modelId, ActionListener.wrap(mlModel -> {
-                FunctionName functionName = mlModel.getAlgorithm();
-                mlPredictionTaskRequest.getMlInput().setAlgorithm(functionName);
-                modelAccessControlHelper
-                    .validateModelGroupAccess(userInfo, mlModel.getModelGroupId(), client, ActionListener.wrap(access -> {
-                        if (!access) {
-                            wrappedListener
-                                .onFailure(
-                                    new MLValidationException("User Doesn't have privilege to perform this operation on this model")
-                                );
-                        } else {
-                            String requestId = mlPredictionTaskRequest.getRequestID();
-                            log.debug("receive predict request " + requestId + " for model " + mlPredictionTaskRequest.getModelId());
-                            long startTime = System.nanoTime();
-                            mlPredictTaskRunner
-                                .run(
-                                    functionName,
-                                    mlPredictionTaskRequest,
-                                    transportService,
-                                    ActionListener.runAfter(wrappedListener, () -> {
-                                        long endTime = System.nanoTime();
-                                        double durationInMs = (endTime - startTime) / 1e6;
-                                        modelCacheHelper.addPredictRequestDuration(modelId, durationInMs);
-                                        log.debug("completed predict request " + requestId + " for model " + modelId);
-                                    })
-                                );
-                        }
-                    }, e -> {
-                        log.error("Failed to Validate Access for ModelId " + modelId, e);
-                        wrappedListener.onFailure(e);
-                    }));
-            }, e -> {
-                log.error("Failed to find model " + modelId, e);
-                wrappedListener.onFailure(e);
-            }));
+            MLModel cachedMlModel = modelCacheHelper.getModelInfo(modelId);
+            ActionListener<MLModel> modelActionListener = new ActionListener<>() {
+                @Override
+                public void onResponse(MLModel mlModel) {
+                    modelCacheHelper.setModelInfo(modelId, mlModel);
+                    FunctionName functionName = mlModel.getAlgorithm();
+                    mlPredictionTaskRequest.getMlInput().setAlgorithm(functionName);
+                    modelAccessControlHelper
+                        .validateModelGroupAccess(userInfo, mlModel.getModelGroupId(), client, ActionListener.wrap(access -> {
+                            if (!access) {
+                                wrappedListener
+                                    .onFailure(
+                                        new MLValidationException("User Doesn't have privilege to perform this operation on this model")
+                                    );
+                            } else {
+                                executePredict(mlPredictionTaskRequest, wrappedListener, modelId);
+                            }
+                        }, e -> {
+                            log.error("Failed to Validate Access for ModelId " + modelId, e);
+                            wrappedListener.onFailure(e);
+                        }));
+                }
 
+                @Override
+                public void onFailure(Exception e) {
+                    log.error("Failed to find model " + modelId, e);
+                    wrappedListener.onFailure(e);
+                }
+            };
+
+            if (cachedMlModel != null) {
+                modelActionListener.onResponse(cachedMlModel);
+            } else if (modelAccessControlHelper.skipModelAccessControl(user)) {
+                executePredict(mlPredictionTaskRequest, wrappedListener, modelId);
+            } else {
+                mlModelManager.getModel(modelId, modelActionListener);
+            }
         }
+    }
+
+    private void executePredict(
+        MLPredictionTaskRequest mlPredictionTaskRequest,
+        ActionListener<MLTaskResponse> wrappedListener,
+        String modelId
+    ) {
+        String requestId = mlPredictionTaskRequest.getRequestID();
+        log.debug("receive predict request " + requestId + " for model " + mlPredictionTaskRequest.getModelId());
+        long startTime = System.nanoTime();
+        mlPredictTaskRunner
+            .run(
+                mlPredictionTaskRequest.getMlInput().getAlgorithm(),
+                mlPredictionTaskRequest,
+                transportService,
+                ActionListener.runAfter(wrappedListener, () -> {
+                    long endTime = System.nanoTime();
+                    double durationInMs = (endTime - startTime) / 1e6;
+                    modelCacheHelper.addPredictRequestDuration(modelId, durationInMs);
+                    log.debug("completed predict request " + requestId + " for model " + modelId);
+                })
+            );
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.exception.MLLimitExceededException;
 import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.MLModelState;
@@ -427,6 +428,16 @@ public class MLModelCacheHelper {
     public boolean getDeployToAllNodes(String modelId) {
         MLModelCache mlModelCache = getExistingModelCache(modelId);
         return mlModelCache.isDeployToAllNodes();
+    }
+
+    public void setModelInfo(String modelId, MLModel mlModel) {
+        MLModelCache mlModelCache = getExistingModelCache(modelId);
+        mlModelCache.setModelInfo(mlModel);
+    }
+
+    public MLModel getModelInfo(String modelId) {
+        MLModelCache mlModelCache = getExistingModelCache(modelId);
+        return mlModelCache.getCachedModelInfo();
     }
 
     private MLModelCache getExistingModelCache(String modelId) {

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelCacheHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelCacheHelperTests.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.model;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -26,6 +27,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.exception.MLLimitExceededException;
 import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.MLModelState;
@@ -251,6 +253,7 @@ public class MLModelCacheHelperTests extends OpenSearchTestCase {
         cacheHelper.syncWorkerNodes(modelWorkerNodes);
         assertEquals(2, cacheHelper.getAllModels().length);
         assertEquals(0, cacheHelper.getWorkerNodes(modelId2).length);
+        assertNull(cacheHelper.getModelInfo(modelId2));
         assertArrayEquals(new String[] { newNodeId }, cacheHelper.getWorkerNodes(modelId));
     }
 
@@ -323,6 +326,15 @@ public class MLModelCacheHelperTests extends OpenSearchTestCase {
         cacheHelper.removeWorkerNodes(ImmutableSet.of(nodeId), false);
         cacheHelper.removeWorkerNode(modelId, nodeId, false);
         assertEquals(0, cacheHelper.getWorkerNodes(modelId).length);
+        assertNull(cacheHelper.getModelInfo(modelId));
+    }
+
+    public void test_setModelInfo_success() {
+        cacheHelper.initModelState(modelId, MLModelState.DEPLOYED, FunctionName.TEXT_EMBEDDING, targetWorkerNodes, true);
+        MLModel model = mock(MLModel.class);
+        when(model.getModelId()).thenReturn("mockId");
+        cacheHelper.setModelInfo(modelId, model);
+        assertEquals("mockId", cacheHelper.getModelInfo(modelId).getModelId());
     }
 
 }


### PR DESCRIPTION
### Description
ML-commons predict API needs to check user permissions before the actual inference happen but the current implementation is not efficient since we need to read index for each single predict request. And fetching model info with getModel leverages the `GET` threadpool in OpenSearch Core, under heavy traffic, there might be rejection exception thrown since the threadpool is saturated.
 
### Issues Resolved
NA
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
