### PR TITLE
[Feature] Split remote inference text list if its number exceeds user configured limitation

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ExecutionContext.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ExecutionContext.java
@@ -7,7 +7,7 @@
 
 package org.opensearch.ml.engine.algorithms.remote;
 
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -30,5 +30,5 @@ public class ExecutionContext {
     private CountDownLatch countDownLatch;
     // This is to hold any exception thrown in a split-batch request
     private AtomicReference<Exception> exceptionHolder;
-    private List<Integer> originalOrder;
+    private Map<Integer, Integer> originalOrder;
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ExecutionContext.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ExecutionContext.java
@@ -7,6 +7,7 @@
 
 package org.opensearch.ml.engine.algorithms.remote;
 
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -29,4 +30,5 @@ public class ExecutionContext {
     private CountDownLatch countDownLatch;
     // This is to hold any exception thrown in a split-batch request
     private AtomicReference<Exception> exceptionHolder;
+    private List<Integer> originalOrder;
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -8,6 +8,9 @@ package org.opensearch.ml.engine.algorithms.remote;
 import static org.opensearch.ml.engine.algorithms.remote.ConnectorUtils.escapeRemoteInferenceInputData;
 import static org.opensearch.ml.engine.algorithms.remote.ConnectorUtils.processInput;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +18,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.client.Client;
@@ -41,6 +45,9 @@ import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.script.ScriptService;
 
 public interface RemoteConnectorExecutor {
+    int DEFAULT_BATCH_SIZE = -1;
+    String MAX_BATCH_SIZE_KEY = "max_batch_size";
+    String STEP_SIZE_KEY = "input_docs_processed_step_size";
 
     default void executePredict(MLInput mlInput, ActionListener<MLTaskResponse> actionListener) {
         ActionListener<List<ModelTensors>> tensorActionListener = ActionListener.wrap(r -> {
@@ -51,12 +58,23 @@ public interface RemoteConnectorExecutor {
             AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
             if (mlInput.getInputDataset() instanceof TextDocsInputDataSet) {
                 TextDocsInputDataSet textDocsInputDataSet = (TextDocsInputDataSet) mlInput.getInputDataset();
-                Tuple<Integer, Integer> calculatedChunkSize = calculateChunkSize(textDocsInputDataSet);
+                int maxBatchSize = getMaxBatchSize();
+                Tuple<Integer, Integer> calculatedChunkSize = calculateChunkSize(
+                    textDocsInputDataSet,
+                    maxBatchSize
+                );
+                List<Integer> textDocOriginalOrder = Collections.emptyList();
+                if (shouldSortBeforeCuttingBatches(maxBatchSize, calculatedChunkSize)) {
+                    Tuple<TextDocsInputDataSet, List<Integer>> sortedData = sortTextDocsByTextLength(textDocsInputDataSet);
+                    textDocsInputDataSet = sortedData.v1();
+                    textDocOriginalOrder = Collections.unmodifiableList(sortedData.v2());
+                }
+
                 CountDownLatch countDownLatch = new CountDownLatch(calculatedChunkSize.v1());
                 int sequence = 0;
-                for (int processedDocs = 0; processedDocs < textDocsInputDataSet.getDocs().size(); processedDocs += calculatedChunkSize
-                    .v2()) {
-                    List<String> textDocs = textDocsInputDataSet.getDocs().subList(processedDocs, textDocsInputDataSet.getDocs().size());
+                for (int processedDocs = 0; processedDocs < textDocsInputDataSet.getDocs().size(); processedDocs += calculatedChunkSize.v2()) {
+                    List<String> textDocs = textDocsInputDataSet.getDocs().subList(processedDocs,
+                        Math.min(processedDocs + calculatedChunkSize.v2(), textDocsInputDataSet.getDocs().size()));
                     preparePayloadAndInvokeRemoteModel(
                         MLInput
                             .builder()
@@ -64,7 +82,12 @@ public interface RemoteConnectorExecutor {
                             .inputDataset(TextDocsInputDataSet.builder().docs(textDocs).build())
                             .build(),
                         modelTensors,
-                        new ExecutionContext(sequence++, countDownLatch, exceptionHolder),
+                        new ExecutionContext(
+                            sequence++,
+                            countDownLatch,
+                            exceptionHolder,
+                            textDocOriginalOrder
+                        ),
                         tensorActionListener
                     );
                 }
@@ -72,7 +95,7 @@ public interface RemoteConnectorExecutor {
                 preparePayloadAndInvokeRemoteModel(
                     mlInput,
                     modelTensors,
-                    new ExecutionContext(0, new CountDownLatch(1), exceptionHolder),
+                    new ExecutionContext(0, new CountDownLatch(1), exceptionHolder, Collections.emptyList()),
                     tensorActionListener
                 );
             }
@@ -86,20 +109,16 @@ public interface RemoteConnectorExecutor {
      * @param textDocsInputDataSet
      * @return Tuple of chunk size and step size.
      */
-    private Tuple<Integer, Integer> calculateChunkSize(TextDocsInputDataSet textDocsInputDataSet) {
+    private Tuple<Integer, Integer> calculateChunkSize(TextDocsInputDataSet textDocsInputDataSet, int maxBatchSize) {
         int textDocsLength = textDocsInputDataSet.getDocs().size();
         Map<String, String> parameters = getConnector().getParameters();
-        if (parameters != null && parameters.containsKey("input_docs_processed_step_size")) {
-            int stepSize = Integer.parseInt(parameters.get("input_docs_processed_step_size"));
+        if (parameters != null && parameters.containsKey(STEP_SIZE_KEY)) {
+            int stepSize = Integer.parseInt(parameters.get(STEP_SIZE_KEY));
             // We need to check the parameter on runtime as parameter can be passed into predict request
             if (stepSize <= 0) {
                 throw new IllegalArgumentException("Invalid parameter: input_docs_processed_step_size. It must be positive integer.");
             } else {
-                boolean isDivisible = textDocsLength % stepSize == 0;
-                if (isDivisible) {
-                    return Tuple.tuple(textDocsLength / stepSize, stepSize);
-                }
-                return Tuple.tuple(textDocsLength / stepSize + 1, stepSize);
+                return Tuple.tuple((int) Math.ceil((double) textDocsLength / stepSize), stepSize);
             }
         } else {
             Optional<ConnectorAction> predictAction = getConnector().findPredictAction();
@@ -111,9 +130,53 @@ public interface RemoteConnectorExecutor {
                 // user defined preprocess script, this case, the chunk size is always equals to text docs length.
                 return Tuple.tuple(textDocsLength, 1);
             }
-            // consider as batch.
-            return Tuple.tuple(1, textDocsLength);
+
+            if (maxBatchSize == DEFAULT_BATCH_SIZE || textDocsLength <= maxBatchSize) {
+                return Tuple.tuple(1, textDocsLength);
+            }
+            return Tuple.tuple((int) Math.ceil((double) textDocsLength / maxBatchSize), maxBatchSize);
         }
+    }
+
+    /**
+     * Get user configured max_batch_size parameter, throw IllegalArgumentException if it's invalid.
+     * Return default value if it's not configured.
+     * @return max batch size
+     */
+    private int getMaxBatchSize() {
+        Map<String, String> parameters = getConnector().getParameters();
+        if (parameters == null || !parameters.containsKey(MAX_BATCH_SIZE_KEY)) {
+            return DEFAULT_BATCH_SIZE;
+        }
+        int maxBatchSize = Integer.parseInt(parameters.get(MAX_BATCH_SIZE_KEY));
+        if (maxBatchSize <= 0) {
+            throw new IllegalArgumentException("Invalid parameter: " + MAX_BATCH_SIZE_KEY + ". It must be positive integer.");
+        }
+        return maxBatchSize;
+    }
+
+    private boolean shouldSortBeforeCuttingBatches(int maxBatchSize, Tuple<Integer, Integer> calculatedChunkSize) {
+        if (maxBatchSize <= 1 || calculatedChunkSize.v1() <= 1 || calculatedChunkSize.v2() <= 1) {
+            return false;
+        }
+        // skip step size situation
+        Map<String, String> parameters = getConnector().getParameters();
+        if (parameters != null && parameters.containsKey(STEP_SIZE_KEY)) {
+            return false;
+        }
+        return true;
+    }
+
+    private Tuple<TextDocsInputDataSet, List<Integer>> sortTextDocsByTextLength(TextDocsInputDataSet textDocsInputDataSet) {
+        List<Tuple<Integer, String>> docsWithIndex = new ArrayList<>();
+        for (int i = 0; i < textDocsInputDataSet.getDocs().size(); ++i) {
+            docsWithIndex.add(Tuple.tuple(i, textDocsInputDataSet.getDocs().get(i)));
+        }
+        docsWithIndex.sort(Comparator.comparingInt(t -> t.v2().length()));
+        List<String> sortedDocs = docsWithIndex.stream().map(Tuple::v2).collect(Collectors.toList());
+        List<Integer> originalIndexOrder = docsWithIndex.stream().map(Tuple::v1).collect(Collectors.toList());
+        TextDocsInputDataSet sortedTextDocsInputDataSet = TextDocsInputDataSet.builder().docs(sortedDocs).build();
+        return Tuple.tuple(sortedTextDocsInputDataSet, originalIndexOrder);
     }
 
     default void setScriptService(ScriptService scriptService) {}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -59,10 +59,7 @@ public interface RemoteConnectorExecutor {
             if (mlInput.getInputDataset() instanceof TextDocsInputDataSet) {
                 TextDocsInputDataSet textDocsInputDataSet = (TextDocsInputDataSet) mlInput.getInputDataset();
                 int maxBatchSize = getMaxBatchSize();
-                Tuple<Integer, Integer> calculatedChunkSize = calculateChunkSize(
-                    textDocsInputDataSet,
-                    maxBatchSize
-                );
+                Tuple<Integer, Integer> calculatedChunkSize = calculateChunkSize(textDocsInputDataSet, maxBatchSize);
                 List<Integer> textDocOriginalOrder = Collections.emptyList();
                 if (shouldSortBeforeCuttingBatches(maxBatchSize, calculatedChunkSize)) {
                     Tuple<TextDocsInputDataSet, List<Integer>> sortedData = sortTextDocsByTextLength(textDocsInputDataSet);
@@ -72,9 +69,11 @@ public interface RemoteConnectorExecutor {
 
                 CountDownLatch countDownLatch = new CountDownLatch(calculatedChunkSize.v1());
                 int sequence = 0;
-                for (int processedDocs = 0; processedDocs < textDocsInputDataSet.getDocs().size(); processedDocs += calculatedChunkSize.v2()) {
-                    List<String> textDocs = textDocsInputDataSet.getDocs().subList(processedDocs,
-                        Math.min(processedDocs + calculatedChunkSize.v2(), textDocsInputDataSet.getDocs().size()));
+                for (int processedDocs = 0; processedDocs < textDocsInputDataSet.getDocs().size(); processedDocs += calculatedChunkSize
+                    .v2()) {
+                    List<String> textDocs = textDocsInputDataSet
+                        .getDocs()
+                        .subList(processedDocs, Math.min(processedDocs + calculatedChunkSize.v2(), textDocsInputDataSet.getDocs().size()));
                     preparePayloadAndInvokeRemoteModel(
                         MLInput
                             .builder()
@@ -82,12 +81,7 @@ public interface RemoteConnectorExecutor {
                             .inputDataset(TextDocsInputDataSet.builder().docs(textDocs).build())
                             .build(),
                         modelTensors,
-                        new ExecutionContext(
-                            sequence++,
-                            countDownLatch,
-                            exceptionHolder,
-                            textDocOriginalOrder
-                        ),
+                        new ExecutionContext(sequence++, countDownLatch, exceptionHolder, textDocOriginalOrder),
                         tensorActionListener
                     );
                 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
@@ -95,7 +95,7 @@ public class HttpJsonConnectorExecutorTest {
                 new HashMap<>(),
                 "{\"input\": \"hello world\"}",
                 new HashMap<>(),
-                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList()),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyMap()),
                 actionListener
             );
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(IllegalArgumentException.class);
@@ -127,7 +127,7 @@ public class HttpJsonConnectorExecutorTest {
                 new HashMap<>(),
                 null,
                 new HashMap<>(),
-                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList()),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyMap()),
                 actionListener
             );
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(IllegalArgumentException.class);
@@ -159,7 +159,7 @@ public class HttpJsonConnectorExecutorTest {
                 new HashMap<>(),
                 null,
                 new HashMap<>(),
-                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList()),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyMap()),
                 actionListener
             );
     }
@@ -187,7 +187,7 @@ public class HttpJsonConnectorExecutorTest {
                 new HashMap<>(),
                 "hello world",
                 new HashMap<>(),
-                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList()),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyMap()),
                 actionListener
             );
     }
@@ -218,7 +218,7 @@ public class HttpJsonConnectorExecutorTest {
                 new HashMap<>(),
                 "hello world",
                 new HashMap<>(),
-                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList()),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyMap()),
                 actionListener
             );
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -94,7 +95,7 @@ public class HttpJsonConnectorExecutorTest {
                 new HashMap<>(),
                 "{\"input\": \"hello world\"}",
                 new HashMap<>(),
-                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>()),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList()),
                 actionListener
             );
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(IllegalArgumentException.class);
@@ -126,7 +127,7 @@ public class HttpJsonConnectorExecutorTest {
                 new HashMap<>(),
                 null,
                 new HashMap<>(),
-                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>()),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList()),
                 actionListener
             );
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(IllegalArgumentException.class);
@@ -158,7 +159,7 @@ public class HttpJsonConnectorExecutorTest {
                 new HashMap<>(),
                 null,
                 new HashMap<>(),
-                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>()),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList()),
                 actionListener
             );
     }
@@ -186,7 +187,7 @@ public class HttpJsonConnectorExecutorTest {
                 new HashMap<>(),
                 "hello world",
                 new HashMap<>(),
-                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>()),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList()),
                 actionListener
             );
     }
@@ -217,7 +218,7 @@ public class HttpJsonConnectorExecutorTest {
                 new HashMap<>(),
                 "hello world",
                 new HashMap<>(),
-                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>()),
+                new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList()),
                 actionListener
             );
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
@@ -46,7 +46,7 @@ public class MLSdkAsyncHttpResponseHandlerTest {
         0,
         new CountDownLatch(1),
         new AtomicReference<>(),
-        Collections.emptyList()
+        Collections.emptyMap()
     );
     @Mock
     private ActionListener<List<ModelTensors>> actionListener;
@@ -266,7 +266,7 @@ public class MLSdkAsyncHttpResponseHandlerTest {
         String response2 = "Model current status is: FAILED";
         CountDownLatch count = new CountDownLatch(2);
         MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler1 = new MLSdkAsyncHttpResponseHandler(
-            new ExecutionContext(0, count, exceptionHolder, Collections.emptyList()),
+            new ExecutionContext(0, count, exceptionHolder, Collections.emptyMap()),
             actionListener,
             parameters,
             tensorOutputs,
@@ -275,7 +275,7 @@ public class MLSdkAsyncHttpResponseHandlerTest {
             null
         );
         MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler2 = new MLSdkAsyncHttpResponseHandler(
-            new ExecutionContext(1, count, exceptionHolder, Collections.emptyList()),
+            new ExecutionContext(1, count, exceptionHolder, Collections.emptyMap()),
             actionListener,
             parameters,
             tensorOutputs,
@@ -334,7 +334,7 @@ public class MLSdkAsyncHttpResponseHandlerTest {
         String response2 = "Model current status is: FAILED";
         CountDownLatch count = new CountDownLatch(2);
         MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler1 = new MLSdkAsyncHttpResponseHandler(
-            new ExecutionContext(0, count, exceptionHolder, Collections.emptyList()),
+            new ExecutionContext(0, count, exceptionHolder, Collections.emptyMap()),
             actionListener,
             parameters,
             tensorOutputs,
@@ -343,7 +343,7 @@ public class MLSdkAsyncHttpResponseHandlerTest {
             null
         );
         MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler2 = new MLSdkAsyncHttpResponseHandler(
-            new ExecutionContext(1, count, exceptionHolder, Collections.emptyList()),
+            new ExecutionContext(1, count, exceptionHolder, Collections.emptyMap()),
             actionListener,
             parameters,
             tensorOutputs,

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
@@ -42,7 +42,12 @@ import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpResponse;
 
 public class MLSdkAsyncHttpResponseHandlerTest {
-    private final ExecutionContext executionContext = new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList());
+    private final ExecutionContext executionContext = new ExecutionContext(
+        0,
+        new CountDownLatch(1),
+        new AtomicReference<>(),
+        Collections.emptyList()
+    );
     @Mock
     private ActionListener<List<ModelTensors>> actionListener;
     @Mock

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,7 +42,7 @@ import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpResponse;
 
 public class MLSdkAsyncHttpResponseHandlerTest {
-    private final ExecutionContext executionContext = new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>());
+    private final ExecutionContext executionContext = new ExecutionContext(0, new CountDownLatch(1), new AtomicReference<>(), Collections.emptyList());
     @Mock
     private ActionListener<List<ModelTensors>> actionListener;
     @Mock
@@ -260,7 +261,7 @@ public class MLSdkAsyncHttpResponseHandlerTest {
         String response2 = "Model current status is: FAILED";
         CountDownLatch count = new CountDownLatch(2);
         MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler1 = new MLSdkAsyncHttpResponseHandler(
-            new ExecutionContext(0, count, exceptionHolder),
+            new ExecutionContext(0, count, exceptionHolder, Collections.emptyList()),
             actionListener,
             parameters,
             tensorOutputs,
@@ -269,7 +270,7 @@ public class MLSdkAsyncHttpResponseHandlerTest {
             null
         );
         MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler2 = new MLSdkAsyncHttpResponseHandler(
-            new ExecutionContext(1, count, exceptionHolder),
+            new ExecutionContext(1, count, exceptionHolder, Collections.emptyList()),
             actionListener,
             parameters,
             tensorOutputs,
@@ -328,7 +329,7 @@ public class MLSdkAsyncHttpResponseHandlerTest {
         String response2 = "Model current status is: FAILED";
         CountDownLatch count = new CountDownLatch(2);
         MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler1 = new MLSdkAsyncHttpResponseHandler(
-            new ExecutionContext(0, count, exceptionHolder),
+            new ExecutionContext(0, count, exceptionHolder, Collections.emptyList()),
             actionListener,
             parameters,
             tensorOutputs,
@@ -337,7 +338,7 @@ public class MLSdkAsyncHttpResponseHandlerTest {
             null
         );
         MLSdkAsyncHttpResponseHandler mlSdkAsyncHttpResponseHandler2 = new MLSdkAsyncHttpResponseHandler(
-            new ExecutionContext(1, count, exceptionHolder),
+            new ExecutionContext(1, count, exceptionHolder, Collections.emptyList()),
             actionListener,
             parameters,
             tensorOutputs,

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
@@ -164,7 +164,13 @@ public class RemoteConnectorExecutorTest {
         verifyBatch(mlInputCaptor.getAllValues().get(1), 2, Arrays.asList("22", "444"));
         // third batch
         verifyBatch(mlInputCaptor.getAllValues().get(2), 1, List.of("5555"));
-        assertEquals(Arrays.asList(4, 1, 2, 0, 3), executionContextCaptor.getValue().getOriginalOrder());
+        Map<Integer, Integer> expectedMap = new HashMap<>();
+        expectedMap.put(3, 0);
+        expectedMap.put(1, 1);
+        expectedMap.put(2, 2);
+        expectedMap.put(0, 4);
+        expectedMap.put(4, 3);
+        assertEquals(expectedMap, executionContextCaptor.getValue().getOriginalOrder());
     }
 
     @Test

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
@@ -1,5 +1,24 @@
 package org.opensearch.ml.engine.algorithms.remote;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,25 +41,6 @@ import org.opensearch.node.Node;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ThreadPool;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 public class RemoteConnectorExecutorTest {
     @Mock
     private ScriptService scriptService;
@@ -61,7 +61,8 @@ public class RemoteConnectorExecutorTest {
 
     private RemoteConnectorExecutor remoteConnectorExecutor;
 
-    private static final String USER_DEFINED_PREPROCESS = "\\n    StringBuilder builder = new StringBuilder();\\n    builder.append(\\\"\\\\\\\"\\\");\\n    String first = params.text_docs[0];\\n    builder.append(first);\\n    builder.append(\\\"\\\\\\\"\\\");\\n    def parameters = \\\"{\\\" +\\\"\\\\\\\"inputText\\\\\\\":\\\" + builder + \\\"}\\\";\\n    return  \\\"{\\\" +\\\"\\\\\\\"parameters\\\\\\\":\\\" + parameters + \\\"}\\\";";
+    private static final String USER_DEFINED_PREPROCESS =
+        "\\n    StringBuilder builder = new StringBuilder();\\n    builder.append(\\\"\\\\\\\"\\\");\\n    String first = params.text_docs[0];\\n    builder.append(first);\\n    builder.append(\\\"\\\\\\\"\\\");\\n    def parameters = \\\"{\\\" +\\\"\\\\\\\"inputText\\\\\\\":\\\" + builder + \\\"}\\\";\\n    return  \\\"{\\\" +\\\"\\\\\\\"parameters\\\\\\\":\\\" + parameters + \\\"}\\\";";
 
     @Before
     public void setup() {
@@ -130,8 +131,7 @@ public class RemoteConnectorExecutorTest {
         when(mockMlInput.getInputDataset()).thenReturn(dataSet);
         when(connectorAction.getPreProcessFunction()).thenReturn(USER_DEFINED_PREPROCESS);
         String preprocessResult = "{\"parameters\": { \"input\": \"test doc1\" } }";
-        when(scriptService.compile(any(), any()))
-            .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult));
+        when(scriptService.compile(any(), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult));
 
         remoteConnectorExecutor.executePredict(mockMlInput, callback);
         ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
@@ -156,8 +156,8 @@ public class RemoteConnectorExecutorTest {
         remoteConnectorExecutor.executePredict(mockMlInput, callback);
         ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
         ArgumentCaptor<ExecutionContext> executionContextCaptor = ArgumentCaptor.forClass(ExecutionContext.class);
-        verify(mockRemoteConnectorExecutor, times(3)).invokeRemoteModel(mlInputCaptor.capture(),
-            any(), any(), any(), executionContextCaptor.capture(), any());
+        verify(mockRemoteConnectorExecutor, times(3))
+            .invokeRemoteModel(mlInputCaptor.capture(), any(), any(), any(), executionContextCaptor.capture(), any());
         // first batch
         verifyBatch(mlInputCaptor.getAllValues().get(0), 2, Arrays.asList("1", "33"));
         // second batch
@@ -179,8 +179,8 @@ public class RemoteConnectorExecutorTest {
         remoteConnectorExecutor.executePredict(mockMlInput, callback);
         ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
         ArgumentCaptor<ExecutionContext> executionContextCaptor = ArgumentCaptor.forClass(ExecutionContext.class);
-        verify(mockRemoteConnectorExecutor, times(5)).invokeRemoteModel(mlInputCaptor.capture(),
-            any(), any(), any(), executionContextCaptor.capture(), any());
+        verify(mockRemoteConnectorExecutor, times(5))
+            .invokeRemoteModel(mlInputCaptor.capture(), any(), any(), any(), executionContextCaptor.capture(), any());
         for (int i = 0; i < 5; ++i) {
             verifyBatch(mlInputCaptor.getAllValues().get(i), 1, Collections.singletonList(docs.get(i)));
             assertTrue(executionContextCaptor.getAllValues().get(i).getOriginalOrder().isEmpty());
@@ -197,7 +197,6 @@ public class RemoteConnectorExecutorTest {
         }
     }
 
-
     private TextDocsInputDataSet prepareTextDocsInputDataSet(int count) {
         List<String> docs = new ArrayList<>();
         for (int i = 0; i < count; ++i) {
@@ -210,7 +209,9 @@ public class RemoteConnectorExecutorTest {
 
         final private RemoteConnectorExecutor delegate;
 
-        private TestRemoteConnectorExecutor(RemoteConnectorExecutor delegate) {this.delegate = delegate;}
+        private TestRemoteConnectorExecutor(RemoteConnectorExecutor delegate) {
+            this.delegate = delegate;
+        }
 
         @Override
         public ScriptService getScriptService() {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
@@ -1,0 +1,257 @@
+package org.opensearch.ml.engine.algorithms.remote;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.client.Client;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.TokenBucket;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ingest.TestTemplateService;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.ConnectorAction;
+import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.model.MLGuard;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.transport.MLTaskResponse;
+import org.opensearch.node.Node;
+import org.opensearch.script.ScriptService;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RemoteConnectorExecutorTest {
+    @Mock
+    private ScriptService scriptService;
+    @Mock
+    private Connector connector;
+    @Mock
+    private Client client;
+    @Mock
+    private MLInput mockMlInput;
+    @Mock
+    private ActionListener<MLTaskResponse> callback;
+    @Mock
+    private RemoteConnectorExecutor mockRemoteConnectorExecutor;
+    @Mock
+    private ConnectorAction connectorAction;
+    @Mock
+    private ThreadPool threadPool;
+
+    private RemoteConnectorExecutor remoteConnectorExecutor;
+
+    private static final String USER_DEFINED_PREPROCESS = "\\n    StringBuilder builder = new StringBuilder();\\n    builder.append(\\\"\\\\\\\"\\\");\\n    String first = params.text_docs[0];\\n    builder.append(first);\\n    builder.append(\\\"\\\\\\\"\\\");\\n    def parameters = \\\"{\\\" +\\\"\\\\\\\"inputText\\\\\\\":\\\" + builder + \\\"}\\\";\\n    return  \\\"{\\\" +\\\"\\\\\\\"parameters\\\\\\\":\\\" + parameters + \\\"}\\\";";
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        remoteConnectorExecutor = new TestRemoteConnectorExecutor(mockRemoteConnectorExecutor);
+        lenient().when(connector.findPredictAction()).thenReturn(Optional.of(connectorAction));
+        threadPool = new ThreadPool(Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), "RemoteConnectorExecutorTest").build());
+        lenient().when(client.threadPool()).thenReturn(threadPool);
+    }
+
+    @Test
+    public void test_executePredict_shouldCutBatch_invalidArgumentException() {
+        TextDocsInputDataSet dataSet = prepareTextDocsInputDataSet(10);
+        when(connector.getParameters()).thenReturn(Collections.singletonMap("max_batch_size", "-1"));
+        when(mockMlInput.getInputDataset()).thenReturn(dataSet);
+
+        remoteConnectorExecutor.executePredict(mockMlInput, callback);
+        verify(callback).onFailure(any(IllegalArgumentException.class));
+        verify(mockRemoteConnectorExecutor, never()).invokeRemoteModel(any(), anyMap(), anyString(), anyMap(), any(), any());
+    }
+
+    @Test
+    public void test_executePredict_shouldCutBatch_parameter_not_set() {
+        TextDocsInputDataSet dataSet = prepareTextDocsInputDataSet(10);
+        when(connector.getParameters()).thenReturn(Collections.emptyMap());
+        when(mockMlInput.getInputDataset()).thenReturn(dataSet);
+
+        remoteConnectorExecutor.executePredict(mockMlInput, callback);
+        ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
+        verify(mockRemoteConnectorExecutor).invokeRemoteModel(mlInputCaptor.capture(), any(), any(), any(), any(), any());
+        assertEquals(TextDocsInputDataSet.class, mlInputCaptor.getValue().getInputDataset().getClass());
+        TextDocsInputDataSet textDocsInputDataSet = (TextDocsInputDataSet) mlInputCaptor.getValue().getInputDataset();
+        assertEquals(10, textDocsInputDataSet.getDocs().size());
+    }
+
+    @Test
+    public void test_executePredict_shouldCutBatch_with_step_size_parameter() {
+        TextDocsInputDataSet dataSet = prepareTextDocsInputDataSet(9);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input_docs_processed_step_size", "2");
+        parameters.put("max_batch_size", "4");
+        when(connector.getParameters()).thenReturn(parameters);
+        when(mockMlInput.getInputDataset()).thenReturn(dataSet);
+
+        remoteConnectorExecutor.executePredict(mockMlInput, callback);
+        ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
+        verify(mockRemoteConnectorExecutor, times(5)).invokeRemoteModel(mlInputCaptor.capture(), any(), any(), any(), any(), any());
+        for (int i = 0; i < 5; ++i) {
+            MLInput mlInput = mlInputCaptor.getAllValues().get(i);
+            assertEquals(TextDocsInputDataSet.class, mlInput.getInputDataset().getClass());
+            TextDocsInputDataSet textDocsInputDataSet = (TextDocsInputDataSet) mlInput.getInputDataset();
+            if (i < 4) {
+                assertEquals(2, textDocsInputDataSet.getDocs().size());
+            } else {
+                assertEquals(1, textDocsInputDataSet.getDocs().size());
+            }
+        }
+    }
+
+    @Test
+    public void test_executePredict_shouldCutBatch_with_preprocess() {
+        TextDocsInputDataSet dataSet = prepareTextDocsInputDataSet(9);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("max_batch_size", "4");
+        when(connector.getParameters()).thenReturn(parameters);
+        when(mockMlInput.getInputDataset()).thenReturn(dataSet);
+        when(connectorAction.getPreProcessFunction()).thenReturn(USER_DEFINED_PREPROCESS);
+        String preprocessResult = "{\"parameters\": { \"input\": \"test doc1\" } }";
+        when(scriptService.compile(any(), any()))
+            .then(invocation -> new TestTemplateService.MockTemplateScript.Factory(preprocessResult));
+
+        remoteConnectorExecutor.executePredict(mockMlInput, callback);
+        ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
+        verify(mockRemoteConnectorExecutor, times(9)).invokeRemoteModel(mlInputCaptor.capture(), any(), any(), any(), any(), any());
+        for (int i = 0; i < 9; ++i) {
+            MLInput mlInput = mlInputCaptor.getAllValues().get(i);
+            assertEquals(TextDocsInputDataSet.class, mlInput.getInputDataset().getClass());
+            TextDocsInputDataSet textDocsInputDataSet = (TextDocsInputDataSet) mlInput.getInputDataset();
+            assertEquals(1, textDocsInputDataSet.getDocs().size());
+        }
+    }
+
+    @Test
+    public void test_executePredict_shouldCutBatch_with_sort_one_batch() {
+        List<String> docs = Arrays.asList("444", "33", "22", "5555", "1");
+        TextDocsInputDataSet dataSet = TextDocsInputDataSet.builder().docs(docs).build();
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("max_batch_size", "2");
+        when(connector.getParameters()).thenReturn(parameters);
+        when(mockMlInput.getInputDataset()).thenReturn(dataSet);
+
+        remoteConnectorExecutor.executePredict(mockMlInput, callback);
+        ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
+        ArgumentCaptor<ExecutionContext> executionContextCaptor = ArgumentCaptor.forClass(ExecutionContext.class);
+        verify(mockRemoteConnectorExecutor, times(3)).invokeRemoteModel(mlInputCaptor.capture(),
+            any(), any(), any(), executionContextCaptor.capture(), any());
+        // first batch
+        verifyBatch(mlInputCaptor.getAllValues().get(0), 2, Arrays.asList("1", "33"));
+        // second batch
+        verifyBatch(mlInputCaptor.getAllValues().get(1), 2, Arrays.asList("22", "444"));
+        // third batch
+        verifyBatch(mlInputCaptor.getAllValues().get(2), 1, List.of("5555"));
+        assertEquals(Arrays.asList(4, 1, 2, 0, 3), executionContextCaptor.getValue().getOriginalOrder());
+    }
+
+    @Test
+    public void test_executePredict_shouldCutBatch_no_sort_one_doc_in_batch() {
+        List<String> docs = Arrays.asList("444", "33", "22", "5555", "1");
+        TextDocsInputDataSet dataSet = TextDocsInputDataSet.builder().docs(docs).build();
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("max_batch_size", "1");
+        when(connector.getParameters()).thenReturn(parameters);
+        when(mockMlInput.getInputDataset()).thenReturn(dataSet);
+
+        remoteConnectorExecutor.executePredict(mockMlInput, callback);
+        ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
+        ArgumentCaptor<ExecutionContext> executionContextCaptor = ArgumentCaptor.forClass(ExecutionContext.class);
+        verify(mockRemoteConnectorExecutor, times(5)).invokeRemoteModel(mlInputCaptor.capture(),
+            any(), any(), any(), executionContextCaptor.capture(), any());
+        for (int i = 0; i < 5; ++i) {
+            verifyBatch(mlInputCaptor.getAllValues().get(i), 1, Collections.singletonList(docs.get(i)));
+            assertTrue(executionContextCaptor.getAllValues().get(i).getOriginalOrder().isEmpty());
+        }
+    }
+
+    private void verifyBatch(MLInput mlInput, int expectedSize, List<String> expectedDocs) {
+        assertEquals(TextDocsInputDataSet.class, mlInput.getInputDataset().getClass());
+        TextDocsInputDataSet textDocsInputDataSet = (TextDocsInputDataSet) mlInput.getInputDataset();
+
+        assertEquals(expectedSize, textDocsInputDataSet.getDocs().size());
+        for (int i = 0; i < expectedSize; ++i) {
+            assertEquals(expectedDocs.get(i), textDocsInputDataSet.getDocs().get(i));
+        }
+    }
+
+
+    private TextDocsInputDataSet prepareTextDocsInputDataSet(int count) {
+        List<String> docs = new ArrayList<>();
+        for (int i = 0; i < count; ++i) {
+            docs.add(RandomStringUtils.random(10, true, false));
+        }
+        return TextDocsInputDataSet.builder().docs(docs).build();
+    }
+
+    private class TestRemoteConnectorExecutor implements RemoteConnectorExecutor {
+
+        final private RemoteConnectorExecutor delegate;
+
+        private TestRemoteConnectorExecutor(RemoteConnectorExecutor delegate) {this.delegate = delegate;}
+
+        @Override
+        public ScriptService getScriptService() {
+            return scriptService;
+        }
+
+        @Override
+        public Connector getConnector() {
+            return connector;
+        }
+
+        @Override
+        public TokenBucket getRateLimiter() {
+            return null;
+        }
+
+        @Override
+        public Map<String, TokenBucket> getUserRateLimiterMap() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public MLGuard getMlGuard() {
+            return null;
+        }
+
+        @Override
+        public Client getClient() {
+            return client;
+        }
+
+        @Override
+        public void invokeRemoteModel(
+            MLInput mlInput,
+            Map<String, String> parameters,
+            String payload,
+            Map<Integer, ModelTensors> tensorOutputs,
+            ExecutionContext countDownLatch,
+            ActionListener<List<ModelTensors>> actionListener
+        ) {
+            this.delegate.invokeRemoteModel(mlInput, parameters, payload, tensorOutputs, countDownLatch, actionListener);
+        }
+    }
+}


### PR DESCRIPTION
### Description
We'd like to have a solution to cut texts into small batches if total number of them in a batch request exceeds the limitation
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/2428
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
