### PR TITLE
AI connector blueprint for the Aleph Alpha Luminous-Base Embedding Model

### DIFF
--- a/docs/remote_inference_blueprints/aleph_alpha_connector_luminous_base_embedding_blueprint.md
+++ b/docs/remote_inference_blueprints/aleph_alpha_connector_luminous_base_embedding_blueprint.md
@@ -1,8 +1,8 @@
 # Aleph Alpha connector blueprint example for luminous-base embedding model
+This is an AI connector blueprint for the [Aleph Alpha Luminous-Base Embedding Model](https://docs.aleph-alpha.com/api/semantic-embed/).
+This model is particularly effective for German language applications, providing nuanced and contextually relevant embeddings. 
 
 ## 1. Add connector endpoint to trusted URLs:
-
-Note: no need to do this after 2.11.0
 
 ```json
 PUT /_cluster/settings
@@ -26,8 +26,8 @@ POST /_plugins/_ml/connectors/_create
   "protocol": "http",
   "parameters": {
     "endpoint": "api.aleph-alpha.com",
-	"representation": "document",
-	"normalize": true
+    "representation": "document",
+    "normalize": true
   },
   "credential": {
     "AlephAlpha_API_Token": "<PLEASE ADD YOUR ALEPH ALPHA API TOKEN HERE>"
@@ -44,7 +44,7 @@ POST /_plugins/_ml/connectors/_create
       },
       "request_body": "{ \"model\": \"luminous-base\", \"prompt\": \"${parameters.input}\", \"representation\": \"${parameters.representation}\", \"normalize\": ${parameters.normalize}}",
       "pre_process_function": "\n    StringBuilder builder = new StringBuilder();\n    builder.append(\"\\\"\");\n    String first = params.text_docs[0];\n    builder.append(first);\n    builder.append(\"\\\"\");\n    def parameters = \"{\" +\"\\\"input\\\":\" + builder + \"}\";\n    return  \"{\" +\"\\\"parameters\\\":\" + parameters + \"}\";",
-      "post_process_function": "\n      def name = \"embedding\";\n      def dataType = \"FLOAT32\";\n      if (params.embedding == null || params.embedding.length == 0) {\n        return params.message;\n      }\n      def shape = [params.embedding.length];\n      def json = \"{\" +\n                 \"\\\"name\\\":\\\"\" + name + \"\\\",\" +\n                 \"\\\"data_type\\\":\\\"\" + dataType + \"\\\",\" +\n                 \"\\\"shape\\\":\" + shape + \",\" +\n                 \"\\\"data\\\":\" + params.embedding +\n                 \"}\";\n      return json;\n    "
+      "post_process_function": "\n      def name = \"sentence_embedding\";\n      def dataType = \"FLOAT32\";\n      if (params.embedding == null || params.embedding.length == 0) {\n        return params.message;\n      }\n      def shape = [params.embedding.length];\n      def json = \"{\" +\n                 \"\\\"name\\\":\\\"\" + name + \"\\\",\" +\n                 \"\\\"data_type\\\":\\\"\" + dataType + \"\\\",\" +\n                 \"\\\"shape\\\":\" + shape + \",\" +\n                 \"\\\"data\\\":\" + params.embedding +\n                 \"}\";\n      return json;\n    "
     }
   ]
 }
@@ -122,7 +122,7 @@ Sample response:
     {
       "output": [
         {
-          "name": "embedding",
+          "name": "sentence_embedding",
           "data_type": "FLOAT32",
           "shape": [
             5120

--- a/docs/remote_inference_blueprints/aleph_alpha_connector_luminous_base_embedding_blueprint.md
+++ b/docs/remote_inference_blueprints/aleph_alpha_connector_luminous_base_embedding_blueprint.md
@@ -1,0 +1,143 @@
+# Aleph Alpha connector blueprint example for luminous-base embedding model
+
+## 1. Add connector endpoint to trusted URLs:
+
+Note: no need to do this after 2.11.0
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.trusted_connector_endpoints_regex": [
+            "^https://api\\.aleph-alpha\\.com/.*$"
+        ]
+    }
+}
+```
+
+## 2. Create connector for Aleph Alpha:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Aleph Alpha Connector: luminous-base, representation: document",
+  "description": "The connector to the Aleph Alpha luminous-base embedding model with representation: document",
+  "version": 1,
+  "protocol": "http",
+  "parameters": {
+    "endpoint": "api.aleph-alpha.com",
+	"representation": "document",
+	"normalize": true
+  },
+  "credential": {
+    "AlephAlpha_API_Token": "<PLEASE ADD YOUR ALEPH ALPHA API TOKEN HERE>"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+	  "url": "https://${parameters.endpoint}/semantic_embed",
+      "headers": {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Authorization": "Bearer ${credential.AlephAlpha_API_Token}"
+      },
+      "request_body": "{ \"model\": \"luminous-base\", \"prompt\": \"${parameters.input}\", \"representation\": \"${parameters.representation}\", \"normalize\": ${parameters.normalize}}",
+      "pre_process_function": "\n    StringBuilder builder = new StringBuilder();\n    builder.append(\"\\\"\");\n    String first = params.text_docs[0];\n    builder.append(first);\n    builder.append(\"\\\"\");\n    def parameters = \"{\" +\"\\\"input\\\":\" + builder + \"}\";\n    return  \"{\" +\"\\\"parameters\\\":\" + parameters + \"}\";",
+      "post_process_function": "\n      def name = \"embedding\";\n      def dataType = \"FLOAT32\";\n      if (params.embedding == null || params.embedding.length == 0) {\n        return params.message;\n      }\n      def shape = [params.embedding.length];\n      def json = \"{\" +\n                 \"\\\"name\\\":\\\"\" + name + \"\\\",\" +\n                 \"\\\"data_type\\\":\\\"\" + dataType + \"\\\",\" +\n                 \"\\\"shape\\\":\" + shape + \",\" +\n                 \"\\\"data\\\":\" + params.embedding +\n                 \"}\";\n      return json;\n    "
+    }
+  ]
+}
+```
+
+Sample response:
+```json
+{
+  "connector_id": "bRa3QI0BWgGoN0Ye9K2u"
+}
+```
+
+## 3. Create model group:
+
+```json
+POST /_plugins/_ml/model_groups/_register
+{
+    "name": "remote_model_group",
+    "description": "This is an example description"
+}
+```
+
+Sample response:
+```json
+{
+  "model_group_id": "XRbIP40BWgGoN0YeZq1V",
+  "status": "CREATED"
+}
+```
+
+## 4. Register model to model group & deploy model:
+
+```json
+POST /_plugins/_ml/models/_register
+{
+  "name": "Luminous-base embedding model",
+  "function_name": "remote",
+  "model_group_id": "XRbIP40BWgGoN0YeZq1V",
+  "description": "embedding model, representation: document",
+  "connector_id": "bRa3QI0BWgGoN0Ye9K2u"
+}
+```
+
+Sample response:
+```json
+{
+  "task_id": "r6R9PIsBQRofe4CSlUoG",
+  "status": "CREATED"
+}
+```
+Get model id from task
+```json
+GET /_plugins/_ml/tasks/r6R9PIsBQRofe4CSlUoG
+```
+Deploy model, in this demo the model id is `sKR9PIsBQRofe4CSlUov`
+```json
+POST /_plugins/_ml/models/sKR9PIsBQRofe4CSlUov/_deploy
+```
+
+## 5. Test model inference
+
+```json
+POST /_plugins/_ml/models/sKR9PIsBQRofe4CSlUov/_predict
+{
+  "parameters": {
+    "input": "Test string with German characters: Moët Hennessy"
+  }
+}
+```
+
+Sample response:
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "embedding",
+          "data_type": "FLOAT32",
+          "shape": [
+            5120
+          ],
+          "data": [
+            -0.012756348,
+            0.001159668,
+            0.0025634766,
+            ...
+          ]
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```
+


### PR DESCRIPTION
Adding an AI connector blueprint for the Aleph Alpha Luminous-Base Embedding Model.

### Description
I'm proposing to add an AI connector blueprint for the [Aleph Alpha Luminous-Base Embedding Model](https://docs.aleph-alpha.com/api/semantic-embed/) to the current collection of remote inference blueprints in [OpenSearch ML Commons](https://github.com/opensearch-project/ml-commons/tree/2.x/docs/remote_inference_blueprints).
This model is particularly effective for German language applications, providing nuanced and contextually relevant embeddings. Given the increasing demand for robust language model solutions in different languages, integrating this model could significantly enhance your offerings for German-language processing tasks.
 
### Issues Resolved
[Issue 1925](https://github.com/opensearch-project/ml-commons/issues/1925)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
