### PR TITLE
Issue 1878/1879/1880 fixing index not found for model group/model/tasks

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.ml.action.connector;
 
-import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleConnectorIndexNotFound;
+import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleSearchIndexNotFound;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,7 +82,7 @@ public class SearchConnectorTransportAction extends HandledTransportAction<Searc
             request.source().fetchSource(rebuiltFetchSourceContext);
 
             final ActionListener<SearchResponse> doubleWrappedListener = ActionListener
-                .wrap(wrappedListener::onResponse, e -> wrapListenerToHandleConnectorIndexNotFound(e, wrappedListener));
+                .wrap(wrappedListener::onResponse, e -> wrapListenerToHandleSearchIndexNotFound(e, wrappedListener));
 
             if (connectorAccessControlHelper.skipConnectorAccessControl(user)) {
                 client.search(request, doubleWrappedListener);

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
@@ -5,16 +5,16 @@
 
 package org.opensearch.ml.action.connector;
 
+import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleConnectorIndexNotFound;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.client.Client;
@@ -22,7 +22,6 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
@@ -30,11 +29,8 @@ import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
-import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
-
-import com.google.common.annotations.VisibleForTesting;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -85,8 +81,8 @@ public class SearchConnectorTransportAction extends HandledTransportAction<Searc
             );
             request.source().fetchSource(rebuiltFetchSourceContext);
 
-            ActionListener<SearchResponse> doubleWrappedListener = ActionListener
-                .wrap(wrappedListener::onResponse, e -> wrapListenerToHandleConnectorIndexNotFound(e, actionListener));
+            final ActionListener<SearchResponse> doubleWrappedListener = ActionListener
+                .wrap(wrappedListener::onResponse, e -> wrapListenerToHandleConnectorIndexNotFound(e, wrappedListener));
 
             if (connectorAccessControlHelper.skipConnectorAccessControl(user)) {
                 client.search(request, doubleWrappedListener);
@@ -98,29 +94,6 @@ public class SearchConnectorTransportAction extends HandledTransportAction<Searc
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             actionListener.onFailure(e);
-        }
-    }
-
-    @VisibleForTesting
-    public static void wrapListenerToHandleConnectorIndexNotFound(Exception e, ActionListener<SearchResponse> listener) {
-        if (ExceptionsHelper.unwrapCause(e) instanceof IndexNotFoundException) {
-            log.debug("Connectors index not created yet, therefore we will swallow the exception and return an empty search result");
-            final InternalSearchResponse internalSearchResponse = InternalSearchResponse.empty();
-            final SearchResponse emptySearchResponse = new SearchResponse(
-                internalSearchResponse,
-                null,
-                0,
-                0,
-                0,
-                0,
-                null,
-                new ShardSearchFailure[] {},
-                SearchResponse.Clusters.EMPTY,
-                null
-            );
-            listener.onResponse(emptySearchResponse);
-        } else {
-            listener.onFailure(e);
         }
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.action.model_group;
 
 import static org.opensearch.ml.action.handler.MLSearchHandler.wrapRestActionListener;
+import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleConnectorIndexNotFound;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -58,13 +59,17 @@ public class SearchModelGroupTransportAction extends HandledTransportAction<Sear
     private void preProcessRoleAndPerformSearch(SearchRequest request, User user, ActionListener<SearchResponse> listener) {
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<SearchResponse> wrappedListener = ActionListener.runBefore(listener, () -> context.restore());
+
+            final ActionListener<SearchResponse> doubleWrappedListener = ActionListener
+                .wrap(wrappedListener::onResponse, e -> wrapListenerToHandleConnectorIndexNotFound(e, wrappedListener));
+
             if (modelAccessControlHelper.skipModelAccessControl(user)) {
-                client.search(request, wrappedListener);
+                client.search(request, doubleWrappedListener);
             } else {
                 // Security is enabled, filter is enabled and user isn't admin
                 modelAccessControlHelper.addUserBackendRolesFilter(user, request.source());
                 log.debug("Filtering result by " + user.getBackendRoles());
-                client.search(request, wrappedListener);
+                client.search(request, doubleWrappedListener);
             }
         } catch (Exception e) {
             log.error("Failed to search", e);

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
@@ -6,7 +6,7 @@
 package org.opensearch.ml.action.model_group;
 
 import static org.opensearch.ml.action.handler.MLSearchHandler.wrapRestActionListener;
-import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleConnectorIndexNotFound;
+import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleSearchIndexNotFound;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -61,7 +61,7 @@ public class SearchModelGroupTransportAction extends HandledTransportAction<Sear
             ActionListener<SearchResponse> wrappedListener = ActionListener.runBefore(listener, () -> context.restore());
 
             final ActionListener<SearchResponse> doubleWrappedListener = ActionListener
-                .wrap(wrappedListener::onResponse, e -> wrapListenerToHandleConnectorIndexNotFound(e, wrappedListener));
+                .wrap(wrappedListener::onResponse, e -> wrapListenerToHandleSearchIndexNotFound(e, wrappedListener));
 
             if (modelAccessControlHelper.skipModelAccessControl(user)) {
                 client.search(request, doubleWrappedListener);

--- a/plugin/src/main/java/org/opensearch/ml/action/models/SearchModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/SearchModelTransportAction.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.ml.action.models;
 
-import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleConnectorIndexNotFound;
-
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -23,7 +21,7 @@ import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class SearchModelTransportAction extends HandledTransportAction<SearchRequest, SearchResponse> {
-    private MLSearchHandler mlSearchHandler;
+    private final MLSearchHandler mlSearchHandler;
 
     @Inject
     public SearchModelTransportAction(TransportService transportService, ActionFilters actionFilters, MLSearchHandler mlSearchHandler) {
@@ -34,8 +32,6 @@ public class SearchModelTransportAction extends HandledTransportAction<SearchReq
     @Override
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> actionListener) {
         request.indices(CommonValue.ML_MODEL_INDEX);
-        final ActionListener<SearchResponse> wrappedListener = ActionListener
-            .wrap(actionListener::onResponse, e -> wrapListenerToHandleConnectorIndexNotFound(e, actionListener));
-        mlSearchHandler.search(request, wrappedListener);
+        mlSearchHandler.search(request, actionListener);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/models/SearchModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/SearchModelTransportAction.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.action.models;
 
+import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleConnectorIndexNotFound;
+
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -32,6 +34,8 @@ public class SearchModelTransportAction extends HandledTransportAction<SearchReq
     @Override
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> actionListener) {
         request.indices(CommonValue.ML_MODEL_INDEX);
-        mlSearchHandler.search(request, actionListener);
+        final ActionListener<SearchResponse> wrappedListener = ActionListener
+            .wrap(actionListener::onResponse, e -> wrapListenerToHandleConnectorIndexNotFound(e, actionListener));
+        mlSearchHandler.search(request, wrappedListener);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/SearchTaskTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/SearchTaskTransportAction.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.ml.action.tasks;
 
-import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleConnectorIndexNotFound;
+import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleSearchIndexNotFound;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -35,7 +35,7 @@ public class SearchTaskTransportAction extends HandledTransportAction<SearchRequ
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> actionListener) {
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             final ActionListener<SearchResponse> wrappedListener = ActionListener
-                .wrap(actionListener::onResponse, e -> wrapListenerToHandleConnectorIndexNotFound(e, actionListener));
+                .wrap(actionListener::onResponse, e -> wrapListenerToHandleSearchIndexNotFound(e, actionListener));
             client.search(request, ActionListener.runBefore(wrappedListener, () -> context.restore()));
         } catch (Exception e) {
             log.error(e.getMessage(), e);

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -266,7 +266,7 @@ public class RestActionUtils {
      * @param e Exception to wrap
      * @param listener ActionListener for a search response to wrap
      */
-    public static void wrapListenerToHandleConnectorIndexNotFound(Exception e, ActionListener<SearchResponse> listener) {
+    public static void wrapListenerToHandleSearchIndexNotFound(Exception e, ActionListener<SearchResponse> listener) {
         if (ExceptionsHelper.unwrapCause(e) instanceof IndexNotFoundException) {
             log.debug("Connectors index not created yet, therefore we will swallow the exception and return an empty search result");
             final InternalSearchResponse internalSearchResponse = InternalSearchResponse.empty();

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -23,6 +23,9 @@ import javax.naming.ldap.LdapName;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
@@ -30,16 +33,22 @@ import org.opensearch.common.Nullable;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
+import org.opensearch.search.internal.InternalSearchResponse;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
 public class RestActionUtils {
 
     private static final Logger logger = LogManager.getLogger(RestActionUtils.class);
@@ -244,6 +253,39 @@ public class RestActionUtils {
             logger.trace("Is principal {} an admin cert? {}", dn.toString(), isAdmin);
         }
         return isAdmin;
+    }
+
+    /**
+     * Utility to wrap over an action listener to handle index not found error to return empty results instead of failing.
+     * This is important when the user is performing a search request against connectors/models/model groups/tasks or other constructs that
+     * do not imply an index error but rather imply no items found.
+     * @see <a href=https://github.com/opensearch-project/ml-commons/issues/1787>Issue 1787</a>
+     * @see <a href=https://github.com/opensearch-project/ml-commons/issues/1778>Issue 1878</a>
+     * @see <a href=https://github.com/opensearch-project/ml-commons/issues/1879>Issue 1879</a>
+     * @see <a href=https://github.com/opensearch-project/ml-commons/issues/1880>Issue 1880</a>
+     * @param e Exception to wrap
+     * @param listener ActionListener for a search response to wrap
+     */
+    public static void wrapListenerToHandleConnectorIndexNotFound(Exception e, ActionListener<SearchResponse> listener) {
+        if (ExceptionsHelper.unwrapCause(e) instanceof IndexNotFoundException) {
+            log.debug("Connectors index not created yet, therefore we will swallow the exception and return an empty search result");
+            final InternalSearchResponse internalSearchResponse = InternalSearchResponse.empty();
+            final SearchResponse emptySearchResponse = new SearchResponse(
+                internalSearchResponse,
+                null,
+                0,
+                0,
+                0,
+                0,
+                null,
+                new ShardSearchFailure[] {},
+                SearchResponse.Clusters.EMPTY,
+                null
+            );
+            listener.onResponse(emptySearchResponse);
+        } else {
+            listener.onFailure(e);
+        }
     }
 
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/handler/MLSearchHandlerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/handler/MLSearchHandlerTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.action.handler;
 
 import java.util.List;

--- a/plugin/src/test/java/org/opensearch/ml/action/handler/MLSearchHandlerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/handler/MLSearchHandlerTests.java
@@ -1,0 +1,94 @@
+package org.opensearch.ml.action.handler;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryStringQueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class MLSearchHandlerTests extends OpenSearchTestCase {
+
+    public void testRewriteQueryBuilder_accessControlIgnored() {
+        final String expectedQueryString = "{\n"
+            + "  \"bool\" : {\n"
+            + "    \"must\" : [\n"
+            + "      {\n"
+            + "        \"query_string\" : {\n"
+            + "          \"query\" : \"\",\n"
+            + "          \"fields\" : [ ],\n"
+            + "          \"type\" : \"best_fields\",\n"
+            + "          \"default_operator\" : \"or\",\n"
+            + "          \"max_determinized_states\" : 10000,\n"
+            + "          \"enable_position_increments\" : true,\n"
+            + "          \"fuzziness\" : \"AUTO\",\n"
+            + "          \"fuzzy_prefix_length\" : 0,\n"
+            + "          \"fuzzy_max_expansions\" : 50,\n"
+            + "          \"phrase_slop\" : 0,\n"
+            + "          \"escape\" : false,\n"
+            + "          \"auto_generate_synonyms_phrase_query\" : true,\n"
+            + "          \"fuzzy_transpositions\" : true,\n"
+            + "          \"boost\" : 1.0\n"
+            + "        }\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"bool\" : {\n"
+            + "          \"must_not\" : [\n"
+            + "            {\n"
+            + "              \"exists\" : {\n"
+            + "                \"field\" : \"model_group_id\",\n"
+            + "                \"boost\" : 1.0\n"
+            + "              }\n"
+            + "            }\n"
+            + "          ],\n"
+            + "          \"adjust_pure_negative\" : true,\n"
+            + "          \"boost\" : 1.0\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ],\n"
+            + "    \"adjust_pure_negative\" : true,\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}";
+        final QueryBuilder queryBuilder = MLSearchHandler.rewriteQueryBuilder(new QueryStringQueryBuilder(""), List.of("group1", "group2"));
+        final String queryString = queryBuilder.toString();
+        Assert.assertEquals(expectedQueryString, queryString);
+    }
+
+    public void testRewriteQueryBuilder_accessControlUsed_withNullQuery() {
+        final String expectedQueryString = "{\n"
+            + "  \"bool\" : {\n"
+            + "    \"should\" : [\n"
+            + "      {\n"
+            + "        \"terms\" : {\n"
+            + "          \"model_group_id\" : [\n"
+            + "            \"group1\",\n"
+            + "            \"group2\"\n"
+            + "          ],\n"
+            + "          \"boost\" : 1.0\n"
+            + "        }\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"bool\" : {\n"
+            + "          \"must_not\" : [\n"
+            + "            {\n"
+            + "              \"exists\" : {\n"
+            + "                \"field\" : \"model_group_id\",\n"
+            + "                \"boost\" : 1.0\n"
+            + "              }\n"
+            + "            }\n"
+            + "          ],\n"
+            + "          \"adjust_pure_negative\" : true,\n"
+            + "          \"boost\" : 1.0\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ],\n"
+            + "    \"adjust_pure_negative\" : true,\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}";
+        final QueryBuilder queryBuilder = MLSearchHandler.rewriteQueryBuilder(null, List.of("group1", "group2"));
+        final String queryString = queryBuilder.toString();
+        Assert.assertEquals(expectedQueryString, queryString);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -780,7 +780,7 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
         return taskId;
     }
 
-    private Map parseResponseToMap(Response response) throws IOException {
+    Map parseResponseToMap(Response response) throws IOException {
         HttpEntity entity = response.getEntity();
         assertNotNull(response);
         String entityString = TestHelper.httpEntityToString(entity);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
@@ -95,7 +95,7 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         assertEquals("deleted", (String) responseMap.get("result"));
     }
 
-    public void testSearchConnectors_beforeConnectorCreation() throws IOException {
+    public void testSearchConnectors_beforeCreation() throws IOException {
         String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
         Response response = TestHelper
             .makeRequest(client(), "GET", "/_plugins/_ml/connectors/_search", null, TestHelper.toHttpEntity(searchEntity), null);
@@ -103,11 +103,63 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         assertEquals((Double) 0.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
     }
 
-    public void testSearchConnectors_afterConnectorCreation() throws IOException {
+    public void testSearchConnectors_afterCreation() throws IOException {
         createConnector(completionModelConnectorEntity);
         String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
         Response response = TestHelper
             .makeRequest(client(), "GET", "/_plugins/_ml/connectors/_search", null, TestHelper.toHttpEntity(searchEntity), null);
+        Map responseMap = parseResponseToMap(response);
+        assertEquals((Double) 1.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
+    }
+
+    public void testSearchRemoteModels_beforeCreation() throws IOException {
+        String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
+        Response response = TestHelper
+            .makeRequest(client(), "GET", "/_plugins/_ml/models/_search", null, TestHelper.toHttpEntity(searchEntity), null);
+        Map responseMap = parseResponseToMap(response);
+        assertEquals((Double) 0.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
+    }
+
+    public void testSearchRemoteModels_afterCreation() throws IOException {
+        registerRemoteModel();
+        String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
+        Response response = TestHelper
+            .makeRequest(client(), "GET", "/_plugins/_ml/models/_search", null, TestHelper.toHttpEntity(searchEntity), null);
+        Map responseMap = parseResponseToMap(response);
+        assertEquals((Double) 1.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
+    }
+
+    public void testSearchModelGroups_beforeCreation() throws IOException {
+        String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
+        Response response = TestHelper
+            .makeRequest(client(), "GET", "/_plugins/_ml/model_groups/_search", null, TestHelper.toHttpEntity(searchEntity), null);
+        Map responseMap = parseResponseToMap(response);
+        assertEquals((Double) 0.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
+    }
+
+    public void testSearchModelGroups_afterCreation() throws IOException {
+        registerRemoteModel();
+        String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
+        Response response = TestHelper
+            .makeRequest(client(), "GET", "/_plugins/_ml/model_groups/_search", null, TestHelper.toHttpEntity(searchEntity), null);
+        Map responseMap = parseResponseToMap(response);
+        assertEquals((Double) 1.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
+    }
+
+    public void testSearchMLTasks_beforeCreation() throws IOException {
+        String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
+        Response response = TestHelper
+            .makeRequest(client(), "GET", "/_plugins/_ml/tasks/_search", null, TestHelper.toHttpEntity(searchEntity), null);
+        Map responseMap = parseResponseToMap(response);
+        assertEquals((Double) 0.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
+    }
+
+    public void testSearchMLTasks_afterCreation() throws IOException {
+        registerRemoteModel();
+
+        String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
+        Response response = TestHelper
+            .makeRequest(client(), "GET", "/_plugins/_ml/tasks/_search", null, TestHelper.toHttpEntity(searchEntity), null);
         Map responseMap = parseResponseToMap(response);
         assertEquals((Double) 1.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
     }
@@ -740,4 +792,14 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         return TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/tasks/" + taskId, null, "", null);
     }
 
+    private String registerRemoteModel() throws IOException {
+        Response response = createConnector(completionModelConnectorEntity);
+        Map responseMap = parseResponseToMap(response);
+        String connectorId = (String) responseMap.get("connector_id");
+        response = registerRemoteModel("openAI-GPT-3.5 completions", connectorId);
+        responseMap = parseResponseToMap(response);
+        String taskId = (String) responseMap.get("task_id");
+        logger.info("task ID created: {}", taskId);
+        return taskId;
+    }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.Before;
@@ -766,13 +765,6 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         Map map = (Map) responseMap.get("error");
         String message = (String) map.get("message");
         return message.equals("You exceeded your current quota, please check your plan and billing details.");
-    }
-
-    private Map parseResponseToMap(Response response) throws IOException {
-        HttpEntity entity = response.getEntity();
-        assertNotNull(response);
-        String entityString = TestHelper.httpEntityToString(entity);
-        return gson.fromJson(entityString, Map.class);
     }
 
     private void disableClusterConnectorAccessControl() throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchConnectorActionTests.java
@@ -20,12 +20,10 @@ import java.util.List;
 
 import org.apache.lucene.search.TotalHits;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.OpenSearchWrapperException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
@@ -37,8 +35,6 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.index.IndexNotFoundException;
-import org.opensearch.ml.action.connector.SearchConnectorTransportAction;
 import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
 import org.opensearch.ml.utils.TestHelper;
 import org.opensearch.rest.RestChannel;
@@ -193,52 +189,5 @@ public class RestMLSearchConnectorActionTests extends OpenSearchTestCase {
         );
         RestResponse restResponse = responseCaptor.getValue();
         assertEquals(RestStatus.REQUEST_TIMEOUT, restResponse.status());
-    }
-
-    public void testDoubleWrapper_handleIndexNotFound() {
-        final IndexNotFoundException indexNotFoundException = new IndexNotFoundException("Index not found", ML_CONNECTOR_INDEX);
-        final DummyActionListener actionListener = new DummyActionListener();
-
-        SearchConnectorTransportAction.wrapListenerToHandleConnectorIndexNotFound(indexNotFoundException, actionListener);
-        Assert.assertTrue(actionListener.success);
-    }
-
-    public void testDoubleWrapper_handleIndexNotFoundWrappedException() {
-        final WrappedException wrappedException = new WrappedException();
-        final DummyActionListener actionListener = new DummyActionListener();
-
-        SearchConnectorTransportAction.wrapListenerToHandleConnectorIndexNotFound(wrappedException, actionListener);
-        Assert.assertTrue(actionListener.success);
-    }
-
-    public void testDoubleWrapper_notRelatedException() {
-        final RuntimeException exception = new RuntimeException("some random exception");
-        final DummyActionListener actionListener = new DummyActionListener();
-
-        SearchConnectorTransportAction.wrapListenerToHandleConnectorIndexNotFound(exception, actionListener);
-        Assert.assertFalse(actionListener.success);
-    }
-
-    public class DummyActionListener implements ActionListener<SearchResponse> {
-        public boolean success = false;
-
-        @Override
-        public void onResponse(SearchResponse searchResponse) {
-            logger.info("success");
-            this.success = true;
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            logger.error("failure", e);
-            this.success = false;
-        }
-    }
-
-    public static class WrappedException extends Exception implements OpenSearchWrapperException {
-        @Override
-        public synchronized Throwable getCause() {
-            return new IndexNotFoundException("Index not found", ML_CONNECTOR_INDEX);
-        }
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelActionIT.java
@@ -11,21 +11,16 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.hc.core5.http.HttpEntity;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 import org.opensearch.client.Response;
-import org.opensearch.client.ResponseException;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.utils.TestHelper;
 
 public class RestMLSearchModelActionIT extends MLCommonsRestTestCase {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     public void testSearchModelAPI_EmptyResources() throws Exception {
-        exceptionRule.expect(ResponseException.class);
-        exceptionRule.expectMessage("index_not_found_exception");
-        TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/models/_search", null, matchAllSearchQuery(), null);
+        Response response = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/models/_search", null, matchAllSearchQuery(), null);
+        Map responseMap = parseResponseToMap(response);
+        assertEquals((Double) 0.0, (Double) ((Map) ((Map) responseMap.get("hits")).get("total")).get("value"));
     }
 
     public void testSearchModelAPI_Success() throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
@@ -327,7 +327,7 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
         final IndexNotFoundException indexNotFoundException = new IndexNotFoundException("Index not found", ML_CONNECTOR_INDEX);
         final DummyActionListener actionListener = new DummyActionListener();
 
-        RestActionUtils.wrapListenerToHandleConnectorIndexNotFound(indexNotFoundException, actionListener);
+        RestActionUtils.wrapListenerToHandleSearchIndexNotFound(indexNotFoundException, actionListener);
         Assert.assertTrue(actionListener.success);
     }
 
@@ -335,7 +335,7 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
         final WrappedException wrappedException = new WrappedException();
         final DummyActionListener actionListener = new DummyActionListener();
 
-        RestActionUtils.wrapListenerToHandleConnectorIndexNotFound(wrappedException, actionListener);
+        RestActionUtils.wrapListenerToHandleSearchIndexNotFound(wrappedException, actionListener);
         Assert.assertTrue(actionListener.success);
     }
 
@@ -343,7 +343,7 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
         final RuntimeException exception = new RuntimeException("some random exception");
         final DummyActionListener actionListener = new DummyActionListener();
 
-        RestActionUtils.wrapListenerToHandleConnectorIndexNotFound(exception, actionListener);
+        RestActionUtils.wrapListenerToHandleSearchIndexNotFound(exception, actionListener);
         Assert.assertFalse(actionListener.success);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.utils;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED;
 import static org.opensearch.ml.utils.RestActionUtils.OPENSEARCH_DASHBOARDS_USER_AGENT;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_ALGORITHM;
@@ -28,7 +29,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.opensearch.OpenSearchWrapperException;
 import org.opensearch.Version;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -38,8 +41,10 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.plugin.MachineLearningPlugin;
 import org.opensearch.rest.RestChannel;
@@ -316,5 +321,52 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
 
         boolean isAdmin = RestActionUtils.isSuperAdminUser(clusterService, client);
         Assert.assertFalse(isAdmin);
+    }
+
+    public void testDoubleWrapper_handleIndexNotFound() {
+        final IndexNotFoundException indexNotFoundException = new IndexNotFoundException("Index not found", ML_CONNECTOR_INDEX);
+        final DummyActionListener actionListener = new DummyActionListener();
+
+        RestActionUtils.wrapListenerToHandleConnectorIndexNotFound(indexNotFoundException, actionListener);
+        Assert.assertTrue(actionListener.success);
+    }
+
+    public void testDoubleWrapper_handleIndexNotFoundWrappedException() {
+        final WrappedException wrappedException = new WrappedException();
+        final DummyActionListener actionListener = new DummyActionListener();
+
+        RestActionUtils.wrapListenerToHandleConnectorIndexNotFound(wrappedException, actionListener);
+        Assert.assertTrue(actionListener.success);
+    }
+
+    public void testDoubleWrapper_notRelatedException() {
+        final RuntimeException exception = new RuntimeException("some random exception");
+        final DummyActionListener actionListener = new DummyActionListener();
+
+        RestActionUtils.wrapListenerToHandleConnectorIndexNotFound(exception, actionListener);
+        Assert.assertFalse(actionListener.success);
+    }
+
+    public class DummyActionListener implements ActionListener<SearchResponse> {
+        public boolean success = false;
+
+        @Override
+        public void onResponse(SearchResponse searchResponse) {
+            logger.info("success");
+            this.success = true;
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            logger.error("failure", e);
+            this.success = false;
+        }
+    }
+
+    public static class WrappedException extends Exception implements OpenSearchWrapperException {
+        @Override
+        public synchronized Throwable getCause() {
+            return new IndexNotFoundException("Index not found", ML_CONNECTOR_INDEX);
+        }
     }
 }


### PR DESCRIPTION
### Description
When model/model group/task is not created yet, return an empty search response instead of a broken 404 with cryptic index not found message.
More description in:
https://github.com/opensearch-project/ml-commons/issues/1878
https://github.com/opensearch-project/ml-commons/issues/1879
https://github.com/opensearch-project/ml-commons/issues/1880
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/1878
https://github.com/opensearch-project/ml-commons/issues/1879
https://github.com/opensearch-project/ml-commons/issues/1880
 
### Check List
- [X ] New functionality includes testing.
  - [ X] All tests pass
- [X] New functionality has been documented.
  - [X ] New functionality has javadoc added
- [ X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
