### PR TITLE
add the agent execute into the execute rest/transport actions

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/execute/TransportExecuteTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/execute/TransportExecuteTaskAction.java
@@ -42,8 +42,8 @@ public class TransportExecuteTaskAction extends HandledTransportAction<ActionReq
 
     @Override
     protected void doExecute(Task task, ActionRequest request, ActionListener<MLExecuteTaskResponse> listener) {
-        MLExecuteTaskRequest mlPredictionTaskRequest = MLExecuteTaskRequest.fromActionRequest(request);
-        FunctionName functionName = mlPredictionTaskRequest.getFunctionName();
-        mlExecuteTaskRunner.run(functionName, mlPredictionTaskRequest, transportService, listener);
+        MLExecuteTaskRequest mlExecuteTaskRequest = MLExecuteTaskRequest.fromActionRequest(request);
+        FunctionName functionName = mlExecuteTaskRequest.getFunctionName();
+        mlExecuteTaskRunner.run(functionName, mlExecuteTaskRequest, transportService, listener);
     }
 }


### PR DESCRIPTION
### Description
The agent execution in the Rest and Transport actions are missing in the main branch. Add them into the main to unblock the end-to-end tests. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
