### PR TITLE
add Austin and Henry as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @b4sjoo @dhrubo-os @jngz-es @model-collapse @rbhavna @wujunshen @ylwu-amzn @zane-neo @Zhangxunmt
+*   @b4sjoo @dhrubo-os @jngz-es @model-collapse @rbhavna @wujunshen @ylwu-amzn @zane-neo @Zhangxunmt @austintlee @HenryL27

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 ## Current Maintainers
 
 | Maintainer           | GitHub ID                                           | Affiliation |
-| -------------------- | --------------------------------------------------- | ----------- |
+|----------------------|-----------------------------------------------------|-------------|
 | Bhavana Goud Ramaram | [rbhavna](https://github.com/rbhavna)               | Amazon      |
 | Charlie Yang         | [model-collapse](https://github.com/model-collapse) | Amazon      |
 | Dhrubo Saha          | [dhrubo-os](https://github.com/dhrubo-os)           | Amazon      |
@@ -15,6 +15,8 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Xun Zhang            | [Zhangxunmt](https://github.com/Zhangxunmt)         | Amazon      |
 | Yaliang Wu           | [ylwu-amzn](https://github.com/ylwu-amzn)           | Amazon      |
 | Zan Niu              | [zane-neo](https://github.com/zane-neo)             | Amazon      |
+| Austin Lee           | [austintlee](https://github.com/austintlee)         | Aryn        |
+| Henry Lindeman       | [HenryL27](https://github.com/HenryL27)             | Aryn        |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description

Nominate Austin and Henry as maintainer by following this [process](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#nomination).

We already got approval from current maintainers.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
