### PR TITLE
Fix sort on get trace API and flaky test of conversation

### DIFF
--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -337,7 +337,10 @@ public class InteractionsIndex {
 
         request.source(searchSourceBuilder);
         request.source().from(from).size(maxResults);
-        request.source().sort(ConversationalIndexConstants.INTERACTIONS_CREATE_TIME_FIELD, SortOrder.ASC);
+        request
+            .source()
+            .sort(ConversationalIndexConstants.INTERACTIONS_CREATE_TIME_FIELD, SortOrder.ASC)
+            .sort(ConversationalIndexConstants.INTERACTIONS_TRACE_NUMBER_FIELD, SortOrder.ASC);
         try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<List<Interaction>> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());
             ActionListener<SearchResponse> al = ActionListener.wrap(response -> {

--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -337,10 +337,7 @@ public class InteractionsIndex {
 
         request.source(searchSourceBuilder);
         request.source().from(from).size(maxResults);
-        request
-            .source()
-            .sort(ConversationalIndexConstants.INTERACTIONS_CREATE_TIME_FIELD, SortOrder.ASC)
-            .sort(ConversationalIndexConstants.INTERACTIONS_TRACE_NUMBER_FIELD, SortOrder.ASC);
+        request.source().sort(ConversationalIndexConstants.INTERACTIONS_TRACE_NUMBER_FIELD, SortOrder.ASC);
         try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<List<Interaction>> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());
             ActionListener<SearchResponse> al = ActionListener.wrap(response -> {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/MLMemoryManager.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/MLMemoryManager.java
@@ -14,6 +14,7 @@ import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Client;
@@ -266,6 +267,7 @@ public class MLMemoryManager {
         UpdateRequest updateRequest = new UpdateRequest(indexName, interactionId);
         updateRequest.doc(updateContent);
         updateRequest.docAsUpsert(true);
+        updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<UpdateResponse> al = ActionListener.runBefore(ActionListener.wrap(updateResponse -> {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetConversationsActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetConversationsActionIT.java
@@ -20,6 +20,7 @@ package org.opensearch.ml.rest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
@@ -120,7 +121,7 @@ public class RestMemoryGetConversationsActionIT extends MLCommonsRestTestCase {
         assert (((Double) map.get("next_token")).intValue() == 1);
     }
 
-    public void testGetConversations_nextPage() throws IOException {
+    public void testGetConversations_nextPage() throws IOException, InterruptedException {
         Response ccresponse1 = TestHelper.makeRequest(client(), "POST", ActionConstants.CREATE_CONVERSATION_REST_PATH, null, "", null);
         assert (ccresponse1 != null);
         assert (TestHelper.restStatus(ccresponse1) == RestStatus.OK);
@@ -131,6 +132,9 @@ public class RestMemoryGetConversationsActionIT extends MLCommonsRestTestCase {
         assert (ccmap1.containsKey("conversation_id"));
         String id1 = (String) ccmap1.get("conversation_id");
 
+        // wait for 0.1s to make sure update time is different between conversation 1 and 2
+        TimeUnit.MICROSECONDS.sleep(100);
+
         Response ccresponse2 = TestHelper.makeRequest(client(), "POST", ActionConstants.CREATE_CONVERSATION_REST_PATH, null, "", null);
         assert (ccresponse2 != null);
         assert (TestHelper.restStatus(ccresponse2) == RestStatus.OK);
@@ -140,21 +144,6 @@ public class RestMemoryGetConversationsActionIT extends MLCommonsRestTestCase {
         Map ccmap2 = gson.fromJson(ccentityString2, Map.class);
         assert (ccmap2.containsKey("conversation_id"));
         String id2 = (String) ccmap2.get("conversation_id");
-        logger.info("id2={}", id2);
-
-        // for debug
-        Response _response = TestHelper
-            .makeRequest(
-                client(),
-                "GET",
-                ActionConstants.GET_CONVERSATIONS_REST_PATH,
-                Map.of(ActionConstants.REQUEST_MAX_RESULTS_FIELD, "10"),
-                "",
-                null
-            );
-        HttpEntity _httpEntity = _response.getEntity();
-        String entityStringAll = TestHelper.httpEntityToString(_httpEntity);
-        logger.info("entityString={}", entityStringAll);
 
         Response response1 = TestHelper
             .makeRequest(

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetConversationsActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetConversationsActionIT.java
@@ -135,9 +135,11 @@ public class RestMemoryGetConversationsActionIT extends MLCommonsRestTestCase {
         assert (TestHelper.restStatus(ccresponse2) == RestStatus.OK);
         HttpEntity cchttpEntity2 = ccresponse2.getEntity();
         String ccentityString2 = TestHelper.httpEntityToString(cchttpEntity2);
+        logger.info("ccentityString2={}", ccentityString2);
         Map ccmap2 = gson.fromJson(ccentityString2, Map.class);
         assert (ccmap2.containsKey("conversation_id"));
         String id2 = (String) ccmap2.get("conversation_id");
+        logger.info("id2={}", id2);
 
         Response response1 = TestHelper
             .makeRequest(
@@ -152,6 +154,7 @@ public class RestMemoryGetConversationsActionIT extends MLCommonsRestTestCase {
         assert (TestHelper.restStatus(response1) == RestStatus.OK);
         HttpEntity httpEntity1 = response1.getEntity();
         String entityString1 = TestHelper.httpEntityToString(httpEntity1);
+        logger.info("entityString1={}", entityString1);
         Map map1 = gson.fromJson(entityString1, Map.class);
         assert (map1.containsKey("conversations"));
         assert (map1.containsKey("next_token"));

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetConversationsActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetConversationsActionIT.java
@@ -126,6 +126,7 @@ public class RestMemoryGetConversationsActionIT extends MLCommonsRestTestCase {
         assert (TestHelper.restStatus(ccresponse1) == RestStatus.OK);
         HttpEntity cchttpEntity1 = ccresponse1.getEntity();
         String ccentityString1 = TestHelper.httpEntityToString(cchttpEntity1);
+        logger.info("ccentityString1={}", ccentityString1);
         Map ccmap1 = gson.fromJson(ccentityString1, Map.class);
         assert (ccmap1.containsKey("conversation_id"));
         String id1 = (String) ccmap1.get("conversation_id");
@@ -140,6 +141,20 @@ public class RestMemoryGetConversationsActionIT extends MLCommonsRestTestCase {
         assert (ccmap2.containsKey("conversation_id"));
         String id2 = (String) ccmap2.get("conversation_id");
         logger.info("id2={}", id2);
+
+        // for debug
+        Response _response = TestHelper
+            .makeRequest(
+                client(),
+                "GET",
+                ActionConstants.GET_CONVERSATIONS_REST_PATH,
+                Map.of(ActionConstants.REQUEST_MAX_RESULTS_FIELD, "10"),
+                "",
+                null
+            );
+        HttpEntity _httpEntity = _response.getEntity();
+        String entityStringAll = TestHelper.httpEntityToString(_httpEntity);
+        logger.info("entityString={}", entityStringAll);
 
         Response response1 = TestHelper
             .makeRequest(

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetConversationsActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetConversationsActionIT.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.message.BasicHeader;
+import org.junit.Assert;
 import org.junit.Before;
 import org.opensearch.client.Response;
 import org.opensearch.core.rest.RestStatus;
@@ -158,7 +159,7 @@ public class RestMemoryGetConversationsActionIT extends MLCommonsRestTestCase {
         ArrayList<Map> conversations1 = (ArrayList<Map>) map1.get("conversations");
         assert (conversations1.size() == 1);
         assert (conversations1.get(0).containsKey("conversation_id"));
-        assert (((String) conversations1.get(0).get("conversation_id")).equals(id2));
+        Assert.assertEquals(conversations1.get(0).get("conversation_id"), id2);
         assert (((Double) map1.get("next_token")).intValue() == 1);
 
         Response response = TestHelper


### PR DESCRIPTION
### Description

1. Fix sort on get trace Api, in the case two traces with create time are `"create_time": "2023-12-05T05:14:42.823172Z"` and `"create_time": "2023-12-05T05:14:42.823833Z"` they are equally same date due to mapping field of [`create_time`](https://github.com/opensearch-project/ml-commons/blob/feature/agent_framework_dev/common/src/main/java/org/opensearch/ml/common/conversation/ConversationalIndexConstants.java#L97) is `date` not `date_nanos`, either we change type to `date_nanos` or add one more sort field.

2. Add refresh policy to update interaction api so that get conversation api will able to fetch latest data.

3. fix flaky test for conversation

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
