### PR TITLE
avoid race condition in syncup model state refresh and handle NP of I…

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
@@ -9,6 +9,7 @@ import static org.opensearch.ml.common.CommonValue.CREATE_TIME_FIELD;
 import static org.opensearch.ml.common.CommonValue.MASTER_KEY;
 import static org.opensearch.ml.common.CommonValue.ML_CONFIG_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+import static org.opensearch.ml.utils.RestActionUtils.getAllNodes;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -41,8 +42,9 @@ import org.opensearch.ml.common.transport.sync.MLSyncUpAction;
 import org.opensearch.ml.common.transport.sync.MLSyncUpInput;
 import org.opensearch.ml.common.transport.sync.MLSyncUpNodeResponse;
 import org.opensearch.ml.common.transport.sync.MLSyncUpNodesRequest;
-import org.opensearch.ml.common.transport.undeploy.MLUndeployModelAction;
-import org.opensearch.ml.common.transport.undeploy.MLUndeployModelNodesRequest;
+import org.opensearch.ml.common.transport.undeploy.MLUndeployModelNodesResponse;
+import org.opensearch.ml.common.transport.undeploy.MLUndeployModelsAction;
+import org.opensearch.ml.common.transport.undeploy.MLUndeployModelsRequest;
 import org.opensearch.ml.engine.encryptor.Encryptor;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.search.SearchHit;
@@ -97,6 +99,9 @@ public class MLSyncUpCron implements Runnable {
         // gather running model/tasks on nodes
         client.execute(MLSyncUpAction.INSTANCE, gatherInfoRequest, ActionListener.wrap(r -> {
             List<MLSyncUpNodeResponse> responses = r.getNodes();
+            if (r.failures() != null && r.failures().size() != 0) {
+                log.debug("Received {} failures in the sync up response on nodes", r.failures().size());
+            }
             // key is model id, value is set of worker node ids
             Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
             // key is task id, value is set of worker node ids
@@ -143,7 +148,6 @@ public class MLSyncUpCron implements Runnable {
                 if (modelWorkerNodes.containsKey(modelId)
                     && expiredModelToNodes.get(modelId).size() == modelWorkerNodes.get(modelId).size()) {
                     // this model has expired in all the nodes
-                    modelWorkerNodes.remove(modelId);
                     modelsToUndeploy.add(modelId);
                 }
             }
@@ -168,37 +172,44 @@ public class MLSyncUpCron implements Runnable {
             MLSyncUpInput syncUpInput = inputBuilder.build();
             MLSyncUpNodesRequest syncUpRequest = new MLSyncUpNodesRequest(allNodes, syncUpInput);
             // sync up running model/tasks on nodes
-            client
-                .execute(
-                    MLSyncUpAction.INSTANCE,
-                    syncUpRequest,
-                    ActionListener.wrap(re -> { log.debug("sync model routing job finished"); }, ex -> {
-                        log.error("Failed to sync model routing", ex);
-                    })
-                );
-            // Undeploy expired models
-            undeployExpiredModels(modelsToUndeploy, modelWorkerNodes);
+            client.execute(MLSyncUpAction.INSTANCE, syncUpRequest, ActionListener.wrap(re -> {
+                log.debug("sync model routing job finished");
+                if (!modelsToUndeploy.isEmpty()) {
+                    // Undeploy expired models
+                    undeployExpiredModels(modelsToUndeploy, modelWorkerNodes, deployingModels);
+                    return;
+                }
+                // refresh model status
+                mlIndicesHandler
+                    .initModelIndexIfAbsent(ActionListener.wrap(res -> { refreshModelState(modelWorkerNodes, deployingModels); }, e -> {
+                        log.error("Failed to init model index", e);
+                    }));
+            }, ex -> { log.error("Failed to sync model routing", ex); }));
+        }, e -> { log.error("Failed to sync model routing", e); }));
+    }
 
-            // refresh model status
+    private void undeployExpiredModels(
+        Set<String> expiredModels,
+        Map<String, Set<String>> modelWorkerNodes,
+        Map<String, Set<String>> deployingModels
+    ) {
+        String[] targetNodeIds = getAllNodes(clusterService);
+        MLUndeployModelsRequest mlUndeployModelsRequest = new MLUndeployModelsRequest(
+            expiredModels.toArray(new String[expiredModels.size()]),
+            targetNodeIds
+        );
+
+        client.execute(MLUndeployModelsAction.INSTANCE, mlUndeployModelsRequest, ActionListener.wrap(r -> {
+            MLUndeployModelNodesResponse mlUndeployModelNodesResponse = r.getResponse();
+            if (mlUndeployModelNodesResponse.failures() != null && mlUndeployModelNodesResponse.failures().size() != 0) {
+                log.debug("Received failures in undeploying expired models", mlUndeployModelNodesResponse.failures());
+            }
+
             mlIndicesHandler
                 .initModelIndexIfAbsent(ActionListener.wrap(res -> { refreshModelState(modelWorkerNodes, deployingModels); }, e -> {
                     log.error("Failed to init model index", e);
                 }));
-        }, e -> { log.error("Failed to sync model routing", e); }));
-    }
-
-    private void undeployExpiredModels(Set<String> expiredModels, Map<String, Set<String>> modelWorkerNodes) {
-        expiredModels.forEach(modelId -> {
-            String[] targetNodeIds = modelWorkerNodes.keySet().toArray(new String[0]);
-
-            MLUndeployModelNodesRequest mlUndeployModelNodesRequest = new MLUndeployModelNodesRequest(
-                targetNodeIds,
-                new String[] { modelId }
-            );
-            client.execute(MLUndeployModelAction.INSTANCE, mlUndeployModelNodesRequest, ActionListener.wrap(r -> {
-                log.debug("model {} is un_deployed", modelId);
-            }, e -> { log.error("Failed to undeploy model {}", modelId, e); }));
-        });
+        }, e -> { log.error("Failed to undeploy models {}", expiredModels, e); }));
     }
 
     @VisibleForTesting

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
@@ -100,7 +100,12 @@ public class MLSyncUpCron implements Runnable {
         client.execute(MLSyncUpAction.INSTANCE, gatherInfoRequest, ActionListener.wrap(r -> {
             List<MLSyncUpNodeResponse> responses = r.getNodes();
             if (r.failures() != null && r.failures().size() != 0) {
-                log.error("Received {} failures in the sync up response on nodes", r.failures().size());
+                log
+                    .debug(
+                        "Received {} failures in the sync up response on nodes. Error messages are {}",
+                        r.failures().size(),
+                        r.failures().stream().map(Exception::getMessage).collect(Collectors.joining(", "))
+                    );
             }
             // key is model id, value is set of worker node ids
             Map<String, Set<String>> modelWorkerNodes = new HashMap<>();

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
@@ -100,7 +100,7 @@ public class MLSyncUpCron implements Runnable {
         client.execute(MLSyncUpAction.INSTANCE, gatherInfoRequest, ActionListener.wrap(r -> {
             List<MLSyncUpNodeResponse> responses = r.getNodes();
             if (r.failures() != null && r.failures().size() != 0) {
-                log.debug("Received {} failures in the sync up response on nodes", r.failures().size());
+                log.error("Received {} failures in the sync up response on nodes", r.failures().size());
             }
             // key is model id, value is set of worker node ids
             Map<String, Set<String>> modelWorkerNodes = new HashMap<>();

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLUndeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLUndeployModelAction.java
@@ -9,16 +9,14 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ALLOW_CUSTOM_DEPLOYMENT_PLAN;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
+import static org.opensearch.ml.utils.RestActionUtils.getAllNodes;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.XContentParser;
@@ -102,24 +100,15 @@ public class RestMLUndeployModelAction extends BaseRestHandler {
                 }
                 targetNodeIds = nodeIds;
             } else {
-                targetNodeIds = getAllNodes();
+                targetNodeIds = getAllNodes(clusterService);
             }
             if (ArrayUtils.isNotEmpty(modelIds)) {
                 targetModelIds = modelIds;
             }
         } else {
-            targetNodeIds = getAllNodes();
+            targetNodeIds = getAllNodes(clusterService);
         }
 
         return new MLUndeployModelsRequest(targetModelIds, targetNodeIds);
-    }
-
-    private String[] getAllNodes() {
-        Iterator<DiscoveryNode> iterator = clusterService.state().nodes().iterator();
-        List<String> nodeIds = new ArrayList<>();
-        while (iterator.hasNext()) {
-            nodeIds.add(iterator.next().getId());
-        }
-        return nodeIds.toArray(new String[0]);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -263,7 +263,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
     }
 
     private boolean checkModelAutoDeployEnabled(MLModel mlModel) {
-        if (mlModel.getDeploySetting() == null) {
+        if (mlModel.getDeploySetting() == null || mlModel.getDeploySetting().getIsAutoDeployEnabled() == null) {
             return true;
         }
         return mlModel.getDeploySetting().getIsAutoDeployEnabled();


### PR DESCRIPTION
### Description
Avoid race condition in sync up job to un-deploy expired models and refresh model states. Without this change, the sync up job sometimes sets wrong Model State after model is un-deployed. Default AutoDeploy to enabled when it's a null value. 

Verified and tested in local 2.14 cluster.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
