### PR TITLE
Add abstract tool support

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/AbstractRetrieverTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/AbstractRetrieverTool.java
@@ -22,6 +22,7 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.spi.tools.AbstractTool;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -36,7 +37,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 @Getter
 @Setter
-public abstract class AbstractRetrieverTool implements Tool {
+public abstract class AbstractRetrieverTool extends AbstractTool {
     public static final String DEFAULT_DESCRIPTION = "Use this tool to search data in OpenSearch index.";
     public static final String INPUT_FIELD = "input";
     public static final String INDEX_FIELD = "index";
@@ -52,12 +53,15 @@ public abstract class AbstractRetrieverTool implements Tool {
     protected Integer docSize;
 
     protected AbstractRetrieverTool(
+        String type,
+        String description,
         Client client,
         NamedXContentRegistry xContentRegistry,
         String index,
         String[] sourceFields,
         Integer docSize
     ) {
+        super(type, description);
         this.client = client;
         this.xContentRegistry = xContentRegistry;
         this.index = index;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/AgentTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/AgentTool.java
@@ -34,7 +34,8 @@ public class AgentTool extends AbstractTool {
 
     private String agentId;
 
-    private static String DEFAULT_DESCRIPTION = "Use this tool to run any agent.";
+    @VisibleForTesting
+    static String DEFAULT_DESCRIPTION = "Use this tool to run any agent.";
 
     public AgentTool(Client client, String agentId) {
         super(TYPE, DEFAULT_DESCRIPTION);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/AgentTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/AgentTool.java
@@ -14,14 +14,13 @@ import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.execute.agent.AgentMLInput;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.spi.tools.AbstractTool;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskAction;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskRequest;
 import org.opensearch.ml.repackage.com.google.common.annotations.VisibleForTesting;
 
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
 /**
@@ -29,22 +28,16 @@ import lombok.extern.log4j.Log4j2;
  */
 @Log4j2
 @ToolAnnotation(AgentTool.TYPE)
-public class AgentTool implements Tool {
+public class AgentTool extends AbstractTool {
     public static final String TYPE = "AgentTool";
     private final Client client;
 
     private String agentId;
-    @Setter
-    @Getter
-    private String name = TYPE;
 
-    @VisibleForTesting
-    static String DEFAULT_DESCRIPTION = "Use this tool to run any agent.";
-    @Getter
-    @Setter
-    private String description = DEFAULT_DESCRIPTION;
+    private static String DEFAULT_DESCRIPTION = "Use this tool to run any agent.";
 
     public AgentTool(Client client, String agentId) {
+        super(TYPE, DEFAULT_DESCRIPTION);
         this.client = client;
         this.agentId = agentId;
     }
@@ -66,26 +59,6 @@ public class AgentTool implements Tool {
             listener.onFailure(e);
         }));
 
-    }
-
-    @Override
-    public String getType() {
-        return TYPE;
-    }
-
-    @Override
-    public String getVersion() {
-        return null;
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public void setName(String s) {
-        this.name = s;
     }
 
     @Override

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/IndexMappingTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/IndexMappingTool.java
@@ -23,45 +23,27 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.spi.tools.AbstractTool;
 import org.opensearch.ml.common.spi.tools.Parser;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 
-import lombok.Getter;
-import lombok.Setter;
-
-@ToolAnnotation(IndexMappingTool.NAME)
-public class IndexMappingTool implements Tool {
-    public static final String NAME = "IndexMappingTool";
+@ToolAnnotation(IndexMappingTool.TYPE)
+public class IndexMappingTool extends AbstractTool {
+    public static final String TYPE = "IndexMappingTool";
 
     private static final String DEFAULT_DESCRIPTION = "Use this tool to get index mapping information.";
-    @Setter
-    @Getter
-    private String name = IndexMappingTool.NAME;
-    @Getter
-    @Setter
-    private String description = DEFAULT_DESCRIPTION;
-    @Getter
-    private String type;
-    @Getter
-    private String version;
     private Client client;
-    @Setter
-    private Parser<?, ?> inputParser;
-    @Setter
-    private Parser<?, ?> outputParser;
 
     public IndexMappingTool(Client client) {
+        super(TYPE, DEFAULT_DESCRIPTION);
         this.client = client;
 
-        outputParser = new Parser<>() {
-            @Override
-            public Object parse(Object o) {
-                @SuppressWarnings("unchecked")
-                List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
-                return mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap().get("response");
-            }
-        };
+        this.setOutputParser((Parser<Object, Object>) o -> {
+            @SuppressWarnings("unchecked")
+            List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
+            return mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap().get("response");
+        });
     }
 
     @Override

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
@@ -16,15 +16,13 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
-import org.opensearch.ml.common.spi.tools.Parser;
+import org.opensearch.ml.common.spi.tools.AbstractTool;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
 /**
@@ -32,31 +30,22 @@ import lombok.extern.log4j.Log4j2;
  */
 @Log4j2
 @ToolAnnotation(MLModelTool.TYPE)
-public class MLModelTool implements Tool {
+public class MLModelTool extends AbstractTool {
     public static final String TYPE = "MLModelTool";
 
-    @Setter
-    @Getter
-    private String name = TYPE;
     private static String DEFAULT_DESCRIPTION = "Use this tool to run any model.";
-    @Getter
-    @Setter
-    private String description = DEFAULT_DESCRIPTION;
     private Client client;
     private String modelId;
-    @Setter
-    private Parser inputParser;
-    @Setter
-    private Parser outputParser;
 
     public MLModelTool(Client client, String modelId) {
+        super(TYPE, DEFAULT_DESCRIPTION);
         this.client = client;
         this.modelId = modelId;
 
-        outputParser = o -> {
+        this.setOutputParser(o -> {
             List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
             return mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap().get("response");
-        };
+        });
     }
 
     @Override
@@ -69,31 +58,11 @@ public class MLModelTool implements Tool {
         client.execute(MLPredictionTaskAction.INSTANCE, request, ActionListener.<MLTaskResponse>wrap(r -> {
             ModelTensorOutput modelTensorOutput = (ModelTensorOutput) r.getOutput();
             modelTensorOutput.getMlModelOutputs();
-            listener.onResponse((T) outputParser.parse(modelTensorOutput.getMlModelOutputs()));
+            listener.onResponse((T) this.getOutputParser().parse(modelTensorOutput.getMlModelOutputs()));
         }, e -> {
             log.error("Failed to run model " + modelId, e);
             listener.onFailure(e);
         }));
-    }
-
-    @Override
-    public String getType() {
-        return TYPE;
-    }
-
-    @Override
-    public String getVersion() {
-        return null;
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public void setName(String s) {
-        this.name = s;
     }
 
     @Override

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MathTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MathTool.java
@@ -12,31 +12,24 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.spi.tools.AbstractTool;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.repackage.com.google.common.collect.ImmutableMap;
 import org.opensearch.script.ScriptService;
 
-import lombok.Getter;
 import lombok.Setter;
 
 @ToolAnnotation(MathTool.TYPE)
-public class MathTool implements Tool {
+public class MathTool extends AbstractTool {
     public static final String TYPE = "MathTool";
-
-    @Setter
-    @Getter
-    private String name = TYPE;
-
     @Setter
     private ScriptService scriptService;
 
     private static String DEFAULT_DESCRIPTION = "Use this tool to calculate any math problem.";
-    @Getter
-    @Setter
-    private String description = DEFAULT_DESCRIPTION;
 
     public MathTool(ScriptService scriptService) {
+        super(TYPE, DEFAULT_DESCRIPTION);
         this.scriptService = scriptService;
     }
 
@@ -57,26 +50,6 @@ public class MathTool implements Tool {
         }
         String result = executeScript(scriptService, input + "+ \"\"", ImmutableMap.of());
         listener.onResponse((T) result);
-    }
-
-    @Override
-    public String getType() {
-        return TYPE;
-    }
-
-    @Override
-    public String getVersion() {
-        return null;
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public void setName(String s) {
-        this.name = s;
     }
 
     @Override

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/NeuralSparseTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/NeuralSparseTool.java
@@ -30,7 +30,6 @@ public class NeuralSparseTool extends AbstractRetrieverTool {
     public static final String TYPE = "NeuralSparseTool";
     public static final String MODEL_ID_FIELD = "model_id";
     public static final String EMBEDDING_FIELD = "embedding_field";
-    private String name = TYPE;
     private String modelId;
     private String embeddingField;
 
@@ -45,7 +44,7 @@ public class NeuralSparseTool extends AbstractRetrieverTool {
         Integer docSize,
         String modelId
     ) {
-        super(client, xContentRegistry, index, sourceFields, docSize);
+        super(TYPE, DEFAULT_DESCRIPTION, client, xContentRegistry, index, sourceFields, docSize);
         this.modelId = modelId;
         this.embeddingField = embeddingField;
     }
@@ -65,21 +64,6 @@ public class NeuralSparseTool extends AbstractRetrieverTool {
             + modelId
             + "\"}}}"
             + " }";
-    }
-
-    @Override
-    public String getType() {
-        return TYPE;
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public void setName(String s) {
-        this.name = s;
     }
 
     public static class Factory extends AbstractRetrieverTool.Factory<NeuralSparseTool> {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/VectorDBTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/VectorDBTool.java
@@ -46,7 +46,7 @@ public class VectorDBTool extends AbstractRetrieverTool {
         Integer docSize,
         String modelId
     ) {
-        super(client, xContentRegistry, index, sourceFields, docSize);
+        super(TYPE, DEFAULT_DESCRIPTION, client, xContentRegistry, index, sourceFields, docSize);
         this.modelId = modelId;
         this.embeddingField = embeddingField;
         this.k = k == null ? DEFAULT_K : k;
@@ -69,21 +69,6 @@ public class VectorDBTool extends AbstractRetrieverTool {
             + k
             + "}}}"
             + " }";
-    }
-
-    @Override
-    public String getType() {
-        return TYPE;
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public void setName(String s) {
-        this.name = s;
     }
 
     public static class Factory extends AbstractRetrieverTool.Factory<VectorDBTool> {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/VisualizationsTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/VisualizationsTool.java
@@ -18,6 +18,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.ml.common.spi.tools.AbstractTool;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.repackage.com.google.common.annotations.VisibleForTesting;
@@ -31,7 +32,7 @@ import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 @ToolAnnotation(VisualizationsTool.TYPE)
-public class VisualizationsTool implements Tool {
+public class VisualizationsTool extends AbstractTool {
     public static final String NAME = "Find Visualizations";
     public static final String TYPE = "VisualizationTool";
     public static final String VERSION = "v1.0";
@@ -39,15 +40,14 @@ public class VisualizationsTool implements Tool {
     public static final String SAVED_OBJECT_TYPE = "visualization";
     private static final String DEFAULT_DESCRIPTION =
         "Use this tool to find user created visualizations. This tool takes the visualization name as input and returns the first 3 matching visualizations";
-    private String description = DEFAULT_DESCRIPTION;
 
-    private String name = NAME;
     private final Client client;
     @Getter
     private final String index;
 
     @Builder
     public VisualizationsTool(Client client, String index) {
+        super(TYPE, DEFAULT_DESCRIPTION);
         this.client = client;
         this.index = index;
     }
@@ -101,36 +101,6 @@ public class VisualizationsTool implements Tool {
             return id.substring(prefix.length());
         }
         return id;
-    }
-
-    @Override
-    public String getType() {
-        return TYPE;
-    }
-
-    @Override
-    public String getVersion() {
-        return VERSION;
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public void setDescription(String description) {
-        this.description = description;
     }
 
     @Override

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/AbstractRetrieverToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/AbstractRetrieverToolTests.java
@@ -60,7 +60,15 @@ public class AbstractRetrieverToolTests {
                 AbstractRetrieverTool.class,
                 Mockito
                     .withSettings()
-                    .useConstructor(null, TEST_XCONTENT_REGISTRY_FOR_QUERY, TEST_INDEX, TEST_SOURCE_FIELDS, TEST_DOC_SIZE)
+                    .useConstructor(
+                        "type",
+                        "description",
+                        null,
+                        TEST_XCONTENT_REGISTRY_FOR_QUERY,
+                        TEST_INDEX,
+                        TEST_SOURCE_FIELDS,
+                        TEST_DOC_SIZE
+                    )
                     .defaultAnswer(Mockito.CALLS_REAL_METHODS)
             );
         when(mockedImpl.getQueryBody(any(String.class))).thenReturn(TEST_QUERY);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/IndexMappingToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/IndexMappingToolTests.java
@@ -174,7 +174,7 @@ public class IndexMappingToolTests {
     @Test
     public void testTool() {
         Tool tool = IndexMappingTool.Factory.getInstance().create(Collections.emptyMap());
-        assertEquals(IndexMappingTool.NAME, tool.getName());
+        assertEquals(IndexMappingTool.TYPE, tool.getName());
         assertTrue(tool.validate(indexParams));
         assertTrue(tool.validate(otherParams));
         assertFalse(tool.validate(emptyParams));

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -529,8 +529,8 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
         toolFactories.put(PainlessScriptTool.TYPE, PainlessScriptTool.Factory.getInstance());
         toolFactories.put(VisualizationsTool.TYPE, VisualizationsTool.Factory.getInstance());
         toolFactories.put(SearchAlertsTool.TYPE, SearchAlertsTool.Factory.getInstance());
-        toolFactories.put(IndexMappingTool.NAME, IndexMappingTool.Factory.getInstance());
         toolFactories.put(RAGTool.TYPE, RAGTool.Factory.getInstance());
+        toolFactories.put(IndexMappingTool.TYPE, IndexMappingTool.Factory.getInstance());
 
         if (externalToolFactories != null) {
             toolFactories.putAll(externalToolFactories);

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -61,6 +61,7 @@ configurations.all {
 shadowJar {
     archiveClassifier = null
 }
+jar.enabled = false
 
 test {
     doFirst {

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -7,15 +7,15 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin
 import org.opensearch.gradle.test.RestIntegTestTask
 
 plugins {
-    id 'com.github.johnrengelman.shadow'
+    id 'java'
+    id "io.freefair.lombok"
     id 'jacoco'
+    id 'com.github.johnrengelman.shadow'
     id 'maven-publish'
+    id 'com.diffplug.spotless' version '6.18.0'
     id 'signing'
 }
 
-apply plugin: 'opensearch.java'
-apply plugin: 'opensearch.testclusters'
-apply plugin: 'opensearch.java-rest-test'
 
 repositories {
     mavenLocal()
@@ -48,7 +48,8 @@ dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
-    testImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
 }
 
 configurations.all {
@@ -78,10 +79,6 @@ task integTest(type: RestIntegTestTask) {
     dependsOn test
 }
 check.dependsOn integTest
-
-testClusters.javaRestTest {
-    testDistribution = 'INTEG_TEST'
-}
 
 task sourcesJar(type: Jar) {
     archiveClassifier.set 'sources'

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -8,7 +8,6 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 plugins {
     id 'java'
-    id "io.freefair.lombok"
     id 'jacoco'
     id 'com.github.johnrengelman.shadow'
     id 'maven-publish'
@@ -71,14 +70,6 @@ test {
     }
     systemProperty 'tests.security.manager', 'false'
 }
-
-task integTest(type: RestIntegTestTask) {
-    description 'Run integ test with opensearch test framework'
-    group 'verification'
-    systemProperty 'tests.security.manager', 'false'
-    dependsOn test
-}
-check.dependsOn integTest
 
 task sourcesJar(type: Jar) {
     archiveClassifier.set 'sources'

--- a/spi/src/main/java/org/opensearch/ml/common/spi/tools/AbstractTool.java
+++ b/spi/src/main/java/org/opensearch/ml/common/spi/tools/AbstractTool.java
@@ -1,0 +1,118 @@
+package org.opensearch.ml.common.spi.tools;
+
+import java.util.Map;
+
+/**
+ * Abstract tool used to simplify tool creation.
+ */
+public abstract class AbstractTool implements Tool {
+
+    /**
+     * Name of the tool to be used in prompt.
+     */
+    private String name;
+
+    /**
+     * Default description of the tool. This description will be used by LLM to select next tool to execute.
+     */
+    private String description;
+
+    /**
+     * Tool type mapping to the corresponding run function. Tool type will be used by agent framework to identify the tool.
+     */
+    private String type;
+
+    /**
+     * Current tool version.
+     */
+    private String version;
+
+    /**
+     * Parser used to read tool input.
+     */
+    private Parser inputParser;
+
+    /**
+     * Parser used to write tool output.
+     */
+    private Parser outputParser;
+
+    /**
+     * Default tool constructor.
+     *
+     * @param type
+     * @param name
+     * @param description
+     */
+    protected AbstractTool(String type, String name, String description) {
+        this.type = type;
+        this.name = name;
+        this.description = description;
+    }
+
+    protected AbstractTool(String type, String description) {
+        this(type, type, description);
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+
+    @Override
+    public String getType() {
+        return this.type;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public String getVersion() {
+        return this.version;
+    }
+
+    @Override
+    public void setInputParser(Parser inputParser) {
+        this.inputParser = inputParser;
+    }
+
+    public Parser getInputParser() {
+        return this.inputParser;
+    }
+
+    @Override
+    public void setOutputParser(Parser outputParser) {
+        this.outputParser = outputParser;
+    }
+
+    public Parser getOutputParser() {
+        return this.outputParser;
+    }
+
+    /**
+     * Validate tool input and check if request could be processed by the tool.
+     *
+     * @param parameters
+     * @return
+     */
+    @Override
+    public abstract boolean validate(Map<String, String> parameters);
+
+}

--- a/spi/src/test/java/org.opensearch.ml.common.spi.tools/AbstractToolTest.java
+++ b/spi/src/test/java/org.opensearch.ml.common.spi.tools/AbstractToolTest.java
@@ -1,0 +1,75 @@
+package org.opensearch.ml.common.spi.tools;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+public class AbstractToolTest {
+
+    public static final String TOOL_TYPE = "tool_type";
+    public static final String TOOL_NAME = "tool_name";
+    public static final String TOOL_DESCRIPTION = "tool_description";
+    private AbstractTool abstractTool;
+
+    @Mock
+    private Parser mockInputParser;
+
+    @Mock
+    private Parser mockOutputParser;
+
+    @Before
+    public void setup() {
+        abstractTool = Mockito.mock(AbstractTool.class,
+                Mockito.withSettings().useConstructor(TOOL_TYPE, TOOL_DESCRIPTION).defaultAnswer(Mockito.CALLS_REAL_METHODS));
+    }
+
+    @Test
+    public void testConstructorValueIsPersisted() {
+        Assert.assertEquals(TOOL_TYPE, abstractTool.getType());
+        Assert.assertEquals(TOOL_TYPE, abstractTool.getName());
+        Assert.assertEquals(TOOL_DESCRIPTION, abstractTool.getDescription());
+    }
+
+    @Test
+    public void testGetterSetterName() {
+        abstractTool.setName("test_name");
+        Assert.assertEquals("test_name", abstractTool.getName());
+    }
+
+    @Test
+    public void testGetterSetterDescription() {
+        abstractTool.setDescription("test_description");
+        Assert.assertEquals("test_description", abstractTool.getDescription());
+    }
+
+
+    @Test
+    public void testGetterSetterVersion() {
+        abstractTool.setVersion("test_version");
+        Assert.assertEquals("test_version", abstractTool.getVersion());
+    }
+
+    @Test
+    public void testGetterSetterInputParser() {
+        abstractTool.setInputParser(mockInputParser);
+        Assert.assertEquals(mockInputParser, abstractTool.getInputParser());
+    }
+
+    @Test
+    public void testGetterSetterOutputParser() {
+        abstractTool.setOutputParser(mockOutputParser);
+        Assert.assertEquals(mockOutputParser, abstractTool.getOutputParser());
+    }
+
+    @Test
+    public void testConstructor() {
+        abstractTool = Mockito.mock(AbstractTool.class,
+                Mockito.withSettings().useConstructor(TOOL_TYPE, TOOL_NAME, TOOL_DESCRIPTION).defaultAnswer(Mockito.CALLS_REAL_METHODS));
+        Assert.assertEquals(TOOL_TYPE, abstractTool.getType());
+        Assert.assertEquals(TOOL_NAME, abstractTool.getName());
+        Assert.assertEquals(TOOL_DESCRIPTION, abstractTool.getDescription());
+    }
+
+}


### PR DESCRIPTION
### Description
Build Abstract tool to simplify tool creation and remove boilerplate tool management implementations to abstract super class. Refactored existing tools to make use of `AbstractTool`.

Tools that extends `AbstractTool` would only need to implement `run` and `validate` methods.


### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
