### PR TITLE
fix CVE for org.eclipse.core.runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,11 @@ buildscript {
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
         classpath "gradle.plugin.com.dorongold.plugins:task-tree:1.5"
+        configurations.all {
+            resolutionStrategy {
+                force("org.eclipse.platform:org.eclipse.core.runtime:3.29.0") // for spotless transitive dependency CVE (for 3.26.100)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Description
The Spotless Gradle Plugin brings in a transitive dependency on Eclipse Core Runtime 3.26.100. That version is impacted by a CVE. This forces the newest version, currently 3.29.0.
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/1863
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
