### PR TITLE
[Backport to 2.x] add maintainer (#1951)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @b4sjoo @dhrubo-os @jngz-es @model-collapse @rbhavna @wujunshen @ylwu-amzn @zane-neo @Zhangxunmt @austintlee @HenryL27
+*   @b4sjoo @dhrubo-os @jngz-es @model-collapse @rbhavna @wujunshen @ylwu-amzn @zane-neo @Zhangxunmt @austintlee @HenryL27 @samuel-oci


### PR DESCRIPTION
### Description
Backport #1951 to 2.x
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
