### PR TITLE
fix bug in delete empty memory

### DIFF
--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -467,6 +467,10 @@ public class InteractionsIndex {
         try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());
             ActionListener<List<Interaction>> searchListener = ActionListener.wrap(interactions -> {
+                if (interactions.size() == 0) {
+                    internalListener.onResponse(true);
+                    return;
+                }
                 BulkRequest request = Requests.bulkRequest();
                 for (Interaction interaction : interactions) {
                     DeleteRequest delRequest = Requests.deleteRequest(INTERACTIONS_INDEX_NAME).id(interaction.getId());


### PR DESCRIPTION
### Description
When deleting a memory with no interactions, the response throws an error from the bulk delete interactions which is not expected. 

This PR fixes the bug that when deleting an empty memory, the process should go through and delete it successfully.

Before the change: 

~~~
# Create a new memory/conversation
POST /_plugins/_ml/memory
{
    "name": "Create a new Memory"
}
#Response
{
  "memory_id": "xxxxxxxxx"
}

# Delete empty memory
DELETE /_plugins/_ml/memory/xxxxxxxxx
# Response
{
  "error": {
    "root_cause": [
      {
        "type": "action_request_validation_exception",
        "reason": "Validation Failed: 1: no requests added;"
      }
    ],
    "type": "action_request_validation_exception",
    "reason": "Validation Failed: 1: no requests added;"
  },
  "status": 400
}
~~~
 

After this change, the empty memory is deleted successfully.
~~~
DELETE /_plugins/_ml/memory/xxxxxxxxx
# Response
{
  "success": true
}
~~~

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
