### PR TITLE
Implement search monitors tool

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchMonitorsTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchMonitorsTool.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.tools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.commons.alerting.AlertingPluginInterface;
+import org.opensearch.commons.alerting.action.GetMonitorRequest;
+import org.opensearch.commons.alerting.action.GetMonitorResponse;
+import org.opensearch.commons.alerting.action.SearchMonitorRequest;
+import org.opensearch.commons.alerting.model.Monitor;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.ExistsQueryBuilder;
+import org.opensearch.index.query.NestedQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.spi.tools.Parser;
+import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.ml.common.spi.tools.ToolAnnotation;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortOrder;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@ToolAnnotation(SearchMonitorsTool.TYPE)
+public class SearchMonitorsTool implements Tool {
+    public static final String TYPE = "SearchMonitorsTool";
+    private static final String DEFAULT_DESCRIPTION = "Use this tool to search alerting monitors.";
+
+    @Setter
+    @Getter
+    private String name = TYPE;
+    @Getter
+    @Setter
+    private String description = DEFAULT_DESCRIPTION;
+    @Getter
+    private String type;
+    @Getter
+    private String version;
+
+    private Client client;
+    @Setter
+    private Parser<?, ?> inputParser;
+    @Setter
+    private Parser<?, ?> outputParser;
+
+    public SearchMonitorsTool(Client client) {
+        this.client = client;
+
+        // probably keep this overridden output parser. need to ensure the output matches what's expected
+        outputParser = new Parser<>() {
+            @Override
+            public Object parse(Object o) {
+                @SuppressWarnings("unchecked")
+                List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
+                return mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap().get("response");
+            }
+        };
+    }
+
+    // Response is currently in a simple string format including the list of monitors (only name and ID attached), and
+    // number of total monitors. The output will likely need to be updated, standardized, and include more fields in the
+    // future to cover a sufficient amount of potential questions the agent will need to handle.
+    @Override
+    public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
+        final String monitorId = parameters.getOrDefault("monitorId", null);
+        final String monitorName = parameters.getOrDefault("monitorName", null);
+        final String monitorNamePattern = parameters.getOrDefault("monitorNamePattern", null);
+        final Boolean enabled = parameters.containsKey("enabled") ? Boolean.parseBoolean(parameters.get("enabled")) : null;
+        final Boolean hasTriggers = parameters.containsKey("hasTriggers") ? Boolean.parseBoolean(parameters.get("hasTriggers")) : null;
+        final String indices = parameters.getOrDefault("indices", null);
+        final String sortOrderStr = parameters.getOrDefault("sortOrder", "asc");
+        final SortOrder sortOrder = sortOrderStr == "asc" ? SortOrder.ASC : SortOrder.DESC;
+        final String sortString = parameters.getOrDefault("sortString", "monitor.name.keyword");
+        final int size = parameters.containsKey("size") ? Integer.parseInt(parameters.get("size")) : 20;
+        final int startIndex = parameters.containsKey("startIndex") ? Integer.parseInt(parameters.get("startIndex")) : 0;
+
+        // If a monitor ID is specified, all other params will be ignored. Simply return the monitor details based on that ID
+        // via the get monitor transport action
+        if (monitorId != null) {
+            GetMonitorRequest getMonitorRequest = new GetMonitorRequest(monitorId, 1L, RestRequest.Method.GET, null);
+            ActionListener<GetMonitorResponse> getMonitorListener = ActionListener.<GetMonitorResponse>wrap(response -> {
+                StringBuilder sb = new StringBuilder();
+                Monitor monitor = response.getMonitor();
+                if (monitor != null) {
+                    sb.append("Monitors=[");
+                    sb.append("{");
+                    sb.append("id=").append(monitor.getId()).append(",");
+                    sb.append("name=").append(monitor.getName());
+                    sb.append("}]");
+                    sb.append("TotalMonitors=1");
+                } else {
+                    sb.append("Monitors=[]TotalMonitors=0");
+                }
+                listener.onResponse((T) sb.toString());
+            }, e -> { listener.onFailure(e); });
+            AlertingPluginInterface.INSTANCE.getMonitor((NodeClient) client, getMonitorRequest, getMonitorListener);
+        } else {
+            List<QueryBuilder> mustList = new ArrayList<QueryBuilder>();
+            if (monitorName != null) {
+                mustList.add(new TermQueryBuilder("monitor.name.keyword", monitorName));
+            }
+            if (monitorNamePattern != null) {
+                mustList.add(new WildcardQueryBuilder("monitor.name.keyword", monitorNamePattern));
+            }
+            if (enabled != null) {
+                mustList.add(new TermQueryBuilder("monitor.enabled", enabled));
+            }
+            if (hasTriggers != null) {
+                NestedQueryBuilder nestedTriggerQuery = new NestedQueryBuilder(
+                    "monitor.triggers",
+                    new ExistsQueryBuilder("monitor.triggers"),
+                    null
+                );
+                BoolQueryBuilder triggerQuery = new BoolQueryBuilder();
+                if (hasTriggers) {
+                    triggerQuery.must(nestedTriggerQuery);
+                } else {
+                    triggerQuery.mustNot(nestedTriggerQuery);
+                }
+                mustList.add(triggerQuery);
+            }
+            if (indices != null) {
+                mustList
+                    .add(
+                        new NestedQueryBuilder("monitor.inputs", new WildcardQueryBuilder("monitor.inputs.search.indices", indices), null)
+                    );
+            }
+
+            BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+            boolQueryBuilder.must().addAll(mustList);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+                .query(boolQueryBuilder)
+                .size(size)
+                .from(startIndex)
+                .sort(sortString, sortOrder);
+
+            SearchMonitorRequest searchMonitorRequest = new SearchMonitorRequest(new SearchRequest().source(searchSourceBuilder));
+
+            ActionListener<SearchResponse> searchMonitorListener = ActionListener.<SearchResponse>wrap(response -> {
+                StringBuilder sb = new StringBuilder();
+                SearchHit[] hits = response.getHits().getHits();
+                sb.append("Monitors=[");
+                for (SearchHit hit : hits) {
+                    sb.append("{");
+                    sb.append("id=").append(hit.getId()).append(",");
+                    sb.append("name=").append(hit.getSourceAsMap().get("name"));
+                    sb.append("}");
+                }
+                sb.append("]");
+                sb.append("TotalMonitors=").append(response.getHits().getTotalHits().value);
+                listener.onResponse((T) sb.toString());
+            }, e -> { listener.onFailure(e); });
+            AlertingPluginInterface.INSTANCE.searchMonitors((NodeClient) client, searchMonitorRequest, searchMonitorListener);
+        }
+    }
+
+    @Override
+    public boolean validate(Map<String, String> parameters) {
+        return true;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    /**
+     * Factory for the {@link SearchMonitorsTool}
+     */
+    public static class Factory implements Tool.Factory<SearchMonitorsTool> {
+        private Client client;
+
+        private static Factory INSTANCE;
+
+        /** 
+         * Create or return the singleton factory instance
+         */
+        public static Factory getInstance() {
+            if (INSTANCE != null) {
+                return INSTANCE;
+            }
+            synchronized (SearchMonitorsTool.class) {
+                if (INSTANCE != null) {
+                    return INSTANCE;
+                }
+                INSTANCE = new Factory();
+                return INSTANCE;
+            }
+        }
+
+        /**
+         * Initialize this factory
+         * @param client The OpenSearch client
+         */
+        public void init(Client client) {
+            this.client = client;
+        }
+
+        @Override
+        public SearchMonitorsTool create(Map<String, Object> map) {
+            return new SearchMonitorsTool(client);
+        }
+
+        @Override
+        public String getDefaultDescription() {
+            return DEFAULT_DESCRIPTION;
+        }
+    }
+
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchMonitorsToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchMonitorsToolTests.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.ActionType;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.ClusterAdminClient;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.commons.alerting.action.GetMonitorResponse;
+import org.opensearch.commons.alerting.model.CronSchedule;
+import org.opensearch.commons.alerting.model.DataSources;
+import org.opensearch.commons.alerting.model.Monitor;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.Aggregations;
+
+public class SearchMonitorsToolTests {
+    @Mock
+    private NodeClient nodeClient;
+    @Mock
+    private AdminClient adminClient;
+    @Mock
+    private IndicesAdminClient indicesAdminClient;
+    @Mock
+    private ClusterAdminClient clusterAdminClient;
+
+    private Map<String, String> nullParams;
+    private Map<String, String> emptyParams;
+    private Map<String, String> nonEmptyParams;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        SearchMonitorsTool.Factory.getInstance().init(nodeClient);
+
+        nullParams = null;
+        emptyParams = Collections.emptyMap();
+        nonEmptyParams = Map.of("monitorName", "foo");
+    }
+
+    @Test
+    public void testRunWithNoMonitors() throws Exception {
+        Tool tool = SearchMonitorsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        SearchHit[] hits = new SearchHit[0];
+
+        TotalHits totalHits = new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO);
+
+        SearchResponse getMonitorsResponse = new SearchResponse(
+            new SearchResponseSections(new SearchHits(hits, totalHits, 0), new Aggregations(new ArrayList<>()), null, false, null, null, 0),
+            null,
+            0,
+            0,
+            0,
+            0,
+            null,
+            null
+        );
+        String expectedResponseStr = String.format("Monitors=[]TotalMonitors=%d", hits.length);
+
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+
+        doAnswer((invocation) -> {
+            ActionListener<SearchResponse> responseListener = invocation.getArgument(2);
+            responseListener.onResponse(getMonitorsResponse);
+            return null;
+        }).when(nodeClient).execute(any(ActionType.class), any(), any());
+
+        tool.run(emptyParams, listener);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals(expectedResponseStr, responseCaptor.getValue());
+    }
+
+    @Test
+    public void testRunWithMonitorId() throws Exception {
+        final String monitorId = "monitor-1-id";
+        final String monitorName = "monitor-1";
+        Tool tool = SearchMonitorsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        Monitor monitor = new Monitor(
+            monitorId,
+            0L,
+            monitorName,
+            true,
+            new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), null),
+            Instant.now(),
+            Instant.now(),
+            Monitor.MonitorType.QUERY_LEVEL_MONITOR,
+            new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
+            0,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            new DataSources(),
+            ""
+        );
+
+        GetMonitorResponse getMonitorResponse = new GetMonitorResponse(monitorId, 1L, 2L, 0L, monitor, Collections.emptyList());
+        String expectedResponseStr = String.format("Monitors=[{id=%s,name=%s}]TotalMonitors=%d", monitorId, monitorName, 1);
+
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+
+        doAnswer((invocation) -> {
+            ActionListener<GetMonitorResponse> responseListener = invocation.getArgument(2);
+            responseListener.onResponse(getMonitorResponse);
+            return null;
+        }).when(nodeClient).execute(any(ActionType.class), any(), any());
+
+        tool.run(emptyParams, listener);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals(expectedResponseStr, responseCaptor.getValue());
+    }
+
+    @Test
+    public void testRunWithSingleMonitor() throws Exception {
+        final String monitorName = "monitor-1";
+        final String monitorId = "monitor-1-id";
+        Tool tool = SearchMonitorsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        XContentBuilder content = XContentBuilder.builder(XContentType.JSON.xContent());
+        content.startObject();
+        content.field("type", "monitor");
+        content.field("name", monitorName);
+        content.endObject();
+        SearchHit[] hits = new SearchHit[1];
+        hits[0] = new SearchHit(0, monitorId, null, null).sourceRef(BytesReference.bytes(content));
+
+        TotalHits totalHits = new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO);
+
+        SearchResponse getMonitorsResponse = new SearchResponse(
+            new SearchResponseSections(new SearchHits(hits, totalHits, 0), new Aggregations(new ArrayList<>()), null, false, null, null, 0),
+            null,
+            0,
+            0,
+            0,
+            0,
+            null,
+            null
+        );
+        String expectedResponseStr = String.format("Monitors=[{id=%s,name=%s}]TotalMonitors=%d", monitorId, monitorName, hits.length);
+
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+
+        doAnswer((invocation) -> {
+            ActionListener<SearchResponse> responseListener = invocation.getArgument(2);
+            responseListener.onResponse(getMonitorsResponse);
+            return null;
+        }).when(nodeClient).execute(any(ActionType.class), any(), any());
+
+        tool.run(emptyParams, listener);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals(expectedResponseStr, responseCaptor.getValue());
+    }
+
+    @Test
+    public void testValidate() {
+        Tool tool = SearchMonitorsTool.Factory.getInstance().create(Collections.emptyMap());
+        assertEquals(SearchMonitorsTool.TYPE, tool.getType());
+        assertTrue(tool.validate(emptyParams));
+        assertTrue(tool.validate(nonEmptyParams));
+        assertTrue(tool.validate(nullParams));
+    }
+}


### PR DESCRIPTION
### Description
Adds a search monitors tool. Utilizes the added `getMonitor()` & `searchMonitors()`  fns exposed by the alerting interface in common utils. These were refactored from the alerting plugin -> common utils plugin. See related PRs for details:
https://github.com/opensearch-project/common-utils/pull/566
https://github.com/opensearch-project/alerting/pull/1305

Based on the passed parameters, the tool will execute either the get monitor transport action, or search monitors transport action. The get monitor action is straightforward, and just takes in a monitor ID. The search monitors action takes in DSL to query the system index containing the monitor info. The tool handles the query generation logic to prevent the agent from generating it, which would likely be error prone and need advanced prompt engineering. Various params (all optional) are available to pass to the tool's `run()` function to generate a query (see [here](https://github.com/opensearch-project/ml-commons/issues/1545#issuecomment-1828563626) for an example generated query).

The amount of parameters and/or the default values may be changed later on depending on agent performance and accuracy. For example, too much parameter tuning may lead to messy or invalid results.

Additionally, further integration testing will need to be done to validate different alerting-related questions input to the agent that will have this tool associated to it. 
 
### Issues Resolved
Closes #1545
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
