### PR TITLE
Guardrails for remote model input and output

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -56,7 +56,7 @@ public class CommonValue {
         public static final String ML_MODEL_INDEX = ".plugins-ml-model";
         public static final String ML_TASK_INDEX = ".plugins-ml-task";
         public static final Integer ML_MODEL_GROUP_INDEX_SCHEMA_VERSION = 2;
-        public static final Integer ML_MODEL_INDEX_SCHEMA_VERSION = 9;
+        public static final Integer ML_MODEL_INDEX_SCHEMA_VERSION = 10;
         public static final String ML_CONNECTOR_INDEX = ".plugins-ml-connector";
         public static final Integer ML_TASK_INDEX_SCHEMA_VERSION = 2;
         public static final Integer ML_CONNECTOR_SCHEMA_VERSION = 2;

--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -265,7 +265,10 @@ public class CommonValue {
                         + MLModel.CONNECTOR_FIELD
                         + "\": {" + ML_CONNECTOR_INDEX_FIELDS + "    }\n},"
                         + USER_FIELD_MAPPING
-                        + "    }\n"
+                        + "    },\n"
+                        + "      \""
+                        + MLModel.GUARDRAILS_FIELD
+                        + "\" : {\"type\": \"flat_object\"},\n"
                         + "}";
 
         public static final String ML_TASK_INDEX_MAPPING = "{\n"

--- a/common/src/main/java/org/opensearch/ml/common/MLModel.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModel.java
@@ -16,6 +16,7 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.model.Guardrails;
 import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.controller.MLRateLimiter;
 import org.opensearch.ml.common.model.MLModelFormat;
@@ -84,6 +85,7 @@ public class MLModel implements ToXContentObject {
     public static final String IS_HIDDEN_FIELD = "is_hidden";
     public static final String CONNECTOR_FIELD = "connector";
     public static final String CONNECTOR_ID_FIELD = "connector_id";
+    public static final String GUARDRAILS_FIELD = "guardrails";
 
     private String name;
     private String modelGroupId;
@@ -127,6 +129,7 @@ public class MLModel implements ToXContentObject {
     @Setter
     private Connector connector;
     private String connectorId;
+    private Guardrails guardrails;
 
     @Builder(toBuilder = true)
     public MLModel(String name,
@@ -158,7 +161,8 @@ public class MLModel implements ToXContentObject {
             boolean deployToAllNodes,
             Boolean isHidden,
             Connector connector,
-            String connectorId) {
+            String connectorId,
+            Guardrails guardrails) {
         this.name = name;
         this.modelGroupId = modelGroupId;
         this.algorithm = algorithm;
@@ -190,6 +194,7 @@ public class MLModel implements ToXContentObject {
         this.isHidden = isHidden;
         this.connector = connector;
         this.connectorId = connectorId;
+        this.guardrails = guardrails;
     }
 
     public MLModel(StreamInput input) throws IOException {
@@ -243,6 +248,9 @@ public class MLModel implements ToXContentObject {
                 connector = Connector.fromStream(input);
             }
             connectorId = input.readOptionalString();
+            if (input.readBoolean()) {
+                this.guardrails = new Guardrails(input);
+            }
         }
     }
 
@@ -308,6 +316,12 @@ public class MLModel implements ToXContentObject {
             out.writeBoolean(false);
         }
         out.writeOptionalString(connectorId);
+        if (guardrails != null) {
+            out.writeBoolean(true);
+            guardrails.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
     }
 
     @Override
@@ -406,6 +420,9 @@ public class MLModel implements ToXContentObject {
         if (connectorId != null) {
             builder.field(CONNECTOR_ID_FIELD, connectorId);
         }
+        if (guardrails != null) {
+            builder.field(GUARDRAILS_FIELD, guardrails);
+        }
         builder.endObject();
         return builder;
     }
@@ -448,6 +465,7 @@ public class MLModel implements ToXContentObject {
         boolean isHidden = false;
         Connector connector = null;
         String connectorId = null;
+        Guardrails guardrails = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -571,6 +589,9 @@ public class MLModel implements ToXContentObject {
                 case LAST_UNDEPLOYED_TIME_FIELD:
                     lastUndeployedTime = Instant.ofEpochMilli(parser.longValue());
                     break;
+                case GUARDRAILS_FIELD:
+                    guardrails = Guardrails.parse(parser);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -608,6 +629,7 @@ public class MLModel implements ToXContentObject {
                 .isHidden(isHidden)
                 .connector(connector)
                 .connectorId(connectorId)
+                .guardrails(guardrails)
                 .build();
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/model/Guardrail.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/Guardrail.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.model;
 
 import lombok.Builder;

--- a/common/src/main/java/org/opensearch/ml/common/model/Guardrail.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/Guardrail.java
@@ -1,0 +1,100 @@
+package org.opensearch.ml.common.model;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+@EqualsAndHashCode
+@Getter
+public class Guardrail implements ToXContentObject {
+    public static final String STOP_WORDS_FIELD = "stop_words";
+    public static final String REGEX_FIELD = "regex";
+
+    private List<StopWords> stopWords;
+    private String[] regex;
+
+    @Builder(toBuilder = true)
+    public Guardrail(List<StopWords> stopWords, String[] regex) {
+        this.stopWords = stopWords;
+        this.regex = regex;
+    }
+
+    public Guardrail(StreamInput input) throws IOException {
+        if (input.readBoolean()) {
+            stopWords = new ArrayList<>();
+            int size = input.readInt();
+            for (int i=0; i<size; i++) {
+                stopWords.add(new StopWords(input));
+            }
+        }
+        regex = input.readStringArray();
+    }
+
+    public void writeTo(StreamOutput out) throws IOException {
+        if (stopWords != null && stopWords.size() > 0) {
+            out.writeBoolean(true);
+            out.writeInt(stopWords.size());
+            for (StopWords e : stopWords) {
+                e.writeTo(out);
+            }
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeStringArray(regex);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (stopWords != null && stopWords.size() > 0) {
+            builder.field(STOP_WORDS_FIELD, stopWords);
+        }
+        if (regex != null) {
+            builder.field(REGEX_FIELD, regex);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static Guardrail parse(XContentParser parser) throws IOException {
+        List<StopWords> stopWords = null;
+        String[] regex = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case STOP_WORDS_FIELD:
+                    stopWords = new ArrayList<>();
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        stopWords.add(StopWords.parse(parser));
+                    }
+                    break;
+                case REGEX_FIELD:
+                    regex = parser.list().toArray(new String[0]);
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return Guardrail.builder()
+                .stopWords(stopWords)
+                .regex(regex)
+                .build();
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/model/Guardrails.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/Guardrails.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.model;
 
 import lombok.Builder;

--- a/common/src/main/java/org/opensearch/ml/common/model/Guardrails.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/Guardrails.java
@@ -1,0 +1,120 @@
+package org.opensearch.ml.common.model;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+@EqualsAndHashCode
+@Getter
+public class Guardrails implements ToXContentObject {
+    public static final String TYPE_FIELD = "type";
+    public static final String ENGLISH_DETECTION_ENABLED_FIELD = "english_detection_enabled";
+    public static final String INPUT_GUARDRAIL_FIELD = "input_guardrail";
+    public static final String OUTPUT_GUARDRAIL_FIELD = "output_guardrail";
+
+    private String type;
+    private Boolean engDetectionEnabled;
+    private Guardrail inputGuardrail;
+    private Guardrail outputGuardrail;
+
+    @Builder(toBuilder = true)
+    public Guardrails(String type, Boolean engDetectionEnabled, Guardrail inputGuardrail, Guardrail outputGuardrail) {
+        this.type = type;
+        this.engDetectionEnabled = engDetectionEnabled;
+        this.inputGuardrail = inputGuardrail;
+        this.outputGuardrail = outputGuardrail;
+    }
+
+    public Guardrails(StreamInput input) throws IOException {
+        type = input.readString();
+        engDetectionEnabled = input.readBoolean();
+        if (input.readBoolean()) {
+            inputGuardrail = new Guardrail(input);
+        }
+        if (input.readBoolean()) {
+            outputGuardrail = new Guardrail(input);
+        }
+    }
+
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(type);
+        out.writeBoolean(engDetectionEnabled);
+        if (inputGuardrail != null) {
+            out.writeBoolean(true);
+            inputGuardrail.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (outputGuardrail != null) {
+            out.writeBoolean(true);
+            outputGuardrail.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (type != null) {
+            builder.field(TYPE_FIELD, type);
+        }
+        if (engDetectionEnabled != null) {
+            builder.field(ENGLISH_DETECTION_ENABLED_FIELD, engDetectionEnabled);
+        }
+        if (inputGuardrail != null) {
+            builder.field(INPUT_GUARDRAIL_FIELD, inputGuardrail);
+        }
+        if (outputGuardrail != null) {
+            builder.field(OUTPUT_GUARDRAIL_FIELD, outputGuardrail);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static Guardrails parse(XContentParser parser) throws IOException {
+        String type = null;
+        Boolean engDetectionEnabled = null;
+        Guardrail inputGuardrail = null;
+        Guardrail outputGuardrail = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case TYPE_FIELD:
+                    type = parser.text();
+                    break;
+                case ENGLISH_DETECTION_ENABLED_FIELD:
+                    engDetectionEnabled = parser.booleanValue();
+                    break;
+                case INPUT_GUARDRAIL_FIELD:
+                    inputGuardrail = Guardrail.parse(parser);
+                    break;
+                case OUTPUT_GUARDRAIL_FIELD:
+                    outputGuardrail = Guardrail.parse(parser);
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return Guardrails.builder()
+                .type(type)
+                .engDetectionEnabled(engDetectionEnabled)
+                .inputGuardrail(inputGuardrail)
+                .outputGuardrail(outputGuardrail)
+                .build();
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
@@ -87,7 +87,7 @@ public class MLGuard {
     public Boolean validateRegex(String input, String regex) {
         Pattern pattern = Pattern.compile(regex);
         Matcher matcher = pattern.matcher(input);
-        return matcher.matches();
+        return !matcher.matches();
     }
 
     public Boolean validateStopWords(String input, Map<String, List<String>> stopWordsIndices) {

--- a/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.model;
 
 import lombok.Getter;

--- a/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
@@ -1,0 +1,133 @@
+package org.opensearch.ml.common.model;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.extern.log4j.Log4j2;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.opensearch.ml.common.utils.StringUtils.gson;
+
+@Log4j2
+@Getter
+public class MLGuard {
+    private Map<String, List<String>> stopWordsIndicesInput = new HashMap<>();
+    private Map<String, List<String>> stopWordsIndicesOutput = new HashMap<>();
+    private List<String> inputRegex;
+    private List<String> outputRegex;
+    private NamedXContentRegistry xContentRegistry;
+    private Client client;
+
+    public MLGuard(Guardrails guardrails, NamedXContentRegistry xContentRegistry, Client client) {
+        this.xContentRegistry = xContentRegistry;
+        this.client = client;
+        if (guardrails == null) {
+            return;
+        }
+        Guardrail inputGuardrail = guardrails.getInputGuardrail();
+        Guardrail outputGuardrail = guardrails.getOutputGuardrail();
+        if (inputGuardrail != null) {
+            fillStopWordsToMap(inputGuardrail, stopWordsIndicesInput);
+            inputRegex = inputGuardrail.getRegex() == null ? new ArrayList<>() : Arrays.asList(inputGuardrail.getRegex());
+        }
+        if (outputGuardrail != null) {
+            fillStopWordsToMap(outputGuardrail, stopWordsIndicesOutput);
+            outputRegex = outputGuardrail.getRegex() == null ? new ArrayList<>() : Arrays.asList(outputGuardrail.getRegex());
+        }
+    }
+
+    private void fillStopWordsToMap(@NonNull Guardrail guardrail, Map<String, List<String>> map) {
+        List<StopWords> stopWords = guardrail.getStopWords();
+        if (stopWords == null || stopWords.isEmpty()) {
+            return;
+        }
+        for (StopWords e : stopWords) {
+            map.put(e.getIndex(), Arrays.asList(e.getSourceFields()));
+        }
+    }
+
+    public Boolean validate(String input, int type) {
+        switch (type) {
+            case 0: // validate input
+                return validateRegexList(input, inputRegex) && validateStopWords(input, stopWordsIndicesInput);
+            case 1: // validate output
+                return validateRegexList(input, outputRegex) && validateStopWords(input, stopWordsIndicesOutput);
+            default:
+                return true;
+        }
+    }
+
+    public Boolean validateRegexList(String input, List<String> regexList) {
+        for (String regex : regexList) {
+            if (!validateRegex(input, regex)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public Boolean validateRegex(String input, String regex) {
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(input);
+        return matcher.matches();
+    }
+
+    public Boolean validateStopWords(String input, Map<String, List<String>> stopWordsIndices) {
+        for (Map.Entry entry : stopWordsIndices.entrySet()) {
+            if (!validateStopWordsSingleIndex(input, (String) entry.getKey(), (List<String>) entry.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public Boolean validateStopWordsSingleIndex(String input, String indexName, List<String> fieldNames) {
+        SearchRequest searchRequest;
+        SearchResponse searchResponse;
+        String queryBody;
+        Map<String, String> documentMap = new HashMap<>();
+        for (String field : fieldNames) {
+            documentMap.put(field, input);
+        }
+        Map<String, Object> queryBodyMap = Map
+                .of("query", Map.of("percolate", Map.of("field", "query", "document", documentMap)));
+
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            queryBody = AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> gson.toJson(queryBodyMap));
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            XContentParser queryParser = XContentType.JSON.xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, queryBody);
+            searchSourceBuilder.parseXContent(queryParser);
+            searchSourceBuilder.size(1); //Only need 1 doc returned, if hit.
+            searchRequest = new SearchRequest().source(searchSourceBuilder).indices(indexName);
+            searchResponse = client.search(searchRequest).actionGet(1000l * 30);
+            context.restore();
+        } catch (Exception e) {
+            log.error("[validateStopWords] Searching stop words index failed.", e);
+            return false;
+        }
+
+        SearchHit[] hits = searchResponse.getHits().getHits();
+        if (hits != null && hits.length > 0) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
@@ -147,6 +147,7 @@ public class MLGuard {
             }), latch), () -> context.restore()));
         } catch (Exception e) {
             log.error("[validateStopWords] Searching stop words index failed.", e);
+            latch.countDown();
             hitStopWords.set(true);
         }
 

--- a/common/src/main/java/org/opensearch/ml/common/model/StopWords.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/StopWords.java
@@ -1,0 +1,80 @@
+package org.opensearch.ml.common.model;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+@EqualsAndHashCode
+@Getter
+public class StopWords implements ToXContentObject {
+    public static final String INDEX_NAME_FIELD = "index_name";
+    public static final String SOURCE_FIELDS_FIELD = "source_fields";
+
+    private String index;
+    private String[] sourceFields;
+
+    @Builder(toBuilder = true)
+    public StopWords(String index, String[] sourceFields) {
+        this.index = index;
+        this.sourceFields = sourceFields;
+    }
+
+    public StopWords(StreamInput input) throws IOException {
+        index = input.readString();
+        sourceFields = input.readStringArray();
+    }
+
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(index);
+        out.writeStringArray(sourceFields);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (index != null) {
+            builder.field(INDEX_NAME_FIELD, index);
+        }
+        if (sourceFields != null) {
+            builder.field(SOURCE_FIELDS_FIELD, sourceFields);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static StopWords parse(XContentParser parser) throws IOException {
+        String index = null;
+        String[] sourceFields = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case INDEX_NAME_FIELD:
+                    index = parser.text();
+                    break;
+                case SOURCE_FIELDS_FIELD:
+                    sourceFields = parser.list().toArray(new String[0]);
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return StopWords.builder()
+                .index(index)
+                .sourceFields(sourceFields)
+                .build();
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/model/StopWords.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/StopWords.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.model;
 
 import lombok.Builder;

--- a/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
@@ -18,6 +18,7 @@ import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.model.Guardrails;
 import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.controller.MLRateLimiter;
 import org.opensearch.ml.common.model.MLModelFormat;
@@ -58,9 +59,11 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
     public static final String BACKEND_ROLES_FIELD = "backend_roles";
     public static final String ADD_ALL_BACKEND_ROLES_FIELD = "add_all_backend_roles";
     public static final String DOES_VERSION_CREATE_MODEL_GROUP = "does_version_create_model_group";
+    public static final String GUARDRAILS_FIELD = "guardrails";
 
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_DOES_VERSION_CREATE_MODEL_GROUP = Version.V_2_11_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_AGENT_FRAMEWORK = Version.V_2_12_0;
+    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_GUARDRAILS = Version.V_2_13_0;
 
     private FunctionName functionName;
     private String modelName;
@@ -86,6 +89,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
     private Boolean doesVersionCreateModelGroup;
 
     private Boolean isHidden;
+    private Guardrails guardrails;
 
     @Builder(toBuilder = true)
     public MLRegisterModelInput(FunctionName functionName,
@@ -107,7 +111,8 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
             Boolean addAllBackendRoles,
             AccessMode accessMode,
             Boolean doesVersionCreateModelGroup,
-            Boolean isHidden) {
+            Boolean isHidden,
+            Guardrails guardrails) {
         this.functionName = Objects.requireNonNullElse(functionName, FunctionName.TEXT_EMBEDDING);
         if (modelName == null) {
             throw new IllegalArgumentException("model name is null");
@@ -143,6 +148,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         this.accessMode = accessMode;
         this.doesVersionCreateModelGroup = doesVersionCreateModelGroup;
         this.isHidden = isHidden;
+        this.guardrails = guardrails;
     }
 
     public MLRegisterModelInput(StreamInput in) throws IOException {
@@ -186,6 +192,11 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                 this.rateLimiter = new MLRateLimiter(in);
             }
             this.isHidden = in.readOptionalBoolean();
+        }
+        if (streamInputVersion.onOrAfter(MINIMAL_SUPPORTED_VERSION_FOR_GUARDRAILS)) {
+            if (in.readBoolean()) {
+                this.guardrails = new Guardrails(in);
+            }
         }
     }
 
@@ -246,6 +257,14 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
             }
             out.writeOptionalBoolean(isHidden);
         }
+        if (streamOutputVersion.onOrAfter(MINIMAL_SUPPORTED_VERSION_FOR_GUARDRAILS)) {
+            if (guardrails != null) {
+                out.writeBoolean(true);
+                guardrails.writeTo(out);
+            } else {
+                out.writeBoolean(false);
+            }
+        }
     }
 
     @Override
@@ -305,6 +324,9 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         if (isHidden != null) {
             builder.field(MLModel.IS_HIDDEN_FIELD, isHidden);
         }
+        if (guardrails != null) {
+            builder.field(GUARDRAILS_FIELD, guardrails);
+        }
         builder.endObject();
         return builder;
     }
@@ -328,6 +350,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         AccessMode accessMode = null;
         Boolean doesVersionCreateModelGroup = null;
         Boolean isHidden = null;
+        Guardrails guardrails = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -391,6 +414,9 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                 case DOES_VERSION_CREATE_MODEL_GROUP:
                     doesVersionCreateModelGroup = parser.booleanValue();
                     break;
+                case GUARDRAILS_FIELD:
+                    guardrails = Guardrails.parse(parser);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -399,7 +425,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         return new MLRegisterModelInput(functionName, modelName, modelGroupId, version, description, isEnabled,
                 rateLimiter, url, hashValue, modelFormat, modelConfig, deployModel, modelNodeIds.toArray(new String[0]),
                 connector, connectorId, backendRoles, addAllBackendRoles, accessMode, doesVersionCreateModelGroup,
-                isHidden);
+                isHidden, guardrails);
     }
 
     public static MLRegisterModelInput parse(XContentParser parser, boolean deployModel) throws IOException {
@@ -422,6 +448,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         Boolean addAllBackendRoles = null;
         Boolean doesVersionCreateModelGroup = null;
         Boolean isHidden = null;
+        Guardrails guardrails = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -492,6 +519,9 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                 case MLModel.IS_HIDDEN_FIELD:
                     isHidden = parser.booleanValue();
                     break;
+                case GUARDRAILS_FIELD:
+                    guardrails = Guardrails.parse(parser);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -499,6 +529,6 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         }
         return new MLRegisterModelInput(functionName, name, modelGroupId, version, description, isEnabled, rateLimiter,
                 url, hashValue, modelFormat, modelConfig, deployModel, modelNodeIds.toArray(new String[0]), connector,
-                connectorId, backendRoles, addAllBackendRoles, accessMode, doesVersionCreateModelGroup, isHidden);
+                connectorId, backendRoles, addAllBackendRoles, accessMode, doesVersionCreateModelGroup, isHidden, guardrails);
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/model/GuardrailTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/GuardrailTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.model;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.TestHelper;
+import org.opensearch.search.SearchModule;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class GuardrailTests {
+    StopWords stopWords;
+    String[] regex;
+
+    @Before
+    public void setUp() {
+        stopWords = new StopWords("test_index", List.of("test_field").toArray(new String[0]));
+        regex = List.of("regex1").toArray(new String[0]);
+    }
+
+    @Test
+    public void writeTo() throws IOException {
+        Guardrail guardrail = new Guardrail(List.of(stopWords), regex);
+        BytesStreamOutput output = new BytesStreamOutput();
+        guardrail.writeTo(output);
+        Guardrail guardrail1 = new Guardrail(output.bytes().streamInput());
+
+        Assert.assertArrayEquals(guardrail.getStopWords().toArray(), guardrail1.getStopWords().toArray());
+        Assert.assertArrayEquals(guardrail.getRegex(), guardrail1.getRegex());
+    }
+
+    @Test
+    public void toXContent() throws IOException {
+        Guardrail guardrail = new Guardrail(List.of(stopWords), regex);
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        guardrail.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+
+        Assert.assertEquals("{\"stop_words\":[{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}],\"regex\":[\"regex1\"]}", content);
+    }
+
+    @Test
+    public void parse() throws IOException {
+        String jsonStr = "{\"stop_words\":[{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}],\"regex\":[\"regex1\"]}";
+        XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                Collections.emptyList()).getNamedXContents()), null, jsonStr);
+        parser.nextToken();
+        Guardrail guardrail = Guardrail.parse(parser);
+
+        Assert.assertArrayEquals(guardrail.getStopWords().toArray(), List.of(stopWords).toArray());
+        Assert.assertArrayEquals(guardrail.getRegex(), regex);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/model/GuardrailsTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/GuardrailsTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.model;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.TestHelper;
+import org.opensearch.search.SearchModule;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class GuardrailsTests {
+    StopWords stopWords;
+    String[] regex;
+    Guardrail inputGuardrail;
+    Guardrail outputGuardrail;
+
+    @Before
+    public void setUp() {
+        stopWords = new StopWords("test_index", List.of("test_field").toArray(new String[0]));
+        regex = List.of("regex1").toArray(new String[0]);
+        inputGuardrail = new Guardrail(List.of(stopWords), regex);
+        outputGuardrail = new Guardrail(List.of(stopWords), regex);
+    }
+
+    @Test
+    public void writeTo() throws IOException {
+        Guardrails guardrails = new Guardrails("test_type", false, inputGuardrail, outputGuardrail);
+        BytesStreamOutput output = new BytesStreamOutput();
+        guardrails.writeTo(output);
+        Guardrails guardrails1 = new Guardrails(output.bytes().streamInput());
+
+        Assert.assertEquals(guardrails.getType(), guardrails1.getType());
+        Assert.assertEquals(guardrails.getEngDetectionEnabled(), guardrails1.getEngDetectionEnabled());
+        Assert.assertEquals(guardrails.getInputGuardrail(), guardrails1.getInputGuardrail());
+        Assert.assertEquals(guardrails.getOutputGuardrail(), guardrails1.getOutputGuardrail());
+    }
+
+    @Test
+    public void toXContent() throws IOException {
+        Guardrails guardrails = new Guardrails("test_type", false, inputGuardrail, outputGuardrail);
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        guardrails.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+
+        Assert.assertEquals("{\"type\":\"test_type\"," +
+                "\"english_detection_enabled\":false," +
+                "\"input_guardrail\":{\"stop_words\":[{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}],\"regex\":[\"regex1\"]}," +
+                "\"output_guardrail\":{\"stop_words\":[{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}],\"regex\":[\"regex1\"]}}",
+                content);
+    }
+
+    @Test
+    public void parse() throws IOException {
+        String jsonStr = "{\"type\":\"test_type\"," +
+                "\"english_detection_enabled\":false," +
+                "\"input_guardrail\":{\"stop_words\":[{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}],\"regex\":[\"regex1\"]}," +
+                "\"output_guardrail\":{\"stop_words\":[{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}],\"regex\":[\"regex1\"]}}";
+        XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                Collections.emptyList()).getNamedXContents()), null, jsonStr);
+        parser.nextToken();
+        Guardrails guardrails = Guardrails.parse(parser);
+
+        Assert.assertEquals(guardrails.getType(), "test_type");
+        Assert.assertEquals(guardrails.getEngDetectionEnabled(), false);
+        Assert.assertEquals(guardrails.getInputGuardrail(), inputGuardrail);
+        Assert.assertEquals(guardrails.getOutputGuardrail(), outputGuardrail);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/model/MLGuardTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/MLGuardTests.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.model;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.client.Client;
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.conversation.ConversationalIndexConstants;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.SearchModule;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.internal.InternalSearchResponse;
+import org.opensearch.search.profile.SearchProfileShardResults;
+import org.opensearch.search.suggest.Suggest;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+public class MLGuardTests {
+
+    NamedXContentRegistry xContentRegistry;
+    @Mock
+    Client client;
+    @Mock
+    ThreadPool threadPool;
+    ThreadContext threadContext;
+
+    StopWords stopWords;
+    String[] regex;
+    Guardrail inputGuardrail;
+    Guardrail outputGuardrail;
+    Guardrails guardrails;
+    MLGuard mlGuard;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        xContentRegistry = new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents());
+        Settings settings = Settings.builder().build();
+        this.threadContext = new ThreadContext(settings);
+        when(this.client.threadPool()).thenReturn(this.threadPool);
+        when(this.threadPool.getThreadContext()).thenReturn(this.threadContext);
+
+        stopWords = new StopWords("test_index", List.of("test_field").toArray(new String[0]));
+        regex = List.of("regex1").toArray(new String[0]);
+        inputGuardrail = new Guardrail(List.of(stopWords), regex);
+        outputGuardrail = new Guardrail(List.of(stopWords), regex);
+        guardrails = new Guardrails("test_type", false, inputGuardrail, outputGuardrail);
+        mlGuard = new MLGuard(guardrails, xContentRegistry, client);
+    }
+
+    @Test
+    public void validate() {
+    }
+
+    @Test
+    public void validateRegexList() {
+    }
+
+    @Test
+    public void validateRegex() {
+    }
+
+    @Test
+    public void validateStopWords() {
+    }
+
+    @Test
+    public void validateStopWordsSingleIndex() throws IOException {
+        SearchResponse searchResponse = createSearchResponse(1);
+        ActionFuture<SearchResponse> future = createSearchResponseFuture(searchResponse);
+        when(this.client.search(any())).thenReturn(future);
+
+        Boolean res = mlGuard.validateStopWordsSingleIndex("hello world", "test_index", List.of("test_field"));
+        Assert.assertFalse(res);
+    }
+
+    private SearchResponse createSearchResponse(int size) throws IOException {
+        XContentBuilder content = guardrails.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
+        SearchHit[] hits = new SearchHit[size];
+        if (size > 0) {
+            hits[0] = new SearchHit(0).sourceRef(BytesReference.bytes(content));
+        }
+        return new SearchResponse(
+                new InternalSearchResponse(
+                        new SearchHits(hits, new TotalHits(size, TotalHits.Relation.EQUAL_TO), 1.0f),
+                        InternalAggregations.EMPTY,
+                        new Suggest(Collections.emptyList()),
+                        new SearchProfileShardResults(Collections.emptyMap()),
+                        false,
+                        false,
+                        1
+                ),
+                "",
+                5,
+                5,
+                0,
+                100,
+                ShardSearchFailure.EMPTY_ARRAY,
+                SearchResponse.Clusters.EMPTY
+        );
+    }
+
+    private ActionFuture<SearchResponse> createSearchResponseFuture(SearchResponse searchResponse) {
+        return new ActionFuture<>() {
+            @Override
+            public SearchResponse actionGet() {
+                return searchResponse;
+            }
+
+            @Override
+            public SearchResponse actionGet(String timeout) {
+                return searchResponse;
+            }
+
+            @Override
+            public SearchResponse actionGet(long timeoutMillis) {
+                return searchResponse;
+            }
+
+            @Override
+            public SearchResponse actionGet(long timeout, TimeUnit unit) {
+                return searchResponse;
+            }
+
+            @Override
+            public SearchResponse actionGet(TimeValue timeout) {
+                return searchResponse;
+            }
+
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                return false;
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return false;
+            }
+
+            @Override
+            public boolean isDone() {
+                return false;
+            }
+
+            @Override
+            public SearchResponse get() throws InterruptedException, ExecutionException {
+                return searchResponse;
+            }
+
+            @Override
+            public SearchResponse get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+                return searchResponse;
+            }
+        };
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/model/MLGuardTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/MLGuardTests.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -54,6 +55,7 @@ public class MLGuardTests {
 
     StopWords stopWords;
     String[] regex;
+    List<Pattern> regexPatterns;
     Guardrail inputGuardrail;
     Guardrail outputGuardrail;
     Guardrails guardrails;
@@ -70,6 +72,7 @@ public class MLGuardTests {
 
         stopWords = new StopWords("test_index", List.of("test_field").toArray(new String[0]));
         regex = List.of("(.|\n)*stop words(.|\n)*").toArray(new String[0]);
+        regexPatterns = List.of(Pattern.compile("(.|\n)*stop words(.|\n)*"));
         inputGuardrail = new Guardrail(List.of(stopWords), regex);
         outputGuardrail = new Guardrail(List.of(stopWords), regex);
         guardrails = new Guardrails("test_type", false, inputGuardrail, outputGuardrail);
@@ -95,8 +98,7 @@ public class MLGuardTests {
     @Test
     public void validateRegexListSuccess() {
         String input = "\n\nHuman:hello good words.\n\nAssistant:";
-        List<String> regexList = List.of(regex);
-        Boolean res = mlGuard.validateRegexList(input, regexList);
+        Boolean res = mlGuard.validateRegexList(input, regexPatterns);
 
         Assert.assertTrue(res);
     }
@@ -104,8 +106,7 @@ public class MLGuardTests {
     @Test
     public void validateRegexListFailed() {
         String input = "\n\nHuman:hello stop words.\n\nAssistant:";
-        List<String> regexList = List.of(regex);
-        Boolean res = mlGuard.validateRegexList(input, regexList);
+        Boolean res = mlGuard.validateRegexList(input, regexPatterns);
 
         Assert.assertFalse(res);
     }
@@ -113,7 +114,7 @@ public class MLGuardTests {
     @Test
     public void validateRegexSuccess() {
         String input = "\n\nHuman:hello good words.\n\nAssistant:";
-        Boolean res = mlGuard.validateRegex(input, regex[0]);
+        Boolean res = mlGuard.validateRegex(input, regexPatterns.get(0));
 
         Assert.assertTrue(res);
     }
@@ -121,7 +122,7 @@ public class MLGuardTests {
     @Test
     public void validateRegexFailed() {
         String input = "\n\nHuman:hello stop words.\n\nAssistant:";
-        Boolean res = mlGuard.validateRegex(input, regex[0]);
+        Boolean res = mlGuard.validateRegex(input, regexPatterns.get(0));
 
         Assert.assertFalse(res);
     }

--- a/common/src/test/java/org/opensearch/ml/common/model/StopWordsTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/StopWordsTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.TestHelper;
+import org.opensearch.search.SearchModule;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+public class StopWordsTests {
+
+    @Test
+    public void writeTo() throws IOException {
+        StopWords stopWords = new StopWords("test_index", List.of("test_field").toArray(new String[0]));
+        BytesStreamOutput output = new BytesStreamOutput();
+        stopWords.writeTo(output);
+        StopWords stopWords1 = new StopWords(output.bytes().streamInput());
+
+        Assert.assertEquals(stopWords.getIndex(), stopWords1.getIndex());
+        Assert.assertArrayEquals(stopWords.getSourceFields(), stopWords1.getSourceFields());
+    }
+
+    @Test
+    public void toXContent() throws IOException {
+        StopWords stopWords = new StopWords("test_index", List.of("test_field").toArray(new String[0]));
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        stopWords.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+
+        Assert.assertEquals("{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}", content);
+    }
+
+    @Test
+    public void parse() throws IOException {
+        String jsonStr = "{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}";
+        XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(new SearchModule(Settings.EMPTY,
+                Collections.emptyList()).getNamedXContents()), null, jsonStr);
+        parser.nextToken();
+        StopWords stopWords = StopWords.parse(parser);
+
+        Assert.assertEquals(stopWords.getIndex(), "test_index");
+        Assert.assertArrayEquals(stopWords.getSourceFields(), List.of("test_field").toArray(new String[0]));
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -28,6 +28,7 @@ import org.opensearch.ml.common.connector.AwsConnector;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.engine.annotation.ConnectorExecutor;
 import org.opensearch.script.ScriptService;
@@ -64,6 +65,9 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
     @Setter
     @Getter
     private Client client;
+    @Setter
+    @Getter
+    private MLGuard mlGuard;
 
     public AwsConnectorExecutor(Connector connector, SdkHttpClient httpClient) {
         this.connector = (AwsConnector) connector;
@@ -145,6 +149,9 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
                 throw new OpenSearchStatusException("No response from model", RestStatus.BAD_REQUEST);
             }
             String modelResponse = responseBuilder.toString();
+            if (getMlGuard() != null && !getMlGuard().validate(modelResponse, 1)) {
+                throw new IllegalArgumentException("guardrails triggered for LLM output");
+            }
             if (statusCode < 200 || statusCode >= 300) {
                 throw new OpenSearchStatusException(REMOTE_SERVICE_ERROR + modelResponse, RestStatus.fromCode(statusCode));
             }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -27,6 +27,7 @@ import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.script.ScriptService;
@@ -87,6 +88,8 @@ public interface RemoteConnectorExecutor {
 
     Map<String, TokenBucket> getUserRateLimiterMap();
 
+    MLGuard getMlGuard();
+
     Client getClient();
 
     default void setClient(Client client) {}
@@ -98,6 +101,8 @@ public interface RemoteConnectorExecutor {
     default void setRateLimiter(TokenBucket rateLimiter) {}
 
     default void setUserRateLimiterMap(Map<String, TokenBucket> userRateLimiterMap) {}
+
+    default void setMlGuard(MLGuard mlGuard) {}
 
     default void preparePayloadAndInvokeRemoteModel(MLInput mlInput, List<ModelTensors> tensorOutputs) {
         Connector connector = getConnector();
@@ -137,6 +142,9 @@ public interface RemoteConnectorExecutor {
                 RestStatus.TOO_MANY_REQUESTS
             );
         } else {
+            if (getMlGuard() != null && !getMlGuard().validate(payload, 0)) {
+                throw new IllegalArgumentException("guardrails triggered for user input");
+            }
             invokeRemoteModel(mlInput, parameters, payload, tensorOutputs);
         }
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
@@ -16,6 +16,7 @@ import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.engine.MLEngineClassLoader;
 import org.opensearch.ml.engine.Predictable;
@@ -37,6 +38,7 @@ public class RemoteModel implements Predictable {
     public static final String XCONTENT_REGISTRY = "xcontent_registry";
     public static final String RATE_LIMITER = "rate_limiter";
     public static final String USER_RATE_LIMITER_MAP = "user_rate_limiter_map";
+    public static final String GUARDRAILS = "guardrails";
 
     private RemoteConnectorExecutor connectorExecutor;
 
@@ -90,6 +92,7 @@ public class RemoteModel implements Predictable {
             this.connectorExecutor.setXContentRegistry((NamedXContentRegistry) params.get(XCONTENT_REGISTRY));
             this.connectorExecutor.setRateLimiter((TokenBucket) params.get(RATE_LIMITER));
             this.connectorExecutor.setUserRateLimiterMap((Map<String, TokenBucket>) params.get(USER_RATE_LIMITER_MAP));
+            this.connectorExecutor.setMlGuard((MLGuard) params.get(GUARDRAILS));
         } catch (RuntimeException e) {
             log.error("Failed to init remote model.", e);
             throw e;

--- a/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
@@ -206,11 +206,13 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         String newConnectorId = Strings.hasLength(updateModelInput.getConnectorId()) ? updateModelInput.getConnectorId() : null;
         boolean isModelDeployed = isModelDeployed(mlModel.getModelState());
         // This flag is used to decide if we need to re-deploy the predictor(model) when updating the model cache.
-        // If one of the internal connector, stand-alone connector id, model quota flag, as well as the model rate limiter needs update, we
+        // If one of the internal connector, stand-alone connector id, model quota flag, as well as the model rate limiter and guardrails
+        // need update, we
         // need to perform a re-deploy.
         boolean isPredictorUpdate = (updateModelInput.getConnector() != null)
             || (newConnectorId != null)
-            || !Objects.equals(updateModelInput.getIsEnabled(), mlModel.getIsEnabled());
+            || !Objects.equals(updateModelInput.getIsEnabled(), mlModel.getIsEnabled())
+            || (updateModelInput.getGuardrails() != null);
         if (MLRateLimiter.updateValidityPreCheck(mlModel.getRateLimiter(), updateModelInput.getRateLimiter())) {
             MLRateLimiter updatedRateLimiterConfig = MLRateLimiter.update(mlModel.getRateLimiter(), updateModelInput.getRateLimiter());
             updateModelInput.setRateLimiter(updatedRateLimiterConfig);

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
@@ -17,6 +17,7 @@ import java.util.stream.DoubleStream;
 import org.opensearch.common.util.TokenBucket;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.engine.MLExecutable;
 import org.opensearch.ml.engine.Predictable;
@@ -45,6 +46,7 @@ public class MLModelCache {
     private final Queue<Double> predictRequestDurationQueue;
     private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) Long memSizeEstimationCPU;
     private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) Long memSizeEstimationGPU;
+    private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) MLGuard mlGuard;
 
     // In rare case, this could be null, e.g. model info not synced up yet a predict request comes in.
     @Setter
@@ -166,6 +168,7 @@ public class MLModelCache {
         isModelEnabled = null;
         rateLimiter = null;
         userRateLimiterMap = null;
+        mlGuard = null;
     }
 
     public void addModelInferenceDuration(double duration, long maxRequestCount) {

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
@@ -21,6 +21,7 @@ import org.opensearch.common.util.TokenBucket;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.exception.MLLimitExceededException;
+import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.engine.MLExecutable;
@@ -158,6 +159,40 @@ public class MLModelCacheHelper {
             return null;
         }
         return userRateLimiterMap.get(user);
+    }
+
+    /**
+     * Set a ml guard
+     *
+     * @param modelId     model id
+     * @param mlGuard mlGuard
+     */
+    public synchronized void setMLGuard(String modelId, MLGuard mlGuard) {
+        log.debug("Setting ML guard {} for Model {}", mlGuard, modelId);
+        getExistingModelCache(modelId).setMlGuard(mlGuard);
+    }
+
+    /**
+     * Get the current ML guard for the model.
+     *
+     * @param modelId model id
+     */
+    public MLGuard getMLGuard(String modelId) {
+        MLModelCache modelCache = modelCaches.get(modelId);
+        if (modelCache == null) {
+            return null;
+        }
+        return modelCache.getMlGuard();
+    }
+
+    /**
+     * Remove the ML guard from cache
+     *
+     * @param modelId model id
+     */
+    public synchronized void removeMLGuard(String modelId) {
+        log.debug("Removing the ML guard from Model {}", modelId);
+        getExistingModelCache(modelId).setMlGuard(null);
     }
 
     /**


### PR DESCRIPTION
### Description
Add guardrails for remote model input and output. We support two ways stop words and regex.

Example:
```
POST /_plugins/_ml/models/LHkGS44BStH5-WXNbXxT/_predict
{
  "parameters": {
    "prompt": "\n\nHuman:this is a test of <stop words>\n\nnAssistant:"
  }
}

The response
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "guardrails triggered for user input"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "guardrails triggered for user input"
  },
  "status": 400
}
```

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
