### PR TITLE
add updated_time in conversation meta index and update transport actions

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/conversation/ConversationMeta.java
+++ b/common/src/main/java/org/opensearch/ml/common/conversation/ConversationMeta.java
@@ -44,6 +44,8 @@ public class ConversationMeta implements Writeable, ToXContentObject {
     @Getter
     private Instant createdTime;
     @Getter
+    private Instant updatedTime;
+    @Getter
     private String name;
     @Getter
     private String user;
@@ -66,9 +68,10 @@ public class ConversationMeta implements Writeable, ToXContentObject {
      */
     public static ConversationMeta fromMap(String id, Map<String, Object> docFields) {
         Instant created = Instant.parse((String) docFields.get(ConversationalIndexConstants.META_CREATED_FIELD));
+        Instant updated = Instant.parse((String) docFields.get(ConversationalIndexConstants.META_UPDATED_FIELD));
         String name = (String) docFields.get(ConversationalIndexConstants.META_NAME_FIELD);
         String user = (String) docFields.get(ConversationalIndexConstants.USER_FIELD);
-        return new ConversationMeta(id, created, name, user);
+        return new ConversationMeta(id, created, updated, name, user);
     }
 
     /**
@@ -81,15 +84,17 @@ public class ConversationMeta implements Writeable, ToXContentObject {
     public static ConversationMeta fromStream(StreamInput in) throws IOException {
         String id = in.readString();
         Instant created = in.readInstant();
+        Instant updated = in.readInstant();
         String name = in.readString();
         String user = in.readOptionalString();
-        return new ConversationMeta(id, created, name, user);
+        return new ConversationMeta(id, created, updated, name, user);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(id);
         out.writeInstant(createdTime);
+        out.writeInstant(updatedTime);
         out.writeString(name);
         out.writeOptionalString(user);
     }
@@ -104,6 +109,7 @@ public class ConversationMeta implements Writeable, ToXContentObject {
         IndexRequest request = new IndexRequest(index);
         return request.id(this.id).source(
             ConversationalIndexConstants.META_CREATED_FIELD, this.createdTime,
+            ConversationalIndexConstants.META_UPDATED_FIELD, this.createdTime,
             ConversationalIndexConstants.META_NAME_FIELD, this.name
         );
     }
@@ -113,6 +119,7 @@ public class ConversationMeta implements Writeable, ToXContentObject {
         return "{id=" + id
             + ", name=" + name
             + ", created=" + createdTime.toString()
+            + ", updated=" + updatedTime.toString()
             + ", user=" + user
             + "}";
     }
@@ -122,6 +129,7 @@ public class ConversationMeta implements Writeable, ToXContentObject {
         builder.startObject();
         builder.field(ActionConstants.CONVERSATION_ID_FIELD, this.id);
         builder.field(ConversationalIndexConstants.META_CREATED_FIELD, this.createdTime);
+        builder.field(ConversationalIndexConstants.META_UPDATED_FIELD, this.updatedTime);
         builder.field(ConversationalIndexConstants.META_NAME_FIELD, this.name);
         if(this.user != null) {
             builder.field(ConversationalIndexConstants.USER_FIELD, this.user);
@@ -139,6 +147,7 @@ public class ConversationMeta implements Writeable, ToXContentObject {
         return Objects.equals(this.id, otherConversation.id) &&
            Objects.equals(this.user, otherConversation.user) &&
            Objects.equals(this.createdTime, otherConversation.createdTime) &&
+           Objects.equals(this.updatedTime, otherConversation.updatedTime) &&
            Objects.equals(this.name, otherConversation.name);
     }
     

--- a/common/src/main/java/org/opensearch/ml/common/conversation/ConversationalIndexConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/conversation/ConversationalIndexConstants.java
@@ -29,6 +29,8 @@ public class ConversationalIndexConstants {
     public final static String META_INDEX_NAME = ".plugins-ml-memory-meta";
     /** Name of the metadata field for initial timestamp */
     public final static String META_CREATED_FIELD = "create_time";
+    /** Name of the metadata field for updated timestamp */
+    public final static String META_UPDATED_FIELD = "updated_time";
     /** Name of the metadata field for name of the conversation */
     public final static String META_NAME_FIELD = "name";
     /** Name of the owning user field in all indices */
@@ -46,6 +48,9 @@ public class ConversationalIndexConstants {
         + "\": {\"type\": \"keyword\"},\n"
         + "        \""
         + META_CREATED_FIELD
+        + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
+        + "        \""
+        + META_UPDATED_FIELD
         + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
         + "        \""
         + USER_FIELD

--- a/memory/src/main/java/org/opensearch/ml/memory/ConversationalMemoryHandler.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/ConversationalMemoryHandler.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.conversation.ConversationMeta;
@@ -238,4 +239,10 @@ public interface ConversationalMemoryHandler {
      */
     public ActionFuture<SearchResponse> searchInteractions(String conversationId, SearchRequest request);
 
+    /**
+     * Update a conversation
+     * @param updateContent update content for the conversations index
+     * @param listener receives the update response
+     */
+    public void updateConversation(String conversationId, Map<String, Object> updateContent, ActionListener<UpdateResponse> listener);
 }

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/UpdateConversationTransportAction.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/UpdateConversationTransportAction.java
@@ -5,6 +5,9 @@
 
 package org.opensearch.ml.memory.action.conversation;
 
+import java.time.Instant;
+import java.util.Map;
+
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -36,7 +39,10 @@ public class UpdateConversationTransportAction extends HandledTransportAction<Ac
         UpdateConversationRequest updateConversationRequest = UpdateConversationRequest.fromActionRequest(request);
         String conversationId = updateConversationRequest.getConversationId();
         UpdateRequest updateRequest = new UpdateRequest(ConversationalIndexConstants.META_INDEX_NAME, conversationId);
-        updateRequest.doc(updateConversationRequest.getUpdateContent());
+        Map<String, Object> updateContent = updateConversationRequest.getUpdateContent();
+        updateContent.putIfAbsent(ConversationalIndexConstants.META_UPDATED_FIELD, Instant.now());
+
+        updateRequest.doc(updateContent);
         updateRequest.docAsUpsert(true);
 
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {

--- a/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
@@ -37,6 +37,8 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Client;
 import org.opensearch.client.Requests;
 import org.opensearch.cluster.service.ClusterService;
@@ -127,6 +129,8 @@ public class ConversationMetaIndex {
                     .indexRequest(indexName)
                     .source(
                         ConversationalIndexConstants.META_CREATED_FIELD,
+                        Instant.now(),
+                        ConversationalIndexConstants.META_UPDATED_FIELD,
                         Instant.now(),
                         ConversationalIndexConstants.META_NAME_FIELD,
                         name,
@@ -343,6 +347,20 @@ public class ConversationMetaIndex {
                 internalListener.onFailure(e);
             }));
         } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    /**
+     * Update conversations in the index
+     * @param updateRequest original update request
+     * @param listener receives the update response for the wrapped query
+     */
+    public void updateConversation(UpdateRequest updateRequest, ActionListener<UpdateResponse> listener) {
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            client.update(updateRequest, listener);
+        } catch (Exception e) {
+            log.error("Failed to update Conversation. Details {}:", e);
             listener.onFailure(e);
         }
     }

--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -213,7 +213,7 @@ public class InteractionsIndex {
         Instant timestamp,
         ActionListener<String> listener
     ) {
-        createInteraction(conversationId, input, promptTemplate, response, origin, additionalInfo, timestamp, listener, "", null);
+        createInteraction(conversationId, input, promptTemplate, response, origin, additionalInfo, timestamp, listener, null, null);
     }
 
     /**
@@ -235,7 +235,7 @@ public class InteractionsIndex {
         Map<String, String> additionalInfo,
         ActionListener<String> listener
     ) {
-        createInteraction(conversationId, input, promptTemplate, response, origin, additionalInfo, Instant.now(), listener, "", null);
+        createInteraction(conversationId, input, promptTemplate, response, origin, additionalInfo, Instant.now(), listener, null, null);
     }
 
     /**

--- a/memory/src/main/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandler.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandler.java
@@ -25,11 +25,14 @@ import org.opensearch.action.StepListener;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.conversation.ConversationMeta;
+import org.opensearch.ml.common.conversation.ConversationalIndexConstants;
 import org.opensearch.ml.common.conversation.Interaction;
 import org.opensearch.ml.common.conversation.Interaction.InteractionBuilder;
 import org.opensearch.ml.memory.ConversationalMemoryHandler;
@@ -383,4 +386,13 @@ public class OpenSearchConversationalMemoryHandler implements ConversationalMemo
         interactionsIndex.getTraces(interactionId, from, maxResults, listener);
     }
 
+    public void updateConversation(String conversationId, Map<String, Object> updateContent, ActionListener<UpdateResponse> listener) {
+        UpdateRequest updateRequest = new UpdateRequest(ConversationalIndexConstants.META_INDEX_NAME, conversationId);
+        updateContent.putIfAbsent(ConversationalIndexConstants.META_UPDATED_FIELD, Instant.now());
+
+        updateRequest.doc(updateContent);
+        updateRequest.docAsUpsert(true);
+
+        conversationMetaIndex.updateConversation(updateRequest, listener);
+    }
 }

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsResponseTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsResponseTests.java
@@ -46,9 +46,9 @@ public class GetConversationsResponseTests extends OpenSearchTestCase {
     public void setup() {
         conversations = List
             .of(
-                new ConversationMeta("0", Instant.now(), "name0", "user0"),
-                new ConversationMeta("1", Instant.now(), "name1", "user0"),
-                new ConversationMeta("2", Instant.now(), "name2", "user2")
+                new ConversationMeta("0", Instant.now(), Instant.now(), "name0", "user0"),
+                new ConversationMeta("1", Instant.now(), Instant.now(), "name1", "user0"),
+                new ConversationMeta("2", Instant.now(), Instant.now(), "name2", "user2")
             );
     }
 
@@ -75,6 +75,8 @@ public class GetConversationsResponseTests extends OpenSearchTestCase {
         String result = BytesReference.bytes(builder).utf8ToString();
         String expected = "{\"conversations\":[{\"conversation_id\":\"0\",\"create_time\":\""
             + conversation.getCreatedTime()
+            + "\",\"updated_time\":\""
+            + conversation.getCreatedTime()
             + "\",\"name\":\"name0\",\"user\":\"user0\"}],\"next_token\":2}";
         log.info("FINDME");
         log.info(result);
@@ -92,6 +94,8 @@ public class GetConversationsResponseTests extends OpenSearchTestCase {
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         String result = BytesReference.bytes(builder).utf8ToString();
         String expected = "{\"conversations\":[{\"conversation_id\":\"0\",\"create_time\":\""
+            + conversation.getCreatedTime()
+            + "\",\"updated_time\":\""
             + conversation.getCreatedTime()
             + "\",\"name\":\"name0\",\"user\":\"user0\"}]}";
         log.info("FINDME");

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsTransportActionTests.java
@@ -112,8 +112,8 @@ public class GetConversationsTransportActionTests extends OpenSearchTestCase {
         log.info("testing get conversations transport");
         List<ConversationMeta> testResult = List
             .of(
-                new ConversationMeta("testcid1", Instant.now(), "", null),
-                new ConversationMeta("testcid2", Instant.now(), "testname", null)
+                new ConversationMeta("testcid1", Instant.now(), Instant.now(), "", null),
+                new ConversationMeta("testcid2", Instant.now(), Instant.now(), "testname", null)
             );
         doAnswer(invocation -> {
             ActionListener<List<ConversationMeta>> listener = invocation.getArgument(2);
@@ -130,9 +130,9 @@ public class GetConversationsTransportActionTests extends OpenSearchTestCase {
     public void testPagination() {
         List<ConversationMeta> testResult = List
             .of(
-                new ConversationMeta("testcid1", Instant.now(), "", null),
-                new ConversationMeta("testcid2", Instant.now(), "testname", null),
-                new ConversationMeta("testcid3", Instant.now(), "testname", null)
+                new ConversationMeta("testcid1", Instant.now(), Instant.now(), "", null),
+                new ConversationMeta("testcid2", Instant.now(), Instant.now(), "testname", null),
+                new ConversationMeta("testcid3", Instant.now(), Instant.now(), "testname", null)
             );
         doAnswer(invocation -> {
             ActionListener<List<ConversationMeta>> listener = invocation.getArgument(2);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetInteractionsActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetInteractionsActionIT.java
@@ -247,6 +247,7 @@ public class RestMemoryGetInteractionsActionIT extends MLCommonsRestTestCase {
         Map map = gson.fromJson(entityString, Map.class);
         assert (map.containsKey("interaction_id"));
         String iid = (String) map.get("interaction_id");
+        System.out.println("iid is " + iid);
 
         Response response2 = TestHelper
             .makeRequest(
@@ -264,6 +265,7 @@ public class RestMemoryGetInteractionsActionIT extends MLCommonsRestTestCase {
         Map map2 = gson.fromJson(entityString2, Map.class);
         assert (map2.containsKey("interaction_id"));
         String iid2 = (String) map2.get("interaction_id");
+        System.out.println("iid2 is " + iid2);
 
         Response response1 = TestHelper
             .makeRequest(
@@ -284,6 +286,9 @@ public class RestMemoryGetInteractionsActionIT extends MLCommonsRestTestCase {
         assert (((ArrayList) map1.get("interactions")).size() == 1);
         @SuppressWarnings("unchecked")
         ArrayList<Map> interactions = (ArrayList<Map>) map1.get("interactions");
+        System.out.println("interaction_id is " + ((String) interactions.get(0).get("interaction_id")));
+        System.out.println("iid2 is " + iid2);
+        System.out.println("iid is " + iid);
         assert (((String) interactions.get(0).get("interaction_id")).equals(iid2));
         assert (((Double) map1.get("next_token")).intValue() == 1);
 


### PR DESCRIPTION
### Description
Add updated_time field in the Memory meta index. The updated_time will be updated when creating a new conversation, updating a conversation and creating a new interaction for the conversation. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
