### PR TITLE
fix stopwords npe

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/MLGuard.java
@@ -77,7 +77,9 @@ public class MLGuard {
             return;
         }
         for (StopWords e : stopWords) {
-            map.put(e.getIndex(), Arrays.asList(e.getSourceFields()));
+            if (e.getIndex() != null && e.getSourceFields() != null) {
+                map.put(e.getIndex(), Arrays.asList(e.getSourceFields()));
+            }
         }
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/model/MLGuardTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/MLGuardTests.java
@@ -88,6 +88,21 @@ public class MLGuardTests {
     }
 
     @Test
+    public void validateInitializedStopWordsEmpty() {
+        stopWords = new StopWords(null, null);
+        regex = List.of("(.|\n)*stop words(.|\n)*").toArray(new String[0]);
+        regexPatterns = List.of(Pattern.compile("(.|\n)*stop words(.|\n)*"));
+        inputGuardrail = new Guardrail(List.of(stopWords), regex);
+        outputGuardrail = new Guardrail(List.of(stopWords), regex);
+        guardrails = new Guardrails("test_type", inputGuardrail, outputGuardrail);
+        mlGuard = new MLGuard(guardrails, xContentRegistry, client);
+
+        String input = "\n\nHuman:hello good words.\n\nAssistant:";
+        Boolean res = mlGuard.validate(input, MLGuard.Type.INPUT);
+        Assert.assertTrue(res);
+    }
+
+    @Test
     public void validateOutput() {
         String input = "\n\nHuman:hello stop words.\n\nAssistant:";
         Boolean res = mlGuard.validate(input, MLGuard.Type.OUTPUT);


### PR DESCRIPTION
### Description
Fix the npe issue when passing an empty stopwords as following.
```
POST /_plugins/_ml/models/_register?deploy=true
{
    "name": "model name",
    "function_name": "remote",
    "model_group_id": "<group id>",
    "description": "test model",
    "connector_id": "<connector id>",
    "guardrails": {
      "type": "local_regex",
        "input_guardrail": {
          "stop_words": [
            {
            }
          ],
          "regex": []
        },
        "output_guardrail": {
        }
    }
}
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
