### PR TITLE
prevent exposing internal ip

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/utils/error/ErrorMessage.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/error/ErrorMessage.java
@@ -51,7 +51,7 @@ public class ErrorMessage {
     }
 
     protected String fetchDetails() {
-        String msg;
+        final String msg;
         // Prevent the method from exposing internal information such as internal ip address etc. that is a security concern.
         if (hasInternalInformation(exception)) {
             msg = decorateMessage(exception);

--- a/plugin/src/main/java/org/opensearch/ml/utils/error/ErrorMessage.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/error/ErrorMessage.java
@@ -75,8 +75,9 @@ public class ErrorMessage {
 
     private String decorateMessage(Throwable t) {
         if (t instanceof ActionTransportException) {
-            String regexIPPort = "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}(:\\d{1,5})?";
-            return emptyStringIfNull(t.getLocalizedMessage()).replaceAll(regexIPPort, "x.x.x.x:x");
+            String regexIPv4 = "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}(:\\d{1,5})?";
+            String regexIPv6 = "\\[?((?:[\\da-fA-F]{0,4}:[\\da-fA-F]{0,4}){2,7})(?:[\\/\\\\%](\\d{1,3}))?\\]?(:\\d{1,5})?";
+            return emptyStringIfNull(t.getLocalizedMessage()).replaceAll(regexIPv4, "x.x.x.x:x").replaceAll(regexIPv6, "x.x.x.x.x.x:x");
         }
         return "";
     }

--- a/plugin/src/test/java/org/opensearch/ml/utils/error/ErrorMessageTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/error/ErrorMessageTests.java
@@ -10,7 +10,12 @@ import static org.junit.Assert.assertEquals;
 import static org.opensearch.core.rest.RestStatus.BAD_REQUEST;
 import static org.opensearch.core.rest.RestStatus.SERVICE_UNAVAILABLE;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 import org.junit.Test;
+import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.transport.ActionTransportException;
 
 public class ErrorMessageTests {
 
@@ -26,6 +31,22 @@ public class ErrorMessageTests {
         ErrorMessage errorMessage = new ErrorMessage(new IllegalStateException("illegal state"), SERVICE_UNAVAILABLE.getStatus());
 
         assertEquals(errorMessage.fetchDetails(), "illegal state");
+    }
+
+    @Test
+    public void fetchDetailsWithPrivateIP() throws UnknownHostException {
+        InetAddress ipAddress = InetAddress.getByName("192.168.1.1");
+        Throwable throwable = new ActionTransportException(
+            "node 1",
+            new TransportAddress(ipAddress, 9300),
+            null,
+            "Node not connected",
+            null
+        );
+        ErrorMessage errorMessage = new ErrorMessage(throwable, SERVICE_UNAVAILABLE.getStatus());
+
+        assertEquals(throwable.getLocalizedMessage(), "[node 1][192.168.1.1:9300] Node not connected");
+        assertEquals(errorMessage.fetchDetails(), "[node 1][x.x.x.x:x] Node not connected");
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/utils/error/ErrorMessageTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/error/ErrorMessageTests.java
@@ -34,7 +34,7 @@ public class ErrorMessageTests {
     }
 
     @Test
-    public void fetchDetailsWithPrivateIP() throws UnknownHostException {
+    public void fetchDetailsWithPrivateIPv4() throws UnknownHostException {
         InetAddress ipAddress = InetAddress.getByName("192.168.1.1");
         Throwable throwable = new ActionTransportException(
             "node 1",
@@ -47,6 +47,54 @@ public class ErrorMessageTests {
 
         assertEquals(throwable.getLocalizedMessage(), "[node 1][192.168.1.1:9300] Node not connected");
         assertEquals(errorMessage.fetchDetails(), "[node 1][x.x.x.x:x] Node not connected");
+    }
+
+    @Test
+    public void fetchDetailsWithPrivateIPv6_0() throws UnknownHostException {
+        InetAddress ipAddress = InetAddress.getByName("0:0:0:0:0:0:0:1");
+        Throwable throwable = new ActionTransportException(
+            "node 1",
+            new TransportAddress(ipAddress, 9300),
+            null,
+            "Node not connected",
+            null
+        );
+        ErrorMessage errorMessage = new ErrorMessage(throwable, SERVICE_UNAVAILABLE.getStatus());
+
+        assertEquals(throwable.getLocalizedMessage(), "[node 1][[::1]:9300] Node not connected");
+        assertEquals(errorMessage.fetchDetails(), "[node 1][x.x.x.x.x.x:x] Node not connected");
+    }
+
+    @Test
+    public void fetchDetailsWithPrivateIPv6_1() throws UnknownHostException {
+        InetAddress ipAddress = InetAddress.getByName("::1");
+        Throwable throwable = new ActionTransportException(
+            "node 1",
+            new TransportAddress(ipAddress, 9300),
+            null,
+            "Node not connected",
+            null
+        );
+        ErrorMessage errorMessage = new ErrorMessage(throwable, SERVICE_UNAVAILABLE.getStatus());
+
+        assertEquals(throwable.getLocalizedMessage(), "[node 1][[::1]:9300] Node not connected");
+        assertEquals(errorMessage.fetchDetails(), "[node 1][x.x.x.x.x.x:x] Node not connected");
+    }
+
+    @Test
+    public void fetchDetailsWithPrivateIPv61() throws UnknownHostException {
+        InetAddress ipAddress = InetAddress.getByName("1234:0000:F560:0000:0000:07C0:89AB:222D");
+        Throwable throwable = new ActionTransportException(
+            "node 1",
+            new TransportAddress(ipAddress, 9300),
+            null,
+            "Node not connected",
+            null
+        );
+        ErrorMessage errorMessage = new ErrorMessage(throwable, SERVICE_UNAVAILABLE.getStatus());
+
+        assertEquals(throwable.getLocalizedMessage(), "[node 1][[1234:0:f560::7c0:89ab:222d]:9300] Node not connected");
+        assertEquals(errorMessage.fetchDetails(), "[node 1][x.x.x.x.x.x:x] Node not connected");
     }
 
     @Test


### PR DESCRIPTION
### Description
Prevent exposing internal ip addresses.
```
{
    "error": {
        ......,
        "reason": "[opensearch-cluster-master-1][192.168.31.112:9300] Node not connected"
    },
    "status": 500
}
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
