### PR TITLE
[Backport 2.x] changes to hidden model code to use OPENDISTRO_SECURITY_USER instad of ssl principal (#1897)

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
@@ -94,7 +94,6 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         assertEquals("deleted", (String) responseMap.get("result"));
     }
 
-
     public void testSearchConnectors_beforeConnectorCreation() throws IOException {
         String searchEntity = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 1000\n" + "}";
         Response response = TestHelper

--- a/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
@@ -297,15 +297,19 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
 
         when(clusterService.getSettings())
-            .thenReturn(Settings.builder().putList(RestActionUtils.SECURITY_AUTHCZ_ADMIN_DN, "cn=admin").build());
+            .thenReturn(
+                Settings.builder().putList(RestActionUtils.SECURITY_AUTHCZ_ADMIN_DN, "CN=kirk,OU=client,O=client,L=test, C=de").build()
+            );
         when(client.threadPool()).thenReturn(mock(ThreadPool.class));
         when(client.threadPool().getThreadContext()).thenReturn(threadContext);
 
-        threadContext.putTransient(RestActionUtils.OPENDISTRO_SECURITY_SSL_PRINCIPAL, "cn=admin");
+        threadContext.putTransient(RestActionUtils.OPENDISTRO_SECURITY_USER, Map.of("name", "CN=kirk,OU=client,O=client,L=test,C=de"));
 
         boolean isAdmin = RestActionUtils.isSuperAdminUser(clusterService, client);
         Assert.assertTrue(isAdmin);
     }
+
+    // Need to add a test case to cover non Ldap user
 
     @Test
     public void testIsSuperAdminUser_NotAdmin() {
@@ -317,7 +321,7 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
             .thenReturn(Settings.builder().putList(RestActionUtils.SECURITY_AUTHCZ_ADMIN_DN, "cn=admin").build());
         when(client.threadPool()).thenReturn(mock(ThreadPool.class));
         when(client.threadPool().getThreadContext()).thenReturn(threadContext);
-        threadContext.putTransient(RestActionUtils.OPENDISTRO_SECURITY_SSL_PRINCIPAL, "cn=notadmin");
+        threadContext.putTransient(RestActionUtils.OPENDISTRO_SECURITY_USER, Map.of("name", "nonAdmin"));
 
         boolean isAdmin = RestActionUtils.isSuperAdminUser(clusterService, client);
         Assert.assertFalse(isAdmin);


### PR DESCRIPTION

Signed-off-by: Bhavana Ramaram <rbhavna@amazon.com>
(cherry picked from commit de59efc80d2a4b53917edfd941ba14bf99956639)

### Description
Backport https://github.com/opensearch-project/ml-commons/commit/de59efc80d2a4b53917edfd941ba14bf99956639 from https://github.com/opensearch-project/ml-commons/pull/1897

* changes to hidden model code to use OPENDISTRO_SECURITY_USER instad of ssl principal
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
