### PR TITLE
feat: add interaction id into execute response(#1788)

### DIFF
--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/UpdateInteractionRequest.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/UpdateInteractionRequest.java
@@ -37,7 +37,9 @@ public class UpdateInteractionRequest extends ActionRequest {
     private String interactionId;
     private Map<String, Object> updateContent;
 
-    private static final Set<String> allowedList = new HashSet<>(Arrays.asList(INTERACTIONS_ADDITIONAL_INFO_FIELD, INTERACTIONS_RESPONSE_FIELD));
+    private static final Set<String> allowedList = new HashSet<>(
+        Arrays.asList(INTERACTIONS_ADDITIONAL_INFO_FIELD, INTERACTIONS_RESPONSE_FIELD)
+    );
 
     @Builder
     public UpdateInteractionRequest(String interactionId, Map<String, Object> updateContent) {

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/UpdateInteractionRequest.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/UpdateInteractionRequest.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.memory.action.conversation;
 
 import static org.opensearch.action.ValidateActions.addValidationError;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_ADDITIONAL_INFO_FIELD;
+import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_RESPONSE_FIELD;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -36,7 +37,7 @@ public class UpdateInteractionRequest extends ActionRequest {
     private String interactionId;
     private Map<String, Object> updateContent;
 
-    private static final Set<String> allowedList = new HashSet<>(Arrays.asList(INTERACTIONS_ADDITIONAL_INFO_FIELD));
+    private static final Set<String> allowedList = new HashSet<>(Arrays.asList(INTERACTIONS_ADDITIONAL_INFO_FIELD, INTERACTIONS_RESPONSE_FIELD));
 
     @Builder
     public UpdateInteractionRequest(String interactionId, Map<String, Object> updateContent) {

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/UpdateInteractionRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/UpdateInteractionRequestTests.java
@@ -9,8 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
-import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_ADDITIONAL_INFO_FIELD;
-import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_RESPONSE_FIELD;
+import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.*;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -60,7 +59,7 @@ public class UpdateInteractionRequestTests {
 
     @Test
     public void testConstructor_UpdateContentNotAllowed() throws IOException {
-        updateContent.put(INTERACTIONS_RESPONSE_FIELD, "response");
+        updateContent.put(INTERACTIONS_INPUT_FIELD, "input");
         UpdateInteractionRequest updateInteractionRequest = new UpdateInteractionRequest("interaction_id", updateContent);
         assert (updateInteractionRequest.validate() == null);
         assert (updateInteractionRequest.getInteractionId().equals("interaction_id"));
@@ -105,7 +104,7 @@ public class UpdateInteractionRequestTests {
 
     @Test
     public void testParse_UpdateContentNotAllowed() throws IOException {
-        String jsonStr = "{\"response\": \"new response!\"}";
+        String jsonStr = "{\"input\": \"input!\"}";
         XContentParser parser = XContentType.JSON
             .xContent()
             .createParser(

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/UpdateInteractionRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/UpdateInteractionRequestTests.java
@@ -9,7 +9,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
-import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.*;
+import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_ADDITIONAL_INFO_FIELD;
+import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_INPUT_FIELD;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -265,9 +265,23 @@ public class MLChatAgentRunner implements MLAgentRunner {
                 ModelTensors
                     .builder()
                     .mlModelTensors(
-                        Collections.singletonList(ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build())
+                        Collections.singletonList(
+                                ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build()
+                        )
                     )
                     .build()
+            );
+
+        cotModelTensors
+            .add(
+                ModelTensors
+                        .builder()
+                        .mlModelTensors(
+                                Collections.singletonList(
+                                        ModelTensor.builder().name(MLAgentExecutor.PARENT_INTERACTION_ID).result(parentInteractionId).build()
+                                )
+                        )
+                        .build()
             );
 
         StringBuilder scratchpadBuilder = new StringBuilder();

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -265,9 +265,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
                 ModelTensors
                     .builder()
                     .mlModelTensors(
-                            List.of(
-                                    ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build(),
-                                    ModelTensor.builder().name(MLAgentExecutor.PARENT_INTERACTION_ID).result(parentInteractionId).build()
+                        List
+                            .of(
+                                ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build(),
+                                ModelTensor.builder().name(MLAgentExecutor.PARENT_INTERACTION_ID).result(parentInteractionId).build()
                             )
                     )
                     .build()

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -265,23 +265,12 @@ public class MLChatAgentRunner implements MLAgentRunner {
                 ModelTensors
                     .builder()
                     .mlModelTensors(
-                        Collections.singletonList(
-                                ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build()
-                        )
+                            List.of(
+                                    ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build(),
+                                    ModelTensor.builder().name(MLAgentExecutor.PARENT_INTERACTION_ID).result(parentInteractionId).build()
+                            )
                     )
                     .build()
-            );
-
-        cotModelTensors
-            .add(
-                ModelTensors
-                        .builder()
-                        .mlModelTensors(
-                                Collections.singletonList(
-                                        ModelTensor.builder().name(MLAgentExecutor.PARENT_INTERACTION_ID).result(parentInteractionId).build()
-                                )
-                        )
-                        .build()
             );
 
         StringBuilder scratchpadBuilder = new StringBuilder();

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerTest.java
@@ -168,6 +168,7 @@ public class MLChatAgentRunnerTest {
         // Create an MLAgent and run the MLChatAgentRunner
         MLAgent mlAgent = createMLAgentWithTools();
         Map<String, String> params = new HashMap<>();
+        params.put(MLAgentExecutor.PARENT_INTERACTION_ID, "parent_interaction_id");
         params.put("verbose", "true");
         mlChatAgentRunner.run(mlAgent, params, agentActionListener);
 
@@ -180,10 +181,12 @@ public class MLChatAgentRunnerTest {
         assertTrue(capturedResponse instanceof ModelTensorOutput);
         ModelTensorOutput modelTensorOutput = (ModelTensorOutput) capturedResponse;
 
+        ModelTensor parentInteractionModelTensor = modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(1);
         ModelTensor modelTensor1 = modelTensorOutput.getMlModelOutputs().get(1).getMlModelTensors().get(0);
         ModelTensor modelTensor2 = modelTensorOutput.getMlModelOutputs().get(2).getMlModelTensors().get(0);
 
         // Verify that the parsed values from JSON block are correctly set
+        assertEquals("parent_interaction_id", parentInteractionModelTensor.getResult());
         assertEquals("Thought: parsed thought", modelTensor1.getResult());
         assertEquals("parsed final answer", modelTensor2.getResult());
     }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/MLMemoryManagerTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/MLMemoryManagerTests.java
@@ -360,7 +360,14 @@ public class MLMemoryManagerTests {
     @Test
     public void testUpdateInteraction() {
         Map<String, Object> updateContent = Map
-            .of(INTERACTIONS_ADDITIONAL_INFO_FIELD, Map.of("feedback", "thumbs up!"), INTERACTIONS_RESPONSE_FIELD, "response", INTERACTIONS_INPUT_FIELD, "input");
+            .of(
+                INTERACTIONS_ADDITIONAL_INFO_FIELD,
+                Map.of("feedback", "thumbs up!"),
+                INTERACTIONS_RESPONSE_FIELD,
+                "response",
+                INTERACTIONS_INPUT_FIELD,
+                "input"
+            );
         ShardId shardId = new ShardId(new Index("indexName", "uuid"), 1);
         UpdateResponse updateResponse = new UpdateResponse(shardId, "taskId", 1, 1, 1, DocWriteResponse.Result.UPDATED);
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/MLMemoryManagerTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/MLMemoryManagerTests.java
@@ -15,8 +15,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_ADDITIONAL_INFO_FIELD;
-import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_RESPONSE_FIELD;
+import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.*;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -361,7 +360,7 @@ public class MLMemoryManagerTests {
     @Test
     public void testUpdateInteraction() {
         Map<String, Object> updateContent = Map
-            .of(INTERACTIONS_ADDITIONAL_INFO_FIELD, Map.of("feedback", "thumbs up!"), INTERACTIONS_RESPONSE_FIELD, "response");
+            .of(INTERACTIONS_ADDITIONAL_INFO_FIELD, Map.of("feedback", "thumbs up!"), INTERACTIONS_RESPONSE_FIELD, "response", INTERACTIONS_INPUT_FIELD, "input");
         ShardId shardId = new ShardId(new Index("indexName", "uuid"), 1);
         UpdateResponse updateResponse = new UpdateResponse(shardId, "taskId", 1, 1, 1, DocWriteResponse.Result.UPDATED);
 
@@ -375,7 +374,7 @@ public class MLMemoryManagerTests {
         mlMemoryManager.updateInteraction("iid", updateContent, updateResponseActionListener);
         verify(client, times(1)).execute(eq(UpdateInteractionAction.INSTANCE), captor.capture(), any());
         assertEquals("iid", captor.getValue().getInteractionId());
-        assertEquals(1, captor.getValue().getUpdateContent().keySet().size());
+        assertEquals(2, captor.getValue().getUpdateContent().keySet().size());
         assertNotEquals(updateContent, captor.getValue().getUpdateContent());
     }
 


### PR DESCRIPTION
### Description
1. Add interaction into the response of execute API.
2. Fix the issue that response won't be updated because it is not included in allowedList of `UpdateInteractionRequest`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
