### PR TITLE
disable dynamic mapping for config index

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -355,6 +355,7 @@ public class CommonValue {
                         + "    \"_meta\": {\"schema_version\": "
                         + ML_CONFIG_INDEX_SCHEMA_VERSION
                         + "},\n"
+                        + "    \"dynamic\": \"strict\",\n"
                         + "    \"properties\": {\n"
                         + "      \""
                         + MASTER_KEY


### PR DESCRIPTION
### Description
disable dynamic mapping for config index. Setting dynamic mapping to "strict" prevents from writing new fields into the index.
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
