### PR TITLE
Bump common-compress package to fix CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects {
     configurations.all {
         // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
         resolutionStrategy.force "com.google.guava:guava:32.1.2-jre"
-        resolutionStrategy.force 'org.apache.commons:commons-compress:1.25.0'
+        resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
     }
 }
 

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -77,7 +77,7 @@ lombok {
 
 configurations.all {
     resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.21.9'
-    resolutionStrategy.force 'org.apache.commons:commons-compress:1.25.0'
+    resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
 }
 
 jacocoTestReport {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation group: 'org.tribuo', name: 'tribuo-regression-sgd', version: '4.2.1'
     implementation group: 'org.tribuo', name: 'tribuo-anomaly-libsvm', version: '4.2.1'
     implementation group: 'org.tribuo', name: 'tribuo-classification-sgd', version: '4.2.1'
-    implementation group: 'commons-io', name: 'commons-io', version: '2.15.0'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.15.1'
     implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:3.0-rc3'
     implementation 'software.amazon.randomcutforest:randomcutforest-core:3.0-rc3'
     implementation group: 'io.protostuff', name: 'protostuff-core', version: '1.8.0'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.19.0"
-    testImplementation group: 'commons-io', name: 'commons-io', version: '2.15.0'
+    testImplementation group: 'commons-io', name: 'commons-io', version: '2.15.1'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 
     checkstyle "com.puppycrawl.tools:checkstyle:${project.checkstyle.toolVersion}"


### PR DESCRIPTION
### Description
Bump common-compress package to 1.26 to fix CVE
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
