### PR TITLE
Fix for controller error stack trace and tokenbucket

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -272,11 +272,11 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
             if (deleteResponse.getResult() == DocWriteResponse.Result.DELETED) {
                 log.info("Model controller for model {} successfully deleted from index, result: {}", modelId, deleteResponse.getResult());
             } else {
-                log.warn("The deletion of model controller for model {} returned with result: {}", modelId, deleteResponse.getResult());
+                log.info("The deletion of model controller for model {} returned with result: {}", modelId, deleteResponse.getResult());
             }
         }, e -> {
             if (e instanceof IndexNotFoundException) {
-                log.warn("Model controller not deleted due to no model controller found for model: " + modelId);
+                log.debug("Model controller not deleted due to no model controller found for model: " + modelId);
             } else {
                 log.error("Failed to delete model controller for model: " + modelId, e);
             }

--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -251,7 +251,7 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
             @Override
             public void onFailure(Exception e) {
                 if (e instanceof IndexNotFoundException) {
-                    log.info("Model controller not deleted due to no model controller was found for model: " + modelId);
+                    log.info("Model controller not deleted due to no model controller found for model: " + modelId);
                     actionListener.onFailure(e);
                 } else {
                     log.error("Failed to delete model controller for model: " + modelId, e);
@@ -274,7 +274,13 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
             } else {
                 log.warn("The deletion of model controller for model {} returned with result: {}", modelId, deleteResponse.getResult());
             }
-        }, e -> log.error("Failed to re-deploy the model controller for model: " + modelId, e)));
+        }, e -> {
+            if (e instanceof IndexNotFoundException) {
+                log.warn("Model controller not deleted due to no model controller found for model: " + modelId);
+            } else {
+                log.error("Failed to delete model controller for model: " + modelId, e);
+            }
+        }));
     }
 
     private Boolean isModelNotDeployed(MLModelState mlModelState) {

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -1286,10 +1286,10 @@ public class MLModelManager {
                             + " is expected not having a model controller. Please use the create controller api to create one if this is unexpected."
                     );
                 log
-                    .warn(
+                    .debug(
                         "No controller is deployed because the model "
                             + modelId
-                            + " is expected not having a model controller. Please use the create model controller api to create one if this is unexpected."
+                            + " is expected not having a model controller."
                     );
             } else {
                 listener.onFailure(new OpenSearchStatusException("Failed to find model controller", RestStatus.NOT_FOUND));
@@ -1306,10 +1306,10 @@ public class MLModelManager {
                                 + " is expected not having a model controller. Please use the create model controller api to create one if this is unexpected."
                         );
                     log
-                        .warn(
+                        .debug(
                             "No controller is deployed because the model "
                                 + modelId
-                                + " is expected not having a model controller. Please use the create model controller api to create one if this is unexpected."
+                                + " is expected not having a model controller."
                         );
                 } else {
                     listener.onFailure(new OpenSearchStatusException("Failed to find model controller", RestStatus.NOT_FOUND));

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -1287,9 +1287,7 @@ public class MLModelManager {
                     );
                 log
                     .debug(
-                        "No controller is deployed because the model "
-                            + modelId
-                            + " is expected not having an enabled model controller."
+                        "No controller is deployed because the model " + modelId + " is expected not having an enabled model controller."
                     );
             } else {
                 listener.onFailure(new OpenSearchStatusException("Failed to find model controller", RestStatus.NOT_FOUND));


### PR DESCRIPTION
### Description
This PR should:
1. Hide the error stack tracing when we expected no model controller existed for a model.
2. Fix the rate limiter performance on the multi-node cluster.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
