### PR TITLE
add memory id and interation id for non-verbose

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -416,6 +416,23 @@ public class MLChatAgentRunner implements MLAgentRunner {
                                 ModelTensors
                                     .builder()
                                     .mlModelTensors(
+                                        List
+                                            .of(
+                                                ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build(),
+                                                ModelTensor
+                                                    .builder()
+                                                    .name(MLAgentExecutor.PARENT_INTERACTION_ID)
+                                                    .result(parentInteractionId)
+                                                    .build()
+                                            )
+                                    )
+                                    .build()
+                            );
+                        finalModelTensors
+                            .add(
+                                ModelTensors
+                                    .builder()
+                                    .mlModelTensors(
                                         Collections
                                             .singletonList(
                                                 ModelTensor
@@ -603,6 +620,23 @@ public class MLChatAgentRunner implements MLAgentRunner {
                             listener.onResponse(ModelTensorOutput.builder().mlModelOutputs(cotModelTensors).build());
                         } else {
                             List<ModelTensors> finalModelTensors = new ArrayList<>();
+                            finalModelTensors
+                                .add(
+                                    ModelTensors
+                                        .builder()
+                                        .mlModelTensors(
+                                            List
+                                                .of(
+                                                    ModelTensor.builder().name(MLAgentExecutor.MEMORY_ID).result(sessionId).build(),
+                                                    ModelTensor
+                                                        .builder()
+                                                        .name(MLAgentExecutor.PARENT_INTERACTION_ID)
+                                                        .result(parentInteractionId)
+                                                        .build()
+                                                )
+                                        )
+                                        .build()
+                                );
                             finalModelTensors
                                 .add(
                                     ModelTensors


### PR DESCRIPTION
### Description
Add memory id and parent interaction id in response.

An example,
```
The request,

POST /_plugins/_ml/agents/ZtW3XI0BS7ZuQOvZvMqS/_execute
{
    "parameters": {
        "question": "how many index I have?"
    }
}


Old response,

{
  "inference_results": [
    {
      "output": [
        {
          "name": "response",
          "dataAsMap": {
            "response": "Unfortunately, without access to the tools, I do not have enough information to determine the number of indexes you currently have.",
            "additional_info": {}
          }
        }
      ]
    }
  ]
}

New response,

{
  "inference_results": [
    {
      "output": [
        {
          "name": "memory_id",
          "result": "ZujBbY0BRiMrBD-_tYrq"
        },
        {
          "name": "parent_interaction_id",
          "result": "Z-jBbY0BRiMrBD-_tooF"
        },
        {
          "name": "response",
          "dataAsMap": {
            "response": "Unfortunately, without access to the tools, I do not have enough information to determine the number of indexes you currently have.",
            "additional_info": {}
          }
        }
      ]
    }
  ]
}
```
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/1988
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
