### PR TITLE
Adjust ListTool response format

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/tools/MLToolsListResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/tools/MLToolsListResponse.java
@@ -45,6 +45,7 @@ public class MLToolsListResponse extends ActionResponse implements ToXContentObj
 
     @Override
     public XContentBuilder toXContent(XContentBuilder xContentBuilder, ToXContent.Params params) throws IOException {
+        xContentBuilder.startArray();
         for (ToolMetadata toolMetadata : toolMetadataList) {
             xContentBuilder.startObject();
             xContentBuilder.field(ToolMetadata.TOOL_NAME_FIELD, toolMetadata.getName());
@@ -53,6 +54,7 @@ public class MLToolsListResponse extends ActionResponse implements ToXContentObj
             xContentBuilder.field(ToolMetadata.TOOL_VERSION_FIELD, toolMetadata.getVersion() != null ? toolMetadata.getVersion() : "undefined");
             xContentBuilder.endObject();
         }
+        xContentBuilder.endArray();
         return xContentBuilder;
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/transport/tools/MLToolsListResponseTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/tools/MLToolsListResponseTests.java
@@ -67,7 +67,8 @@ public class MLToolsListResponseTests {
         mlToolsListResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertNotNull(builder);
         String jsonStr = builder.toString();
-        assertEquals("{\"name\":\"SearchWikipediaTool\",\"description\":\"Useful when you need to use this tool to search general knowledge on wikipedia.\",\"type\":\"SearchWikipediaTool\",\"version\":\"undefined\"} {\"name\":\"MathTool\",\"description\":\"Use this tool to calculate any math problem.\",\"type\":\"MathTool\",\"version\":\"test\"}", jsonStr);
+        System.out.println(jsonStr);
+        assertEquals("[{\"name\":\"SearchWikipediaTool\",\"description\":\"Useful when you need to use this tool to search general knowledge on wikipedia.\",\"type\":\"SearchWikipediaTool\",\"version\":\"undefined\"},{\"name\":\"MathTool\",\"description\":\"Use this tool to calculate any math problem.\",\"type\":\"MathTool\",\"version\":\"test\"}]", jsonStr);
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/tools/MLToolsListResponseTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/tools/MLToolsListResponseTests.java
@@ -67,7 +67,6 @@ public class MLToolsListResponseTests {
         mlToolsListResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertNotNull(builder);
         String jsonStr = builder.toString();
-        System.out.println(jsonStr);
         assertEquals("[{\"name\":\"SearchWikipediaTool\",\"description\":\"Useful when you need to use this tool to search general knowledge on wikipedia.\",\"type\":\"SearchWikipediaTool\",\"version\":\"undefined\"},{\"name\":\"MathTool\",\"description\":\"Use this tool to calculate any math problem.\",\"type\":\"MathTool\",\"version\":\"test\"}]", jsonStr);
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/tools/GetToolTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/tools/GetToolTransportAction.java
@@ -6,13 +6,14 @@
 package org.opensearch.ml.tools;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.ToolMetadata;
 import org.opensearch.ml.common.transport.tools.*;
 import org.opensearch.tasks.Task;
@@ -45,7 +46,12 @@ public class GetToolTransportAction extends HandledTransportAction<ActionRequest
                 .stream()
                 .filter(tool -> tool.getName().equals(toolName))
                 .findFirst()
-                .orElseThrow(NoSuchElementException::new);
+                .orElseThrow(
+                    () -> new OpenSearchStatusException(
+                        "Failed to find tool information with the provided tool name: " + toolName,
+                        RestStatus.NOT_FOUND
+                    )
+                );
             listener.onResponse(MLToolGetResponse.builder().toolMetadata(theTool).build());
         } catch (Exception e) {
             log.error("Failed to get tool", e);


### PR DESCRIPTION
### Description
Adjust ListTool response format to fix `Request failed to get to the server (status code: 502)` error when calling ListTool API

Also, adjust exception type for GetTool when there's no such tool. Now it returns 404 when no tool found
```
{
	"error": {
		"root_cause": [
			{
				"type": "status_exception",
				"reason": "Failed to find tool information with the provided tool name: CatIndexTo"
			}
		],
		"type": "status_exception",
		"reason": "Failed to find tool information with the provided tool name: CatIndexTo"
	},
	"status": 404
}
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
