### PR TITLE
separate get Trace actions into a new rest API

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/conversation/ActionConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/conversation/ActionConstants.java
@@ -29,6 +29,8 @@ public class ActionConstants {
     public final static String RESPONSE_CONVERSATION_LIST_FIELD = "conversations";
     /** name of list on interactions in all responses */
     public final static String RESPONSE_INTERACTION_LIST_FIELD = "interactions";
+    /** name of list on interactions in all responses */
+    public final static String RESPONSE_TRACES_LIST_FIELD = "traces";
     /** name of interaction Id field in all responses */
     public final static String RESPONSE_INTERACTION_ID_FIELD = "interaction_id";
 
@@ -67,6 +69,8 @@ public class ActionConstants {
     public final static String CREATE_INTERACTION_REST_PATH = BASE_REST_PATH + "/{conversation_id}/_create";
     /** path for get interactions */
     public final static String GET_INTERACTIONS_REST_PATH = BASE_REST_PATH + "/{conversation_id}/_list";
+    /** path for get interactions */
+    public final static String GET_TRACES_REST_PATH = "/_plugins/_ml/memory/trace" + "/{interaction_id}/_list";
     /** path for delete conversation */
     public final static String DELETE_CONVERSATION_REST_PATH = BASE_REST_PATH + "/{conversation_id}/_delete";
     /** path for search conversations */

--- a/memory/src/main/java/org/opensearch/ml/memory/ConversationalMemoryHandler.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/ConversationalMemoryHandler.java
@@ -153,6 +153,8 @@ public interface ConversationalMemoryHandler {
      */
     public void getInteractions(String conversationId, int from, int maxResults, ActionListener<List<Interaction>> listener);
 
+    public void getTraces(String interactionId, int from, int maxResults, ActionListener<List<Interaction>> listener);
+
     /**
      * Get the interactions associate with this conversation, sorted by recency
      * @param conversationId the conversation whose interactions to get

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesAction.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesAction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.memory.action.conversation;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Action to return the traces associated with an interaction
+ */
+public class GetTracesAction extends ActionType<GetTracesResponse> {
+    /** Instance of this */
+    public static final GetTracesAction INSTANCE = new GetTracesAction();
+    /** Name of this action */
+    public static final String NAME = "cluster:admin/opensearch/ml/memory/trace/get";
+
+    private GetTracesAction() {
+        super(NAME, GetTracesResponse::new);
+    }
+
+}

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesRequest.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesRequest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.memory.action.conversation;
+
+import static org.opensearch.action.ValidateActions.addValidationError;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.ml.common.conversation.ActionConstants;
+import org.opensearch.rest.RestRequest;
+
+import lombok.Getter;
+
+/**
+ * ActionRequest for get traces
+ */
+public class GetTracesRequest extends ActionRequest {
+    @Getter
+    private String interactionId;
+    @Getter
+    private int maxResults = ActionConstants.DEFAULT_MAX_RESULTS;
+    @Getter
+    private int from = 0;
+
+    /**
+     * Constructor
+     * @param interactionId UID of the interaction to get traces from
+     */
+    public GetTracesRequest(String interactionId) {
+        this.interactionId = interactionId;
+    }
+
+    /**
+     * Constructor
+     * @param interactionId UID of the conversation to get interactions from
+     * @param maxResults number of interactions to retrieve
+     */
+    public GetTracesRequest(String interactionId, int maxResults) {
+        this.interactionId = interactionId;
+        this.maxResults = maxResults;
+    }
+
+    /**
+     * Constructor
+     * @param interactionId UID of the conversation to get interactions from
+     * @param maxResults number of interactions to retrieve
+     * @param from position of first interaction to retrieve
+     */
+    public GetTracesRequest(String interactionId, int maxResults, int from) {
+        this.interactionId = interactionId;
+        this.maxResults = maxResults;
+        this.from = from;
+    }
+
+    /**
+     * Constructor
+     * @param in streaminput to read this from. assumes there was a GetTracesRequest.writeTo
+     * @throws IOException if there wasn't a GIR in the stream
+     */
+    public GetTracesRequest(StreamInput in) throws IOException {
+        super(in);
+        this.interactionId = in.readString();
+        this.maxResults = in.readInt();
+        this.from = in.readInt();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(interactionId);
+        out.writeInt(maxResults);
+        out.writeInt(from);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException exception = null;
+        if (interactionId == null) {
+            exception = addValidationError("Traces must be retrieved from an interaction", exception);
+        }
+        if (maxResults <= 0) {
+            exception = addValidationError("The number of traces to retrieve must be positive", exception);
+        }
+        if (from < 0) {
+            exception = addValidationError("The starting position must be nonnegative", exception);
+        }
+
+        return exception;
+    }
+
+    /**
+     * Makes a GetTracesRequest out of a RestRequest
+     * @param request Rest Request representing a get traces request
+     * @return a new GetTracesRequest
+     * @throws IOException if something goes wrong
+     */
+    public static GetTracesRequest fromRestRequest(RestRequest request) throws IOException {
+        String cid = request.param(ActionConstants.RESPONSE_INTERACTION_ID_FIELD);
+        if (request.hasParam(ActionConstants.NEXT_TOKEN_FIELD)) {
+            int from = Integer.parseInt(request.param(ActionConstants.NEXT_TOKEN_FIELD));
+            if (request.hasParam(ActionConstants.REQUEST_MAX_RESULTS_FIELD)) {
+                int maxResults = Integer.parseInt(request.param(ActionConstants.REQUEST_MAX_RESULTS_FIELD));
+                return new GetTracesRequest(cid, maxResults, from);
+            } else {
+                return new GetTracesRequest(cid, ActionConstants.DEFAULT_MAX_RESULTS, from);
+            }
+        } else {
+            if (request.hasParam(ActionConstants.REQUEST_MAX_RESULTS_FIELD)) {
+                int maxResults = Integer.parseInt(request.param(ActionConstants.REQUEST_MAX_RESULTS_FIELD));
+                return new GetTracesRequest(cid, maxResults);
+            } else {
+                return new GetTracesRequest(cid);
+            }
+        }
+    }
+}

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesResponse.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesResponse.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.memory.action.conversation;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.conversation.ActionConstants;
+import org.opensearch.ml.common.conversation.Interaction;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Action Response for get traces for an interaction
+ */
+@AllArgsConstructor
+public class GetTracesResponse extends ActionResponse implements ToXContentObject {
+    @Getter
+    private List<Interaction> traces;
+
+    /**
+     * Constructor
+     * @param in stream input; assumes GetTracesResponse.writeTo was called
+     * @throws IOException if there's not a G.I.R. in the stream
+     */
+    public GetTracesResponse(StreamInput in) throws IOException {
+        super(in);
+        traces = in.readList(Interaction::fromStream);
+    }
+
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeList(traces);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.startArray(ActionConstants.RESPONSE_TRACES_LIST_FIELD);
+        for (Interaction trace : traces) {
+            trace.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+}

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesTransportAction.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesTransportAction.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.memory.action.conversation;
+
+import java.util.List;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.conversation.Interaction;
+import org.opensearch.ml.memory.ConversationalMemoryHandler;
+import org.opensearch.ml.memory.index.OpenSearchConversationalMemoryHandler;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class GetTracesTransportAction extends HandledTransportAction<GetTracesRequest, GetTracesResponse> {
+    private Client client;
+    private ConversationalMemoryHandler cmHandler;
+
+    /**
+     * Constructor
+     * @param transportService for inter-node communications
+     * @param actionFilters for filtering actions
+     * @param cmHandler Handler for conversational memory operations
+     * @param client OS Client for dealing with OS
+     * @param clusterService for some cluster ops
+     */
+    @Inject
+    public GetTracesTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        OpenSearchConversationalMemoryHandler cmHandler,
+        Client client,
+        ClusterService clusterService
+    ) {
+        super(GetTracesAction.NAME, transportService, actionFilters, GetTracesRequest::new);
+        this.client = client;
+        this.cmHandler = cmHandler;
+    }
+
+    @Override
+    public void doExecute(Task task, GetTracesRequest request, ActionListener<GetTracesResponse> actionListener) {
+        int maxResults = request.getMaxResults();
+        int from = request.getFrom();
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().newStoredContext(true)) {
+            ActionListener<GetTracesResponse> internalListener = ActionListener.runBefore(actionListener, () -> context.restore());
+            ActionListener<List<Interaction>> al = ActionListener
+                .wrap(traces -> { internalListener.onResponse(new GetTracesResponse(traces)); }, e -> {
+                    internalListener.onFailure(e);
+                });
+            cmHandler.getTraces(request.getInteractionId(), from, maxResults, al);
+        } catch (Exception e) {
+            log.error("Failed to get traces for conversation " + request.getInteractionId(), e);
+            actionListener.onFailure(e);
+        }
+    }
+}

--- a/memory/src/main/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandler.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandler.java
@@ -379,4 +379,8 @@ public class OpenSearchConversationalMemoryHandler implements ConversationalMemo
         return fut;
     }
 
+    public void getTraces(String interactionId, int from, int maxResults, ActionListener<List<Interaction>> listener) {
+        interactionsIndex.getTraces(interactionId, from, maxResults, listener);
+    }
+
 }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -163,6 +163,8 @@ import org.opensearch.ml.memory.action.conversation.GetConversationsAction;
 import org.opensearch.ml.memory.action.conversation.GetConversationsTransportAction;
 import org.opensearch.ml.memory.action.conversation.GetInteractionsAction;
 import org.opensearch.ml.memory.action.conversation.GetInteractionsTransportAction;
+import org.opensearch.ml.memory.action.conversation.GetTracesAction;
+import org.opensearch.ml.memory.action.conversation.GetTracesTransportAction;
 import org.opensearch.ml.memory.action.conversation.SearchConversationsAction;
 import org.opensearch.ml.memory.action.conversation.SearchConversationsTransportAction;
 import org.opensearch.ml.memory.action.conversation.SearchInteractionsAction;
@@ -211,6 +213,7 @@ import org.opensearch.ml.rest.RestMemoryCreateInteractionAction;
 import org.opensearch.ml.rest.RestMemoryDeleteConversationAction;
 import org.opensearch.ml.rest.RestMemoryGetConversationsAction;
 import org.opensearch.ml.rest.RestMemoryGetInteractionsAction;
+import org.opensearch.ml.rest.RestMemoryGetTracesAction;
 import org.opensearch.ml.rest.RestMemorySearchConversationsAction;
 import org.opensearch.ml.rest.RestMemorySearchInteractionsAction;
 import org.opensearch.ml.rest.RestMemoryUpdateConversationAction;
@@ -352,7 +355,8 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
                 new ActionHandler<>(SearchInteractionsAction.INSTANCE, SearchInteractionsTransportAction.class),
                 new ActionHandler<>(SearchConversationsAction.INSTANCE, SearchConversationsTransportAction.class),
                 new ActionHandler<>(UpdateConversationAction.INSTANCE, UpdateConversationTransportAction.class),
-                new ActionHandler<>(UpdateInteractionAction.INSTANCE, UpdateInteractionTransportAction.class)
+                new ActionHandler<>(UpdateInteractionAction.INSTANCE, UpdateInteractionTransportAction.class),
+                new ActionHandler<>(GetTracesAction.INSTANCE, GetTracesTransportAction.class)
             );
     }
 
@@ -649,6 +653,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
         RestMemorySearchInteractionsAction restSearchInteractionsAction = new RestMemorySearchInteractionsAction();
         RestMemoryUpdateConversationAction restMemoryUpdateConversationAction = new RestMemoryUpdateConversationAction();
         RestMemoryUpdateInteractionAction restMemoryUpdateInteractionAction = new RestMemoryUpdateInteractionAction();
+        RestMemoryGetTracesAction restMemoryGetTracesAction = new RestMemoryGetTracesAction();
         return ImmutableList
             .of(
                 restMLStatsAction,
@@ -689,7 +694,8 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
                 restSearchConversationsAction,
                 restSearchInteractionsAction,
                 restMemoryUpdateConversationAction,
-                restMemoryUpdateInteractionAction
+                restMemoryUpdateInteractionAction,
+                restMemoryGetTracesAction
             );
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMemoryGetTracesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMemoryGetTracesAction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.ml.common.conversation.ActionConstants;
+import org.opensearch.ml.memory.action.conversation.GetTracesAction;
+import org.opensearch.ml.memory.action.conversation.GetTracesRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+
+public class RestMemoryGetTracesAction extends BaseRestHandler {
+    private final static String GET_TRACES_NAME = "conversational_get_traces";
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(RestRequest.Method.GET, ActionConstants.GET_TRACES_REST_PATH));
+    }
+
+    @Override
+    public String getName() {
+        return GET_TRACES_NAME;
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        GetTracesRequest gtRequest = GetTracesRequest.fromRestRequest(request);
+        return channel -> client.execute(GetTracesAction.INSTANCE, gtRequest, new RestToXContentListener<>(channel));
+    }
+}


### PR DESCRIPTION
### Description
Only return final results in the "List Conversation" API. Add a new API of "Get Trace" to return only traces for an interaction. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
