### PR TITLE
[Backport] [2.x] Bump Mockito dependencies

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/bwc/MLCommonsBackwardsCompatibilityRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/bwc/MLCommonsBackwardsCompatibilityRestTestCase.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.bwc;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_ENABLED;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
@@ -735,7 +736,7 @@ public class MLCommonsBackwardsCompatibilityRestTestCase extends OpenSearchRestT
         return (String) task.get("state");
     }
 
-    public void waitForTask(String taskId, MLTaskState targetState) throws InterruptedException {
+    public void waitForTask(String taskId, MLTaskState targetState) throws InterruptedException, IOException {
         AtomicBoolean taskDone = new AtomicBoolean(false);
         waitUntil(() -> {
             try {
@@ -748,6 +749,7 @@ public class MLCommonsBackwardsCompatibilityRestTestCase extends OpenSearchRestT
             }
             return taskDone.get();
         }, CUSTOM_MODEL_TIMEOUT, TimeUnit.SECONDS);
+        assertThat(getTaskState(taskId), equalTo(targetState.name()));
         assertTrue(taskDone.get());
     }
 }


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/ml-commons/pull/1711 to `2.x` (the mockito deps were updated in https://github.com/opensearch-project/ml-commons/pull/1697 backport proactively)
 
### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/10334
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
