### PR TITLE
enhance: make response_field customizable in MLModelTool

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
@@ -34,6 +34,9 @@ import lombok.extern.log4j.Log4j2;
 @ToolAnnotation(MLModelTool.TYPE)
 public class MLModelTool implements Tool {
     public static final String TYPE = "MLModelTool";
+    public static final String RESPONSE_FIELD = "response_field";
+    public static final String MODEL_ID_FIELD = "model_id";
+    public static final String DEFAULT_RESPONSE_FIELD = "response";
 
     @Setter
     @Getter
@@ -52,14 +55,18 @@ public class MLModelTool implements Tool {
     @Setter
     @Getter
     private Parser outputParser;
+    @Setter
+    @Getter
+    private String responseField;
 
-    public MLModelTool(Client client, String modelId) {
+    public MLModelTool(Client client, String modelId, String responseField) {
         this.client = client;
         this.modelId = modelId;
+        this.responseField = responseField;
 
         outputParser = o -> {
             List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
-            return mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap().get("response");
+            return mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap().get(responseField);
         };
     }
 
@@ -132,7 +139,11 @@ public class MLModelTool implements Tool {
 
         @Override
         public MLModelTool create(Map<String, Object> map) {
-            return new MLModelTool(client, (String) map.get("model_id"));
+            return new MLModelTool(
+                client,
+                (String) map.get(MODEL_ID_FIELD),
+                (String) map.getOrDefault(RESPONSE_FIELD, DEFAULT_RESPONSE_FIELD)
+            );
         }
 
         @Override

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/MLModelToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/MLModelToolTests.java
@@ -5,13 +5,20 @@
 
 package org.opensearch.ml.engine.tools;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
 import static org.opensearch.ml.engine.tools.MLModelTool.DEFAULT_DESCRIPTION;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 


### PR DESCRIPTION
### Description
Current MLModelTool hard code to fetch the `response` field from response body. However, in other non-LLM cases or non-Claude LLM services, we can not assume all of them use `response` keyword.

This PR makes response_field customizable in MLModelTool. If not provided, it will use `response` by default. This will make current API invokation behavior consistent.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
