### PR TITLE
Re-order the FunctionName enum class to ensure bwc in 2.11

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/FunctionName.java
+++ b/common/src/main/java/org/opensearch/ml/common/FunctionName.java
@@ -17,10 +17,10 @@ public enum FunctionName {
     RCF_SUMMARIZE,
     LOGISTIC_REGRESSION,
     TEXT_EMBEDDING,
-    SPARSE_ENCODING,
-    SPARSE_TOKENIZE,
     METRICS_CORRELATION,
-    REMOTE;
+    REMOTE,
+    SPARSE_ENCODING,
+    SPARSE_TOKENIZE;
 
     public static FunctionName from(String value) {
         try {


### PR DESCRIPTION
### Description
This PR re-ordered the FunctionName by the time we introduced them to ensure backward compatibility on 2.11.

### Issue
This will partly resolved #1838

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
