### PR TITLE
add auto expand replica settings to memories

### DIFF
--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -18,6 +18,7 @@
 package org.opensearch.ml.memory.index;
 
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_INDEX_NAME;
+import static org.opensearch.ml.memory.index.ConversationMetaIndex.INDEX_SETTINGS;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -87,7 +88,8 @@ public class InteractionsIndex {
             log.debug("No interactions index found. Adding it");
             CreateIndexRequest request = Requests
                 .createIndexRequest(INTERACTIONS_INDEX_NAME)
-                .mapping(ConversationalIndexConstants.INTERACTIONS_MAPPINGS);
+                .mapping(ConversationalIndexConstants.INTERACTIONS_MAPPINGS)
+                .settings(INDEX_SETTINGS);
             try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
                 ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());
                 ActionListener<CreateIndexResponse> al = ActionListener.wrap(r -> {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.engine.indices;
 
 import static org.opensearch.ml.common.CommonValue.META;
 import static org.opensearch.ml.common.CommonValue.SCHEMA_VERSION_FIELD;
+import static org.opensearch.ml.memory.index.ConversationMetaIndex.INDEX_SETTINGS;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +38,6 @@ public class MLIndicesHandler {
 
     ClusterService clusterService;
     Client client;
-    private static final Map<String, Object> indexSettings = Map.of("index.auto_expand_replicas", "0-1");
     private static final Map<String, AtomicBoolean> indexMappingUpdated = new HashMap<>();
 
     static {
@@ -100,7 +100,7 @@ public class MLIndicesHandler {
                     log.error("Failed to create index " + indexName, e);
                     internalListener.onFailure(e);
                 });
-                CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping).settings(indexSettings);
+                CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping).settings(INDEX_SETTINGS);
                 client.admin().indices().create(request, actionListener);
             } else {
                 log.debug("index:{} is already created", indexName);
@@ -116,7 +116,7 @@ public class MLIndicesHandler {
                                     ActionListener.wrap(response -> {
                                         if (response.isAcknowledged()) {
                                             UpdateSettingsRequest updateSettingRequest = new UpdateSettingsRequest();
-                                            updateSettingRequest.indices(indexName).settings(indexSettings);
+                                            updateSettingRequest.indices(indexName).settings(INDEX_SETTINGS);
                                             client
                                                 .admin()
                                                 .indices()


### PR DESCRIPTION
### Description
add the auto expand replica setting to memory indices. 

CI would still fail due to the same test coverage issue in https://github.com/opensearch-project/ml-commons/pull/1800
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
