### PR TITLE
Fix partially response issue in profile API result

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -67,7 +67,6 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
             mlModelManager.removeWorkerNodes(removedNodeIds, false);
         } else if (delta.added()) {
             List<String> addedNodesIds = delta.addedNodes().stream().map(DiscoveryNode::getId).collect(Collectors.toList());
-            mlModelManager.addModelWorkerNodes(addedNodesIds);
             mlModelAutoReDeployer.buildAutoReloadArrangement(addedNodesIds, state.getNodes().getClusterManagerNodeId());
         }
     }


### PR DESCRIPTION
### Description
Fix partially response issue in profile API result. The root cause is when cluster nodes receive cluster change event(nodes add in this case), the added nodes will be put into the cache's target_worker_nodes blindly(without checking if the new nodes are eligible or not), and then trigger the auto redeploy job. The auto redeploy job can make sure the models are only deployed to eligible nodes and the deploy job can make sure the target_worker_nodes is correct.
If the added nodes put into cache, it won't get updated unless user performs model deploy, and for profile API and ML Dashboard(depends on profile API results), the target_worker_nodes and worker_nodes will show difference(target_worker_nodes has new nodes added even the node is not an eligible nodes for model running), and the model status will show as partial_response on ML Dashboard.
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/1774
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
