### PR TITLE
Fixing ml-client build.gradle for publishing

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -122,3 +122,5 @@ publishing {
     }
 
 }
+compileJava.dependsOn(':opensearch-ml-common:shadowJar')
+delombok.dependsOn(':opensearch-ml-common:shadowJar')

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation project(':opensearch-ml-common')
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.3.1'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
 
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -14,11 +14,10 @@ plugins {
 }
 
 dependencies {
-    implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
-    compileOnly project(':opensearch-ml-common')
+    implementation project(':opensearch-ml-common')
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.3.1'
 
 }
 
@@ -123,5 +122,3 @@ publishing {
     }
 
 }
-compileJava.dependsOn(':opensearch-ml-common:shadowJar')
-delombok.dependsOn(':opensearch-ml-common:shadowJar')


### PR DESCRIPTION
### Description

Removed shadowJar so we can publish the ml-client. 
Currently the feature branch is not publishing ml-client when running `./gradlew publishToMavenLocal`
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
