### PR TITLE
Add kotlin stblib dependency for SearchAlertTool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
         }
 
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
+        kotlin_version = System.getProperty("kotlin.version", "1.8.21")
     }
 
     repositories {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     implementation "org.opensearch:common-utils:${common_utils_version}"
+    implementation ("org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}") {
+       exclude group: "org.jetbrains", module: "annotations"
+    }
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation group: 'org.reflections', name: 'reflections', version: '0.9.12'
     implementation group: 'org.tribuo', name: 'tribuo-clustering-kmeans', version: '4.2.1'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -338,6 +338,7 @@ configurations.all {
     resolutionStrategy.force 'org.apache.httpcomponents:httpclient:4.5.14'
     resolutionStrategy.force 'commons-codec:commons-codec:1.15'
     resolutionStrategy.force 'org.slf4j:slf4j-api:1.7.36'
+    resolutionStrategy.force 'org.codehaus.plexus:plexus-utils:3.3.0'
 }
 
 apply plugin: 'com.netflix.nebula.ospackage'


### PR DESCRIPTION
### Description
Add kotlin stblib dependency for SearchAlertTool, issue comes from skills repo and need to fix in ml-commons. The reason of this fix described in [issue](https://github.com/opensearch-project/skills/issues/116) 
 
### Issues Resolved
https://github.com/opensearch-project/skills/issues/116
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
