### PR TITLE
Update memory if tool output needs to be included in response

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunner.java
@@ -106,6 +106,9 @@ public class MLFlowAgentRunner implements MLAgentRunner {
                         ? previousToolSpec.getName() + ".output"
                         : previousToolSpec.getType() + ".output";
 
+                    String outputResponse = parseResponse(output);
+                    params.put(outputKey, escapeJson(outputResponse));
+
                     if (previousToolSpec.isIncludeOutputInAgentResponse() || finalI == toolSpecs.size()) {
                         if (output instanceof ModelTensorOutput) {
                             flowAgentOutput.addAll(((ModelTensorOutput) output).getMlModelOutputs().get(0).getMlModelTensors());
@@ -117,11 +120,9 @@ public class MLFlowAgentRunner implements MLAgentRunner {
                             ModelTensor stepOutput = ModelTensor.builder().name(key).result(result).build();
                             flowAgentOutput.add(stepOutput);
                         }
-                    }
 
-                    String outputResponse = parseResponse(output);
-                    params.put(outputKey, escapeJson(outputResponse));
-                    additionalInfo.put(outputKey, outputResponse);
+                        additionalInfo.put(outputKey, outputResponse);
+                    }
 
                     if (finalI == toolSpecs.size()) {
                         updateMemory(additionalInfo, memorySpec, memoryId, parentInteractionId);


### PR DESCRIPTION
### Description
Updating memory with all tool output results in update failure for larger tool responses. To solve the problem, memory will be optionally updated for tools with includeOutputInAgentResponse field set.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
