### PR TITLE
Model level quota and throttling feature with in-cache update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext {
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "2.12.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.11.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
 
         // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT

--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -37,7 +37,7 @@ public class CommonValue {
     public static final String ML_MODEL_INDEX = ".plugins-ml-model";
     public static final String ML_TASK_INDEX = ".plugins-ml-task";
     public static final Integer ML_MODEL_GROUP_INDEX_SCHEMA_VERSION = 2;
-    public static final Integer ML_MODEL_INDEX_SCHEMA_VERSION = 7;
+    public static final Integer ML_MODEL_INDEX_SCHEMA_VERSION = 8;
     public static final String ML_CONNECTOR_INDEX = ".plugins-ml-connector";
     public static final Integer ML_TASK_INDEX_SCHEMA_VERSION = 2;
     public static final Integer ML_CONNECTOR_SCHEMA_VERSION = 2;
@@ -195,6 +195,15 @@ public class CommonValue {
             + NORMALIZE_RESULT_FIELD + "\":{\"type\":\"boolean\"},\""
             + MODEL_MAX_LENGTH_FIELD + "\":{\"type\":\"integer\"},\""
             + ALL_CONFIG_FIELD + "\":{\"type\":\"text\"}}},\n"
+            + "      \""
+            + MLModel.QUOTA_FLAG_FIELD
+            + "\" : {\"type\": \"boolean\"},\n"
+            + "      \""
+            + MLModel.RATE_LIMIT_NUMBER_FIELD
+            + "\" : {\"type\": \"keyword\"},\n"
+            + "      \""
+            + MLModel.RATE_LIMIT_UNIT_FIELD
+            + "\" : {\"type\": \"keyword\"},\n"
             + "      \""
             + MLModel.MODEL_CONTENT_HASH_VALUE_FIELD
             + "\" : {\"type\": \"keyword\"},\n"

--- a/common/src/main/java/org/opensearch/ml/common/MLModel.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModel.java
@@ -409,7 +409,7 @@ public class MLModel implements ToXContentObject {
         String oldContent = null;
         User user = null;
 
-        String description = null;;
+        String description = null;
         MLModelFormat modelFormat = null;
         MLModelState modelState = null;
         Long modelContentSizeInBytes = null;

--- a/common/src/main/java/org/opensearch/ml/common/MLModel.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModel.java
@@ -23,10 +23,12 @@ import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
 import org.opensearch.ml.common.model.MetricsCorrelationModelConfig;
 
 import java.io.IOException;
+import java.sql.Time;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.USER;
@@ -50,8 +52,13 @@ public class MLModel implements ToXContentObject {
     public static final String MODEL_FORMAT_FIELD = "model_format";
     public static final String MODEL_STATE_FIELD = "model_state";
     public static final String MODEL_CONTENT_SIZE_IN_BYTES_FIELD = "model_content_size_in_bytes";
-    //SHA256 hash value of model content.
+    // SHA256 hash value of model content.
     public static final String MODEL_CONTENT_HASH_VALUE_FIELD = "model_content_hash_value";
+
+    // Model level quota and throttling control
+    public static final String QUOTA_FLAG_FIELD = "quota_flag";
+    public static final String RATE_LIMIT_NUMBER_FIELD = "rate_limit_number";
+    public static final String RATE_LIMIT_UNIT_FIELD = "rate_limit_unit";
 
     public static final String MODEL_CONFIG_FIELD = "model_config";
     public static final String CREATED_TIME_FIELD = "created_time";
@@ -92,6 +99,9 @@ public class MLModel implements ToXContentObject {
     private Long modelContentSizeInBytes;
     private String modelContentHash;
     private MLModelConfig modelConfig;
+    private Boolean quotaFlag;
+    private String rateLimitNumber;
+    private TimeUnit rateLimitUnit;
     private Instant createdTime;
     private Instant lastUpdateTime;
     private Instant lastRegisteredTime;
@@ -126,6 +136,9 @@ public class MLModel implements ToXContentObject {
                    MLModelState modelState,
                    Long modelContentSizeInBytes,
                    String modelContentHash,
+                   Boolean quotaFlag,
+                   String rateLimitNumber,
+                   TimeUnit rateLimitUnit,
                    MLModelConfig modelConfig,
                    Instant createdTime,
                    Instant lastUpdateTime,
@@ -152,6 +165,9 @@ public class MLModel implements ToXContentObject {
         this.modelState = modelState;
         this.modelContentSizeInBytes = modelContentSizeInBytes;
         this.modelContentHash = modelContentHash;
+        this.quotaFlag = quotaFlag;
+        this.rateLimitNumber = rateLimitNumber;
+        this.rateLimitUnit = rateLimitUnit;
         this.modelConfig = modelConfig;
         this.createdTime = createdTime;
         this.lastUpdateTime = lastUpdateTime;
@@ -196,6 +212,11 @@ public class MLModel implements ToXContentObject {
                 } else {
                     modelConfig = new TextEmbeddingModelConfig(input);
                 }
+            }
+            quotaFlag = input.readOptionalBoolean();
+            rateLimitNumber = input.readOptionalString();
+            if (input.readBoolean()) {
+                rateLimitUnit = input.readEnum(TimeUnit.class);
             }
             createdTime = input.readOptionalInstant();
             lastUpdateTime = input.readOptionalInstant();
@@ -247,6 +268,14 @@ public class MLModel implements ToXContentObject {
         if (modelConfig != null) {
             out.writeBoolean(true);
             modelConfig.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeOptionalBoolean(quotaFlag);
+        out.writeOptionalString(rateLimitNumber);
+        if (rateLimitUnit != null) {
+            out.writeBoolean(true);
+            out.writeEnum(rateLimitUnit);
         } else {
             out.writeBoolean(false);
         }
@@ -311,6 +340,15 @@ public class MLModel implements ToXContentObject {
         }
         if (modelConfig != null) {
             builder.field(MODEL_CONFIG_FIELD, modelConfig);
+        }
+        if (quotaFlag != null) {
+            builder.field(QUOTA_FLAG_FIELD, quotaFlag);
+        }
+        if (rateLimitNumber != null) {
+            builder.field(RATE_LIMIT_NUMBER_FIELD, rateLimitNumber);
+        }
+        if (rateLimitUnit != null) {
+            builder.field(RATE_LIMIT_UNIT_FIELD, rateLimitUnit);
         }
         if (createdTime != null) {
             builder.field(CREATED_TIME_FIELD, createdTime.toEpochMilli());
@@ -377,6 +415,9 @@ public class MLModel implements ToXContentObject {
         Long modelContentSizeInBytes = null;
         String modelContentHash = null;
         MLModelConfig modelConfig = null;
+        Boolean quotaFlag = null;
+        String rateLimitNumber = null;
+        TimeUnit rateLimitUnit = null;
         Instant createdTime = null;
         Instant lastUpdateTime = null;
         Instant lastUploadedTime = null;
@@ -461,6 +502,15 @@ public class MLModel implements ToXContentObject {
                         modelConfig = TextEmbeddingModelConfig.parse(parser);
                     }
                     break;
+                case QUOTA_FLAG_FIELD:
+                    quotaFlag = parser.booleanValue();
+                    break;
+                case RATE_LIMIT_NUMBER_FIELD:
+                    rateLimitNumber = parser.text();
+                    break;
+                case RATE_LIMIT_UNIT_FIELD:
+                    rateLimitUnit = TimeUnit.valueOf(parser.text());
+                    break;
                 case PLANNING_WORKER_NODE_COUNT_FIELD:
                     planningWorkerNodeCount = parser.intValue();
                     break;
@@ -524,6 +574,9 @@ public class MLModel implements ToXContentObject {
                 .modelContentSizeInBytes(modelContentSizeInBytes)
                 .modelContentHash(modelContentHash)
                 .modelConfig(modelConfig)
+                .quotaFlag(quotaFlag)
+                .rateLimitNumber(rateLimitNumber)
+                .rateLimitUnit(rateLimitUnit)
                 .createdTime(createdTime)
                 .lastUpdateTime(lastUpdateTime)
                 .lastRegisteredTime(lastRegisteredTime == null? lastUploadedTime : lastRegisteredTime)

--- a/common/src/main/java/org/opensearch/ml/common/transport/model/MLInPlaceUpdateModelAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model/MLInPlaceUpdateModelAction.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.model;
+
+import org.opensearch.action.ActionType;
+
+public class MLInPlaceUpdateModelAction extends ActionType<MLInPlaceUpdateModelNodesResponse> {
+    public static final MLInPlaceUpdateModelAction INSTANCE = new MLInPlaceUpdateModelAction();
+    public static final String NAME = "cluster:admin/opensearch/ml/models/in_place_update";
+
+    private MLInPlaceUpdateModelAction() { super(NAME, MLInPlaceUpdateModelNodesResponse::new);}
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/model/MLInPlaceUpdateModelNodeRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model/MLInPlaceUpdateModelNodeRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.model;
+
+import org.opensearch.action.support.nodes.BaseNodeRequest;
+import java.io.IOException;
+import lombok.Getter;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+public class MLInPlaceUpdateModelNodeRequest extends BaseNodeRequest {
+    @Getter
+    private MLInPlaceUpdateModelNodesRequest mlInPlaceUpdateModelNodesRequest;
+
+    public MLInPlaceUpdateModelNodeRequest(StreamInput in) throws IOException {
+        super(in);
+        this.mlInPlaceUpdateModelNodesRequest = new MLInPlaceUpdateModelNodesRequest(in);
+    }
+
+    public MLInPlaceUpdateModelNodeRequest(MLInPlaceUpdateModelNodesRequest request) {
+        this.mlInPlaceUpdateModelNodesRequest = request;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        mlInPlaceUpdateModelNodesRequest.writeTo(out);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/model/MLInPlaceUpdateModelNodeResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model/MLInPlaceUpdateModelNodeResponse.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.model;
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Getter
+@Log4j2
+public class MLInPlaceUpdateModelNodeResponse extends BaseNodeResponse implements ToXContentFragment {
+    private Map<String, String> modelUpdateStatus;
+
+    public MLInPlaceUpdateModelNodeResponse(DiscoveryNode node, Map<String, String> modelUpdateStatus) {
+        super(node);
+        this.modelUpdateStatus = modelUpdateStatus;
+    }
+
+    public MLInPlaceUpdateModelNodeResponse(StreamInput in) throws IOException {
+        super(in);
+        if (in.readBoolean()) {
+            this.modelUpdateStatus = in.readMap(StreamInput::readString, StreamInput::readString);
+        }
+    }
+
+    public static MLInPlaceUpdateModelNodeResponse readStats(StreamInput in) throws IOException {
+        return new MLInPlaceUpdateModelNodeResponse(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+
+        if (!isEmpty()) {
+            out.writeBoolean(true);
+            out.writeMap(modelUpdateStatus, StreamOutput::writeString, StreamOutput::writeString);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("stats");
+        if (modelUpdateStatus != null && modelUpdateStatus.size() > 0) {
+            for (Map.Entry<String, String> stat : modelUpdateStatus.entrySet()) {
+                builder.field(stat.getKey(), stat.getValue());
+            }
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public boolean isEmpty() {
+        return modelUpdateStatus == null || modelUpdateStatus.size() == 0;
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/model/MLInPlaceUpdateModelNodesRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model/MLInPlaceUpdateModelNodesRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.model;
+
+import lombok.Getter;
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import java.io.IOException;
+
+public class MLInPlaceUpdateModelNodesRequest extends BaseNodesRequest<MLInPlaceUpdateModelNodesRequest> {
+
+    @Getter
+    private String modelId;
+    @Getter
+    private boolean updatePredictorFlag;
+
+    public MLInPlaceUpdateModelNodesRequest(StreamInput in) throws IOException {
+        super(in);
+        this.modelId = in.readString();
+        this.updatePredictorFlag = in.readBoolean();
+    }
+
+    public MLInPlaceUpdateModelNodesRequest(String[] nodeIds, String modelId, boolean updatePredictorFlag) {
+        super(nodeIds);
+        this.modelId = modelId;
+        this.updatePredictorFlag = updatePredictorFlag;
+    }
+
+    public MLInPlaceUpdateModelNodesRequest(DiscoveryNode[] nodeIds, String modelId, boolean updatePredictorFlag) {
+        super(nodeIds);
+        this.modelId = modelId;
+        this.updatePredictorFlag = updatePredictorFlag;
+    }
+
+    public MLInPlaceUpdateModelNodesRequest(DiscoveryNode... nodes) {
+        super(nodes);
+        this.updatePredictorFlag = false;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(modelId);
+        out.writeBoolean(updatePredictorFlag);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/model/MLInPlaceUpdateModelNodesResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model/MLInPlaceUpdateModelNodesResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.model;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+public class MLInPlaceUpdateModelNodesResponse extends BaseNodesResponse<MLInPlaceUpdateModelNodeResponse> implements ToXContentObject {
+
+    public MLInPlaceUpdateModelNodesResponse(StreamInput in) throws IOException {
+        super(new ClusterName(in), in.readList(MLInPlaceUpdateModelNodeResponse::readStats), in.readList(FailedNodeException::new));
+    }
+
+    public MLInPlaceUpdateModelNodesResponse(ClusterName clusterName, List<MLInPlaceUpdateModelNodeResponse> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+
+    @Override
+    public void writeNodesTo(StreamOutput out, List<MLInPlaceUpdateModelNodeResponse> nodes) throws IOException {
+        out.writeList(nodes);
+    }
+
+    @Override
+    public List<MLInPlaceUpdateModelNodeResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(MLInPlaceUpdateModelNodeResponse::readStats);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        String nodeId;
+        DiscoveryNode node;
+        builder.startObject();
+        for (MLInPlaceUpdateModelNodeResponse undeployStats : getNodes()) {
+            if (!undeployStats.isEmpty()) {
+                node = undeployStats.getNode();
+                nodeId = node.getId();
+                builder.startObject(nodeId);
+                undeployStats.toXContent(builder, params);
+                builder.endObject();
+            }
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/model/MLUpdateModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model/MLUpdateModelInput.java
@@ -222,6 +222,7 @@ public class MLUpdateModelInput implements ToXContentObject, Writeable {
                     break;
                 case CONNECTOR_FIELD:
                     connector = Connector.createConnector(parser);
+                    break;
                 case CONNECTOR_ID_FIELD:
                     connectorId = parser.text();
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/transport/model/MLUpdateModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model/MLUpdateModelInput.java
@@ -17,12 +17,12 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
+import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.connector.Connector.createConnector;
 
 @Data
 public class MLUpdateModelInput implements ToXContentObject, Writeable {
@@ -32,8 +32,13 @@ public class MLUpdateModelInput implements ToXContentObject, Writeable {
     public static final String MODEL_VERSION_FIELD = "model_version"; // optional
     public static final String MODEL_NAME_FIELD = "name"; // optional
     public static final String MODEL_GROUP_ID_FIELD = "model_group_id"; // optional
+    public static final String QUOTA_FLAG_FIELD = "quota_flag"; // optional
+    public static final String RATE_LIMIT_NUMBER_FIELD = "rate_limit_number"; // optional
+    public static final String RATE_LIMIT_UNIT_FIELD = "rate_limit_unit"; // optional
     public static final String MODEL_CONFIG_FIELD = "model_config"; // optional
+    public static final String CONNECTOR_FIELD = "connector"; // optional
     public static final String CONNECTOR_ID_FIELD = "connector_id"; // optional
+    public static final String CONNECTOR_UPDATE_CONTENT_FIELD = "connector_update_content"; // optional
 
     @Getter
     private String modelId;
@@ -41,31 +46,56 @@ public class MLUpdateModelInput implements ToXContentObject, Writeable {
     private String version;
     private String name;
     private String modelGroupId;
+    private Boolean quotaFlag;
+    private String rateLimitNumber;
+    private TimeUnit rateLimitUnit;
     private MLModelConfig modelConfig;
+    private Connector connector;
     private String connectorId;
+    private MLCreateConnectorInput connectorUpdateContent;
 
     @Builder(toBuilder = true)
-    public MLUpdateModelInput(String modelId, String description, String version, String name, String modelGroupId, MLModelConfig modelConfig, String connectorId) {
+    public MLUpdateModelInput(String modelId, String description, String version, String name, String modelGroupId,
+                              Boolean quotaFlag, String rateLimitNumber, TimeUnit rateLimitUnit, MLModelConfig modelConfig,
+                              Connector connector, String connectorId, MLCreateConnectorInput connectorUpdateContent) {
         this.modelId = modelId;
         this.description = description;
         this.version = version;
         this.name = name;
         this.modelGroupId = modelGroupId;
+        this.quotaFlag = quotaFlag;
+        this.rateLimitNumber = rateLimitNumber;
+        this.rateLimitUnit = rateLimitUnit;
         this.modelConfig = modelConfig;
+        this.connector = connector;
         this.connectorId = connectorId;
+        this.connectorUpdateContent = connectorUpdateContent;
     }
 
     public MLUpdateModelInput(StreamInput in) throws IOException {
-        this.modelId = in.readString();
-        this.description = in.readOptionalString();
-        this.version = in.readOptionalString();
-        this.name = in.readOptionalString();
-        this.modelGroupId = in.readOptionalString();
+        modelId = in.readString();
+        description = in.readOptionalString();
+        version = in.readOptionalString();
+        name = in.readOptionalString();
+        modelGroupId = in.readOptionalString();
+        quotaFlag = in.readOptionalBoolean();
+        rateLimitNumber = in.readOptionalString();
+        if (in.readBoolean()) {
+            rateLimitUnit = in.readEnum(TimeUnit.class);
+        }
         if (in.readBoolean()) {
             modelConfig = new TextEmbeddingModelConfig(in);
         }
-        this.connectorId = in.readOptionalString();
+        if (in.readBoolean()) {
+            connector = Connector.fromStream(in);
+        }
+        connectorId = in.readOptionalString();
+        if (in.readBoolean()) {
+            connectorUpdateContent = new MLCreateConnectorInput(in);
+        }
     }
+
+    public MLUpdateModelInput() {}
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -83,11 +113,26 @@ public class MLUpdateModelInput implements ToXContentObject, Writeable {
         if (modelGroupId != null) {
             builder.field(MODEL_GROUP_ID_FIELD, modelGroupId);
         }
+        if (quotaFlag != null) {
+            builder.field(QUOTA_FLAG_FIELD, quotaFlag);
+        }
+        if (rateLimitNumber != null) {
+            builder.field(RATE_LIMIT_NUMBER_FIELD, rateLimitNumber);
+        }
+        if (rateLimitUnit != null) {
+            builder.field(RATE_LIMIT_UNIT_FIELD, rateLimitUnit);
+        }
         if (modelConfig != null) {
             builder.field(MODEL_CONFIG_FIELD, modelConfig);
         }
+        if (connector != null) {
+            builder.field(CONNECTOR_FIELD, connector);
+        }
         if (connectorId != null) {
             builder.field(CONNECTOR_ID_FIELD, connectorId);
+        }
+        if (connectorUpdateContent != null) {
+            builder.field(CONNECTOR_UPDATE_CONTENT_FIELD, connectorUpdateContent);
         }
         builder.endObject();
         return builder;
@@ -100,13 +145,33 @@ public class MLUpdateModelInput implements ToXContentObject, Writeable {
         out.writeOptionalString(version);
         out.writeOptionalString(name);
         out.writeOptionalString(modelGroupId);
+        out.writeOptionalBoolean(quotaFlag);
+        out.writeOptionalString(rateLimitNumber);
+        if (rateLimitUnit != null) {
+            out.writeBoolean(true);
+            out.writeEnum(rateLimitUnit);
+        } else {
+            out.writeBoolean(false);
+        }
         if (modelConfig != null) {
             out.writeBoolean(true);
             modelConfig.writeTo(out);
         } else {
             out.writeBoolean(false);
         }
+        if (connector != null) {
+            out.writeBoolean(true);
+            connector.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
         out.writeOptionalString(connectorId);
+        if (connectorUpdateContent != null) {
+            out.writeBoolean(true);
+            connectorUpdateContent.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
     }
 
     public static MLUpdateModelInput parse(XContentParser parser) throws IOException {
@@ -115,8 +180,13 @@ public class MLUpdateModelInput implements ToXContentObject, Writeable {
         String version = null;
         String name = null;
         String modelGroupId = null;
+        Boolean quotaFlag = null;
+        String rateLimitNumber = null;
+        TimeUnit rateLimitUnit = null;
         MLModelConfig modelConfig = null;
+        Connector connector = null;
         String connectorId = null;
+        MLCreateConnectorInput connectorUpdateContent = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -138,11 +208,25 @@ public class MLUpdateModelInput implements ToXContentObject, Writeable {
                 case MODEL_GROUP_ID_FIELD:
                     modelGroupId = parser.text();
                     break;
+                case QUOTA_FLAG_FIELD:
+                    quotaFlag = parser.booleanValue();
+                    break;
+                case RATE_LIMIT_NUMBER_FIELD:
+                    rateLimitNumber = parser.text();
+                    break;
+                case RATE_LIMIT_UNIT_FIELD:
+                    rateLimitUnit = TimeUnit.valueOf(parser.text());
+                    break;
                 case MODEL_CONFIG_FIELD:
                     modelConfig = TextEmbeddingModelConfig.parse(parser);
                     break;
+                case CONNECTOR_FIELD:
+                    connector = Connector.createConnector(parser);
                 case CONNECTOR_ID_FIELD:
                     connectorId = parser.text();
+                    break;
+                case CONNECTOR_UPDATE_CONTENT_FIELD:
+                    connectorUpdateContent = MLCreateConnectorInput.parse(parser, true);
                     break;
                 default:
                     parser.skipChildren();
@@ -150,6 +234,6 @@ public class MLUpdateModelInput implements ToXContentObject, Writeable {
             }
         }
         // Model ID can only be set through RestRequest. Model version can only be set automatically.
-        return new MLUpdateModelInput(modelId, description, version, name, modelGroupId, modelConfig, connectorId);
+        return new MLUpdateModelInput(modelId, description, version, name, modelGroupId, quotaFlag, rateLimitNumber, rateLimitUnit, modelConfig, connector, connectorId, connectorUpdateContent);
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/upload_chunk/MLRegisterModelMetaInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/upload_chunk/MLRegisterModelMetaInput.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -34,7 +35,9 @@ public class MLRegisterModelMetaInput implements ToXContentObject, Writeable{
     public static final String FUNCTION_NAME_FIELD = "function_name";
     public static final String MODEL_NAME_FIELD = "name"; //mandatory
     public static final String DESCRIPTION_FIELD = "description"; //optional
-
+    public static final String QUOTA_FLAG_FIELD = "quota_flag";
+    public static final String RATE_LIMIT_NUMBER_FIELD = "rate_limit_number";
+    public static final String RATE_LIMIT_UNIT_FIELD = "rate_limit_unit";
     public static final String VERSION_FIELD = "version";
     public static final String MODEL_FORMAT_FIELD = "model_format"; //mandatory
     public static final String MODEL_STATE_FIELD = "model_state";
@@ -55,7 +58,9 @@ public class MLRegisterModelMetaInput implements ToXContentObject, Writeable{
     private String modelGroupId;
     private String description;
     private String version;
-
+    private Boolean quotaFlag;
+    private String rateLimitNumber;
+    private TimeUnit rateLimitUnit;
     private MLModelFormat modelFormat;
 
     private MLModelState modelState;
@@ -70,7 +75,7 @@ public class MLRegisterModelMetaInput implements ToXContentObject, Writeable{
     private Boolean doesVersionCreateModelGroup;
 
     @Builder(toBuilder = true)
-    public MLRegisterModelMetaInput(String name, FunctionName functionName, String modelGroupId, String version, String description, MLModelFormat modelFormat, MLModelState modelState, Long modelContentSizeInBytes, String modelContentHashValue, MLModelConfig modelConfig, Integer totalChunks, List<String> backendRoles,
+    public MLRegisterModelMetaInput(String name, FunctionName functionName, String modelGroupId, String version, String description, Boolean quotaFlag, String rateLimitNumber, TimeUnit rateLimitUnit, MLModelFormat modelFormat, MLModelState modelState, Long modelContentSizeInBytes, String modelContentHashValue, MLModelConfig modelConfig, Integer totalChunks, List<String> backendRoles,
                                     AccessMode accessMode,
                                     Boolean isAddAllBackendRoles,
                                     Boolean doesVersionCreateModelGroup) {
@@ -98,6 +103,9 @@ public class MLRegisterModelMetaInput implements ToXContentObject, Writeable{
         this.modelGroupId = modelGroupId;
         this.version = version;
         this.description = description;
+        this.quotaFlag = quotaFlag;
+        this.rateLimitNumber = rateLimitNumber;
+        this.rateLimitUnit = rateLimitUnit;
         this.modelFormat = modelFormat;
         this.modelState = modelState;
         this.modelContentSizeInBytes = modelContentSizeInBytes;
@@ -116,6 +124,11 @@ public class MLRegisterModelMetaInput implements ToXContentObject, Writeable{
         this.modelGroupId = in.readOptionalString();
         this.version = in.readOptionalString();
         this.description = in.readOptionalString();
+        this.quotaFlag = in.readOptionalBoolean();
+        this.rateLimitNumber = in.readOptionalString();
+        if (in.readBoolean()) {
+            rateLimitUnit = in.readEnum(TimeUnit.class);
+        }
         if (in.readBoolean()) {
             modelFormat = in.readEnum(MLModelFormat.class);
         }
@@ -143,6 +156,14 @@ public class MLRegisterModelMetaInput implements ToXContentObject, Writeable{
         out.writeOptionalString(modelGroupId);
         out.writeOptionalString(version);
         out.writeOptionalString(description);
+        out.writeOptionalBoolean(quotaFlag);
+        out.writeOptionalString(rateLimitNumber);
+        if (rateLimitUnit != null) {
+            out.writeBoolean(true);
+            out.writeEnum(rateLimitUnit);
+        } else {
+            out.writeBoolean(false);
+        }
         if (modelFormat != null) {
             out.writeBoolean(true);
             out.writeEnum(modelFormat);
@@ -194,6 +215,15 @@ public class MLRegisterModelMetaInput implements ToXContentObject, Writeable{
         if (description != null) {
             builder.field(DESCRIPTION_FIELD, description);
         }
+        if (quotaFlag != null) {
+            builder.field(QUOTA_FLAG_FIELD, quotaFlag);
+        }
+        if (rateLimitNumber != null) {
+            builder.field(RATE_LIMIT_NUMBER_FIELD, rateLimitNumber);
+        }
+        if (rateLimitUnit != null) {
+            builder.field(RATE_LIMIT_UNIT_FIELD, rateLimitUnit);
+        }
         builder.field(MODEL_FORMAT_FIELD, modelFormat);
         if (modelState != null) {
             builder.field(MODEL_STATE_FIELD, modelState);
@@ -226,6 +256,9 @@ public class MLRegisterModelMetaInput implements ToXContentObject, Writeable{
         String modelGroupId = null;
         String version = null;
         String description = null;
+        Boolean quotaFlag = null;
+        String rateLimitNumber = null;
+        TimeUnit rateLimitUnit = null;
         MLModelFormat modelFormat = null;
         MLModelState modelState = null;
         Long modelContentSizeInBytes = null;
@@ -256,6 +289,15 @@ public class MLRegisterModelMetaInput implements ToXContentObject, Writeable{
                     break;
                 case DESCRIPTION_FIELD:
                     description = parser.text();
+                    break;
+                case QUOTA_FLAG_FIELD:
+                    quotaFlag = parser.booleanValue();
+                    break;
+                case RATE_LIMIT_NUMBER_FIELD:
+                    rateLimitNumber = parser.text();
+                    break;
+                case RATE_LIMIT_UNIT_FIELD:
+                    rateLimitUnit = TimeUnit.valueOf(parser.text());
                     break;
                 case MODEL_FORMAT_FIELD:
                     modelFormat = MLModelFormat.from(parser.text());
@@ -296,7 +338,7 @@ public class MLRegisterModelMetaInput implements ToXContentObject, Writeable{
                     break;
             }
         }
-        return new MLRegisterModelMetaInput(name, functionName, modelGroupId, version, description, modelFormat, modelState, modelContentSizeInBytes, modelContentHashValue, modelConfig, totalChunks,  backendRoles, accessMode, isAddAllBackendRoles, doesVersionCreateModelGroup);
+        return new MLRegisterModelMetaInput(name, functionName, modelGroupId, version, description, quotaFlag, rateLimitNumber, rateLimitUnit, modelFormat, modelState, modelContentSizeInBytes, modelContentHashValue, modelConfig, totalChunks,  backendRoles, accessMode, isAddAllBackendRoles, doesVersionCreateModelGroup);
     }
 
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/upload_chunk/MLRegisterModelMetaInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/upload_chunk/MLRegisterModelMetaInputTest.java
@@ -43,7 +43,7 @@ public class MLRegisterModelMetaInputTest {
 		config = new TextEmbeddingModelConfig("Model Type", 123, FrameworkType.SENTENCE_TRANSFORMERS, "All Config",
 				TextEmbeddingModelConfig.PoolingMode.MEAN, true, 512);
 		mLRegisterModelMetaInput = new MLRegisterModelMetaInput("Model Name", FunctionName.BATCH_RCF, "model_group_id", "1.0",
-				"Model Description", MLModelFormat.TORCH_SCRIPT, MLModelState.DEPLOYING, 200L, "123", config, 2, null, null, null, null);
+				"Model Description", null, null, null, MLModelFormat.TORCH_SCRIPT, MLModelState.DEPLOYING, 200L, "123", config, 2, null, null, null, null);
 	}
 
 	@Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/upload_chunk/MLRegisterModelMetaRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/upload_chunk/MLRegisterModelMetaRequestTest.java
@@ -33,7 +33,7 @@ public class MLRegisterModelMetaRequestTest {
 		config = new TextEmbeddingModelConfig("Model Type", 123, FrameworkType.SENTENCE_TRANSFORMERS, "All Config",
 				TextEmbeddingModelConfig.PoolingMode.MEAN, true, 512);
 		mlRegisterModelMetaInput = new MLRegisterModelMetaInput("Model Name", FunctionName.BATCH_RCF, "Model Group Id", "1.0",
-				"Model Description", MLModelFormat.TORCH_SCRIPT, MLModelState.DEPLOYING, 200L, "123", config, 2, null, null, null, null);
+				"Model Description", null, null, null, MLModelFormat.TORCH_SCRIPT, MLModelState.DEPLOYING, 200L, "123", config, 2, null, null, null, null);
 	}
 
 	@Test

--- a/plugin/src/main/java/org/opensearch/ml/action/models/InPlaceUpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/InPlaceUpdateModelTransportAction.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.models;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.TransportNodesAction;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.cluster.DiscoveryNodeHelper;
+import org.opensearch.ml.common.transport.model.MLInPlaceUpdateModelAction;
+import org.opensearch.ml.common.transport.model.MLInPlaceUpdateModelNodeRequest;
+import org.opensearch.ml.common.transport.model.MLInPlaceUpdateModelNodeResponse;
+import org.opensearch.ml.common.transport.model.MLInPlaceUpdateModelNodesRequest;
+import org.opensearch.ml.common.transport.model.MLInPlaceUpdateModelNodesResponse;
+import org.opensearch.ml.helper.ModelAccessControlHelper;
+import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.stats.MLStats;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class InPlaceUpdateModelTransportAction extends
+    TransportNodesAction<MLInPlaceUpdateModelNodesRequest, MLInPlaceUpdateModelNodesResponse, MLInPlaceUpdateModelNodeRequest, MLInPlaceUpdateModelNodeResponse> {
+    private final MLModelManager mlModelManager;
+    private final ClusterService clusterService;
+    private final Client client;
+    private DiscoveryNodeHelper nodeFilter;
+    private final MLStats mlStats;
+    private NamedXContentRegistry xContentRegistry;
+
+    private ModelAccessControlHelper modelAccessControlHelper;
+
+    @Inject
+    public InPlaceUpdateModelTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        MLModelManager mlModelManager,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        Client client,
+        DiscoveryNodeHelper nodeFilter,
+        MLStats mlStats,
+        NamedXContentRegistry xContentRegistry,
+        ModelAccessControlHelper modelAccessControlHelper
+    ) {
+        super(
+            MLInPlaceUpdateModelAction.NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            MLInPlaceUpdateModelNodesRequest::new,
+            MLInPlaceUpdateModelNodeRequest::new,
+            ThreadPool.Names.MANAGEMENT,
+            MLInPlaceUpdateModelNodeResponse.class
+        );
+        this.mlModelManager = mlModelManager;
+        this.clusterService = clusterService;
+        this.client = client;
+        this.nodeFilter = nodeFilter;
+        this.mlStats = mlStats;
+        this.xContentRegistry = xContentRegistry;
+        this.modelAccessControlHelper = modelAccessControlHelper;
+    }
+
+    @Override
+    protected MLInPlaceUpdateModelNodesResponse newResponse(
+        MLInPlaceUpdateModelNodesRequest nodesRequest,
+        List<MLInPlaceUpdateModelNodeResponse> responses,
+        List<FailedNodeException> failures
+    ) {
+        return new MLInPlaceUpdateModelNodesResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected MLInPlaceUpdateModelNodeRequest newNodeRequest(MLInPlaceUpdateModelNodesRequest request) {
+        return new MLInPlaceUpdateModelNodeRequest(request);
+    }
+
+    @Override
+    protected MLInPlaceUpdateModelNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new MLInPlaceUpdateModelNodeResponse(in);
+    }
+
+    @Override
+    protected MLInPlaceUpdateModelNodeResponse nodeOperation(MLInPlaceUpdateModelNodeRequest request) {
+        return createInPlaceUpdateModelNodeResponse(request.getMlInPlaceUpdateModelNodesRequest());
+    }
+
+    private MLInPlaceUpdateModelNodeResponse createInPlaceUpdateModelNodeResponse(
+        MLInPlaceUpdateModelNodesRequest mlInPlaceUpdateModelNodesRequest
+    ) {
+        String modelId = mlInPlaceUpdateModelNodesRequest.getModelId();
+        boolean updatePredictorFlag = mlInPlaceUpdateModelNodesRequest.isUpdatePredictorFlag();
+
+        Map<String, String> modelUpdateStatus = new HashMap<>();
+        modelUpdateStatus.put(modelId, "received");
+
+        String localNodeId = clusterService.localNode().getId();
+
+        mlModelManager.inplaceUpdateModel(modelId, updatePredictorFlag, ActionListener.wrap(r -> {
+            log.info("Successfully performing in-place update model {} on node {}", modelId, localNodeId);
+        }, e -> { log.error("Failed to perform in-place update model for model {} on node {}", modelId, localNodeId); }));
+        return new MLInPlaceUpdateModelNodeResponse(clusterService.localNode(), modelUpdateStatus);
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
@@ -9,9 +9,13 @@ import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.common.FunctionName.REMOTE;
 import static org.opensearch.ml.common.FunctionName.TEXT_EMBEDDING;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -25,7 +29,10 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.commons.authuser.User;
@@ -36,11 +43,15 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.MLModelGroup;
+import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.exception.MLValidationException;
 import org.opensearch.ml.common.model.MLModelState;
+import org.opensearch.ml.common.transport.model.MLInPlaceUpdateModelAction;
+import org.opensearch.ml.common.transport.model.MLInPlaceUpdateModelNodesRequest;
 import org.opensearch.ml.common.transport.model.MLUpdateModelAction;
 import org.opensearch.ml.common.transport.model.MLUpdateModelInput;
 import org.opensearch.ml.common.transport.model.MLUpdateModelRequest;
+import org.opensearch.ml.engine.MLEngine;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelGroupManager;
@@ -54,13 +65,16 @@ import lombok.experimental.FieldDefaults;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
-@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class UpdateModelTransportAction extends HandledTransportAction<ActionRequest, UpdateResponse> {
     Client client;
+    ClusterService clusterService;
     ModelAccessControlHelper modelAccessControlHelper;
     ConnectorAccessControlHelper connectorAccessControlHelper;
     MLModelManager mlModelManager;
     MLModelGroupManager mlModelGroupManager;
+    MLEngine mlEngine;
+    volatile List<String> trustedConnectorEndpointsRegex;
 
     @Inject
     public UpdateModelTransportAction(
@@ -70,7 +84,10 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         ConnectorAccessControlHelper connectorAccessControlHelper,
         ModelAccessControlHelper modelAccessControlHelper,
         MLModelManager mlModelManager,
-        MLModelGroupManager mlModelGroupManager
+        MLModelGroupManager mlModelGroupManager,
+        Settings settings,
+        ClusterService clusterService,
+        MLEngine mlEngine
     ) {
         super(MLUpdateModelAction.NAME, transportService, actionFilters, MLUpdateModelRequest::new);
         this.client = client;
@@ -78,6 +95,12 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         this.connectorAccessControlHelper = connectorAccessControlHelper;
         this.mlModelManager = mlModelManager;
         this.mlModelGroupManager = mlModelGroupManager;
+        this.clusterService = clusterService;
+        this.mlEngine = mlEngine;
+        trustedConnectorEndpointsRegex = ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX.get(settings);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX, it -> trustedConnectorEndpointsRegex = it);
     }
 
     @Override
@@ -91,25 +114,21 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
 
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             mlModelManager.getModel(modelId, null, excludes, ActionListener.wrap(mlModel -> {
+                boolean modelDeployFlag = isModelDeployed(mlModel.getModelState());
                 FunctionName functionName = mlModel.getAlgorithm();
-                MLModelState mlModelState = mlModel.getModelState();
                 if (functionName == TEXT_EMBEDDING || functionName == REMOTE) {
                     modelAccessControlHelper
                         .validateModelGroupAccess(user, mlModel.getModelGroupId(), client, ActionListener.wrap(hasPermission -> {
                             if (hasPermission) {
-                                if (isModelDeployed(mlModelState)) {
-                                    updateRemoteOrTextEmbeddingModel(modelId, updateModelInput, mlModel, user, actionListener, context);
-                                } else {
-                                    actionListener
-                                        .onFailure(
-                                            new OpenSearchStatusException(
-                                                "ML Model "
-                                                    + modelId
-                                                    + " is in deploying or deployed state, please undeploy the models first!",
-                                                RestStatus.FORBIDDEN
-                                            )
-                                        );
-                                }
+                                updateRemoteOrTextEmbeddingModel(
+                                    modelId,
+                                    updateModelInput,
+                                    mlModel,
+                                    user,
+                                    actionListener,
+                                    context,
+                                    modelDeployFlag
+                                );
                             } else {
                                 actionListener
                                     .onFailure(
@@ -153,28 +172,48 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         MLModel mlModel,
         User user,
         ActionListener<UpdateResponse> actionListener,
-        ThreadContext.StoredContext context
+        ThreadContext.StoredContext context,
+        boolean modelDeployFlag
     ) {
         String newModelGroupId = (Strings.hasLength(updateModelInput.getModelGroupId())
             && !Objects.equals(updateModelInput.getModelGroupId(), mlModel.getModelGroupId())) ? updateModelInput.getModelGroupId() : null;
         String relinkConnectorId = Strings.hasLength(updateModelInput.getConnectorId()) ? updateModelInput.getConnectorId() : null;
 
         if (mlModel.getAlgorithm() == TEXT_EMBEDDING) {
-            if (relinkConnectorId == null) {
-                updateModelWithRegisteringToAnotherModelGroup(modelId, newModelGroupId, user, updateModelInput, actionListener, context);
+            if (relinkConnectorId == null && updateModelInput.getConnectorUpdateContent() == null) {
+                updateModelWithRegisteringToAnotherModelGroup(
+                    modelId,
+                    newModelGroupId,
+                    user,
+                    updateModelInput,
+                    actionListener,
+                    context,
+                    modelDeployFlag
+                );
             } else {
                 actionListener
                     .onFailure(
-                        new OpenSearchStatusException(
-                            "Trying to update the connector or connector_id field on a local model",
-                            RestStatus.BAD_REQUEST
-                        )
+                        new OpenSearchStatusException("Trying to update the connector_id field on a local model.", RestStatus.BAD_REQUEST)
                     );
             }
         } else {
             // mlModel.getAlgorithm() == REMOTE
             if (relinkConnectorId == null) {
-                updateModelWithRegisteringToAnotherModelGroup(modelId, newModelGroupId, user, updateModelInput, actionListener, context);
+                if (updateModelInput.getConnectorUpdateContent() != null) {
+                    Connector connector = mlModel.getConnector();
+                    connector.update(updateModelInput.getConnectorUpdateContent(), mlEngine::encrypt);
+                    connector.validateConnectorURL(trustedConnectorEndpointsRegex);
+                    updateModelInput.setConnector(connector);
+                }
+                updateModelWithRegisteringToAnotherModelGroup(
+                    modelId,
+                    newModelGroupId,
+                    user,
+                    updateModelInput,
+                    actionListener,
+                    context,
+                    modelDeployFlag
+                );
             } else {
                 updateModelWithRelinkStandAloneConnector(
                     modelId,
@@ -184,7 +223,8 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                     user,
                     updateModelInput,
                     actionListener,
-                    context
+                    context,
+                    modelDeployFlag
                 );
             }
         }
@@ -198,7 +238,8 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         User user,
         MLUpdateModelInput updateModelInput,
         ActionListener<UpdateResponse> actionListener,
-        ThreadContext.StoredContext context
+        ThreadContext.StoredContext context,
+        boolean modelDeployFlag
     ) {
         if (Strings.hasLength(mlModel.getConnectorId())) {
             connectorAccessControlHelper
@@ -210,7 +251,8 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                             user,
                             updateModelInput,
                             actionListener,
-                            context
+                            context,
+                            modelDeployFlag
                         );
                     } else {
                         actionListener
@@ -242,9 +284,18 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         User user,
         MLUpdateModelInput updateModelInput,
         ActionListener<UpdateResponse> actionListener,
-        ThreadContext.StoredContext context
+        ThreadContext.StoredContext context,
+        boolean modelDeployFlag
     ) {
         UpdateRequest updateRequest = new UpdateRequest(ML_MODEL_INDEX, modelId);
+        // This flag is used to decide if we need to re-deploy the predictor(model) when performing the in-place update
+        boolean updatePredictorFlag = (updateModelInput.getConnector() != null || updateModelInput.getConnectorId() != null);
+        boolean inPlaceUpdateFieldFlag = (updateModelInput.getQuotaFlag() != null
+            || updateModelInput.getRateLimitNumber() != null
+            || updateModelInput.getRateLimitUnit() != null
+            || updatePredictorFlag);
+        // This flag is used to decide if we need to perform an in-place update
+        boolean inPlaceUpdateFlag = modelDeployFlag && inPlaceUpdateFieldFlag;
         if (newModelGroupId != null) {
             modelAccessControlHelper.validateModelGroupAccess(user, newModelGroupId, client, ActionListener.wrap(hasRelinkPermission -> {
                 if (hasRelinkPermission) {
@@ -256,7 +307,9 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                             updateModelInput,
                             newModelGroupResponse,
                             actionListener,
-                            context
+                            context,
+                            inPlaceUpdateFlag,
+                            updatePredictorFlag
                         );
                     },
                         exception -> actionListener
@@ -283,7 +336,15 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                 actionListener.onFailure(exception);
             }));
         } else {
-            updateRequestConstructor(modelId, updateRequest, updateModelInput, actionListener, context);
+            updateRequestConstructor(
+                modelId,
+                updateRequest,
+                updateModelInput,
+                actionListener,
+                context,
+                inPlaceUpdateFlag,
+                updatePredictorFlag
+            );
         }
     }
 
@@ -292,12 +353,24 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         UpdateRequest updateRequest,
         MLUpdateModelInput updateModelInput,
         ActionListener<UpdateResponse> actionListener,
-        ThreadContext.StoredContext context
+        ThreadContext.StoredContext context,
+        boolean inPlaceUpdateFlag,
+        boolean updatePredictorFlag
     ) {
         try {
             updateRequest.doc(updateModelInput.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
             updateRequest.docAsUpsert(true);
-            client.update(updateRequest, getUpdateResponseListener(modelId, actionListener, context));
+            if (inPlaceUpdateFlag) {
+                String[] targetNodeIds = getAllNodes();
+                MLInPlaceUpdateModelNodesRequest mlInPlaceUpdateModelNodesRequest = new MLInPlaceUpdateModelNodesRequest(
+                    targetNodeIds,
+                    modelId,
+                    updatePredictorFlag
+                );
+                client.update(updateRequest, getUpdateResponseListener(modelId, actionListener, context, mlInPlaceUpdateModelNodesRequest));
+            } else {
+                client.update(updateRequest, getUpdateResponseListener(modelId, actionListener, context));
+            }
         } catch (IOException e) {
             log.error("Failed to build update request.");
             actionListener.onFailure(e);
@@ -311,7 +384,9 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         MLUpdateModelInput updateModelInput,
         GetResponse newModelGroupResponse,
         ActionListener<UpdateResponse> actionListener,
-        ThreadContext.StoredContext context
+        ThreadContext.StoredContext context,
+        boolean inPlaceUpdateFlag,
+        boolean updatePredictorFlag
     ) {
         Map<String, Object> newModelGroupSourceMap = newModelGroupResponse.getSourceAsMap();
         String updatedVersion = incrementLatestVersion(newModelGroupSourceMap);
@@ -326,21 +401,70 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         try {
             updateRequest.doc(updateModelInput.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
             updateRequest.docAsUpsert(true);
-            client.update(updateModelGroupRequest, ActionListener.wrap(r -> {
-                client.update(updateRequest, getUpdateResponseListener(modelId, actionListener, context));
-            }, e -> {
-                log
-                    .error(
-                        "Failed to register ML model with model ID {} to the new model group with model group ID {}",
-                        modelId,
-                        newModelGroupId
-                    );
-                actionListener.onFailure(e);
-            }));
+            if (inPlaceUpdateFlag) {
+                String[] targetNodeIds = getAllNodes();
+                MLInPlaceUpdateModelNodesRequest mlInPlaceUpdateModelNodesRequest = new MLInPlaceUpdateModelNodesRequest(
+                    targetNodeIds,
+                    modelId,
+                    updatePredictorFlag
+                );
+                client.update(updateModelGroupRequest, ActionListener.wrap(r -> {
+                    client
+                        .update(
+                            updateRequest,
+                            getUpdateResponseListener(modelId, actionListener, context, mlInPlaceUpdateModelNodesRequest)
+                        );
+                }, e -> {
+                    log
+                        .error(
+                            "Failed to register ML model with model ID {} to the new model group with model group ID {}",
+                            modelId,
+                            newModelGroupId
+                        );
+                    actionListener.onFailure(e);
+                }));
+            } else {
+                client.update(updateModelGroupRequest, ActionListener.wrap(r -> {
+                    client.update(updateRequest, getUpdateResponseListener(modelId, actionListener, context));
+                }, e -> {
+                    log
+                        .error(
+                            "Failed to register ML model with model ID {} to the new model group with model group ID {}",
+                            modelId,
+                            newModelGroupId
+                        );
+                    actionListener.onFailure(e);
+                }));
+            }
         } catch (IOException e) {
             log.error("Failed to build update request.");
             actionListener.onFailure(e);
         }
+    }
+
+    private ActionListener<UpdateResponse> getUpdateResponseListener(
+        String modelId,
+        ActionListener<UpdateResponse> actionListener,
+        ThreadContext.StoredContext context,
+        MLInPlaceUpdateModelNodesRequest mlInPlaceUpdateModelNodesRequest
+    ) {
+        return ActionListener.runBefore(ActionListener.wrap(updateResponse -> {
+            if (updateResponse != null && updateResponse.getResult() != DocWriteResponse.Result.UPDATED) {
+                log.info("Model id:{} failed update", modelId);
+                actionListener.onResponse(updateResponse);
+                return;
+            }
+            client.execute(MLInPlaceUpdateModelAction.INSTANCE, mlInPlaceUpdateModelNodesRequest, ActionListener.wrap(r -> {
+                log.info("Successfully perform in-place update ML model with model ID {}", modelId);
+                actionListener.onResponse(updateResponse);
+            }, e -> {
+                log.error("Failed to perform in-place update for model: {}" + modelId, e);
+                actionListener.onFailure(e);
+            }));
+        }, exception -> {
+            log.error("Failed to update ML model: " + modelId, exception);
+            actionListener.onFailure(exception);
+        }), context::restore);
     }
 
     private ActionListener<UpdateResponse> getUpdateResponseListener(
@@ -389,11 +513,18 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
     }
 
     private Boolean isModelDeployed(MLModelState mlModelState) {
-        return !mlModelState.equals(MLModelState.LOADED)
-            && !mlModelState.equals(MLModelState.LOADING)
-            && !mlModelState.equals(MLModelState.PARTIALLY_LOADED)
-            && !mlModelState.equals(MLModelState.DEPLOYED)
-            && !mlModelState.equals(MLModelState.DEPLOYING)
-            && !mlModelState.equals(MLModelState.PARTIALLY_DEPLOYED);
+        return mlModelState.equals(MLModelState.LOADED)
+            || mlModelState.equals(MLModelState.PARTIALLY_LOADED)
+            || mlModelState.equals(MLModelState.DEPLOYED)
+            || mlModelState.equals(MLModelState.PARTIALLY_DEPLOYED);
+    }
+
+    private String[] getAllNodes() {
+        Iterator<DiscoveryNode> iterator = clusterService.state().nodes().iterator();
+        List<String> nodeIds = new ArrayList<>();
+        while (iterator.hasNext()) {
+            nodeIds.add(iterator.next().getId());
+        }
+        return nodeIds.toArray(new String[0]);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
@@ -204,6 +204,7 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                     connector.update(updateModelInput.getConnectorUpdateContent(), mlEngine::encrypt);
                     connector.validateConnectorURL(trustedConnectorEndpointsRegex);
                     updateModelInput.setConnector(connector);
+                    updateModelInput.setConnectorUpdateContent(null);
                 }
                 updateModelWithRegisteringToAnotherModelGroup(
                     modelId,

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.DoubleStream;
 
+import org.opensearch.common.util.TokenBucket;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.model.MLModelState;
@@ -33,6 +34,8 @@ public class MLModelCache {
     private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) FunctionName functionName;
     private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) Predictable predictor;
     private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) MLExecutable executor;
+    private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) TokenBucket rateLimiter;
+    private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) Boolean quotaFlag;
     private final Set<String> targetWorkerNodes;
     private final Set<String> workerNodes;
     private MLModel modelInfo;

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.TokenBucket;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.exception.MLLimitExceededException;
@@ -73,6 +74,50 @@ public class MLModelCacheHelper {
     public synchronized void setModelState(String modelId, MLModelState state) {
         log.debug("Updating State of Model {}  to state {}", modelId, state);
         getExistingModelCache(modelId).setModelState(state);
+    }
+
+    /**
+     * Set a rate limiter to enable throttling
+     * @param modelId model id
+     * @param rateLimiter rate limiter
+     */
+    public synchronized void setRateLimiter(String modelId, TokenBucket rateLimiter) {
+        log.debug("Setting the rate limiter for Model {}", modelId);
+        getExistingModelCache(modelId).setRateLimiter(rateLimiter);
+    }
+
+    /**
+     * Get the current rate limiter for the model
+     * @param modelId model id
+     */
+    public TokenBucket getRateLimiter(String modelId) {
+        MLModelCache modelCache = modelCaches.get(modelId);
+        if (modelCache == null) {
+            return null;
+        }
+        return modelCache.getRateLimiter();
+    }
+
+    /**
+     * Set a quota flag to control if the model can still receive request
+     * @param modelId model id
+     * @param quotaFlag rate limiter
+     */
+    public synchronized void setQuotaFlag(String modelId, Boolean quotaFlag) {
+        log.debug("Setting the quota flag for Model {}", modelId);
+        getExistingModelCache(modelId).setQuotaFlag(quotaFlag);
+    }
+
+    /**
+     * Get the current quota flag condition for the model
+     * @param modelId model id
+     */
+    public Boolean getQuotaFlag(String modelId) {
+        MLModelCache modelCache = modelCaches.get(modelId);
+        if (modelCache == null) {
+            return null;
+        }
+        return modelCache.getQuotaFlag();
     }
 
     /**

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -1112,12 +1112,13 @@ public class MLModelManager {
             TimeUnit rateLimitUnit = mlModel.getRateLimitUnit();
             log
                 .debug(
-                    "Initializing the rate limiter for Model {}, with TPS limit {}, evenly distributed on {} nodes",
+                    "Initializing the rate limiter for Model {}, with TPS limit {} and burst capacity {}, evenly distributed on {} nodes",
                     mlModel.getModelId(),
                     rateLimitNumber / rateLimitUnit.toSeconds(1),
+                    rateLimitNumber,
                     eligibleNodeCount
                 );
-            return new TokenBucket(System::nanoTime, rateLimitNumber / rateLimitUnit.toNanos(1) / eligibleNodeCount, 2);
+            return new TokenBucket(System::nanoTime, rateLimitNumber / rateLimitUnit.toNanos(1) / eligibleNodeCount, rateLimitNumber);
         }
         return null;
     }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -8,7 +8,6 @@ package org.opensearch.ml.model;
 import static org.opensearch.common.xcontent.XContentType.JSON;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.common.CommonValue.NOT_FOUND;
@@ -90,6 +89,7 @@ import org.opensearch.index.reindex.DeleteByQueryAction;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.ml.breaker.MLCircuitBreakerService;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.MLModelGroup;
@@ -120,6 +120,7 @@ import org.opensearch.ml.stats.MLNodeLevelStat;
 import org.opensearch.ml.stats.MLStats;
 import org.opensearch.ml.task.MLTaskManager;
 import org.opensearch.ml.utils.MLExceptionUtils;
+import org.opensearch.ml.utils.MLNodeUtils;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.threadpool.ThreadPool;
@@ -657,7 +658,6 @@ public class MLModelManager {
                     log.error("Failed to index model meta doc", e);
                     handleException(functionName, taskId, e);
                 });
-
                 client.index(indexModelMetaRequest, threadedActionListener(REGISTER_THREAD_POOL, listener));
             }, e -> {
                 log.error("Failed to init model index", e);
@@ -900,6 +900,55 @@ public class MLModelManager {
         mlTaskManager.updateMLTask(taskId, updated, TIMEOUT_IN_MILLIS, true);
     }
 
+    public synchronized Map<String, String> inplaceUpdateModel(
+        String modelId,
+        boolean updatePredictorFlag,
+        ActionListener<String> listener
+    ) {
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<String> wrappedListener = ActionListener.runBefore(listener, context::restore);
+            getModel(modelId, ActionListener.wrap(mlModel -> {
+                int NodeCount = getWorkerNodes(modelId, mlModel.getAlgorithm()).length;
+                modelCacheHelper.setRateLimiter(modelId, rateLimiterConstructor(NodeCount, mlModel));
+                modelCacheHelper.setQuotaFlag(modelId, mlModel.getQuotaFlag());
+                if (updatePredictorFlag) {
+                    assert FunctionName.REMOTE == mlModel.getAlgorithm()
+                        : "In-place update is only supported on REMOTE models at this time.";
+                    Map<String, Object> params = ImmutableMap
+                        .of(
+                            ML_ENGINE,
+                            mlEngine,
+                            SCRIPT_SERVICE,
+                            scriptService,
+                            CLIENT,
+                            client,
+                            XCONTENT_REGISTRY,
+                            xContentRegistry,
+                            CLUSTER_SERVICE,
+                            clusterService
+                        );
+                    if (mlModel.getConnector() != null) {
+                        Predictable predictable = mlEngine.deploy(mlModel, params);
+                        modelCacheHelper.setPredictor(modelId, predictable);
+                        wrappedListener.onResponse("successfully performed in-place update for the model " + modelId);
+                        log.info("Completed in-place update internal connector for the model {}", modelId);
+                    } else {
+                        getConnector(client, mlModel.getConnectorId(), ActionListener.wrap(connector -> {
+                            mlModel.setConnector(connector);
+                            Predictable predictable = mlEngine.deploy(mlModel, params);
+                            modelCacheHelper.setPredictor(modelId, predictable);
+                            wrappedListener.onResponse("successfully performed in-place update for the model " + modelId);
+                            log.info("Completed in-place update stand-alone connector for the model {}", modelId);
+                        }, wrappedListener::onFailure));
+                    }
+                    wrappedListener.onResponse("successfully performed in-place update for the model " + modelId);
+                    log.info("Completed in-place update quota/throttling setting for the model {}", modelId);
+                }
+            }, wrappedListener::onFailure));
+        }
+        return null;
+    }
+
     /**
      * Read model chunks from model index. Concat chunks into a whole model file, then load
      * into memory.
@@ -965,28 +1014,12 @@ public class MLModelManager {
                         return;
                     }
                     log.info("Set connector {} for the model: {}", mlModel.getConnectorId(), modelId);
-                    GetRequest getConnectorRequest = new GetRequest();
-                    FetchSourceContext fetchContext = new FetchSourceContext(true, null, null);
-                    getConnectorRequest.index(ML_CONNECTOR_INDEX).id(mlModel.getConnectorId()).fetchSourceContext(fetchContext);
-                    // get connector and deploy remote model with standalone connector
-                    client.get(getConnectorRequest, ActionListener.wrap(getResponse -> {
-                        if (getResponse != null && getResponse.isExists()) {
-                            try (
-                                XContentParser parser = createXContentParserFromRegistry(
-                                    xContentRegistry,
-                                    getResponse.getSourceAsBytesRef()
-                                )
-                            ) {
-                                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-                                Connector connector = Connector.createConnector(parser);
-                                mlModel.setConnector(connector);
-                                setupPredictable(modelId, mlModel, params, eligibleNodeCount);
-                                wrappedListener.onResponse("successful");
-                                log.info("Completed setting connector {} in the model {}", mlModel.getConnectorId(), modelId);
-                            }
-                        }
-                    }, e -> { wrappedListener.onFailure(e); }));
-
+                    getConnector(client, mlModel.getConnectorId(), ActionListener.wrap(connector -> {
+                        mlModel.setConnector(connector);
+                        setupPredictable(modelId, mlModel, params, eligibleNodeCount);
+                        wrappedListener.onResponse("successful");
+                        log.info("Completed setting connector {} in the model {}", mlModel.getConnectorId(), modelId);
+                    }, wrappedListener::onFailure));
                     return;
                 }
                 // check circuit breaker before deploying custom model chunks
@@ -1129,6 +1162,30 @@ public class MLModelManager {
                 listener.onFailure(new OpenSearchStatusException("Failed to find model", RestStatus.NOT_FOUND));
             }
         }, e -> { listener.onFailure(e); }));
+    }
+
+    private void getConnector(Client client, String connectorId, ActionListener<Connector> listener) {
+        GetRequest getRequest = new GetRequest().index(CommonValue.ML_CONNECTOR_INDEX).id(connectorId);
+        client.get(getRequest, ActionListener.wrap(r -> {
+            if (r != null && r.isExists()) {
+                try (
+                    XContentParser parser = MLNodeUtils
+                        .createXContentParserFromRegistry(NamedXContentRegistry.EMPTY, r.getSourceAsBytesRef())
+                ) {
+                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                    Connector connector = Connector.createConnector(parser);
+                    listener.onResponse(connector);
+                } catch (Exception e) {
+                    log.error("Failed to parse connector:" + connectorId);
+                    listener.onFailure(e);
+                }
+            } else {
+                listener.onFailure(new OpenSearchStatusException("Failed to find connector:" + connectorId, RestStatus.NOT_FOUND));
+            }
+        }, e -> {
+            log.error("Failed to get connector", e);
+            listener.onFailure(new OpenSearchStatusException("Failed to get connector:" + connectorId, RestStatus.NOT_FOUND));
+        }));
     }
 
     private void retrieveModelChunks(MLModel mlModelMeta, ActionListener<File> listener) throws InterruptedException {
@@ -1339,6 +1396,10 @@ public class MLModelManager {
         return eligibleNodeIds;
     }
 
+    public int getWorkerNodesSize(String modelId, FunctionName functionName, boolean onlyEligibleNode) {
+        return getWorkerNodes(modelId, functionName, onlyEligibleNode).length;
+    }
+
     /**
      * Get worker node of specific model without filtering eligible node.
      *
@@ -1348,6 +1409,10 @@ public class MLModelManager {
      */
     public String[] getWorkerNodes(String modelId, FunctionName functionName) {
         return getWorkerNodes(modelId, functionName, false);
+    }
+
+    public int getWorkerNodesSize(String modelId, FunctionName functionName) {
+        return getWorkerNodes(modelId, functionName, false).length;
     }
 
     /**

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -942,7 +942,7 @@ public class MLModelManager {
                         }, wrappedListener::onFailure));
                     }
                     wrappedListener.onResponse("successfully performed in-place update for the model " + modelId);
-                    log.info("Completed in-place update quota/throttling setting for the model {}", modelId);
+                    log.info("Completed in-place update for the model {}", modelId);
                 }
             }, wrappedListener::onFailure));
         }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -52,6 +52,7 @@ import org.opensearch.ml.action.model_group.TransportRegisterModelGroupAction;
 import org.opensearch.ml.action.model_group.TransportUpdateModelGroupAction;
 import org.opensearch.ml.action.models.DeleteModelTransportAction;
 import org.opensearch.ml.action.models.GetModelTransportAction;
+import org.opensearch.ml.action.models.InPlaceUpdateModelTransportAction;
 import org.opensearch.ml.action.models.SearchModelTransportAction;
 import org.opensearch.ml.action.models.UpdateModelTransportAction;
 import org.opensearch.ml.action.prediction.TransportPredictionTaskAction;
@@ -98,6 +99,7 @@ import org.opensearch.ml.common.transport.deploy.MLDeployModelAction;
 import org.opensearch.ml.common.transport.deploy.MLDeployModelOnNodeAction;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskAction;
 import org.opensearch.ml.common.transport.forward.MLForwardAction;
+import org.opensearch.ml.common.transport.model.MLInPlaceUpdateModelAction;
 import org.opensearch.ml.common.transport.model.MLModelDeleteAction;
 import org.opensearch.ml.common.transport.model.MLModelGetAction;
 import org.opensearch.ml.common.transport.model.MLModelSearchAction;
@@ -286,6 +288,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
                 new ActionHandler<>(MLRegisterModelMetaAction.INSTANCE, TransportRegisterModelMetaAction.class),
                 new ActionHandler<>(MLUploadModelChunkAction.INSTANCE, TransportUploadModelChunkAction.class),
                 new ActionHandler<>(MLUpdateModelAction.INSTANCE, UpdateModelTransportAction.class),
+                new ActionHandler<>(MLInPlaceUpdateModelAction.INSTANCE, InPlaceUpdateModelTransportAction.class),
                 new ActionHandler<>(MLForwardAction.INSTANCE, TransportForwardAction.class),
                 new ActionHandler<>(MLSyncUpAction.INSTANCE, TransportSyncUpOnNodeAction.class),
                 new ActionHandler<>(MLRegisterModelGroupAction.INSTANCE, TransportRegisterModelGroupAction.class),

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateModelAction.java
@@ -15,7 +15,9 @@ import java.util.List;
 import java.util.Locale;
 
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.transport.model.MLUpdateModelAction;
 import org.opensearch.ml.common.transport.model.MLUpdateModelInput;
@@ -64,9 +66,16 @@ public class RestMLUpdateModelAction extends BaseRestHandler {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         try {
             MLUpdateModelInput input = MLUpdateModelInput.parse(parser);
-            // Model ID can only be set here. Model version can only be set automatically.
+            if (input.getConnectorId() != null && input.getConnectorUpdateContent() != null) {
+                throw new OpenSearchStatusException(
+                    "Model cannot have both stand-alone connector and internal connector. Please check your update input body",
+                    RestStatus.BAD_REQUEST
+                );
+            }
+            // Model ID can only be set here. Model version as well as connector field can only be set automatically.
             input.setModelId(modelId);
             input.setVersion(null);
+            input.setConnector(null);
             return new MLUpdateModelRequest(input);
         } catch (IllegalStateException e) {
             throw new OpenSearchParseException(e.getMessage());


### PR DESCRIPTION
### Description
This PR should enabling both model level throttling and quota feature as well as allowing in-cache multi-node update of these features.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
