### PR TITLE
Fix null taskId causing model undeploy issue

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeAction.java
@@ -197,6 +197,9 @@ public class TransportSyncUpOnNodeAction extends
             return;
         }
         for (String taskId : allTaskIds) {
+            if (taskId == null) {
+                continue;
+            }
             MLTaskCache mlTaskCache = mlTaskManager.getMLTaskCache(taskId);
             // Task could be a prediction task, and it could be completed and removed from cache in predict thread during the cleaning up.
             if (mlTaskCache == null) {


### PR DESCRIPTION
### Description
During intensive benchmark test, sometimes can get below error:
```
[ERROR] Cannot execute-test. Error in load generator [3]
        Cannot run task [bulk]: Request returned an error. Error type: bulk, Description: HTTP status: 400, message: Model not ready yet. Please run this first: POST /_plugins/_ml/models/z7cLVI0BDnAEuuAYMD8k/_deploy
```
Even after this fix: https://github.com/opensearch-project/ml-commons/pull/1903, after investigation found sometimes taskId is null like below:
```
... c055db11-f6ff-49c3-ae7b-ae597959756e,1db175b1-1845-407e-8ef5-2ec00a655677,edf5815a-e061-4d3f-945f-fee5c4f29821,c021b4b9-764f-4ed8-b0bb-d57e3ed2d9c6,null
```
So adding this null check to by pass this issue.
 
### Issues Resolved
NA
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
