### PR TITLE
Set the number of ml system index primary shards to 1

### DIFF
--- a/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
@@ -74,7 +74,7 @@ public class ConversationMetaIndex {
     private Client client;
     private ClusterService clusterService;
 
-    public static final Map<String, Object> INDEX_SETTINGS = Map.of("index.auto_expand_replicas", "0-1");
+    public static final Map<String, Object> INDEX_SETTINGS = Map.of("index.number_of_shards", "1", "index.auto_expand_replicas", "0-1");
 
     private String getUserStrFromThreadContext() {
         return client.threadPool().getThreadContext().getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);


### PR DESCRIPTION
### Description
Set the number of ml system index primary shards to 1
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
