### PR TITLE
Fix Tool interface javadocs and generic types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ ml-algorithms/build/
 plugin/build/
 plugin/src/test/resources/bwc/*
 .DS_Store
+*/bin/
+.classpath
+.project
+.settings

--- a/spi/src/main/java/org/opensearch/ml/common/spi/MLCommonsExtension.java
+++ b/spi/src/main/java/org/opensearch/ml/common/spi/MLCommonsExtension.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.spi;
 
 import org.opensearch.ml.common.spi.tools.Tool;
@@ -11,13 +16,13 @@ public interface MLCommonsExtension {
 
     /**
      * Get tools.
-     * @return
+     * @return A list of provided tools
      */
     List<Tool> getTools();
 
     /**
      * Get tool factories.
-     * @return
+     * @return A list of tool factories
      */
-    List<Tool.Factory> getToolFactories();
+    List<Tool.Factory<? extends Tool>> getToolFactories();
 }

--- a/spi/src/main/java/org/opensearch/ml/common/spi/tools/Parser.java
+++ b/spi/src/main/java/org/opensearch/ml/common/spi/tools/Parser.java
@@ -1,16 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.spi.tools;
 
 /**
  * General parser interface.
- * @param <S>
- * @param <T>
+ * @param <S> The input type
+ * @param <T> The return type
  */
 public interface Parser<S, T> {
 
     /**
      * Parse input.
      * @param input
-     * @return
+     * @return output
      */
     T parse(S input);
 }

--- a/spi/src/main/java/org/opensearch/ml/common/spi/tools/Tool.java
+++ b/spi/src/main/java/org/opensearch/ml/common/spi/tools/Tool.java
@@ -16,10 +16,12 @@ public interface Tool {
     /**
      * Run tool and return response.
      * @param parameters input parameters
-     * @return
-     * @param <T>
+     * @return the tool's output
+     * @param <T> The output type
      */
-    default <T> T run(Map<String, String> parameters) {return null;};
+    default <T> T run(Map<String, String> parameters) {
+        return null;
+    };
 
     default <T> void run(Map<String, String> parameters, ActionListener<T> listener) {};
 
@@ -27,13 +29,13 @@ public interface Tool {
      * Set input parser.
      * @param parser
      */
-    default void setInputParser(Parser parser){};
+    default void setInputParser(Parser<?, ?> parser) {};
 
     /**
      * Set output parser.
      * @param parser
      */
-    default void setOutputParser(Parser parser){};
+    default void setOutputParser(Parser<?, ?> parser) {};
 
     /**
      * Get tool name.
@@ -78,13 +80,15 @@ public interface Tool {
      * the tool may end the whole CoT process by returning true.
      * @param input
      * @param toolParameters
-     * @return
+     * @return true as a signal to CoT to end the chain, false to continue CoT
      */
-    default boolean end(String input, Map<String, String> toolParameters){return false;}
+    default boolean end(String input, Map<String, String> toolParameters) {
+        return false;
+    }
 
     /**
      * Tool factory which can create instance of {@link Tool}.
-     * @param <T>
+     * @param <T> The subclass this factory produces
      */
     interface Factory<T extends Tool> {
         T create(Map<String, Object> params);

--- a/spi/src/main/java/org/opensearch/ml/common/spi/tools/ToolAnnotation.java
+++ b/spi/src/main/java/org/opensearch/ml/common/spi/tools/ToolAnnotation.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.spi.tools;
 
 import java.lang.annotation.ElementType;


### PR DESCRIPTION
### Description

Adds generic types to Tool interfaces

### Issues Resolved

In support of #1161 , #1521, #1545, #1546, #1547, #1548
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
