### PR TITLE
fix flaky test of PredictionITTests and RestConnectorToolIT

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.action;
 import static org.opensearch.ml.common.input.parameter.regression.LogisticRegressionParams.ObjectiveType.LOGMULTICLASS;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_NATIVE_MEM_THRESHOLD;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ONLY_RUN_ON_ML_NODE;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS;
 import static org.opensearch.ml.utils.RestActionUtils.getAllNodes;
 import static org.opensearch.ml.utils.TestData.TARGET_FIELD;
 import static org.opensearch.ml.utils.TestData.TIME_FIELD;
@@ -93,14 +94,26 @@ import org.opensearch.ml.profile.MLProfileInput;
 import org.opensearch.ml.utils.TestData;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 
-public class MLCommonsIntegTestCase extends OpenSearchIntegTestCase {
+public class MLCommonsIntegTestCase extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     private Gson gson = new Gson();
+
+    /**
+     * set ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS to 0 to disable ML_COMMONS_SYNC_UP_JOB
+     * the cluster will be pre-created with the settings at startup
+     */
+    public MLCommonsIntegTestCase() {
+        super(Settings.builder().put(ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS.getKey(), 0).build());
+    }
+
+    public MLCommonsIntegTestCase(Settings nodeSettings) {
+        super(nodeSettings);
+    }
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
@@ -8,7 +8,6 @@ package org.opensearch.ml.action;
 import static org.opensearch.ml.common.input.parameter.regression.LogisticRegressionParams.ObjectiveType.LOGMULTICLASS;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_NATIVE_MEM_THRESHOLD;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ONLY_RUN_ON_ML_NODE;
-import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS;
 import static org.opensearch.ml.utils.RestActionUtils.getAllNodes;
 import static org.opensearch.ml.utils.TestData.TARGET_FIELD;
 import static org.opensearch.ml.utils.TestData.TIME_FIELD;
@@ -103,12 +102,8 @@ import com.google.gson.Gson;
 public class MLCommonsIntegTestCase extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     private Gson gson = new Gson();
 
-    /**
-     * set ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS to 0 to disable ML_COMMONS_SYNC_UP_JOB
-     * the cluster will be pre-created with the settings at startup
-     */
     public MLCommonsIntegTestCase() {
-        super(Settings.builder().put(ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS.getKey(), 0).build());
+        super(Settings.EMPTY);
     }
 
     public MLCommonsIntegTestCase(Settings nodeSettings) {

--- a/plugin/src/test/java/org/opensearch/ml/action/prediction/PredictionITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prediction/PredictionITTests.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.action.prediction;
 
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS;
 import static org.opensearch.ml.utils.TestData.IRIS_DATA_SIZE;
 import static org.opensearch.ml.utils.TestData.TIME_FIELD;
 
@@ -16,6 +17,7 @@ import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.action.MLCommonsIntegTestCase;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
@@ -48,6 +50,14 @@ public class PredictionITTests extends MLCommonsIntegTestCase {
     private String linearRegressionModelId;
     private String logisticRegressionModelId;
     private int batchRcfDataSize = 100;
+
+    /**
+     * set ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS to 0 to disable ML_COMMONS_SYNC_UP_JOB
+     * the cluster will be pre-created with the settings at startup
+     */
+    public PredictionITTests() {
+        super(Settings.builder().put(ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS.getKey(), 0).build());
+    }
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -969,10 +969,18 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
     }
 
     public String registerConnector(String createConnectorInput) throws IOException, InterruptedException {
-        Response response = RestMLRemoteInferenceIT.createConnector(createConnectorInput);
+        Response response;
+        try {
+            response = RestMLRemoteInferenceIT.createConnector(createConnectorInput);
+        } catch (Throwable throwable) {
+            // Add retry for `The ML encryption master key has not been initialized yet. Please retry after waiting for 10 seconds.`
+            TimeUnit.SECONDS.sleep(10);
+            response = RestMLRemoteInferenceIT.createConnector(createConnectorInput);
+        }
         Map responseMap = parseResponseToMap(response);
         String connectorId = (String) responseMap.get("connector_id");
         return connectorId;
+
     }
 
     public String registerRemoteModel(String createConnectorInput, String modelName, boolean deploy) throws IOException,

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestConnectorToolIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestConnectorToolIT.java
@@ -86,6 +86,9 @@ public class RestConnectorToolIT extends RestBaseAgentToolsIT {
     }
 
     public void testConnectorToolInFlowAgent_WrongAction() throws IOException, ParseException {
+        if (AWS_ACCESS_KEY_ID == null || AWS_SECRET_ACCESS_KEY == null || AWS_SESSION_TOKEN == null) {
+            return;
+        }
         String registerAgentRequestBody = "{\n"
             + "  \"name\": \"Test agent with connector tool\",\n"
             + "  \"type\": \"flow\",\n"
@@ -111,6 +114,9 @@ public class RestConnectorToolIT extends RestBaseAgentToolsIT {
     }
 
     public void testConnectorToolInFlowAgent() throws IOException, ParseException {
+        if (AWS_ACCESS_KEY_ID == null || AWS_SECRET_ACCESS_KEY == null || AWS_SESSION_TOKEN == null) {
+            return;
+        }
         String registerAgentRequestBody = "{\n"
             + "  \"name\": \"Test agent with connector tool\",\n"
             + "  \"type\": \"flow\",\n"


### PR DESCRIPTION
### Description

1. Add per-defined cluster setting to disable MLSyncUpJob for JVM private OpenSearch Cluster, so that it will not create `.plugin-ml-config` index automatically every 10 seconds.
2. Skip RestConnectorToolIT if `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are not set
3. Add retry for creating connector if ML encryption master key has not been initialized yet


### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/2436
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
