### PR TITLE
Fix connector can use subfield of secrectArn to bypass extraction of credential from AWS

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -148,7 +148,14 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
                     parameters = getParameterMap(parser.map());
                     break;
                 case CONNECTOR_CREDENTIAL_FIELD:
-                    credential = parser.mapStrings();
+                    // We need to filter out any key string that is trying to imitate the subfield of the secretArn of the credential map
+                    credential = new HashMap<>();
+                    Map<String, String> credentialKeyToAdd = parser.mapStrings();
+                    for (String key : credentialKeyToAdd.keySet()) {
+                        if (!key.startsWith("secretArn.")) {
+                            credential.put(key, credentialKeyToAdd.get(key));
+                        }
+                    }
                     break;
                 case CONNECTOR_ACTIONS_FIELD:
                     actions = new ArrayList<>();

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.utils.StringUtils.getParameterMap;
@@ -151,8 +153,11 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
                     // We need to filter out any key string that is trying to imitate the subfield of the secretArn of the credential map
                     credential = new HashMap<>();
                     Map<String, String> credentialKeyToAdd = parser.mapStrings();
+                    Pattern pattern = Pattern.compile("[a-zA-Z]+Arn\\.");
                     for (String key : credentialKeyToAdd.keySet()) {
-                        if (!key.startsWith("secretArn.")) {
+                        Matcher matcher = pattern.matcher(key);
+                        boolean matchFound = matcher.find();
+                        if (!matchFound) {
                             credential.put(key, credentialKeyToAdd.get(key));
                         }
                     }

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -150,7 +150,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
                     parameters = getParameterMap(parser.map());
                     break;
                 case CONNECTOR_CREDENTIAL_FIELD:
-                    // We need to filter out any key string that is trying to imitate the subfield of the secretArn of the credential map
+                    // We need to filter out any key string that is trying to imitate the subfield of any kind of ARN of the credential map
                     credential = new HashMap<>();
                     Map<String, String> credentialKeyToAdd = parser.mapStrings();
                     Pattern pattern = Pattern.compile("[a-zA-Z]+Arn\\.");

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -188,6 +189,25 @@ public class MLCreateConnectorInputTests {
             assertEquals("test_connector_name", parsedInput.getName());
             assertEquals(1, parsedInput.getParameters().size());
             assertEquals("[\"test input value\"]", parsedInput.getParameters().get("input"));
+        });
+    }
+
+    @Test
+    public void testParse_SecretArnPrefix() throws Exception {
+        String expectedInputStr = "{\"name\":\"test_connector_name\"," +
+                "\"description\":\"this is a test connector\",\"version\":\"1\",\"protocol\":\"http\"," +
+                "\"parameters\":{\"input\":[\"test input value\"]},\"credential\":{\"key\":\"test_key_value\", \"secretArn\":\"test_secretArn_value\", \"secretArn.key\":\"test_key_value\"}," +
+                "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\"," +
+                "\"headers\":{\"api_key\":\"${credential.key}\"}," +
+                "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\"," +
+                "\"pre_process_function\":\"connector.pre_process.openai.embedding\"," +
+                "\"post_process_function\":\"connector.post_process.openai.embedding\"}]," +
+                "\"backend_roles\":[\"role1\",\"role2\"],\"add_all_backend_roles\":false," +
+                "\"access_mode\":\"PUBLIC\"}";
+        HashSet<String> expectedCredentialKeys = new HashSet<>(Arrays.asList("key", "secretArn"));
+        testParseFromJsonString(expectedInputStr, parsedInput -> {
+            assertEquals(expectedCredentialKeys, parsedInput.getCredential().keySet());
+            assertEquals("test_secretArn_value", parsedInput.getCredential().get("secretArn"));
         });
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -196,7 +196,9 @@ public class MLCreateConnectorInputTests {
     public void testParse_SecretArnPrefix() throws Exception {
         String expectedInputStr = "{\"name\":\"test_connector_name\"," +
                 "\"description\":\"this is a test connector\",\"version\":\"1\",\"protocol\":\"http\"," +
-                "\"parameters\":{\"input\":[\"test input value\"]},\"credential\":{\"key\":\"test_key_value\", \"secretArn\":\"test_secretArn_value\", \"secretArn.key\":\"test_key_value\"}," +
+                "\"parameters\":{\"input\":[\"test input value\"]},\"credential\":{\"key\":\"test_key_value\"," +
+                "\"secretArn\":\"test_secretArn_value\", \"secretArn.key\":\"test_key_value\"," +
+                "\"roleArn\":\"test_roleArn_value\", \"roleArn.subfield\":\"test_subfield_value\",\"test_Arn_test\":\"test_value\"}," +
                 "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\"," +
                 "\"headers\":{\"api_key\":\"${credential.key}\"}," +
                 "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\"," +
@@ -204,10 +206,11 @@ public class MLCreateConnectorInputTests {
                 "\"post_process_function\":\"connector.post_process.openai.embedding\"}]," +
                 "\"backend_roles\":[\"role1\",\"role2\"],\"add_all_backend_roles\":false," +
                 "\"access_mode\":\"PUBLIC\"}";
-        HashSet<String> expectedCredentialKeys = new HashSet<>(Arrays.asList("key", "secretArn"));
+        HashSet<String> expectedCredentialKeys = new HashSet<>(Arrays.asList("key", "secretArn", "roleArn","test_Arn_test"));
         testParseFromJsonString(expectedInputStr, parsedInput -> {
             assertEquals(expectedCredentialKeys, parsedInput.getCredential().keySet());
             assertEquals("test_secretArn_value", parsedInput.getCredential().get("secretArn"));
+            assertEquals("test_roleArn_value", parsedInput.getCredential().get("roleArn"));
         });
     }
 


### PR DESCRIPTION
### Description
We found connector can use subfield of `secretArn` (e.g. `secretArn.key`) to bypass extraction of credential from AWS, so we need to filter out any key string which tries to imitate the subfield of the `secretArn` of the credential map to avoid security issue. UT has added.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
