### PR TITLE
Fix Alerting tool runtime failure on ClassNotFoundException

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -48,7 +48,9 @@ dependencies {
     implementation("ai.djl.onnxruntime:onnxruntime-engine:0.21.0") {
         exclude group: "com.microsoft.onnxruntime", module: "onnxruntime"
     }
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}") {
+        exclude group: "org.jetbrains", module: "annotations"
+    }
 
     def os = DefaultNativePlatform.currentOperatingSystem
     //mac doesn't support GPU


### PR DESCRIPTION
### Description
Fix Alerting tool runtime failure on ClassNotFoundException. 
 
### Issues Resolved
```[2023-12-06T23:16:09,151][ERROR][o.o.b.OpenSearchUncaughtExceptionHandler] [[dev-dsk-arjung-2c-3dee26a3.us-west-2.amazon.com](http://dev-dsk-arjung-2c-3dee26a3.us-west-2.amazon.com/)] fatal error in thread [opensearch[[dev-dsk-arjung-2c-3dee26a3.us-west-2.amazon.com](http://dev-dsk-arjung-2c-3dee26a3.us-west-2.amazon.com/)][opensearch_ml_predict][T#8]], exiting
java.lang.NoClassDefFoundError: kotlin/jvm/internal/Intrinsics
	at org.opensearch.commons.alerting.model.Table.<init>(Table.kt) ~[?:?]
	at org.opensearch.ml.engine.tools.SearchAlertsTool.run(SearchAlertsTool.java:74) ~[?:?]
	at org.opensearch.ml.engine.algorithms.agent.MLChatAgentRunner.lambda$runReAct$7(MLChatAgentRunner.java:512) ~[?:?]
	at org.opensearch.core.action.ActionListener$1.onResponse(ActionListener.java:82) ~[opensearch-core-2.11.0.jar:2.11.0]
	at org.opensearch.common.util.concurrent.ListenableFuture$1.doRun(ListenableFuture.java:126) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.common.util.concurrent.OpenSearchExecutors$DirectExecutorService.execute(OpenSearchExecutors.java:343) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.common.util.concurrent.ListenableFuture.notifyListener(ListenableFuture.java:120) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.common.util.concurrent.ListenableFuture.lambda$done$0(ListenableFuture.java:112) ~[opensearch-2.11.0.jar:2.11.0]
	at java.util.ArrayList.forEach(ArrayList.java:1511) ~[?:?]
	at org.opensearch.common.util.concurrent.ListenableFuture.done(ListenableFuture.java:112) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.common.util.concurrent.BaseFuture.set(BaseFuture.java:160) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.common.util.concurrent.ListenableFuture.onResponse(ListenableFuture.java:141) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.action.StepListener.innerOnResponse(StepListener.java:79) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.core.action.NotifyOnceListener.onResponse(NotifyOnceListener.java:55) ~[opensearch-core-2.11.0.jar:2.11.0]
	at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:113) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:107) ~[opensearch-2.11.0.jar:2.11.0]
	at org.opensearch.core.action.ActionListener$6.onResponse(ActionListener.java:301) ~[opensearch-core-2.11.0.jar:2.11.0]
	at org.opensearch.core.action.ActionListener$5.onResponse(ActionListener.java:268) ~[opensearch-core-2.11.0.jar:2.11.0]
	at org.opensearch.core.action.ActionListener$5.onResponse(ActionListener.java:268) ~[opensearch-core-2.11.0.jar:2.11.0]
	at org.opensearch.ml.task.MLPredictTaskRunner.predict(MLPredictTaskRunner.java:229) ~[?:?]
	at org.opensearch.ml.task.MLPredictTaskRunner.lambda$executeTask$4(MLPredictTaskRunner.java:193) ~[?:?]
	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:849) ~[opensearch-2.11.0.jar:2.11.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
Caused by: java.lang.ClassNotFoundException: kotlin.jvm.internal.Intrinsics
	at [java.net](http://java.net/).URLClassLoader.findClass(URLClassLoader.java:445) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:592) ~[?:?]
	at [java.net](http://java.net/).FactoryURLClassLoader.loadClass(URLClassLoader.java:872) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:525) ~[?:?]
	... 26 more
```

Need to exclude annotation jar as it was resulting in failure 
```
org.opensearch.bootstrap.StartupException: java.lang.IllegalStateException: codebase property already set: codebase.annotations -> file:/local/home/arjung/opensearch/opensearch-2.11.0/plugins/opensearch-ml/annotations-13.0.jar, cannot set to file:/local/home/arjung/opensearch/opensearch-2.11.0/plugins/opensearch-ml/annotations-2.21.15.jar
```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
