### PR TITLE
[WIP] Implement search monitors tool

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/CatIndexTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/CatIndexTool.java
@@ -98,7 +98,7 @@ public class CatIndexTool implements Tool {
         final String[] indices = indexList.toArray(Strings.EMPTY_ARRAY);
 
         final IndicesOptions indicesOptions = IndicesOptions.strictExpand();
-        final boolean local = parameters.containsKey("local") ? Boolean.parseBoolean("local") : false;
+        final boolean local = parameters.containsKey("local") ? Boolean.parseBoolean(parameters.get("local")) : false;
         final TimeValue clusterManagerNodeTimeout = DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
         final boolean includeUnloadedSegments = parameters.containsKey("include_unloaded_segments")
             ? Boolean.parseBoolean(parameters.get("include_unloaded_segments"))

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchMonitorsTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchMonitorsTool.java
@@ -26,6 +26,7 @@ import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.spi.tools.Parser;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
+import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortOrder;
 
@@ -132,7 +133,16 @@ public class SearchMonitorsTool implements Tool {
             // stringify the response, may change to a standard format in the future
             ActionListener<SearchResponse> searchMonitorListener = ActionListener.<SearchResponse>wrap(response -> {
                 StringBuilder sb = new StringBuilder();
-                sb.append("Response placeholder");
+                SearchHit[] hits = response.getHits().getHits();
+                sb.append("Monitors=[");
+                for (SearchHit hit : hits) {
+                    sb.append("{");
+                    sb.append("id=").append(hit.getId()).append(",");
+                    sb.append("name=").append(hit.getSourceAsMap().get("name"));
+                    sb.append("}");
+                }
+                sb.append("]");
+                sb.append("TotalMonitors=").append(response.getHits().getTotalHits().value);
                 listener.onResponse((T) sb.toString());
             }, e -> { listener.onFailure(e); });
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchMonitorsTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchMonitorsTool.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.spi.tools.Parser;
+import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.ml.common.spi.tools.ToolAnnotation;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@ToolAnnotation(SearchMonitorsTool.TYPE)
+public class SearchMonitorsTool implements Tool {
+    public static final String TYPE = "SearchMonitorsTool";
+    private static final String DEFAULT_DESCRIPTION = "Use this tool to search alerting monitors.";
+
+    @Setter
+    @Getter
+    private String name = TYPE;
+    @Getter
+    @Setter
+    private String description = DEFAULT_DESCRIPTION;
+    @Getter
+    private String type;
+    @Getter
+    private String version;
+
+    private Client client;
+    @Setter
+    private Parser<?, ?> inputParser;
+    @Setter
+    private Parser<?, ?> outputParser;
+
+    public SearchMonitorsTool(Client client) {
+        this.client = client;
+
+        // probably keep this overridden output parser. need to ensure the output matches what's expected
+        outputParser = new Parser<>() {
+            @Override
+            public Object parse(Object o) {
+                @SuppressWarnings("unchecked")
+                List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
+                return mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap().get("response");
+            }
+        };
+    }
+
+    @Override
+    public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
+        final String monitorName = parameters.getOrDefault("monitorName", null);
+
+        // generate the search request based on parameters
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(new MatchQueryBuilder("monitor.name", monitorName));
+
+        SearchRequest searchRequest = new SearchRequest().source(searchSourceBuilder);
+
+        /// SearchMonitorRequest searchMonitorRequest = new SearchMonitorRequest(searchRequest);
+
+        // create response listener
+        // stringify the response, may change to a standard format in the future
+        ActionListener<SearchResponse> searchMonitorsListener = ActionListener.<SearchResponse>wrap(response -> {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Response placeholder");
+            listener.onResponse((T) sb.toString());
+        }, e -> { listener.onFailure(e); });
+
+        // execute the search
+        // AlertingPluginInterface.INSTANCE.searchMonitors((NodeClient) client, searchMonitorsRequest, searchMonitorsListener);
+    }
+
+    @Override
+    public boolean validate(Map<String, String> parameters) {
+        return true;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    /**
+     * Factory for the {@link SearchAlertsTool}
+     */
+    public static class Factory implements Tool.Factory<SearchAlertsTool> {
+        private Client client;
+
+        private static Factory INSTANCE;
+
+        /** 
+         * Create or return the singleton factory instance
+         */
+        public static Factory getInstance() {
+            if (INSTANCE != null) {
+                return INSTANCE;
+            }
+            synchronized (SearchAlertsTool.class) {
+                if (INSTANCE != null) {
+                    return INSTANCE;
+                }
+                INSTANCE = new Factory();
+                return INSTANCE;
+            }
+        }
+
+        /**
+         * Initialize this factory
+         * @param client The OpenSearch client
+         */
+        public void init(Client client) {
+            this.client = client;
+        }
+
+        @Override
+        public SearchAlertsTool create(Map<String, Object> map) {
+            return new SearchAlertsTool(client);
+        }
+
+        @Override
+        public String getDefaultDescription() {
+            return DEFAULT_DESCRIPTION;
+        }
+    }
+
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchMonitorsToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchMonitorsToolTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.ActionType;
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.ClusterAdminClient;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.commons.alerting.action.GetAlertsResponse;
+import org.opensearch.commons.alerting.model.Alert;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.spi.tools.Tool;
+
+public class SearchMonitorsToolTests {
+    @Mock
+    private NodeClient nodeClient;
+    @Mock
+    private AdminClient adminClient;
+    @Mock
+    private IndicesAdminClient indicesAdminClient;
+    @Mock
+    private ClusterAdminClient clusterAdminClient;
+
+    private Map<String, String> nullParams;
+    private Map<String, String> emptyParams;
+    private Map<String, String> nonEmptyParams;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        SearchMonitorsTool.Factory.getInstance().init(nodeClient);
+
+        nullParams = null;
+        emptyParams = Collections.emptyMap();
+        nonEmptyParams = Map.of("monitorName", "foo");
+    }
+
+    // TODO: add tests to trigger run() with different param values
+
+    @Test
+    public void testValidate() {
+        Tool tool = SearchMonitorsTool.Factory.getInstance().create(Collections.emptyMap());
+        assertEquals(SearchMonitorsTool.TYPE, tool.getType());
+        assertTrue(tool.validate(emptyParams));
+        assertTrue(tool.validate(nonEmptyParams));
+        assertTrue(tool.validate(nullParams));
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchMonitorsToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchMonitorsToolTests.java
@@ -65,8 +65,6 @@ public class SearchMonitorsToolTests {
 
     @Test
     public void testRunWithNoMonitors() throws Exception {
-        final String monitorName = "monitor-1";
-        final String monitorId = "monitor-1-id";
         Tool tool = SearchMonitorsTool.Factory.getInstance().create(Collections.emptyMap());
 
         SearchHit[] hits = new SearchHit[0];
@@ -100,11 +98,27 @@ public class SearchMonitorsToolTests {
         assertEquals(expectedResponseStr, responseCaptor.getValue());
     }
 
+    // TODO: add tests to exercise get monitor action vs. search monitor action
+
     @Test
-    public void testRunWitSingleMonitor() throws Exception {
+    public void testRunWithSingleMonitor() throws Exception {
         final String monitorName = "monitor-1";
         final String monitorId = "monitor-1-id";
         Tool tool = SearchMonitorsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        // TODO: explore more detailed monitor response. IndexMonitorRequest translates to a PUT request
+        // to the system index, and is the same result as what's returned by the search response in search monitors API.
+        // explore converting the response to this to test it
+
+        // IndexMonitorRequest indexedMonitor = new IndexMonitorRequest(
+        // "1234",
+        // 1L,
+        // 2L,
+        // WriteRequest.RefreshPolicy.IMMEDIATE,
+        // RestRequest.Method.POST,
+        // // randomQueryLevelMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder())));
+        // randomQueryLevelMonitor()
+        // );
 
         XContentBuilder content = XContentBuilder.builder(XContentType.JSON.xContent());
         content.startObject();


### PR DESCRIPTION
### Description
Adds a search monitors tool. Utilizes the added `getMonitor()` & `searchMonitors()`  fns exposed by the alerting interface in common utils. These were refactored from the alerting plugin -> common utils plugin. See related PRs for details:
https://github.com/opensearch-project/common-utils/pull/566
https://github.com/opensearch-project/alerting/pull/1305

Based on the passed parameters, the tool will execute either the get monitor transport action, or search monitors transport action. The get monitor action is straightforward, and just takes in a monitor ID. The search monitors action takes in DSL to query the system index containing the monitor info. The tool handles the query generation logic to prevent the agent from generating it, which would likely be error prone and need advanced prompt engineering. Various params (all optional) are available to pass to the tool's `run()` function to generate a query (see [here](https://github.com/opensearch-project/ml-commons/issues/1545#issuecomment-1828563626) for an example generated query).

The amount of parameters and/or the default values may be changed later on depending on agent performance and accuracy. For example, too much parameter tuning may lead to messy or invalid results.

Additionally, further integration testing will need to be done to validate different alerting-related questions input to the agent that will have this tool associated to it. 
 
### Issues Resolved
#1545
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
