### PR TITLE
bug fix - tool parameters missing

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -491,6 +491,7 @@ public class MLChatAgentRunner implements MLAgentRunner {
                                     llmToolTmpParameters.put(MLAgentExecutor.QUESTION, actionInput);
                                     tools.get(action).run(llmToolTmpParameters, toolListener); // run tool
                                 } else {
+                                    toolParams.putAll(toolSpecMap.get(action).getParameters());
                                     tools.get(action).run(toolParams, toolListener); // run tool
                                 }
                             } catch (Exception e) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -465,7 +465,7 @@ public class MLChatAgentRunner implements MLAgentRunner {
                     action = toolName;
 
                     if (tools.containsKey(action) && inputTools.contains(action)) {
-                        Map<String, String> toolParams = new HashMap<>();
+                        Map<String, String> toolParams = new HashMap<>(toolSpecMap.get(action).getParameters());
                         toolParams.put("input", actionInput);
                         if (tools.get(action).validate(toolParams)) {
                             try {
@@ -491,7 +491,6 @@ public class MLChatAgentRunner implements MLAgentRunner {
                                     llmToolTmpParameters.put(MLAgentExecutor.QUESTION, actionInput);
                                     tools.get(action).run(llmToolTmpParameters, toolListener); // run tool
                                 } else {
-                                    toolParams.putAll(toolSpecMap.get(action).getParameters());
                                     tools.get(action).run(toolParams, toolListener); // run tool
                                 }
                             } catch (Exception e) {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerTest.java
@@ -191,8 +191,18 @@ public class MLChatAgentRunnerTest {
     @Test
     public void testRunWithIncludeOutputNotSet() {
         LLMSpec llmSpec = LLMSpec.builder().modelId("MODEL_ID").build();
-        MLToolSpec firstToolSpec = MLToolSpec.builder().name(FIRST_TOOL).type(FIRST_TOOL).build();
-        MLToolSpec secondToolSpec = MLToolSpec.builder().name(SECOND_TOOL).type(SECOND_TOOL).build();
+        MLToolSpec firstToolSpec = MLToolSpec
+            .builder()
+            .name(FIRST_TOOL)
+            .type(FIRST_TOOL)
+            .parameters(ImmutableMap.of("key1", "value1", "key2", "value2"))
+            .build();
+        MLToolSpec secondToolSpec = MLToolSpec
+            .builder()
+            .name(SECOND_TOOL)
+            .type(SECOND_TOOL)
+            .parameters(ImmutableMap.of("key1", "value1", "key2", "value2"))
+            .build();
         final MLAgent mlAgent = MLAgent
             .builder()
             .name("TestAgent")


### PR DESCRIPTION
### Description
The tool's parameters configured in agent registration are missing when conversational agent runs the tool.
Tested in my local environment.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
