### PR TITLE
fix CVE-2023-2976 and upgrade guava to be consistent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,11 @@ subprojects {
     configurations {
         testImplementation.extendsFrom compileOnly
     }
+
+    configurations.all {
+        // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
+        resolutionStrategy.force "com.google.guava:guava:32.1.2-jre"
+    }
 }
 
 ext {

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.2.2'
     implementation "org.opensearch:common-utils:${common_utils_version}"
-    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
     testImplementation (group: 'junit', name: 'junit', version: '4.13.2') {
         exclude module : 'hamcrest'
         exclude module : 'hamcrest-core'

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation group: 'io.protostuff', name: 'protostuff-collectionschema', version: '1.8.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     implementation platform("ai.djl:bom:0.21.0")
     implementation group: 'ai.djl.pytorch', name: 'pytorch-model-zoo', version: '0.21.0'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
-    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'

--- a/search-processors/build.gradle
+++ b/search-processors/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation group: 'org.opensearch', name: 'common-utils', version: "${common_utils_version}"
     // https://mvnrepository.com/artifact/org.apache.httpcomponents.core5/httpcore5
     implementation group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.2.2'
-    implementation("com.google.guava:guava:32.0.1-jre")
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
     implementation group: 'org.json', name: 'json', version: '20231013'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     testImplementation "org.opensearch.test:framework:${opensearch_version}"


### PR DESCRIPTION
### Description
There is a guava vulnerability https://github.com/opensearch-project/ml-commons/issues/1862.

There are 2 use cases in the code base that use older version of guava:

1. A dependency of Gradle plugin. spotless.
2. A dependency of Gradle core plugin checksytle.

Also, the guava dependencies are not consistent in ML-Commons. The latest version used is 32.1.2.
So to address the problems, this PR set dependency resolution strategy to use guava version 32.1.2-jre for all Gradle projects.


Verified that after this PR, my local cache under ./gradle/caches/modules-2/files-2.1/com.google.guava only contains the 32.1.2 version. 
 
Also after the code change, it can be seen that only the newer version of guava is being used.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
