### PR TITLE
[BUG FIX] Fix updating plugins.ml_commons.jvm_heap_memory_threshold takes no effect

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/breaker/MemoryCircuitBreaker.java
+++ b/plugin/src/main/java/org/opensearch/ml/breaker/MemoryCircuitBreaker.java
@@ -44,7 +44,12 @@ public class MemoryCircuitBreaker extends ThresholdCircuitBreaker<Short> {
     }
 
     @Override
+    public Short getThreshold() {
+        return this.jvmHeapMemThreshold.shortValue();
+    }
+
+    @Override
     public boolean isOpen() {
-        return jvmService.stats().getMem().getHeapUsedPercent() > jvmHeapMemThreshold;
+        return jvmService.stats().getMem().getHeapUsedPercent() > this.getThreshold();
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/breaker/MemoryCircuitBreaker.java
+++ b/plugin/src/main/java/org/opensearch/ml/breaker/MemoryCircuitBreaker.java
@@ -45,6 +45,6 @@ public class MemoryCircuitBreaker extends ThresholdCircuitBreaker<Short> {
 
     @Override
     public boolean isOpen() {
-        return jvmService.stats().getMem().getHeapUsedPercent() > this.getThreshold();
+        return jvmService.stats().getMem().getHeapUsedPercent() > jvmHeapMemThreshold;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/breaker/MemoryCircuitBreakerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/breaker/MemoryCircuitBreakerTests.java
@@ -6,12 +6,16 @@
 package org.opensearch.ml.breaker;
 
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_JVM_HEAP_MEM_THRESHOLD;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.monitor.jvm.JvmService;
 import org.opensearch.monitor.jvm.JvmStats;
 
@@ -25,6 +29,9 @@ public class MemoryCircuitBreakerTests {
 
     @Mock
     JvmStats.Mem mem;
+
+    @Mock
+    ClusterService clusterService;
 
     @Before
     public void setup() {
@@ -59,5 +66,22 @@ public class MemoryCircuitBreakerTests {
 
         when(mem.getHeapUsedPercent()).thenReturn((short) 95);
         Assert.assertTrue(breaker.isOpen());
+    }
+
+    @Test
+    public void testIsOpen_UpdatedByClusterSettings_ExceedMemoryThreshold() {
+        ClusterSettings settingsService = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        settingsService.registerSetting(ML_COMMONS_JVM_HEAP_MEM_THRESHOLD);
+        when(clusterService.getClusterSettings()).thenReturn(settingsService);
+
+        CircuitBreaker breaker = new MemoryCircuitBreaker(Settings.builder().build(), clusterService, jvmService);
+
+        when(mem.getHeapUsedPercent()).thenReturn((short) 90);
+        Assert.assertTrue(breaker.isOpen());
+
+        Settings.Builder newSettingsBuilder = Settings.builder();
+        newSettingsBuilder.put("plugins.ml_commons.jvm_heap_memory_threshold", 95);
+        settingsService.applySettings(newSettingsBuilder.build());
+        Assert.assertFalse(breaker.isOpen());
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryCircuitBreakerIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryCircuitBreakerIT.java
@@ -1,0 +1,76 @@
+package org.opensearch.ml.rest;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+
+import java.io.IOException;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.After;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.ml.breaker.MemoryCircuitBreaker;
+import org.opensearch.ml.utils.TestHelper;
+
+import com.google.common.collect.ImmutableList;
+
+public class RestMLMemoryCircuitBreakerIT extends MLCommonsRestTestCase {
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        // restore the threshold to default value
+        Response response1 = TestHelper
+            .makeRequest(
+                client(),
+                "PUT",
+                "_cluster/settings",
+                null,
+                "{\"persistent\":{\"plugins.ml_commons.jvm_heap_memory_threshold\":"
+                    + MemoryCircuitBreaker.DEFAULT_JVM_HEAP_USAGE_THRESHOLD
+                    + "}}",
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+            );
+        assertEquals(200, response1.getStatusLine().getStatusCode());
+    }
+
+    public void testRunWithMemoryCircuitBreaker() throws IOException {
+        // set a low threshold
+        Response response1 = TestHelper
+            .makeRequest(
+                client(),
+                "PUT",
+                "_cluster/settings",
+                null,
+                "{\"persistent\":{\"plugins.ml_commons.jvm_heap_memory_threshold\":1}}",
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+            );
+        assertEquals(200, response1.getStatusLine().getStatusCode());
+
+        // expect task fail due to memory limit
+        Exception exception = assertThrows(ResponseException.class, () -> ingestModelData());
+        org.hamcrest.MatcherAssert
+            .assertThat(
+                exception.getMessage(),
+                allOf(
+                    containsString("Memory Circuit Breaker is open, please check your resources!"),
+                    containsString("m_l_limit_exceeded_exception")
+                )
+            );
+
+        // set a higher threshold
+        Response response2 = TestHelper
+            .makeRequest(
+                client(),
+                "PUT",
+                "_cluster/settings",
+                null,
+                "{\"persistent\":{\"plugins.ml_commons.jvm_heap_memory_threshold\":100}}",
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+            );
+        assertEquals(200, response2.getStatusLine().getStatusCode());
+
+        // expect task success
+        ingestModelData();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryCircuitBreakerIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryCircuitBreakerIT.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.opensearch.ml.rest;
 
 import static org.hamcrest.Matchers.allOf;


### PR DESCRIPTION
### Description
In skills repo we have a flaky test of triggering the memory circuit breaker ([ref](https://github.com/opensearch-project/skills/actions/runs/7660776972/job/20878791576?pr=148)). We try to increase the threshold value, but the issue still exists. Then we find there is a bug in `MemoryCircuitBreaker`. It use `super.threshold` to check whether CB is open. But if we update the cluster settings, `jvmHeapMemThreshold` gets updated.

In this PR I fix the bug to use `jvmHeapMemThreshold` to check CB. Add more UT and IT for this.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
