### PR TITLE
Fix local build failure for RestMLInferenceIngestProcessorIT

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLInferenceIngestProcessorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLInferenceIngestProcessorIT.java
@@ -115,6 +115,10 @@ public class RestMLInferenceIngestProcessorIT extends MLCommonsRestTestCase {
         String index_name = "daily_index";
         createPipelineProcessor(createPipelineRequestBody, "diary_embedding_pipeline");
         createIndex(index_name, createIndexRequestBody);
+        // Skip test if key is null
+        if (OPENAI_KEY == null) {
+            return;
+        }
         uploadDocument(index_name, "1", uploadDocumentRequestBody);
         Map document = getDocument(index_name, "1");
         List embeddingList = JsonPath.parse(document).read("_source.diary_embedding");
@@ -197,6 +201,10 @@ public class RestMLInferenceIngestProcessorIT extends MLCommonsRestTestCase {
         String index_name = "book_index";
         createPipelineProcessor(createPipelineRequestBody, "embedding_pipeline");
         createIndex(index_name, createIndexRequestBody);
+        // Skip test if key is null
+        if (OPENAI_KEY == null) {
+            return;
+        }
         uploadDocument(index_name, "1", uploadDocumentRequestBody);
         Map document = getDocument(index_name, "1");
 


### PR DESCRIPTION
### Description
fix local build failure for RestMLInferenceIngestProcessorIT

when openai key is null, skip running predict
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
