### PR TITLE
Fix model not deploy issue under intensive prediction tasks

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeAction.java
@@ -198,6 +198,10 @@ public class TransportSyncUpOnNodeAction extends
         }
         for (String taskId : allTaskIds) {
             MLTaskCache mlTaskCache = mlTaskManager.getMLTaskCache(taskId);
+            // Task could be a prediction task, and it could be completed and removed from cache in predict thread during the cleaning up.
+            if (mlTaskCache == null) {
+                continue;
+            }
             MLTask mlTask = mlTaskCache.getMlTask();
             Instant lastUpdateTime = mlTask.getLastUpdateTime();
             Instant now = Instant.now();

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -117,7 +117,7 @@ public class MLTaskManager {
             throw new IllegalArgumentException("Duplicate taskId");
         }
         taskCaches.put(taskId, new MLTaskCache(mlTask, workerNodes));
-        log.debug("add ML task to cache " + taskId);
+        log.debug("add ML task to cache, taskId: {}, taskType: {} ", taskId, mlTask.getTaskType());
     }
 
     /**


### PR DESCRIPTION
### Description
Under intensive prediction tasks, the model not deployed error can happen occasionally like below: 
```
[ERROR] Cannot execute-test. Error in load generator [0]
        Cannot run task [bulk]: Request returned an error. Error type: bulk, Description: HTTP status: 400, message: Model not ready yet. Please run this first: POST /_plugins/_ml/models/Cc36M40Bxy1iWleaz3Bl/_deploy
``` 
The reason is the SyncUpJob cleans timed out deploying model tasks from all tasks not filtering prediction tasks, and a prediction task can be removed from cache when prediction is done. And the corresponding taskCache is cleared, the syncUpJob will encounter NPE and return error response for gatherInfoRequest, and in this case, SyncUpJob sends clearRoutingTable request and clear all routingTable info, the next prediction task will see no model in the cache and throw model needs deploy exception.
 
### Issues Resolved
NA
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
