### PR TITLE
Add TTL to un-deploy model automatically

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/model/MLDeploySetting.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/MLDeploySetting.java
@@ -16,7 +16,6 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.ml.common.transport.sync.MLSyncUpInput;
 
 import java.io.IOException;
 
@@ -28,6 +27,7 @@ public class MLDeploySetting implements ToXContentObject, Writeable {
     public static final String IS_AUTO_DEPLOY_ENABLED_FIELD = "is_auto_deploy_enabled";
     public static final String MODEL_TTL_MINUTES_FIELD = "model_ttl_minutes";
     private static final long DEFAULT_TTL_MINUTES = -1;
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL = Version.V_2_14_0;
 
     private Boolean isAutoDeployEnabled;
     private Long modelTTLInMinutes; // in minutes
@@ -44,7 +44,7 @@ public class MLDeploySetting implements ToXContentObject, Writeable {
     public MLDeploySetting(StreamInput in) throws IOException {
         this.isAutoDeployEnabled = in.readOptionalBoolean();
         Version streamInputVersion = in.getVersion();
-        if (streamInputVersion.onOrAfter(MLSyncUpInput.MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL)) {
+        if (streamInputVersion.onOrAfter(MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL)) {
             this.modelTTLInMinutes = in.readOptionalLong();
         }
     }
@@ -53,7 +53,7 @@ public class MLDeploySetting implements ToXContentObject, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         Version streamOutputVersion = out.getVersion();
         out.writeOptionalBoolean(isAutoDeployEnabled);
-        if (streamOutputVersion.onOrAfter(MLSyncUpInput.MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL)) {
+        if (streamOutputVersion.onOrAfter(MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL)) {
             out.writeOptionalLong(modelTTLInMinutes);
         }
     }

--- a/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpInput.java
@@ -36,8 +36,6 @@ public class MLSyncUpInput implements Writeable {
     // profile API has consistent data with model index.
     private Map<String, Boolean> deployToAllNodes;
 
-    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL = Version.V_2_14_0;
-
     @Builder
     public MLSyncUpInput(boolean getDeployedModels,
                          Map<String, String[]> addedWorkerNodes,

--- a/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpInput.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.transport.sync;
 
 import lombok.Builder;
 import lombok.Data;
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -34,6 +35,8 @@ public class MLSyncUpInput implements Writeable {
     // deployToAll flag for models, when deploy/undeploy a model, this will passed to each node to update cache value to make sure
     // profile API has consistent data with model index.
     private Map<String, Boolean> deployToAllNodes;
+
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL = Version.V_2_14_0;
 
     @Builder
     public MLSyncUpInput(boolean getDeployedModels,

--- a/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponse.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.transport.sync;
 
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
+import org.opensearch.Version;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -36,11 +37,14 @@ public class MLSyncUpNodeResponse extends BaseNodeResponse  {
 
     public MLSyncUpNodeResponse(StreamInput in) throws IOException {
         super(in);
+        Version streamInputVersion = in.getVersion();
         this.modelStatus = in.readOptionalString();
         this.deployedModelIds = in.readOptionalStringArray();
         this.runningDeployModelIds = in.readOptionalStringArray();
         this.runningDeployModelTaskIds = in.readOptionalStringArray();
-        this.expiredModelIds = in.readOptionalStringArray();
+        if (streamInputVersion.onOrAfter(MLSyncUpInput.MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL)) {
+            this.expiredModelIds = in.readOptionalStringArray();
+        }
     }
 
     public static MLSyncUpNodeResponse readStats(StreamInput in) throws IOException {
@@ -49,12 +53,14 @@ public class MLSyncUpNodeResponse extends BaseNodeResponse  {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        Version streamOutputVersion = out.getVersion();
         super.writeTo(out);
         out.writeOptionalString(modelStatus);
         out.writeOptionalStringArray(deployedModelIds);
         out.writeOptionalStringArray(runningDeployModelIds);
         out.writeOptionalStringArray(runningDeployModelTaskIds);
-        out.writeOptionalStringArray(expiredModelIds);
+        if (streamOutputVersion.onOrAfter(MLSyncUpInput.MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL)) {
+            out.writeOptionalStringArray(expiredModelIds);
+        }
     }
-
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponse.java
@@ -12,6 +12,7 @@ import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.ml.common.model.MLDeploySetting;
 
 import java.io.IOException;
 
@@ -42,7 +43,7 @@ public class MLSyncUpNodeResponse extends BaseNodeResponse  {
         this.deployedModelIds = in.readOptionalStringArray();
         this.runningDeployModelIds = in.readOptionalStringArray();
         this.runningDeployModelTaskIds = in.readOptionalStringArray();
-        if (streamInputVersion.onOrAfter(MLSyncUpInput.MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL)) {
+        if (streamInputVersion.onOrAfter(MLDeploySetting.MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL)) {
             this.expiredModelIds = in.readOptionalStringArray();
         }
     }
@@ -59,7 +60,7 @@ public class MLSyncUpNodeResponse extends BaseNodeResponse  {
         out.writeOptionalStringArray(deployedModelIds);
         out.writeOptionalStringArray(runningDeployModelIds);
         out.writeOptionalStringArray(runningDeployModelTaskIds);
-        if (streamOutputVersion.onOrAfter(MLSyncUpInput.MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL)) {
+        if (streamOutputVersion.onOrAfter(MLDeploySetting.MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL)) {
             out.writeOptionalStringArray(expiredModelIds);
         }
     }

--- a/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponse.java
@@ -22,14 +22,16 @@ public class MLSyncUpNodeResponse extends BaseNodeResponse  {
     private String[] deployedModelIds;
     private String[] runningDeployModelIds; // model ids which have deploying model task running
     private String[] runningDeployModelTaskIds; // deploy model task ids which is running
+    private String[] expiredModelIds;
 
     public MLSyncUpNodeResponse(DiscoveryNode node, String modelStatus, String[] deployedModelIds, String[] runningDeployModelIds,
-                                String[] runningDeployModelTaskIds) {
+                                String[] runningDeployModelTaskIds, String[] expiredModelIds) {
         super(node);
         this.modelStatus = modelStatus;
         this.deployedModelIds = deployedModelIds;
         this.runningDeployModelIds = runningDeployModelIds;
         this.runningDeployModelTaskIds = runningDeployModelTaskIds;
+        this.expiredModelIds = expiredModelIds;
     }
 
     public MLSyncUpNodeResponse(StreamInput in) throws IOException {
@@ -38,6 +40,7 @@ public class MLSyncUpNodeResponse extends BaseNodeResponse  {
         this.deployedModelIds = in.readOptionalStringArray();
         this.runningDeployModelIds = in.readOptionalStringArray();
         this.runningDeployModelTaskIds = in.readOptionalStringArray();
+        this.expiredModelIds = in.readOptionalStringArray();
     }
 
     public static MLSyncUpNodeResponse readStats(StreamInput in) throws IOException {
@@ -51,6 +54,7 @@ public class MLSyncUpNodeResponse extends BaseNodeResponse  {
         out.writeOptionalStringArray(deployedModelIds);
         out.writeOptionalStringArray(runningDeployModelIds);
         out.writeOptionalStringArray(runningDeployModelTaskIds);
+        out.writeOptionalStringArray(expiredModelIds);
     }
 
 }

--- a/common/src/test/java/org/opensearch/ml/common/model/MLDeployingSettingTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/MLDeployingSettingTests.java
@@ -36,7 +36,7 @@ public class MLDeployingSettingTests {
 
     private MLDeploySetting deploySettingNull;
 
-    private final String expectedInputStr = "{\"is_auto_deploy_enabled\":true,\"model_ttl\":-1}";
+    private final String expectedInputStr = "{\"is_auto_deploy_enabled\":true,\"model_ttl_hours\":-1,\"model_ttl_minutes\":-1}";
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
@@ -66,7 +66,7 @@ public class MLDeployingSettingTests {
 
     @Test
     public void testToXContentIncomplete() throws Exception {
-        final String expectedIncompleteInputStr = "{\"model_ttl\":-1}";
+        final String expectedIncompleteInputStr = "{\"model_ttl_hours\":-1,\"model_ttl_minutes\":-1}";
 
         String jsonStr = serializationWithToXContent(deploySettingNull);
         assertEquals(expectedIncompleteInputStr, jsonStr);
@@ -109,12 +109,12 @@ public class MLDeployingSettingTests {
 
     @Test
     public void parseWithIllegalField() throws Exception {
-        final String expectedInputStrWithIllegalField = "{\"is_auto_deploy_enabled\":true," + "\"model_ttl\":-1," +
+        final String expectedInputStrWithIllegalField = "{\"is_auto_deploy_enabled\":true," + "\"model_ttl_hours\":0," +
                 "\"illegal_field\":\"This field need to be skipped.\"}";
 
         testParseFromJsonString(expectedInputStrWithIllegalField, parsedInput -> {
             try {
-                assertEquals(expectedInputStr, serializationWithToXContent(parsedInput));
+                assertEquals("{\"is_auto_deploy_enabled\":true,\"model_ttl_hours\":0,\"model_ttl_minutes\":0}", serializationWithToXContent(parsedInput));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/common/src/test/java/org/opensearch/ml/common/model/MLDeployingSettingTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/MLDeployingSettingTests.java
@@ -36,7 +36,7 @@ public class MLDeployingSettingTests {
 
     private MLDeploySetting deploySettingNull;
 
-    private final String expectedInputStr = "{\"is_auto_deploy_enabled\":true,\"model_ttl_hours\":-1,\"model_ttl_minutes\":-1}";
+    private final String expectedInputStr = "{\"is_auto_deploy_enabled\":true,\"model_ttl_minutes\":-1}";
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
@@ -66,7 +66,7 @@ public class MLDeployingSettingTests {
 
     @Test
     public void testToXContentIncomplete() throws Exception {
-        final String expectedIncompleteInputStr = "{\"model_ttl_hours\":-1,\"model_ttl_minutes\":-1}";
+        final String expectedIncompleteInputStr = "{\"model_ttl_minutes\":-1}";
 
         String jsonStr = serializationWithToXContent(deploySettingNull);
         assertEquals(expectedIncompleteInputStr, jsonStr);
@@ -114,7 +114,7 @@ public class MLDeployingSettingTests {
 
         testParseFromJsonString(expectedInputStrWithIllegalField, parsedInput -> {
             try {
-                assertEquals("{\"is_auto_deploy_enabled\":true,\"model_ttl_hours\":0,\"model_ttl_minutes\":0}", serializationWithToXContent(parsedInput));
+                assertEquals("{\"is_auto_deploy_enabled\":true,\"model_ttl_minutes\":-1}", serializationWithToXContent(parsedInput));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/common/src/test/java/org/opensearch/ml/common/model/MLDeployingSettingTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/MLDeployingSettingTests.java
@@ -36,7 +36,7 @@ public class MLDeployingSettingTests {
 
     private MLDeploySetting deploySettingNull;
 
-    private final String expectedInputStr = "{\"is_auto_deploy_enabled\":true}";
+    private final String expectedInputStr = "{\"is_auto_deploy_enabled\":true,\"model_ttl\":-1}";
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
@@ -66,7 +66,7 @@ public class MLDeployingSettingTests {
 
     @Test
     public void testToXContentIncomplete() throws Exception {
-        final String expectedIncompleteInputStr = "{}";
+        final String expectedIncompleteInputStr = "{\"model_ttl\":-1}";
 
         String jsonStr = serializationWithToXContent(deploySettingNull);
         assertEquals(expectedIncompleteInputStr, jsonStr);
@@ -109,7 +109,7 @@ public class MLDeployingSettingTests {
 
     @Test
     public void parseWithIllegalField() throws Exception {
-        final String expectedInputStrWithIllegalField = "{\"is_auto_deploy_enabled\":true," +
+        final String expectedInputStrWithIllegalField = "{\"is_auto_deploy_enabled\":true," + "\"model_ttl\":-1," +
                 "\"illegal_field\":\"This field need to be skipped.\"}";
 
         testParseFromJsonString(expectedInputStrWithIllegalField, parsedInput -> {

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponseTest.java
@@ -24,6 +24,8 @@ public class MLSyncUpNodeResponseTest {
     private final String[] loadedModelIds = {"loadedModelIds"};
     private final String[] runningLoadModelTaskIds = {"runningLoadModelTaskIds"};
     private final String[] runningLoadModelIds = {"modelid1"};
+
+    private final String[] expiredModelIds = {"modelExpired"};
     @Before
     public void setUp() throws Exception {
         localNode = new DiscoveryNode(
@@ -38,7 +40,7 @@ public class MLSyncUpNodeResponseTest {
 
     @Test
     public void testSerializationDeserialization() throws IOException {
-        MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(localNode, modelStatus, loadedModelIds, runningLoadModelIds, runningLoadModelTaskIds);
+        MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(localNode, modelStatus, loadedModelIds, runningLoadModelIds, runningLoadModelTaskIds, expiredModelIds);
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
         MLSyncUpNodeResponse newResponse = new MLSyncUpNodeResponse(output.bytes().streamInput());
@@ -51,7 +53,7 @@ public class MLSyncUpNodeResponseTest {
 
     @Test
     public void testReadProfile() throws IOException {
-        MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(localNode, modelStatus, loadedModelIds, runningLoadModelIds, runningLoadModelTaskIds);
+        MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(localNode, modelStatus, loadedModelIds, runningLoadModelIds, runningLoadModelTaskIds, expiredModelIds);
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
         MLSyncUpNodeResponse newResponse = MLSyncUpNodeResponse.readStats(output.bytes().streamInput());

--- a/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
@@ -223,6 +223,7 @@ public class TransportPredictionTaskAction extends HandledTransportAction<Action
                     long endTime = System.nanoTime();
                     double durationInMs = (endTime - startTime) / 1e6;
                     modelCacheHelper.addPredictRequestDuration(modelId, durationInMs);
+                    modelCacheHelper.refreshLastAccessTime(modelId);
                     log.debug("completed predict request " + requestId + " for model " + modelId);
                 })
             );

--- a/plugin/src/main/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeAction.java
@@ -162,11 +162,13 @@ public class TransportSyncUpOnNodeAction extends
         String[] deployedModelIds = null;
         String[] runningDeployModelTaskIds = null;
         String[] runningDeployModelIds = null;
+        String[] expiredModelIds = null;
         if (syncUpInput.isGetDeployedModels()) {
             deployedModelIds = mlModelManager.getLocalDeployedModels();
             List<String[]> localRunningDeployModel = mlTaskManager.getLocalRunningDeployModelTasks();
             runningDeployModelTaskIds = localRunningDeployModel.get(0);
             runningDeployModelIds = localRunningDeployModel.get(1);
+            expiredModelIds = mlModelManager.getExpiredModels();
         }
 
         if (syncUpInput.isClearRoutingTable()) {
@@ -186,7 +188,8 @@ public class TransportSyncUpOnNodeAction extends
             "ok",
             deployedModelIds,
             runningDeployModelIds,
-            runningDeployModelTaskIds
+            runningDeployModelTaskIds,
+            expiredModelIds
         );
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
@@ -140,7 +140,8 @@ public class MLSyncUpCron implements Runnable {
 
             Set<String> modelsToUndeploy = new HashSet<>();
             for (String modelId : expiredModelToNodes.keySet()) {
-                if (expiredModelToNodes.get(modelId).size() == modelWorkerNodes.get(modelId).size()) {
+                if (modelWorkerNodes.containsKey(modelId)
+                    && expiredModelToNodes.get(modelId).size() == modelWorkerNodes.get(modelId).size()) {
                     // this model has expired in all the nodes
                     modelWorkerNodes.remove(modelId);
                     modelsToUndeploy.add(modelId);

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
@@ -140,7 +140,7 @@ public class MLSyncUpCron implements Runnable {
 
             Set<String> modelsToUndeploy = new HashSet<>();
             for (String modelId : expiredModelToNodes.keySet()) {
-                if (expiredModelToNodes.get(modelId) == modelWorkerNodes.get(modelId)) {
+                if (expiredModelToNodes.get(modelId).size() == modelWorkerNodes.get(modelId).size()) {
                     // this model has expired in all the nodes
                     modelWorkerNodes.remove(modelId);
                     modelsToUndeploy.add(modelId);
@@ -194,7 +194,6 @@ public class MLSyncUpCron implements Runnable {
                 targetNodeIds,
                 new String[] { modelId }
             );
-
             client.execute(MLUndeployModelAction.INSTANCE, mlUndeployModelNodesRequest, ActionListener.wrap(r -> {
                 log.debug("model {} is un_deployed", modelId);
             }, e -> { log.error("Failed to undeploy model {}", modelId, e); }));

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.model;
 
+import java.time.Instant;
 import java.util.DoubleSummaryStatistics;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +52,7 @@ public class MLModelCache {
     // In rare case, this could be null, e.g. model info not synced up yet a predict request comes in.
     @Setter
     private Boolean deployToAllNodes;
+    private @Setter(AccessLevel.PROTECTED) @Getter(AccessLevel.PROTECTED) Instant lastAccessTime;
 
     public MLModelCache() {
         targetWorkerNodes = ConcurrentHashMap.newKeySet();

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
@@ -357,14 +357,14 @@ public class MLModelCacheHelper {
                 return false;  // no TTL, never expire
             }
             Duration liveDuration = Duration.between(entry.getValue().getLastAccessTime(), Instant.now());
-            Long ttlInHour = mlModel.getDeploySetting().getModelTTLInHours();
             Long ttlInMinutes = mlModel.getDeploySetting().getModelTTLInMinutes();
-            if (ttlInHour < 0 || ttlInMinutes < 0) {
+            if (ttlInMinutes < 0) {
                 return false;
             }
-            Duration ttl = Duration.ofHours(ttlInHour).plusMinutes(ttlInMinutes);
-            boolean isModelExpired = liveDuration.getSeconds() > ttl.getSeconds();
-            return isModelExpired && mlModel.getModelState() == MLModelState.DEPLOYED;
+            Duration ttl = Duration.ofMinutes(ttlInMinutes);
+            boolean isModelExpired = liveDuration.getSeconds() >= ttl.getSeconds();
+            return isModelExpired
+                && (mlModel.getModelState() == MLModelState.DEPLOYED || mlModel.getModelState() == MLModelState.PARTIALLY_DEPLOYED);
         }).map(entry -> entry.getKey()).collect(Collectors.toList()).toArray(new String[0]);
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -967,6 +967,7 @@ public class MLModelManager {
                 log.info("Set new target node ids {} for model {}", Arrays.toString(workerNodes.toArray(new String[0])), modelId);
                 modelCacheHelper.setDeployToAllNodes(modelId, deployToAllNodes);
                 modelCacheHelper.setTargetWorkerNodes(modelId, workerNodes);
+                modelCacheHelper.refreshLastAccessTime(modelId);
             }
             listener.onResponse("successful");
             return;
@@ -1041,6 +1042,7 @@ public class MLModelManager {
                             modelCacheHelper.setMLExecutor(modelId, mlExecutable);
                             mlStats.getStat(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT).increment();
                             modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
+                            modelCacheHelper.refreshLastAccessTime(modelId);
                             wrappedListener.onResponse("successful");
                         } catch (Exception e) {
                             log.error("Failed to add predictor to cache", e);
@@ -1053,6 +1055,7 @@ public class MLModelManager {
                             modelCacheHelper.setPredictor(modelId, predictable);
                             mlStats.getStat(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT).increment();
                             modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
+                            modelCacheHelper.refreshLastAccessTime(modelId);
                             Long modelContentSizeInBytes = mlModel.getModelContentSizeInBytes();
                             long contentSize = modelContentSizeInBytes == null
                                 ? mlModel.getTotalChunks() * CHUNK_SIZE
@@ -1105,6 +1108,7 @@ public class MLModelManager {
             setupParamsAndPredictable(modelId, mlModel);
             mlStats.getStat(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT).increment();
             modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
+            modelCacheHelper.refreshLastAccessTime(modelId);
             wrappedListener.onResponse("successful");
             return;
         }
@@ -1114,6 +1118,7 @@ public class MLModelManager {
             setupParamsAndPredictable(modelId, mlModel);
             mlStats.getStat(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT).increment();
             modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
+            modelCacheHelper.refreshLastAccessTime(modelId);
             wrappedListener.onResponse("successful");
             log.info("Completed setting connector {} in the model {}", mlModel.getConnectorId(), modelId);
         }, wrappedListener::onFailure));
@@ -1855,6 +1860,10 @@ public class MLModelManager {
      */
     public String[] getLocalDeployedModels() {
         return modelCacheHelper.getDeployedModels();
+    }
+
+    public String[] getExpiredModels() {
+        return modelCacheHelper.getExpiredModels();
     }
 
     /**

--- a/plugin/src/test/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeActionTests.java
@@ -171,12 +171,14 @@ public class TransportSyncUpOnNodeActionTests extends OpenSearchTestCase {
         String[] deployedModelIds = new String[] { "123" };
         String[] runningDeployModelIds = new String[] { "model1" };
         String[] runningDeployModelTaskIds = new String[] { "1" };
+        String[] expiredModelIds = new String[] { "modelExpired" };
         MLSyncUpNodeResponse response = new MLSyncUpNodeResponse(
             mlNode1,
             "DEPLOYED",
             deployedModelIds,
             runningDeployModelIds,
-            runningDeployModelTaskIds
+            runningDeployModelTaskIds,
+            expiredModelIds
         );
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
@@ -415,7 +415,18 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
             String[] deployedModelIds = new String[] { randomAlphaOfLength(10) };
             String[] runningDeployModelIds = new String[] { randomAlphaOfLength(10) };
             String[] runningDeployModelTaskIds = new String[] { randomAlphaOfLength(10) };
-            nodeResponses.add(new MLSyncUpNodeResponse(mlNode1, "ok", deployedModelIds, runningDeployModelIds, runningDeployModelTaskIds));
+            String[] expiredModelIds = new String[] { randomAlphaOfLength(10) };
+            nodeResponses
+                .add(
+                    new MLSyncUpNodeResponse(
+                        mlNode1,
+                        "ok",
+                        deployedModelIds,
+                        runningDeployModelIds,
+                        runningDeployModelTaskIds,
+                        expiredModelIds
+                    )
+                );
             MLSyncUpNodesResponse response = new MLSyncUpNodesResponse(ClusterName.DEFAULT, nodeResponses, Arrays.asList());
             listener.onResponse(response);
             return null;


### PR DESCRIPTION
### Description
Reuse the current cron job and transport APIs to implement auto-undeploy ML_Models based on TTL after any model is un-used for a certain time. This is to mate the automatic remote model deployment and save memory for long idling local models. Verified in a single host cluster. Will verify in bigger cluster. 
 
### Issues Resolved
[https://github.com/opensearch-project/ml-commons/issues/1343] , https://github.com/opensearch-project/ml-commons/issues/1148

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
