### PR TITLE
fix duplicate node if node has both data and ml role

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/cluster/DiscoveryNodeHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/DiscoveryNodeHelper.java
@@ -68,7 +68,7 @@ public class DiscoveryNodeHelper {
 
     public DiscoveryNode[] getEligibleNodes(FunctionName functionName) {
         ClusterState state = this.clusterService.state();
-        final List<DiscoveryNode> eligibleNodes = new ArrayList<>();
+        final Set<DiscoveryNode> eligibleNodes = new HashSet<>();
         for (DiscoveryNode node : state.nodes()) {
             if (excludedNodeNames != null && excludedNodeNames.contains(node.getName())) {
                 continue;
@@ -88,7 +88,7 @@ public class DiscoveryNodeHelper {
         return eligibleNodes.toArray(new DiscoveryNode[0]);
     }
 
-    private void getEligibleNodes(Set<String> allowedNodeRoles, List<DiscoveryNode> eligibleNodes, DiscoveryNode node) {
+    private void getEligibleNodes(Set<String> allowedNodeRoles, Set<DiscoveryNode> eligibleNodes, DiscoveryNode node) {
         if (allowedNodeRoles.contains("data") && isEligibleDataNode(node)) {
             eligibleNodes.add(node);
         }
@@ -110,21 +110,21 @@ public class DiscoveryNodeHelper {
                 continue;
             }
             if (functionName == FunctionName.REMOTE) {// remote model
-                getEligibleNodes(remoteModelEligibleNodeRoles, eligibleNodes, node);
+                getEligibleNodeIds(remoteModelEligibleNodeRoles, eligibleNodes, node);
             } else { // local model
                 if (onlyRunOnMLNode) {
                     if (MLNodeUtils.isMLNode(node)) {
                         eligibleNodes.add(node.getId());
                     }
                 } else {
-                    getEligibleNodes(localModelEligibleNodeRoles, eligibleNodes, node);
+                    getEligibleNodeIds(localModelEligibleNodeRoles, eligibleNodes, node);
                 }
             }
         }
         return eligibleNodes.toArray(new String[0]);
     }
 
-    private void getEligibleNodes(Set<String> allowedNodeRoles, Set<String> eligibleNodes, DiscoveryNode node) {
+    private void getEligibleNodeIds(Set<String> allowedNodeRoles, Set<String> eligibleNodes, DiscoveryNode node) {
         if (allowedNodeRoles.contains("data") && isEligibleDataNode(node)) {
             eligibleNodes.add(node.getId());
         }

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -10,6 +10,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.DATA_ROLE;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.INGEST_ROLE;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.SEARCH_ROLE;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_AGENT_ID;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_ALGORITHM;
@@ -21,12 +24,15 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -91,6 +97,11 @@ public class TestHelper {
             return IS_ML_NODE_SETTING;
         }
     };
+
+    public static SortedSet<DiscoveryNodeRole> ALL_ROLES = Collections
+        .unmodifiableSortedSet(
+            new TreeSet<>(Arrays.asList(DATA_ROLE, INGEST_ROLE, CLUSTER_MANAGER_ROLE, REMOTE_CLUSTER_CLIENT_ROLE, SEARCH_ROLE, ML_ROLE))
+        );
 
     public static XContentParser parser(String xc) throws IOException {
         return parser(xc, true);


### PR DESCRIPTION
### Description
If a node has both `data` and `ml` role, the eligible nodes will have duplicate node ids. Then deploy model will fail on the duplicate node.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
