### PR TITLE
support question answering model

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/FunctionName.java
+++ b/common/src/main/java/org/opensearch/ml/common/FunctionName.java
@@ -28,6 +28,7 @@ public enum FunctionName {
     SPARSE_ENCODING,
     SPARSE_TOKENIZE,
     TEXT_SIMILARITY,
+    QUESTION_ANSWERING,
     AGENT;
 
     public static FunctionName from(String value) {
@@ -42,7 +43,8 @@ public enum FunctionName {
         TEXT_EMBEDDING,
         TEXT_SIMILARITY,
         SPARSE_ENCODING,
-        SPARSE_TOKENIZE
+        SPARSE_TOKENIZE,
+        QUESTION_ANSWERING
     ));
 
     /**

--- a/common/src/main/java/org/opensearch/ml/common/MLModel.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModel.java
@@ -21,6 +21,7 @@ import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.controller.MLRateLimiter;
 import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.MLModelState;
+import org.opensearch.ml.common.model.QuestionAnsweringModelConfig;
 import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
 import org.opensearch.ml.common.model.MetricsCorrelationModelConfig;
 
@@ -39,6 +40,7 @@ public class MLModel implements ToXContentObject {
     @Deprecated
     public static final String ALGORITHM_FIELD = "algorithm";
     public static final String FUNCTION_NAME_FIELD = "function_name";
+    public static final String MODEL_TASK_TYPE_FIELD = "model_task_type";
     public static final String MODEL_NAME_FIELD = "name";
     public static final String MODEL_GROUP_ID_FIELD = "model_group_id";
     // We use int type for version in first release 1.3. In 2.4, we changed to
@@ -219,6 +221,8 @@ public class MLModel implements ToXContentObject {
             if (input.readBoolean()) {
                 if (algorithm.equals(FunctionName.METRICS_CORRELATION)) {
                     modelConfig = new MetricsCorrelationModelConfig(input);
+                } else if (algorithm.equals(FunctionName.QUESTION_ANSWERING)) {
+                    modelConfig = new QuestionAnsweringModelConfig(input);
                 } else {
                     modelConfig = new TextEmbeddingModelConfig(input);
                 }
@@ -499,6 +503,7 @@ public class MLModel implements ToXContentObject {
                 case USER:
                     user = User.parse(parser);
                     break;
+                case MODEL_TASK_TYPE_FIELD:
                 case ALGORITHM_FIELD:
                 case FUNCTION_NAME_FIELD:
                     algorithm = FunctionName.from(parser.text().toUpperCase(Locale.ROOT));
@@ -527,6 +532,8 @@ public class MLModel implements ToXContentObject {
                 case MODEL_CONFIG_FIELD:
                     if (FunctionName.METRICS_CORRELATION.name().equals(algorithmName)) {
                         modelConfig = MetricsCorrelationModelConfig.parse(parser);
+                    } else if (FunctionName.QUESTION_ANSWERING.name().equals(algorithmName)) {
+                        modelConfig = QuestionAnsweringModelConfig.parse(parser);
                     } else {
                         modelConfig = TextEmbeddingModelConfig.parse(parser);
                     }

--- a/common/src/main/java/org/opensearch/ml/common/MLModel.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModel.java
@@ -40,7 +40,6 @@ public class MLModel implements ToXContentObject {
     @Deprecated
     public static final String ALGORITHM_FIELD = "algorithm";
     public static final String FUNCTION_NAME_FIELD = "function_name";
-    public static final String MODEL_TASK_TYPE_FIELD = "model_task_type";
     public static final String MODEL_NAME_FIELD = "name";
     public static final String MODEL_GROUP_ID_FIELD = "model_group_id";
     // We use int type for version in first release 1.3. In 2.4, we changed to
@@ -503,7 +502,6 @@ public class MLModel implements ToXContentObject {
                 case USER:
                     user = User.parse(parser);
                     break;
-                case MODEL_TASK_TYPE_FIELD:
                 case ALGORITHM_FIELD:
                 case FUNCTION_NAME_FIELD:
                     algorithm = FunctionName.from(parser.text().toUpperCase(Locale.ROOT));

--- a/common/src/main/java/org/opensearch/ml/common/dataset/MLInputDataType.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataset/MLInputDataType.java
@@ -13,5 +13,6 @@ public enum MLInputDataType {
     DATA_FRAME,
     TEXT_DOCS,
     REMOTE,
-    TEXT_SIMILARITY
+    TEXT_SIMILARITY,
+    QUESTION_ANSWERING
 }

--- a/common/src/main/java/org/opensearch/ml/common/dataset/QuestionAnsweringInputDataSet.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataset/QuestionAnsweringInputDataSet.java
@@ -37,7 +37,7 @@ public class QuestionAnsweringInputDataSet extends MLInputDataset {
     }
 
     public QuestionAnsweringInputDataSet(StreamInput in) throws IOException {
-        super(MLInputDataType.TEXT_SIMILARITY);
+        super(MLInputDataType.QUESTION_ANSWERING);
         this.question = in.readString();
         this.context = in.readString();
     }

--- a/common/src/main/java/org/opensearch/ml/common/dataset/QuestionAnsweringInputDataSet.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataset/QuestionAnsweringInputDataSet.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.ml.common.dataset;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.ml.common.annotation.InputDataSet;
+
+import java.io.IOException;
+
+@Getter
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@InputDataSet(MLInputDataType.QUESTION_ANSWERING)
+public class QuestionAnsweringInputDataSet extends MLInputDataset {
+
+   String question;
+
+   String context;
+
+    @Builder(toBuilder = true)
+    public QuestionAnsweringInputDataSet(String question, String context) {
+        super(MLInputDataType.QUESTION_ANSWERING);
+        if(question == null) {
+            throw new IllegalArgumentException("Question is not provided");
+        }
+        if(context == null) {
+            throw new IllegalArgumentException("Context is not provided");
+        }
+        this.question = question;
+        this.context = context;
+    }
+
+    public QuestionAnsweringInputDataSet(StreamInput in) throws IOException {
+        super(MLInputDataType.TEXT_SIMILARITY);
+        this.question = in.readString();
+        this.context = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(question);
+        out.writeString(context);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/input/MLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/MLInput.java
@@ -269,7 +269,7 @@ public class MLInput implements Input {
             }
         }
         MLInputDataset inputDataSet = null;
-        if (algorithm == FunctionName.TEXT_EMBEDDING || algorithm == FunctionName.SPARSE_ENCODING || algorithm == FunctionName.SPARSE_TOKENIZE) {
+        if (algorithm == FunctionName.TEXT_EMBEDDING || algorithm == FunctionName.SPARSE_ENCODING || algorithm == FunctionName.SPARSE_TOKENIZE || algorithm == FunctionName.QUESTION_ANSWERING) {
             ModelResultFilter filter = new ModelResultFilter(returnBytes, returnNumber, targetResponse, targetResponsePositions);
             inputDataSet = new TextDocsInputDataSet(textDocs, filter);
         }

--- a/common/src/main/java/org/opensearch/ml/common/input/MLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/MLInput.java
@@ -294,11 +294,9 @@ public class MLInput implements Input {
         if (algorithm == FunctionName.TEXT_EMBEDDING || algorithm == FunctionName.SPARSE_ENCODING || algorithm == FunctionName.SPARSE_TOKENIZE) {
             ModelResultFilter filter = new ModelResultFilter(returnBytes, returnNumber, targetResponse, targetResponsePositions);
             inputDataSet = new TextDocsInputDataSet(textDocs, filter);
-        }
-        if (algorithm == FunctionName.TEXT_SIMILARITY) {
+        } else if (algorithm == FunctionName.TEXT_SIMILARITY) {
             inputDataSet = new TextSimilarityInputDataSet(queryText, textDocs);
-        }
-        if (algorithm == FunctionName.QUESTION_ANSWERING) {
+        } else if (algorithm == FunctionName.QUESTION_ANSWERING) {
             inputDataSet = new QuestionAnsweringInputDataSet(question, context);
         }
         return new MLInput(algorithm, mlParameters, searchSourceBuilder, sourceIndices, dataFrame, inputDataSet);

--- a/common/src/main/java/org/opensearch/ml/common/input/MLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/MLInput.java
@@ -17,6 +17,7 @@ import org.opensearch.ml.common.MLCommonsClassLoader;
 import org.opensearch.ml.common.dataframe.DataFrame;
 import org.opensearch.ml.common.dataframe.DefaultDataFrame;
 import org.opensearch.ml.common.dataset.DataFrameInputDataset;
+import org.opensearch.ml.common.dataset.QuestionAnsweringInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.output.model.ModelResultFilter;
 import org.opensearch.ml.common.dataset.MLInputDataset;
@@ -62,6 +63,12 @@ public class MLInput implements Input {
     // Input query text to compare against for text similarity model
     public static final String QUERY_TEXT_FIELD = "query_text";
     public static final String PARAMETERS_FIELD = "parameters";
+
+    // Input question in question answering model
+    public static final String QUESTION_FIELD = "question";
+
+    // Input context in question answering model
+    public static final String CONTEXT_FIELD = "context";
 
     // Algorithm name
     protected FunctionName algorithm;
@@ -178,6 +185,13 @@ public class MLInput implements Input {
                         builder.endArray();
                     }
                     break;
+                case QUESTION_ANSWERING:
+                    QuestionAnsweringInputDataSet qaInputDataSet = (QuestionAnsweringInputDataSet) this.inputDataset;
+                    String question = qaInputDataSet.getQuestion();
+                    String context = qaInputDataSet.getContext();
+                    builder.field(QUESTION_FIELD, question);
+                    builder.field(CONTEXT_FIELD, context);
+                    break;
                 case REMOTE:
                     RemoteInferenceInputDataSet remoteInferenceInputDataSet = (RemoteInferenceInputDataSet) this.inputDataset;
                     Map<String, String> parameters = remoteInferenceInputDataSet.getParameters();
@@ -213,6 +227,8 @@ public class MLInput implements Input {
         List<Integer> targetResponsePositions = new ArrayList<>();
         List<String> textDocs = new ArrayList<>();
         String queryText = null;
+        String question = null;
+        String context = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -263,18 +279,27 @@ public class MLInput implements Input {
                 case QUERY_TEXT_FIELD:
                     queryText = parser.text();
                     break;
+                case QUESTION_FIELD:
+                    question = parser.text();
+                    break;
+                case CONTEXT_FIELD:
+                    context = parser.text();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
             }
         }
         MLInputDataset inputDataSet = null;
-        if (algorithm == FunctionName.TEXT_EMBEDDING || algorithm == FunctionName.SPARSE_ENCODING || algorithm == FunctionName.SPARSE_TOKENIZE || algorithm == FunctionName.QUESTION_ANSWERING) {
+        if (algorithm == FunctionName.TEXT_EMBEDDING || algorithm == FunctionName.SPARSE_ENCODING || algorithm == FunctionName.SPARSE_TOKENIZE) {
             ModelResultFilter filter = new ModelResultFilter(returnBytes, returnNumber, targetResponse, targetResponsePositions);
             inputDataSet = new TextDocsInputDataSet(textDocs, filter);
         }
         if (algorithm == FunctionName.TEXT_SIMILARITY) {
             inputDataSet = new TextSimilarityInputDataSet(queryText, textDocs);
+        }
+        if (algorithm == FunctionName.QUESTION_ANSWERING) {
+            inputDataSet = new QuestionAnsweringInputDataSet(question, context);
         }
         return new MLInput(algorithm, mlParameters, searchSourceBuilder, sourceIndices, dataFrame, inputDataSet);
     }

--- a/common/src/main/java/org/opensearch/ml/common/input/nlp/QuestionAnsweringMLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/nlp/QuestionAnsweringMLInput.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.ml.common.input.nlp;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.dataset.MLInputDataset;
+import org.opensearch.ml.common.dataset.QuestionAnsweringInputDataSet;
+import org.opensearch.ml.common.input.MLInput;
+
+import java.io.IOException;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+
+/**
+ * MLInput which supports a question answering algorithm
+ * Inputs are question and context. Output is the answer
+ */
+@org.opensearch.ml.common.annotation.MLInput(functionNames = {FunctionName.QUESTION_ANSWERING})
+public class QuestionAnsweringMLInput extends MLInput {
+
+    public QuestionAnsweringMLInput(FunctionName algorithm, MLInputDataset dataset) {
+        super(algorithm, null, dataset);
+    }
+
+    public QuestionAnsweringMLInput(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(ALGORITHM_FIELD, algorithm.name());
+        if(parameters != null) {
+            builder.field(ML_PARAMETERS_FIELD, parameters);
+        }
+        if(inputDataset != null) {
+            QuestionAnsweringInputDataSet ds = (QuestionAnsweringInputDataSet) this.inputDataset;
+            String question = ds.getQuestion();
+            String context = ds.getContext();
+            builder.field(QUESTION_FIELD, question);
+            builder.field(CONTEXT_FIELD, context);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public QuestionAnsweringMLInput(XContentParser parser, FunctionName functionName) throws IOException {
+        super();
+        this.algorithm = functionName;
+        String question = null;
+        String context = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case QUESTION_FIELD:
+                    question = parser.text();
+                case CONTEXT_FIELD:
+                    context = parser.text();
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }        
+        if(question == null) {
+            throw new IllegalArgumentException("Question is not provided");
+        }
+        if(context == null) {
+            throw new IllegalArgumentException("Context is not provided");
+        }
+        inputDataset = new QuestionAnsweringInputDataSet(question, context);
+    }
+
+}

--- a/common/src/main/java/org/opensearch/ml/common/input/nlp/QuestionAnsweringMLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/nlp/QuestionAnsweringMLInput.java
@@ -70,8 +70,10 @@ public class QuestionAnsweringMLInput extends MLInput {
             switch (fieldName) {
                 case QUESTION_FIELD:
                     question = parser.text();
+                    break;
                 case CONTEXT_FIELD:
                     context = parser.text();
+                    break;
                 default:
                     parser.skipChildren();
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/input/nlp/TextDocsMLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/nlp/TextDocsMLInput.java
@@ -25,7 +25,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
  * ML input class which supports a list fo text docs.
  * This class can be used for TEXT_EMBEDDING model.
  */
-@org.opensearch.ml.common.annotation.MLInput(functionNames = {FunctionName.TEXT_EMBEDDING, FunctionName.SPARSE_ENCODING, FunctionName.SPARSE_TOKENIZE, FunctionName.QUESTION_ANSWERING})
+@org.opensearch.ml.common.annotation.MLInput(functionNames = {FunctionName.TEXT_EMBEDDING, FunctionName.SPARSE_ENCODING, FunctionName.SPARSE_TOKENIZE})
 public class TextDocsMLInput extends MLInput {
     public static final String TEXT_DOCS_FIELD = "text_docs";
     public static final String RESULT_FILTER_FIELD = "result_filter";

--- a/common/src/main/java/org/opensearch/ml/common/input/nlp/TextDocsMLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/nlp/TextDocsMLInput.java
@@ -25,7 +25,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
  * ML input class which supports a list fo text docs.
  * This class can be used for TEXT_EMBEDDING model.
  */
-@org.opensearch.ml.common.annotation.MLInput(functionNames = {FunctionName.TEXT_EMBEDDING, FunctionName.SPARSE_ENCODING, FunctionName.SPARSE_TOKENIZE})
+@org.opensearch.ml.common.annotation.MLInput(functionNames = {FunctionName.TEXT_EMBEDDING, FunctionName.SPARSE_ENCODING, FunctionName.SPARSE_TOKENIZE, FunctionName.QUESTION_ANSWERING})
 public class TextDocsMLInput extends MLInput {
     public static final String TEXT_DOCS_FIELD = "text_docs";
     public static final String RESULT_FILTER_FIELD = "result_filter";

--- a/common/src/main/java/org/opensearch/ml/common/input/nlp/TextSimilarityMLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/nlp/TextSimilarityMLInput.java
@@ -99,6 +99,7 @@ public class TextSimilarityMLInput extends MLInput {
                     break;
                 case QUERY_TEXT_FIELD: 
                     queryText = parser.text();
+                    break;
                 default:
                     parser.skipChildren();
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/model/QuestionAnsweringModelConfig.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/QuestionAnsweringModelConfig.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.FunctionName;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+@Setter
+@Getter
+public class QuestionAnsweringModelConfig extends MLModelConfig {
+    public static final String PARSE_FIELD_NAME = FunctionName.QUESTION_ANSWERING.name();
+    public static final NamedXContentRegistry.Entry XCONTENT_REGISTRY = new NamedXContentRegistry.Entry(
+            QuestionAnsweringModelConfig.class,
+            new ParseField(PARSE_FIELD_NAME),
+            it -> parse(it)
+    );
+    public static final String FRAMEWORK_TYPE_FIELD = "framework_type";
+    public static final String POOLING_MODE_FIELD = "pooling_mode";
+    public static final String NORMALIZE_RESULT_FIELD = "normalize_result";
+    public static final String MODEL_MAX_LENGTH_FIELD = "model_max_length";
+
+    private final FrameworkType frameworkType;
+    private final PoolingMode poolingMode;
+    private final boolean normalizeResult;
+    private final Integer modelMaxLength;
+
+    @Builder(toBuilder = true)
+    public QuestionAnsweringModelConfig(String modelType, FrameworkType frameworkType, String allConfig,
+                                        PoolingMode poolingMode, boolean normalizeResult, Integer modelMaxLength) {
+        super(modelType, allConfig);
+        if (frameworkType == null) {
+            throw new IllegalArgumentException("framework type is null");
+        }
+        this.frameworkType = frameworkType;
+        this.poolingMode = poolingMode;
+        this.normalizeResult = normalizeResult;
+        this.modelMaxLength = modelMaxLength;
+    }
+
+    public static QuestionAnsweringModelConfig parse(XContentParser parser) throws IOException {
+        String modelType = null;
+        FrameworkType frameworkType = null;
+        String allConfig = null;
+        PoolingMode poolingMode = null;
+        boolean normalizeResult = false;
+        Integer modelMaxLength = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case MODEL_TYPE_FIELD:
+                    modelType = parser.text();
+                    break;
+                case FRAMEWORK_TYPE_FIELD:
+                    frameworkType = FrameworkType.from(parser.text().toUpperCase(Locale.ROOT));
+                    break;
+                case ALL_CONFIG_FIELD:
+                    allConfig = parser.text();
+                    break;
+                case POOLING_MODE_FIELD:
+                    poolingMode = PoolingMode.from(parser.text().toUpperCase(Locale.ROOT));
+                    break;
+                case NORMALIZE_RESULT_FIELD:
+                    normalizeResult = parser.booleanValue();
+                    break;
+                case MODEL_MAX_LENGTH_FIELD:
+                    modelMaxLength = parser.intValue();
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return new QuestionAnsweringModelConfig(modelType, frameworkType, allConfig, poolingMode, normalizeResult, modelMaxLength);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return PARSE_FIELD_NAME;
+    }
+
+    public QuestionAnsweringModelConfig(StreamInput in) throws IOException{
+        super(in);
+        frameworkType = in.readEnum(FrameworkType.class);
+        if (in.readBoolean()) {
+            poolingMode = in.readEnum(PoolingMode.class);
+        } else {
+            poolingMode = null;
+        }
+        normalizeResult = in.readBoolean();
+        modelMaxLength = in.readOptionalInt();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeEnum(frameworkType);
+        if (poolingMode != null) {
+            out.writeBoolean(true);
+            out.writeEnum(poolingMode);
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeBoolean(normalizeResult);
+        out.writeOptionalInt(modelMaxLength);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (modelType != null) {
+            builder.field(MODEL_TYPE_FIELD, modelType);
+        }
+        if (frameworkType != null) {
+            builder.field(FRAMEWORK_TYPE_FIELD, frameworkType);
+        }
+        if (allConfig != null) {
+            builder.field(ALL_CONFIG_FIELD, allConfig);
+        }
+        if (modelMaxLength != null) {
+            builder.field(MODEL_MAX_LENGTH_FIELD, modelMaxLength);
+        }
+        if (poolingMode != null) {
+            builder.field(POOLING_MODE_FIELD, poolingMode);
+        }
+        if (normalizeResult) {
+            builder.field(NORMALIZE_RESULT_FIELD, normalizeResult);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public enum PoolingMode {
+        MEAN("mean"),
+        MEAN_SQRT_LEN("mean_sqrt_len"),
+        MAX("max"),
+        WEIGHTED_MEAN("weightedmean"),
+        CLS("cls"),
+        LAST_TOKEN("lasttoken");
+
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+        PoolingMode(String name) {
+            this.name = name;
+        }
+
+        public static PoolingMode from(String value) {
+            try {
+                return PoolingMode.valueOf(value.toUpperCase(Locale.ROOT));
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Wrong pooling method");
+            }
+        }
+    }
+    public enum FrameworkType {
+        HUGGINGFACE_TRANSFORMERS,
+        SENTENCE_TRANSFORMERS,
+        HUGGINGFACE_TRANSFORMERS_NEURON;
+
+        public static FrameworkType from(String value) {
+            try {
+                return FrameworkType.valueOf(value.toUpperCase(Locale.ROOT));
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Wrong framework type");
+            }
+        }
+    }
+
+}

--- a/common/src/main/java/org/opensearch/ml/common/model/QuestionAnsweringModelConfig.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/QuestionAnsweringModelConfig.java
@@ -31,24 +31,20 @@ public class QuestionAnsweringModelConfig extends MLModelConfig {
             it -> parse(it)
     );
     public static final String FRAMEWORK_TYPE_FIELD = "framework_type";
-    public static final String POOLING_MODE_FIELD = "pooling_mode";
     public static final String NORMALIZE_RESULT_FIELD = "normalize_result";
     public static final String MODEL_MAX_LENGTH_FIELD = "model_max_length";
 
     private final FrameworkType frameworkType;
-    private final PoolingMode poolingMode;
     private final boolean normalizeResult;
     private final Integer modelMaxLength;
 
     @Builder(toBuilder = true)
-    public QuestionAnsweringModelConfig(String modelType, FrameworkType frameworkType, String allConfig,
-                                        PoolingMode poolingMode, boolean normalizeResult, Integer modelMaxLength) {
+    public QuestionAnsweringModelConfig(String modelType, FrameworkType frameworkType, String allConfig, boolean normalizeResult, Integer modelMaxLength) {
         super(modelType, allConfig);
         if (frameworkType == null) {
             throw new IllegalArgumentException("framework type is null");
         }
         this.frameworkType = frameworkType;
-        this.poolingMode = poolingMode;
         this.normalizeResult = normalizeResult;
         this.modelMaxLength = modelMaxLength;
     }
@@ -57,7 +53,6 @@ public class QuestionAnsweringModelConfig extends MLModelConfig {
         String modelType = null;
         FrameworkType frameworkType = null;
         String allConfig = null;
-        PoolingMode poolingMode = null;
         boolean normalizeResult = false;
         Integer modelMaxLength = null;
 
@@ -76,9 +71,6 @@ public class QuestionAnsweringModelConfig extends MLModelConfig {
                 case ALL_CONFIG_FIELD:
                     allConfig = parser.text();
                     break;
-                case POOLING_MODE_FIELD:
-                    poolingMode = PoolingMode.from(parser.text().toUpperCase(Locale.ROOT));
-                    break;
                 case NORMALIZE_RESULT_FIELD:
                     normalizeResult = parser.booleanValue();
                     break;
@@ -90,7 +82,7 @@ public class QuestionAnsweringModelConfig extends MLModelConfig {
                     break;
             }
         }
-        return new QuestionAnsweringModelConfig(modelType, frameworkType, allConfig, poolingMode, normalizeResult, modelMaxLength);
+        return new QuestionAnsweringModelConfig(modelType, frameworkType, allConfig, normalizeResult, modelMaxLength);
     }
 
     @Override
@@ -101,11 +93,6 @@ public class QuestionAnsweringModelConfig extends MLModelConfig {
     public QuestionAnsweringModelConfig(StreamInput in) throws IOException{
         super(in);
         frameworkType = in.readEnum(FrameworkType.class);
-        if (in.readBoolean()) {
-            poolingMode = in.readEnum(PoolingMode.class);
-        } else {
-            poolingMode = null;
-        }
         normalizeResult = in.readBoolean();
         modelMaxLength = in.readOptionalInt();
     }
@@ -114,12 +101,6 @@ public class QuestionAnsweringModelConfig extends MLModelConfig {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeEnum(frameworkType);
-        if (poolingMode != null) {
-            out.writeBoolean(true);
-            out.writeEnum(poolingMode);
-        } else {
-            out.writeBoolean(false);
-        }
         out.writeBoolean(normalizeResult);
         out.writeOptionalInt(modelMaxLength);
     }
@@ -139,40 +120,11 @@ public class QuestionAnsweringModelConfig extends MLModelConfig {
         if (modelMaxLength != null) {
             builder.field(MODEL_MAX_LENGTH_FIELD, modelMaxLength);
         }
-        if (poolingMode != null) {
-            builder.field(POOLING_MODE_FIELD, poolingMode);
-        }
         if (normalizeResult) {
             builder.field(NORMALIZE_RESULT_FIELD, normalizeResult);
         }
         builder.endObject();
         return builder;
-    }
-
-    public enum PoolingMode {
-        MEAN("mean"),
-        MEAN_SQRT_LEN("mean_sqrt_len"),
-        MAX("max"),
-        WEIGHTED_MEAN("weightedmean"),
-        CLS("cls"),
-        LAST_TOKEN("lasttoken");
-
-        private String name;
-
-        public String getName() {
-            return name;
-        }
-        PoolingMode(String name) {
-            this.name = name;
-        }
-
-        public static PoolingMode from(String value) {
-            try {
-                return PoolingMode.valueOf(value.toUpperCase(Locale.ROOT));
-            } catch (Exception e) {
-                throw new IllegalArgumentException("Wrong pooling method");
-            }
-        }
     }
     public enum FrameworkType {
         HUGGINGFACE_TRANSFORMERS,

--- a/common/src/main/java/org/opensearch/ml/common/output/model/ModelTensor.java
+++ b/common/src/main/java/org/opensearch/ml/common/output/model/ModelTensor.java
@@ -63,6 +63,11 @@ public class ModelTensor implements Writeable, ToXContentObject {
         this.dataAsMap = dataAsMap;
     }
 
+    public ModelTensor(String name, String result) {
+        this.name = name;
+        this.result = result;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject();

--- a/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
@@ -23,6 +23,7 @@ import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.controller.MLRateLimiter;
 import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.MetricsCorrelationModelConfig;
+import org.opensearch.ml.common.model.QuestionAnsweringModelConfig;
 import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
 
 import java.io.IOException;
@@ -41,6 +42,8 @@ import static org.opensearch.ml.common.connector.Connector.createConnector;
 public class MLRegisterModelInput implements ToXContentObject, Writeable {
 
     public static final String FUNCTION_NAME_FIELD = "function_name";
+    public static final String MODEL_TASK_TYPE_FIELD = "model_task_type";
+
     public static final String NAME_FIELD = "name";
     public static final String MODEL_GROUP_ID_FIELD = "model_group_id";
     public static final String DESCRIPTION_FIELD = "description";
@@ -166,6 +169,8 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         if (in.readBoolean()) {
             if (this.functionName.equals(FunctionName.METRICS_CORRELATION)) {
                 this.modelConfig = new MetricsCorrelationModelConfig(in);
+            } else if (this.functionName.equals(FunctionName.QUESTION_ANSWERING)) {
+                this.modelConfig = new QuestionAnsweringModelConfig(in);
             } else {
                 this.modelConfig = new TextEmbeddingModelConfig(in);
             }
@@ -357,6 +362,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
             String fieldName = parser.currentName();
             parser.nextToken();
             switch (fieldName) {
+                case MODEL_TASK_TYPE_FIELD:
                 case FUNCTION_NAME_FIELD:
                     functionName = FunctionName.from(parser.text().toUpperCase(Locale.ROOT));
                     break;
@@ -382,7 +388,11 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                     modelFormat = MLModelFormat.from(parser.text().toUpperCase(Locale.ROOT));
                     break;
                 case MODEL_CONFIG_FIELD:
-                    modelConfig = TextEmbeddingModelConfig.parse(parser);
+                    if (FunctionName.QUESTION_ANSWERING.equals(functionName)) {
+                        modelConfig = QuestionAnsweringModelConfig.parse(parser);
+                    } else {
+                        modelConfig = TextEmbeddingModelConfig.parse(parser);
+                    }
                     break;
                 case CONNECTOR_FIELD:
                     connector = createConnector(parser);
@@ -456,6 +466,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
             parser.nextToken();
 
             switch (fieldName) {
+                case MODEL_TASK_TYPE_FIELD:
                 case FUNCTION_NAME_FIELD:
                     functionName = FunctionName.from(parser.text().toUpperCase(Locale.ROOT));
                     break;
@@ -493,7 +504,11 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                     modelFormat = MLModelFormat.from(parser.text().toUpperCase(Locale.ROOT));
                     break;
                 case MODEL_CONFIG_FIELD:
-                    modelConfig = TextEmbeddingModelConfig.parse(parser);
+                    if (FunctionName.QUESTION_ANSWERING.equals(functionName)) {
+                        modelConfig = QuestionAnsweringModelConfig.parse(parser);
+                    } else {
+                        modelConfig = TextEmbeddingModelConfig.parse(parser);
+                    }
                     break;
                 case MODEL_NODE_IDS_FIELD:
                     ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);

--- a/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
@@ -42,8 +42,6 @@ import static org.opensearch.ml.common.connector.Connector.createConnector;
 public class MLRegisterModelInput implements ToXContentObject, Writeable {
 
     public static final String FUNCTION_NAME_FIELD = "function_name";
-    public static final String MODEL_TASK_TYPE_FIELD = "model_task_type";
-
     public static final String NAME_FIELD = "name";
     public static final String MODEL_GROUP_ID_FIELD = "model_group_id";
     public static final String DESCRIPTION_FIELD = "description";
@@ -362,7 +360,6 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
             String fieldName = parser.currentName();
             parser.nextToken();
             switch (fieldName) {
-                case MODEL_TASK_TYPE_FIELD:
                 case FUNCTION_NAME_FIELD:
                     functionName = FunctionName.from(parser.text().toUpperCase(Locale.ROOT));
                     break;
@@ -466,7 +463,6 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
             parser.nextToken();
 
             switch (fieldName) {
-                case MODEL_TASK_TYPE_FIELD:
                 case FUNCTION_NAME_FIELD:
                     functionName = FunctionName.from(parser.text().toUpperCase(Locale.ROOT));
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/transport/upload_chunk/MLRegisterModelMetaInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/upload_chunk/MLRegisterModelMetaInput.java
@@ -22,7 +22,6 @@ import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.controller.MLRateLimiter;
 import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.MLModelState;
-import org.opensearch.ml.common.model.MetricsCorrelationModelConfig;
 import org.opensearch.ml.common.model.QuestionAnsweringModelConfig;
 import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
 
@@ -37,7 +36,6 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 public class MLRegisterModelMetaInput implements ToXContentObject, Writeable {
 
     public static final String FUNCTION_NAME_FIELD = "function_name";
-    public static final String MODEL_TASK_TYPE_FIELD = "model_task_type";
     public static final String MODEL_NAME_FIELD = "name"; // mandatory
     public static final String DESCRIPTION_FIELD = "description"; // optional
     public static final String IS_ENABLED_FIELD = "is_enabled"; // optional
@@ -305,7 +303,6 @@ public class MLRegisterModelMetaInput implements ToXContentObject, Writeable {
                 case MODEL_NAME_FIELD:
                     name = parser.text();
                     break;
-                case MODEL_TASK_TYPE_FIELD:
                 case FUNCTION_NAME_FIELD:
                     functionName = FunctionName.from(parser.text());
                     break;

--- a/common/src/test/java/org/opensearch/ml/common/MLCommonsClassLoaderTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/MLCommonsClassLoaderTests.java
@@ -171,8 +171,9 @@ public class MLCommonsClassLoaderTests {
     @Test
     public void testClassLoader_MLInput() throws IOException {
         testClassLoader_MLInput_DlModel(FunctionName.TEXT_EMBEDDING);
-        testClassLoader_MLInput_DlModel(FunctionName.SPARSE_TOKENIZE);
+        testClassLoader_MLInput_DlModel(FunctionName.QUESTION_ANSWERING);
         testClassLoader_MLInput_DlModel(FunctionName.SPARSE_ENCODING);
+        testClassLoader_MLInput_DlModel(FunctionName.SPARSE_TOKENIZE);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/common/src/test/java/org/opensearch/ml/common/MLCommonsClassLoaderTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/MLCommonsClassLoaderTests.java
@@ -171,7 +171,6 @@ public class MLCommonsClassLoaderTests {
     @Test
     public void testClassLoader_MLInput() throws IOException {
         testClassLoader_MLInput_DlModel(FunctionName.TEXT_EMBEDDING);
-        testClassLoader_MLInput_DlModel(FunctionName.QUESTION_ANSWERING);
         testClassLoader_MLInput_DlModel(FunctionName.SPARSE_ENCODING);
         testClassLoader_MLInput_DlModel(FunctionName.SPARSE_TOKENIZE);
     }

--- a/common/src/test/java/org/opensearch/ml/common/dataset/QuestionAnsweringInputDatasetTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataset/QuestionAnsweringInputDatasetTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.ml.common.dataset;
+
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.BytesStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertThrows;
+
+public class QuestionAnsweringInputDatasetTest {
+    
+    @Test
+    public void testStreaming() throws IOException {
+        String question = "What color is apple";
+        String context = "I like Apples. They are red";
+        QuestionAnsweringInputDataSet dataset = QuestionAnsweringInputDataSet.builder().question(question).context(context).build();
+        BytesStreamOutput outbytes = new BytesStreamOutput();
+        StreamOutput osso = new OutputStreamStreamOutput(outbytes);
+        dataset.writeTo(osso);
+        StreamInput in = new BytesStreamInput(BytesReference.toBytes(outbytes.bytes()));
+        QuestionAnsweringInputDataSet newDs = (QuestionAnsweringInputDataSet) MLInputDataset.fromStream(in);
+        assert (question.equals("What color is apple"));
+        assert (context.equals("I like Apples. They are red"));
+    }
+
+    @Test
+    public void noContext_ThenFail() {
+        String question = "What color is apple";
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, 
+            () -> QuestionAnsweringInputDataSet.builder().question(question).build());
+        assert (e.getMessage().equals("Context is not provided"));
+    }
+
+    @Test
+    public void noQuestion_ThenFail() {
+        String context = "I like Apples. They are red";
+        assertThrows(IllegalArgumentException.class,
+            () -> QuestionAnsweringInputDataSet.builder().context(context).build());
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/input/nlp/QuestionAnsweringMLInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/nlp/QuestionAnsweringMLInputTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.ml.common.input.nlp;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.BytesStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.dataset.MLInputDataset;
+import org.opensearch.ml.common.dataset.QuestionAnsweringInputDataSet;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.search.SearchModule;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertThrows;
+
+public class QuestionAnsweringMLInputTest {
+    
+    MLInput input;
+
+    private final FunctionName algorithm = FunctionName.QUESTION_ANSWERING;
+
+    @Before
+    public void setup() {
+        String question = "What color is apple";
+        String context = "I like Apples. They are red";
+        MLInputDataset dataset = QuestionAnsweringInputDataSet.builder().question(question).context(context).build();
+        input = new QuestionAnsweringMLInput(algorithm, dataset);
+    }
+
+    @Test
+    public void testXContent_IsInternallyConsistent() throws IOException {
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        input.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String jsonStr = builder.toString();
+        XContentParser parser = XContentType.JSON.xContent()
+                .createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                        Collections.emptyList()).getNamedXContents()), null, jsonStr);
+        parser.nextToken();
+
+        MLInput parsedInput = MLInput.parse(parser, input.getFunctionName().name());
+        assert (parsedInput instanceof QuestionAnsweringMLInput);
+        QuestionAnsweringMLInput parsedQAMLI = (QuestionAnsweringMLInput) parsedInput;
+        String question = ((QuestionAnsweringInputDataSet) parsedQAMLI.getInputDataset()).getQuestion();
+        String context = ((QuestionAnsweringInputDataSet) parsedQAMLI.getInputDataset()).getContext();
+        assert (question.equals("What color is apple"));
+        assert (context.equals("I like Apples. They are red"));
+    }
+
+    @Test
+    public void testXContent_String() throws IOException {
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        input.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String jsonStr = builder.toString();
+        assert (jsonStr.equals("{\"algorithm\":\"QUESTION_ANSWERING\",\"question\":\"What color is apple\",\"context\":\"I like Apples. They are red\"}"));
+    }
+
+    @Test
+    public void testParseJson() throws IOException {
+        String json = "{\"algorithm\":\"QUESTION_ANSWERING\",\"question\":\"What color is apple\",\"context\":\"I like Apples. They are red\"}";
+        XContentParser parser = XContentType.JSON.xContent()
+                .createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                        Collections.emptyList()).getNamedXContents()), null, json);
+        parser.nextToken();
+
+        MLInput parsedInput = MLInput.parse(parser, input.getFunctionName().name());
+        assert (parsedInput instanceof QuestionAnsweringMLInput);
+        QuestionAnsweringMLInput parsedQAMLI = (QuestionAnsweringMLInput) parsedInput;
+        String question = ((QuestionAnsweringInputDataSet) parsedQAMLI.getInputDataset()).getQuestion();
+        String context = ((QuestionAnsweringInputDataSet) parsedQAMLI.getInputDataset()).getContext();
+        assert (question.equals("What color is apple"));
+        assert (context.equals("I like Apples. They are red"));
+    }
+
+    @Test
+    public void testStreaming() throws IOException {
+        BytesStreamOutput outbytes = new BytesStreamOutput();
+        StreamOutput osso = new OutputStreamStreamOutput(outbytes);
+        input.writeTo(osso);
+        StreamInput in = new BytesStreamInput(BytesReference.toBytes(outbytes.bytes()));
+        QuestionAnsweringMLInput newInput = new QuestionAnsweringMLInput(in);
+        String newQuestion = ((QuestionAnsweringInputDataSet) newInput.getInputDataset()).getQuestion();
+        String oldQuestion = ((QuestionAnsweringInputDataSet) input.getInputDataset()).getQuestion();
+        assert (newQuestion.equals(oldQuestion));
+    }
+
+}

--- a/common/src/test/java/org/opensearch/ml/common/model/QuestionAnsweringModelConfigTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/QuestionAnsweringModelConfigTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.model;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.TestHelper;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
+
+public class QuestionAnsweringModelConfigTests {
+
+    QuestionAnsweringModelConfig config;
+    Function<XContentParser, QuestionAnsweringModelConfig> function;
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        config = QuestionAnsweringModelConfig.builder()
+                .modelType("testModelType")
+                .allConfig("{\"field1\":\"value1\",\"field2\":\"value2\"}")
+                .frameworkType(QuestionAnsweringModelConfig.FrameworkType.SENTENCE_TRANSFORMERS)
+                .build();
+        function = parser -> {
+            try {
+                return QuestionAnsweringModelConfig.parse(parser);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to parse QuestionAnsweringModelConfig", e);
+            }
+        };
+    }
+
+    @Test
+    public void toXContent() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        config.toXContent(builder, EMPTY_PARAMS);
+        String configContent = TestHelper.xContentBuilderToString(builder);
+        assertEquals("{\"model_type\":\"testModelType\",\"framework_type\":\"SENTENCE_TRANSFORMERS\",\"all_config\":\"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\"}\"}", configContent);
+    }
+
+    @Test
+    public void nullFields_ModelType() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("model type is null");
+        config = QuestionAnsweringModelConfig.builder()
+                .build();
+    }
+
+    @Test
+    public void nullFields_FrameworkType() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("framework type is null");
+        config = QuestionAnsweringModelConfig.builder()
+                .modelType("testModelType")
+                .build();
+    }
+
+    @Test
+    public void parse() throws IOException {
+        String content = "{\"wrong_field\":\"test_value\", \"model_type\":\"testModelType\",\"framework_type\":\"SENTENCE_TRANSFORMERS\",\"all_config\":\"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\"}\"}";
+        TestHelper.testParseFromString(config, content, function);
+    }
+
+    @Test
+    public void frameworkType_wrongValue() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Wrong framework type");
+        QuestionAnsweringModelConfig.FrameworkType.from("test_wrong_value");
+    }
+
+    @Test
+    public void readInputStream_Success() throws IOException {
+        readInputStream(config);
+    }
+
+    public void readInputStream(QuestionAnsweringModelConfig config) throws IOException {
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        config.writeTo(bytesStreamOutput);
+
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        QuestionAnsweringModelConfig parsedConfig = new QuestionAnsweringModelConfig(streamInput);
+        assertEquals(config.getModelType(), parsedConfig.getModelType());
+        assertEquals(config.getAllConfig(), parsedConfig.getAllConfig());
+        assertEquals(config.getFrameworkType(), parsedConfig.getFrameworkType());
+        assertEquals(config.getWriteableName(), parsedConfig.getWriteableName());
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/model/QuestionAnsweringModelConfigTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/QuestionAnsweringModelConfigTests.java
@@ -34,6 +34,7 @@ public class QuestionAnsweringModelConfigTests {
         config = QuestionAnsweringModelConfig.builder()
                 .modelType("testModelType")
                 .allConfig("{\"field1\":\"value1\",\"field2\":\"value2\"}")
+                .normalizeResult(false)
                 .frameworkType(QuestionAnsweringModelConfig.FrameworkType.SENTENCE_TRANSFORMERS)
                 .build();
         function = parser -> {
@@ -72,7 +73,7 @@ public class QuestionAnsweringModelConfigTests {
 
     @Test
     public void parse() throws IOException {
-        String content = "{\"wrong_field\":\"test_value\", \"model_type\":\"testModelType\",\"framework_type\":\"SENTENCE_TRANSFORMERS\",\"all_config\":\"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\"}\"}";
+        String content = "{\"wrong_field\":\"test_value\", \"model_type\":\"testModelType\",\"framework_type\":\"SENTENCE_TRANSFORMERS\",\"normalize_result\":false,\"all_config\":\"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\"}\"}";
         TestHelper.testParseFromString(config, content, function);
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
@@ -92,6 +92,10 @@ public class ModelHelper {
 
                 MLRegisterModelInput.MLRegisterModelInputBuilder builder = MLRegisterModelInput.builder();
 
+                String functionName = config.containsKey("function_name")
+                    ? (String) config.get("function_name")
+                    : (String) config.get("model_task_type");
+
                 builder
                     .modelName(modelName)
                     .version(version)
@@ -100,7 +104,7 @@ public class ModelHelper {
                     .modelNodeIds(modelNodeIds)
                     .isHidden(isHidden)
                     .modelGroupId(modelGroupId)
-                    .functionName(FunctionName.from((String) config.get("model_task_type")));
+                    .functionName(FunctionName.from((functionName)));
 
                 config.entrySet().forEach(entry -> {
                     switch (entry.getKey().toString()) {
@@ -125,19 +129,6 @@ public class ModelHelper {
                                                 .frameworkType(
                                                     QuestionAnsweringModelConfig.FrameworkType.from(configEntry.getValue().toString())
                                                 );
-                                            break;
-                                        case QuestionAnsweringModelConfig.POOLING_MODE_FIELD:
-                                            configBuilder
-                                                .poolingMode(
-                                                    QuestionAnsweringModelConfig.PoolingMode
-                                                        .from(configEntry.getValue().toString().toUpperCase(Locale.ROOT))
-                                                );
-                                            break;
-                                        case QuestionAnsweringModelConfig.NORMALIZE_RESULT_FIELD:
-                                            configBuilder.normalizeResult(Boolean.parseBoolean(configEntry.getValue().toString()));
-                                            break;
-                                        case QuestionAnsweringModelConfig.MODEL_MAX_LENGTH_FIELD:
-                                            configBuilder.modelMaxLength(((Double) configEntry.getValue()).intValue());
                                             break;
                                         default:
                                             break;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
@@ -29,6 +29,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.model.MLModelFormat;
+import org.opensearch.ml.common.model.QuestionAnsweringModelConfig;
 import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 
@@ -62,6 +63,7 @@ public class ModelHelper {
         ActionListener<MLRegisterModelInput> listener
     ) {
         String modelName = registerModelInput.getModelName();
+        FunctionName algorithm = registerModelInput.getFunctionName();
         String version = registerModelInput.getVersion();
         MLModelFormat modelFormat = registerModelInput.getModelFormat();
         Boolean isHidden = registerModelInput.getIsHidden();
@@ -106,47 +108,87 @@ public class ModelHelper {
                             builder.modelFormat(MLModelFormat.from(entry.getValue().toString()));
                             break;
                         case MLRegisterModelInput.MODEL_CONFIG_FIELD:
-                            TextEmbeddingModelConfig.TextEmbeddingModelConfigBuilder configBuilder = TextEmbeddingModelConfig.builder();
-                            Map<?, ?> configMap = (Map<?, ?>) entry.getValue();
-                            for (Map.Entry<?, ?> configEntry : configMap.entrySet()) {
-                                switch (configEntry.getKey().toString()) {
-                                    case MLModelConfig.MODEL_TYPE_FIELD:
-                                        configBuilder.modelType(configEntry.getValue().toString());
-                                        break;
-                                    case MLModelConfig.ALL_CONFIG_FIELD:
-                                        configBuilder.allConfig(configEntry.getValue().toString());
-                                        break;
-                                    case TextEmbeddingModelConfig.EMBEDDING_DIMENSION_FIELD:
-                                        configBuilder.embeddingDimension(((Double) configEntry.getValue()).intValue());
-                                        break;
-                                    case TextEmbeddingModelConfig.FRAMEWORK_TYPE_FIELD:
-                                        configBuilder
-                                            .frameworkType(TextEmbeddingModelConfig.FrameworkType.from(configEntry.getValue().toString()));
-                                        break;
-                                    case TextEmbeddingModelConfig.POOLING_MODE_FIELD:
-                                        configBuilder
-                                            .poolingMode(
-                                                TextEmbeddingModelConfig.PoolingMode
-                                                    .from(configEntry.getValue().toString().toUpperCase(Locale.ROOT))
-                                            );
-                                        break;
-                                    case TextEmbeddingModelConfig.NORMALIZE_RESULT_FIELD:
-                                        configBuilder.normalizeResult(Boolean.parseBoolean(configEntry.getValue().toString()));
-                                        break;
-                                    case TextEmbeddingModelConfig.MODEL_MAX_LENGTH_FIELD:
-                                        configBuilder.modelMaxLength(((Double) configEntry.getValue()).intValue());
-                                        break;
-                                    case TextEmbeddingModelConfig.QUERY_PREFIX:
-                                        configBuilder.queryPrefix(configEntry.getValue().toString());
-                                        break;
-                                    case TextEmbeddingModelConfig.PASSAGE_PREFIX:
-                                        configBuilder.passagePrefix(configEntry.getValue().toString());
-                                        break;
-                                    default:
-                                        break;
+                            if (FunctionName.QUESTION_ANSWERING.equals(algorithm)) {
+                                QuestionAnsweringModelConfig.QuestionAnsweringModelConfigBuilder configBuilder =
+                                    QuestionAnsweringModelConfig.builder();
+                                Map<?, ?> configMap = (Map<?, ?>) entry.getValue();
+                                for (Map.Entry<?, ?> configEntry : configMap.entrySet()) {
+                                    switch (configEntry.getKey().toString()) {
+                                        case MLModelConfig.MODEL_TYPE_FIELD:
+                                            configBuilder.modelType(configEntry.getValue().toString());
+                                            break;
+                                        case MLModelConfig.ALL_CONFIG_FIELD:
+                                            configBuilder.allConfig(configEntry.getValue().toString());
+                                            break;
+                                        case QuestionAnsweringModelConfig.FRAMEWORK_TYPE_FIELD:
+                                            configBuilder
+                                                .frameworkType(
+                                                    QuestionAnsweringModelConfig.FrameworkType.from(configEntry.getValue().toString())
+                                                );
+                                            break;
+                                        case QuestionAnsweringModelConfig.POOLING_MODE_FIELD:
+                                            configBuilder
+                                                .poolingMode(
+                                                    QuestionAnsweringModelConfig.PoolingMode
+                                                        .from(configEntry.getValue().toString().toUpperCase(Locale.ROOT))
+                                                );
+                                            break;
+                                        case QuestionAnsweringModelConfig.NORMALIZE_RESULT_FIELD:
+                                            configBuilder.normalizeResult(Boolean.parseBoolean(configEntry.getValue().toString()));
+                                            break;
+                                        case QuestionAnsweringModelConfig.MODEL_MAX_LENGTH_FIELD:
+                                            configBuilder.modelMaxLength(((Double) configEntry.getValue()).intValue());
+                                            break;
+                                        default:
+                                            break;
+                                    }
                                 }
+                                builder.modelConfig(configBuilder.build());
+                            } else {
+                                TextEmbeddingModelConfig.TextEmbeddingModelConfigBuilder configBuilder = TextEmbeddingModelConfig.builder();
+                                Map<?, ?> configMap = (Map<?, ?>) entry.getValue();
+                                for (Map.Entry<?, ?> configEntry : configMap.entrySet()) {
+                                    switch (configEntry.getKey().toString()) {
+                                        case MLModelConfig.MODEL_TYPE_FIELD:
+                                            configBuilder.modelType(configEntry.getValue().toString());
+                                            break;
+                                        case MLModelConfig.ALL_CONFIG_FIELD:
+                                            configBuilder.allConfig(configEntry.getValue().toString());
+                                            break;
+                                        case TextEmbeddingModelConfig.EMBEDDING_DIMENSION_FIELD:
+                                            configBuilder.embeddingDimension(((Double) configEntry.getValue()).intValue());
+                                            break;
+                                        case TextEmbeddingModelConfig.FRAMEWORK_TYPE_FIELD:
+                                            configBuilder
+                                                .frameworkType(
+                                                    TextEmbeddingModelConfig.FrameworkType.from(configEntry.getValue().toString())
+                                                );
+                                            break;
+                                        case TextEmbeddingModelConfig.POOLING_MODE_FIELD:
+                                            configBuilder
+                                                .poolingMode(
+                                                    TextEmbeddingModelConfig.PoolingMode
+                                                        .from(configEntry.getValue().toString().toUpperCase(Locale.ROOT))
+                                                );
+                                            break;
+                                        case TextEmbeddingModelConfig.NORMALIZE_RESULT_FIELD:
+                                            configBuilder.normalizeResult(Boolean.parseBoolean(configEntry.getValue().toString()));
+                                            break;
+                                        case TextEmbeddingModelConfig.MODEL_MAX_LENGTH_FIELD:
+                                            configBuilder.modelMaxLength(((Double) configEntry.getValue()).intValue());
+                                            break;
+                                        case TextEmbeddingModelConfig.QUERY_PREFIX:
+                                            configBuilder.queryPrefix(configEntry.getValue().toString());
+                                            break;
+                                        case TextEmbeddingModelConfig.PASSAGE_PREFIX:
+                                            configBuilder.passagePrefix(configEntry.getValue().toString());
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                }
+                                builder.modelConfig(configBuilder.build());
                             }
-                            builder.modelConfig(configBuilder.build());
                             break;
                         case MLRegisterModelInput.MODEL_CONTENT_HASH_VALUE_FIELD:
                             builder.hashValue(entry.getValue().toString());

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModel.java
@@ -12,10 +12,9 @@ import java.util.List;
 
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.MLInputDataset;
-import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
+import org.opensearch.ml.common.dataset.QuestionAnsweringInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.model.MLModelConfig;
-import org.opensearch.ml.common.output.model.ModelResultFilter;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.engine.algorithms.DLModel;
@@ -50,15 +49,14 @@ public class QuestionAnsweringModel extends DLModel {
         MLInputDataset inputDataSet = mlInput.getInputDataset();
         List<ModelTensors> tensorOutputs = new ArrayList<>();
         Output output;
-        TextDocsInputDataSet textDocsInput = (TextDocsInputDataSet) inputDataSet;
-        ModelResultFilter resultFilter = textDocsInput.getResultFilter();
-        String question = textDocsInput.getDocs().get(0);
-        String context = textDocsInput.getDocs().get(1);
+        QuestionAnsweringInputDataSet qaInputDataSet = (QuestionAnsweringInputDataSet) inputDataSet;
+        String question = qaInputDataSet.getQuestion();
+        String context = qaInputDataSet.getContext();
         Input input = new Input();
         input.add(question);
         input.add(context);
         output = getPredictor().predict(input);
-        tensorOutputs.add(parseModelTensorOutput(output, resultFilter));
+        tensorOutputs.add(parseModelTensorOutput(output, null));
         return new ModelTensorOutput(tensorOutputs);
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModel.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.question_answering;
+
+import static org.opensearch.ml.engine.ModelHelper.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.dataset.MLInputDataset;
+import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.model.MLModelConfig;
+import org.opensearch.ml.common.output.model.ModelResultFilter;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.engine.algorithms.DLModel;
+import org.opensearch.ml.engine.annotation.Function;
+
+import ai.djl.inference.Predictor;
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.translate.TranslateException;
+import ai.djl.translate.Translator;
+import ai.djl.translate.TranslatorFactory;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@Function(FunctionName.QUESTION_ANSWERING)
+public class QuestionAnsweringModel extends DLModel {
+
+    @Override
+    public void warmUp(Predictor predictor, String modelId, MLModelConfig modelConfig) throws TranslateException {
+        String question = "How is the weather?";
+        String context = "The weather is nice, it is beautiful day.";
+        Input input = new Input();
+        input.add(question);
+        input.add(context);
+
+        // First request takes longer time. Predict once to warm up model.
+        predictor.predict(input);
+    }
+
+    @Override
+    public ModelTensorOutput predict(String modelId, MLInput mlInput) throws TranslateException {
+        MLInputDataset inputDataSet = mlInput.getInputDataset();
+        List<ModelTensors> tensorOutputs = new ArrayList<>();
+        Output output;
+        TextDocsInputDataSet textDocsInput = (TextDocsInputDataSet) inputDataSet;
+        ModelResultFilter resultFilter = textDocsInput.getResultFilter();
+        String question = textDocsInput.getDocs().get(0);
+        String context = textDocsInput.getDocs().get(1);
+        Input input = new Input();
+        input.add(question);
+        input.add(context);
+        output = getPredictor().predict(input);
+        tensorOutputs.add(parseModelTensorOutput(output, resultFilter));
+        return new ModelTensorOutput(tensorOutputs);
+    }
+
+    @Override
+    public Translator<Input, Output> getTranslator(String engine, MLModelConfig modelConfig) throws IllegalArgumentException {
+        return new QuestionAnsweringTranslator();
+    }
+
+    @Override
+    public TranslatorFactory getTranslatorFactory(String engine, MLModelConfig modelConfig) {
+        return null;
+    }
+
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringTranslator.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringTranslator.java
@@ -22,17 +22,16 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.translate.TranslatorContext;
 
 public class QuestionAnsweringTranslator extends SentenceTransformerTranslator {
-    // private static final int[] AXIS = {0};
     private List<String> tokens;
 
     @Override
     public NDList processInput(TranslatorContext ctx, Input input) {
         NDManager manager = ctx.getNDManager();
         String question = input.getAsString(0);
-        String paragraph = input.getAsString(1);
+        String context = input.getAsString(1);
         NDList ndList = new NDList();
 
-        Encoding encodings = tokenizer.encode(question, paragraph);
+        Encoding encodings = tokenizer.encode(question, context);
         tokens = Arrays.asList(encodings.getTokens());
         ctx.setAttachment("encoding", encodings);
         long[] indices = encodings.getIds();
@@ -49,7 +48,6 @@ public class QuestionAnsweringTranslator extends SentenceTransformerTranslator {
         return ndList;
     }
 
-    /** {@inheritDoc} */
     @Override
     public Output processOutput(TranslatorContext ctx, NDList list) {
         Output output = new Output(200, "OK");
@@ -67,7 +65,7 @@ public class QuestionAnsweringTranslator extends SentenceTransformerTranslator {
         }
         String answer = tokenizer.buildSentence(tokens.subList(startIdx, endIdx + 1));
 
-        outputs.add(new ModelTensor("answer", answer));
+        outputs.add(new ModelTensor(null, answer));
 
         ModelTensors modelTensorOutput = new ModelTensors(outputs);
         output.add(modelTensorOutput.toBytes());

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringTranslator.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringTranslator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.question_answering;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.engine.algorithms.SentenceTransformerTranslator;
+
+import ai.djl.huggingface.tokenizers.Encoding;
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.translate.TranslatorContext;
+
+public class QuestionAnsweringTranslator extends SentenceTransformerTranslator {
+    // private static final int[] AXIS = {0};
+    private List<String> tokens;
+
+    @Override
+    public NDList processInput(TranslatorContext ctx, Input input) {
+        NDManager manager = ctx.getNDManager();
+        String question = input.getAsString(0);
+        String paragraph = input.getAsString(1);
+        NDList ndList = new NDList();
+
+        Encoding encodings = tokenizer.encode(question, paragraph);
+        tokens = Arrays.asList(encodings.getTokens());
+        ctx.setAttachment("encoding", encodings);
+        long[] indices = encodings.getIds();
+        long[] attentionMask = encodings.getAttentionMask();
+
+        NDArray indicesArray = manager.create(indices);
+        indicesArray.setName("input_ids");
+
+        NDArray attentionMaskArray = manager.create(attentionMask);
+        attentionMaskArray.setName("attention_mask");
+
+        ndList.add(indicesArray);
+        ndList.add(attentionMaskArray);
+        return ndList;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Output processOutput(TranslatorContext ctx, NDList list) {
+        Output output = new Output(200, "OK");
+
+        List<ModelTensor> outputs = new ArrayList<>();
+
+        NDArray startLogits = list.get(0);
+        NDArray endLogits = list.get(1);
+        int startIdx = (int) startLogits.argMax().getLong();
+        int endIdx = (int) endLogits.argMax().getLong();
+        if (startIdx >= endIdx) {
+            int tmp = startIdx;
+            startIdx = endIdx;
+            endIdx = tmp;
+        }
+        String answer = tokenizer.buildSentence(tokens.subList(startIdx, endIdx + 1));
+
+        outputs.add(new ModelTensor("answer", answer));
+
+        ModelTensors modelTensorOutput = new ModelTensors(outputs);
+        output.add(modelTensorOutput.toBytes());
+        return output;
+    }
+
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModelTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2023 Aryn
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opensearch.ml.engine.algorithms.question_answering;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.engine.algorithms.DLModel.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
+import org.opensearch.ml.common.exception.MLException;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.model.MLModelFormat;
+import org.opensearch.ml.common.model.MLModelState;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.engine.MLEngine;
+import org.opensearch.ml.engine.ModelHelper;
+import org.opensearch.ml.engine.encryptor.Encryptor;
+import org.opensearch.ml.engine.encryptor.EncryptorImpl;
+import org.opensearch.ml.engine.utils.FileUtils;
+
+import ai.djl.Model;
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.modality.nlp.preprocess.Tokenizer;
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.translate.TranslatorContext;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class QuestionAnsweringModelTest {
+
+    private File modelZipFile;
+    private MLModel model;
+    private ModelHelper modelHelper;
+    private Map<String, Object> params;
+    private QuestionAnsweringModel questionAnsweringModel;
+    private Path mlCachePath;
+    private TextDocsInputDataSet inputDataSet;
+    private MLEngine mlEngine;
+    private Encryptor encryptor;
+
+    @Before
+    public void setUp() throws URISyntaxException {
+        mlCachePath = Path.of("/tmp/ml_cache" + UUID.randomUUID());
+        encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
+        mlEngine = new MLEngine(mlCachePath, encryptor);
+        model = MLModel
+            .builder()
+            .modelFormat(MLModelFormat.TORCH_SCRIPT)
+            .name("test_model_name")
+            .modelId("test_model_id")
+            .algorithm(FunctionName.QUESTION_ANSWERING)
+            .version("1.0.0")
+            .modelState(MLModelState.TRAINED)
+            .build();
+        modelHelper = new ModelHelper(mlEngine);
+        params = new HashMap<>();
+        modelZipFile = new File(getClass().getResource("question_answering_pt.zip").toURI());
+        params.put(MODEL_ZIP_FILE, modelZipFile);
+        params.put(MODEL_HELPER, modelHelper);
+        params.put(ML_ENGINE, mlEngine);
+        questionAnsweringModel = new QuestionAnsweringModel();
+
+        inputDataSet = TextDocsInputDataSet
+            .builder()
+            .docs(Arrays.asList("What color is rose", "I love apples. Because they are red"))
+            .build();
+    }
+
+    @Test
+    public void test_QuestionAnswering_Translator_ProcessInput() throws URISyntaxException, IOException {
+        QuestionAnsweringTranslator questionAnsweringTranslator = new QuestionAnsweringTranslator();
+        TranslatorContext translatorContext = mock(TranslatorContext.class);
+        Model mlModel = mock(Model.class);
+        when(translatorContext.getModel()).thenReturn(mlModel);
+        when(mlModel.getModelPath()).thenReturn(Paths.get(getClass().getResource("../tokenize/tokenizer.json").toURI()).getParent());
+        questionAnsweringTranslator.prepare(translatorContext);
+
+        NDManager manager = mock(NDManager.class);
+        when(translatorContext.getNDManager()).thenReturn(manager);
+        Input input = mock(Input.class);
+        String question = "What color is rose";
+        String context = "I love roses. Because they are red";
+        when(input.getAsString(0)).thenReturn(question);
+        when(input.getAsString(1)).thenReturn(context);
+        NDArray indiceNdArray = mock(NDArray.class);
+        when(indiceNdArray.toLongArray()).thenReturn(new long[] { 102l, 101l });
+        when(manager.create((long[]) any())).thenReturn(indiceNdArray);
+        doNothing().when(indiceNdArray).setName(any());
+        NDList outputList = questionAnsweringTranslator.processInput(translatorContext, input);
+        assertEquals(2, outputList.size());
+        Iterator<NDArray> iterator = outputList.iterator();
+        while (iterator.hasNext()) {
+            NDArray ndArray = iterator.next();
+            long[] output = ndArray.toLongArray();
+            assertEquals(2, output.length);
+        }
+    }
+
+    // Working on this unit test
+    @Ignore
+    @Test
+    public void test_QuestionAnswering_Translator_ProcessOutput() throws URISyntaxException, IOException {
+        QuestionAnsweringTranslator questionAnsweringTranslator = new QuestionAnsweringTranslator();
+        TranslatorContext translatorContext = mock(TranslatorContext.class);
+        Model mlModel = mock(Model.class);
+        when(translatorContext.getModel()).thenReturn(mlModel);
+        when(mlModel.getModelPath()).thenReturn(Paths.get(getClass().getResource("../tokenize/tokenizer.json").toURI()).getParent());
+        List<String> tokens = mock(List.class);
+        List<String> tokens2 = mock(List.class);
+        when(tokens.subList(anyInt(), anyInt())).thenReturn(tokens2);
+        Tokenizer tokenizer = mock(Tokenizer.class);
+        when(tokenizer.buildSentence(anyList())).thenReturn("red");
+        questionAnsweringTranslator.prepare(translatorContext);
+
+        NDArray startLogits = mock(NDArray.class);
+        NDArray endLogits = mock(NDArray.class);
+        when(startLogits.argMax()).thenReturn(startLogits);
+        when(startLogits.getLong()).thenReturn(3L);
+        when(endLogits.argMax()).thenReturn(endLogits);
+        when(endLogits.getLong()).thenReturn(7L);
+
+        List<NDArray> ndArrayList = new ArrayList<>();
+        ndArrayList.add(startLogits);
+        ndArrayList.add(endLogits);
+        NDList ndList = new NDList(ndArrayList);
+
+        Output output = questionAnsweringTranslator.processOutput(translatorContext, ndList);
+        assertNotNull(output);
+        byte[] bytes = output.getData().getAsBytes();
+        ModelTensors tensorOutput = ModelTensors.fromBytes(bytes);
+        List<ModelTensor> modelTensorsList = tensorOutput.getMlModelTensors();
+        assertEquals(1, modelTensorsList.size());
+        ModelTensor modelTensor = modelTensorsList.get(0);
+        assertEquals("answer", modelTensor.getName());
+        assertEquals("red", modelTensor.getData());
+    }
+
+    @Test
+    public void initModel_predict_TorchScript_QuestionAnswering() throws URISyntaxException {
+        questionAnsweringModel.initModel(model, params, encryptor);
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.QUESTION_ANSWERING).inputDataset(inputDataSet).build();
+        ModelTensorOutput output = (ModelTensorOutput) questionAnsweringModel.predict(mlInput);
+        List<ModelTensors> mlModelOutputs = output.getMlModelOutputs();
+        assertEquals(1, mlModelOutputs.size());
+        for (int i = 0; i < mlModelOutputs.size(); i++) {
+            ModelTensors tensors = mlModelOutputs.get(i);
+            List<ModelTensor> mlModelTensors = tensors.getMlModelTensors();
+            assertEquals(1, mlModelTensors.size());
+        }
+        questionAnsweringModel.close();
+    }
+
+    // ONNX is working fine but the model is too big to upload to git. Trying to find small models
+
+    @Ignore
+    @Test
+    public void initModel_predict_ONNX_QuestionAnswering() throws URISyntaxException {
+        model = MLModel
+            .builder()
+            .modelFormat(MLModelFormat.ONNX)
+            .name("test_model_name")
+            .modelId("test_model_id")
+            .algorithm(FunctionName.TEXT_SIMILARITY)
+            .version("1.0.0")
+            .modelState(MLModelState.TRAINED)
+            .build();
+        modelZipFile = new File(getClass().getResource("question_answering_onnx.zip").toURI());
+        params.put(MODEL_ZIP_FILE, modelZipFile);
+
+        questionAnsweringModel.initModel(model, params, encryptor);
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_SIMILARITY).inputDataset(inputDataSet).build();
+        ModelTensorOutput output = (ModelTensorOutput) questionAnsweringModel.predict(mlInput);
+        List<ModelTensors> mlModelOutputs = output.getMlModelOutputs();
+        assertEquals(1, mlModelOutputs.size());
+        for (int i = 1; i < mlModelOutputs.size(); i++) {
+            ModelTensors tensors = mlModelOutputs.get(i);
+            List<ModelTensor> mlModelTensors = tensors.getMlModelTensors();
+            assertEquals(1, mlModelTensors.size());
+        }
+        questionAnsweringModel.close();
+    }
+
+    @Test
+    public void initModel_NullModelHelper() throws URISyntaxException {
+        Map<String, Object> params = new HashMap<>();
+        params.put(MODEL_ZIP_FILE, new File(getClass().getResource("question_answering_pt.zip").toURI()));
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> questionAnsweringModel.initModel(model, params, encryptor)
+        );
+        assert (e.getMessage().equals("model helper is null"));
+    }
+
+    @Test
+    public void initModel_NullMLEngine() throws URISyntaxException {
+        Map<String, Object> params = new HashMap<>();
+        params.put(MODEL_ZIP_FILE, new File(getClass().getResource("question_answering_pt.zip").toURI()));
+        params.put(MODEL_HELPER, modelHelper);
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> questionAnsweringModel.initModel(model, params, encryptor)
+        );
+        assert (e.getMessage().equals("ML engine is null"));
+    }
+
+    @Test
+    public void initModel_NullModelId() {
+        model.setModelId(null);
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> questionAnsweringModel.initModel(model, params, encryptor)
+        );
+        assert (e.getMessage().equals("model id is null"));
+    }
+
+    @Test
+    public void initModel_WrongModelFile() throws URISyntaxException {
+        Map<String, Object> params = new HashMap<>();
+        params.put(MODEL_HELPER, modelHelper);
+        params.put(MODEL_ZIP_FILE, new File(getClass().getResource("../text_embedding/wrong_zip_with_2_pt_file.zip").toURI()));
+        params.put(ML_ENGINE, mlEngine);
+        MLException e = assertThrows(MLException.class, () -> questionAnsweringModel.initModel(model, params, encryptor));
+        Throwable rootCause = e.getCause();
+        assert (rootCause instanceof IllegalArgumentException);
+        assert (rootCause.getMessage().equals("found multiple models"));
+    }
+
+    @Test
+    public void initModel_WrongFunctionName() {
+        MLModel mlModel = model.toBuilder().algorithm(FunctionName.KMEANS).build();
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> questionAnsweringModel.initModel(mlModel, params, encryptor)
+        );
+        assert (e.getMessage().equals("wrong function name"));
+    }
+
+    @Test
+    public void predict_NullModelHelper() {
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> questionAnsweringModel
+                .predict(MLInput.builder().algorithm(FunctionName.QUESTION_ANSWERING).inputDataset(inputDataSet).build())
+        );
+        assert (e.getMessage().equals("model not deployed"));
+    }
+
+    @Test
+    public void predict_NullModelId() {
+        model.setModelId(null);
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> questionAnsweringModel.initModel(model, params, encryptor)
+        );
+        assert (e.getMessage().equals("model id is null"));
+        IllegalArgumentException e2 = assertThrows(
+            IllegalArgumentException.class,
+            () -> questionAnsweringModel
+                .predict(MLInput.builder().algorithm(FunctionName.QUESTION_ANSWERING).inputDataset(inputDataSet).build())
+        );
+        assert (e2.getMessage().equals("model not deployed"));
+    }
+
+    @Test
+    public void predict_AfterModelClosed() {
+        questionAnsweringModel.initModel(model, params, encryptor);
+        questionAnsweringModel.close();
+        MLException e = assertThrows(
+            MLException.class,
+            () -> questionAnsweringModel
+                .predict(MLInput.builder().algorithm(FunctionName.QUESTION_ANSWERING).inputDataset(inputDataSet).build())
+        );
+        log.info(e.getMessage());
+        assert (e.getMessage().startsWith("Failed to inference QUESTION_ANSWERING"));
+    }
+
+    @After
+    public void tearDown() {
+        FileUtils.deleteFileQuietly(mlCachePath);
+    }
+
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModelTest.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
@@ -156,8 +155,7 @@ public class QuestionAnsweringModelTest {
         questionAnsweringModel.close();
     }
 
-    // ONNX is working fine but the model is too big to upload to git. Trying to find small models
-    @Ignore
+    // ONNX is working fine but the model is too big to upload to git. Trying to find small models @Test
     @Test
     public void initModel_predict_ONNX_QuestionAnswering() throws URISyntaxException {
         model = MLModel


### PR DESCRIPTION
### Description
support question answering model. This PR adds question answering model to the list of existing list of models supported by ml-commons. It expects question and context and gives the answer based on the context provides. Below is a sample predict API request to QA model and its expected output

```
POST /_plugins/_ml/models/m6LBVI4BuIvXgszWP7KN/_predict
{
    "question": "Where do I live",
    "context":  "I am Clara. I live in Texas."
}
```
```
// Response
{
    "inference_results": [
        {
            "output": [
                {
                    "result": "Texas"
                }
            ]
        }
    ]
}
            
```

 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/1873
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
