### PR TITLE
[Backport] fix CVE-2023-42503 due to djl models (#2011)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ subprojects {
     configurations.all {
         // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
         resolutionStrategy.force "com.google.guava:guava:32.1.2-jre"
+        resolutionStrategy.force 'org.apache.commons:commons-compress:1.25.0'
     }
 }
 

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -26,7 +26,7 @@ plugins {
 dependencies {
     implementation project(path: ":${rootProject.name}-common", configuration: 'shadow')
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
-    implementation group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.2.1'
+    implementation group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.2.2'
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
     testImplementation (group: 'junit', name: 'junit', version: '4.13.2') {


### PR DESCRIPTION
### Description
Fix CVE-2023-42503 and upgrade the org.apache.httpcomponents to 5.2.2 to mitigate the delta between main and 2.x
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
