### PR TITLE
feat: search index tool

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/MLCommonsClassLoader.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLCommonsClassLoader.java
@@ -265,7 +265,7 @@ public class MLCommonsClassLoader {
     }
 
     private static <T, S> S init(Map<T, Class<?>> map, T type,
-                                 Object[] initArgs, Class<?>... constructorParameterTypes) throws Throwable {
+                                 Object[] initArgs, Class<?>... constructorParameterTypes) {
         Class<?> clazz = map.get(type);
         if (clazz == null) {
             throw new IllegalArgumentException("Can't find class for type " + type);
@@ -275,8 +275,10 @@ public class MLCommonsClassLoader {
             return (S) constructor.newInstance(initArgs);
         } catch (Exception e) {
             Throwable cause = e.getCause();
-            if (cause instanceof MLException || cause instanceof IllegalArgumentException) {
-                throw cause;
+            if (cause instanceof MLException) {
+                throw (MLException) cause;
+            } else if (cause instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) cause;
             } else {
                 log.error("Failed to init instance for type " + type, e);
                 return null;

--- a/common/src/main/java/org/opensearch/ml/common/MLCommonsClassLoader.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLCommonsClassLoader.java
@@ -277,7 +277,7 @@ public class MLCommonsClassLoader {
             Throwable cause = e.getCause();
             if (cause instanceof MLException) {
                 throw (MLException)cause;
-	    } else if (cause instanceof IllegalArgumentException) {
+            } else if (cause instanceof IllegalArgumentException) {
                 throw (IllegalArgumentException) cause;
             } else {
                 log.error("Failed to init instance for type " + type, e);

--- a/common/src/main/java/org/opensearch/ml/common/MLCommonsClassLoader.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLCommonsClassLoader.java
@@ -265,7 +265,7 @@ public class MLCommonsClassLoader {
     }
 
     private static <T, S> S init(Map<T, Class<?>> map, T type,
-                                 Object[] initArgs, Class<?>... constructorParameterTypes) {
+                                 Object[] initArgs, Class<?>... constructorParameterTypes) throws Throwable {
         Class<?> clazz = map.get(type);
         if (clazz == null) {
             throw new IllegalArgumentException("Can't find class for type " + type);
@@ -275,10 +275,8 @@ public class MLCommonsClassLoader {
             return (S) constructor.newInstance(initArgs);
         } catch (Exception e) {
             Throwable cause = e.getCause();
-            if (cause instanceof MLException) {
-                throw (MLException)cause;
-            } else if (cause instanceof IllegalArgumentException) {
-                throw (IllegalArgumentException) cause;
+            if (cause instanceof MLException || cause instanceof IllegalArgumentException) {
+                throw cause;
             } else {
                 log.error("Failed to init instance for type " + type, e);
                 return null;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
@@ -8,7 +8,6 @@ package org.opensearch.ml.engine.tools;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 
-import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
@@ -96,9 +95,11 @@ public class SearchIndexTool implements Tool {
             String index = "";
             String query = "";
             try {
+                // need this try catch block, because index, query field may not exist
                 JsonObject jsonObject = gson.fromJson(input, JsonObject.class);
                 index = jsonObject.get(INDEX_FIELD).getAsString();
                 query = jsonObject.get(QUERY_FIELD).toString();
+                query = "{\"query\": " + query + "}";
             } catch (Exception e) {
                 // throw new IllegalArgumentException("wrong input");
             }
@@ -148,8 +149,8 @@ public class SearchIndexTool implements Tool {
             } else {
                 client.search(searchRequest, actionListener);
             }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        } catch (Exception e) {
+            listener.onFailure(e);
         }
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
@@ -139,6 +139,8 @@ public class SearchIndexTool implements Tool {
                 listener.onFailure(e);
             });
 
+            // since searching connector and model needs access control, we need
+            // to forward the request corresponding transport action
             if (Objects.equals(index, ML_CONNECTOR_INDEX)) {
                 client.execute(MLConnectorSearchAction.INSTANCE, searchRequest, actionListener);
             } else if (Objects.equals(index, ML_MODEL_INDEX)) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
@@ -49,7 +49,7 @@ public class SearchIndexTool implements Tool {
 
     public static final String TYPE = "SearchIndexTool";
     private static final String DEFAULT_DESCRIPTION =
-        "Use this tool to search index with a query. You should pass in two parameters: index name and query body.";
+        "Use this tool to search index with a query. You should pass in two parameters: index and query. Index is the index name and the query is an OpenSearch DSL query.";
 
     private String name = TYPE;
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
@@ -81,11 +81,7 @@ public class SearchIndexTool implements Tool {
 
     @Override
     public boolean validate(Map<String, String> parameters) {
-        if (parameters == null || !parameters.containsKey(INPUT_FIELD)) {
-            return false;
-        }
-        String input = parameters.get(INPUT_FIELD);
-        return input != null;
+        return parameters != null && parameters.containsKey(INPUT_FIELD) && parameters.get(INPUT_FIELD) != null;
     }
 
     @Override

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
@@ -26,10 +26,10 @@ import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
 import org.opensearch.ml.common.transport.model.MLModelSearchAction;
+import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
 import lombok.Getter;
@@ -58,12 +58,6 @@ public class SearchIndexTool implements Tool {
 
     private NamedXContentRegistry xContentRegistry;
 
-    public static final Gson gson;
-
-    static {
-        gson = new Gson();
-    }
-
     public SearchIndexTool(Client client, NamedXContentRegistry xContentRegistry) {
         this.client = client;
         this.xContentRegistry = xContentRegistry;
@@ -91,14 +85,10 @@ public class SearchIndexTool implements Tool {
             String index = "";
             String query = "";
 
-            JsonObject jsonObject = gson.fromJson(input, JsonObject.class);
+            JsonObject jsonObject = StringUtils.gson.fromJson(input, JsonObject.class);
             index = jsonObject.get(INDEX_FIELD).getAsString();
             query = jsonObject.get(QUERY_FIELD).toString();
             query = "{\"query\": " + query + "}";
-
-            if (org.apache.commons.lang3.StringUtils.isBlank(query)) {
-                listener.onFailure(new IllegalArgumentException("[" + QUERY_FIELD + "] is null or empty, can not process it."));
-            }
 
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
             XContentParser queryParser = XContentType.JSON
@@ -120,11 +110,11 @@ public class SearchIndexTool implements Tool {
                             docContent.put("_id", hit.getId());
                             docContent.put("_score", hit.getScore());
                             docContent.put("_source", hit.getSourceAsMap());
-                            return gson.toJson(docContent);
+                            return StringUtils.gson.toJson(docContent);
                         });
                         contextBuilder.append(doc).append("\n");
                     }
-                    listener.onResponse((T) gson.toJson(contextBuilder.toString()));
+                    listener.onResponse((T) StringUtils.gson.toJson(contextBuilder.toString()));
                 } else {
                     listener.onResponse((T) "");
                 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
@@ -124,7 +124,7 @@ public class SearchIndexTool implements Tool {
                 client.search(searchRequest, actionListener);
             }
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            log.error("Failed to search index", e);
             listener.onFailure(e);
         }
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
@@ -26,7 +26,6 @@ import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
 import org.opensearch.ml.common.transport.model.MLModelSearchAction;
-import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
@@ -82,10 +82,10 @@ public class SearchIndexTool implements Tool {
 
     @Override
     public boolean validate(Map<String, String> parameters) {
-        if (parameters == null || !parameters.containsKey("input")) {
+        if (parameters == null || !parameters.containsKey(INPUT_FIELD)) {
             return false;
         }
-        String input = parameters.get("input");
+        String input = parameters.get(INPUT_FIELD);
         return input != null;
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.tools;
+
+import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.ml.common.spi.tools.ToolAnnotation;
+import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
+import org.opensearch.ml.common.transport.model.MLModelSearchAction;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+
+@Getter
+@Setter
+@Log4j2
+@ToolAnnotation(SearchIndexTool.TYPE)
+public class SearchIndexTool implements Tool {
+
+    public static final String INPUT_FIELD = "input";
+    public static final String INDEX_FIELD = "index";
+    public static final String QUERY_FIELD = "query";
+
+    public static final String TYPE = "SearchIndexTool";
+    private static final String DEFAULT_DESCRIPTION =
+        "Use this tool to search index with a query. You should pass in two parameters: index name and query body.";
+
+    private String name = TYPE;
+
+    private String description = DEFAULT_DESCRIPTION;
+
+    private Client client;
+
+    private NamedXContentRegistry xContentRegistry;
+
+    public static final Gson gson;
+
+    static {
+        gson = new Gson();
+    }
+
+    public SearchIndexTool(Client client, NamedXContentRegistry xContentRegistry) {
+        this.client = client;
+        this.xContentRegistry = xContentRegistry;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String getVersion() {
+        return null;
+    }
+
+    @Override
+    public boolean validate(Map<String, String> parameters) {
+        if (parameters == null || !parameters.containsKey("input")) {
+            return false;
+        }
+        String input = parameters.get("input");
+        return input != null;
+    }
+
+    @Override
+    public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
+        try {
+            String input = parameters.get(INPUT_FIELD);
+            String index = "";
+            String query = "";
+            try {
+                JsonObject jsonObject = gson.fromJson(input, JsonObject.class);
+                index = jsonObject.get(INDEX_FIELD).getAsString();
+                query = jsonObject.get(QUERY_FIELD).toString();
+            } catch (Exception e) {
+                // throw new IllegalArgumentException("wrong input");
+            }
+            if (org.apache.commons.lang3.StringUtils.isBlank(query)) {
+                throw new IllegalArgumentException("[" + QUERY_FIELD + "] is null or empty, can not process it.");
+            }
+
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            XContentParser queryParser = XContentType.JSON
+                .xContent()
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, query);
+            searchSourceBuilder.parseXContent(queryParser);
+            SearchRequest searchRequest = new SearchRequest().source(searchSourceBuilder).indices(index);
+
+            ActionListener actionListener = ActionListener.<SearchResponse>wrap(r -> {
+                SearchHit[] hits = r.getHits().getHits();
+
+                if (hits != null && hits.length > 0) {
+                    StringBuilder contextBuilder = new StringBuilder();
+                    for (int i = 0; i < hits.length; i++) {
+                        SearchHit hit = hits[i];
+                        String doc = AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> {
+                            Map<String, Object> docContent = new HashMap<>();
+                            docContent.put("_index", hit.getIndex());
+                            docContent.put("_id", hit.getId());
+                            docContent.put("_score", hit.getScore());
+                            docContent.put("_source", hit.getSourceAsMap());
+                            return gson.toJson(docContent);
+                        });
+                        contextBuilder.append(doc).append("\n");
+                    }
+                    listener.onResponse((T) gson.toJson(contextBuilder.toString()));
+                } else {
+                    listener.onResponse((T) "");
+                }
+            }, e -> {
+                log.error("Failed to search index", e);
+                listener.onFailure(e);
+            });
+
+            if (Objects.equals(index, ML_CONNECTOR_INDEX)) {
+                client.execute(MLConnectorSearchAction.INSTANCE, searchRequest, actionListener);
+            } else if (Objects.equals(index, ML_MODEL_INDEX)) {
+                client.execute(MLModelSearchAction.INSTANCE, searchRequest, actionListener);
+            } else {
+                client.search(searchRequest, actionListener);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class Factory implements Tool.Factory<SearchIndexTool> {
+
+        private Client client;
+        private static Factory INSTANCE;
+
+        private NamedXContentRegistry xContentRegistry;
+
+        /**
+         * Create or return the singleton factory instance
+         */
+        public static Factory getInstance() {
+            if (INSTANCE != null) {
+                return INSTANCE;
+            }
+            synchronized (MLModelTool.class) {
+                if (INSTANCE != null) {
+                    return INSTANCE;
+                }
+                INSTANCE = new Factory();
+                return INSTANCE;
+            }
+        }
+
+        public void init(Client client, NamedXContentRegistry xContentRegistry) {
+            this.client = client;
+            this.xContentRegistry = xContentRegistry;
+        }
+
+        @Override
+        public SearchIndexTool create(Map<String, Object> params) {
+            return new SearchIndexTool(client, xContentRegistry);
+        }
+
+        @Override
+        public String getDefaultDescription() {
+            return DEFAULT_DESCRIPTION;
+        }
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java
@@ -26,6 +26,7 @@ import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
 import org.opensearch.ml.common.transport.model.MLModelSearchAction;
+import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
@@ -90,17 +91,14 @@ public class SearchIndexTool implements Tool {
             String input = parameters.get(INPUT_FIELD);
             String index = "";
             String query = "";
-            try {
-                // need this try catch block, because index, query field may not exist
-                JsonObject jsonObject = gson.fromJson(input, JsonObject.class);
-                index = jsonObject.get(INDEX_FIELD).getAsString();
-                query = jsonObject.get(QUERY_FIELD).toString();
-                query = "{\"query\": " + query + "}";
-            } catch (Exception e) {
-                // throw new IllegalArgumentException("wrong input");
-            }
+
+            JsonObject jsonObject = gson.fromJson(input, JsonObject.class);
+            index = jsonObject.get(INDEX_FIELD).getAsString();
+            query = jsonObject.get(QUERY_FIELD).toString();
+            query = "{\"query\": " + query + "}";
+
             if (org.apache.commons.lang3.StringUtils.isBlank(query)) {
-                throw new IllegalArgumentException("[" + QUERY_FIELD + "] is null or empty, can not process it.");
+                listener.onFailure(new IllegalArgumentException("[" + QUERY_FIELD + "] is null or empty, can not process it."));
             }
 
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/AbstractRetrieverToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/AbstractRetrieverToolTests.java
@@ -92,7 +92,7 @@ public class AbstractRetrieverToolTests {
         future.join();
         assertEquals(
             "{\"_index\":\"hybrid-index\",\"_source\":{\"passage_text\":\"Company test_mock have a history of 100 years.\"},\"_id\":\"1\",\"_score\":89.2917}\n"
-                + "{\"_index\":\"hybrid-index\",\"_source\":{\"passage_text\":\"the price of the api is 2$ per invokation\"},\"_id\":\"2\",\"_score\":0.10702579}\n",
+                + "{\"_index\":\"hybrid-index\",\"_source\":{\"passage_text\":\"the price of the api is 2$ per invocation\"},\"_id\":\"2\",\"_score\":0.10702579}\n",
             gson.fromJson(future.get(), String.class)
         );
     }
@@ -125,27 +125,23 @@ public class AbstractRetrieverToolTests {
     }
 
     @Test
-    @SneakyThrows
     public void testRunAsyncWithIllegalQueryThenThrowException() {
         Client client = mock(Client.class);
         mockedImpl.setClient(client);
 
-        assertThrows(
-            "[input] is null or empty, can not process it.",
+        Exception exception = assertThrows(
             IllegalArgumentException.class,
             () -> mockedImpl.run(Map.of(AbstractRetrieverTool.INPUT_FIELD, ""), null)
         );
+        assertEquals("[input] is null or empty, can not process it.", exception.getMessage());
 
-        assertThrows(
-            "[input] is null or empty, can not process it.",
+        exception = assertThrows(
             IllegalArgumentException.class,
             () -> mockedImpl.run(Map.of(AbstractRetrieverTool.INPUT_FIELD, "  "), null)
         );
+        assertEquals("[input] is null or empty, can not process it.", exception.getMessage());
 
-        assertThrows(
-            "[input] is null or empty, can not process it.",
-            IllegalArgumentException.class,
-            () -> mockedImpl.run(Map.of("test", "hello world"), null)
-        );
+        exception = assertThrows(IllegalArgumentException.class, () -> mockedImpl.run(Map.of("test", "hello world"), null));
+        assertEquals("[input] is null or empty, can not process it.", exception.getMessage());
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/NeuralSparseToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/NeuralSparseToolTests.java
@@ -64,8 +64,8 @@ public class NeuralSparseToolTests {
         );
 
         Map<String, Object> illegalParams2 = new HashMap<>(params);
-        illegalParams1.remove(NeuralSparseTool.EMBEDDING_FIELD);
-        NeuralSparseTool tool2 = NeuralSparseTool.Factory.getInstance().create(illegalParams1);
+        illegalParams2.remove(NeuralSparseTool.EMBEDDING_FIELD);
+        NeuralSparseTool tool2 = NeuralSparseTool.Factory.getInstance().create(illegalParams2);
         assertThrows(
             "Parameter [embedding_field] and [model_id] can not be null or empty.",
             IllegalArgumentException.class,

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchIndexToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchIndexToolTests.java
@@ -15,7 +15,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
@@ -41,6 +40,7 @@ public class SearchIndexToolTests {
     private SearchIndexTool mockedSearchIndexTool;
 
     private String mockedSearchResponseString;
+
     @Before
     @SneakyThrows
     public void setup() {
@@ -111,10 +111,10 @@ public class SearchIndexToolTests {
     @SneakyThrows
     public void testRunWithSearchResults() {
         SearchResponse mockedSearchResponse = SearchResponse
-                .fromXContent(
-                        JsonXContent.jsonXContent
-                                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, mockedSearchResponseString)
-                );
+            .fromXContent(
+                JsonXContent.jsonXContent
+                    .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, mockedSearchResponseString)
+            );
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onResponse(mockedSearchResponse);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchIndexToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchIndexToolTests.java
@@ -1,0 +1,104 @@
+package org.opensearch.ml.engine.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opensearch.client.Client;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
+import org.opensearch.ml.common.transport.model.MLModelSearchAction;
+import org.opensearch.search.SearchModule;
+
+import lombok.SneakyThrows;
+
+public class SearchIndexToolTests {
+    static public final NamedXContentRegistry TEST_XCONTENT_REGISTRY_FOR_QUERY = new NamedXContentRegistry(
+        new SearchModule(Settings.EMPTY, List.of()).getNamedXContents()
+    );
+
+    private Client client;
+    private SearchIndexTool mockedSearchIndexTool;
+
+    @Before
+    @SneakyThrows
+    public void setup() {
+        client = mock(Client.class);
+        mockedSearchIndexTool = Mockito
+            .mock(
+                SearchIndexTool.class,
+                Mockito.withSettings().useConstructor(client, TEST_XCONTENT_REGISTRY_FOR_QUERY).defaultAnswer(Mockito.CALLS_REAL_METHODS)
+            );
+    }
+
+    @Test
+    @SneakyThrows
+    public void testGetType() {
+        String type = mockedSearchIndexTool.getType();
+        assertFalse(Strings.isNullOrEmpty(type));
+        assertEquals("SearchIndexTool", type);
+    }
+
+    @Test
+    @SneakyThrows
+    public void testValidate() {
+        Map<String, String> parameters = Map.of("input", "{}");
+        assertTrue(mockedSearchIndexTool.validate(parameters));
+    }
+
+    @Test
+    @SneakyThrows
+    public void testValidateWithEmptyInput() {
+        Map<String, String> parameters = Map.of();
+        assertFalse(mockedSearchIndexTool.validate(parameters));
+    }
+
+    @Test
+    public void testRunWithNormalIndex() {
+        String inputString = "{\"index\": \"test-index\", \"query\": {\"size\": 10000}}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, null);
+        Mockito.verify(client, times(1)).search(any(), any());
+        Mockito.verify(client, Mockito.never()).execute(any(), any(), any());
+    }
+
+    @Test
+    public void testRunWithConnectorIndex() {
+        String inputString = "{\"index\": \".plugins-ml-connector\", \"query\": {\"size\": 10000}}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, null);
+        Mockito.verify(client, never()).search(any(), any());
+        Mockito.verify(client, times(1)).execute(eq(MLConnectorSearchAction.INSTANCE), any(), any());
+    }
+
+    @Test
+    public void testRunWithModelIndex() {
+        String inputString = "{\"index\": \".plugins-ml-model\", \"query\": {\"size\": 10000}}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, null);
+        Mockito.verify(client, never()).search(any(), any());
+        Mockito.verify(client, times(1)).execute(eq(MLModelSearchAction.INSTANCE), any(), any());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testRunWithEmptyQuery() {
+        String inputString = "{\"index\": \"test_index\"}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> mockedSearchIndexTool.run(parameters, null));
+        assertEquals("[query] is null or empty, can not process it.", exception.getMessage());
+        Mockito.verify(client, Mockito.never()).execute(any(), any(), any());
+        Mockito.verify(client, Mockito.never()).search(any(), any());
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchIndexToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchIndexToolTests.java
@@ -142,9 +142,6 @@ public class SearchIndexToolTests {
         mockedSearchIndexTool.run(parameters, listener);
         Mockito.verify(client, Mockito.never()).execute(any(), any(), any());
         Mockito.verify(client, Mockito.never()).search(any(), any());
-        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(IllegalArgumentException.class);
-        verify(listener).onFailure(argumentCaptor.capture());
-        assertEquals("[" + SearchIndexTool.QUERY_FIELD + "] is null or empty, can not process it.", argumentCaptor.getValue().getMessage());
     }
 
     @Test

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchIndexToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchIndexToolTests.java
@@ -51,7 +51,7 @@ public class SearchIndexToolTests {
                 Mockito.withSettings().useConstructor(client, TEST_XCONTENT_REGISTRY_FOR_QUERY).defaultAnswer(Mockito.CALLS_REAL_METHODS)
             );
 
-        try (InputStream searchResponseIns = AbstractRetrieverTool.class.getResourceAsStream("retrieval_tool_search_response.json")) {
+        try (InputStream searchResponseIns = SearchIndexTool.class.getResourceAsStream("retrieval_tool_search_response.json")) {
             if (searchResponseIns != null) {
                 mockedSearchResponseString = new String(searchResponseIns.readAllBytes());
             }

--- a/ml-algorithms/src/test/resources/org/opensearch/ml/engine/tools/retrieval_tool_search_response.json
+++ b/ml-algorithms/src/test/resources/org/opensearch/ml/engine/tools/retrieval_tool_search_response.json
@@ -27,7 +27,7 @@
         "_id": "2",
         "_score": 0.10702579,
         "_source": {
-          "passage_text": "the price of the api is 2$ per invokation"
+          "passage_text": "the price of the api is 2$ per invocation"
         }
       }
     ]

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -530,7 +530,6 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
         toolFactories.put(PainlessScriptTool.TYPE, PainlessScriptTool.Factory.getInstance());
         toolFactories.put(VisualizationsTool.TYPE, VisualizationsTool.Factory.getInstance());
         toolFactories.put(SearchAlertsTool.TYPE, SearchAlertsTool.Factory.getInstance());
-        toolFactories.put(IndexMappingTool.NAME, IndexMappingTool.Factory.getInstance());
         toolFactories.put(SearchIndexTool.TYPE, SearchIndexTool.Factory.getInstance());
         toolFactories.put(RAGTool.TYPE, RAGTool.Factory.getInstance());
         toolFactories.put(IndexMappingTool.TYPE, IndexMappingTool.Factory.getInstance());

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -519,6 +519,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
         SearchAlertsTool.Factory.getInstance().init(client);
         IndexMappingTool.Factory.getInstance().init(client);
 
+        SearchIndexTool.Factory.getInstance().init(client, xContentRegistry);
         toolFactories.put(MLModelTool.TYPE, MLModelTool.Factory.getInstance());
         toolFactories.put(MathTool.TYPE, MathTool.Factory.getInstance());
         toolFactories.put(VectorDBTool.TYPE, VectorDBTool.Factory.getInstance());
@@ -529,6 +530,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
         toolFactories.put(VisualizationsTool.TYPE, VisualizationsTool.Factory.getInstance());
         toolFactories.put(SearchAlertsTool.TYPE, SearchAlertsTool.Factory.getInstance());
         toolFactories.put(IndexMappingTool.NAME, IndexMappingTool.Factory.getInstance());
+        toolFactories.put(SearchIndexTool.TYPE, SearchIndexTool.Factory.getInstance());
 
         if (externalToolFactories != null) {
             toolFactories.putAll(externalToolFactories);


### PR DESCRIPTION
### Description

Implement SearchIndexTool to support agent framework. It takes in two string parameters: index and query. Here is the sample usage of this tool. Please remember to replace the model id and agent id.

```
POST /_plugins/_ml/agents/_register
{
  "name": "Test_Agent_For_ReAct",
  "type": "conversational",
  "description": "this is a test agent",
  "llm": {
    "model_id": "xxxxx",
    "parameters": {
      "max_iteration": 10,
      "stop_when_no_tool_found": true,
      "response_filter": "$.completion"
    }
  },
  "memory": {
    "type": "conversation_index"
  },
  "tools": [
    {
      "type": "SearchIndexTool",
      "description": "Use this tool to search index with a query. You should pass in two parameters: index and query. Index is the index name and the query is an OpenSearch DSL query."
    }
  ],
  "app_type": "my app"
}


POST /_plugins/_ml/agents/xxxxx/_execute
{
  "parameters": {
    "question": "Show me all the name field of all documents in index .plugins-ml-agent",
    "verbose": true
  }
}
```

The expected successful response should be 

```
{
  "inference_results": [
    {
      "output": [
        {
          "name": "memory_id",
          "result": "xxxxx"
        },
        {
          "name": "response",
          "result": "Thought: To get the name field of documents in the .plugins-ml-agent index, I should search that index using the SearchIndexTool."
        },
        {
          "name": "response",
          "result": "\nObservation: \"{\\\"_index\\\":\\\".plugins-ml-agent\\\",\\\"_source\\\":{\\\"name\\\":\\\"Test_Agent_For_ReAct\\\"},\\\"_id\\\":\\\"xxxxx\\\",\\\"_score\\\":1.0}\\n\""
        },
        {
          "name": "response",
          "result": "Based on the information I was previously provided from searching the index, the name field of the documents in the .plugins-ml-agent index contains 'Test_Agent_For_ReAct'."
        },
        {
          "name": "response",
          "result": "The name field of the documents in the .plugins-ml-agent index is 'Test_Agent_For_ReAct'."
        }
      ]
    }
  ]
}
```

If there is error when parsing the input, the expected error response could be:

```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "[query] is null or empty, can not process it."
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "[query] is null or empty, can not process it."
  },
  "status": 400
}
```
### Issues Resolved
 
1. Implement search index tool
2. Fix bugs in unt tests

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
