### PR TITLE
send agent execution response after saving memory

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -395,22 +395,22 @@ public class MLChatAgentRunner implements MLAgentRunner {
 
                             List<ModelTensors> finalModelTensors = new ArrayList<>();
                             finalModelTensors
-                            .add(
-                                ModelTensors
-                                    .builder()
-                                    .mlModelTensors(
-                                        List
-                                            .of(
-                                                ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build(),
-                                                ModelTensor
-                                                    .builder()
-                                                    .name(MLAgentExecutor.PARENT_INTERACTION_ID)
-                                                    .result(parentInteractionId)
-                                                    .build()
-                                            )
-                                    )
-                                    .build()
-                            );
+                                .add(
+                                    ModelTensors
+                                        .builder()
+                                        .mlModelTensors(
+                                            List
+                                                .of(
+                                                    ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build(),
+                                                    ModelTensor
+                                                        .builder()
+                                                        .name(MLAgentExecutor.PARENT_INTERACTION_ID)
+                                                        .result(parentInteractionId)
+                                                        .build()
+                                                )
+                                        )
+                                        .build()
+                                );
                             finalModelTensors
                                 .add(
                                     ModelTensors


### PR DESCRIPTION
### Description
The agent sends execution response after finished saving last trace and final answer.
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/1894
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
