### PR TITLE
enable customize http client parameters

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutor.java
@@ -3,15 +3,11 @@ package org.opensearch.ml.engine.algorithms.remote;
 import lombok.Getter;
 import lombok.Setter;
 
+@Setter
+@Getter
 public abstract class AbstractConnectorExecutor implements RemoteConnectorExecutor{
-    @Setter
-    @Getter
     private Integer maxConnections;
-    @Setter
-    @Getter
     private Integer connectionTimeoutInMillis;
-    @Setter
-    @Getter
     private Integer readTimeoutInMillis;
 
     public void validate() {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutor.java
@@ -1,0 +1,28 @@
+package org.opensearch.ml.engine.algorithms.remote;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public abstract class AbstractConnectorExecutor implements RemoteConnectorExecutor{
+    @Setter
+    @Getter
+    private Integer maxConnections;
+    @Setter
+    @Getter
+    private Integer connectionTimeoutInMillis;
+    @Setter
+    @Getter
+    private Integer readTimeoutInMillis;
+
+    public void validate() {
+        if (connectionTimeoutInMillis == null) {
+            throw new IllegalArgumentException("connectionTimeoutInMillis must be set to non null value, please check your configuration");
+        }
+        if (readTimeoutInMillis == null) {
+            throw new IllegalArgumentException("readTimeoutInMillis must be set to non null value, please check your configuration");
+        }
+        if (maxConnections == null) {
+            throw new IllegalArgumentException("maxConnections must be set to non null value, please check your configuration");
+        }
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms.remote;
 
 import lombok.Getter;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -52,6 +52,10 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor{
     @Setter @Getter
     private ScriptService scriptService;
 
+    public AwsConnectorExecutor(Connector connector, SdkHttpClient httpClient) {
+        this.connector = (AwsConnector) connector;
+        this.httpClient = httpClient;
+    }
 
     public AwsConnectorExecutor(Connector connector) {
         this.connector = (AwsConnector) connector;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
@@ -49,6 +49,11 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
 
     private CloseableHttpClient httpClient;
 
+    public HttpJsonConnectorExecutor(Connector connector, CloseableHttpClient httpClient) {
+        this(connector);
+        this.httpClient = httpClient;
+    }
+
     public HttpJsonConnectorExecutor(Connector connector) {
         this.connector = (HttpConnector)connector;
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -56,6 +56,10 @@ public interface RemoteConnectorExecutor {
     default void setClient(Client client){}
     default void setXContentRegistry(NamedXContentRegistry xContentRegistry){}
     default void setClusterService(ClusterService clusterService){}
+    default void setConnectionTimeoutInMillis(Integer connectionTimeout){}
+    default void setReadTimeoutInMillis(Integer readTimeout){}
+    default void setMaxConnections(Integer maxConnections){}
+    default void initialize(){}
 
     default void preparePayloadAndInvokeRemoteModel(MLInput mlInput, List<ModelTensors> tensorOutputs) {
         Connector connector = getConnector();

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
@@ -33,6 +33,10 @@ public class RemoteModel implements Predictable {
     public static final String CLIENT = "client";
     public static final String XCONTENT_REGISTRY = "xcontent_registry";
 
+    public static final String CONNECTION_TIMEOUT = "ConnectionTimeout";
+    public static final String READ_TIMEOUT = "ReadTimeout";
+    public static final String MAX_CONNECTIONS = "MaxConnections";
+
     private RemoteConnectorExecutor connectorExecutor;
 
     @VisibleForTesting
@@ -79,10 +83,14 @@ public class RemoteModel implements Predictable {
             Connector connector = model.getConnector().cloneConnector();
             connector.decrypt((credential) -> encryptor.decrypt(credential));
             this.connectorExecutor = MLEngineClassLoader.initInstance(connector.getProtocol(), connector, Connector.class);
+            this.connectorExecutor.setConnectionTimeoutInMillis((Integer) params.get(CONNECTION_TIMEOUT));
+            this.connectorExecutor.setReadTimeoutInMillis((Integer) params.get(READ_TIMEOUT));
+            this.connectorExecutor.setMaxConnections((Integer) params.get(MAX_CONNECTIONS));
             this.connectorExecutor.setScriptService((ScriptService) params.get(SCRIPT_SERVICE));
             this.connectorExecutor.setClusterService((ClusterService) params.get(CLUSTER_SERVICE));
             this.connectorExecutor.setClient((Client) params.get(CLIENT));
             this.connectorExecutor.setXContentRegistry((NamedXContentRegistry) params.get(XCONTENT_REGISTRY));
+            this.connectorExecutor.initialize();
         } catch (RuntimeException e) {
             log.error("Failed to init remote model", e);
             throw e;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactory.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactory.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.UnsupportedSchemeException;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -27,11 +28,11 @@ import java.util.Arrays;
 @Log4j2
 public class MLHttpClientFactory {
 
-    public static CloseableHttpClient getCloseableHttpClient() {
-       return createHttpClient();
+    public static CloseableHttpClient getCloseableHttpClient(Integer connectionTimeout, Integer readTimeout, Integer maxConnections) {
+       return createHttpClient(connectionTimeout, readTimeout, maxConnections);
     }
 
-    private static CloseableHttpClient createHttpClient() {
+    private static CloseableHttpClient createHttpClient(Integer connectionTimeout, Integer readTimeout, Integer maxConnections) {
         HttpClientBuilder builder = HttpClientBuilder.create();
 
         // Only allow HTTP and HTTPS schemes
@@ -52,6 +53,13 @@ public class MLHttpClientFactory {
                 return false;
             }
         });
+        builder.setMaxConnTotal(maxConnections);
+        builder.setMaxConnPerRoute(maxConnections);
+        RequestConfig requestConfig = RequestConfig.custom()
+            .setConnectTimeout(connectionTimeout)
+            .setSocketTimeout(readTimeout)
+            .build();
+        builder.setDefaultRequestConfig(requestConfig);
         return builder.build();
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms.remote;
 
 import org.junit.Test;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
@@ -1,0 +1,57 @@
+package org.opensearch.ml.engine.algorithms.remote;
+
+import org.junit.Test;
+import org.mockito.Answers;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class AbstractConnectorExecutorTest {
+    private final AbstractConnectorExecutor connectorExecutor = mock(AbstractConnectorExecutor.class, Answers.CALLS_REAL_METHODS);
+
+    @Test
+    public void test_setters() {
+        connectorExecutor.setMaxConnections(10);
+        connectorExecutor.setReadTimeoutInMillis(1000);
+        connectorExecutor.setConnectionTimeoutInMillis(1000);
+    }
+
+    @Test
+    public void test_getters() {
+        connectorExecutor.setMaxConnections(10);
+        connectorExecutor.setReadTimeoutInMillis(1000);
+        connectorExecutor.setConnectionTimeoutInMillis(1000);
+        assertEquals(10L, (long)connectorExecutor.getMaxConnections());
+        assertEquals(1000L, (long)connectorExecutor.getReadTimeoutInMillis());
+        assertEquals(1000L, (long)connectorExecutor.getConnectionTimeoutInMillis());
+    }
+
+    @Test
+    public void test_validate() {
+        connectorExecutor.setMaxConnections(10);
+        connectorExecutor.setReadTimeoutInMillis(1000);
+        connectorExecutor.setConnectionTimeoutInMillis(1000);
+        connectorExecutor.validate();
+    }
+
+    @Test
+    public void test_validate_fail() {
+        try {
+            connectorExecutor.validate();
+        } catch (IllegalArgumentException e) {
+            assertEquals("connectionTimeoutInMillis must be set to non null value, please check your configuration", e.getMessage());
+        }
+        connectorExecutor.setConnectionTimeoutInMillis(1000);
+        try {
+            connectorExecutor.validate();
+        } catch (IllegalArgumentException e) {
+            assertEquals("readTimeoutInMillis must be set to non null value, please check your configuration", e.getMessage());
+        }
+        connectorExecutor.setReadTimeoutInMillis(1000);
+        try {
+            connectorExecutor.validate();
+        } catch (IllegalArgumentException e) {
+            assertEquals("maxConnections must be set to non null value, please check your configuration", e.getMessage());
+        }
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
@@ -109,8 +109,7 @@ public class AwsConnectorExecutorTest {
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector.awsConnectorBuilder().name("test connector").version("1").protocol("http").parameters(parameters).credential(credential).actions(Arrays.asList(predictAction)).build();
         connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
-
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
         MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
         executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
     }
@@ -139,8 +138,7 @@ public class AwsConnectorExecutorTest {
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector.awsConnectorBuilder().name("test connector").version("1").protocol("http").parameters(parameters).credential(credential).actions(Arrays.asList(predictAction)).build();
         connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
-
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
         MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
         executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
     }
@@ -167,8 +165,7 @@ public class AwsConnectorExecutorTest {
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector.awsConnectorBuilder().name("test connector").version("1").protocol("http").parameters(parameters).credential(credential).actions(Arrays.asList(predictAction)).build();
         connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
-
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
         MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
         ModelTensorOutput modelTensorOutput = executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
         Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());
@@ -201,8 +198,7 @@ public class AwsConnectorExecutorTest {
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector.awsConnectorBuilder().name("test connector").version("1").protocol("http").parameters(parameters).credential(credential).actions(Arrays.asList(predictAction)).build();
         connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
-
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
         MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(ImmutableList.of("input")).build();
         ModelTensorOutput modelTensorOutput = executor.executePredict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build());
         Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
@@ -7,9 +7,6 @@ package org.opensearch.ml.engine.algorithms.remote;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.StatusLine;
-import org.apache.http.message.BasicStatusLine;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -112,7 +109,7 @@ public class AwsConnectorExecutorTest {
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector.awsConnectorBuilder().name("test connector").version("1").protocol("http").parameters(parameters).credential(credential).actions(Arrays.asList(predictAction)).build();
         connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
 
         MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
         executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
@@ -142,7 +139,7 @@ public class AwsConnectorExecutorTest {
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector.awsConnectorBuilder().name("test connector").version("1").protocol("http").parameters(parameters).credential(credential).actions(Arrays.asList(predictAction)).build();
         connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
 
         MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
         executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
@@ -170,7 +167,7 @@ public class AwsConnectorExecutorTest {
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector.awsConnectorBuilder().name("test connector").version("1").protocol("http").parameters(parameters).credential(credential).actions(Arrays.asList(predictAction)).build();
         connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
 
         MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
         ModelTensorOutput modelTensorOutput = executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
@@ -204,7 +201,7 @@ public class AwsConnectorExecutorTest {
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector.awsConnectorBuilder().name("test connector").version("1").protocol("http").parameters(parameters).credential(credential).actions(Arrays.asList(predictAction)).build();
         connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
 
         MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(ImmutableList.of("input")).build();
         ModelTensorOutput modelTensorOutput = executor.executePredict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
@@ -84,7 +84,7 @@ public class HttpJsonConnectorExecutorTest {
                 .requestBody("{\"input\": \"${parameters.input}\"}")
                 .build();
         Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").actions(Arrays.asList(predictAction)).build();
-        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector, httpClient));
         when(httpClient.execute(any())).thenReturn(response);
         HttpEntity entity = new StringEntity("{\"response\": \"test result\"}");
         when(response.getEntity()).thenReturn(entity);
@@ -112,7 +112,7 @@ public class HttpJsonConnectorExecutorTest {
         StatusLine statusLine = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
         when(response.getStatusLine()).thenReturn(statusLine);
         Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").actions(Arrays.asList(predictAction)).build();
-        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector, httpClient));
         MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test doc1", "test doc2")).build();
         ModelTensorOutput modelTensorOutput = executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
         Assert.assertEquals(2, modelTensorOutput.getMlModelOutputs().size());
@@ -137,7 +137,7 @@ public class HttpJsonConnectorExecutorTest {
         StatusLine statusLine = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 429, "OK");
         when(response.getStatusLine()).thenReturn(statusLine);
         Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").actions(Arrays.asList(predictAction)).build();
-        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector, httpClient));
         MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test doc1", "test doc2")).build();
         executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
     }
@@ -159,7 +159,7 @@ public class HttpJsonConnectorExecutorTest {
                 .requestBody("{\"input\": ${parameters.input}}")
                 .build();
         Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").actions(Arrays.asList(predictAction)).build();
-        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector, httpClient));
         executor.setScriptService(scriptService);
         when(httpClient.execute(any())).thenReturn(response);
         String modelResponse = "{\n" + "    \"object\": \"list\",\n" + "    \"data\": [\n" + "        {\n"

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
@@ -21,7 +21,6 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.cluster.ClusterStateTaskConfig;
 import org.opensearch.ingest.TestTemplateService;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.connector.Connector;
@@ -34,15 +33,12 @@ import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
-import org.opensearch.ml.engine.httpclient.MLHttpClientFactory;
 import org.opensearch.script.ScriptService;
 
 import java.io.IOException;
 import java.util.Arrays;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -94,7 +90,6 @@ public class HttpJsonConnectorExecutorTest {
         when(response.getEntity()).thenReturn(entity);
         StatusLine statusLine = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
         when(response.getStatusLine()).thenReturn(statusLine);
-        when(executor.getHttpClient()).thenReturn(httpClient);
         MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
         ModelTensorOutput modelTensorOutput = executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
         Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());
@@ -118,7 +113,6 @@ public class HttpJsonConnectorExecutorTest {
         when(response.getStatusLine()).thenReturn(statusLine);
         Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").actions(Arrays.asList(predictAction)).build();
         HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
-        when(executor.getHttpClient()).thenReturn(httpClient);
         MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test doc1", "test doc2")).build();
         ModelTensorOutput modelTensorOutput = executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
         Assert.assertEquals(2, modelTensorOutput.getMlModelOutputs().size());
@@ -144,7 +138,6 @@ public class HttpJsonConnectorExecutorTest {
         when(response.getStatusLine()).thenReturn(statusLine);
         Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").actions(Arrays.asList(predictAction)).build();
         HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
-        when(executor.getHttpClient()).thenReturn(httpClient);
         MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test doc1", "test doc2")).build();
         executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
     }
@@ -181,7 +174,6 @@ public class HttpJsonConnectorExecutorTest {
         when(response.getStatusLine()).thenReturn(statusLine);
         HttpEntity entity = new StringEntity(modelResponse);
         when(response.getEntity()).thenReturn(entity);
-        when(executor.getHttpClient()).thenReturn(httpClient);
         MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test doc1", "test doc2")).build();
         ModelTensorOutput modelTensorOutput = executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
         Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
@@ -182,4 +182,24 @@ public class HttpJsonConnectorExecutorTest {
         Assert.assertArrayEquals(new Number[] {-0.014555434, -0.002135904, 0.0035105038}, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getData());
         Assert.assertArrayEquals(new Number[] {-0.014555434, -0.002135904, 0.0035105038}, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(1).getData());
     }
+
+    @Test
+    public void test_initialize() {
+        ConnectorAction predictAction = ConnectorAction.builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("http://test.com/mock")
+            .requestBody("{\"input\": ${parameters.input}}")
+            .build();
+        Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").actions(Arrays.asList(predictAction)).build();
+        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector, httpClient));
+        initializeExecutor(executor);
+    }
+
+    private void initializeExecutor(RemoteConnectorExecutor executor) {
+        executor.setConnectionTimeoutInMillis(1000);
+        executor.setReadTimeoutInMillis(1000);
+        executor.setMaxConnections(30);
+        executor.initialize();
+    }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
@@ -44,6 +44,8 @@ public class RemoteModelTest {
     RemoteModel remoteModel;
     Encryptor encryptor;
 
+    private Map<String, Object> params = Map.of(RemoteModel.CONNECTION_TIMEOUT, 1000,  RemoteModel.READ_TIMEOUT, 1000, RemoteModel.MAX_CONNECTIONS, 30);
+
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
@@ -71,7 +73,7 @@ public class RemoteModelTest {
         exceptionRule.expectMessage("Wrong input type");
         Connector connector = createConnector(ImmutableMap.of("Authorization", "Bearer ${credential.key}"));
         when(mlModel.getConnector()).thenReturn(connector);
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        remoteModel.initModel(mlModel, params, encryptor);
         remoteModel.predict(mlInput);
     }
 
@@ -82,14 +84,14 @@ public class RemoteModelTest {
         Connector connector = createConnector(null);
         when(mlModel.getConnector()).thenReturn(connector);
         doThrow(new IllegalArgumentException("Tag mismatch!")).when(encryptor).decrypt(any());
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        remoteModel.initModel(mlModel, params, encryptor);
     }
 
     @Test
     public void initModel_NullHeader() {
         Connector connector = createConnector(null);
         when(mlModel.getConnector()).thenReturn(connector);
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        remoteModel.initModel(mlModel, params, encryptor);
         Map<String, String> decryptedHeaders = connector.getDecryptedHeaders();
         Assert.assertNull(decryptedHeaders);
     }
@@ -98,7 +100,7 @@ public class RemoteModelTest {
     public void initModel_WithHeader() {
         Connector connector = createConnector(ImmutableMap.of("Authorization", "Bearer ${credential.key}"));
         when(mlModel.getConnector()).thenReturn(connector);
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        remoteModel.initModel(mlModel, params, encryptor);
         Map<String, String> decryptedHeaders = connector.getDecryptedHeaders();
         RemoteConnectorExecutor executor = remoteModel.getConnectorExecutor();
         Assert.assertNotNull(executor);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactoryTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactoryTests.java
@@ -22,7 +22,7 @@ public class MLHttpClientFactoryTests {
 
     @Test
     public void test_getCloseableHttpClient_success() {
-        CloseableHttpClient client = MLHttpClientFactory.getCloseableHttpClient();
+        CloseableHttpClient client = MLHttpClientFactory.getCloseableHttpClient(1000, 1000, 30);
         assertNotNull(client);
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -948,7 +948,8 @@ public class MLModelManager {
                             connectionTimeoutInMillis,
                             READ_TIMEOUT,
                             readTimeoutInMillis,
-                            MAX_CONNECTIONS, maxConnections
+                            MAX_CONNECTIONS,
+                            maxConnections
                         );
                     // deploy remote model with internal connector or model trained by built-in algorithm like kmeans
                     if (mlModel.getConnector() != null || FunctionName.REMOTE != mlModel.getAlgorithm()) {

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -695,7 +695,10 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
                 MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED,
                 MLCommonsSettings.ML_COMMONS_UPDATE_CONNECTOR_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MEMORY_FEATURE_ENABLED,
-                MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED
+                MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED,
+                MLCommonsSettings.ML_COMMONS_HTTP_CLIENT_CONNECTION_TIMEOUT_IN_MILLI_SECOND,
+                MLCommonsSettings.ML_COMMONS_HTTP_CLIENT_READ_TIMEOUT_IN_MILLI_SECOND,
+                MLCommonsSettings.ML_COMMONS_HTTP_CLIENT_MAX_CONNECTIONS
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -178,12 +178,24 @@ public final class MLCommonsSettings {
     public static final Setting<Boolean> ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED =
         GenerativeQAProcessorConstants.RAG_PIPELINE_FEATURE_ENABLED;
 
-    public static final Setting<Integer> ML_COMMONS_HTTP_CLIENT_CONNECTION_TIMEOUT_IN_MILLI_SECOND =
-        Setting.intSetting("plugins.ml_commons.http_client.connection_timeout.in_millisecond", 1000, 1, Setting.Property.NodeScope, Setting.Property.Final);
+    public static final Setting<Integer> ML_COMMONS_HTTP_CLIENT_CONNECTION_TIMEOUT_IN_MILLI_SECOND = Setting
+        .intSetting(
+            "plugins.ml_commons.http_client.connection_timeout.in_millisecond",
+            1000,
+            1,
+            Setting.Property.NodeScope,
+            Setting.Property.Final
+        );
 
-    public static final Setting<Integer> ML_COMMONS_HTTP_CLIENT_READ_TIMEOUT_IN_MILLI_SECOND =
-        Setting.intSetting("plugins.ml_commons.http_client.read_timeout.in_millisecond", 3000, 1, Setting.Property.NodeScope, Setting.Property.Final);
+    public static final Setting<Integer> ML_COMMONS_HTTP_CLIENT_READ_TIMEOUT_IN_MILLI_SECOND = Setting
+        .intSetting(
+            "plugins.ml_commons.http_client.read_timeout.in_millisecond",
+            3000,
+            1,
+            Setting.Property.NodeScope,
+            Setting.Property.Final
+        );
 
-    public static final Setting<Integer> ML_COMMONS_HTTP_CLIENT_MAX_CONNECTIONS =
-        Setting.intSetting("plugins.ml_commons.http_client.max_connections", 20, 20, Setting.Property.NodeScope, Setting.Property.Final);
+    public static final Setting<Integer> ML_COMMONS_HTTP_CLIENT_MAX_CONNECTIONS = Setting
+        .intSetting("plugins.ml_commons.http_client.max_connections", 20, 20, Setting.Property.NodeScope, Setting.Property.Final);
 }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -177,4 +177,13 @@ public final class MLCommonsSettings {
     // Feature flag for enabling search processors for Retrieval Augmented Generation using OpenSearch and Remote Inference.
     public static final Setting<Boolean> ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED =
         GenerativeQAProcessorConstants.RAG_PIPELINE_FEATURE_ENABLED;
+
+    public static final Setting<Integer> ML_COMMONS_HTTP_CLIENT_CONNECTION_TIMEOUT_IN_MILLI_SECOND =
+        Setting.intSetting("plugins.ml_commons.http_client.connection_timeout.in_millisecond", 1000, 1, Setting.Property.NodeScope, Setting.Property.Final);
+
+    public static final Setting<Integer> ML_COMMONS_HTTP_CLIENT_READ_TIMEOUT_IN_MILLI_SECOND =
+        Setting.intSetting("plugins.ml_commons.http_client.read_timeout.in_millisecond", 3000, 1, Setting.Property.NodeScope, Setting.Property.Final);
+
+    public static final Setting<Integer> ML_COMMONS_HTTP_CLIENT_MAX_CONNECTIONS =
+        Setting.intSetting("plugins.ml_commons.http_client.max_connections", 20, 20, Setting.Property.NodeScope, Setting.Property.Final);
 }


### PR DESCRIPTION
### Description
Currently remote inference using CloseableHttpClient with default configurations both for AWS protocol and http protocol,  the drawback is customer can't configure the client base on their own use case. Sometimes issue can be found thrown from httpclient, this feature enables customer to configure their own parameters for httpclient.
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/1470
https://github.com/opensearch-project/ml-commons/issues/1537
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
