### PR TITLE
parse tool input to map

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -15,6 +15,7 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.PROMPT_SUFFIX
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.RESPONSE_FORMAT_INSTRUCTION;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_RESPONSE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.VERBOSE;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.constructToolParams;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.createTools;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.getMessageHistoryLimit;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.getMlToolSpecs;
@@ -482,28 +483,6 @@ public class MLChatAgentRunner implements MLAgentRunner {
             String res = String.format(Locale.ROOT, "Failed to run the tool %s due to wrong input %s.", action, actionInput);
             nextStepListener.onResponse(res);
         }
-    }
-
-    private static Map<String, String> constructToolParams(
-        Map<String, Tool> tools,
-        Map<String, MLToolSpec> toolSpecMap,
-        String question,
-        AtomicReference<String> lastActionInput,
-        String action,
-        String actionInput
-    ) {
-        Map<String, String> toolParams = new HashMap<>();
-        Map<String, String> toolSpecParams = toolSpecMap.get(action).getParameters();
-        if (toolSpecParams != null) {
-            toolParams.putAll(toolSpecParams);
-        }
-        if (tools.get(action).useOriginalInput()) {
-            toolParams.put("input", question);
-            lastActionInput.set(question);
-        } else {
-            toolParams.put("input", actionInput);
-        }
-        return toolParams;
     }
 
     private static void saveTraceData(


### PR DESCRIPTION
### Description
Chat agent runner will pass a string input json to tool , for example `"{'detectorName': 'abc', 'indices': 'sample-data' }"`, then the tool side need to parse the json string to Map, for example [PPLTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/PPLTool.java#L452). 

This PR parse the tool input json string to Map and put the parameters to tool's parameter map. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
