### PR TITLE
agent out of the setting only_run_on_ml_node

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/cluster/DiscoveryNodeHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/DiscoveryNodeHelper.java
@@ -73,7 +73,7 @@ public class DiscoveryNodeHelper {
             if (excludedNodeNames != null && excludedNodeNames.contains(node.getName())) {
                 continue;
             }
-            if (functionName == FunctionName.REMOTE || functionName == FunctionName.AGENT) {// remote model
+            if (functionName == FunctionName.REMOTE || functionName == FunctionName.AGENT) {// non-local model (remote model, agent)
                 getEligibleNode(remoteModelEligibleNodeRoles, eligibleNodes, node);
             } else { // local model
                 if (onlyRunOnMLNode) {

--- a/plugin/src/main/java/org/opensearch/ml/cluster/DiscoveryNodeHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/DiscoveryNodeHelper.java
@@ -73,7 +73,7 @@ public class DiscoveryNodeHelper {
             if (excludedNodeNames != null && excludedNodeNames.contains(node.getName())) {
                 continue;
             }
-            if (functionName == FunctionName.REMOTE) {// remote model
+            if (functionName == FunctionName.REMOTE || functionName == FunctionName.AGENT) {// remote model
                 getEligibleNode(remoteModelEligibleNodeRoles, eligibleNodes, node);
             } else { // local model
                 if (onlyRunOnMLNode) {

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -37,7 +37,7 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MAX_ML_TASK_PER_NODE = Setting
         .intSetting("plugins.ml_commons.max_ml_task_per_node", 10, 0, 10000, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Boolean> ML_COMMONS_ONLY_RUN_ON_ML_NODE = Setting
-        .boolSetting("plugins.ml_commons.only_run_on_ml_node", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .boolSetting("plugins.ml_commons.only_run_on_ml_node", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Boolean> ML_COMMONS_ENABLE_INHOUSE_PYTHON_MODEL = Setting
         .boolSetting("plugins.ml_commons.enable_inhouse_python_model", false, Setting.Property.NodeScope, Setting.Property.Dynamic);

--- a/plugin/src/test/java/org/opensearch/ml/cluster/DiscoveryNodeHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/DiscoveryNodeHelperTests.java
@@ -182,6 +182,19 @@ public class DiscoveryNodeHelperTests extends OpenSearchTestCase {
         assertFalse(nodeIds.contains(warmDataNode1.getId()));
     }
 
+    public void testGetEligibleNodes_MLNode_Agent() {
+        DiscoveryNode[] eligibleNodes = discoveryNodeHelper.getEligibleNodes(FunctionName.AGENT);
+        assertEquals(5, eligibleNodes.length);
+        Set<String> nodeIds = new HashSet<>();
+        nodeIds.addAll(Arrays.asList(eligibleNodes).stream().map(n -> n.getId()).collect(Collectors.toList()));
+        assertTrue(nodeIds.contains(mlNode1.getId()));
+        assertTrue(nodeIds.contains(mlNode2.getId()));
+        assertTrue(nodeIds.contains(dataNode1.getId()));
+        assertTrue(nodeIds.contains(dataNode2.getId()));
+        assertTrue(nodeIds.contains(allRoleNode.getId()));
+        assertFalse(nodeIds.contains(warmDataNode1.getId()));
+    }
+
     public void testGetEligibleNodes_MLNode_LocalModel() {
         DiscoveryNode[] eligibleNodes = discoveryNodeHelper.getEligibleNodes(FunctionName.TEXT_EMBEDDING);
         assertEquals(3, eligibleNodes.length);


### PR DESCRIPTION
### Description
Take agent out of the scope of only_run_on_ml_node flag.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
