### PR TITLE
Support Pretrained Model from on-prem or different cloud provider

### DIFF
--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/MLEngineTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/MLEngineTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -59,7 +60,7 @@ public class MLEngineTest {
     @Before
     public void setUp() {
         Encryptor encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(Path.of("/tmp/test" + UUID.randomUUID()), encryptor);
+        mlEngine = new MLEngine(Path.of("/tmp/test" + UUID.randomUUID()), encryptor, Settings.EMPTY);
     }
 
     @Test
@@ -394,7 +395,7 @@ public class MLEngineTest {
     @Test
     public void testMLEngineInitialization() {
         Path testPath = Path.of("/tmp/test" + UUID.randomUUID());
-        mlEngine = new MLEngine(testPath, new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w="));
+        mlEngine = new MLEngine(testPath, new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w="), Settings.EMPTY);
 
         Path expectedMlCachePath = testPath.resolve("ml_cache");
         Path expectedMlConfigPath = expectedMlCachePath.resolve("config");

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelationTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelationTest.java
@@ -183,7 +183,7 @@ public class MetricsCorrelationTest {
 
         mlCachePath = Path.of("/tmp/djl_cache_" + UUID.randomUUID());
         encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(mlCachePath, encryptor);
+        mlEngine = new MLEngine(mlCachePath, encryptor, Settings.EMPTY);
         modelConfig = MetricsCorrelationModelConfig.builder().modelType(MetricsCorrelation.MODEL_TYPE).allConfig(null).build();
 
         model = MLModel

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/sparse_encoding/TextEmbeddingSparseEncodingModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/sparse_encoding/TextEmbeddingSparseEncodingModelTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
@@ -73,7 +74,7 @@ public class TextEmbeddingSparseEncodingModelTest {
     public void setUp() throws URISyntaxException {
         mlCachePath = Path.of("/tmp/ml_cache" + UUID.randomUUID());
         encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(mlCachePath, encryptor);
+        mlEngine = new MLEngine(mlCachePath, encryptor, Settings.EMPTY);
         modelId = "test_model_id";
         modelName = "test_model_name";
         functionName = FunctionName.SPARSE_ENCODING;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
@@ -26,6 +26,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.model.MLModelConfig;
@@ -60,7 +61,7 @@ public class ModelHelperTest {
         modelFormat = MLModelFormat.TORCH_SCRIPT;
         modelId = "model_id";
         encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(Path.of("/tmp/test" + modelId), encryptor);
+        mlEngine = new MLEngine(Path.of("/tmp/test" + modelId), encryptor, Settings.EMPTY);
         modelHelper = new ModelHelper(mlEngine);
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/TextEmbeddingDenseModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/TextEmbeddingDenseModelTest.java
@@ -29,6 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.opensearch.ResourceNotFoundException;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
@@ -73,7 +74,7 @@ public class TextEmbeddingDenseModelTest {
     public void setUp() throws URISyntaxException {
         mlCachePath = Path.of("/tmp/ml_cache" + UUID.randomUUID());
         encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(mlCachePath, encryptor);
+        mlEngine = new MLEngine(mlCachePath, encryptor, Settings.EMPTY);
         modelId = "test_model_id";
         modelName = "test_model_name";
         functionName = FunctionName.TEXT_EMBEDDING;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_similarity/TextSimilarityCrossEncoderModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_similarity/TextSimilarityCrossEncoderModelTest.java
@@ -42,6 +42,7 @@ import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -86,7 +87,7 @@ public class TextSimilarityCrossEncoderModelTest {
     public void setUp() throws URISyntaxException {
         mlCachePath = Path.of("/tmp/ml_cache" + UUID.randomUUID());
         encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(mlCachePath, encryptor);
+        mlEngine = new MLEngine(mlCachePath, encryptor, Settings.EMPTY);
         model = MLModel
             .builder()
             .modelFormat(MLModelFormat.TORCH_SCRIPT)

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/tokenize/SparseTokenizerModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/tokenize/SparseTokenizerModelTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
@@ -69,7 +70,7 @@ public class SparseTokenizerModelTest {
     public void setUp() throws URISyntaxException {
         mlCachePath = Path.of("/tmp/ml_cache" + UUID.randomUUID());
         encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(mlCachePath, encryptor);
+        mlEngine = new MLEngine(mlCachePath, encryptor, Settings.EMPTY);
         modelId = "test_model_id";
         modelName = "test_model_name";
         functionName = FunctionName.SPARSE_TOKENIZE;

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -437,7 +437,7 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
 
         encryptor = new EncryptorImpl(clusterService, client);
 
-        mlEngine = new MLEngine(dataPath, encryptor);
+        mlEngine = new MLEngine(dataPath, encryptor, settings);
         nodeHelper = new DiscoveryNodeHelper(clusterService, settings);
         modelCacheHelper = new MLModelCacheHelper(clusterService, settings);
         cmHandler = new OpenSearchConversationalMemoryHandler(client, clusterService);
@@ -879,7 +879,9 @@ public class MachineLearningPlugin extends Plugin implements ActionPlugin, Searc
                 MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MEMORY_FEATURE_ENABLED,
                 MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED,
-                MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED
+                MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED,
+                MLCommonsSettings.ML_COMMON_MODEL_REPO_ENDPOINT,
+                MLCommonsSettings.ML_COMMON_MODEL_METALIST_ENDPOINT
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 
 import org.opensearch.common.settings.Setting;
 import org.opensearch.ml.common.conversation.ConversationalIndexConstants;
+import org.opensearch.ml.engine.MLEngine;
 import org.opensearch.searchpipelines.questionanswering.generative.GenerativeQAProcessorConstants;
 
 import com.google.common.collect.ImmutableList;
@@ -168,6 +169,12 @@ public final class MLCommonsSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
+
+    public static final Setting<String> ML_COMMON_MODEL_REPO_ENDPOINT =
+            MLEngine.ML_COMMON_MODEL_REPO_ENDPOINT;
+
+    public static final Setting<String> ML_COMMON_MODEL_METALIST_ENDPOINT =
+            MLEngine.ML_COMMON_MODEL_METALIST_ENDPOINT;
 
     public static final Setting<Boolean> ML_COMMONS_MEMORY_FEATURE_ENABLED = ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_ENABLED;
 

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
@@ -155,7 +155,7 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
         );
 
         Encryptor encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(Path.of("/tmp/test" + UUID.randomUUID()), encryptor);
+        mlEngine = new MLEngine(Path.of("/tmp/test" + UUID.randomUUID()), encryptor, Settings.EMPTY);
 
         updateConnectorTransportAction = new UpdateConnectorTransportAction(
             transportService,

--- a/plugin/src/test/java/org/opensearch/ml/action/deploy/TransportDeployModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/deploy/TransportDeployModelActionTests.java
@@ -149,7 +149,7 @@ public class TransportDeployModelActionTests extends OpenSearchTestCase {
         when(clusterService.getSettings()).thenReturn(settings);
 
         encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(Path.of("/tmp/test" + randomAlphaOfLength(10)), encryptor);
+        mlEngine = new MLEngine(Path.of("/tmp/test" + randomAlphaOfLength(10)), encryptor, Settings.EMPTY);
         modelHelper = new ModelHelper(mlEngine);
         when(mlDeployModelRequest.getModelId()).thenReturn("mockModelId");
         when(mlDeployModelRequest.getModelNodeIds()).thenReturn(new String[] { "node1" });

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -181,7 +181,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         String masterKey = "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=";
         MockitoAnnotations.openMocks(this);
         encryptor = new EncryptorImpl(masterKey);
-        mlEngine = new MLEngine(Path.of("/tmp/test" + randomAlphaOfLength(10)), encryptor);
+        mlEngine = new MLEngine(Path.of("/tmp/test" + randomAlphaOfLength(10)), encryptor, Settings.EMPTY);
         settings = Settings.builder().put(ML_COMMONS_MAX_MODELS_PER_NODE.getKey(), 10).build();
         settings = Settings.builder().put(ML_COMMONS_MAX_REGISTER_MODEL_TASKS_PER_NODE.getKey(), 10).build();
         settings = Settings.builder().put(ML_COMMONS_MONITORING_REQUEST_COUNT.getKey(), 10).build();

--- a/plugin/src/test/java/org/opensearch/ml/task/MLExecuteTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLExecuteTaskRunnerTests.java
@@ -94,7 +94,7 @@ public class MLExecuteTaskRunnerTests extends OpenSearchTestCase {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(Path.of("/tmp/djl-cache/" + randomAlphaOfLength(10)), encryptor);
+        mlEngine = new MLEngine(Path.of("/tmp/djl-cache/" + randomAlphaOfLength(10)), encryptor, Settings.EMPTY);
         when(threadPool.executor(anyString())).thenReturn(executorService);
         doAnswer(invocation -> {
             Runnable runnable = invocation.getArgument(0);

--- a/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
@@ -128,7 +128,7 @@ public class MLPredictTaskRunnerTests extends OpenSearchTestCase {
     public void setup() throws IOException {
         MockitoAnnotations.openMocks(this);
         encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(Path.of("/tmp/test" + randomAlphaOfLength(10)), encryptor);
+        mlEngine = new MLEngine(Path.of("/tmp/test" + randomAlphaOfLength(10)), encryptor, Settings.EMPTY);
         localNode = new DiscoveryNode("localNodeId", buildNewFakeTransportAddress(), Version.CURRENT);
         remoteNode = new DiscoveryNode("remoteNodeId", buildNewFakeTransportAddress(), Version.CURRENT);
         when(clusterService.localNode()).thenReturn(localNode);

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunnerTests.java
@@ -102,7 +102,7 @@ public class MLTrainAndPredictTaskRunnerTests extends OpenSearchTestCase {
     @Before
     public void setup() {
         encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(Path.of("/tmp/test" + randomAlphaOfLength(10)), encryptor);
+        mlEngine = new MLEngine(Path.of("/tmp/test" + randomAlphaOfLength(10)), encryptor, Settings.EMPTY);
         settings = Settings.builder().build();
         MockitoAnnotations.openMocks(this);
         localNode = new DiscoveryNode("localNodeId", buildNewFakeTransportAddress(), Version.CURRENT);

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTrainingTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTrainingTaskRunnerTests.java
@@ -112,7 +112,7 @@ public class MLTrainingTaskRunnerTests extends OpenSearchTestCase {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        mlEngine = new MLEngine(Path.of("/tmp/djl-cache_" + randomAlphaOfLength(10)), encryptor);
+        mlEngine = new MLEngine(Path.of("/tmp/djl-cache_" + randomAlphaOfLength(10)), encryptor, Settings.EMPTY);
         localNode = new DiscoveryNode("localNodeId", buildNewFakeTransportAddress(), Version.CURRENT);
         remoteNode = new DiscoveryNode("remoteNodeId", buildNewFakeTransportAddress(), Version.CURRENT);
         when(clusterService.localNode()).thenReturn(localNode);


### PR DESCRIPTION
### Problem statement
Today, pre-trained model endpoints and model meta list endpoint are hardcoded and point to openearch artifactory. When OpenSerach is deployed on prem on in different cloud provider, opensearch artifactory endpoint is not reachable and pre-trained model won't be able to used.

### Proposal
* Other cloud provider will mirror opensearch artifactory and host it in their artifactory
* Add a setting to customize the model endpoint and model meta list endpoint

### Changes
* Add settings for model repo endpoint and model meta list endpoint

### Test plan
* E2E test for pre-trained model workflow

### Description
[Describe what this change achieves]
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/2118
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
