### PR TITLE
Clear planningWorkerNodes when model auto-deploys again after undeploy

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -167,6 +167,10 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
                                 return;
                             }
                             String[] planningWorkerNodes = model.getPlanningWorkerNodes();
+                            boolean deployToAllNodes = model.isDeployToAllNodes();
+                            if (deployToAllNodes) {
+                                planningWorkerNodes = null;
+                            }
                             MLModel modelBeingAutoDeployed = mlModelManager.addModelToAutoDeployCache(modelId, model);
                             if (modelBeingAutoDeployed == model) {
                                 log.info(getErrorMessage("Automatically deploy model", modelId, isHidden));


### PR DESCRIPTION
### Description
When a model auto-deploys again after TTL expire or undeployed, it needs to check if isDeployToAllNodes is true. If so, the planningWorkerNodes needs to be set to null so the next deployment knows it's not customized deployment. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
