### PR TITLE
[Backport to 2.9] Bump json version to address CVE-2023-5072

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     compileOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     compileOnly group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
-    compileOnly group: 'org.json', name: 'json', version: '20230227'
+    compileOnly group: 'org.json', name: 'json', version: '20231013'
 }
 
 jacocoTestReport {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'software.amazon.awssdk:apache-client'
     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.0'
     implementation 'com.jayway.jsonpath:json-path:2.8.0'
-    implementation group: 'org.json', name: 'json', version: '20230227'
+    implementation group: 'org.json', name: 'json', version: '20231013'
 }
 
 configurations.all {


### PR DESCRIPTION
### Description
Backport PR #1551 to 2.9
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
