### PR TITLE
feat: add interaction id into execute response

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -282,7 +282,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
             .add(
                 ModelTensors
                     .builder()
-                    .mlModelTensors(Arrays.asList(ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build()))
+                    .mlModelTensors(Arrays.asList(
+                            ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build(),
+                            ModelTensor.builder().name(MLAgentExecutor.PARENT_INTERACTION_ID).result(parentInteractionId).build()
+                    ))
                     .build()
             );
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -282,10 +282,13 @@ public class MLChatAgentRunner implements MLAgentRunner {
             .add(
                 ModelTensors
                     .builder()
-                    .mlModelTensors(Arrays.asList(
-                            ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build(),
-                            ModelTensor.builder().name(MLAgentExecutor.PARENT_INTERACTION_ID).result(parentInteractionId).build()
-                    ))
+                    .mlModelTensors(
+                        Arrays
+                            .asList(
+                                ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build(),
+                                ModelTensor.builder().name(MLAgentExecutor.PARENT_INTERACTION_ID).result(parentInteractionId).build()
+                            )
+                    )
                     .build()
             );
 


### PR DESCRIPTION
### Description
Chatbot now retrieve all the interactions every time doing a `execute`. There are some drawbacks:
1. When the conversation grows larger and larger, it costs a lot to fetch all the interactions. 
2. Chatbot will always try to get the latest interactions once `execute` API returns but in opensearch there is a refresh delay which will make the result staled when calling a search API.

In order to address the issues above, Chatbot need an interaction id for the ongoing interaction.

#### What the changes achieves:
1. Add `parent_interaction_id` into response of execute API.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
