### PR TITLE
remove more sensitive logs in pipeline/responseProcessor logs

### DIFF
--- a/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/GenerativeQAResponseProcessor.java
+++ b/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/GenerativeQAResponseProcessor.java
@@ -120,7 +120,6 @@ public class GenerativeQAResponseProcessor extends AbstractProcessor implements 
         if (timeout == null || timeout == GenerativeQAParameters.SIZE_NULL_VALUE) {
             timeout = DEFAULT_PROCESSOR_TIME_IN_SECONDS;
         }
-        log.info("Timeout for this request: {} seconds.", timeout);
 
         String llmQuestion = params.getLlmQuestion();
         String llmModel = params.getLlmModel() == null ? this.llmModel : params.getLlmModel();
@@ -129,17 +128,14 @@ public class GenerativeQAResponseProcessor extends AbstractProcessor implements 
         }
         String conversationId = params.getConversationId();
 
-        log.info("LLM model {}, conversation id: {}", llmModel, conversationId);
         Instant start = Instant.now();
         Integer interactionSize = params.getInteractionSize();
         if (interactionSize == null || interactionSize == GenerativeQAParameters.SIZE_NULL_VALUE) {
             interactionSize = DEFAULT_CHAT_HISTORY_WINDOW;
         }
-        log.info("Using interaction size of {}", interactionSize);
         List<Interaction> chatHistory = (conversationId == null)
             ? Collections.emptyList()
             : memoryClient.getInteractions(conversationId, interactionSize);
-        log.info("Retrieved chat history. ({})", getDuration(start));
 
         Integer topN = params.getContextSize();
         if (topN == null) {
@@ -147,8 +143,6 @@ public class GenerativeQAResponseProcessor extends AbstractProcessor implements 
         }
         List<String> searchResults = getSearchResults(response, topN);
 
-        log.info("system_prompt: {}", systemPrompt);
-        log.info("user_instructions: {}", userInstructions);
         start = Instant.now();
         try {
             ChatCompletionOutput output = llm
@@ -313,15 +307,6 @@ public class GenerativeQAResponseProcessor extends AbstractProcessor implements 
                         tag,
                         config,
                         GenerativeQAProcessorConstants.CONFIG_NAME_USER_INSTRUCTIONS
-                    );
-                log
-                    .info(
-                        "model_id {}, llm_model {}, context_field_list {}, system_prompt {}, user_instructions {}",
-                        modelId,
-                        llmModel,
-                        contextFields,
-                        systemPrompt,
-                        userInstructions
                     );
                 return new GenerativeQAResponseProcessor(
                     client,

--- a/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/client/ConversationalMemoryClient.java
+++ b/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/client/ConversationalMemoryClient.java
@@ -102,14 +102,12 @@ public class ConversationalMemoryClient {
                 interactions.addAll(list);
                 from += list.size();
                 maxResults -= list.size();
-                log.info("Interactions: {}, from: {}, maxResults: {}", interactions, from, maxResults);
             } else if (response.hasMorePages()) {
                 // If we didn't get any results back, we ignore this flag and break out of the loop
                 // to avoid an infinite loop.
                 // But in the future, we may support this mode, e.g. DynamoDB.
                 break;
             }
-            log.info("Interactions: {}, from: {}, maxResults: {}", interactions, from, maxResults);
             allInteractionsFetched = !response.hasMorePages();
         } while (from < lastN && !allInteractionsFetched);
 


### PR DESCRIPTION
### Description
Pen testers still pointed out "Finding: Search Pipeline / Response Processor Logs Contains Sensitive Data" not resolved. This PR is to delete the leftovers in the sensitive logs required by the pen tests. 

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
