### PR TITLE
return parsing exception 400 for parsing errors

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateConnectorAction.java
@@ -64,7 +64,7 @@ public class RestMLUpdateConnectorAction extends BaseRestHandler {
             throw new IllegalStateException(UPDATE_CONNECTOR_DISABLED_ERR_MSG);
         }
         if (!request.hasContent()) {
-            throw new IOException("Failed to update connector: Request body is empty");
+            throw new OpenSearchParseException("Failed to update connector: Request body is empty");
         }
 
         String connectorId = getParameterId(request, PARAMETER_CONNECTOR_ID);

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateConnectorAction.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.transport.connector.MLUpdateConnectorAction;
@@ -68,9 +69,12 @@ public class RestMLUpdateConnectorAction extends BaseRestHandler {
 
         String connectorId = getParameterId(request, PARAMETER_CONNECTOR_ID);
 
-        XContentParser parser = request.contentParser();
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-
-        return MLUpdateConnectorRequest.parse(parser, connectorId);
+        try {
+            XContentParser parser = request.contentParser();
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+            return MLUpdateConnectorRequest.parse(parser, connectorId);
+        } catch (IllegalStateException illegalStateException) {
+            throw new OpenSearchParseException(illegalStateException.getMessage());
+        }
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLUpdateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLUpdateConnectorActionTests.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.utils.MLExceptionUtils.REMOTE_INFERENCE_DISABLED_ERR_MSG;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +24,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.settings.Settings;
@@ -114,8 +114,15 @@ public class RestMLUpdateConnectorActionTests extends OpenSearchTestCase {
         assertEquals("2", updateConnectorRequest.getUpdateContent().getVersion());
     }
 
+    public void testUpdateConnectorRequestWithParsingException() throws Exception {
+        exceptionRule.expect(OpenSearchParseException.class);
+        exceptionRule.expectMessage("Can't get text on a VALUE_NULL");
+        RestRequest request = getRestRequestWithNullValue();
+        restMLUpdateConnectorAction.handleRequest(request, channel, client);
+    }
+
     public void testUpdateConnectorRequestWithEmptyContent() throws Exception {
-        exceptionRule.expect(IOException.class);
+        exceptionRule.expect(OpenSearchParseException.class);
         exceptionRule.expectMessage("Failed to update connector: Request body is empty");
         RestRequest request = getRestRequestWithEmptyContent();
         restMLUpdateConnectorAction.handleRequest(request, channel, client);
@@ -141,6 +148,20 @@ public class RestMLUpdateConnectorActionTests extends OpenSearchTestCase {
         RestRequest.Method method = RestRequest.Method.POST;
         final Map<String, Object> updateContent = Map.of("version", "2", "description", "This is test description");
         String requestContent = new Gson().toJson(updateContent).toString();
+        Map<String, String> params = new HashMap<>();
+        params.put("connector_id", "test_connectorId");
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(method)
+            .withPath("/_plugins/_ml/connectors/_update/{connector_id}")
+            .withParams(params)
+            .withContent(new BytesArray(requestContent), XContentType.JSON)
+            .build();
+        return request;
+    }
+
+    private RestRequest getRestRequestWithNullValue() {
+        RestRequest.Method method = RestRequest.Method.POST;
+        String requestContent = "{\"version\":\"2\",\"description\":null}";
         Map<String, String> params = new HashMap<>();
         params.put("connector_id", "test_connectorId");
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)


### PR DESCRIPTION
### Description
Fix the 500 internal service error reported in the pen test. All parsing errors should return 400 error code showing it's coming from users.

 
Test: 
~~~
PUT /_plugins/_ml/connectors/zmMCmIsBaumhjugAg9cu
{
  "description": null
}
Response:
{
  "error": {
    "root_cause": [
      {
        "type": "parse_exception",
        "reason": "Can't get text on a VALUE_NULL at 2:18"
      }
    ],
    "type": "parse_exception",
    "reason": "Can't get text on a VALUE_NULL at 2:18"
  },
  "status": 400
}
~~~

~~~
PUT /_plugins/_ml/connectors/zmMCmIsBaumhjugAg9cu
{
  "description": "Update description"
}
Response:
{
  "_index": ".plugins-ml-connector",
  "_id": "zmMCmIsBaumhjugAg9cu",
  "_version": 3,
  "result": "updated",
  "_shards": {
    "total": 1,
    "successful": 1,
    "failed": 0
  },
  "_seq_no": 2,
  "_primary_term": 2
}
~~~

### Issues Resolved
[[List any issues this PR will resolve]](https://talos.security.aws.a2z.com/#/talos/engagement/arn:aws:talos-engagement:engagement/1224cf1a-48cb-4cfd-bd70-d170bbaa2b93/finding/8f543629-903f-4c57-a03d-df61b8b20601)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
