### PR TITLE
fix race confition in index initialization and RestUpdateConnector UT

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLUpdateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLUpdateConnectorActionTests.java
@@ -142,14 +142,14 @@ public class RestMLUpdateConnectorActionTests extends OpenSearchTestCase {
     }
 
     private RestRequest getRestRequest() {
-        RestRequest.Method method = RestRequest.Method.POST;
+        RestRequest.Method method = RestRequest.Method.PUT;
         final Map<String, Object> updateContent = Map.of("version", "2", "description", "This is test description");
         String requestContent = new Gson().toJson(updateContent).toString();
         Map<String, String> params = new HashMap<>();
         params.put("connector_id", "test_connectorId");
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withMethod(method)
-            .withPath("/_plugins/_ml/connectors/_update/{connector_id}")
+            .withPath("/_plugins/_ml/connectors/{connector_id}")
             .withParams(params)
             .withContent(new BytesArray(requestContent), XContentType.JSON)
             .build();
@@ -157,13 +157,13 @@ public class RestMLUpdateConnectorActionTests extends OpenSearchTestCase {
     }
 
     private RestRequest getRestRequestWithNullValue() {
-        RestRequest.Method method = RestRequest.Method.POST;
+        RestRequest.Method method = RestRequest.Method.PUT;
         String requestContent = "{\"version\":\"2\",\"description\":null}";
         Map<String, String> params = new HashMap<>();
         params.put("connector_id", "test_connectorId");
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withMethod(method)
-            .withPath("/_plugins/_ml/connectors/_update/{connector_id}")
+            .withPath("/_plugins/_ml/connectors/{connector_id}")
             .withParams(params)
             .withContent(new BytesArray(requestContent), XContentType.JSON)
             .build();
@@ -171,12 +171,12 @@ public class RestMLUpdateConnectorActionTests extends OpenSearchTestCase {
     }
 
     private RestRequest getRestRequestWithEmptyContent() {
-        RestRequest.Method method = RestRequest.Method.POST;
+        RestRequest.Method method = RestRequest.Method.PUT;
         Map<String, String> params = new HashMap<>();
         params.put("connector_id", "test_connectorId");
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withMethod(method)
-            .withPath("/_plugins/_ml/connectors/_update/{connector_id}")
+            .withPath("/_plugins/_ml/connectors/{connector_id}")
             .withParams(params)
             .withContent(new BytesArray(""), XContentType.JSON)
             .build();
@@ -184,13 +184,13 @@ public class RestMLUpdateConnectorActionTests extends OpenSearchTestCase {
     }
 
     private RestRequest getRestRequestWithNullConnectorId() {
-        RestRequest.Method method = RestRequest.Method.POST;
+        RestRequest.Method method = RestRequest.Method.PUT;
         final Map<String, Object> updateContent = Map.of("version", "2", "description", "This is test description");
         String requestContent = new Gson().toJson(updateContent).toString();
         Map<String, String> params = new HashMap<>();
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withMethod(method)
-            .withPath("/_plugins/_ml/connectors/_update/{connector_id}")
+            .withPath("/_plugins/_ml/connectors/{connector_id}")
             .withParams(params)
             .withContent(new BytesArray(requestContent), XContentType.JSON)
             .build();


### PR DESCRIPTION
### Description
Fix the issue in https://github.com/opensearch-project/ml-commons/issues/1851, and update the url in the RestUpdateConnector UT.
 
CI pass depends on the fix in https://github.com/opensearch-project/ml-commons/pull/1846. 

CI failed due to:
Tests with failures:
 - org.opensearch.ml.rest.RestMLRemoteInferenceIT.testOpenAIEditsModel
 - org.opensearch.ml.rest.RestMLRemoteInferenceIT.testPredictRemoteModel

~~~
 ERROR][o.o.m.e.a.r.RemoteModel  ] [integTest-0] Failed to call remote model.
org.opensearch.OpenSearchStatusException: Error from remote service: {
     "error": {
         "message": "The model `text-davinci-003` has been deprecated, learn more here: https://platform.openai.com/docs/deprecations",
         "type": "invalid_request_error",
         "param": null,
         "code": "model_not_found"
     }
 }
~~~

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
