### PR TITLE
removed empty host check, inherently within httpHost object generation

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactory.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactory.java
@@ -57,10 +57,6 @@ public class MLHttpClientFactory {
 
     @VisibleForTesting
     protected static void validateSchemaAndPort(HttpHost host) {
-        if (Strings.isBlank(host.getHostName())) {
-            log.error("Remote inference host name is empty!");
-            throw new IllegalArgumentException("Host name is empty!");
-        }
         String scheme = host.getSchemeName();
         if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
             String[] hostNamePort = host.getHostName().split(":");

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactoryTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactoryTests.java
@@ -102,5 +102,4 @@ public class MLHttpClientFactoryTests {
         HttpHost httpHost = new HttpHost("api.openai.com:65537", -1, "https");
         MLHttpClientFactory.validateSchemaAndPort(httpHost);
     }
-
 }


### PR DESCRIPTION
### Description
if statement to check if httpHost name is not needed as an exception is already raised when creating the httpHost object for null, empty, and whitespace hostNames
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
