### PR TITLE
add agent framework security it tests

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/FunctionName.java
+++ b/common/src/main/java/org/opensearch/ml/common/FunctionName.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 // Please strictly add new FunctionName to the last line
@@ -33,7 +34,7 @@ public enum FunctionName {
 
     public static FunctionName from(String value) {
         try {
-            return FunctionName.valueOf(value);
+            return FunctionName.valueOf(value.toUpperCase(Locale.ROOT));
         } catch (Exception e) {
             throw new IllegalArgumentException("Wrong function name");
         }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
@@ -122,7 +122,7 @@ public class RestMLPredictionAction extends BaseRestHandler {
     MLPredictionTaskRequest getRequest(String modelId, String algorithm, RestRequest request) throws IOException {
         if (FunctionName.REMOTE.name().equals(algorithm) && !mlFeatureEnabledSetting.isRemoteInferenceEnabled()) {
             throw new IllegalStateException(REMOTE_INFERENCE_DISABLED_ERR_MSG);
-        } else if (FunctionName.isDLModel(FunctionName.from(algorithm)) && !mlFeatureEnabledSetting.isLocalModelEnabled()) {
+        } else if (FunctionName.isDLModel(FunctionName.from(algorithm.toUpperCase())) && !mlFeatureEnabledSetting.isLocalModelEnabled()) {
             throw new IllegalStateException(LOCAL_MODEL_DISABLED_ERR_MSG);
         }
         XContentParser parser = request.contentParser();

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -73,6 +73,8 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.agent.MLAgent;
+import org.opensearch.ml.common.agent.MLToolSpec;
 import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.SearchQueryInputDataset;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
@@ -744,6 +746,47 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
     public String registerModel(String input) throws IOException {
         Response response = TestHelper.makeRequest(client(), "POST", "/_plugins/_ml/models/_register", null, input, null);
         return parseTaskIdFromResponse(response);
+    }
+
+    public void registerMLAgent(RestClient client, String input, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "POST", "/_plugins/_ml/agents/_register", null, input, null);
+        verifyResponse(function, response);
+    }
+
+    public void executeAgent(RestClient client, String agentId, String input, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "POST", "/_plugins/_ml/agents/" + agentId + "/_execute", null, input, null);
+        verifyResponse(function, response);
+    }
+
+    public void getAgent(RestClient client, String agentId, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "GET", "/_plugins/_ml/agents/" + agentId, null, "", null);
+        verifyResponse(function, response);
+    }
+
+    public void searchAgent(RestClient client, String input, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "POST", "/_plugins/_ml/agents/_search", null, input, null);
+        verifyResponse(function, response);
+    }
+
+    public void deleteAgent(RestClient client, String agentId, Consumer<Map<String, Object>> function) throws IOException {
+        Response response = TestHelper.makeRequest(client, "DELETE", "/_plugins/_ml/agents/" + agentId, null, "", null);
+        verifyResponse(function, response);
+    }
+
+    public MLAgent createCatIndexToolMLAgent() {
+        MLToolSpec catIndexTool = MLToolSpec
+            .builder()
+            .type("CatIndexTool")
+            .name("DemoCatIndexTool")
+            .parameters(Map.of("input", "${parameters.question}"))
+            .build();
+        return MLAgent
+            .builder()
+            .name("Test_Agent_For_CatIndex_tool")
+            .type("flow")
+            .description("this is a test agent for the CatIndexTool")
+            .tools(List.of(catIndexTool))
+            .build();
     }
 
     public void deployModel(RestClient client, MLRegisterModelInput registerModelInput, Consumer<Map<String, Object>> function)

--- a/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
@@ -27,7 +27,11 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.agent.MLAgent;
+import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.input.execute.agent.AgentMLInput;
 import org.opensearch.ml.common.input.parameter.clustering.KMeansParams;
+import org.opensearch.ml.common.transport.agent.MLAgentGetRequest;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.utils.TestHelper;
@@ -59,6 +63,8 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     private String modelGroupId;
+
+    private MLAgent mlAgent;
 
     /**
      * Create an unguessable password. Simple password are weak due to https://tinyurl.com/383em9zk
@@ -152,6 +158,8 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
             this.modelGroupId = (String) registerModelGroupResult.get("model_group_id");
         });
         mlRegisterModelInput = createRegisterModelInput(modelGroupId);
+
+        mlAgent = createCatIndexToolMLAgent();
     }
 
     @After
@@ -247,6 +255,150 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
             String status = (String) deployModelResult.get("status");
             assertEquals(MLTaskState.CREATED.name(), status);
         });
+    }
+
+    public void testExecuteAgentWithFullAccess() throws IOException {
+        registerMLAgent(mlFullAccessClient, TestHelper.toJsonString(mlAgent), registerMLAgentResult -> {
+            assertNotNull(registerMLAgentResult);
+            assertTrue(registerMLAgentResult.containsKey("agent_id"));
+            String agentId = (String) registerMLAgentResult.get("agent_id");
+            try {
+                AgentMLInput agentMLInput = AgentMLInput
+                    .AgentMLInputBuilder()
+                    .agentId(agentId)
+                    .functionName(FunctionName.AGENT)
+                    .inputDataset(
+                        RemoteInferenceInputDataSet.builder().parameters(Map.of("question", "How many indices do I have?")).build()
+                    )
+                    .build();
+
+                executeAgent(mlFullAccessClient, agentId, TestHelper.toJsonString(agentMLInput), mlExecuteTaskResponse -> {
+                    assertNotNull(mlExecuteTaskResponse);
+                    assertTrue(mlExecuteTaskResponse.containsKey("inference_results"));
+                });
+            } catch (IOException e) {
+                assertNull(e);
+            }
+        });
+    }
+
+    public void testExecuteAgentWithReadOnlyAccess() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.toString();
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/execute]");
+        AgentMLInput agentMLInput = AgentMLInput
+            .AgentMLInputBuilder()
+            .agentId("test-agent")
+            .functionName(FunctionName.AGENT)
+            .inputDataset(RemoteInferenceInputDataSet.builder().parameters(Map.of("question", "How many indices do I have?")).build())
+            .build();
+
+        executeAgent(mlReadOnlyClient, "test-agent", TestHelper.toJsonString(agentMLInput), mlExecuteTaskResponse -> {
+            assertNotNull(mlExecuteTaskResponse);
+            assertTrue(mlExecuteTaskResponse.containsKey("inference_results"));
+        });
+    }
+
+    public void testGetAgentWithFullAccess() throws IOException {
+        registerMLAgent(mlFullAccessClient, TestHelper.toJsonString(mlAgent), registerMLAgentResult -> {
+            assertNotNull(registerMLAgentResult);
+            assertTrue(registerMLAgentResult.containsKey("agent_id"));
+            String agentId = (String) registerMLAgentResult.get("agent_id");
+            try {
+                MLAgentGetRequest mlAgentGetRequest = MLAgentGetRequest.builder().agentId(agentId).build();
+                getAgent(mlFullAccessClient, agentId, mlGetAgentResponse -> {
+                    assertNotNull(mlGetAgentResponse);
+                    assertTrue(mlGetAgentResponse.containsKey("name"));
+                    assertEquals(mlGetAgentResponse.get("name"), "Test_Agent_For_CatIndex_tool");
+                });
+            } catch (IOException e) {
+                assertNull(e);
+            }
+        });
+    }
+
+    public void testGetAgentWithNoAccess() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/agents/get]");
+
+        getAgent(mlNoAccessClient, "test-agent", mlExecuteTaskResponse -> {
+            assertNotNull(mlExecuteTaskResponse);
+            assertTrue(mlExecuteTaskResponse.containsKey("inference_results"));
+        });
+    }
+
+    public void testSearchAgentWithFullAccess() throws IOException {
+        registerMLAgent(mlFullAccessClient, TestHelper.toJsonString(mlAgent), registerMLAgentResult -> {
+            assertNotNull(registerMLAgentResult);
+            assertTrue(registerMLAgentResult.containsKey("agent_id"));
+            try {
+                searchAgent(
+                    mlFullAccessClient,
+                    "{\n" + "    \"query\": {\n" + "        \"match_all\": {}\n" + "    }\n" + "}",
+                    mlSearchAgentResponse -> {
+                        assertNotNull(mlSearchAgentResponse);
+                        assertTrue(mlSearchAgentResponse.containsKey("hits"));
+                    }
+                );
+            } catch (IOException e) {
+                assertNull(e);
+            }
+        });
+    }
+
+    public void testSearchAgentWithNoAccess() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/agents/search]");
+
+        searchAgent(
+            mlNoAccessClient,
+            "{\n" + "    \"query\": {\n" + "        \"match_all\": {}\n" + "    }\n" + "}",
+            mlSearchAgentResponse -> {
+                assertNotNull(mlSearchAgentResponse);
+                assertTrue(mlSearchAgentResponse.containsKey("hits"));
+            }
+        );
+    }
+
+    public void testDeleteAgentWithFullAccess() throws IOException {
+        registerMLAgent(mlFullAccessClient, TestHelper.toJsonString(mlAgent), registerMLAgentResult -> {
+            assertNotNull(registerMLAgentResult);
+            assertTrue(registerMLAgentResult.containsKey("agent_id"));
+            String agentId = (String) registerMLAgentResult.get("agent_id");
+            try {
+                deleteAgent(mlFullAccessClient, agentId, mlSearchAgentResponse -> {
+                    assertNotNull(mlSearchAgentResponse);
+                    assertTrue(mlSearchAgentResponse.containsKey("result"));
+                    assertEquals(mlSearchAgentResponse.get("result"), "deleted");
+                });
+            } catch (IOException e) {
+                assertNull(e);
+            }
+        });
+    }
+
+    public void testDeleteAgentWithNoAccess() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/agents/delete]");
+
+        deleteAgent(mlReadOnlyClient, "agentId", mlSearchAgentResponse -> {
+            assertNotNull(mlSearchAgentResponse);
+            assertTrue(mlSearchAgentResponse.containsKey("result"));
+            assertEquals(mlSearchAgentResponse.get("result"), "deleted");
+        });
+    }
+
+    public void testRegisterAgentWithFullAccess() throws IOException {
+        registerMLAgent(mlFullAccessClient, TestHelper.toJsonString(mlAgent), registerMLAgentResult -> {
+            assertNotNull(registerMLAgentResult);
+            assertTrue(registerMLAgentResult.containsKey("agent_id"));
+        });
+    }
+
+    public void testRegisterAgentWithReadOnlyMLAccess() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/agents/register]");
+        registerMLAgent(mlReadOnlyClient, TestHelper.toJsonString(mlAgent), null);
     }
 
     public void testTrainWithReadOnlyMLAccess() throws IOException {


### PR DESCRIPTION
### Description
Add Security IT tests for Agent Framework. The tests all verified by a local 2.13 cluster.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
