### PR TITLE
update the response code to 404 when deleting a memory that is not al…

### DIFF
--- a/memory/src/main/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandler.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandler.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.StepListener;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -32,6 +33,7 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.conversation.ConversationMeta;
 import org.opensearch.ml.common.conversation.ConversationalIndexConstants;
 import org.opensearch.ml.common.conversation.Interaction;
@@ -325,7 +327,14 @@ public class OpenSearchConversationalMemoryHandler implements ConversationalMemo
                 }, listener::onFailure);
 
             } else {
-                listener.onResponse(false);
+                log.error("No access to delete the memory for " + conversationId);
+                listener
+                    .onFailure(
+                        new OpenSearchStatusException(
+                            "Resources not found. Failed to delete the memory for " + conversationId,
+                            RestStatus.NOT_FOUND
+                        )
+                    );
             }
         }, listener::onFailure);
     }

--- a/memory/src/test/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandlerTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandlerTests.java
@@ -33,6 +33,7 @@ import java.util.List;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -201,9 +202,9 @@ public class OpenSearchConversationalMemoryHandlerTests extends OpenSearchTestCa
         @SuppressWarnings("unchecked")
         ActionListener<Boolean> deleteListener = mock(ActionListener.class);
         cmHandler.deleteConversation("cid", deleteListener);
-        ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
-        verify(deleteListener, times(1)).onResponse(argCaptor.capture());
-        assert (!argCaptor.getValue());
+        ArgumentCaptor<OpenSearchStatusException> argCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(deleteListener).onFailure(argCaptor.capture());
+        assert (argCaptor.getValue().getMessage().equals("Resources not found. Failed to delete the memory for cid"));
     }
 
     public void testDelete_ConversationMetaDeleteFalse_ThenFalse() {


### PR DESCRIPTION
…lowed to access

### Description
Return 404 not found when deleting a memory that is not allowed to access. Previously it returned only "success": "false"
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
