### PR TITLE
fix failing flaky tests due to pytorch library not available for dependency plugins

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     implementation platform("ai.djl:bom:0.21.0")
-    implementation group: 'ai.djl.pytorch', name: 'pytorch-model-zoo'
+    implementation group: 'ai.djl.pytorch', name: 'pytorch-model-zoo', version: '0.21.0'
     implementation group: 'ai.djl', name: 'api'
     implementation group: 'ai.djl.huggingface', name: 'tokenizers'
     implementation("ai.djl.onnxruntime:onnxruntime-engine:0.21.0") {


### PR DESCRIPTION
### Description
There are flaky tests failing on neural search plugin that need a deployed model to be used. But the pytorch model is failing to deploy due to EngineException failure with the error "Failed to load PyTorch native library". 

Since pytorch-engine can load older version of pytorch native library, it could be possible a different version is being loaded than the expected one "pytorch-engine-0.21.0.jar". Here, we are explicitly specifying the required package version to override it to resolve the issue.
 
### Issues Resolved
Fixes the flaky test: https://github.com/opensearch-project/ml-commons/issues/1843
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
