### PR TITLE
agent framework disable/enable flag

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -659,7 +659,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
         RestMLTrainingAction restMLTrainingAction = new RestMLTrainingAction();
         RestMLTrainAndPredictAction restMLTrainAndPredictAction = new RestMLTrainAndPredictAction();
         RestMLPredictionAction restMLPredictionAction = new RestMLPredictionAction(mlModelManager, mlFeatureEnabledSetting);
-        RestMLExecuteAction restMLExecuteAction = new RestMLExecuteAction();
+        RestMLExecuteAction restMLExecuteAction = new RestMLExecuteAction(mlFeatureEnabledSetting);
         RestMLGetModelAction restMLGetModelAction = new RestMLGetModelAction();
         RestMLDeleteModelAction restMLDeleteModelAction = new RestMLDeleteModelAction();
         RestMLSearchModelAction restMLSearchModelAction = new RestMLSearchModelAction();
@@ -672,7 +672,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
             settings,
             mlFeatureEnabledSetting
         );
-        RestMLRegisterAgentAction restMLRegisterAgentAction = new RestMLRegisterAgentAction();
+        RestMLRegisterAgentAction restMLRegisterAgentAction = new RestMLRegisterAgentAction(mlFeatureEnabledSetting);
         RestMLDeployModelAction restMLDeployModelAction = new RestMLDeployModelAction();
         RestMLUndeployModelAction restMLUndeployModelAction = new RestMLUndeployModelAction(clusterService, settings);
         RestMLRegisterModelMetaAction restMLRegisterModelMetaAction = new RestMLRegisterModelMetaAction(clusterService, settings);
@@ -701,12 +701,12 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
         RestMLGetControllerAction restMLGetControllerAction = new RestMLGetControllerAction();
         RestMLUpdateControllerAction restMLUpdateControllerAction = new RestMLUpdateControllerAction();
         RestMLDeleteControllerAction restMLDeleteControllerAction = new RestMLDeleteControllerAction();
-        RestMLGetAgentAction restMLGetAgentAction = new RestMLGetAgentAction();
-        RestMLDeleteAgentAction restMLDeleteAgentAction = new RestMLDeleteAgentAction();
+        RestMLGetAgentAction restMLGetAgentAction = new RestMLGetAgentAction(mlFeatureEnabledSetting);
+        RestMLDeleteAgentAction restMLDeleteAgentAction = new RestMLDeleteAgentAction(mlFeatureEnabledSetting);
         RestMemoryUpdateConversationAction restMemoryUpdateConversationAction = new RestMemoryUpdateConversationAction();
         RestMemoryUpdateInteractionAction restMemoryUpdateInteractionAction = new RestMemoryUpdateInteractionAction();
         RestMemoryGetTracesAction restMemoryGetTracesAction = new RestMemoryGetTracesAction();
-        RestMLSearchAgentAction restMLSearchAgentAction = new RestMLSearchAgentAction();
+        RestMLSearchAgentAction restMLSearchAgentAction = new RestMLSearchAgentAction(mlFeatureEnabledSetting);
         RestMLListToolsAction restMLListToolsAction = new RestMLListToolsAction(toolFactories);
         RestMLGetToolAction restMLGetToolAction = new RestMLGetToolAction(toolFactories);
         return ImmutableList
@@ -869,7 +869,8 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
                 MLCommonsSettings.ML_COMMONS_LOCAL_MODEL_ELIGIBLE_NODE_ROLES,
                 MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MEMORY_FEATURE_ENABLED,
-                MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED
+                MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED,
+                MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLDeleteAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLDeleteAgentAction.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.rest;
 
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.MLExceptionUtils.AGENT_FRAMEWORK_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_AGENT_ID;
 
 import java.io.IOException;
@@ -15,6 +16,7 @@ import java.util.Locale;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.ml.common.transport.agent.MLAgentDeleteAction;
 import org.opensearch.ml.common.transport.agent.MLAgentDeleteRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestToXContentListener;
@@ -26,8 +28,11 @@ import com.google.common.collect.ImmutableList;
  */
 public class RestMLDeleteAgentAction extends BaseRestHandler {
     private static final String ML_DELETE_AGENT_ACTION = "ml_delete_agent_action";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
-    public void RestMLDeleteAgentAction() {}
+    public RestMLDeleteAgentAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
 
     @Override
     public String getName() {
@@ -42,6 +47,9 @@ public class RestMLDeleteAgentAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (!mlFeatureEnabledSetting.isAgentFrameworkEnabled()) {
+            throw new IllegalStateException(AGENT_FRAMEWORK_DISABLED_ERR_MSG);
+        }
         String agentId = request.param(PARAMETER_AGENT_ID);
 
         MLAgentDeleteRequest mlAgentDeleteRequest = new MLAgentDeleteRequest(agentId);

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetAgentAction.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.rest;
 
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.MLExceptionUtils.AGENT_FRAMEWORK_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_AGENT_ID;
 import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
 
@@ -16,6 +17,7 @@ import java.util.Locale;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.ml.common.transport.agent.MLAgentGetAction;
 import org.opensearch.ml.common.transport.agent.MLAgentGetRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestToXContentListener;
@@ -25,11 +27,14 @@ import com.google.common.collect.ImmutableList;
 
 public class RestMLGetAgentAction extends BaseRestHandler {
     private static final String ML_GET_Agent_ACTION = "ml_get_agent_action";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     /**
      * Constructor
      */
-    public RestMLGetAgentAction() {}
+    public RestMLGetAgentAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
 
     @Override
     public String getName() {
@@ -56,6 +61,9 @@ public class RestMLGetAgentAction extends BaseRestHandler {
      */
     @VisibleForTesting
     MLAgentGetRequest getRequest(RestRequest request) throws IOException {
+        if (!mlFeatureEnabledSetting.isAgentFrameworkEnabled()) {
+            throw new IllegalStateException(AGENT_FRAMEWORK_DISABLED_ERR_MSG);
+        }
         String agentId = getParameterId(request, PARAMETER_AGENT_ID);
 
         return new MLAgentGetRequest(agentId);

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLRegisterAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLRegisterAgentAction.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.rest;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.MLExceptionUtils.AGENT_FRAMEWORK_DISABLED_ERR_MSG;
 
 import java.io.IOException;
 import java.util.List;
@@ -17,6 +18,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentAction;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestToXContentListener;
@@ -26,11 +28,14 @@ import com.google.common.collect.ImmutableList;
 
 public class RestMLRegisterAgentAction extends BaseRestHandler {
     private static final String ML_REGISTER_AGENT_ACTION = "ml_register_agent_action";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     /**
      * Constructor
      */
-    public RestMLRegisterAgentAction() {}
+    public RestMLRegisterAgentAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
 
     @Override
     public String getName() {
@@ -56,6 +61,9 @@ public class RestMLRegisterAgentAction extends BaseRestHandler {
      */
     @VisibleForTesting
     MLRegisterAgentRequest getRequest(RestRequest request) throws IOException {
+        if (!mlFeatureEnabledSetting.isAgentFrameworkEnabled()) {
+            throw new IllegalStateException(AGENT_FRAMEWORK_DISABLED_ERR_MSG);
+        }
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         MLAgent mlAgent = MLAgent.parse(parser);

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLSearchAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLSearchAgentAction.java
@@ -7,10 +7,16 @@ package org.opensearch.ml.rest;
 
 import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.MLExceptionUtils.AGENT_FRAMEWORK_DISABLED_ERR_MSG;
 
+import java.io.IOException;
+
+import org.opensearch.client.node.NodeClient;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.transport.agent.MLSearchAgentAction;
 import org.opensearch.ml.repackage.com.google.common.collect.ImmutableList;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
+import org.opensearch.rest.RestRequest;
 
 /**
  * This class consists of the REST handler to search ML Agents.
@@ -18,13 +24,24 @@ import org.opensearch.ml.repackage.com.google.common.collect.ImmutableList;
 public class RestMLSearchAgentAction extends AbstractMLSearchAction<MLAgent> {
     private static final String ML_SEARCH_AGENT_ACTION = "ml_search_agent_action";
     private static final String SEARCH_AGENT_PATH = ML_BASE_URI + "/agents/_search";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
-    public RestMLSearchAgentAction() {
+    public RestMLSearchAgentAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
         super(ImmutableList.of(SEARCH_AGENT_PATH), ML_AGENT_INDEX, MLAgent.class, MLSearchAgentAction.INSTANCE);
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
     }
 
     @Override
     public String getName() {
         return ML_SEARCH_AGENT_ACTION;
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (!mlFeatureEnabledSetting.isAgentFrameworkEnabled()) {
+            throw new IllegalStateException(AGENT_FRAMEWORK_DISABLED_ERR_MSG);
+        }
+
+        return super.prepareRequest(request, client);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -174,4 +174,8 @@ public final class MLCommonsSettings {
     // Feature flag for enabling search processors for Retrieval Augmented Generation using OpenSearch and Remote Inference.
     public static final Setting<Boolean> ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED =
         GenerativeQAProcessorConstants.RAG_PIPELINE_FEATURE_ENABLED;
+
+    // This setting is to enable/disable agent related API register/execute/delete/get/search agent.
+    public static final Setting<Boolean> ML_COMMONS_AGENT_FRAMEWORK_ENABLED = Setting
+        .boolSetting("plugins.ml_commons.agent_framework_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
@@ -7,6 +7,7 @@
 
 package org.opensearch.ml.settings;
 
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED;
 
 import org.opensearch.cluster.service.ClusterService;
@@ -15,13 +16,18 @@ import org.opensearch.common.settings.Settings;
 public class MLFeatureEnabledSetting {
 
     private volatile Boolean isRemoteInferenceEnabled;
+    private volatile Boolean isAgentFrameworkEnabled;
 
     public MLFeatureEnabledSetting(ClusterService clusterService, Settings settings) {
         isRemoteInferenceEnabled = ML_COMMONS_REMOTE_INFERENCE_ENABLED.get(settings);
+        isAgentFrameworkEnabled = ML_COMMONS_AGENT_FRAMEWORK_ENABLED.get(settings);
 
         clusterService
             .getClusterSettings()
             .addSettingsUpdateConsumer(ML_COMMONS_REMOTE_INFERENCE_ENABLED, it -> isRemoteInferenceEnabled = it);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_AGENT_FRAMEWORK_ENABLED, it -> isAgentFrameworkEnabled = it);
     }
 
     /**
@@ -30,6 +36,14 @@ public class MLFeatureEnabledSetting {
      */
     public boolean isRemoteInferenceEnabled() {
         return isRemoteInferenceEnabled;
+    }
+
+    /**
+     * Whether the agent framework feature is enabled. If disabled, APIs in ml-commons will block agent framework.
+     * @return whether the agent framework is enabled.
+     */
+    public boolean isAgentFrameworkEnabled() {
+        return isAgentFrameworkEnabled;
     }
 
 }

--- a/plugin/src/main/java/org/opensearch/ml/utils/MLExceptionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/MLExceptionUtils.java
@@ -20,6 +20,8 @@ public class MLExceptionUtils {
     public static final String NOT_SERIALIZABLE_EXCEPTION_WRAPPER = "NotSerializableExceptionWrapper: ";
     public static final String REMOTE_INFERENCE_DISABLED_ERR_MSG =
         "Remote Inference is currently disabled. To enable it, update the setting \"plugins.ml_commons.remote_inference_enabled\" to true.";
+    public static final String AGENT_FRAMEWORK_DISABLED_ERR_MSG =
+        "Agent Framework is currently disabled. To enable it, update the setting \"plugins.ml_commons.agent_framework_enabled\" to true.";
 
     public static String getRootCauseMessage(final Throwable throwable) {
         String message = ExceptionUtils.getRootCauseMessage(throwable);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RegisterAgentTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RegisterAgentTransportActionTests.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.agent.LLMSpec.MODEL_ID_FIELD;
 import static org.opensearch.ml.common.agent.MLAgent.AGENT_NAME_FIELD;
 import static org.opensearch.ml.common.agent.MLAgent.AGENT_TYPE_FIELD;
@@ -33,12 +34,15 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentAction;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
@@ -52,14 +56,19 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
     Gson gson;
     Instant time;
 
+    @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
     @Before
     public void setup() {
+        MockitoAnnotations.openMocks(this);
         gson = new Gson();
         time = Instant.ofEpochMilli(123);
+        when(mlFeatureEnabledSetting.isAgentFrameworkEnabled()).thenReturn(true);
     }
 
     public void test_GetName_Routes() {
-        RestMLRegisterAgentAction action = new RestMLRegisterAgentAction();
+        RestMLRegisterAgentAction action = new RestMLRegisterAgentAction(mlFeatureEnabledSetting);
         assert (action.getName().equals("ml_register_agent_action"));
         List<RestHandler.Route> routes = action.routes();
         assert (routes.size() == 1);
@@ -67,7 +76,7 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
     }
 
     public void testPrepareRequest() throws Exception {
-        RestMLRegisterAgentAction action = new RestMLRegisterAgentAction();
+        RestMLRegisterAgentAction action = new RestMLRegisterAgentAction(mlFeatureEnabledSetting);
         final Map<String, Object> llmSpec = Map.of(MODEL_ID_FIELD, "id", PARAMETERS_FIELD, new HashMap<>());
         final Map<String, Object> memorySpec = Map.of(MEMORY_TYPE_FIELD, "conversation", SESSION_ID_FIELD, "sid", WINDOW_SIZE_FIELD, 2);
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
@@ -117,5 +126,50 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
         assert (argumentCaptor.getValue().getMlAgent().getLlm().getModelId().equals("id"));
         assert (argumentCaptor.getValue().getMlAgent().getParameters().equals(new HashMap<>()));
         assert (argumentCaptor.getValue().getMlAgent().getMemory().getType().equals("conversation"));
+    }
+
+    public void testPrepareRequest_disabled() {
+        when(mlFeatureEnabledSetting.isAgentFrameworkEnabled()).thenReturn(false);
+        RestMLRegisterAgentAction action = new RestMLRegisterAgentAction(mlFeatureEnabledSetting);
+        final Map<String, Object> llmSpec = Map.of(MODEL_ID_FIELD, "id", PARAMETERS_FIELD, new HashMap<>());
+        final Map<String, Object> memorySpec = Map.of(MEMORY_TYPE_FIELD, "conversation", SESSION_ID_FIELD, "sid", WINDOW_SIZE_FIELD, 2);
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+                .withContent(
+                        new BytesArray(
+                                gson
+                                        .toJson(
+                                                Map
+                                                        .of(
+                                                                AGENT_NAME_FIELD,
+                                                                "agent-name",
+                                                                AGENT_TYPE_FIELD,
+                                                                "agent-type",
+                                                                DESCRIPTION_FIELD,
+                                                                "description",
+                                                                LLM_FIELD,
+                                                                llmSpec,
+                                                                TOOLS_FIELD,
+                                                                new ArrayList<>(),
+                                                                PARAMETERS_FIELD,
+                                                                new HashMap<>(),
+                                                                MEMORY_FIELD,
+                                                                memorySpec,
+                                                                MEMORY_ID_FIELD,
+                                                                "memory_id",
+                                                                CREATED_TIME_FIELD,
+                                                                time.getEpochSecond(),
+                                                                LAST_UPDATED_TIME_FIELD,
+                                                                time.getEpochSecond()
+                                                        )
+                                        )
+                        ),
+                        MediaTypeRegistry.JSON
+                )
+                .build();
+
+        NodeClient client = mock(NodeClient.class);
+        RestChannel channel = mock(RestChannel.class);
+
+        assertThrows(IllegalStateException.class, () -> action.handleRequest(request, channel, client));
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchAgentActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchAgentActionTests.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
 import static org.opensearch.ml.utils.TestHelper.getSearchAllRestRequest;
 
@@ -36,6 +37,7 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.transport.agent.MLSearchAgentAction;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.utils.TestHelper;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
@@ -57,10 +59,14 @@ public class RestMLSearchAgentActionTests extends OpenSearchTestCase {
     @Mock
     RestChannel channel;
 
+    @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
     @Before
     public void setup() throws IOException {
         MockitoAnnotations.openMocks(this);
-        restMLSearchAgentAction = new RestMLSearchAgentAction();
+        when(mlFeatureEnabledSetting.isAgentFrameworkEnabled()).thenReturn(true);
+        restMLSearchAgentAction = new RestMLSearchAgentAction(mlFeatureEnabledSetting);
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
         client = spy(new NodeClient(Settings.EMPTY, threadPool));
 
@@ -106,7 +112,7 @@ public class RestMLSearchAgentActionTests extends OpenSearchTestCase {
     }
 
     public void testConstructor() {
-        RestMLSearchAgentAction mlSearchAgentAction = new RestMLSearchAgentAction();
+        RestMLSearchAgentAction mlSearchAgentAction = new RestMLSearchAgentAction(mlFeatureEnabledSetting);
         assertNotNull(mlSearchAgentAction);
     }
 
@@ -143,6 +149,13 @@ public class RestMLSearchAgentActionTests extends OpenSearchTestCase {
         );
         RestResponse agentResponse = responseCaptor.getValue();
         assertEquals(RestStatus.OK, agentResponse.status());
+    }
+
+    public void testPrepareRequest_disabled() throws Exception {
+        RestRequest request = getSearchAllRestRequest();
+        when(mlFeatureEnabledSetting.isAgentFrameworkEnabled()).thenReturn(false);
+
+        assertThrows(IllegalStateException.class, () -> restMLSearchAgentAction.handleRequest(request, channel, client));
     }
 
     public void testPrepareRequest_timeout() throws Exception {


### PR DESCRIPTION
### Description
Add a setting to enable/disable agent framework feature. Currently the setting is set to false by default.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
