### PR TITLE
Fix: RestStatus 500 returned ml validation

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.delete.DeleteRequest;
@@ -23,6 +24,7 @@ import org.opensearch.client.Client;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
@@ -87,10 +89,10 @@ public class DeleteConnectorTransportAction extends HandledTransportAction<Actio
                             }
                             actionListener
                                 .onFailure(
-                                    new MLValidationException(
+                                    new OpenSearchStatusException(
                                         searchHits.length
                                             + " models are still using this connector, please delete or update the models first: "
-                                            + Arrays.toString(modelIds.toArray(new String[0]))
+                                            + Arrays.toString(modelIds.toArray(new String[0]), RestStatus.CONFLICT)
                                     )
                                 );
                         }

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
@@ -92,7 +92,7 @@ public class DeleteConnectorTransportAction extends HandledTransportAction<Actio
                                     new OpenSearchStatusException(
                                         searchHits.length
                                             + " models are still using this connector, please delete or update the models first: "
-                                            + Arrays.toString(modelIds.toArray(new String[0]), RestStatus.CONFLICT)
+                                            + Arrays.toString(modelIds.toArray(new String[0])), RestStatus.CONFLICT
                                     )
                                 );
                         }

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
@@ -92,7 +92,8 @@ public class DeleteConnectorTransportAction extends HandledTransportAction<Actio
                                     new OpenSearchStatusException(
                                         searchHits.length
                                             + " models are still using this connector, please delete or update the models first: "
-                                            + Arrays.toString(modelIds.toArray(new String[0])), RestStatus.CONFLICT
+                                            + Arrays.toString(modelIds.toArray(new String[0])),
+                                        RestStatus.CONFLICT
                                     )
                                 );
                         }

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/DeleteConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/DeleteConnectorTransportActionTests.java
@@ -20,6 +20,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.delete.DeleteResponse;
@@ -41,7 +42,6 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.connector.HttpConnector;
-import org.opensearch.ml.common.exception.MLValidationException;
 import org.opensearch.ml.common.transport.connector.MLConnectorDeleteRequest;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.utils.TestHelper;
@@ -178,7 +178,7 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
         }).when(client).search(any(), any());
 
         deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
-        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(MLValidationException.class);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
             "1 models are still using this connector, please delete or update the models first: [model_ID]",


### PR DESCRIPTION
### Description
When connector is already in use in a model, deleting connector will now result in 409 CONFLICT
 
### Issues Resolved
closes #1716 
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
