### PR TITLE
Implement search alerts tool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
         }
 
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
+        kotlin_version = System.getProperty("kotlin.version", "1.8.21")
     }
 
     repositories {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -47,7 +47,8 @@ dependencies {
     implementation("ai.djl.onnxruntime:onnxruntime-engine:0.21.0") {
         exclude group: "com.microsoft.onnxruntime", module: "onnxruntime"
     }
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.50"
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
+
     def os = DefaultNativePlatform.currentOperatingSystem
     //mac doesn't support GPU
     if (os.macOsX) {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -18,6 +18,7 @@ repositories {
 dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
     implementation project(path: ":${rootProject.name}-common", configuration: 'shadow')
+    implementation project(':opensearch-ml-memory')
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -9,7 +9,6 @@ plugins {
     id 'java'
     id 'jacoco'
     id "io.freefair.lombok"
-    id 'com.diffplug.spotless' version '6.18.0'
 }
 
 repositories {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id "io.freefair.lombok"
+    id 'com.diffplug.spotless' version '6.18.0'
 }
 
 repositories {
@@ -18,7 +19,6 @@ repositories {
 dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
     implementation project(path: ":${rootProject.name}-common", configuration: 'shadow')
-    implementation project(':opensearch-ml-memory')
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
@@ -47,6 +47,7 @@ dependencies {
     implementation("ai.djl.onnxruntime:onnxruntime-engine:0.21.0") {
         exclude group: "com.microsoft.onnxruntime", module: "onnxruntime"
     }
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.50"
     def os = DefaultNativePlatform.currentOperatingSystem
     //mac doesn't support GPU
     if (os.macOsX) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchAlertsTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchAlertsTool.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.tools;
+
+import static org.opensearch.ml.common.utils.StringUtils.gson;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.commons.alerting.AlertingPluginInterface;
+import org.opensearch.commons.alerting.action.GetAlertsRequest;
+import org.opensearch.commons.alerting.action.GetAlertsResponse;
+import org.opensearch.commons.alerting.model.Table;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.spi.tools.Parser;
+import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.ml.common.spi.tools.ToolAnnotation;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@ToolAnnotation(SearchAlertsTool.NAME)
+public class SearchAlertsTool implements Tool {
+    public static final String NAME = "SearchAlertsTool";
+    private static final String DEFAULT_DESCRIPTION = "Use this tool to search alerts.";
+
+    @Setter
+    @Getter
+    private String name = SearchAlertsTool.NAME;
+    @Getter
+    @Setter
+    private String description = DEFAULT_DESCRIPTION;
+    @Getter
+    private String type;
+    @Getter
+    private String version;
+
+    private Client client;
+    @Setter
+    private Parser<?, ?> inputParser;
+    @Setter
+    private Parser<?, ?> outputParser;
+    @SuppressWarnings("unused")
+    private ClusterService clusterService;
+
+    public SearchAlertsTool(Client client, ClusterService clusterService) {
+        this.client = client;
+        this.clusterService = clusterService;
+
+        // probably keep this overridden output parser. need to ensure the output matches what's expected
+        outputParser = new Parser<>() {
+            @Override
+            public Object parse(Object o) {
+                @SuppressWarnings("unchecked")
+                List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
+                return mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap().get("response");
+            }
+        };
+    }
+
+    @Override
+    public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
+
+        // build out the request
+        final String tableSortOrder = parameters.containsKey("sortOrder") ? parameters.get("sortOrder") : "asc";
+        final String tableSortString = parameters.containsKey("sortString") ? parameters.get("sortString") : "monitor_name.keyword";
+        final int tableSize = parameters.containsKey("size") ? Integer.parseInt(parameters.get("size")) : 20;
+        final String searchString = parameters.containsKey("searchString") ? parameters.get("searchString") : null;
+
+        // not exposing "missing" or "startIndex" from the table, using defaults of null/0, respectively
+        final Table table = new Table(tableSortOrder, tableSortString, null, tableSize, 0, searchString);
+
+        final String severityLevel = parameters.containsKey("severityLevel") ? parameters.get("severityLevel") : "ALL";
+        final String alertState = parameters.containsKey("alertState") ? parameters.get("alertState") : "ALL";
+        final String monitorId = parameters.containsKey("monitorId") ? parameters.get("monitorId") : null;
+        final String alertIndex = parameters.containsKey("alertIndex") ? parameters.get("alertIndex") : null;
+        @SuppressWarnings("unchecked")
+        final List<String> monitorIds = parameters.containsKey("monitorIds")
+            ? gson.fromJson(parameters.get("monitorIds"), List.class)
+            : null;
+        @SuppressWarnings("unchecked")
+        final List<String> workflowIds = parameters.containsKey("workflowIds")
+            ? gson.fromJson(parameters.get("workflowIds"), List.class)
+            : null;
+        @SuppressWarnings("unchecked")
+        final List<String> alertIds = parameters.containsKey("alertIds") ? gson.fromJson(parameters.get("alertIds"), List.class) : null;
+
+        GetAlertsRequest getAlertsRequest = new GetAlertsRequest(
+            table,
+            severityLevel,
+            alertState,
+            monitorId,
+            alertIndex,
+            monitorIds,
+            workflowIds,
+            alertIds
+        );
+
+        // create response listener
+        ActionListener<GetAlertsResponse> getAlertsListener = ActionListener.<GetAlertsResponse>wrap(response -> {
+            listener.onResponse((T) response);
+        }, e -> { listener.onFailure(e); });
+
+        // execute the search
+        AlertingPluginInterface.INSTANCE.getAlerts((NodeClient) client, getAlertsRequest, getAlertsListener);
+    }
+
+    @Override
+    public boolean validate(Map<String, String> parameters) {
+        if (parameters == null || parameters.size() == 0) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Factory for the {@link SearchAlertsTool}
+     */
+    public static class Factory implements Tool.Factory<SearchAlertsTool> {
+        private Client client;
+        private ClusterService clusterService;
+
+        private static Factory INSTANCE;
+
+        /** 
+         * Create or return the singleton factory instance
+         */
+        public static Factory getInstance() {
+            if (INSTANCE != null) {
+                return INSTANCE;
+            }
+            synchronized (SearchAlertsTool.class) {
+                if (INSTANCE != null) {
+                    return INSTANCE;
+                }
+                INSTANCE = new Factory();
+                return INSTANCE;
+            }
+        }
+
+        /**
+         * Initialize this factory
+         * @param client The OpenSearch client
+         * @param clusterService The OpenSearch cluster service
+         */
+        public void init(Client client, ClusterService clusterService) {
+            this.client = client;
+            this.clusterService = clusterService;
+        }
+
+        @Override
+        public SearchAlertsTool create(Map<String, Object> map) {
+            return new SearchAlertsTool(client, clusterService);
+        }
+
+        @Override
+        public String getDefaultDescription() {
+            return DEFAULT_DESCRIPTION;
+        }
+    }
+
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchAlertsTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchAlertsTool.java
@@ -67,10 +67,11 @@ public class SearchAlertsTool implements Tool {
         final String tableSortOrder = parameters.getOrDefault("sortOrder", "asc");
         final String tableSortString = parameters.getOrDefault("sortString", "monitor_name.keyword");
         final int tableSize = parameters.containsKey("size") ? Integer.parseInt(parameters.get("size")) : 20;
+        final int startIndex = parameters.containsKey("startIndex") ? Integer.parseInt(parameters.get("startIndex")) : 0;
         final String searchString = parameters.getOrDefault("searchString", null);
 
-        // not exposing "missing" or "startIndex" from the table, using defaults of null/0, respectively
-        final Table table = new Table(tableSortOrder, tableSortString, null, tableSize, 0, searchString);
+        // not exposing "missing" from the table, using default of null
+        final Table table = new Table(tableSortOrder, tableSortString, null, tableSize, startIndex, searchString);
 
         final String severityLevel = parameters.getOrDefault("severityLevel", "ALL");
         final String alertState = parameters.getOrDefault("alertState", "ALL");

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchAlertsTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchAlertsTool.java
@@ -114,7 +114,7 @@ public class SearchAlertsTool implements Tool {
 
     @Override
     public boolean validate(Map<String, String> parameters) {
-        if (parameters == null || parameters.size() == 0) {
+        if (parameters == null) {
             return false;
         }
         return true;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchAlertsTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchAlertsTool.java
@@ -117,9 +117,6 @@ public class SearchAlertsTool implements Tool {
 
     @Override
     public boolean validate(Map<String, String> parameters) {
-        if (parameters == null) {
-            return false;
-        }
         return true;
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchAlertsToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchAlertsToolTests.java
@@ -29,7 +29,6 @@ import org.opensearch.client.AdminClient;
 import org.opensearch.client.ClusterAdminClient;
 import org.opensearch.client.IndicesAdminClient;
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.commons.alerting.action.GetAlertsResponse;
 import org.opensearch.commons.alerting.model.Alert;
 import org.opensearch.core.action.ActionListener;
@@ -44,8 +43,6 @@ public class SearchAlertsToolTests {
     private IndicesAdminClient indicesAdminClient;
     @Mock
     private ClusterAdminClient clusterAdminClient;
-    @Mock
-    private ClusterService clusterService;
 
     private Map<String, String> nullParams;
     private Map<String, String> emptyParams;
@@ -54,7 +51,7 @@ public class SearchAlertsToolTests {
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        SearchAlertsTool.Factory.getInstance().init(nodeClient, clusterService);
+        SearchAlertsTool.Factory.getInstance().init(nodeClient);
 
         nullParams = null;
         emptyParams = Collections.emptyMap();

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchAlertsToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchAlertsToolTests.java
@@ -62,9 +62,10 @@ public class SearchAlertsToolTests {
     public void testRunWithNoAlerts() throws Exception {
         Tool tool = SearchAlertsTool.Factory.getInstance().create(Collections.emptyMap());
         GetAlertsResponse getAlertsResponse = new GetAlertsResponse(Collections.emptyList(), 0);
+        String expectedResponseStr = "Alerts=[]TotalAlerts=0";
 
         @SuppressWarnings("unchecked")
-        ActionListener<GetAlertsResponse> listener = Mockito.mock(ActionListener.class);
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
 
         doAnswer((invocation) -> {
             ActionListener<GetAlertsResponse> responseListener = invocation.getArgument(2);
@@ -73,9 +74,9 @@ public class SearchAlertsToolTests {
         }).when(nodeClient).execute(any(ActionType.class), any(), any());
 
         tool.run(nonEmptyParams, listener);
-        ArgumentCaptor<GetAlertsResponse> responseCaptor = ArgumentCaptor.forClass(GetAlertsResponse.class);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
         verify(listener, times(1)).onResponse(responseCaptor.capture());
-        assertEquals((Integer) 0, responseCaptor.getValue().getTotalAlerts());
+        assertEquals(expectedResponseStr, responseCaptor.getValue());
     }
 
     @Test
@@ -138,9 +139,15 @@ public class SearchAlertsToolTests {
         List<Alert> mockAlerts = List.of(alert1, alert2);
 
         GetAlertsResponse getAlertsResponse = new GetAlertsResponse(mockAlerts, mockAlerts.size());
+        String expectedResponseStr = new StringBuilder()
+            .append("Alerts=[")
+            .append(alert1.toString())
+            .append(alert2.toString())
+            .append("]TotalAlerts=2")
+            .toString();
 
         @SuppressWarnings("unchecked")
-        ActionListener<GetAlertsResponse> listener = Mockito.mock(ActionListener.class);
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
 
         doAnswer((invocation) -> {
             ActionListener<GetAlertsResponse> responseListener = invocation.getArgument(2);
@@ -149,15 +156,15 @@ public class SearchAlertsToolTests {
         }).when(nodeClient).execute(any(ActionType.class), any(), any());
 
         tool.run(nonEmptyParams, listener);
-        ArgumentCaptor<GetAlertsResponse> responseCaptor = ArgumentCaptor.forClass(GetAlertsResponse.class);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
         verify(listener, times(1)).onResponse(responseCaptor.capture());
-        assertEquals((Integer) mockAlerts.size(), responseCaptor.getValue().getTotalAlerts());
+        assertEquals(expectedResponseStr, responseCaptor.getValue());
     }
 
     @Test
     public void testValidate() {
         Tool tool = SearchAlertsTool.Factory.getInstance().create(Collections.emptyMap());
-        assertEquals(SearchAlertsTool.NAME, tool.getName());
+        assertEquals(SearchAlertsTool.TYPE, tool.getType());
         assertTrue(tool.validate(emptyParams));
         assertTrue(tool.validate(nonEmptyParams));
         assertFalse(tool.validate(nullParams));

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchAlertsToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchAlertsToolTests.java
@@ -167,6 +167,6 @@ public class SearchAlertsToolTests {
         assertEquals(SearchAlertsTool.TYPE, tool.getType());
         assertTrue(tool.validate(emptyParams));
         assertTrue(tool.validate(nonEmptyParams));
-        assertFalse(tool.validate(nullParams));
+        assertTrue(tool.validate(nullParams));
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchAlertsToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchAlertsToolTests.java
@@ -35,9 +35,6 @@ import org.opensearch.commons.alerting.model.Alert;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.spi.tools.Tool;
 
-import lombok.extern.log4j.Log4j2;
-
-@Log4j2
 public class SearchAlertsToolTests {
     @Mock
     private NodeClient nodeClient;
@@ -50,18 +47,18 @@ public class SearchAlertsToolTests {
     @Mock
     private ClusterService clusterService;
 
-    private Map<String, String> indicesParams;
-    private Map<String, String> otherParams;
+    private Map<String, String> nullParams;
     private Map<String, String> emptyParams;
+    private Map<String, String> nonEmptyParams;
 
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
         SearchAlertsTool.Factory.getInstance().init(nodeClient, clusterService);
 
-        indicesParams = Map.of("index", "[\"foo\"]");
-        otherParams = Map.of("other", "[\"bar\"]");
+        nullParams = null;
         emptyParams = Collections.emptyMap();
+        nonEmptyParams = Map.of("searchString", "foo");
     }
 
     @Test
@@ -78,7 +75,7 @@ public class SearchAlertsToolTests {
             return null;
         }).when(nodeClient).execute(any(ActionType.class), any(), any());
 
-        tool.run(otherParams, listener);
+        tool.run(nonEmptyParams, listener);
         ArgumentCaptor<GetAlertsResponse> responseCaptor = ArgumentCaptor.forClass(GetAlertsResponse.class);
         verify(listener, times(1)).onResponse(responseCaptor.capture());
         assertEquals((Integer) 0, responseCaptor.getValue().getTotalAlerts());
@@ -154,7 +151,7 @@ public class SearchAlertsToolTests {
             return null;
         }).when(nodeClient).execute(any(ActionType.class), any(), any());
 
-        tool.run(otherParams, listener);
+        tool.run(nonEmptyParams, listener);
         ArgumentCaptor<GetAlertsResponse> responseCaptor = ArgumentCaptor.forClass(GetAlertsResponse.class);
         verify(listener, times(1)).onResponse(responseCaptor.capture());
         assertEquals((Integer) mockAlerts.size(), responseCaptor.getValue().getTotalAlerts());
@@ -164,8 +161,8 @@ public class SearchAlertsToolTests {
     public void testValidate() {
         Tool tool = SearchAlertsTool.Factory.getInstance().create(Collections.emptyMap());
         assertEquals(SearchAlertsTool.NAME, tool.getName());
-        assertTrue(tool.validate(indicesParams));
-        assertTrue(tool.validate(otherParams));
-        assertFalse(tool.validate(emptyParams));
+        assertTrue(tool.validate(emptyParams));
+        assertTrue(tool.validate(nonEmptyParams));
+        assertFalse(tool.validate(nullParams));
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchAlertsToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchAlertsToolTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.ActionType;
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.ClusterAdminClient;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.commons.alerting.action.GetAlertsResponse;
+import org.opensearch.commons.alerting.model.Alert;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.spi.tools.Tool;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class SearchAlertsToolTests {
+    @Mock
+    private NodeClient nodeClient;
+    @Mock
+    private AdminClient adminClient;
+    @Mock
+    private IndicesAdminClient indicesAdminClient;
+    @Mock
+    private ClusterAdminClient clusterAdminClient;
+    @Mock
+    private ClusterService clusterService;
+
+    private Map<String, String> indicesParams;
+    private Map<String, String> otherParams;
+    private Map<String, String> emptyParams;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        SearchAlertsTool.Factory.getInstance().init(nodeClient, clusterService);
+
+        indicesParams = Map.of("index", "[\"foo\"]");
+        otherParams = Map.of("other", "[\"bar\"]");
+        emptyParams = Collections.emptyMap();
+    }
+
+    @Test
+    public void testRunWithNoAlerts() throws Exception {
+        Tool tool = SearchAlertsTool.Factory.getInstance().create(Collections.emptyMap());
+        GetAlertsResponse getAlertsResponse = new GetAlertsResponse(Collections.emptyList(), 0);
+
+        @SuppressWarnings("unchecked")
+        ActionListener<GetAlertsResponse> listener = Mockito.mock(ActionListener.class);
+
+        doAnswer((invocation) -> {
+            ActionListener<GetAlertsResponse> responseListener = invocation.getArgument(2);
+            responseListener.onResponse(getAlertsResponse);
+            return null;
+        }).when(nodeClient).execute(any(ActionType.class), any(), any());
+
+        tool.run(otherParams, listener);
+        ArgumentCaptor<GetAlertsResponse> responseCaptor = ArgumentCaptor.forClass(GetAlertsResponse.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals((Integer) 0, responseCaptor.getValue().getTotalAlerts());
+    }
+
+    @Test
+    public void testRunWithAlerts() throws Exception {
+        Tool tool = SearchAlertsTool.Factory.getInstance().create(Collections.emptyMap());
+        Alert alert1 = new Alert(
+            "alert-id-1",
+            1234,
+            1,
+            "monitor-id",
+            "workflow-id",
+            "workflow-name",
+            "monitor-name",
+            1234,
+            null,
+            "trigger-id",
+            "trigger-name",
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Alert.State.ACKNOWLEDGED,
+            Instant.now(),
+            null,
+            null,
+            null,
+            null,
+            Collections.emptyList(),
+            "test-severity",
+            Collections.emptyList(),
+            null,
+            null,
+            Collections.emptyList()
+        );
+        Alert alert2 = new Alert(
+            "alert-id-2",
+            1234,
+            1,
+            "monitor-id",
+            "workflow-id",
+            "workflow-name",
+            "monitor-name",
+            1234,
+            null,
+            "trigger-id",
+            "trigger-name",
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Alert.State.ACKNOWLEDGED,
+            Instant.now(),
+            null,
+            null,
+            null,
+            null,
+            Collections.emptyList(),
+            "test-severity",
+            Collections.emptyList(),
+            null,
+            null,
+            Collections.emptyList()
+        );
+        List<Alert> mockAlerts = List.of(alert1, alert2);
+
+        GetAlertsResponse getAlertsResponse = new GetAlertsResponse(mockAlerts, mockAlerts.size());
+
+        @SuppressWarnings("unchecked")
+        ActionListener<GetAlertsResponse> listener = Mockito.mock(ActionListener.class);
+
+        doAnswer((invocation) -> {
+            ActionListener<GetAlertsResponse> responseListener = invocation.getArgument(2);
+            responseListener.onResponse(getAlertsResponse);
+            return null;
+        }).when(nodeClient).execute(any(ActionType.class), any(), any());
+
+        tool.run(otherParams, listener);
+        ArgumentCaptor<GetAlertsResponse> responseCaptor = ArgumentCaptor.forClass(GetAlertsResponse.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals((Integer) mockAlerts.size(), responseCaptor.getValue().getTotalAlerts());
+    }
+
+    @Test
+    public void testValidate() {
+        Tool tool = SearchAlertsTool.Factory.getInstance().create(Collections.emptyMap());
+        assertEquals(SearchAlertsTool.NAME, tool.getName());
+        assertTrue(tool.validate(indicesParams));
+        assertTrue(tool.validate(otherParams));
+        assertFalse(tool.validate(emptyParams));
+    }
+}


### PR DESCRIPTION
### Description
Adds a search alerts tool. Utilizes [getAlerts()](https://github.com/opensearch-project/common-utils/blob/main/src/main/kotlin/org/opensearch/commons/alerting/AlertingPluginInterface.kt#L135) exposed by the alerting interface in common utils.

Exposes all of the parameters offered by the interface, besides `missing` since that doesn't seem relevant (defaults to `null`). All parameters have defaults which match that of the [get alerts API](https://opensearch.org/docs/latest/observing-your-data/alerting/api/#get-alerts) for now.

The amount of parameters and/or the default values may be changed later on depending on agent performance and accuracy. For example, too much parameter tuning may lead to messy or invalid results.

Additionally, further integration testing will need to be done to validate different alerting-related questions input to the agent that will have this tool associated to it. 
 
### Issues Resolved
Closes #1521 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
