### PR TITLE
Fix flaky test of visualization tool

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/tools/ToolIntegrationWithLLMTest.java
+++ b/plugin/src/test/java/org/opensearch/ml/tools/ToolIntegrationWithLLMTest.java
@@ -8,15 +8,19 @@ package org.opensearch.ml.tools;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
+import lombok.SneakyThrows;
 import org.apache.hc.core5.http.ParseException;
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.client.Response;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.rest.RestBaseAgentToolsIT;
 import org.opensearch.ml.utils.TestHelper;
 
@@ -26,6 +30,10 @@ import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public abstract class ToolIntegrationWithLLMTest extends RestBaseAgentToolsIT {
+
+    private static final int MAX_TASK_RESULT_QUERY_TIME_IN_SECOND = 60 * 5;
+    private static final int DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND = 1000;
+
     protected HttpServer server;
     protected String modelId;
     protected String agentId;
@@ -63,7 +71,44 @@ public abstract class ToolIntegrationWithLLMTest extends RestBaseAgentToolsIT {
     @After
     public void deleteModel() throws IOException {
         undeployModel(modelId);
+        waitModelUndeployed(modelId);
         deleteModel(client(), modelId, null);
+    }
+
+    @SneakyThrows
+    private void waitModelUndeployed(String modelId) {
+        Predicate<Response> condition = response -> {
+            try {
+                Map<String, Object> responseInMap = parseResponseToMap(response);
+                String state = responseInMap.get(MLModel.MODEL_STATE_FIELD).toString();
+                return !state.equals(MLModelState.DEPLOYED.toString())
+                        && !state.equals(MLModelState.DEPLOYING.toString())
+                        && !state.equals(MLModelState.PARTIALLY_DEPLOYED.toString());
+            } catch (IOException e) {
+               return false;
+            }
+        };
+        waitResponseMeetingCondition("GET", "/_plugins/_ml/models/" + modelId, null, condition);
+    }
+
+    @SneakyThrows
+    protected Response waitResponseMeetingCondition(
+            String method,
+            String endpoint,
+            String jsonEntity,
+            Predicate<Response> condition
+    ) {
+        for (int i = 0; i < MAX_TASK_RESULT_QUERY_TIME_IN_SECOND; i++) {
+            Response response = TestHelper.makeRequest(client(), method, endpoint, null, jsonEntity, null);
+            assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+            if (condition.test(response)) {
+                return response;
+            }
+            logger.info("The {}-th response: {}", i, response.toString());
+            Thread.sleep(DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND);
+        }
+        fail("The response failed to meet condition after " + MAX_TASK_RESULT_QUERY_TIME_IN_SECOND + " seconds.");
+        return null;
     }
 
     private String setUpConnectorWithRetry(int maxRetryTimes) throws InterruptedException {

--- a/plugin/src/test/java/org/opensearch/ml/tools/ToolIntegrationWithLLMTest.java
+++ b/plugin/src/test/java/org/opensearch/ml/tools/ToolIntegrationWithLLMTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -80,11 +81,9 @@ public abstract class ToolIntegrationWithLLMTest extends RestBaseAgentToolsIT {
         Predicate<Response> condition = response -> {
             try {
                 Map<String, Object> responseInMap = parseResponseToMap(response);
-                String state = responseInMap.get(MLModel.MODEL_STATE_FIELD).toString();
-                return !state.equals(MLModelState.DEPLOYED.toString())
-                    && !state.equals(MLModelState.DEPLOYING.toString())
-                    && !state.equals(MLModelState.PARTIALLY_DEPLOYED.toString());
-            } catch (IOException e) {
+                MLModelState state = MLModelState.from(responseInMap.get(MLModel.MODEL_STATE_FIELD).toString());
+                return Set.of(MLModelState.UNDEPLOYED, MLModelState.DEPLOY_FAILED).contains(state);
+            } catch (Exception e) {
                 return false;
             }
         };

--- a/plugin/src/test/java/org/opensearch/ml/tools/ToolIntegrationWithLLMTest.java
+++ b/plugin/src/test/java/org/opensearch/ml/tools/ToolIntegrationWithLLMTest.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
-import lombok.SneakyThrows;
 import org.apache.hc.core5.http.ParseException;
 import org.junit.After;
 import org.junit.Before;
@@ -26,6 +25,7 @@ import org.opensearch.ml.utils.TestHelper;
 
 import com.sun.net.httpserver.HttpServer;
 
+import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
@@ -82,22 +82,17 @@ public abstract class ToolIntegrationWithLLMTest extends RestBaseAgentToolsIT {
                 Map<String, Object> responseInMap = parseResponseToMap(response);
                 String state = responseInMap.get(MLModel.MODEL_STATE_FIELD).toString();
                 return !state.equals(MLModelState.DEPLOYED.toString())
-                        && !state.equals(MLModelState.DEPLOYING.toString())
-                        && !state.equals(MLModelState.PARTIALLY_DEPLOYED.toString());
+                    && !state.equals(MLModelState.DEPLOYING.toString())
+                    && !state.equals(MLModelState.PARTIALLY_DEPLOYED.toString());
             } catch (IOException e) {
-               return false;
+                return false;
             }
         };
         waitResponseMeetingCondition("GET", "/_plugins/_ml/models/" + modelId, null, condition);
     }
 
     @SneakyThrows
-    protected Response waitResponseMeetingCondition(
-            String method,
-            String endpoint,
-            String jsonEntity,
-            Predicate<Response> condition
-    ) {
+    protected Response waitResponseMeetingCondition(String method, String endpoint, String jsonEntity, Predicate<Response> condition) {
         for (int i = 0; i < MAX_TASK_RESULT_QUERY_TIME_IN_SECOND; i++) {
             Response response = TestHelper.makeRequest(client(), method, endpoint, null, jsonEntity, null);
             assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));

--- a/plugin/src/test/java/org/opensearch/ml/tools/ToolIntegrationWithLLMTest.java
+++ b/plugin/src/test/java/org/opensearch/ml/tools/ToolIntegrationWithLLMTest.java
@@ -32,7 +32,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public abstract class ToolIntegrationWithLLMTest extends RestBaseAgentToolsIT {
 
-    private static final int MAX_TASK_RESULT_QUERY_TIME_IN_SECOND = 60 * 5;
+    private static final int MAX_TASK_RESULT_QUERY_TIME_IN_SECOND = 30;
     private static final int DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND = 1000;
 
     protected HttpServer server;


### PR DESCRIPTION
### Description
This PR is add waiting for model to be undeployed to fix flaky test introduced by #2363, 

https://github.com/opensearch-project/ml-commons/actions/runs/8933312245/job/24539185907?pr=2402
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
