### PR TITLE
Bump json version to address CVE-2023-5072

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     compileOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     compileOnly group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
-    compileOnly group: 'org.json', name: 'json', version: '20230227'
+    compileOnly group: 'org.json', name: 'json', version: '20231013'
 }
 
 lombok {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation 'software.amazon.awssdk:apache-client'
     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
     implementation 'com.jayway.jsonpath:json-path:2.8.0'
-    implementation group: 'org.json', name: 'json', version: '20230227'
+    implementation group: 'org.json', name: 'json', version: '20231013'
 }
 
 lombok {

--- a/search-processors/build.gradle
+++ b/search-processors/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.apache.httpcomponents.core5/httpcore5
     implementation group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.2.2'
     implementation("com.google.guava:guava:32.0.1-jre")
-    implementation group: 'org.json', name: 'json', version: '20230227'
+    implementation group: 'org.json', name: 'json', version: '20231013'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 }


### PR DESCRIPTION
### Description
Bump json version to address CVE-2023-5072
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
