### PR TITLE
[Backport 2.x] Get model group API

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/model_group/MLModelGroupGetAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model_group/MLModelGroupGetAction.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.model_group;
+
+import org.opensearch.action.ActionType;
+
+public class MLModelGroupGetAction extends ActionType<MLModelGroupGetResponse> {
+    public static final MLModelGroupGetAction INSTANCE = new MLModelGroupGetAction();
+    public static final String NAME = "cluster:admin/opensearch/ml/model_groups/get";
+
+    private MLModelGroupGetAction() { super(NAME, MLModelGroupGetResponse::new);}
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/model_group/MLModelGroupGetRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model_group/MLModelGroupGetRequest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.model_group;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static org.opensearch.action.ValidateActions.addValidationError;
+
+@Getter
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@ToString
+public class MLModelGroupGetRequest extends ActionRequest {
+
+    String modelGroupId;
+
+    @Builder
+    public MLModelGroupGetRequest(String modelGroupId) {
+        this.modelGroupId = modelGroupId;
+    }
+
+    public MLModelGroupGetRequest(StreamInput in) throws IOException {
+        super(in);
+        this.modelGroupId = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(this.modelGroupId);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException exception = null;
+
+        if (this.modelGroupId == null) {
+            exception = addValidationError("Model group id can't be null", exception);
+        }
+
+        return exception;
+    }
+
+    public static MLModelGroupGetRequest fromActionRequest(ActionRequest actionRequest) {
+        if (actionRequest instanceof MLModelGroupGetRequest) {
+            return (MLModelGroupGetRequest)actionRequest;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionRequest.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLModelGroupGetRequest(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionRequest into MLModelGroupGetRequest", e);
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/model_group/MLModelGroupGetResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model_group/MLModelGroupGetResponse.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.model_group;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.MLModelGroup;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+@Getter
+@ToString
+public class MLModelGroupGetResponse extends ActionResponse implements ToXContentObject {
+
+    MLModelGroup mlModelGroup;
+
+    @Builder
+    public MLModelGroupGetResponse(MLModelGroup mlModelGroup) {
+        this.mlModelGroup = mlModelGroup;
+    }
+
+
+    public MLModelGroupGetResponse(StreamInput in) throws IOException {
+        super(in);
+        mlModelGroup = mlModelGroup.fromStream(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException{
+        mlModelGroup.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
+        return mlModelGroup.toXContent(xContentBuilder, params);
+    }
+
+    public static MLModelGroupGetResponse fromActionResponse(ActionResponse actionResponse) {
+        if (actionResponse instanceof MLModelGroupGetResponse) {
+            return (MLModelGroupGetResponse) actionResponse;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionResponse.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLModelGroupGetResponse(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionResponse into MLModelGroupGetResponse", e);
+        }
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLModelGroupGetRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLModelGroupGetRequestTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.model_group;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class MLModelGroupGetRequestTest {
+    private String modelGroupId;
+
+    @Before
+    public void setUp() {
+        modelGroupId = "test_id";
+    }
+
+    @Test
+    public void writeTo_Success() throws IOException {
+        MLModelGroupGetRequest mlModelGroupGetRequest = MLModelGroupGetRequest.builder()
+                .modelGroupId(modelGroupId).build();
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        mlModelGroupGetRequest.writeTo(bytesStreamOutput);
+        MLModelGroupGetRequest parsedModel = new MLModelGroupGetRequest(bytesStreamOutput.bytes().streamInput());
+        assertEquals(parsedModel.getModelGroupId(), modelGroupId);
+    }
+
+    @Test
+    public void validate_Exception_NullmodelGroupId() {
+        MLModelGroupGetRequest mlModelGroupGetRequest = MLModelGroupGetRequest.builder().build();
+
+        ActionRequestValidationException exception = mlModelGroupGetRequest.validate();
+        assertEquals("Validation Failed: 1: Model group id can't be null;", exception.getMessage());
+    }
+
+    @Test
+    public void fromActionRequest_Success() {
+        MLModelGroupGetRequest mlModelGroupGetRequest = MLModelGroupGetRequest.builder()
+                .modelGroupId(modelGroupId).build();
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+              return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+              mlModelGroupGetRequest.writeTo(out);
+            }
+        };
+        MLModelGroupGetRequest result = MLModelGroupGetRequest.fromActionRequest(actionRequest);
+        assertNotSame(result, mlModelGroupGetRequest);
+        assertEquals(result.getModelGroupId(), mlModelGroupGetRequest.getModelGroupId());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void fromActionRequest_IOException() {
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+              return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+              throw new IOException("test");
+            }
+        };
+        MLModelGroupGetRequest.fromActionRequest(actionRequest);
+    }
+
+    @Test
+    public void validate_Success() {
+        MLModelGroupGetRequest mlModelGroupGetRequest = MLModelGroupGetRequest.builder().modelGroupId(modelGroupId).build();
+        ActionRequestValidationException actionRequestValidationException = mlModelGroupGetRequest.validate();
+        assertNull(actionRequestValidationException);
+    }
+
+    @Test
+    public void fromActionRequestWithMLModelGroupGetRequest_Success() {
+        MLModelGroupGetRequest mlModelGroupGetRequest = MLModelGroupGetRequest.builder().modelGroupId(modelGroupId).build();
+        MLModelGroupGetRequest mlModelGroupGetRequestFromActionRequest = MLModelGroupGetRequest.fromActionRequest(mlModelGroupGetRequest);
+        assertSame(mlModelGroupGetRequest, mlModelGroupGetRequestFromActionRequest);
+        assertEquals(mlModelGroupGetRequest.getModelGroupId(), mlModelGroupGetRequestFromActionRequest.getModelGroupId());
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLModelGroupGetResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLModelGroupGetResponseTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.model_group;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.MLModelGroup;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public class MLModelGroupGetResponseTest {
+
+    MLModelGroup mlModelGroup;
+
+    @Before
+    public void setUp() {
+        mlModelGroup = MLModelGroup.builder()
+                .name("modelGroup1")
+                .latestVersion(1)
+                .description("This is an example model group")
+                .access("public")
+                .build();
+    }
+
+    @Test
+    public void writeTo_Success() throws IOException {
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        MLModelGroupGetResponse response = MLModelGroupGetResponse.builder().mlModelGroup(mlModelGroup).build();
+        response.writeTo(bytesStreamOutput);
+        MLModelGroupGetResponse parsedResponse = new MLModelGroupGetResponse(bytesStreamOutput.bytes().streamInput());
+        assertNotEquals(response.mlModelGroup, parsedResponse.mlModelGroup);
+        assertEquals(response.mlModelGroup.getName(), parsedResponse.mlModelGroup.getName());
+        assertEquals(response.mlModelGroup.getDescription(), parsedResponse.mlModelGroup.getDescription());
+        assertEquals(response.mlModelGroup.getLatestVersion(), parsedResponse.mlModelGroup.getLatestVersion());
+    }
+
+    @Test
+    public void toXContentTest() throws IOException {
+        MLModelGroupGetResponse mlModelGroupGetResponse = MLModelGroupGetResponse.builder().mlModelGroup(mlModelGroup).build();
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        mlModelGroupGetResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(builder);
+        String jsonStr = builder.toString();
+        assertEquals("{\"name\":\"modelGroup1\"," +
+                "\"latest_version\":1," +
+                "\"description\":\"This is an example model group\"," +
+                "\"access\":\"public\"}",
+                jsonStr);
+    }
+
+    @Test
+    public void fromActionResponseWithMLModelGroupGetResponse_Success() {
+        MLModelGroupGetResponse mlModelGroupGetResponse = MLModelGroupGetResponse.builder().mlModelGroup(mlModelGroup).build();
+        MLModelGroupGetResponse mlModelGroupGetResponseFromActionResponse = MLModelGroupGetResponse.fromActionResponse(mlModelGroupGetResponse);
+        assertSame(mlModelGroupGetResponse, mlModelGroupGetResponseFromActionResponse);
+        assertEquals(mlModelGroupGetResponse.mlModelGroup, mlModelGroupGetResponseFromActionResponse.mlModelGroup);
+    }
+
+    @Test
+    public void fromActionResponse_Success() {
+        MLModelGroupGetResponse mlModelGroupGetResponse = MLModelGroupGetResponse.builder().mlModelGroup(mlModelGroup).build();
+        ActionResponse actionResponse = new ActionResponse() {
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                mlModelGroupGetResponse.writeTo(out);
+            }
+        };
+        MLModelGroupGetResponse mlModelGroupGetResponseFromActionResponse = MLModelGroupGetResponse.fromActionResponse(actionResponse);
+        assertNotSame(mlModelGroupGetResponse, mlModelGroupGetResponseFromActionResponse);
+        assertNotEquals(mlModelGroupGetResponse.mlModelGroup, mlModelGroupGetResponseFromActionResponse.mlModelGroup);
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void fromActionResponse_IOException() {
+        ActionResponse actionResponse = new ActionResponse() {
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException();
+            }
+        };
+        MLModelGroupGetResponse.fromActionResponse(actionResponse);
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/GetModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/GetModelGroupTransportAction.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.model_group;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
+import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.ml.common.MLModelGroup;
+import org.opensearch.ml.common.exception.MLResourceNotFoundException;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetAction;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetRequest;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetResponse;
+import org.opensearch.ml.helper.ModelAccessControlHelper;
+import org.opensearch.ml.utils.RestActionUtils;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class GetModelGroupTransportAction extends HandledTransportAction<ActionRequest, MLModelGroupGetResponse> {
+
+    Client client;
+    NamedXContentRegistry xContentRegistry;
+    ClusterService clusterService;
+
+    ModelAccessControlHelper modelAccessControlHelper;
+
+    @Inject
+    public GetModelGroupTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        ClusterService clusterService,
+        ModelAccessControlHelper modelAccessControlHelper
+    ) {
+        super(MLModelGroupGetAction.NAME, transportService, actionFilters, MLModelGroupGetRequest::new);
+        this.client = client;
+        this.xContentRegistry = xContentRegistry;
+        this.clusterService = clusterService;
+        this.modelAccessControlHelper = modelAccessControlHelper;
+    }
+
+    @Override
+    protected void doExecute(Task task, ActionRequest request, ActionListener<MLModelGroupGetResponse> actionListener) {
+        MLModelGroupGetRequest mlModelGroupGetRequest = MLModelGroupGetRequest.fromActionRequest(request);
+        String modelGroupId = mlModelGroupGetRequest.getModelGroupId();
+        GetRequest getRequest = new GetRequest(ML_MODEL_GROUP_INDEX).id(modelGroupId);
+        User user = RestActionUtils.getUserContext(client);
+
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<MLModelGroupGetResponse> wrappedListener = ActionListener.runBefore(actionListener, () -> context.restore());
+            client.get(getRequest, ActionListener.wrap(r -> {
+                if (r != null && r.isExists()) {
+                    try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, r.getSourceAsBytesRef())) {
+                        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+
+                        MLModelGroup mlModelGroup = MLModelGroup.parse(parser);
+                        modelAccessControlHelper.validateModelGroupAccess(user, modelGroupId, client, ActionListener.wrap(access -> {
+                            if (!access) {
+                                wrappedListener
+                                    .onFailure(
+                                        new OpenSearchStatusException(
+                                            "User doesn't have privilege to perform this operation on this model group",
+                                            RestStatus.FORBIDDEN
+                                        )
+                                    );
+                            } else {
+                                wrappedListener.onResponse(MLModelGroupGetResponse.builder().mlModelGroup(mlModelGroup).build());
+                            }
+                        }, e -> {
+                            log.error("Failed to validate access for Model Group " + modelGroupId, e);
+                            wrappedListener.onFailure(e);
+                        }));
+
+                    } catch (Exception e) {
+                        log.error("Failed to parse ml model group" + r.getId(), e);
+                        wrappedListener.onFailure(e);
+                    }
+                } else {
+                    wrappedListener
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "Failed to find model group with the provided model group id: " + modelGroupId,
+                                RestStatus.NOT_FOUND
+                            )
+                        );
+                }
+            }, e -> {
+                if (e instanceof IndexNotFoundException) {
+                    wrappedListener.onFailure(new MLResourceNotFoundException("Fail to find model group index"));
+                } else {
+                    log.error("Failed to get ML model group" + modelGroupId, e);
+                    wrappedListener.onFailure(e);
+                }
+            }));
+        } catch (Exception e) {
+            log.error("Failed to get ML model group " + modelGroupId, e);
+            actionListener.onFailure(e);
+        }
+
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -47,6 +47,7 @@ import org.opensearch.ml.action.execute.TransportExecuteTaskAction;
 import org.opensearch.ml.action.forward.TransportForwardAction;
 import org.opensearch.ml.action.handler.MLSearchHandler;
 import org.opensearch.ml.action.model_group.DeleteModelGroupTransportAction;
+import org.opensearch.ml.action.model_group.GetModelGroupTransportAction;
 import org.opensearch.ml.action.model_group.SearchModelGroupTransportAction;
 import org.opensearch.ml.action.model_group.TransportRegisterModelGroupAction;
 import org.opensearch.ml.action.model_group.TransportUpdateModelGroupAction;
@@ -103,6 +104,7 @@ import org.opensearch.ml.common.transport.model.MLModelGetAction;
 import org.opensearch.ml.common.transport.model.MLModelSearchAction;
 import org.opensearch.ml.common.transport.model.MLUpdateModelAction;
 import org.opensearch.ml.common.transport.model_group.MLModelGroupDeleteAction;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetAction;
 import org.opensearch.ml.common.transport.model_group.MLModelGroupSearchAction;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupAction;
 import org.opensearch.ml.common.transport.model_group.MLUpdateModelGroupAction;
@@ -153,6 +155,7 @@ import org.opensearch.ml.rest.RestMLDeployModelAction;
 import org.opensearch.ml.rest.RestMLExecuteAction;
 import org.opensearch.ml.rest.RestMLGetConnectorAction;
 import org.opensearch.ml.rest.RestMLGetModelAction;
+import org.opensearch.ml.rest.RestMLGetModelGroupAction;
 import org.opensearch.ml.rest.RestMLGetTaskAction;
 import org.opensearch.ml.rest.RestMLPredictionAction;
 import org.opensearch.ml.rest.RestMLProfileAction;
@@ -290,6 +293,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
                 new ActionHandler<>(MLSyncUpAction.INSTANCE, TransportSyncUpOnNodeAction.class),
                 new ActionHandler<>(MLRegisterModelGroupAction.INSTANCE, TransportRegisterModelGroupAction.class),
                 new ActionHandler<>(MLUpdateModelGroupAction.INSTANCE, TransportUpdateModelGroupAction.class),
+                new ActionHandler<>(MLModelGroupGetAction.INSTANCE, GetModelGroupTransportAction.class),
                 new ActionHandler<>(MLModelGroupSearchAction.INSTANCE, SearchModelGroupTransportAction.class),
                 new ActionHandler<>(MLModelGroupDeleteAction.INSTANCE, DeleteModelGroupTransportAction.class),
                 new ActionHandler<>(MLCreateConnectorAction.INSTANCE, TransportCreateConnectorAction.class),
@@ -541,6 +545,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
         RestMLUploadModelChunkAction restMLUploadModelChunkAction = new RestMLUploadModelChunkAction(clusterService, settings);
         RestMLRegisterModelGroupAction restMLCreateModelGroupAction = new RestMLRegisterModelGroupAction();
         RestMLUpdateModelGroupAction restMLUpdateModelGroupAction = new RestMLUpdateModelGroupAction();
+        RestMLGetModelGroupAction restMLGetModelGroupAction = new RestMLGetModelGroupAction();
         RestMLSearchModelGroupAction restMLSearchModelGroupAction = new RestMLSearchModelGroupAction();
         RestMLUpdateModelAction restMLUpdateModelAction = new RestMLUpdateModelAction();
         RestMLDeleteModelGroupAction restMLDeleteModelGroupAction = new RestMLDeleteModelGroupAction();
@@ -576,6 +581,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
                 restMLUploadModelChunkAction,
                 restMLCreateModelGroupAction,
                 restMLUpdateModelGroupAction,
+                restMLGetModelGroupAction,
                 restMLSearchModelGroupAction,
                 restMLDeleteModelGroupAction,
                 restMLCreateConnectorAction,

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetModelGroupAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetModelGroupAction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_GROUP_ID;
+import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetAction;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+public class RestMLGetModelGroupAction extends BaseRestHandler {
+    private static final String ML_GET_MODEL_GROUP_ACTION = "ml_get_model_group_action";
+
+    /**
+     * Constructor
+     */
+    public RestMLGetModelGroupAction() {}
+
+    @Override
+    public String getName() {
+        return ML_GET_MODEL_GROUP_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList
+            .of(
+                new Route(RestRequest.Method.GET, String.format(Locale.ROOT, "%s/model_groups/{%s}", ML_BASE_URI, PARAMETER_MODEL_GROUP_ID))
+            );
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        MLModelGroupGetRequest mlModelGroupGetRequest = getRequest(request);
+        return channel -> client.execute(MLModelGroupGetAction.INSTANCE, mlModelGroupGetRequest, new RestToXContentListener<>(channel));
+    }
+
+    /**
+     * Creates a MLModelGroupGetRequest from a RestRequest
+     *
+     * @param request RestRequest
+     * @return MLModelGroupGetRequest
+     */
+    @VisibleForTesting
+    MLModelGroupGetRequest getRequest(RestRequest request) throws IOException {
+        String modelGroupId = getParameterId(request, PARAMETER_MODEL_GROUP_ID);
+
+        return new MLModelGroupGetRequest(modelGroupId);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
@@ -37,6 +37,7 @@ import org.opensearch.ml.action.profile.MLProfileResponse;
 import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.MLModelGroup;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.dataframe.ColumnMeta;
 import org.opensearch.ml.common.dataframe.ColumnType;
@@ -65,6 +66,9 @@ import org.opensearch.ml.common.transport.model.MLModelGetAction;
 import org.opensearch.ml.common.transport.model.MLModelGetRequest;
 import org.opensearch.ml.common.transport.model.MLModelGetResponse;
 import org.opensearch.ml.common.transport.model.MLModelSearchAction;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetAction;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetRequest;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 import org.opensearch.ml.common.transport.register.MLRegisterModelAction;
@@ -384,6 +388,12 @@ public class MLCommonsIntegTestCase extends OpenSearchIntegTestCase {
         MLModelGetRequest getRequest = new MLModelGetRequest(modelId, false);
         MLModelGetResponse response = client().execute(MLModelGetAction.INSTANCE, getRequest).actionGet(5000);
         return response.getMlModel();
+    }
+
+    public MLModelGroup getModelGroup(String modelGroupId) {
+        MLModelGroupGetRequest getRequest = new MLModelGroupGetRequest(modelGroupId);
+        MLModelGroupGetResponse response = client().execute(MLModelGroupGetAction.INSTANCE, getRequest).actionGet(5000);
+        return response.getMlModelGroup();
     }
 
     public SearchResponse searchModelChunks(String modelId) {

--- a/plugin/src/test/java/org/opensearch/ml/action/model_group/GetModelGroupITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/model_group/GetModelGroupITTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.model_group;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ml.action.MLCommonsIntegTestCase;
+import org.opensearch.ml.common.MLModelGroup;
+import org.opensearch.ml.common.exception.MLResourceNotFoundException;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
+public class GetModelGroupITTests extends MLCommonsIntegTestCase {
+    private String irisIndexName;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    private String modelGroupId;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Ignore
+    public void testGetModel_IndexNotFound() {
+        exceptionRule.expect(MLResourceNotFoundException.class);
+        MLModelGroup modelGroup = getModelGroup("test_id");
+    }
+
+    public void testGetModel_NullModelIdException() {
+        exceptionRule.expect(ActionRequestValidationException.class);
+        MLModelGroup modelGroup = getModelGroup(null);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/model_group/GetModelGroupTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/model_group/GetModelGroupTransportActionTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.model_group;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.get.GetResult;
+import org.opensearch.ml.common.MLModelGroup;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetRequest;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetResponse;
+import org.opensearch.ml.helper.ModelAccessControlHelper;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+public class GetModelGroupTransportActionTests extends OpenSearchTestCase {
+    @Mock
+    ThreadPool threadPool;
+
+    @Mock
+    Client client;
+
+    @Mock
+    NamedXContentRegistry xContentRegistry;
+
+    @Mock
+    TransportService transportService;
+
+    @Mock
+    ActionFilters actionFilters;
+
+    @Mock
+    ActionListener<MLModelGroupGetResponse> actionListener;
+
+    @Mock
+    ClusterService clusterService;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    GetModelGroupTransportAction getModelGroupTransportAction;
+    MLModelGroupGetRequest mlModelGroupGetRequest;
+    ThreadContext threadContext;
+
+    @Mock
+    private ModelAccessControlHelper modelAccessControlHelper;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.openMocks(this);
+        mlModelGroupGetRequest = MLModelGroupGetRequest.builder().modelGroupId("test_id").build();
+        Settings settings = Settings.builder().build();
+
+        getModelGroupTransportAction = spy(
+            new GetModelGroupTransportAction(
+                transportService,
+                actionFilters,
+                client,
+                xContentRegistry,
+                clusterService,
+                modelAccessControlHelper
+            )
+        );
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(3);
+            listener.onResponse(true);
+            return null;
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any());
+
+        threadContext = new ThreadContext(settings);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+    }
+
+    public void test_Success() throws IOException {
+
+        GetResponse getResponse = prepareMLModelGroup();
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, actionListener);
+        ArgumentCaptor<MLModelGroupGetResponse> argumentCaptor = ArgumentCaptor.forClass(MLModelGroupGetResponse.class);
+        verify(actionListener).onResponse(argumentCaptor.capture());
+    }
+
+    public void testGetModel_UserHasNoAccess() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(3);
+            listener.onResponse(false);
+            return null;
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any());
+
+        GetResponse getResponse = prepareMLModelGroup();
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("User doesn't have privilege to perform this operation on this model group", argumentCaptor.getValue().getMessage());
+    }
+
+    public void testGetModel_ValidateAccessFailed() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(3);
+            listener.onFailure(new Exception("Failed to validate access"));
+            return null;
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any());
+
+        GetResponse getResponse = prepareMLModelGroup();
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Failed to validate access", argumentCaptor.getValue().getMessage());
+    }
+
+    public void testGetModel_NullResponse() {
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(null);
+            return null;
+        }).when(client).get(any(), any());
+        getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Failed to find model group with the provided model group id: test_id", argumentCaptor.getValue().getMessage());
+    }
+
+    public void testGetModel_IndexNotFoundException() {
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new IndexNotFoundException("Fail to find model group index"));
+            return null;
+        }).when(client).get(any(), any());
+        getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Fail to find model group index", argumentCaptor.getValue().getMessage());
+    }
+
+    public void testGetModel_RuntimeException() {
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException("errorMessage"));
+            return null;
+        }).when(client).get(any(), any());
+        getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("errorMessage", argumentCaptor.getValue().getMessage());
+    }
+
+    public GetResponse prepareMLModelGroup() throws IOException {
+        MLModelGroup mlModelGroup = MLModelGroup
+            .builder()
+            .modelGroupId("test_id")
+            .name("modelGroup")
+            .description("this is an example description")
+            .latestVersion(1)
+            .access("private")
+            .build();
+        XContentBuilder content = mlModelGroup.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
+        BytesReference bytesReference = BytesReference.bytes(content);
+        GetResult getResult = new GetResult("indexName", "111", 111l, 111l, 111l, true, bytesReference, null, null);
+        GetResponse getResponse = new GetResponse(getResult);
+        return getResponse;
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+<<<<<<< HEAD
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
@@ -47,6 +48,25 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.util.EntityUtils;
+=======
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.apache.hc.core5.util.Timeout;
+>>>>>>> 500fff9e (Get model group API (#1670))
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.client.Request;
@@ -704,6 +724,11 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
 
     public void deleteModelGroup(RestClient client, String modelGroupId, Consumer<Map<String, Object>> function) throws IOException {
         Response response = TestHelper.makeRequest(client, "DELETE", "/_plugins/_ml/model_groups/" + modelGroupId, null, "", null);
+        verifyResponse(function, response);
+    }
+
+    public void getModelGroup(RestClient client, String modelIGroupd, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "GET", "/_plugins/_ml/model_groups/" + modelIGroupd, null, "", null);
         verifyResponse(function, response);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLModelGroupRestIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLModelGroupRestIT.java
@@ -1212,4 +1212,144 @@ public class MLModelGroupRestIT extends MLCommonsRestTestCase {
         }
     }
 
+    public void test_get_modelGroup() throws IOException {
+        mlRegisterModelGroupInput = createRegisterModelGroupInput("testModelGroup1", Arrays.asList("IT"), AccessMode.RESTRICTED, null);
+        registerModelGroup(user1Client, TestHelper.toJsonString(mlRegisterModelGroupInput), registerModelGroupResult -> {
+            String modelGroupId1 = (String) registerModelGroupResult.get("model_group_id");
+            assertTrue(registerModelGroupResult.containsKey("model_group_id"));
+            try {
+                // User2 successfully gets model group since user2 has IT backend role
+                getModelGroup(
+                    user2Client,
+                    modelGroupId1,
+                    getModelGroupResult -> { assertTrue(getModelGroupResult.containsKey("model_group_id")); }
+                );
+
+                // Admin successfully gets model group
+                getModelGroup(
+                    client(),
+                    modelGroupId1,
+                    getModelGroupResult -> { assertTrue(getModelGroupResult.containsKey("model_group_id")); }
+                );
+            } catch (IOException e) {
+                assertNull(e);
+            }
+            // User2 fails to get model group
+            try {
+                getModelGroup(user3Client, modelGroupId, null);
+            } catch (Exception e) {
+                assertEquals(ResponseException.class, e.getClass());
+                assertTrue(
+                    Throwables
+                        .getStackTraceAsString(e)
+                        .contains("User doesn't have privilege to perform this operation on this model group")
+                );
+            }
+        });
+
+        mlRegisterModelGroupInput = createRegisterModelGroupInput("testModelGroup2", null, AccessMode.PUBLIC, null);
+        registerModelGroup(user2Client, TestHelper.toJsonString(mlRegisterModelGroupInput), registerModelGroupResult -> {
+            String modelGroupId2 = (String) registerModelGroupResult.get("model_group_id");
+            assertTrue(registerModelGroupResult.containsKey("model_group_id"));
+            try {
+                // User1 successfully gets model group since user2 has IT backend role
+                getModelGroup(
+                    user1Client,
+                    modelGroupId2,
+                    getModelGroupResult -> { assertTrue(getModelGroupResult.containsKey("model_group_id")); }
+                );
+
+                // User3 successfully gets model group
+                getModelGroup(
+                    user3Client,
+                    modelGroupId2,
+                    getModelGroupResult -> { assertTrue(getModelGroupResult.containsKey("model_group_id")); }
+                );
+
+                // User4 successfully gets model group
+                getModelGroup(
+                    user4Client,
+                    modelGroupId2,
+                    getModelGroupResult -> { assertTrue(getModelGroupResult.containsKey("model_group_id")); }
+                );
+            } catch (IOException e) {
+                assertNull(e);
+            }
+        });
+
+        mlRegisterModelGroupInput = createRegisterModelGroupInput("testModelGroup3", null, AccessMode.PRIVATE, null);
+        registerModelGroup(user3Client, TestHelper.toJsonString(mlRegisterModelGroupInput), registerModelGroupResult -> {
+            String modelGroupId3 = (String) registerModelGroupResult.get("model_group_id");
+            assertTrue(registerModelGroupResult.containsKey("model_group_id"));
+            try {
+                // User3 successfully gets model group since user2 has IT backend role
+                getModelGroup(
+                    user3Client,
+                    modelGroupId3,
+                    getModelGroupResult -> { assertTrue(getModelGroupResult.containsKey("model_group_id")); }
+                );
+
+                // Admin successfully gets model group
+                getModelGroup(
+                    client(),
+                    modelGroupId3,
+                    getModelGroupResult -> { assertTrue(getModelGroupResult.containsKey("model_group_id")); }
+                );
+            } catch (IOException e) {
+                assertNull(e);
+            }
+            // User2 fails to get model group
+            try {
+                getModelGroup(user2Client, modelGroupId3, null);
+            } catch (Exception e) {
+                assertEquals(ResponseException.class, e.getClass());
+                assertTrue(
+                    Throwables
+                        .getStackTraceAsString(e)
+                        .contains("User doesn't have privilege to perform this operation on this model group")
+                );
+            }
+        });
+
+        mlRegisterModelGroupInput = createRegisterModelGroupInput("testModelGroup4", null, null, null);
+        registerModelGroup(client(), TestHelper.toJsonString(mlRegisterModelGroupInput), registerModelGroupResult -> {
+            String modelGroupId4 = (String) registerModelGroupResult.get("model_group_id");
+            assertTrue(registerModelGroupResult.containsKey("model_group_id"));
+            try {
+                // Admin successfully gets model group
+                getModelGroup(
+                    client(),
+                    modelGroupId4,
+                    getModelGroupResult -> { assertTrue(getModelGroupResult.containsKey("model_group_id")); }
+                );
+            } catch (IOException e) {
+                assertNull(e);
+            }
+
+            // User1 fails to get model group
+            try {
+                getModelGroup(user1Client, modelGroupId4, null);
+            } catch (Exception e) {
+                assertEquals(ResponseException.class, e.getClass());
+                assertTrue(
+                    Throwables
+                        .getStackTraceAsString(e)
+                        .contains("User doesn't have privilege to perform this operation on this model group")
+                );
+            }
+
+            // User2 fails to get model group
+            try {
+                getModelGroup(user2Client, modelGroupId4, null);
+            } catch (Exception e) {
+                assertEquals(ResponseException.class, e.getClass());
+                assertTrue(
+                    Throwables
+                        .getStackTraceAsString(e)
+                        .contains("User doesn't have privilege to perform this operation on this model group")
+                );
+            }
+        });
+    }
+
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelGroupActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelGroupActionIT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.hc.core5.http.HttpEntity;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.utils.TestHelper;
+
+public class RestMLGetModelGroupActionIT extends MLCommonsRestTestCase {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    public void testGetModelAPI_EmptyResources() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("Fail to find model group index");
+        TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/model_groups/111222333", null, "", null);
+    }
+
+    @Ignore
+    public void testGetModelAPI_Success() throws IOException {
+        Response trainModelResponse = ingestModelData();
+        HttpEntity entity = trainModelResponse.getEntity();
+        assertNotNull(trainModelResponse);
+        String entityString = TestHelper.httpEntityToString(entity);
+        Map map = gson.fromJson(entityString, Map.class);
+        String model_group_id = (String) map.get("model_group_id");
+
+        Response getModelResponse = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/models/" + model_group_id, null, "", null);
+        assertNotNull(getModelResponse);
+        assertEquals(RestStatus.OK, TestHelper.restStatus(getModelResponse));
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelGroupActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetModelGroupActionTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_GROUP_ID;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetAction;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetRequest;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupGetResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+public class RestMLGetModelGroupActionTests extends OpenSearchTestCase {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private RestMLGetModelGroupAction restMLGetModelGroupAction;
+
+    NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
+    @Before
+    public void setup() {
+        restMLGetModelGroupAction = new RestMLGetModelGroupAction();
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelGroupGetResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLModelGroupGetAction.INSTANCE), any(), any());
+
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
+    }
+
+    public void testConstructor() {
+        RestMLGetModelAction mlGetModelAction = new RestMLGetModelAction();
+        assertNotNull(mlGetModelAction);
+    }
+
+    public void testGetName() {
+        String actionName = restMLGetModelGroupAction.getName();
+        assertFalse(Strings.isNullOrEmpty(actionName));
+        assertEquals("ml_get_model_group_action", actionName);
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = restMLGetModelGroupAction.routes();
+        assertNotNull(routes);
+        assertFalse(routes.isEmpty());
+        RestHandler.Route route = routes.get(0);
+        assertEquals(RestRequest.Method.GET, route.getMethod());
+        assertEquals("/_plugins/_ml/model_groups/{model_group_id}", route.getPath());
+    }
+
+    public void test_PrepareRequest() throws Exception {
+        RestRequest request = getRestRequest();
+        restMLGetModelGroupAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLModelGroupGetRequest> argumentCaptor = ArgumentCaptor.forClass(MLModelGroupGetRequest.class);
+        verify(client, times(1)).execute(eq(MLModelGroupGetAction.INSTANCE), argumentCaptor.capture(), any());
+        String taskId = argumentCaptor.getValue().getModelGroupId();
+        assertEquals(taskId, "test_id");
+    }
+
+    private RestRequest getRestRequest() {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MODEL_GROUP_ID, "test_id");
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).build();
+        return request;
+    }
+}


### PR DESCRIPTION
### Description
Backport to 2.x: Get model group API (https://github.com/opensearch-project/ml-commons/pull/1670)
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
