### PR TITLE
hanlde the throttling error in the response header

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
@@ -109,6 +109,8 @@ public class MLSdkAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandle
         if (errorsInHeader == null || errorsInHeader.isEmpty()) {
             return;
         }
+        // Check the throttling exception from AMZN servers, e.g. sageMaker.
+        // See [https://github.com/opensearch-project/ml-commons/issues/2429] for more details.
         boolean containsThrottlingException = errorsInHeader.stream().anyMatch(str -> str.startsWith("ThrottlingException"));
         if (containsThrottlingException && executionContext.getExceptionHolder().get() == null) {
             log.error("Remote server returned error code: {}", statusCode);


### PR DESCRIPTION
### Description
Handle the throttling error in the header when the error is only returned in the headers and response body is empty. This is for a specific case discussed in the issues below. 
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/2429, https://github.com/opensearch-project/ml-commons/issues/2249
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
