### PR TITLE
Change the index update settings to make it only contain dynamic settings

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
@@ -41,6 +41,9 @@ public class MLIndicesHandler {
     ClusterService clusterService;
     Client client;
     private static final Map<String, AtomicBoolean> indexMappingUpdated = new HashMap<>();
+    // This setting is for index update only, so only dynamic settings should be contained!
+    // For index creation setting, use INDEX_SETTINGS directly.
+    public static final Map<String, Object> UPDATED_INDEX_SETTINGS = Map.of("index.auto_expand_replicas", "0-1");
 
     static {
         for (MLIndex mlIndex : MLIndex.values()) {
@@ -123,7 +126,7 @@ public class MLIndicesHandler {
                                     ActionListener.wrap(response -> {
                                         if (response.isAcknowledged()) {
                                             UpdateSettingsRequest updateSettingRequest = new UpdateSettingsRequest();
-                                            updateSettingRequest.indices(indexName).settings(INDEX_SETTINGS);
+                                            updateSettingRequest.indices(indexName).settings(UPDATED_INDEX_SETTINGS);
                                             client
                                                 .admin()
                                                 .indices()


### PR DESCRIPTION
### Description
Previously our index settings contain both static setting and dynamic setting, which will cause bug when doing index update. So we change the index update settings to make it only contain dynamic settings.
 
### Issues Resolved
This PR will resolve #2155
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
