### PR TITLE
Handle empty memory type in agent configuration

### DIFF
--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunnerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunnerTest.java
@@ -150,4 +150,25 @@ public class MLFlowAgentRunnerTest {
         Assert.assertEquals("First tool response", agentOutput.get(0).getResult());
         Assert.assertEquals("Second tool response", agentOutput.get(1).getResult());
     }
+
+    @Test
+    public void testWithMemoryNotSet() {
+        final Map<String, String> params = new HashMap<>();
+        params.put(MLAgentExecutor.MEMORY_ID, "memoryId");
+        MLToolSpec firstToolSpec = MLToolSpec.builder().name(FIRST_TOOL).type(FIRST_TOOL).build();
+        MLToolSpec secondToolSpec = MLToolSpec.builder().name(SECOND_TOOL).type(SECOND_TOOL).build();
+        final MLAgent mlAgent = MLAgent
+            .builder()
+            .name("TestAgent")
+            .memory(null)
+            .tools(Arrays.asList(firstToolSpec, secondToolSpec))
+            .build();
+        mlFlowAgentRunner.run(mlAgent, params, agentActionListener);
+        Mockito.verify(agentActionListener).onResponse(objectCaptor.capture());
+        List<ModelTensor> agentOutput = (List<ModelTensor>) objectCaptor.getValue();
+        Assert.assertEquals(1, agentOutput.size());
+        // Respond with last tool output
+        Assert.assertEquals(SECOND_TOOL, agentOutput.get(0).getName());
+        Assert.assertEquals("Second tool response", agentOutput.get(0).getResult());
+    }
 }


### PR DESCRIPTION
### Description
Handle empty memory type in flow agent configuration. Note that conversational agent still requires memory type to be defined.

Test agent configuration
```
POST _plugins/_ml/agents/_register
{
  "name": "Test_Agent_For_RAG",
  "type": "flow",
  "description": "this is a test agent",
  "app_type": "my app",
  "tools": [
      {
      "type": "CatIndexTool",
      "name": "CatIndexTool",
      "description": "Use this tool to get OpenSearch index information: (health, status, index, uuid, primary count, replica count, docs.count, docs.deleted, store.size, primary.store.size).",
      "include_output_in_agent_response": true
    },
    {
      "type": "VectorDBTool",
      "name": "PopulationDataTool",
      "description": "Use this tool to fetch population information",
      "parameters": {
        "model_id": "6nrN2YsBn9PZfduo9pOo",
        "index": "my_test_data_1",
        "embedding_field": "embedding",
        "source_field": ["text"]
      }
    },
    {
      "type": "MLModelTool",
      "description": "A general tool to answer any question",
      "parameters": {
        "model_id": "QahqWowBeu5xSCcODPNw",
        "prompt": "\n\nHuman:You are a professional data analysist. You will always answer question based on the given context first. If the answer is not directly shown in the context, you will analyze the data and find the answer. If you don't know the answer, just say don't know. \n\n Context:\n${parameters.PopulationDataTool.output}\n\nHuman:${parameters.question}\n\nAssistant:"
      }
    }
  ]
}
```

Test request
```
POST /_plugins/_ml/agents/R6huWowBeu5xSCcOoPM4/_execute
{
    "parameters": {
        "question": "What is the population in Seattle?",
        "verbose": false
    }
}
```
 
Response
```
{
  "inference_results": [
    {
      "output": [
        {
          "name": "CatIndexTool",
          "result": """health	status	index	uuid	pri	rep	docs.count	docs.deleted	store.size	pri.store.size
yellow	open	.plugins-ml-memory-message	S_bi7-qaSmeyAC670rQPKw	1	1	978	8	377.2kb	377.2kb
green	open	.plugins-ml-model-group	Ord6f9WNRk6y4Otgj0Omxg	1	0	2	0	10.9kb	10.9kb
yellow	open	.plugins-ml-memory-meta	e_q4R99IQQK3pC1sWZwkJA	1	1	139	6	38kb	38kb
yellow	open	.plugins-ml-conversation-meta	kc-ANGRXQDSU9mqq3g-MQw	1	1	56	0	19.2kb	19.2kb
green	open	.ql-datasources	hqwDvsYLTyOVII30K604ZQ	1	0	0	0	208b	208b
green	open	.plugins-ml-agent	LC2Z2auCRmeCm9aR-IyHPA	1	0	99	0	325.1kb	325.1kb
green	open	.plugins-ml-task	aSFfJGToRJi5ddiSeSS8sA	1	0	87	5	107.7kb	107.7kb
green	open	.plugins-ml-connector	9EeGaG8cTt-owlefp-0zvQ	1	0	13	0	247.2kb	247.2kb
green	open	.kibana_2	nj7tlCwrQnOCO0CAj63vrA	1	0	7	0	16.6kb	16.6kb
green	open	.kibana_1	tC1y7PXRSK6NYVrTzzPXJw	1	0	6	0	26.6kb	26.6kb
green	open	.kibana_3	xN3ybMj0SXO_FCmfgBku8Q	1	0	7	0	11.7kb	11.7kb
green	open	.plugins-ml-config	zENfAIpFQHyxATLkpAV1Ag	1	0	1	0	3.9kb	3.9kb
green	open	.opensearch-observability	uqEoBMIaQ5eSLOqIknsBUg	1	0	0	0	208b	208b
green	open	.plugins-ml-model	69N8PBd_RZa73tF4umwUlw	1	0	27	9	170.4mb	170.4mb
yellow	open	my_test_data	AnsDyfxjSFeO-t-Zi8YmQg	1	1	0	0	208b	208b
yellow	open	.plugins-ml-conversation-interactions	fX-ZMD65S0qeIvzshm8HXw	1	1	14	1	41.5kb	41.5kb
yellow	open	my_test_data_1	qDV348DBSMKGkWX1sqGtWQ	1	1	6	0	45.7kb	45.7kb
"""
        },
        {
          "result": " Based on the given context, there is no information provided about the population in Seattle. The context only contains information about the populations of Chicago and Miami metro areas. Since the answer is not directly shown in the context, I would say I don't know the population in Seattle."
        }
      ]
    }
  ]
}
```

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
