### PR TITLE
update Unthrotized error code to 401

### DIFF
--- a/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
@@ -25,7 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.OpenSearchWrapperException;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.ResourceNotFoundException;
@@ -279,7 +279,10 @@ public class ConversationMetaIndex {
                     listener.onFailure(e);
                 }
             } else {
-                throw new OpenSearchSecurityException("User [" + user + "] does not have access to conversation " + conversationId);
+                throw new OpenSearchStatusException(
+                    "User [" + user + "] does not have access to conversation " + conversationId,
+                    RestStatus.UNAUTHORIZED
+                );
             }
         }, e -> { listener.onFailure(e); }));
     }
@@ -383,7 +386,10 @@ public class ConversationMetaIndex {
                     .getThreadContext()
                     .getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
                 String user = User.parse(userstr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userstr).getName();
-                throw new OpenSearchSecurityException("User [" + user + "] does not have access to conversation " + conversationId);
+                throw new OpenSearchStatusException(
+                    "User [" + user + "] does not have access to conversation " + conversationId,
+                    RestStatus.UNAUTHORIZED
+                );
             }
         }, e -> { listener.onFailure(e); }));
     }
@@ -435,7 +441,10 @@ public class ConversationMetaIndex {
                 // Otherwise you don't have permission
                 internalListener
                     .onFailure(
-                        new OpenSearchSecurityException("User [" + user + "] does not have access to conversation " + conversationId)
+                        new OpenSearchStatusException(
+                            "User [" + user + "] does not have access to conversation " + conversationId,
+                            RestStatus.UNAUTHORIZED
+                        )
                     );
             }, e -> { internalListener.onFailure(e); });
             client.admin().indices().refresh(Requests.refreshRequest(META_INDEX_NAME), ActionListener.wrap(refreshResponse -> {

--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -26,7 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.OpenSearchWrapperException;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.ResourceNotFoundException;
@@ -195,7 +195,10 @@ public class InteractionsIndex {
                             listener.onFailure(e);
                         }
                     } else {
-                        throw new OpenSearchSecurityException("User [" + user + "] does not have access to conversation " + conversationId);
+                        throw new OpenSearchStatusException(
+                            "User [" + user + "] does not have access to conversation " + conversationId,
+                            RestStatus.UNAUTHORIZED
+                        );
                     }
                 }, e -> { listener.onFailure(e); }));
             } else {
@@ -271,7 +274,10 @@ public class InteractionsIndex {
                     .getThreadContext()
                     .getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
                 String user = User.parse(userstr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userstr).getName();
-                throw new OpenSearchSecurityException("User [" + user + "] does not have access to conversation " + conversationId);
+                throw new OpenSearchStatusException(
+                    "User [" + user + "] does not have access to conversation " + conversationId,
+                    RestStatus.UNAUTHORIZED
+                );
             }
         }, e -> { listener.onFailure(e); });
         conversationMetaIndex.checkAccess(conversationId, accessListener);
@@ -355,7 +361,10 @@ public class InteractionsIndex {
                         String user = User.parse(userstr) == null
                             ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS
                             : User.parse(userstr).getName();
-                        throw new OpenSearchSecurityException("User [" + user + "] does not have access to interaction " + interactionId);
+                        throw new OpenSearchStatusException(
+                            "User [" + user + "] does not have access to interaction " + interactionId,
+                            RestStatus.UNAUTHORIZED
+                        );
                     }
                 }, e -> { listener.onFailure(e); });
                 conversationMetaIndex.checkAccess(conversationId, accessListener);
@@ -485,7 +494,10 @@ public class InteractionsIndex {
                 if (access) {
                     getAllInteractions(conversationId, resultsAtATime, searchListener);
                 } else {
-                    throw new OpenSearchSecurityException("User [" + user + "] does not have access to conversation " + conversationId);
+                    throw new OpenSearchStatusException(
+                        "User [" + user + "] does not have access to conversation " + conversationId,
+                        RestStatus.UNAUTHORIZED
+                    );
                 }
             }, e -> { listener.onFailure(e); });
             conversationMetaIndex.checkAccess(conversationId, accessListener);
@@ -531,7 +543,10 @@ public class InteractionsIndex {
                     .getThreadContext()
                     .getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
                 String user = User.parse(userstr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userstr).getName();
-                throw new OpenSearchSecurityException("User [" + user + "] does not have access to conversation " + conversationId);
+                throw new OpenSearchStatusException(
+                    "User [" + user + "] does not have access to conversation " + conversationId,
+                    RestStatus.UNAUTHORIZED
+                );
             }
         }, e -> { listener.onFailure(e); }));
     }
@@ -615,7 +630,10 @@ public class InteractionsIndex {
                         String user = User.parse(userstr) == null
                             ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS
                             : User.parse(userstr).getName();
-                        throw new OpenSearchSecurityException("User [" + user + "] does not have access to interaction " + interactionId);
+                        throw new OpenSearchStatusException(
+                            "User [" + user + "] does not have access to interaction " + interactionId,
+                            RestStatus.UNAUTHORIZED
+                        );
                     }
                 }, e -> { listener.onFailure(e); });
                 conversationMetaIndex.checkAccess(conversationId, accessListener);
@@ -652,7 +670,10 @@ public class InteractionsIndex {
                     .getThreadContext()
                     .getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
                 String user = User.parse(userstr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userstr).getName();
-                throw new OpenSearchSecurityException("User [" + user + "] does not have access to interaction " + interactionId);
+                throw new OpenSearchStatusException(
+                    "User [" + user + "] does not have access to interaction " + interactionId,
+                    RestStatus.UNAUTHORIZED
+                );
             }
         }, e -> { internalListener.onFailure(e); });
         conversationMetaIndex.checkAccess(conversationId, accessListener);

--- a/memory/src/test/java/org/opensearch/ml/memory/ConversationalMemoryHandlerITTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/ConversationalMemoryHandlerITTests.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
 import org.junit.Before;
-import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.StepListener;
 import org.opensearch.client.Client;
@@ -34,6 +34,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.util.concurrent.ThreadContext.StoredContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.conversation.ConversationMeta;
 import org.opensearch.ml.common.conversation.Interaction;
 import org.opensearch.ml.memory.index.OpenSearchConversationalMemoryHandler;
@@ -350,7 +351,10 @@ public class ConversationalMemoryHandlerITTests extends OpenSearchIntegTestCase 
                 while (!contextStack.empty()) {
                     contextStack.pop().close();
                 }
-                OpenSearchSecurityException e = new OpenSearchSecurityException("User was given inappropriate access controls");
+                OpenSearchStatusException e = new OpenSearchStatusException(
+                    "User was given inappropriate access controls",
+                    RestStatus.UNAUTHORIZED
+                );
                 log.error(e);
                 throw e;
             };
@@ -470,7 +474,7 @@ public class ConversationalMemoryHandlerITTests extends OpenSearchIntegTestCase 
             }, onFail);
 
             failiid1.whenComplete(shouldHaveFailedAsString, e -> {
-                if (e instanceof OpenSearchSecurityException
+                if (e instanceof OpenSearchStatusException
                     && e.getMessage().startsWith("User [" + user2 + "] does not have access to conversation ")) {
                     cmHandler
                         .createInteraction(
@@ -488,7 +492,7 @@ public class ConversationalMemoryHandlerITTests extends OpenSearchIntegTestCase 
             });
 
             failiid2.whenComplete(shouldHaveFailedAsString, e -> {
-                if (e instanceof OpenSearchSecurityException
+                if (e instanceof OpenSearchStatusException
                     && e.getMessage().startsWith("User [" + user2 + "] does not have access to conversation ")) {
                     cmHandler.getConversations(10, conversations2);
                 } else {
@@ -510,7 +514,7 @@ public class ConversationalMemoryHandlerITTests extends OpenSearchIntegTestCase 
             }, onFail);
 
             failInter2.whenComplete(shouldHaveFailedAsInterList, e -> {
-                if (e instanceof OpenSearchSecurityException
+                if (e instanceof OpenSearchStatusException
                     && e.getMessage().startsWith("User [" + user2 + "] does not have access to conversation ")) {
                     cmHandler.getInteractions(cid1.result(), 0, 10, failInter1);
                 } else {
@@ -519,7 +523,7 @@ public class ConversationalMemoryHandlerITTests extends OpenSearchIntegTestCase 
             });
 
             failInter1.whenComplete(shouldHaveFailedAsInterList, e -> {
-                if (e instanceof OpenSearchSecurityException
+                if (e instanceof OpenSearchStatusException
                     && e.getMessage().startsWith("User [" + user2 + "] does not have access to conversation ")) {
                     contextStack.pop().restore();
                     cmHandler.getConversations(0, 10, conversations1);
@@ -549,7 +553,7 @@ public class ConversationalMemoryHandlerITTests extends OpenSearchIntegTestCase 
             }, onFail);
 
             failInter3.whenComplete(shouldHaveFailedAsInterList, e -> {
-                if (e instanceof OpenSearchSecurityException
+                if (e instanceof OpenSearchStatusException
                     && e.getMessage().startsWith("User [" + user1 + "] does not have access to conversation ")) {
                     cmHandler
                         .createInteraction(
@@ -567,7 +571,7 @@ public class ConversationalMemoryHandlerITTests extends OpenSearchIntegTestCase 
             });
 
             failiid3.whenComplete(shouldHaveFailedAsString, e -> {
-                if (e instanceof OpenSearchSecurityException
+                if (e instanceof OpenSearchStatusException
                     && e.getMessage().startsWith("User [" + user1 + "] does not have access to conversation ")) {
                     contextStack.pop().restore();
                     cdl.countDown();

--- a/memory/src/test/java/org/opensearch/ml/memory/index/ConversationMetaIndexITTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/index/ConversationMetaIndexITTests.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Ignore;
-import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.StepListener;
 import org.opensearch.action.search.SearchRequest;
@@ -39,6 +39,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.util.concurrent.ThreadContext.StoredContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.ml.common.conversation.ConversationMeta;
 import org.opensearch.ml.common.conversation.ConversationalIndexConstants;
@@ -388,8 +389,9 @@ public class ConversationMetaIndexITTests extends OpenSearchIntegTestCase {
             }, onFail);
 
             delListener.whenComplete(success -> {
-                Exception e = new OpenSearchSecurityException(
-                    "Incorrect access was given to user [" + user2 + "] for conversation " + cid1.result()
+                Exception e = new OpenSearchStatusException(
+                    "Incorrect access was given to user [" + user2 + "] for conversation " + cid1.result(),
+                    RestStatus.UNAUTHORIZED
                 );
                 while (!contextStack.empty()) {
                     contextStack.pop().close();
@@ -398,7 +400,7 @@ public class ConversationMetaIndexITTests extends OpenSearchIntegTestCase {
                 log.error(e);
                 assert (false);
             }, e -> {
-                if (e instanceof OpenSearchSecurityException
+                if (e instanceof OpenSearchStatusException
                     && e.getMessage().startsWith("User [" + user2 + "] does not have access to conversation ")) {
                     contextStack.pop().restore();
                     contextStack.pop().restore();


### PR DESCRIPTION
### Description
Based on the pen tests results. All the requests that fails the authentication in Memory/ConversationalSearch should return 4xx code. Currently the error code 500 internal service error is returned when such requests come.

This PR updates the error code for unauthorized requests. https://github.com/opensearch-project/ml-commons/issues/1997
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
