### PR TITLE
Issue 1787 fixing connector endpoint returns index not found

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -189,6 +189,10 @@ integTest {
     if (System.getProperty("test.debug") != null) {
         jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
     }
+
+    // Set this to true this if you want to see the logs in the terminal test output.
+    // note: if left false the log output will still show in your IDE
+    testLogging.showStandardStreams = true
 }
 
 testClusters.integTest {
@@ -198,7 +202,7 @@ testClusters.integTest {
     // When running integration tests it doesn't forward the --debug-jvm to the cluster anymore
     // i.e. we have to use a custom property to flag when we want to debug elasticsearch JVM
     // since we also support multi node integration tests we increase debugPort per node
-    if (System.getProperty("opensearch.debug") != null) {
+    if (System.getProperty("cluster.debug") != null) {
         def debugPort = 5005
         nodes.forEach { node ->
             node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=*:${debugPort}")

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
@@ -84,19 +84,22 @@ public class SearchConnectorTransportAction extends HandledTransportAction<Searc
 
             ActionListener<SearchResponse> doubleWrappedListener = ActionListener.wrap(wrappedListener::onResponse, e -> {
                 if (e instanceof IndexNotFoundException) {
-                    log.debug("Connectors index not created yet, therefore we will swallow the exception and return an empty search result");
+                    log
+                        .debug(
+                            "Connectors index not created yet, therefore we will swallow the exception and return an empty search result"
+                        );
                     final InternalSearchResponse internalSearchResponse = InternalSearchResponse.empty();
                     final SearchResponse emptySearchResponse = new SearchResponse(
-                            internalSearchResponse,
-                            null,
-                            0,
-                            0,
-                            0,
-                            0,
-                            null,
-                            new ShardSearchFailure[]{},
-                            SearchResponse.Clusters.EMPTY,
-                            null
+                        internalSearchResponse,
+                        null,
+                        0,
+                        0,
+                        0,
+                        0,
+                        null,
+                        new ShardSearchFailure[] {},
+                        SearchResponse.Clusters.EMPTY,
+                        null
                     );
                     wrappedListener.onResponse(emptySearchResponse);
                 } else {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
@@ -107,7 +107,7 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         createConnector(completionModelConnectorEntity);
         String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
         Response response = TestHelper
-                .makeRequest(client(), "GET", "/_plugins/_ml/connectors/_search", null, TestHelper.toHttpEntity(searchEntity), null);
+            .makeRequest(client(), "GET", "/_plugins/_ml/connectors/_search", null, TestHelper.toHttpEntity(searchEntity), null);
         Map responseMap = parseResponseToMap(response);
         assertEquals((Double) 1.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
     }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
@@ -95,11 +95,19 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         assertEquals("deleted", (String) responseMap.get("result"));
     }
 
-    public void testSearchConnectors() throws IOException {
-        createConnector(completionModelConnectorEntity);
+    public void testSearchConnectors_beforeConnectorCreation() throws IOException {
         String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
         Response response = TestHelper
             .makeRequest(client(), "GET", "/_plugins/_ml/connectors/_search", null, TestHelper.toHttpEntity(searchEntity), null);
+        Map responseMap = parseResponseToMap(response);
+        assertEquals((Double) 0.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
+    }
+
+    public void testSearchConnectors_afterConnectorCreation() throws IOException {
+        createConnector(completionModelConnectorEntity);
+        String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
+        Response response = TestHelper
+                .makeRequest(client(), "GET", "/_plugins/_ml/connectors/_search", null, TestHelper.toHttpEntity(searchEntity), null);
         Map responseMap = parseResponseToMap(response);
         assertEquals((Double) 1.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
     }


### PR DESCRIPTION
### Description
When connector is not created yet, return an empty search response instead of a broken 404 with cryptic index not found message.
More description in: https://github.com/opensearch-project/ml-commons/issues/1787

Minor additional issues fixed:
- Ability to run integTest with cluster debugging. 
For example:
`./gradlew :opensearch-ml-plugin:integTest --tests org.opensearch.ml.rest.RestMLSearchConnectorActionIT.testSearchConnector_beforeConnectorCreated -Dcluster.debug=1`
- Show log output during integTest


### Issues Resolved
[[List any issues this PR will resolve]](https://github.com/opensearch-project/ml-commons/issues/1787)
 
### Check List
- [ x] New functionality includes testing.
  - [x ] All tests pass
- [x ] New functionality has been documented.
  - [x ] New functionality has javadoc added
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
