### PR TITLE
Add Undeploy Models to MLClient

### DIFF
--- a/client/src/main/java/org/opensearch/ml/client/MachineLearningClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MachineLearningClient.java
@@ -12,6 +12,7 @@ import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.MLModel;
@@ -28,6 +29,7 @@ import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupResponse;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
+import org.opensearch.ml.common.transport.undeploy.MLUndeployModelsResponse;
 
 /**
  * A client to provide interfaces for machine learning jobs. This will be used by other plugins.
@@ -255,7 +257,7 @@ public interface MachineLearningClient {
 
     /**
      * Deploy model
-     * For additional info on deploy, refer: https://opensearch.org/docs/latest/ml-commons-plugin/api/#deploying-a-model
+     * For additional info on deploy, refer: https://opensearch.org/docs/latest/ml-commons-plugin/api/model-apis/deploy-model/
      * @param modelId the model id
      */
     default ActionFuture<MLDeployModelResponse> deploy(String modelId) {
@@ -266,11 +268,32 @@ public interface MachineLearningClient {
 
     /**
      * Deploy model
-     * For additional info on deploy, refer: https://opensearch.org/docs/latest/ml-commons-plugin/api/#deploying-a-model
+     * For additional info on deploy, refer: https://opensearch.org/docs/latest/ml-commons-plugin/api/model-apis/deploy-model/
      * @param modelId the model id
      * @param listener a listener to be notified of the result
      */
     void deploy(String modelId, ActionListener<MLDeployModelResponse> listener);
+
+    /**
+     * Undeploy models
+     * For additional info on undeploy, refer: https://opensearch.org/docs/latest/ml-commons-plugin/api/model-apis/undeploy-model/
+     * @param modelIds the model ids
+     * @param nodeIds the node ids. May be null for all nodes.
+     */
+    default ActionFuture<MLUndeployModelsResponse> undeploy(String[] modelIds, @Nullable String[] nodeIds) {
+        PlainActionFuture<MLUndeployModelsResponse> actionFuture = PlainActionFuture.newFuture();
+        undeploy(modelIds, nodeIds, actionFuture);
+        return actionFuture;
+    }
+
+    /**
+     * Undeploy model
+     * For additional info on deploy, refer: https://opensearch.org/docs/latest/ml-commons-plugin/api/model-apis/undeploy-model/
+     * @param modelIds the model ids
+     * @param modelIds the node ids. May be null for all nodes.
+     * @param listener a listener to be notified of the result
+     */
+    void undeploy(String[] modelIds, String[] nodeIds, ActionListener<MLUndeployModelsResponse> listener);
 
     /**
      * Create connector for remote model

--- a/client/src/main/java/org/opensearch/ml/client/MachineLearningNodeClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MachineLearningNodeClient.java
@@ -76,6 +76,9 @@ import org.opensearch.ml.common.transport.tools.MLToolsListResponse;
 import org.opensearch.ml.common.transport.training.MLTrainingTaskAction;
 import org.opensearch.ml.common.transport.training.MLTrainingTaskRequest;
 import org.opensearch.ml.common.transport.trainpredict.MLTrainAndPredictionTaskAction;
+import org.opensearch.ml.common.transport.undeploy.MLUndeployModelsAction;
+import org.opensearch.ml.common.transport.undeploy.MLUndeployModelsRequest;
+import org.opensearch.ml.common.transport.undeploy.MLUndeployModelsResponse;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -240,6 +243,12 @@ public class MachineLearningNodeClient implements MachineLearningClient {
     }
 
     @Override
+    public void undeploy(String[] modelIds, String[] nodeIds, ActionListener<MLUndeployModelsResponse> listener) {
+        MLUndeployModelsRequest undeployModelRequest = new MLUndeployModelsRequest(modelIds, nodeIds);
+        client.execute(MLUndeployModelsAction.INSTANCE, undeployModelRequest, getMlUndeployModelsResponseActionListener(listener));
+    }
+
+    @Override
     public void createConnector(MLCreateConnectorInput mlCreateConnectorInput, ActionListener<MLCreateConnectorResponse> listener) {
         MLCreateConnectorRequest createConnectorRequest = new MLCreateConnectorRequest(mlCreateConnectorInput);
         client.execute(MLCreateConnectorAction.INSTANCE, createConnectorRequest, getMlCreateConnectorResponseActionListener(listener));
@@ -318,6 +327,16 @@ public class MachineLearningNodeClient implements MachineLearningClient {
     private ActionListener<MLDeployModelResponse> getMlDeployModelResponseActionListener(ActionListener<MLDeployModelResponse> listener) {
         ActionListener<MLDeployModelResponse> actionListener = wrapActionListener(listener, response -> {
             MLDeployModelResponse deployModelResponse = MLDeployModelResponse.fromActionResponse(response);
+            return deployModelResponse;
+        });
+        return actionListener;
+    }
+
+    private ActionListener<MLUndeployModelsResponse> getMlUndeployModelsResponseActionListener(
+        ActionListener<MLUndeployModelsResponse> listener
+    ) {
+        ActionListener<MLUndeployModelsResponse> actionListener = wrapActionListener(listener, response -> {
+            MLUndeployModelsResponse deployModelResponse = MLUndeployModelsResponse.fromActionResponse(response);
             return deployModelResponse;
         });
         return actionListener;

--- a/client/src/test/java/org/opensearch/ml/client/MachineLearningClientTest.java
+++ b/client/src/test/java/org/opensearch/ml/client/MachineLearningClientTest.java
@@ -49,6 +49,7 @@ import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupResponse;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelResponse;
+import org.opensearch.ml.common.transport.undeploy.MLUndeployModelsResponse;
 
 public class MachineLearningClientTest {
 
@@ -77,6 +78,9 @@ public class MachineLearningClientTest {
 
     @Mock
     MLDeployModelResponse deployModelResponse;
+
+    @Mock
+    MLUndeployModelsResponse undeployModelsResponse;
 
     @Mock
     MLCreateConnectorResponse createConnectorResponse;
@@ -160,6 +164,11 @@ public class MachineLearningClientTest {
             @Override
             public void deploy(String modelId, ActionListener<MLDeployModelResponse> listener) {
                 listener.onResponse(deployModelResponse);
+            }
+
+            @Override
+            public void undeploy(String[] modelIds, String[] nodeIds, ActionListener<MLUndeployModelsResponse> listener) {
+                listener.onResponse(undeployModelsResponse);
             }
 
             @Override
@@ -356,6 +365,11 @@ public class MachineLearningClientTest {
     @Test
     public void deploy() {
         assertEquals(deployModelResponse, machineLearningClient.deploy("modelId").actionGet());
+    }
+
+    @Test
+    public void undeploy() {
+        assertEquals(undeployModelsResponse, machineLearningClient.undeploy(new String[] { "modelId" }, null).actionGet());
     }
 
     @Test

--- a/common/src/main/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelsResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelsResponse.java
@@ -7,12 +7,16 @@ package org.opensearch.ml.common.transport.undeploy;
 
 import lombok.Getter;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
-
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 @Getter
 public class MLUndeployModelsResponse extends ActionResponse implements ToXContentObject {
@@ -48,5 +52,21 @@ public class MLUndeployModelsResponse extends ActionResponse implements ToXConte
             builder.endObject();
         }
         return builder;
+    }
+    
+    public static MLUndeployModelsResponse fromActionResponse(ActionResponse actionResponse) {
+        if (actionResponse instanceof MLUndeployModelsResponse) {
+            return (MLUndeployModelsResponse) actionResponse;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionResponse.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLUndeployModelsResponse(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionResponse into MLUndeployModelsResponse", e);
+        }
     }
 }


### PR DESCRIPTION
### Description

Adds `undeploy()` method to MLClient, invoking undeploy models API
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
