### PR TITLE
add deploySetting in registering local models

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
@@ -27,6 +27,7 @@ import java.util.zip.ZipFile;
 
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.model.MLDeploySetting;
 import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.QuestionAnsweringModelConfig;
@@ -70,6 +71,7 @@ public class ModelHelper {
         boolean deployModel = registerModelInput.isDeployModel();
         String[] modelNodeIds = registerModelInput.getModelNodeIds();
         String modelGroupId = registerModelInput.getModelGroupId();
+        MLDeploySetting mlDeploySetting = registerModelInput.getDeploySetting();
         try {
             AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
 
@@ -104,7 +106,8 @@ public class ModelHelper {
                     .modelNodeIds(modelNodeIds)
                     .isHidden(isHidden)
                     .modelGroupId(modelGroupId)
-                    .functionName(FunctionName.from((functionName)));
+                    .functionName(FunctionName.from((functionName)))
+                    .deploySetting(mlDeploySetting);
 
                 config.entrySet().forEach(entry -> {
                     switch (entry.getKey().toString()) {


### PR DESCRIPTION
### Description
DeploySetting was not included in registering local models (pre-trained or from custom url), which was fine because it only included autoDeploy flag for remote models. Now we added TTL in the DeploySetting which applies to all models so We need to add it back.

Verified in local dev cluster.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
