### PR TITLE
Fix delete model cache on macOS causing model deploy fail with model …

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/FileUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/FileUtils.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -153,7 +155,10 @@ public class FileUtils {
 
     public static void deleteFileQuietly(File file) {
         if (file.exists()) {
-            org.apache.commons.io.FileUtils.deleteQuietly(file);
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                org.apache.commons.io.FileUtils.deleteQuietly(file);
+                return null;
+            });
         }
     }
 


### PR DESCRIPTION
…content changed error

### Description
On MacOS when user undeploy a model and redeploy it again, user will encounter `model content changed` exception, this is caused by the clean up code lacking of permission to delete user file so the cached file keep growing and hash changed.
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/844
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
