### PR TITLE
fix remote register model / circuit breaker 500

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -346,8 +346,8 @@ public class MLModelManager {
         MLTask mlTask,
         ActionListener<MLRegisterModelResponse> listener
     ) {
-        checkAndAddRunningTask(mlTask, maxRegisterTasksPerNode);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            checkAndAddRunningTask(mlTask, maxRegisterTasksPerNode);
             mlStats.getStat(MLNodeLevelStat.ML_REQUEST_COUNT).increment();
             mlStats.createCounterStatIfAbsent(mlTask.getFunctionName(), REGISTER, ML_ACTION_REQUEST_COUNT).increment();
             mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -451,7 +451,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         verify(mlTaskManager).updateMLTask(anyString(), anyMap(), anyLong(), anyBoolean());
     }
 
-    public void testRegisterMLRemoteModel_WhenMemoryCBOpen_ThenFail() throws PrivilegedActionException {
+    public void testRegisterMLRemoteModel_WhenMemoryCBOpen_ThenFail() {
         ActionListener<MLRegisterModelResponse> listener = mock(ActionListener.class);
         MemoryCircuitBreaker memCB = new MemoryCircuitBreaker(mock(JvmService.class));
         String memCBIsOpenMessage = memCB.getName() + " is open, please check your resources!";


### PR DESCRIPTION


### Description
On very rare occasion the memory circuit breaker triggers when registering a remote model. Before this PR, this would throw an exception, and because registerRemoteModel is a actionListener-based method, the error would be dropped and you get a 500 (internal server error) back. This PR moves the circuit breaker check inside the try block so that the exception is caught and 'actionListen'ed.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
