### PR TITLE
Fix string.format wrong parameter position

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/MLEngine.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/MLEngine.java
@@ -58,7 +58,7 @@ public class MLEngine {
 
     public String getPrebuiltModelConfigPath(String modelName, String version, MLModelFormat modelFormat) {
         String format = modelFormat.name().toLowerCase(Locale.ROOT);
-        return String.format("%s/%s/%s/%s/config.json", MODEL_REPO, modelName, version, format, Locale.ROOT);
+        return String.format(Locale.ROOT, "%s/%s/%s/%s/config.json", MODEL_REPO, modelName, version, format);
     }
 
     public String getPrebuiltModelPath(String modelName, String version, MLModelFormat modelFormat) {
@@ -67,7 +67,7 @@ public class MLEngine {
         // /huggingface/sentence-transformers/msmarco-distilbert-base-tas-b/1.0.0/onnx/config.json
         String format = modelFormat.name().toLowerCase(Locale.ROOT);
         String modelZipFileName = modelName.substring(index).replace("/", "_") + "-" + version + "-" + format;
-        return String.format("%s/%s/%s/%s/%s.zip", MODEL_REPO, modelName, version, format, modelZipFileName, Locale.ROOT);
+        return String.format(Locale.ROOT, "%s/%s/%s/%s/%s.zip", MODEL_REPO, modelName, version, format, modelZipFileName);
     }
 
     public Path getRegisterModelPath(String modelId, String modelName, String version) {


### PR DESCRIPTION
### Description
Fix string.format wrong parameter position, the Locale should be first parameter
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
