### PR TITLE
use truncate flag in huggingface tokenizer

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/SentenceTransformerTranslator.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/SentenceTransformerTranslator.java
@@ -25,7 +25,12 @@ public abstract class SentenceTransformerTranslator implements ServingTranslator
     @Override
     public void prepare(TranslatorContext ctx) throws IOException {
         Path path = ctx.getModel().getModelPath();
-        tokenizer = HuggingFaceTokenizer.builder().optPadding(true).optTokenizerPath(path.resolve("tokenizer.json")).build();
+        tokenizer = HuggingFaceTokenizer
+            .builder()
+            .optPadding(true)
+            .optTruncation(true)
+            .optTokenizerPath(path.resolve("tokenizer.json"))
+            .build();
     }
 
     @Override


### PR DESCRIPTION
### Description
Turns on the truncation flag for the tokenizer used for nlp tasks. If the generated encoding is too long, there can be problems (index out of bounds when looking up roberta positional embeddings).
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
