### PR TITLE
Update Lombok and Gradle plugins to support JDK-21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ buildscript {
 plugins {
     id 'com.netflix.nebula.ospackage' version "11.5.0"
     id 'java'
-    id "io.freefair.lombok" version "8.0.1"
+    id "io.freefair.lombok" version "8.4"
     id 'jacoco'
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'jacoco'
     id 'com.github.johnrengelman.shadow'
     id 'maven-publish'
-    id 'com.diffplug.spotless' version '6.18.0'
+    id 'com.diffplug.spotless' version '6.23.0'
     id 'signing'
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 lombok {
-    version = "1.18.28"
+    version = "1.18.30"
 }
 
 jacocoTestReport {

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id "io.freefair.lombok"
-    id 'com.diffplug.spotless' version '6.18.0'
+    id 'com.diffplug.spotless' version '6.23.0'
 }
 
 dependencies {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id "io.freefair.lombok"
-    id 'com.diffplug.spotless' version '6.18.0'
+    id 'com.diffplug.spotless' version '6.23.0'
 }
 
 repositories {
@@ -68,7 +68,7 @@ dependencies {
 }
 
 lombok {
-    version = "1.18.28"
+    version = "1.18.30"
 }
 
 configurations.all {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -13,7 +13,7 @@ plugins {
     id "io.freefair.lombok"
     id 'jacoco'
     id 'java-library'
-    id 'com.diffplug.spotless' version '6.18.0'
+    id 'com.diffplug.spotless' version '6.23.0'
     id 'checkstyle'
 }
 
@@ -36,7 +36,7 @@ checkstyle {
 }
 
 lombok {
-    version = "1.18.28"
+    version = "1.18.30"
 }
 
 opensearchplugin {

--- a/search-processors/build.gradle
+++ b/search-processors/build.gradle
@@ -19,7 +19,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id "io.freefair.lombok"
-    id 'com.diffplug.spotless' version '6.18.0'
+    id 'com.diffplug.spotless' version '6.23.0'
 }
 
 repositories {


### PR DESCRIPTION
### Description
Update Lombok and Gradle plugins to support JDK-21
 
### Issues Resolved
```
> java.lang.NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid'
```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
