### PR TITLE
[Backport 2.x] Change httpclient to async (#1958)

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -63,12 +63,13 @@ dependencies {
         }
     }
 
-    implementation platform('software.amazon.awssdk:bom:2.21.15')
+    implementation platform('software.amazon.awssdk:bom:2.25.40')
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:apache-client'
     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
     implementation 'com.jayway.jsonpath:json-path:2.9.0'
     implementation group: 'org.json', name: 'json', version: '20231013'
+    implementation group: 'software.amazon.awssdk', name: 'netty-nio-client', version: '2.25.40'
 }
 
 lombok {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/Predictable.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/Predictable.java
@@ -7,9 +7,11 @@ package org.opensearch.ml.engine;
 
 import java.util.Map;
 
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.MLOutput;
+import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.engine.encryptor.Encryptor;
 
 /**
@@ -31,7 +33,13 @@ public interface Predictable {
      * @param mlInput input data
      * @return predicted results
      */
-    MLOutput predict(MLInput mlInput);
+    default MLOutput predict(MLInput mlInput) {
+        throw new IllegalStateException("Method is not implemented");
+    }
+
+    default void asyncPredict(MLInput mlInput, ActionListener<MLTaskResponse> actionListener) {
+        actionListener.onFailure(new IllegalStateException("Method is not implemented"));
+    }
 
     /**
      * Init model (load model into memory) with ML model content and params.

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
@@ -15,6 +15,8 @@ import static org.opensearch.ml.common.utils.StringUtils.processTextDocs;
 import static org.opensearch.ml.engine.utils.ScriptUtils.executePostProcessFunction;
 
 import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +36,7 @@ import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.script.ScriptService;
@@ -46,7 +49,9 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.regions.Region;
 
 @Log4j2
@@ -179,10 +184,14 @@ public class ConnectorUtils {
         String modelResponse,
         Connector connector,
         ScriptService scriptService,
-        Map<String, String> parameters
+        Map<String, String> parameters,
+        MLGuard mlGuard
     ) throws IOException {
         if (modelResponse == null) {
             throw new IllegalArgumentException("model response is null");
+        }
+        if (mlGuard != null && !mlGuard.validate(modelResponse, MLGuard.Type.OUTPUT)) {
+            throw new IllegalArgumentException("guardrails triggered for LLM output");
         }
         List<ModelTensor> modelTensors = new ArrayList<>();
         Optional<ConnectorAction> predictAction = connector.findPredictAction();
@@ -251,5 +260,43 @@ public class ConnectorUtils {
             .build();
 
         return signer.sign(request, params);
+    }
+
+    public static SdkHttpFullRequest buildSdkRequest(
+        Connector connector,
+        Map<String, String> parameters,
+        String payload,
+        SdkHttpMethod method
+    ) {
+        String charset = parameters.getOrDefault("charset", "UTF-8");
+        RequestBody requestBody;
+        if (payload != null) {
+            requestBody = RequestBody.fromString(payload, Charset.forName(charset));
+        } else {
+            requestBody = RequestBody.empty();
+        }
+        if (SdkHttpMethod.POST == method && 0 == requestBody.optionalContentLength().get()) {
+            log.error("Content length is 0. Aborting request to remote model");
+            throw new IllegalArgumentException("Content length is 0. Aborting request to remote model");
+        }
+        String endpoint = connector.getPredictEndpoint(parameters);
+        SdkHttpFullRequest.Builder builder = SdkHttpFullRequest
+            .builder()
+            .method(method)
+            .uri(URI.create(endpoint))
+            .contentStreamProvider(requestBody.contentStreamProvider());
+        Map<String, String> headers = connector.getDecryptedHeaders();
+        if (headers != null) {
+            for (String key : headers.keySet()) {
+                builder.putHeader(key, headers.get(key));
+            }
+        }
+        if (builder.matchingHeaders("Content-Type").isEmpty()) {
+            builder.putHeader("Content-Type", "application/json");
+        }
+        if (builder.matchingHeaders("Content-Length").isEmpty()) {
+            builder.putHeader("Content-Length", requestBody.optionalContentLength().get().toString());
+        }
+        return builder.build();
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ExecutionContext.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ExecutionContext.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.ml.engine.algorithms.remote;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * This class encapsulates several parameters that are used in a split-batch request case.
+ * A batch request is that in neural-search side multiple fields are send in one request to ml-commons,
+ * but the remote model doesn't accept list of string inputs so in ml-commons the request needs split.
+ * sequence is used to identify the index of the split request.
+ * countDownLatch is used to wait for all the split requests to finish.
+ * exceptionHolder is used to hold any exception thrown in a split-batch request.
+ */
+@Data
+@AllArgsConstructor
+public class ExecutionContext {
+    // Should never be null
+    private int sequence;
+    private CountDownLatch countDownLatch;
+    // This is to hold any exception thrown in a split-batch request
+    private AtomicReference<Exception> exceptionHolder;
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
@@ -1,0 +1,192 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.ml.engine.algorithms.remote;
+
+import static org.opensearch.ml.common.CommonValue.REMOTE_SERVICE_ERROR;
+import static org.opensearch.ml.engine.algorithms.remote.ConnectorUtils.processOutput;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.util.Strings;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.exception.MLException;
+import org.opensearch.ml.common.model.MLGuard;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.script.ScriptService;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+
+@Log4j2
+public class MLSdkAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandler {
+    @Getter
+    private Integer statusCode;
+    @Getter
+    private final StringBuilder responseBody = new StringBuilder();
+
+    private final ExecutionContext executionContext;
+
+    private final ActionListener<List<ModelTensors>> actionListener;
+
+    private final Map<String, String> parameters;
+
+    private final Map<Integer, ModelTensors> tensorOutputs;
+
+    private final Connector connector;
+
+    private final ScriptService scriptService;
+
+    private final MLGuard mlGuard;
+
+    public MLSdkAsyncHttpResponseHandler(
+        ExecutionContext executionContext,
+        ActionListener<List<ModelTensors>> actionListener,
+        Map<String, String> parameters,
+        Map<Integer, ModelTensors> tensorOutputs,
+        Connector connector,
+        ScriptService scriptService,
+        MLGuard mlGuard
+    ) {
+        this.executionContext = executionContext;
+        this.actionListener = actionListener;
+        this.parameters = parameters;
+        this.tensorOutputs = tensorOutputs;
+        this.connector = connector;
+        this.scriptService = scriptService;
+        this.mlGuard = mlGuard;
+    }
+
+    @Override
+    public void onHeaders(SdkHttpResponse response) {
+        SdkHttpFullResponse sdkResponse = (SdkHttpFullResponse) response;
+        log.debug("received response headers: " + sdkResponse.headers());
+        this.statusCode = sdkResponse.statusCode();
+    }
+
+    @Override
+    public void onStream(Publisher<ByteBuffer> stream) {
+        stream.subscribe(new MLResponseSubscriber());
+    }
+
+    @Override
+    public void onError(Throwable error) {
+        log.error(error.getMessage(), error);
+        RestStatus status = (statusCode == null) ? RestStatus.INTERNAL_SERVER_ERROR : RestStatus.fromCode(statusCode);
+        String errorMessage = "Error communicating with remote model: " + error.getMessage();
+        actionListener.onFailure(new OpenSearchStatusException(errorMessage, status));
+    }
+
+    private void processResponse(
+        Integer statusCode,
+        String body,
+        Map<String, String> parameters,
+        Map<Integer, ModelTensors> tensorOutputs
+    ) {
+        if (Strings.isBlank(body)) {
+            log.error("Remote model response body is empty!");
+            if (executionContext.getExceptionHolder().get() == null) {
+                executionContext
+                    .getExceptionHolder()
+                    .compareAndSet(null, new OpenSearchStatusException("No response from model", RestStatus.BAD_REQUEST));
+            }
+        } else {
+            if (statusCode < HttpStatus.SC_OK || statusCode > HttpStatus.SC_MULTIPLE_CHOICES) {
+                log.error("Remote server returned error code: {}", statusCode);
+                if (executionContext.getExceptionHolder().get() == null) {
+                    executionContext
+                        .getExceptionHolder()
+                        .compareAndSet(null, new OpenSearchStatusException(REMOTE_SERVICE_ERROR + body, RestStatus.fromCode(statusCode)));
+                }
+            } else {
+                try {
+                    ModelTensors tensors = processOutput(body, connector, scriptService, parameters, mlGuard);
+                    tensors.setStatusCode(statusCode);
+                    tensorOutputs.put(executionContext.getSequence(), tensors);
+                } catch (Exception e) {
+                    log.error("Failed to process response body: {}", body, e);
+                    if (executionContext.getExceptionHolder().get() == null) {
+                        executionContext
+                            .getExceptionHolder()
+                            .compareAndSet(null, new MLException("Fail to execute predict in aws connector", e));
+                    }
+                }
+            }
+        }
+    }
+
+    // Only all requests successful case will be processed here.
+    private void reOrderTensorResponses(Map<Integer, ModelTensors> tensorOutputs) {
+        ModelTensors[] modelTensors = new ModelTensors[tensorOutputs.size()];
+        log.debug("Reordered tensor outputs size is {}", tensorOutputs.size());
+        for (Map.Entry<Integer, ModelTensors> entry : tensorOutputs.entrySet()) {
+            modelTensors[entry.getKey()] = entry.getValue();
+        }
+        actionListener.onResponse(Arrays.asList(modelTensors));
+    }
+
+    protected class MLResponseSubscriber implements Subscriber<ByteBuffer> {
+        private Subscription subscription;
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            this.subscription = s;
+            s.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+            responseBody.append(StandardCharsets.UTF_8.decode(byteBuffer));
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            log
+                .error(
+                    "Error on receiving response body from remote: {}",
+                    t instanceof NullPointerException ? "NullPointerException" : t.getMessage(),
+                    t
+                );
+            response(tensorOutputs);
+        }
+
+        @Override
+        public void onComplete() {
+            response(tensorOutputs);
+        }
+    }
+
+    private void response(Map<Integer, ModelTensors> tensors) {
+        processResponse(statusCode, responseBody.toString(), parameters, tensorOutputs);
+        executionContext.getCountDownLatch().countDown();
+        // when countdown's count equals to 0 means all responses are received.
+        if (executionContext.getCountDownLatch().getCount() == 0) {
+            if (executionContext.getExceptionHolder().get() != null) {
+                actionListener.onFailure(executionContext.getExceptionHolder().get());
+                return;
+            }
+            reOrderTensorResponses(tensors);
+        } else {
+            log.debug("Not all responses received, left response count is: " + executionContext.getCountDownLatch().getCount());
+        }
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.util.TokenBucket;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
@@ -18,6 +19,7 @@ import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.output.MLOutput;
+import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.engine.MLEngineClassLoader;
 import org.opensearch.ml.engine.Predictable;
 import org.opensearch.ml.engine.annotation.Function;
@@ -55,18 +57,22 @@ public class RemoteModel implements Predictable {
     }
 
     @Override
-    public MLOutput predict(MLInput mlInput) {
+    public void asyncPredict(MLInput mlInput, ActionListener<MLTaskResponse> actionListener) {
         if (!isModelReady()) {
-            throw new IllegalArgumentException("Model not ready yet. Please run this first: POST /_plugins/_ml/models/<model_id>/_deploy");
+            actionListener
+                .onFailure(
+                    new IllegalArgumentException("Model not ready yet. Please run this first: POST /_plugins/_ml/models/<model_id>/_deploy")
+                );
+            return;
         }
         try {
-            return connectorExecutor.executePredict(mlInput);
+            connectorExecutor.executePredict(mlInput, actionListener);
         } catch (RuntimeException e) {
             log.error("Failed to call remote model.", e);
-            throw e;
+            actionListener.onFailure(e);
         } catch (Throwable e) {
             log.error("Failed to call remote model.", e);
-            throw new MLException(e);
+            actionListener.onFailure(new MLException(e));
         }
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
@@ -5,57 +5,47 @@
 
 package org.opensearch.ml.engine.algorithms.remote;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.connector.AbstractConnector.ACCESS_KEY_FIELD;
 import static org.opensearch.ml.common.connector.AbstractConnector.SECRET_KEY_FIELD;
 import static org.opensearch.ml.common.connector.HttpConnector.REGION_FIELD;
 import static org.opensearch.ml.common.connector.HttpConnector.SERVICE_NAME_FIELD;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.OpenSearchStatusException;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.connector.AwsConnector;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
-import org.opensearch.ml.common.connector.ConnectorClientConfig;
 import org.opensearch.ml.common.connector.MLPreProcessFunction;
 import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
-import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.engine.encryptor.Encryptor;
 import org.opensearch.ml.engine.encryptor.EncryptorImpl;
-import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ThreadPool;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
-import software.amazon.awssdk.http.AbortableInputStream;
-import software.amazon.awssdk.http.ExecutableHttpRequest;
-import software.amazon.awssdk.http.HttpExecuteResponse;
-import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.SdkHttpResponse;
 
 public class AwsConnectorExecutorTest {
 
@@ -73,16 +63,7 @@ public class AwsConnectorExecutorTest {
     ThreadContext threadContext;
 
     @Mock
-    ScriptService scriptService;
-
-    @Mock
-    SdkHttpClient httpClient;
-
-    @Mock
-    ExecutableHttpRequest httpRequest;
-
-    @Mock
-    HttpExecuteResponse response;
+    ActionListener<MLTaskResponse> actionListener;
 
     Encryptor encryptor;
 
@@ -100,7 +81,7 @@ public class AwsConnectorExecutorTest {
             .builder()
             .actionType(ConnectorAction.ActionType.PREDICT)
             .method("POST")
-            .url("http://test.com/mock")
+            .url("http://openai.com/mock")
             .requestBody("{\"input\": \"${parameters.input}\"}")
             .build();
         AwsConnector
@@ -113,21 +94,12 @@ public class AwsConnectorExecutorTest {
     }
 
     @Test
-    public void executePredict_RemoteInferenceInput_NullResponse() throws IOException {
-        exceptionRule.expect(OpenSearchStatusException.class);
-        exceptionRule.expectMessage("No response from model");
-        when(response.responseBody()).thenReturn(Optional.empty());
-        when(httpRequest.call()).thenReturn(response);
-        SdkHttpResponse httpResponse = mock(SdkHttpResponse.class);
-        when(httpResponse.statusCode()).thenReturn(200);
-        when(response.httpResponse()).thenReturn(httpResponse);
-        when(httpClient.prepareRequest(any())).thenReturn(httpRequest);
-
+    public void executePredict_RemoteInferenceInput_EmptyIpAddress() {
         ConnectorAction predictAction = ConnectorAction
             .builder()
             .actionType(ConnectorAction.ActionType.PREDICT)
             .method("POST")
-            .url("http://test.com/mock")
+            .url("http:///mock")
             .requestBody("{\"input\": \"${parameters.input}\"}")
             .build();
         Map<String, String> credential = ImmutableMap
@@ -143,7 +115,7 @@ public class AwsConnectorExecutorTest {
             .actions(Arrays.asList(predictAction))
             .build();
         connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
         Settings settings = Settings.builder().build();
         threadContext = new ThreadContext(settings);
         when(executor.getClient()).thenReturn(client);
@@ -151,120 +123,20 @@ public class AwsConnectorExecutorTest {
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
         MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
-        executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
+        executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build(), actionListener);
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(actionListener, times(1)).onFailure(exceptionCaptor.capture());
+        assert exceptionCaptor.getValue() instanceof NullPointerException;
+        assertEquals("host must not be null.", exceptionCaptor.getValue().getMessage());
     }
 
     @Test
-    public void executePredict_RemoteInferenceInput_InvalidToken() throws IOException {
-        exceptionRule.expect(OpenSearchStatusException.class);
-        exceptionRule.expectMessage("{\"message\":\"The security token included in the request is invalid\"}");
-        String jsonString = "{\"message\":\"The security token included in the request is invalid\"}";
-        InputStream inputStream = new ByteArrayInputStream(jsonString.getBytes());
-        AbortableInputStream abortableInputStream = AbortableInputStream.create(inputStream);
-        when(response.responseBody()).thenReturn(Optional.of(abortableInputStream));
-        when(httpRequest.call()).thenReturn(response);
-        SdkHttpResponse httpResponse = mock(SdkHttpResponse.class);
-        when(httpResponse.statusCode()).thenReturn(403);
-        when(response.httpResponse()).thenReturn(httpResponse);
-        when(httpClient.prepareRequest(any())).thenReturn(httpRequest);
-
+    public void executePredict_TextDocsInferenceInput() {
         ConnectorAction predictAction = ConnectorAction
             .builder()
             .actionType(ConnectorAction.ActionType.PREDICT)
             .method("POST")
-            .url("http://test.com/mock")
-            .requestBody("{\"input\": \"${parameters.input}\"}")
-            .build();
-        Map<String, String> credential = ImmutableMap
-            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key"), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key"));
-        Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
-        Connector connector = AwsConnector
-            .awsConnectorBuilder()
-            .name("test connector")
-            .version("1")
-            .protocol("http")
-            .parameters(parameters)
-            .credential(credential)
-            .actions(Arrays.asList(predictAction))
-            .build();
-        connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
-        Settings settings = Settings.builder().build();
-        threadContext = new ThreadContext(settings);
-        when(executor.getClient()).thenReturn(client);
-        when(client.threadPool()).thenReturn(threadPool);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
-
-        MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
-        executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
-    }
-
-    @Test
-    public void executePredict_RemoteInferenceInput() throws IOException {
-        String jsonString = "{\"key\":\"value\"}";
-        InputStream inputStream = new ByteArrayInputStream(jsonString.getBytes());
-        AbortableInputStream abortableInputStream = AbortableInputStream.create(inputStream);
-        when(response.responseBody()).thenReturn(Optional.of(abortableInputStream));
-        SdkHttpResponse httpResponse = mock(SdkHttpResponse.class);
-        when(httpResponse.statusCode()).thenReturn(200);
-        when(response.httpResponse()).thenReturn(httpResponse);
-        when(httpRequest.call()).thenReturn(response);
-        when(httpClient.prepareRequest(any())).thenReturn(httpRequest);
-
-        ConnectorAction predictAction = ConnectorAction
-            .builder()
-            .actionType(ConnectorAction.ActionType.PREDICT)
-            .method("POST")
-            .url("http://test.com/mock")
-            .requestBody("{\"input\": \"${parameters.input}\"}")
-            .build();
-        Map<String, String> credential = ImmutableMap
-            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key"), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key"));
-        Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
-        Connector connector = AwsConnector
-            .awsConnectorBuilder()
-            .name("test connector")
-            .version("1")
-            .protocol("http")
-            .parameters(parameters)
-            .credential(credential)
-            .actions(Arrays.asList(predictAction))
-            .build();
-        connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
-        Settings settings = Settings.builder().build();
-        threadContext = new ThreadContext(settings);
-        when(executor.getClient()).thenReturn(client);
-        when(client.threadPool()).thenReturn(threadPool);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
-
-        MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
-        ModelTensorOutput modelTensorOutput = executor
-            .executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().size());
-        Assert.assertEquals("response", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getName());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap().size());
-        Assert.assertEquals("value", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap().get("key"));
-    }
-
-    @Test
-    public void executePredict_TextDocsInferenceInput() throws IOException {
-        String jsonString = "{\"key\":\"value\"}";
-        InputStream inputStream = new ByteArrayInputStream(jsonString.getBytes());
-        AbortableInputStream abortableInputStream = AbortableInputStream.create(inputStream);
-        when(response.responseBody()).thenReturn(Optional.of(abortableInputStream));
-        when(httpRequest.call()).thenReturn(response);
-        SdkHttpResponse httpResponse = mock(SdkHttpResponse.class);
-        when(httpResponse.statusCode()).thenReturn(200);
-        when(response.httpResponse()).thenReturn(httpResponse);
-        when(httpClient.prepareRequest(any())).thenReturn(httpRequest);
-
-        ConnectorAction predictAction = ConnectorAction
-            .builder()
-            .actionType(ConnectorAction.ActionType.PREDICT)
-            .method("POST")
-            .url("http://test.com/mock")
+            .url("http://openai.com/mock")
             .requestBody("{\"input\": ${parameters.input}}")
             .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
             .build();
@@ -281,7 +153,7 @@ public class AwsConnectorExecutorTest {
             .actions(Arrays.asList(predictAction))
             .build();
         connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
         Settings settings = Settings.builder().build();
         threadContext = new ThreadContext(settings);
         when(executor.getClient()).thenReturn(client);
@@ -289,28 +161,24 @@ public class AwsConnectorExecutorTest {
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
         MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(ImmutableList.of("input")).build();
-        ModelTensorOutput modelTensorOutput = executor
-            .executePredict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().size());
-        Assert.assertEquals("response", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getName());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap().size());
-        Assert.assertEquals("value", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap().get("key"));
+        executor
+            .executePredict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build(), actionListener);
     }
 
     @Test
-    public void test_initialize() {
+    public void executePredict_TextDocsInferenceInput_withStepSize() {
         ConnectorAction predictAction = ConnectorAction
             .builder()
             .actionType(ConnectorAction.ActionType.PREDICT)
             .method("POST")
-            .url("http://test.com/mock")
-            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .url("http://openai.com/mock")
+            .requestBody("{\"input\": ${parameters.input}}")
+            .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
             .build();
         Map<String, String> credential = ImmutableMap
             .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key"), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key"));
-        Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
-        ConnectorClientConfig httpClientConfig = new ConnectorClientConfig(20, 30000, 30000);
+        Map<String, String> parameters = ImmutableMap
+            .of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker", "input_docs_processed_step_size", "2");
         Connector connector = AwsConnector
             .awsConnectorBuilder()
             .name("test connector")
@@ -319,13 +187,99 @@ public class AwsConnectorExecutorTest {
             .parameters(parameters)
             .credential(credential)
             .actions(Arrays.asList(predictAction))
-            .connectorClientConfig(httpClientConfig)
             .build();
         connector.decrypt((c) -> encryptor.decrypt(c));
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector, httpClient));
-        Assert.assertEquals(20, executor.getConnector().getConnectorClientConfig().getMaxConnections().intValue());
-        Assert.assertEquals(30000, executor.getConnector().getConnectorClientConfig().getConnectionTimeout().intValue());
-        Assert.assertEquals(30000, executor.getConnector().getConnectorClientConfig().getReadTimeout().intValue());
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
+        Settings settings = Settings.builder().build();
+        threadContext = new ThreadContext(settings);
+        when(executor.getClient()).thenReturn(client);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
 
+        MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(ImmutableList.of("input1", "input2", "input3")).build();
+        executor
+            .executePredict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build(), actionListener);
+
+        MLInputDataset inputDataSet1 = TextDocsInputDataSet.builder().docs(ImmutableList.of("input1", "input2")).build();
+        executor
+            .executePredict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet1).build(), actionListener);
+    }
+
+    @Test
+    public void executePredict_RemoteInferenceInput_nullHttpClient_throwNPException() throws NoSuchFieldException, IllegalAccessException {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("http://openai.com/mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+        Map<String, String> credential = ImmutableMap
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key"), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key"));
+        Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
+        Connector connector = AwsConnector
+            .awsConnectorBuilder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .parameters(parameters)
+            .credential(credential)
+            .actions(Arrays.asList(predictAction))
+            .build();
+        connector.decrypt((c) -> encryptor.decrypt(c));
+        AwsConnectorExecutor executor0 = new AwsConnectorExecutor(connector);
+        Field httpClientField = AwsConnectorExecutor.class.getDeclaredField("httpClient");
+        httpClientField.setAccessible(true);
+        httpClientField.set(executor0, null);
+        AwsConnectorExecutor executor = spy(executor0);
+        Settings settings = Settings.builder().build();
+        threadContext = new ThreadContext(settings);
+        when(executor.getClient()).thenReturn(client);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
+        executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build(), actionListener);
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(actionListener, times(1)).onFailure(exceptionCaptor.capture());
+        assert exceptionCaptor.getValue() instanceof NullPointerException;
+    }
+
+    @Test
+    public void executePredict_RemoteInferenceInput_negativeStepSize_throwIllegalArgumentException() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("http://openai.com/mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+        Map<String, String> credential = ImmutableMap
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key"), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key"));
+        Map<String, String> parameters = ImmutableMap
+            .of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker", "input_docs_processed_step_size", "-1");
+        Connector connector = AwsConnector
+            .awsConnectorBuilder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .parameters(parameters)
+            .credential(credential)
+            .actions(Arrays.asList(predictAction))
+            .build();
+        connector.decrypt((c) -> encryptor.decrypt(c));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
+        Settings settings = Settings.builder().build();
+        threadContext = new ThreadContext(settings);
+        when(executor.getClient()).thenReturn(client);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(ImmutableList.of("input1", "input2", "input3")).build();
+        executor
+            .executePredict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build(), actionListener);
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(actionListener, times(1)).onFailure(exceptionCaptor.capture());
+        assert exceptionCaptor.getValue() instanceof IllegalArgumentException;
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
@@ -168,7 +168,7 @@ public class ConnectorUtilsTest {
     public void processOutput_NullResponse() throws IOException {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("model response is null");
-        ConnectorUtils.processOutput(null, null, null, null);
+        ConnectorUtils.processOutput(null, null, null, null, null);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class ConnectorUtilsTest {
             .build();
         String modelResponse =
             "{\"object\":\"list\",\"data\":[{\"object\":\"embedding\",\"index\":0,\"embedding\":[-0.014555434,-0.0002135904,0.0035105038]}],\"model\":\"text-embedding-ada-002-v2\",\"usage\":{\"prompt_tokens\":5,\"total_tokens\":5}}";
-        ModelTensors tensors = ConnectorUtils.processOutput(modelResponse, connector, scriptService, ImmutableMap.of());
+        ModelTensors tensors = ConnectorUtils.processOutput(modelResponse, connector, scriptService, ImmutableMap.of(), null);
         Assert.assertEquals(1, tensors.getMlModelTensors().size());
         Assert.assertEquals("response", tensors.getMlModelTensors().get(0).getName());
         Assert.assertEquals(4, tensors.getMlModelTensors().get(0).getDataAsMap().size());
@@ -224,7 +224,7 @@ public class ConnectorUtilsTest {
             .build();
         String modelResponse =
             "{\"object\":\"list\",\"data\":[{\"object\":\"embedding\",\"index\":0,\"embedding\":[-0.014555434,-0.0002135904,0.0035105038]}],\"model\":\"text-embedding-ada-002-v2\",\"usage\":{\"prompt_tokens\":5,\"total_tokens\":5}}";
-        ModelTensors tensors = ConnectorUtils.processOutput(modelResponse, connector, scriptService, ImmutableMap.of());
+        ModelTensors tensors = ConnectorUtils.processOutput(modelResponse, connector, scriptService, ImmutableMap.of(), null);
         Assert.assertEquals(1, tensors.getMlModelTensors().size());
         Assert.assertEquals("sentence_embedding", tensors.getMlModelTensors().get(0).getName());
         Assert.assertNull(tensors.getMlModelTensors().get(0).getDataAsMap());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
@@ -5,46 +5,34 @@
 
 package org.opensearch.ml.engine.algorithms.remote;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Arrays;
-import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.message.BasicStatusLine;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.OpenSearchStatusException;
-import org.opensearch.client.Client;
-import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.ingest.TestTemplateService;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.HttpConnector;
-import org.opensearch.ml.common.connector.MLPostProcessFunction;
-import org.opensearch.ml.common.connector.MLPreProcessFunction;
 import org.opensearch.ml.common.dataset.MLInputDataset;
-import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
-import org.opensearch.ml.common.output.model.ModelTensorOutput;
-import org.opensearch.script.ScriptService;
-import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.ml.common.output.model.ModelTensors;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -53,23 +41,7 @@ public class HttpJsonConnectorExecutorTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Mock
-    ThreadPool threadPool;
-
-    @Mock
-    ScriptService scriptService;
-
-    @Mock
-    CloseableHttpClient httpClient;
-
-    @Mock
-    Client client;
-
-    @Mock
-    CloseableHttpResponse response;
-
-    Settings settings;
-
-    ThreadContext threadContext;
+    private ActionListener<List<ModelTensors>> actionListener;
 
     @Before
     public void setUp() {
@@ -78,13 +50,11 @@ public class HttpJsonConnectorExecutorTest {
 
     @Test
     public void invokeRemoteModel_WrongHttpMethod() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("unsupported http method");
         ConnectorAction predictAction = ConnectorAction
             .builder()
             .actionType(ConnectorAction.ActionType.PREDICT)
             .method("wrong_method")
-            .url("http://test.com/mock")
+            .url("http://openai.com/mock")
             .requestBody("{\"input\": \"${parameters.input}\"}")
             .build();
         Connector connector = HttpConnector
@@ -94,17 +64,20 @@ public class HttpJsonConnectorExecutorTest {
             .protocol("http")
             .actions(Arrays.asList(predictAction))
             .build();
-        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector, httpClient);
-        executor.invokeRemoteModel(null, null, null, null);
+        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        executor.invokeRemoteModel(null, null, null, null, null, actionListener);
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(IllegalArgumentException.class);
+        Mockito.verify(actionListener, times(1)).onFailure(captor.capture());
+        assertEquals("unsupported http method", captor.getValue().getMessage());
     }
 
     @Test
-    public void executePredict_RemoteInferenceInput() throws IOException {
+    public void invokeRemoteModel_invalidIpAddress() {
         ConnectorAction predictAction = ConnectorAction
             .builder()
             .actionType(ConnectorAction.ActionType.PREDICT)
             .method("POST")
-            .url("http://test.com/mock")
+            .url("http://127.0.0.1/mock")
             .requestBody("{\"input\": \"${parameters.input}\"}")
             .build();
         Connector connector = HttpConnector
@@ -114,320 +87,146 @@ public class HttpJsonConnectorExecutorTest {
             .protocol("http")
             .actions(Arrays.asList(predictAction))
             .build();
-        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector, httpClient));
-        Settings settings = Settings.builder().build();
-        threadContext = new ThreadContext(settings);
-        when(executor.getClient()).thenReturn(client);
-        when(client.threadPool()).thenReturn(threadPool);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
-        when(httpClient.execute(any())).thenReturn(response);
-        HttpEntity entity = new StringEntity("{\"response\": \"test result\"}");
-        when(response.getEntity()).thenReturn(entity);
-        StatusLine statusLine = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
-        when(response.getStatusLine()).thenReturn(statusLine);
+        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        executor
+            .invokeRemoteModel(
+                createMLInput(),
+                new HashMap<>(),
+                "{\"input\": \"hello world\"}",
+                new HashMap<>(),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>()),
+                actionListener
+            );
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(IllegalArgumentException.class);
+        Mockito.verify(actionListener, times(1)).onFailure(captor.capture());
+        assert captor.getValue() instanceof IllegalArgumentException;
+        assertEquals("Remote inference host name has private ip address: 127.0.0.1", captor.getValue().getMessage());
+    }
+
+    @Test
+    public void invokeRemoteModel_Empty_payload() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("http://openai.com/mock")
+            .requestBody("")
+            .build();
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .build();
+        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        executor
+            .invokeRemoteModel(
+                createMLInput(),
+                new HashMap<>(),
+                null,
+                new HashMap<>(),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>()),
+                actionListener
+            );
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(IllegalArgumentException.class);
+        Mockito.verify(actionListener, times(1)).onFailure(captor.capture());
+        assert captor.getValue() instanceof IllegalArgumentException;
+        assertEquals("Content length is 0. Aborting request to remote model", captor.getValue().getMessage());
+    }
+
+    @Test
+    public void invokeRemoteModel_get_request() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("GET")
+            .url("http://openai.com/mock")
+            .requestBody("")
+            .build();
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .build();
+        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        executor
+            .invokeRemoteModel(
+                createMLInput(),
+                new HashMap<>(),
+                null,
+                new HashMap<>(),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>()),
+                actionListener
+            );
+    }
+
+    @Test
+    public void invokeRemoteModel_post_request() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("http://openai.com/mock")
+            .requestBody("hello world")
+            .build();
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .build();
+        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        executor
+            .invokeRemoteModel(
+                createMLInput(),
+                new HashMap<>(),
+                "hello world",
+                new HashMap<>(),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>()),
+                actionListener
+            );
+    }
+
+    @Test
+    public void invokeRemoteModel_nullHttpClient_throwMLException() throws NoSuchFieldException, IllegalAccessException {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("http://openai.com/mock")
+            .requestBody("hello world")
+            .build();
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .build();
+        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        Field httpClientField = HttpJsonConnectorExecutor.class.getDeclaredField("httpClient");
+        httpClientField.setAccessible(true);
+        httpClientField.set(executor, null);
+        executor
+            .invokeRemoteModel(
+                createMLInput(),
+                new HashMap<>(),
+                "hello world",
+                new HashMap<>(),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>()),
+                actionListener
+            );
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(argumentCaptor.capture());
+        assert argumentCaptor.getValue() instanceof NullPointerException;
+    }
+
+    private MLInput createMLInput() {
         MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
-        ModelTensorOutput modelTensorOutput = executor
-            .executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());
-        Assert.assertEquals("response", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getName());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap().size());
-        Assert
-            .assertEquals(
-                "test result",
-                modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap().get("response")
-            );
-    }
-
-    @Test
-    public void executePredict_TextDocsInput_NoPreprocessFunction() throws IOException {
-        ConnectorAction predictAction = ConnectorAction
-            .builder()
-            .actionType(ConnectorAction.ActionType.PREDICT)
-            .method("POST")
-            .url("http://test.com/mock")
-            .requestBody("{\"input\": ${parameters.input}}")
-            .build();
-        when(httpClient.execute(any())).thenReturn(response);
-        HttpEntity entity = new StringEntity("{\"response\": \"test result\"}");
-        when(response.getEntity()).thenReturn(entity);
-        StatusLine statusLine = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
-        when(response.getStatusLine()).thenReturn(statusLine);
-        Connector connector = HttpConnector
-            .builder()
-            .name("test connector")
-            .version("1")
-            .protocol("http")
-            .actions(Arrays.asList(predictAction))
-            .build();
-        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector, httpClient));
-        Settings settings = Settings.builder().build();
-        threadContext = new ThreadContext(settings);
-        when(executor.getClient()).thenReturn(client);
-        when(client.threadPool()).thenReturn(threadPool);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
-        MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test doc1", "test doc2")).build();
-        ModelTensorOutput modelTensorOutput = executor
-            .executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
-        Assert.assertEquals(2, modelTensorOutput.getMlModelOutputs().size());
-        Assert.assertEquals("response", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getName());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap().size());
-        Assert
-            .assertEquals(
-                "test result",
-                modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap().get("response")
-            );
-    }
-
-    @Test
-    public void executePredict_TextDocsInput_LimitExceed() throws IOException {
-        exceptionRule.expect(OpenSearchStatusException.class);
-        exceptionRule.expectMessage("{\"message\": \"Too many requests\"}");
-        ConnectorAction predictAction = ConnectorAction
-            .builder()
-            .actionType(ConnectorAction.ActionType.PREDICT)
-            .method("POST")
-            .url("http://test.com/mock")
-            .requestBody("{\"input\": ${parameters.input}}")
-            .build();
-        when(httpClient.execute(any())).thenReturn(response);
-        HttpEntity entity = new StringEntity("{\"message\": \"Too many requests\"}");
-        when(response.getEntity()).thenReturn(entity);
-        StatusLine statusLine = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 429, "OK");
-        when(response.getStatusLine()).thenReturn(statusLine);
-        Connector connector = HttpConnector
-            .builder()
-            .name("test connector")
-            .version("1")
-            .protocol("http")
-            .actions(Arrays.asList(predictAction))
-            .build();
-        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector, httpClient));
-        Settings settings = Settings.builder().build();
-        threadContext = new ThreadContext(settings);
-        when(executor.getClient()).thenReturn(client);
-        when(client.threadPool()).thenReturn(threadPool);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
-        MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test doc1", "test doc2")).build();
-        executor.executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
-    }
-
-    @Test
-    public void executePredict_TextDocsInput() throws IOException {
-        String preprocessResult1 = "{\"parameters\": { \"input\": \"test doc1\" } }";
-        String preprocessResult2 = "{\"parameters\": { \"input\": \"test doc2\" } }";
-        when(scriptService.compile(any(), any()))
-            .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult1))
-            .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult2));
-
-        ConnectorAction predictAction = ConnectorAction
-            .builder()
-            .actionType(ConnectorAction.ActionType.PREDICT)
-            .method("POST")
-            .url("http://test.com/mock")
-            .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
-            .postProcessFunction(MLPostProcessFunction.OPENAI_EMBEDDING)
-            .requestBody("{\"input\": ${parameters.input}}")
-            .build();
-        HttpConnector connector = HttpConnector
-            .builder()
-            .name("test connector")
-            .version("1")
-            .protocol("http")
-            .actions(Arrays.asList(predictAction))
-            .build();
-        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector, httpClient));
-        Settings settings = Settings.builder().build();
-        threadContext = new ThreadContext(settings);
-        when(executor.getClient()).thenReturn(client);
-        when(client.threadPool()).thenReturn(threadPool);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
-        executor.setScriptService(scriptService);
-        when(httpClient.execute(any())).thenReturn(response);
-        String modelResponse = "{\n"
-            + "    \"object\": \"list\",\n"
-            + "    \"data\": [\n"
-            + "        {\n"
-            + "            \"object\": \"embedding\",\n"
-            + "            \"index\": 0,\n"
-            + "            \"embedding\": [\n"
-            + "                -0.014555434,\n"
-            + "                -0.002135904,\n"
-            + "                0.0035105038\n"
-            + "            ]\n"
-            + "        },\n"
-            + "        {\n"
-            + "            \"object\": \"embedding\",\n"
-            + "            \"index\": 1,\n"
-            + "            \"embedding\": [\n"
-            + "                -0.014555434,\n"
-            + "                -0.002135904,\n"
-            + "                0.0035105038\n"
-            + "            ]\n"
-            + "        }\n"
-            + "    ],\n"
-            + "    \"model\": \"text-embedding-ada-002-v2\",\n"
-            + "    \"usage\": {\n"
-            + "        \"prompt_tokens\": 5,\n"
-            + "        \"total_tokens\": 5\n"
-            + "    }\n"
-            + "}";
-        StatusLine statusLine = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
-        when(response.getStatusLine()).thenReturn(statusLine);
-        HttpEntity entity = new StringEntity(modelResponse);
-        when(response.getEntity()).thenReturn(entity);
-        when(executor.getConnector()).thenReturn(connector);
-        MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test doc1", "test doc2")).build();
-        ModelTensorOutput modelTensorOutput = executor
-            .executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());
-        Assert.assertEquals(2, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().size());
-        Assert.assertEquals("sentence_embedding", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getName());
-        Assert
-            .assertArrayEquals(
-                new Number[] { -0.014555434, -0.002135904, 0.0035105038 },
-                modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getData()
-            );
-        Assert
-            .assertArrayEquals(
-                new Number[] { -0.014555434, -0.002135904, 0.0035105038 },
-                modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(1).getData()
-            );
-    }
-
-    @Test
-    public void executePredict_TextDocsInput_LessEmbeddingThanInputDocs() throws IOException {
-        String preprocessResult1 = "{\"parameters\": { \"input\": \"test doc1\" } }";
-        String preprocessResult2 = "{\"parameters\": { \"input\": \"test doc2\" } }";
-        when(scriptService.compile(any(), any()))
-            .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult1))
-            .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult2));
-
-        ConnectorAction predictAction = ConnectorAction
-            .builder()
-            .actionType(ConnectorAction.ActionType.PREDICT)
-            .method("POST")
-            .url("http://test.com/mock")
-            .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
-            .postProcessFunction(MLPostProcessFunction.OPENAI_EMBEDDING)
-            .requestBody("{\"input\": ${parameters.input}}")
-            .build();
-        Map<String, String> parameters = ImmutableMap.of("input_docs_processed_step_size", "2");
-        HttpConnector connector = HttpConnector
-            .builder()
-            .name("test connector")
-            .version("1")
-            .protocol("http")
-            .parameters(parameters)
-            .actions(Arrays.asList(predictAction))
-            .build();
-        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector, httpClient));
-        Settings settings = Settings.builder().build();
-        threadContext = new ThreadContext(settings);
-        when(executor.getClient()).thenReturn(client);
-        when(client.threadPool()).thenReturn(threadPool);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
-        executor.setScriptService(scriptService);
-        when(httpClient.execute(any())).thenReturn(response);
-        // model takes 2 input docs, but only output 1 embedding
-        String modelResponse = "{\n"
-            + "    \"object\": \"list\",\n"
-            + "    \"data\": [\n"
-            + "        {\n"
-            + "            \"object\": \"embedding\",\n"
-            + "            \"index\": 0,\n"
-            + "            \"embedding\": [\n"
-            + "                -0.014555434,\n"
-            + "                -0.002135904,\n"
-            + "                0.0035105038\n"
-            + "            ]\n"
-            + "        }    ],\n"
-            + "    \"model\": \"text-embedding-ada-002-v2\",\n"
-            + "    \"usage\": {\n"
-            + "        \"prompt_tokens\": 5,\n"
-            + "        \"total_tokens\": 5\n"
-            + "    }\n"
-            + "}";
-        StatusLine statusLine = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
-        when(response.getStatusLine()).thenReturn(statusLine);
-        HttpEntity entity = new StringEntity(modelResponse);
-        when(response.getEntity()).thenReturn(entity);
-        when(executor.getConnector()).thenReturn(connector);
-        MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test doc1", "test doc2")).build();
-        ModelTensorOutput modelTensorOutput = executor
-            .executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().size());
-        Assert.assertEquals(1, modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().size());
-        Assert.assertEquals("sentence_embedding", modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getName());
-        Assert
-            .assertArrayEquals(
-                new Number[] { -0.014555434, -0.002135904, 0.0035105038 },
-                modelTensorOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getData()
-            );
-    }
-
-    @Test
-    public void executePredict_TextDocsInput_LessEmbeddingThanInputDocs_InvalidStepSize() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Invalid parameter: input_docs_processed_step_size. It must be positive integer.");
-        String preprocessResult1 = "{\"parameters\": { \"input\": \"test doc1\" } }";
-        String preprocessResult2 = "{\"parameters\": { \"input\": \"test doc2\" } }";
-        when(scriptService.compile(any(), any()))
-            .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult1))
-            .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult2));
-
-        ConnectorAction predictAction = ConnectorAction
-            .builder()
-            .actionType(ConnectorAction.ActionType.PREDICT)
-            .method("POST")
-            .url("http://test.com/mock")
-            .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
-            .postProcessFunction(MLPostProcessFunction.OPENAI_EMBEDDING)
-            .requestBody("{\"input\": ${parameters.input}}")
-            .build();
-        // step size must be positive integer, here we set it as -1, should trigger IllegalArgumentException
-        Map<String, String> parameters = ImmutableMap.of("input_docs_processed_step_size", "-1");
-        HttpConnector connector = HttpConnector
-            .builder()
-            .name("test connector")
-            .version("1")
-            .protocol("http")
-            .parameters(parameters)
-            .actions(Arrays.asList(predictAction))
-            .build();
-        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector, httpClient));
-        Settings settings = Settings.builder().build();
-        threadContext = new ThreadContext(settings);
-        when(executor.getClient()).thenReturn(client);
-        when(client.threadPool()).thenReturn(threadPool);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
-        executor.setScriptService(scriptService);
-        when(httpClient.execute(any())).thenReturn(response);
-        // model takes 2 input docs, but only output 1 embedding
-        String modelResponse = "{\n"
-            + "    \"object\": \"list\",\n"
-            + "    \"data\": [\n"
-            + "        {\n"
-            + "            \"object\": \"embedding\",\n"
-            + "            \"index\": 0,\n"
-            + "            \"embedding\": [\n"
-            + "                -0.014555434,\n"
-            + "                -0.002135904,\n"
-            + "                0.0035105038\n"
-            + "            ]\n"
-            + "        }    ],\n"
-            + "    \"model\": \"text-embedding-ada-002-v2\",\n"
-            + "    \"usage\": {\n"
-            + "        \"prompt_tokens\": 5,\n"
-            + "        \"total_tokens\": 5\n"
-            + "    }\n"
-            + "}";
-        StatusLine statusLine = new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
-        when(response.getStatusLine()).thenReturn(statusLine);
-        HttpEntity entity = new StringEntity(modelResponse);
-        when(response.getEntity()).thenReturn(entity);
-        when(executor.getConnector()).thenReturn(connector);
-        MLInputDataset inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("test doc1", "test doc2")).build();
-        ModelTensorOutput modelTensorOutput = executor
-            .executePredict(MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build());
+        return MLInput.builder().inputDataset(inputDataSet).algorithm(FunctionName.REMOTE).build();
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
@@ -1,0 +1,422 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.ml.engine.algorithms.remote;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.ConnectorAction;
+import org.opensearch.ml.common.connector.HttpConnector;
+import org.opensearch.ml.common.connector.MLPostProcessFunction;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.script.ScriptService;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+
+import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
+
+public class MLSdkAsyncHttpResponseHandlerTest {
+    private final ExecutionContext executionContext = new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>());
+    @Mock
+    private ActionListener<List<ModelTensors>> actionListener;
+    @Mock
+    private Map<String, String> parameters;
+    private Map<Integer, ModelTensors> tensorOutputs = new ConcurrentHashMap<>();
+    private Connector connector;
+
+    private Connector noProcessFunctionConnector;
+
+    @Mock
+    private SdkHttpFullResponse sdkHttpResponse;
+    @Mock
+    private ScriptService scriptService;
+
+    private MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler;
+
+    MLSdkAsyncHttpResponseHandler.MLResponseSubscriber responseSubscriber;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(sdkHttpResponse.statusCode()).thenReturn(HttpStatusCode.OK);
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .postProcessFunction(MLPostProcessFunction.BEDROCK_EMBEDDING)
+            .url("http://test.com/mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+        connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .build();
+
+        ConnectorAction noProcessFunctionPredictAction = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("http://test.com/mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+        noProcessFunctionConnector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(noProcessFunctionPredictAction))
+            .build();
+        mlSdkAsyncHttpResponseHandler = new MLSdkAsyncHttpResponseHandler(
+            executionContext,
+            actionListener,
+            parameters,
+            tensorOutputs,
+            connector,
+            scriptService,
+            null
+        );
+        responseSubscriber = mlSdkAsyncHttpResponseHandler.new MLResponseSubscriber();
+    }
+
+    @Test
+    public void test_OnHeaders() {
+        mlSdkAsyncHttpResponseHandler.onHeaders(sdkHttpResponse);
+        assert mlSdkAsyncHttpResponseHandler.getStatusCode() == 200;
+    }
+
+    @Test
+    public void test_OnStream_with_postProcessFunction_bedRock() {
+        String response = "{\n"
+            + "    \"embedding\": [\n"
+            + "        0.46484375,\n"
+            + "        -0.017822266,\n"
+            + "        0.17382812,\n"
+            + "        0.10595703,\n"
+            + "        0.875,\n"
+            + "        0.19140625,\n"
+            + "        -0.36914062,\n"
+            + "        -0.0011978149\n"
+            + "    ]\n"
+            + "}";
+        Publisher<ByteBuffer> stream = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(response.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        test_OnHeaders(); // set the status code to non-null
+        mlSdkAsyncHttpResponseHandler.onStream(stream);
+        ArgumentCaptor<List<ModelTensors>> captor = ArgumentCaptor.forClass(List.class);
+        verify(actionListener).onResponse(captor.capture());
+        assert captor.getValue().size() == 1;
+        assert captor.getValue().get(0).getMlModelTensors().get(0).getData().length == 8;
+    }
+
+    @Test
+    public void test_OnStream_without_postProcessFunction() {
+        Publisher<ByteBuffer> stream = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap("{\"key\": \"hello world\"}".getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        MLSdkAsyncHttpResponseHandler noProcessFunctionMlSdkAsyncHttpResponseHandler = new MLSdkAsyncHttpResponseHandler(
+            executionContext,
+            actionListener,
+            parameters,
+            tensorOutputs,
+            noProcessFunctionConnector,
+            scriptService,
+            null
+        );
+        noProcessFunctionMlSdkAsyncHttpResponseHandler.onHeaders(sdkHttpResponse);
+        noProcessFunctionMlSdkAsyncHttpResponseHandler.onStream(stream);
+        ArgumentCaptor<List<ModelTensors>> captor = ArgumentCaptor.forClass(List.class);
+        verify(actionListener).onResponse(captor.capture());
+        assert captor.getValue().size() == 1;
+        assert captor.getValue().get(0).getMlModelTensors().get(0).getDataAsMap().get("key").equals("hello world");
+    }
+
+    @Test
+    public void test_onError() {
+        test_OnHeaders(); // set the status code to non-null
+        mlSdkAsyncHttpResponseHandler.onError(new RuntimeException("runtime exception"));
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assert captor.getValue() instanceof OpenSearchStatusException;
+        assert captor.getValue().getMessage().equals("Error communicating with remote model: runtime exception");
+    }
+
+    @Test
+    public void test_MLSdkAsyncHttpResponseHandler_onError() {
+        mlSdkAsyncHttpResponseHandler.onError(new Exception("error"));
+    }
+
+    @Test
+    public void test_onSubscribe() {
+        Subscription subscription = mock(Subscription.class);
+        responseSubscriber.onSubscribe(subscription);
+    }
+
+    @Test
+    public void test_onNext() {
+        test_onSubscribe();// set the subscription to non-null.
+        responseSubscriber.onNext(ByteBuffer.wrap("hello world".getBytes()));
+        assert mlSdkAsyncHttpResponseHandler.getResponseBody().toString().equals("hello world");
+    }
+
+    @Test
+    public void test_MLResponseSubscriber_onError() {
+        SdkHttpFullResponse response = mock(SdkHttpFullResponse.class);
+        when(response.statusCode()).thenReturn(500);
+        mlSdkAsyncHttpResponseHandler.onHeaders(response);
+        responseSubscriber.onError(new Exception("error"));
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(captor.capture());
+        assert captor.getValue() instanceof OpenSearchStatusException;
+        assert captor.getValue().getMessage().equals("No response from model");
+    }
+
+    @Test
+    public void test_onComplete_success() {
+        String response = "{\n"
+            + "    \"embedding\": [\n"
+            + "        0.46484375,\n"
+            + "        -0.017822266,\n"
+            + "        0.17382812,\n"
+            + "        0.10595703,\n"
+            + "        0.875,\n"
+            + "        0.19140625,\n"
+            + "        -0.36914062,\n"
+            + "        -0.0011978149\n"
+            + "    ]\n"
+            + "}";
+        mlSdkAsyncHttpResponseHandler.onHeaders(sdkHttpResponse);
+        Publisher<ByteBuffer> stream = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(response.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        mlSdkAsyncHttpResponseHandler.onStream(stream);
+        ArgumentCaptor<List<ModelTensors>> captor = ArgumentCaptor.forClass(List.class);
+        verify(actionListener).onResponse(captor.capture());
+        assert captor.getValue().size() == 1;
+        assert captor.getValue().get(0).getMlModelTensors().get(0).getData().length == 8;
+    }
+
+    @Test
+    public void test_onComplete_partial_success_exceptionSecond() {
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+        String response1 = "{\n"
+            + "    \"embedding\": [\n"
+            + "        0.46484375,\n"
+            + "        -0.017822266,\n"
+            + "        0.17382812,\n"
+            + "        0.10595703,\n"
+            + "        0.875,\n"
+            + "        0.19140625,\n"
+            + "        -0.36914062,\n"
+            + "        -0.0011978149\n"
+            + "    ]\n"
+            + "}";
+        String response2 = "Model current status is: FAILED";
+        CountDownLatch count = new CountDownLatch(2);
+        MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler1 = new MLSdkAsyncHttpResponseHandler(
+            new ExecutionContext(0, count, exceptionHolder),
+            actionListener,
+            parameters,
+            tensorOutputs,
+            connector,
+            scriptService,
+            null
+        );
+        MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler2 = new MLSdkAsyncHttpResponseHandler(
+            new ExecutionContext(1, count, exceptionHolder),
+            actionListener,
+            parameters,
+            tensorOutputs,
+            connector,
+            scriptService,
+            null
+        );
+        SdkHttpFullResponse sdkHttpResponse1 = mock(SdkHttpFullResponse.class);
+        when(sdkHttpResponse1.statusCode()).thenReturn(200);
+        mlSdkAsyncHttpResponseHandler1.onHeaders(sdkHttpResponse1);
+        Publisher<ByteBuffer> stream1 = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(response1.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        mlSdkAsyncHttpResponseHandler1.onStream(stream1);
+
+        SdkHttpFullResponse sdkHttpResponse2 = mock(SdkHttpFullResponse.class);
+        when(sdkHttpResponse2.statusCode()).thenReturn(500);
+        mlSdkAsyncHttpResponseHandler2.onHeaders(sdkHttpResponse2);
+        Publisher<ByteBuffer> stream2 = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(response2.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        mlSdkAsyncHttpResponseHandler2.onStream(stream2);
+        ArgumentCaptor<OpenSearchStatusException> captor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener, times(1)).onFailure(captor.capture());
+        assert captor.getValue().getMessage().equals("Error from remote service: Model current status is: FAILED");
+        assert captor.getValue().status().getStatus() == 500;
+    }
+
+    @Test
+    public void test_onComplete_partial_success_exceptionFirst() {
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+        String response1 = "{\n"
+            + "    \"embedding\": [\n"
+            + "        0.46484375,\n"
+            + "        -0.017822266,\n"
+            + "        0.17382812,\n"
+            + "        0.10595703,\n"
+            + "        0.875,\n"
+            + "        0.19140625,\n"
+            + "        -0.36914062,\n"
+            + "        -0.0011978149\n"
+            + "    ]\n"
+            + "}";
+        String response2 = "Model current status is: FAILED";
+        CountDownLatch count = new CountDownLatch(2);
+        MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler1 = new MLSdkAsyncHttpResponseHandler(
+            new ExecutionContext(0, count, exceptionHolder),
+            actionListener,
+            parameters,
+            tensorOutputs,
+            connector,
+            scriptService,
+            null
+        );
+        MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler2 = new MLSdkAsyncHttpResponseHandler(
+            new ExecutionContext(1, count, exceptionHolder),
+            actionListener,
+            parameters,
+            tensorOutputs,
+            connector,
+            scriptService,
+            null
+        );
+
+        SdkHttpFullResponse sdkHttpResponse2 = mock(SdkHttpFullResponse.class);
+        when(sdkHttpResponse2.statusCode()).thenReturn(500);
+        mlSdkAsyncHttpResponseHandler2.onHeaders(sdkHttpResponse2);
+        Publisher<ByteBuffer> stream2 = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(response2.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        mlSdkAsyncHttpResponseHandler2.onStream(stream2);
+
+        SdkHttpFullResponse sdkHttpResponse1 = mock(SdkHttpFullResponse.class);
+        when(sdkHttpResponse1.statusCode()).thenReturn(200);
+        mlSdkAsyncHttpResponseHandler1.onHeaders(sdkHttpResponse1);
+        Publisher<ByteBuffer> stream1 = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(response1.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        mlSdkAsyncHttpResponseHandler1.onStream(stream1);
+        ArgumentCaptor<OpenSearchStatusException> captor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener, times(1)).onFailure(captor.capture());
+        assert captor.getValue().getMessage().equals("Error from remote service: Model current status is: FAILED");
+        assert captor.getValue().status().getStatus() == 500;
+    }
+
+    @Test
+    public void test_onComplete_empty_response_body() {
+        mlSdkAsyncHttpResponseHandler.onHeaders(sdkHttpResponse);
+        Publisher<ByteBuffer> stream = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap("".getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        mlSdkAsyncHttpResponseHandler.onStream(stream);
+        ArgumentCaptor<OpenSearchStatusException> captor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener, times(1)).onFailure(captor.capture());
+        assert captor.getValue().getMessage().equals("No response from model");
+    }
+
+    @Test
+    public void test_onComplete_error_http_status() {
+        String error = "{\"message\": \"runtime error\"}";
+        SdkHttpResponse response = mock(SdkHttpFullResponse.class);
+        when(response.statusCode()).thenReturn(HttpStatusCode.INTERNAL_SERVER_ERROR);
+        mlSdkAsyncHttpResponseHandler.onHeaders(response);
+        Publisher<ByteBuffer> stream = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(error.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        mlSdkAsyncHttpResponseHandler.onStream(stream);
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(captor.capture());
+        assert captor.getValue() instanceof OpenSearchStatusException;
+        System.out.println(captor.getValue().getMessage());
+        assert captor.getValue().getMessage().contains("runtime error");
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
@@ -5,9 +5,12 @@
 
 package org.opensearch.ml.engine.algorithms.remote;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -18,14 +21,17 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.ConnectorProtocols;
 import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.engine.encryptor.Encryptor;
 import org.opensearch.ml.engine.encryptor.EncryptorImpl;
 
@@ -60,20 +66,36 @@ public class RemoteModelTest {
     }
 
     @Test
-    public void predict_NullConnectorExecutor() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Model not ready yet");
+    public void test_predict_throw_IllegalStateException() {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage("Method is not implemented");
         remoteModel.predict(mlInput);
     }
 
     @Test
+    public void predict_NullConnectorExecutor() {
+        ActionListener<MLTaskResponse> actionListener = mock(ActionListener.class);
+        remoteModel.asyncPredict(mlInput, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assert argumentCaptor.getValue() instanceof RuntimeException;
+        assertEquals(
+            "Model not ready yet. Please run this first: POST /_plugins/_ml/models/<model_id>/_deploy",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    @Test
     public void predict_ModelDeployed_WrongInput() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("pre_process_function not defined in connector");
         Connector connector = createConnector(ImmutableMap.of("Authorization", "Bearer ${credential.key}"));
         when(mlModel.getConnector()).thenReturn(connector);
         remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
-        remoteModel.predict(mlInput);
+        ActionListener<MLTaskResponse> actionListener = mock(ActionListener.class);
+        remoteModel.asyncPredict(mlInput, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assert argumentCaptor.getValue() instanceof RuntimeException;
+        assertEquals("pre_process_function not defined in connector", argumentCaptor.getValue().getMessage());
     }
 
     @Test
@@ -105,8 +127,8 @@ public class RemoteModelTest {
         Assert.assertNotNull(executor);
         Assert.assertNull(decryptedHeaders);
         Assert.assertNotNull(executor.getConnector().getDecryptedHeaders());
-        Assert.assertEquals(1, executor.getConnector().getDecryptedHeaders().size());
-        Assert.assertEquals("Bearer test_api_key", executor.getConnector().getDecryptedHeaders().get("Authorization"));
+        assertEquals(1, executor.getConnector().getDecryptedHeaders().size());
+        assertEquals("Bearer test_api_key", executor.getConnector().getDecryptedHeaders().get("Authorization"));
 
         remoteModel.close();
         Assert.assertNull(remoteModel.getConnectorExecutor());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/TextEmbeddingDenseModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/TextEmbeddingDenseModelTest.java
@@ -8,6 +8,8 @@ package org.opensearch.ml.engine.algorithms.text_embedding;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.opensearch.ml.common.model.TextEmbeddingModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS;
 import static org.opensearch.ml.common.model.TextEmbeddingModelConfig.FrameworkType.SENTENCE_TRANSFORMERS;
 import static org.opensearch.ml.engine.algorithms.text_embedding.TextEmbeddingDenseModel.ML_ENGINE;
@@ -30,7 +32,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
 import org.opensearch.ResourceNotFoundException;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
@@ -625,6 +629,16 @@ public class TextEmbeddingDenseModelTest {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("model not deployed");
         textEmbeddingDenseModel.predict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build(), model);
+    }
+
+    @Test
+    public void test_async_inference() {
+        ArgumentCaptor<IllegalStateException> captor = ArgumentCaptor.forClass(IllegalStateException.class);
+        ActionListener actionListener = mock(ActionListener.class);
+        textEmbeddingDenseModel
+            .asyncPredict(MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build(), actionListener);
+        verify(actionListener).onFailure(captor.capture());
+        assert captor.getValue().getMessage().equals("Method is not implemented");
     }
 
     @After

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactoryTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactoryTests.java
@@ -7,13 +7,13 @@ package org.opensearch.ml.engine.httpclient;
 
 import static org.junit.Assert.assertNotNull;
 
-import java.net.UnknownHostException;
+import java.time.Duration;
 
-import org.apache.http.HttpHost;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 
 public class MLHttpClientFactoryTests {
 
@@ -21,84 +21,77 @@ public class MLHttpClientFactoryTests {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Test
-    public void test_getCloseableHttpClient_success() {
-        CloseableHttpClient client = MLHttpClientFactory.getCloseableHttpClient(1000, 1000, 30);
+    public void test_getSdkAsyncHttpClient_success() {
+        SdkAsyncHttpClient client = MLHttpClientFactory.getAsyncHttpClient(Duration.ofSeconds(100), Duration.ofSeconds(100), 100);
         assertNotNull(client);
     }
 
     @Test
-    public void test_validateIp_validIp_noException() throws UnknownHostException {
-        MLHttpClientFactory.validateIp("api.openai.com");
+    public void test_validateIp_validIp_noException() throws Exception {
+        MLHttpClientFactory.validate("http", "api.openai.com", 80);
     }
 
     @Test
-    public void test_validateIp_invalidIp_throwException() throws UnknownHostException {
-        expectedException.expect(UnknownHostException.class);
-        MLHttpClientFactory.validateIp("www.makesureitisaunknownhost.com");
+    public void test_validateIp_rarePrivateIp_throwException() throws Exception {
+        try {
+            MLHttpClientFactory.validate("http", "0254.020.00.01", 80);
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e);
+        }
+
+        try {
+            MLHttpClientFactory.validate("http", "172.1048577", 80);
+        } catch (Exception e) {
+            assertNotNull(e);
+        }
+
+        try {
+            MLHttpClientFactory.validate("http", "2886729729", 80);
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e);
+        }
+
+        try {
+            MLHttpClientFactory.validate("http", "192.11010049", 80);
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e);
+        }
+
+        try {
+            MLHttpClientFactory.validate("http", "3232300545", 80);
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e);
+        }
+
+        try {
+            MLHttpClientFactory.validate("http", "0:0:0:0:0:ffff:127.0.0.1", 80);
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e);
+        }
+
+        try {
+            MLHttpClientFactory.validate("http", "153.24.76.232", 80);
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e);
+        }
     }
 
     @Test
-    public void test_validateIp_privateIp_throwException() throws UnknownHostException {
+    public void test_validateSchemaAndPort_success() throws Exception {
+        MLHttpClientFactory.validate("http", "api.openai.com", 80);
+    }
+
+    @Test
+    public void test_validateSchemaAndPort_notAllowedSchema_throwException() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        MLHttpClientFactory.validateIp("localhost");
+        MLHttpClientFactory.validate("ftp", "api.openai.com", 80);
     }
 
     @Test
-    public void test_validateIp_rarePrivateIp_throwException() throws UnknownHostException {
-        try {
-            MLHttpClientFactory.validateIp("0177.1");
-        } catch (IllegalArgumentException e) {
-            assertNotNull(e);
-        }
-
-        try {
-            MLHttpClientFactory.validateIp("172.1048577");
-        } catch (IllegalArgumentException e) {
-            assertNotNull(e);
-        }
-
-        try {
-            MLHttpClientFactory.validateIp("2886729729");
-        } catch (IllegalArgumentException e) {
-            assertNotNull(e);
-        }
-
-        try {
-            MLHttpClientFactory.validateIp("192.11010049");
-        } catch (IllegalArgumentException e) {
-            assertNotNull(e);
-        }
-
-        try {
-            MLHttpClientFactory.validateIp("3232300545");
-        } catch (IllegalArgumentException e) {
-            assertNotNull(e);
-        }
-
-        try {
-            MLHttpClientFactory.validateIp("0:0:0:0:0:ffff:127.0.0.1");
-        } catch (IllegalArgumentException e) {
-            assertNotNull(e);
-        }
-    }
-
-    @Test
-    public void test_validateSchemaAndPort_success() {
-        HttpHost httpHost = new HttpHost("api.openai.com", 8080, "https");
-        MLHttpClientFactory.validateSchemaAndPort(httpHost);
-    }
-
-    @Test
-    public void test_validateSchemaAndPort_notAllowedSchema_throwException() {
+    public void test_validateSchemaAndPort_portNotInRange_throwException() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        HttpHost httpHost = new HttpHost("api.openai.com", 8080, "ftp");
-        MLHttpClientFactory.validateSchemaAndPort(httpHost);
+        expectedException.expectMessage("Port out of range: 65537");
+        MLHttpClientFactory.validate("https", "api.openai.com", 65537);
     }
 
-    @Test
-    public void test_validateSchemaAndPort_portNotInRange_throwException() {
-        expectedException.expect(IllegalArgumentException.class);
-        HttpHost httpHost = new HttpHost("api.openai.com:65537", -1, "https");
-        MLHttpClientFactory.validateSchemaAndPort(httpHost);
-    }
 }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -1891,6 +1891,12 @@ public class MLModelManager {
         return t;
     }
 
+    public void trackPredictDuration(String modelId, long startTime) {
+        long end = System.nanoTime();
+        double durationInMs = (end - startTime) / 1e6;
+        modelCacheHelper.addModelInferenceDuration(modelId, durationInMs);
+    }
+
     public FunctionName getModelFunctionName(String modelId) {
         return modelCacheHelper.getFunctionName(modelId);
     }


### PR DESCRIPTION
* Change httpclient from sync to async



* Change from CRTAsyncHttpClient to NettyAsyncHttpClient



* Add publisher to request



* Change sync httpclient to async



* Handle error case and return error response in actionLListener



* Fix no response when exception



* Add content type header



* Fix issues found in functional test



* Fix no response issue in functional test



* fix default step size error



* Add track inference duration for async httpclient



* Change client appsec highlight issues implementation for async httpclient



* Add UTs



* Add UTs



* Remove unused file



* Add UTs



* format code



* Change error code to honor remote service error code



* Add more UTs



* Change SSRF code to make it correct for return error stattus



* Fix failure UTs and add more UTs



* Fix failure ITs



* format code



* Fix partial success response not correct issue



* format code



* Fix failure ITs



* Add more UTs to increase code coverage



* Change url regex



* Address comments



* format code



* Fix failure UTs



* Add UT for httpclientFactory throw exception when creating httpclient



* format code



* Address comments and add modelTensor status code



* Address comments



* format code



* Add status code to process error response



* format code



* Rebase main after connector level http parameter support



* Fix UT



* Change error message when remote model return empty and chaange the behavior when one of the requests fails



* Add comments\



* Remove redundant builder and change the error code check



* format code



* Add more UTs for throw exception cases



* fix failure UTs



* format code



* Fix test cases since the error message change



* Rebase code



* fix failure IT



* Add more UTs



* Fix duplicate response to client issue



* fix duplicate response in channel



* change code for all successfully responses case



* Address comments



* format code



* Increase nio httpclient version to fix vulnerbility



* Change validate localhost logic to same with existing code



* change method signature to private



* format code



---------

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
