### PR TITLE
use DSEC order for the interaction history in chat agent

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/MLMemoryManager.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/MLMemoryManager.java
@@ -176,14 +176,14 @@ public class MLMemoryManager {
         searchRequest.source(searchSourceBuilder);
 
         searchRequest.source().size(lastNInteraction);
-        searchRequest.source().sort(ConversationalIndexConstants.INTERACTIONS_CREATE_TIME_FIELD, SortOrder.ASC);
+        searchRequest.source().sort(ConversationalIndexConstants.INTERACTIONS_CREATE_TIME_FIELD, SortOrder.DESC);
 
         try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<List<Interaction>> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());
             ActionListener<SearchResponse> al = ActionListener.wrap(response -> {
                 List<Interaction> result = new LinkedList<Interaction>();
                 for (SearchHit hit : response.getHits()) {
-                    result.add(Interaction.fromSearchHit(hit));
+                    result.add(0, Interaction.fromSearchHit(hit));
                 }
                 internalListener.onResponse(result);
             }, e -> { internalListener.onFailure(e); });


### PR DESCRIPTION
### Description
Unlike the list interactions in the transport layer, the list interactions in the memory Manager needs to return the latest N records from latest to oldest.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
