### PR TITLE
Add dynamic setting for DiskCircuitBreaker default disk shortage thre…

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/breaker/DiskCircuitBreaker.java
+++ b/plugin/src/main/java/org/opensearch/ml/breaker/DiskCircuitBreaker.java
@@ -11,9 +11,9 @@ import java.io.File;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
-import org.opensearch.common.settings.Settings;
-import org.opensearch.cluster.service.ClusterService;
 
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.common.exception.MLException;
 
 /**
@@ -36,6 +36,7 @@ public class DiskCircuitBreaker extends ThresholdCircuitBreaker<Long> {
         super(threshold);
         this.diskDir = diskDir;
     }
+
     public DiskCircuitBreaker(Settings settings, ClusterService clusterService, String diskDir) {
         super(DEFAULT_DISK_SHORTAGE_THRESHOLD);
         this.diskDir = diskDir;

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -168,6 +168,15 @@ public final class MLCommonsSettings {
             Setting.Property.Dynamic
         );
 
+    public static final Setting<Long> ML_COMMONS_DISK_SHORTAGE_THRESHOLD = Setting
+            .longSetting(
+                "plugins.ml_commons.disk_shortage_threshold",
+                5L,
+                1L,
+                10L,
+                Setting.Property.NodeScope,
+                Setting.Property.Dynamic
+            );
     public static final Setting<Boolean> ML_COMMONS_MEMORY_FEATURE_ENABLED = ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_ENABLED;
 
     // Feature flag for enabling search processors for Retrieval Augmented Generation using OpenSearch and Remote Inference.

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -169,14 +169,7 @@ public final class MLCommonsSettings {
         );
 
     public static final Setting<Long> ML_COMMONS_DISK_SHORTAGE_THRESHOLD = Setting
-            .longSetting(
-                "plugins.ml_commons.disk_shortage_threshold",
-                5L,
-                1L,
-                10L,
-                Setting.Property.NodeScope,
-                Setting.Property.Dynamic
-            );
+        .longSetting("plugins.ml_commons.disk_shortage_threshold", 5L, 1L, 10L, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Boolean> ML_COMMONS_MEMORY_FEATURE_ENABLED = ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_ENABLED;
 
     // Feature flag for enabling search processors for Retrieval Augmented Generation using OpenSearch and Remote Inference.


### PR DESCRIPTION
### Description
Adds a dynamic setting for the disk shortage threshold in the DiskCircuitBreaker.

### Issues Resolved
[#1341](https://github.com/opensearch-project/ml-commons/issues/1341)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
