### PR TITLE
change conversation meta name mapping to text to allow keyword search

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/conversation/ConversationalIndexConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/conversation/ConversationalIndexConstants.java
@@ -45,7 +45,7 @@ public class ConversationalIndexConstants {
         + "    \"properties\": {\n"
         + "        \""
         + META_NAME_FIELD
-        + "\": {\"type\": \"keyword\"},\n"
+        + "\": {\"type\": \"text\"},\n"
         + "        \""
         + META_CREATED_FIELD
         + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"


### PR DESCRIPTION
### Description
Update the mapping of conversation meta from keyword to text.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
