### PR TITLE
fix CVE-2023-42503 due to djl models

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ subprojects {
     configurations.all {
         // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
         resolutionStrategy.force "com.google.guava:guava:32.1.2-jre"
+        resolutionStrategy.force 'org.apache.commons:commons-compress:1.25.0'
     }
 }
 


### PR DESCRIPTION
### Description
Upgrade the org.apache.commons-commons-compress from 1.22 to 1.25 to resolve CVE. https://github.com/opensearch-project/ml-commons/issues/1865
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
