### PR TITLE
fix flaky test due to localization

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
@@ -68,7 +68,8 @@ public class EncryptorImpl implements Encryptor {
         initMasterKey();
         final AwsCrypto crypto = AwsCrypto.builder().withCommitmentPolicy(CommitmentPolicy.RequireEncryptRequireDecrypt).build();
         byte[] bytes = Base64.getDecoder().decode(masterKey);
-        JceMasterKey jceMasterKey = JceMasterKey.getInstance(new SecretKeySpec(bytes, "AES"), "Custom", "", "AES/GCM/NoPadding");
+        // https://github.com/aws/aws-encryption-sdk-java/issues/1879
+        JceMasterKey jceMasterKey = JceMasterKey.getInstance(new SecretKeySpec(bytes, "AES"), "Custom", "", "AES/GCM/NOPADDING");
 
         final CryptoResult<byte[], JceMasterKey> encryptResult = crypto
             .encryptData(jceMasterKey, plainText.getBytes(StandardCharsets.UTF_8));
@@ -81,7 +82,7 @@ public class EncryptorImpl implements Encryptor {
         final AwsCrypto crypto = AwsCrypto.builder().withCommitmentPolicy(CommitmentPolicy.RequireEncryptRequireDecrypt).build();
 
         byte[] bytes = Base64.getDecoder().decode(masterKey);
-        JceMasterKey jceMasterKey = JceMasterKey.getInstance(new SecretKeySpec(bytes, "AES"), "Custom", "", "AES/GCM/NoPadding");
+        JceMasterKey jceMasterKey = JceMasterKey.getInstance(new SecretKeySpec(bytes, "AES"), "Custom", "", "AES/GCM/NOPADDING");
 
         final CryptoResult<byte[], JceMasterKey> decryptedResult = crypto
             .decryptData(jceMasterKey, Base64.getDecoder().decode(encryptedText));


### PR DESCRIPTION
### Description

CI run with locale `-Dtests.locale=tr -Dtests.timezone=Cuba` https://github.com/opensearch-project/ml-commons/actions/runs/7097212068/job/19316954587?pr=1733

related to https://github.com/aws/aws-encryption-sdk-java/issues/1879
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
