### PR TITLE
onnxruntime depends on architecture, not os

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -51,9 +51,8 @@ dependencies {
     implementation("ai.djl.onnxruntime:onnxruntime-engine:0.21.0") {
         exclude group: "com.microsoft.onnxruntime", module: "onnxruntime"
     }
-    def os = DefaultNativePlatform.currentOperatingSystem
-    //mac doesn't support GPU
-    if (os.macOsX) {
+    //arm doesn't support GPU
+    if (System.getProperty("os.arch") == "aarch64") {
         dependencies {
             implementation "com.microsoft.onnxruntime:onnxruntime:1.14.0"
         }


### PR DESCRIPTION
### Description
I couldn't get the correct onnxruntime lib running opensearch 2.12 docker on my m1 mac. My guess is that since it's built for arm linux (being a docker image), checking whether the operating system is macos was insufficient. There's also some potential of the culprit being that the plugin would be _built_ in a linux container - hence never hitting this if statement.

This has worked for me, but I'd want to check that this change still works for intel mac as well.
 
### Issues Resolved
I haven't raised a bug about it.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
