### PR TITLE
tool uses original input

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -488,6 +488,7 @@ public class MLChatAgentRunner implements MLAgentRunner {
                         }
                         if (tools.get(action).useOriginalInput()) {
                             toolParams.put("input", question);
+                            lastActionInput.set(question);
                         } else {
                             toolParams.put("input", actionInput);
                         }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -486,7 +486,11 @@ public class MLChatAgentRunner implements MLAgentRunner {
                         if (toolSpecParams != null) {
                             toolParams.putAll(toolSpecParams);
                         }
-                        toolParams.put("input", actionInput);
+                        if (tools.get(action).useOriginalInput()) {
+                            toolParams.put("input", question);
+                        } else {
+                            toolParams.put("input", actionInput);
+                        }
                         if (tools.get(action).validate(toolParams)) {
                             try {
                                 String finalAction = action;


### PR DESCRIPTION
### Description
Conversational agent pass user original question as input to the tool that sets useoriginalinput flag as true.
 
### Issues Resolved
The RAG tool can parse the output from LLM, actually the RAG tool needs user original question to search vector DB.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
