### PR TITLE
fix edge case for validate json method

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.utils;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import lombok.extern.log4j.Log4j2;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -32,7 +33,7 @@ public class StringUtils {
         gson = new Gson();
     }
 
-    public static boolean isJson(String Json) {
+    public static boolean isValidJsonString(String Json) {
         try {
             new JSONObject(Json);
         } catch (JSONException ex) {
@@ -43,6 +44,19 @@ public class StringUtils {
             }
         }
         return true;
+    }
+
+    public static boolean isJson(String json) {
+        try {
+            if (!isValidJsonString(json)) {
+                return false;
+            }
+            //This is to cover such edge case "[]\""
+            gson.fromJson(json, Object.class);
+            return true;
+        } catch(JsonSyntaxException ex) {
+            return false;
+        }
     }
 
     public static String toUTF8(String rawString) {

--- a/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
@@ -24,6 +24,11 @@ public class StringUtilsTest {
         Assert.assertTrue(StringUtils.isJson("[1, 2, 3]"));
         Assert.assertTrue(StringUtils.isJson("[\"a\", \"b\"]"));
         Assert.assertTrue(StringUtils.isJson("[1, \"a\"]"));
+        Assert.assertTrue(StringUtils.isJson("{\"key1\": \"value\", \"key2\": 123}"));
+        Assert.assertTrue(StringUtils.isJson("{}"));
+        Assert.assertTrue(StringUtils.isJson("[]"));
+        Assert.assertTrue(StringUtils.isJson("[abc]"));
+        Assert.assertTrue(StringUtils.isJson("[\"abc\", 123]"));
     }
 
     @Test
@@ -33,6 +38,10 @@ public class StringUtilsTest {
         Assert.assertFalse(StringUtils.isJson("{\"key\": \"value}"));
         Assert.assertFalse(StringUtils.isJson("{\"key\": \"value\", \"key\": 123}"));
         Assert.assertFalse(StringUtils.isJson("[1, \"a]"));
+        Assert.assertFalse(StringUtils.isJson("[]\""));
+        Assert.assertFalse(StringUtils.isJson("[]\"123\""));
+        Assert.assertFalse(StringUtils.isJson("[abc\"]"));
+        Assert.assertFalse(StringUtils.isJson("[abc\n123]"));
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
@@ -27,6 +27,8 @@ public class StringUtilsTest {
         Assert.assertTrue(StringUtils.isJson("{\"key1\": \"value\", \"key2\": 123}"));
         Assert.assertTrue(StringUtils.isJson("{}"));
         Assert.assertTrue(StringUtils.isJson("[]"));
+        Assert.assertTrue(StringUtils.isJson("[ ]"));
+        Assert.assertTrue(StringUtils.isJson("[,]"));
         Assert.assertTrue(StringUtils.isJson("[abc]"));
         Assert.assertTrue(StringUtils.isJson("[\"abc\", 123]"));
     }
@@ -39,6 +41,9 @@ public class StringUtilsTest {
         Assert.assertFalse(StringUtils.isJson("{\"key\": \"value\", \"key\": 123}"));
         Assert.assertFalse(StringUtils.isJson("[1, \"a]"));
         Assert.assertFalse(StringUtils.isJson("[]\""));
+        Assert.assertFalse(StringUtils.isJson("[ ]\""));
+        Assert.assertFalse(StringUtils.isJson("[,]\""));
+        Assert.assertFalse(StringUtils.isJson("[,\"]"));
         Assert.assertFalse(StringUtils.isJson("[]\"123\""));
         Assert.assertFalse(StringUtils.isJson("[abc\"]"));
         Assert.assertFalse(StringUtils.isJson("[abc\n123]"));


### PR DESCRIPTION
### Description
Fix some edge case can't be handled: `"[]\""`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
