### PR TITLE
Fix compilation when backport #1673

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/update_cache/MLUpdateModelCacheNodeRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/update_cache/MLUpdateModelCacheNodeRequest.java
@@ -5,13 +5,13 @@
 
 package org.opensearch.ml.common.transport.update_cache;
 
-import org.opensearch.transport.TransportRequest;
+import org.opensearch.action.support.nodes.BaseNodeRequest;
 import java.io.IOException;
 import lombok.Getter;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
-public class MLUpdateModelCacheNodeRequest extends TransportRequest {
+public class MLUpdateModelCacheNodeRequest extends BaseNodeRequest {
     @Getter
     private MLUpdateModelCacheNodesRequest updateModelCacheNodesRequest;
 


### PR DESCRIPTION
### Description
After backported #1673 to 2.x it will cause java compile failed. This PR should fix this.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
