### PR TITLE
[Backport 2.11] Read function Name from pretrained model (#1529)

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/MLTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLTask.java
@@ -50,7 +50,8 @@ public class MLTask implements ToXContentObject, Writeable {
     @Setter
     private String modelId;
     private final MLTaskType taskType;
-    private final FunctionName functionName;
+    @Setter
+    private FunctionName functionName;
     @Setter
     private MLTaskState state;
     private final MLInputDataType inputType;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
@@ -82,12 +82,15 @@ public class ModelHelper {
 
                 MLRegisterModelInput.MLRegisterModelInputBuilder builder = MLRegisterModelInput.builder();
 
-                builder.modelName(modelName)
-                        .version(version)
-                        .url(modelZipFileUrl)
-                        .deployModel(deployModel)
-                        .modelNodeIds(modelNodeIds)
-                        .modelGroupId(modelGroupId);
+                builder
+                    .modelName(modelName)
+                    .version(version)
+                    .url(modelZipFileUrl)
+                    .deployModel(deployModel)
+                    .modelNodeIds(modelNodeIds)
+                    .modelGroupId(modelGroupId)
+                    .functionName(FunctionName.from((String) config.get("model_task_type")));
+
                 config.entrySet().forEach(entry -> {
                     switch (entry.getKey().toString()) {
                         case MLRegisterModelInput.MODEL_FORMAT_FIELD:

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -15,6 +15,7 @@ import static org.opensearch.ml.common.CommonValue.NOT_FOUND;
 import static org.opensearch.ml.common.CommonValue.UNDEPLOYED;
 import static org.opensearch.ml.common.MLModel.ALGORITHM_FIELD;
 import static org.opensearch.ml.common.MLTask.ERROR_FIELD;
+import static org.opensearch.ml.common.MLTask.FUNCTION_NAME_FIELD;
 import static org.opensearch.ml.common.MLTask.MODEL_ID_FIELD;
 import static org.opensearch.ml.common.MLTask.STATE_FIELD;
 import static org.opensearch.ml.common.MLTaskState.COMPLETED;
@@ -755,6 +756,14 @@ public class MLModelManager {
             throw new IllegalArgumentException("This model is not in the pre-trained model list, please check your parameters.");
         }
         modelHelper.downloadPrebuiltModelConfig(taskId, registerModelInput, ActionListener.wrap(mlRegisterModelInput -> {
+            mlTask.setFunctionName(mlRegisterModelInput.getFunctionName());
+            mlTaskManager
+                .updateMLTask(
+                    taskId,
+                    ImmutableMap.of(FUNCTION_NAME_FIELD, mlRegisterModelInput.getFunctionName()),
+                    TIMEOUT_IN_MILLIS,
+                    false
+                );
             registerModelFromUrl(mlRegisterModelInput, mlTask, modelVersion);
         }, e -> {
             log.error("Failed to register prebuilt model", e);


### PR DESCRIPTION
### Description
backport to 2.11 for pr 1529
 
### Issues Resolved
backport to 2.11 for pr 1529
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
