### PR TITLE
Add tests for MLAgent Get and Delete

### DIFF
--- a/common/src/test/java/org/opensearch/ml/common/transport/agent/MLAgentDeleteRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/agent/MLAgentDeleteRequestTest.java
@@ -5,10 +5,13 @@
 package org.opensearch.ml.common.transport.agent;
 
 import org.junit.Test;
+import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.opensearch.action.ValidateActions.addValidationError;
@@ -56,10 +59,46 @@ public class MLAgentDeleteRequestTest {
     }
 
     @Test
-    public void fromActionRequest() throws IOException {
+    public void fromActionRequest_Success() throws IOException {
         agentId = "test-lmn";
         MLAgentDeleteRequest mLAgentDeleteRequest = new MLAgentDeleteRequest(agentId);
         assertEquals(mLAgentDeleteRequest.fromActionRequest(mLAgentDeleteRequest), mLAgentDeleteRequest);
 
+    }
+    @Test
+    public void fromActionRequest_Success_fromActionRequest() throws IOException {
+        agentId = "test-opq";
+        MLAgentDeleteRequest mLAgentDeleteRequest = new MLAgentDeleteRequest(agentId);
+
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                mLAgentDeleteRequest.writeTo(out);
+            }
+        };
+        MLAgentDeleteRequest request = mLAgentDeleteRequest.fromActionRequest(actionRequest);
+        assertEquals(request.agentId, agentId);
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void fromActionRequest_IOException() {
+        agentId = "test-rst";
+        MLAgentDeleteRequest mLAgentDeleteRequest = new MLAgentDeleteRequest(agentId);
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException();
+            }
+        };
+        mLAgentDeleteRequest.fromActionRequest(actionRequest);
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/agent/MLAgentGetRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/agent/MLAgentGetRequestTest.java
@@ -5,10 +5,14 @@
 package org.opensearch.ml.common.transport.agent;
 
 import org.junit.Test;
+import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
+
 import static org.junit.Assert.assertEquals;
 import static org.opensearch.action.ValidateActions.addValidationError;
 
@@ -54,10 +58,47 @@ public class MLAgentGetRequestTest {
         mLAgentGetRequest.validate().equals(exception) ;
     }
     @Test
-    public void fromActionRequest() throws IOException {
+    public void fromActionRequest_Success()  throws IOException {
         agentId = "test-lmn";
         MLAgentGetRequest mLAgentGetRequest = new MLAgentGetRequest(agentId);
         assertEquals(mLAgentGetRequest.fromActionRequest(mLAgentGetRequest), mLAgentGetRequest);
+    }
+
+    @Test
+    public void fromActionRequest_Success_fromActionRequest() throws IOException {
+        agentId = "test-opq";
+        MLAgentGetRequest mLAgentGetRequest = new MLAgentGetRequest(agentId);
+
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                mLAgentGetRequest.writeTo(out);
+            }
+        };
+        MLAgentGetRequest request = mLAgentGetRequest.fromActionRequest(actionRequest);
+        assertEquals(request.agentId, agentId);
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void fromActionRequest_IOException() {
+        agentId = "test-rst";
+        MLAgentGetRequest mLAgentGetRequest = new MLAgentGetRequest(agentId);
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException();
+            }
+        };
+        mLAgentGetRequest.fromActionRequest(actionRequest);
     }
 }
 

--- a/common/src/test/java/org/opensearch/ml/common/transport/agent/MLAgentGetResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/agent/MLAgentGetResponseTest.java
@@ -99,11 +99,40 @@ public class MLAgentGetResponseTest {
     }
 
     @Test
-    public void FromActionResponse() throws IOException {
+    public void fromActionResponse_Success() throws IOException {
         MLAgentGetResponse mlAgentGetResponse = MLAgentGetResponse.builder()
                 .mlAgent(mlAgent)
                 .build();
         assertEquals(mlAgentGetResponse.fromActionResponse(mlAgentGetResponse), mlAgentGetResponse);
 
         }
+    @Test
+    public void fromActionResponse_Success_fromActionResponse() throws IOException {
+        MLAgentGetResponse mlAgentGetResponse = MLAgentGetResponse.builder()
+                .mlAgent(mlAgent)
+                .build();
+
+        ActionResponse actionResponse = new ActionResponse() {
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                mlAgentGetResponse.writeTo(out);
+            }
+        };
+        MLAgentGetResponse response = mlAgentGetResponse.fromActionResponse(actionResponse);
+        assertEquals(response.getMlAgent(), mlAgent);
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void fromActionResponse_IOException() {
+        MLAgentGetResponse mlAgentGetResponse = MLAgentGetResponse.builder()
+                .mlAgent(mlAgent)
+                .build();
+        ActionResponse actionResponse = new ActionResponse() {
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException();
+            }
+        };
+        mlAgentGetResponse.fromActionResponse(actionResponse);
+    }
     }


### PR DESCRIPTION
### Description
increase test coverage for `MLAgentDeleteRequest`, `MLAgentGetRequest`,` MLAgentGetResponse` to 100%

 
![Screenshot 2023-12-20 at 1 12 16 PM](https://github.com/opensearch-project/ml-commons/assets/113382730/46bd4f4a-cd81-4665-832d-9aad950e0111)

![Screenshot 2023-12-20 at 1 12 22 PM](https://github.com/opensearch-project/ml-commons/assets/113382730/5674f6a7-3fd9-4b6c-9828-22828a87573d)

![Screenshot 2023-12-20 at 1 12 30 PM](https://github.com/opensearch-project/ml-commons/assets/113382730/66a817a1-87fa-485d-8144-389d91091457)

![Screenshot 2023-12-20 at 1 12 37 PM](https://github.com/opensearch-project/ml-commons/assets/113382730/fc2812a4-7c03-4898-9d15-6d4617a32dbe)

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
