### PR TITLE
guardrails npe

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
@@ -93,6 +93,9 @@ public class MLGuard {
     }
 
     public Boolean validateRegexList(String input, List<Pattern> regexPatterns) {
+        if (regexPatterns == null || regexPatterns.isEmpty()) {
+            return true;
+        }
         for (Pattern pattern : regexPatterns) {
             if (!validateRegex(input, pattern)) {
                 return false;
@@ -107,6 +110,9 @@ public class MLGuard {
     }
 
     public Boolean validateStopWords(String input, Map<String, List<String>> stopWordsIndices) {
+        if (stopWordsIndices == null || stopWordsIndices.isEmpty()) {
+            return true;
+        }
         for (Map.Entry entry : stopWordsIndices.entrySet()) {
             if (!validateStopWordsSingleIndex(input, (String) entry.getKey(), (List<String>) entry.getValue())) {
                 return false;

--- a/common/src/test/java/org/opensearch/ml/common/model/MLGuardTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/MLGuardTests.java
@@ -112,6 +112,22 @@ public class MLGuardTests {
     }
 
     @Test
+    public void validateRegexListNull() {
+        String input = "\n\nHuman:hello good words.\n\nAssistant:";
+        Boolean res = mlGuard.validateRegexList(input, null);
+
+        Assert.assertTrue(res);
+    }
+
+    @Test
+    public void validateRegexListEmpty() {
+        String input = "\n\nHuman:hello good words.\n\nAssistant:";
+        Boolean res = mlGuard.validateRegexList(input, List.of());
+
+        Assert.assertTrue(res);
+    }
+
+    @Test
     public void validateRegexSuccess() {
         String input = "\n\nHuman:hello good words.\n\nAssistant:";
         Boolean res = mlGuard.validateRegex(input, regexPatterns.get(0));
@@ -135,6 +151,18 @@ public class MLGuardTests {
         when(this.client.search(any())).thenReturn(future);
 
         Boolean res = mlGuard.validateStopWords("hello world", stopWordsIndices);
+        Assert.assertTrue(res);
+    }
+
+    @Test
+    public void validateStopWordsNull() {
+        Boolean res = mlGuard.validateStopWords("hello world", null);
+        Assert.assertTrue(res);
+    }
+
+    @Test
+    public void validateStopWordsEmpty() {
+        Boolean res = mlGuard.validateStopWords("hello world", Map.of());
         Assert.assertTrue(res);
     }
 


### PR DESCRIPTION
### Description
Support register model with empty guardrails content. Currently we will get npe with empty guardrails when predicting.
```
POST /_plugins/_ml/models/_register?deploy=true
{
    "name": "remote model",
    "function_name": "remote",
    "model_group_id": "<group_id>",
    "description": "test model",
    "connector_id": "<connector_id>",
    "guardrails": {
    }
}
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
