### PR TITLE
fix no worker node exception for remote embedding model

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
@@ -431,8 +431,10 @@ public class MLModelCacheHelper {
     }
 
     public void setModelInfo(String modelId, MLModel mlModel) {
-        MLModelCache mlModelCache = getExistingModelCache(modelId);
-        mlModelCache.setModelInfo(mlModel);
+        MLModelCache mlModelCache = modelCaches.get(modelId);
+        if (mlModelCache != null) {
+            mlModelCache.setModelInfo(mlModel);
+        }
     }
 
     public MLModel getModelInfo(String modelId) {


### PR DESCRIPTION
### Description
For remote embedding model, error happens when ingest documents with neural-search ingest pipeline. Error says no worker nodes found for the model. But actually model already deployed.  neural-search ingest pipeline will send text_embedding request to ml-commons, in ml-commons we will translate it into remote model request. In ml-commons we can't use function name from neural-search(text-embedding), we should use the model's real function name. 

Related PR #1472 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
