### PR TITLE
adding multi tenancy settings

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -43,6 +43,8 @@ public class CommonValue {
         public static final String UNDEPLOYED = "undeployed";
         public static final String NOT_FOUND = "not_found";
 
+        public static final String TENANT_ID = "tenant_id";
+
         public static final String MASTER_KEY = "master_key";
         public static final String CREATE_TIME_FIELD = "create_time";
         public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
@@ -147,6 +149,9 @@ public class CommonValue {
                         + AbstractConnector.PROTOCOL_FIELD
                         + "\" : {\"type\": \"keyword\"},\n"
                         + "      \""
+                        + TENANT_ID
+                        + "\" : {\"type\": \"keyword\"},\n"
+                        + "      \""
                         + AbstractConnector.PARAMETERS_FIELD
                         + "\" : {\"type\": \"flat_object\"},\n"
                         + "      \""
@@ -218,6 +223,9 @@ public class CommonValue {
                         + "      \""
                         + MLModel.IS_HIDDEN_FIELD
                         + "\": {\"type\": \"boolean\"},\n"
+                        + "      \""
+                        + TENANT_ID
+                        + "\" : {\"type\": \"keyword\"},\n"
                         + "      \""
                         + MLModel.MODEL_CONFIG_FIELD
                         + "\" : {\"properties\":{\""
@@ -350,6 +358,9 @@ public class CommonValue {
                         + MLTask.ERROR_FIELD
                         + "\": {\"type\": \"text\"},\n"
                         + "      \""
+                        + TENANT_ID
+                        + "\" : {\"type\": \"keyword\"},\n"
+                        + "      \""
                         + MLTask.IS_ASYNC_TASK_FIELD
                         + "\" : {\"type\" : \"boolean\"}, \n"
                         + USER_FIELD_MAPPING
@@ -461,6 +472,9 @@ public class CommonValue {
                         + "      \""
                         + MLAgent.IS_HIDDEN_FIELD
                         + "\": {\"type\": \"boolean\"},\n"
+                        + "      \""
+                        + TENANT_ID
+                        + "\" : {\"type\": \"keyword\"},\n"
                         + "      \""
                         + MLAgent.CREATED_TIME_FIELD
                         + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"

--- a/common/src/main/java/org/opensearch/ml/common/connector/AbstractConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/AbstractConnector.java
@@ -69,6 +69,8 @@ public abstract class AbstractConnector implements Connector {
     protected Instant lastUpdateTime;
     @Setter
     protected ConnectorClientConfig connectorClientConfig;
+    @Setter
+    protected String tenantId;
 
     protected Map<String, String> createPredictDecryptedHeaders(Map<String, String> headers) {
         if (headers == null) {

--- a/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
@@ -41,6 +41,9 @@ import static org.opensearch.ml.common.utils.StringUtils.gson;
 public interface Connector extends ToXContentObject, Writeable {
 
     String getName();
+    String getTenantId();
+    void setTenantId(String tenantId);
+
     String getProtocol();
     User getOwner();
     void setOwner(User user);

--- a/common/src/main/java/org/opensearch/ml/common/input/Constants.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/Constants.java
@@ -36,4 +36,6 @@ public class Constants {
     public static final String AD_TRAINING_DATA_SIZE = "trainingDataSize";
     public static final String AD_ANOMALY_SCORE_THRESHOLD = "anomalyScoreThreshold";
     public static final String AD_DATE_FORMAT = "dateFormat";
+
+    public static final String TENANT_ID = "tenant_id";
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLConnectorGetRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLConnectorGetRequest.java
@@ -25,17 +25,20 @@ import static org.opensearch.action.ValidateActions.addValidationError;
 public class MLConnectorGetRequest extends ActionRequest {
 
     String connectorId;
+    String tenantId;
     boolean returnContent;
 
     @Builder
-    public MLConnectorGetRequest(String connectorId, boolean returnContent) {
+    public MLConnectorGetRequest(String connectorId, String tenantId, boolean returnContent) {
         this.connectorId = connectorId;
+        this.tenantId = tenantId;
         this.returnContent = returnContent;
     }
 
     public MLConnectorGetRequest(StreamInput in) throws IOException {
         super(in);
         this.connectorId = in.readString();
+        this.tenantId = in.readOptionalString();
         this.returnContent = in.readBoolean();
     }
 
@@ -43,6 +46,7 @@ public class MLConnectorGetRequest extends ActionRequest {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(this.connectorId);
+        out.writeOptionalString(this.tenantId);
         out.writeBoolean(returnContent);
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
@@ -38,6 +38,8 @@ import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.log4j.Log4j2;
 
+import java.util.Objects;
+
 @Log4j2
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class GetConnectorTransportAction extends HandledTransportAction<ActionRequest, MLConnectorGetResponse> {
@@ -65,6 +67,7 @@ public class GetConnectorTransportAction extends HandledTransportAction<ActionRe
     protected void doExecute(Task task, ActionRequest request, ActionListener<MLConnectorGetResponse> actionListener) {
         MLConnectorGetRequest mlConnectorGetRequest = MLConnectorGetRequest.fromActionRequest(request);
         String connectorId = mlConnectorGetRequest.getConnectorId();
+        String tenantId = mlConnectorGetRequest.getTenantId();
         FetchSourceContext fetchSourceContext = getFetchSourceContext(mlConnectorGetRequest.isReturnContent());
         GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
             .index(ML_CONNECTOR_INDEX)

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -933,7 +933,8 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_MEMORY_FEATURE_ENABLED,
                 MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED,
                 MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED,
-                MLCommonsSettings.ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE
+                MLCommonsSettings.ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE,
+                MLCommonsSettings.ML_COMMONS_INDEPENDENT_NODE
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -726,7 +726,7 @@ public class MachineLearningPlugin extends Plugin
         RestMLUpdateModelAction restMLUpdateModelAction = new RestMLUpdateModelAction();
         RestMLDeleteModelGroupAction restMLDeleteModelGroupAction = new RestMLDeleteModelGroupAction();
         RestMLCreateConnectorAction restMLCreateConnectorAction = new RestMLCreateConnectorAction(mlFeatureEnabledSetting);
-        RestMLGetConnectorAction restMLGetConnectorAction = new RestMLGetConnectorAction();
+        RestMLGetConnectorAction restMLGetConnectorAction = new RestMLGetConnectorAction(clusterService, settings);
         RestMLDeleteConnectorAction restMLDeleteConnectorAction = new RestMLDeleteConnectorAction();
         RestMLSearchConnectorAction restMLSearchConnectorAction = new RestMLSearchConnectorAction();
         RestMemoryCreateConversationAction restCreateConversationAction = new RestMemoryCreateConversationAction();

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -934,7 +934,7 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED,
                 MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE,
-                MLCommonsSettings.ML_COMMONS_INDEPENDENT_NODE
+                MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetConnectorAction.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.rest;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_CONNECTOR_ID;
 import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
+import static org.opensearch.ml.utils.RestActionUtils.getTenantID;
 import static org.opensearch.ml.utils.RestActionUtils.returnContent;
 
 import java.io.IOException;
@@ -15,6 +16,8 @@ import java.util.List;
 import java.util.Locale;
 
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetAction;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -27,10 +30,17 @@ import com.google.common.collect.ImmutableList;
 public class RestMLGetConnectorAction extends BaseRestHandler {
     private static final String ML_GET_CONNECTOR_ACTION = "ml_get_connector_action";
 
+    private ClusterService clusterService;
+
+    private Settings settings;
+
     /**
      * Constructor
      */
-    public RestMLGetConnectorAction() {}
+    public RestMLGetConnectorAction(ClusterService clusterService, Settings settings) {
+        this.clusterService = clusterService;
+        this.settings = settings;
+    }
 
     @Override
     public String getName() {
@@ -59,7 +69,7 @@ public class RestMLGetConnectorAction extends BaseRestHandler {
     MLConnectorGetRequest getRequest(RestRequest request) throws IOException {
         String connectorId = getParameterId(request, PARAMETER_CONNECTOR_ID);
         boolean returnContent = returnContent(request);
-
-        return new MLConnectorGetRequest(connectorId, returnContent);
+        String tenantId = getTenantID(clusterService, settings, request);
+        return new MLConnectorGetRequest(connectorId, tenantId, returnContent);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -184,4 +184,7 @@ public final class MLCommonsSettings {
     // This setting is to enable/disable agent related API register/execute/delete/get/search agent.
     public static final Setting<Boolean> ML_COMMONS_AGENT_FRAMEWORK_ENABLED = Setting
         .boolSetting("plugins.ml_commons.agent_framework_enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    public static final Setting<Boolean> ML_COMMONS_INDEPENDENT_NODE = Setting
+        .boolSetting("plugins.ml_commons.independent_node", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -185,6 +185,6 @@ public final class MLCommonsSettings {
     public static final Setting<Boolean> ML_COMMONS_AGENT_FRAMEWORK_ENABLED = Setting
         .boolSetting("plugins.ml_commons.agent_framework_enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
-    public static final Setting<Boolean> ML_COMMONS_INDEPENDENT_NODE = Setting
-        .boolSetting("plugins.ml_commons.independent_node", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
+    public static final Setting<Boolean> ML_COMMONS_MULTI_TENANCY_ENABLED = Setting
+        .boolSetting("plugins.ml_commons.multi_tenancy_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -186,5 +186,5 @@ public final class MLCommonsSettings {
         .boolSetting("plugins.ml_commons.agent_framework_enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Boolean> ML_COMMONS_INDEPENDENT_NODE = Setting
-        .boolSetting("plugins.ml_commons.independent_node", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .boolSetting("plugins.ml_commons.independent_node", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -7,7 +7,7 @@ package org.opensearch.ml.utils;
 
 import static org.opensearch.ml.common.MLModel.MODEL_CONTENT_FIELD;
 import static org.opensearch.ml.common.MLModel.OLD_MODEL_CONTENT_FIELD;
-import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_INDEPENDENT_NODE;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
 
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
@@ -89,7 +89,7 @@ public class RestActionUtils {
     static final ObjectMapper objectMapper = new ObjectMapper();
 
     // This is to identify if this node is in multi-tenancy or not.
-    public static volatile Boolean isIndependentNode;
+    public static volatile Boolean isMultiTenant;
 
     public static String getAlgorithm(RestRequest request) {
         String algorithm = request.param(PARAMETER_ALGORITHM);
@@ -316,14 +316,14 @@ public class RestActionUtils {
         }
     }
 
-    public static boolean isIndependentNode(ClusterService clusterService, Settings settings) {
-        isIndependentNode = ML_COMMONS_INDEPENDENT_NODE.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_INDEPENDENT_NODE, it -> isIndependentNode = it);
-        return isIndependentNode;
+    public static boolean isMultiTenant(ClusterService clusterService, Settings settings) {
+        isMultiTenant = ML_COMMONS_MULTI_TENANCY_ENABLED.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_MULTI_TENANCY_ENABLED, it -> isMultiTenant = it);
+        return isMultiTenant;
     }
 
     public static String getTenantID(ClusterService clusterService, Settings settings, RestRequest restRequest) {
-        if (isIndependentNode(clusterService, settings)) {
+        if (isMultiTenant(clusterService, settings)) {
             Map<String, List<String>> headers = restRequest.getHeaders();
             if (headers != null) {
                 String tenantId = restRequest.getHeaders().get(Constants.TENANT_ID).get(0);

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -323,11 +324,16 @@ public class RestActionUtils {
 
     public static String getTenantID(ClusterService clusterService, Settings settings, RestRequest restRequest) {
         if (IsIndependentNode(clusterService, settings)) {
-            String tenantId = restRequest.getHeaders().get(Constants.TENANT_ID).get(0);
-            if (tenantId == null) {
-                throw new OpenSearchStatusException("Tenant ID can't be null", RestStatus.INTERNAL_SERVER_ERROR);
+            Map<String, List<String>> headers = restRequest.getHeaders();
+            if (headers != null) {
+                String tenantId = restRequest.getHeaders().get(Constants.TENANT_ID).get(0);
+                if (tenantId == null) {
+                    throw new OpenSearchStatusException("Tenant ID can't be null", RestStatus.INTERNAL_SERVER_ERROR);
+                }
+                return tenantId;
+            } else {
+                throw new OpenSearchStatusException("Rest request header can't be null", RestStatus.INTERNAL_SERVER_ERROR);
             }
-            return tenantId;
         } else {
             return null;
         }

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -316,14 +316,14 @@ public class RestActionUtils {
         }
     }
 
-    public static boolean IsIndependentNode(ClusterService clusterService, Settings settings) {
+    public static boolean isIndependentNode(ClusterService clusterService, Settings settings) {
         isIndependentNode = ML_COMMONS_INDEPENDENT_NODE.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_INDEPENDENT_NODE, it -> isIndependentNode = it);
         return isIndependentNode;
     }
 
     public static String getTenantID(ClusterService clusterService, Settings settings, RestRequest restRequest) {
-        if (IsIndependentNode(clusterService, settings)) {
+        if (isIndependentNode(clusterService, settings)) {
             Map<String, List<String>> headers = restRequest.getHeaders();
             if (headers != null) {
                 String tenantId = restRequest.getHeaders().get(Constants.TENANT_ID).get(0);

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.utils;
 
 import static org.opensearch.ml.common.MLModel.MODEL_CONTENT_FIELD;
 import static org.opensearch.ml.common.MLModel.OLD_MODEL_CONTENT_FIELD;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_INDEPENDENT_NODE;
 
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
@@ -27,18 +28,21 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.ml.common.input.Constants;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
@@ -82,6 +86,9 @@ public class RestActionUtils {
     static final Set<LdapName> adminDn = new HashSet<>();
     static final Set<String> adminUsernames = new HashSet<String>();
     static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // This is to identify if this node is in multi-tenancy or not.
+    public static volatile Boolean isIndependentNode;
 
     public static String getAlgorithm(RestRequest request) {
         String algorithm = request.param(PARAMETER_ALGORITHM);
@@ -305,6 +312,24 @@ public class RestActionUtils {
             listener.onResponse(emptySearchResponse);
         } else {
             listener.onFailure(e);
+        }
+    }
+
+    public static boolean IsIndependentNode(ClusterService clusterService, Settings settings) {
+        isIndependentNode = ML_COMMONS_INDEPENDENT_NODE.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_INDEPENDENT_NODE, it -> isIndependentNode = it);
+        return isIndependentNode;
+    }
+
+    public static String getTenantID(ClusterService clusterService, Settings settings, RestRequest restRequest) {
+        if (IsIndependentNode(clusterService, settings)) {
+            String tenantId = restRequest.getHeaders().get(Constants.TENANT_ID).get(0);
+            if (tenantId == null) {
+                throw new OpenSearchStatusException("Tenant ID can't be null", RestStatus.INTERNAL_SERVER_ERROR);
+            }
+            return tenantId;
+        } else {
+            return null;
         }
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -177,14 +177,14 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
             .makeRequest(client(), "PUT", "_cluster/settings", ImmutableMap.of(), TestHelper.toHttpEntity(jsonEntity), null);
         assertEquals(200, response.getStatusLine().getStatusCode());
 
-        String independentEntity = "{\n"
+        String multiTenancyEntity = "{\n"
             + "  \"persistent\" : {\n"
-            + "    \"plugins.ml_commons.independent_node\" : false \n"
+            + "    \"plugins.ml_commons.multi_tenancy_enabled\" : false \n"
             + "  }\n"
             + "}";
 
         response = TestHelper
-            .makeRequest(client(), "PUT", "_cluster/settings", ImmutableMap.of(), TestHelper.toHttpEntity(independentEntity), null);
+            .makeRequest(client(), "PUT", "_cluster/settings", ImmutableMap.of(), TestHelper.toHttpEntity(multiTenancyEntity), null);
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -176,6 +176,16 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
         response = TestHelper
             .makeRequest(client(), "PUT", "_cluster/settings", ImmutableMap.of(), TestHelper.toHttpEntity(jsonEntity), null);
         assertEquals(200, response.getStatusLine().getStatusCode());
+
+        String independentEntity = "{\n"
+            + "  \"persistent\" : {\n"
+            + "    \"plugins.ml_commons.independent_node\" : false \n"
+            + "  }\n"
+            + "}";
+
+        response = TestHelper
+            .makeRequest(client(), "PUT", "_cluster/settings", ImmutableMap.of(), TestHelper.toHttpEntity(independentEntity), null);
+        assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
     @Override

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetConnectorActionTests.java
@@ -11,11 +11,14 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_INDEPENDENT_NODE;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_CONNECTOR_ID;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -25,10 +28,13 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.conversation.ConversationalIndexConstants;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetAction;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetRequest;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetResponse;
@@ -60,7 +66,10 @@ public class RestMLGetConnectorActionTests extends OpenSearchTestCase {
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        settings = Settings.builder().build();
+        settings = Settings.builder().put(ML_COMMONS_INDEPENDENT_NODE.getKey(), false).build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        when(clusterService.getClusterSettings())
+                .thenReturn(new ClusterSettings(settings, Set.of(ML_COMMONS_INDEPENDENT_NODE)));
         restMLGetConnectorAction = new RestMLGetConnectorAction(clusterService, settings);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetConnectorActionTests.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_INDEPENDENT_NODE;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_CONNECTOR_ID;
 
 import java.util.HashMap;
@@ -64,9 +64,9 @@ public class RestMLGetConnectorActionTests extends OpenSearchTestCase {
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        settings = Settings.builder().put(ML_COMMONS_INDEPENDENT_NODE.getKey(), false).build();
+        settings = Settings.builder().put(ML_COMMONS_MULTI_TENANCY_ENABLED.getKey(), false).build();
         when(clusterService.getSettings()).thenReturn(settings);
-        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, Set.of(ML_COMMONS_INDEPENDENT_NODE)));
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, Set.of(ML_COMMONS_MULTI_TENANCY_ENABLED)));
         restMLGetConnectorAction = new RestMLGetConnectorAction(clusterService, settings);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetConnectorActionTests.java
@@ -29,12 +29,10 @@ import org.mockito.MockitoAnnotations;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
-import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.ml.common.conversation.ConversationalIndexConstants;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetAction;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetRequest;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetResponse;
@@ -68,8 +66,7 @@ public class RestMLGetConnectorActionTests extends OpenSearchTestCase {
         MockitoAnnotations.openMocks(this);
         settings = Settings.builder().put(ML_COMMONS_INDEPENDENT_NODE.getKey(), false).build();
         when(clusterService.getSettings()).thenReturn(settings);
-        when(clusterService.getClusterSettings())
-                .thenReturn(new ClusterSettings(settings, Set.of(ML_COMMONS_INDEPENDENT_NODE)));
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, Set.of(ML_COMMONS_INDEPENDENT_NODE)));
         restMLGetConnectorAction = new RestMLGetConnectorAction(clusterService, settings);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetConnectorActionTests.java
@@ -22,7 +22,9 @@ import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
@@ -42,17 +44,24 @@ public class RestMLGetConnectorActionTests extends OpenSearchTestCase {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
+    @Mock
+    private ClusterService clusterService;
+
     private RestMLGetConnectorAction restMLGetConnectorAction;
 
     NodeClient client;
     private ThreadPool threadPool;
+
+    Settings settings;
 
     @Mock
     RestChannel channel;
 
     @Before
     public void setup() {
-        restMLGetConnectorAction = new RestMLGetConnectorAction();
+        MockitoAnnotations.openMocks(this);
+        settings = Settings.builder().build();
+        restMLGetConnectorAction = new RestMLGetConnectorAction(clusterService, settings);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
         client = spy(new NodeClient(Settings.EMPTY, threadPool));
@@ -72,7 +81,7 @@ public class RestMLGetConnectorActionTests extends OpenSearchTestCase {
     }
 
     public void testConstructor() {
-        RestMLGetConnectorAction mlGetConnectorAction = new RestMLGetConnectorAction();
+        RestMLGetConnectorAction mlGetConnectorAction = new RestMLGetConnectorAction(clusterService, settings);
         assertNotNull(mlGetConnectorAction);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
@@ -10,7 +10,8 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED;
-import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_INDEPENDENT_NODE;
+
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
 import static org.opensearch.ml.utils.RestActionUtils.OPENSEARCH_DASHBOARDS_USER_AGENT;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_ALGORITHM;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_ASYNC;
@@ -73,14 +74,14 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
     String urlPath = MachineLearningPlugin.ML_BASE_URI + "/_train/" + algoName;
 
     ClusterService clusterService = mock(ClusterService.class);
-    Settings settings = Settings.builder().put(ML_COMMONS_INDEPENDENT_NODE.getKey(), true).build();
+    Settings settings = Settings.builder().put(ML_COMMONS_MULTI_TENANCY_ENABLED.getKey(), true).build();
 
     @Before
     public void setup() {
         param = ImmutableMap.<String, String>builder().put(PARAMETER_ALGORITHM, algoName).build();
         fakeRestRequest = createRestRequest(param);
 
-        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, Set.of(ML_COMMONS_INDEPENDENT_NODE)));
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, Set.of(ML_COMMONS_MULTI_TENANCY_ENABLED)));
         when(clusterService.getSettings()).thenReturn(settings);
 
     }
@@ -387,14 +388,14 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
 
     @Test
     public void testIsIndependentNode() {
-        boolean isIndependentNode = RestActionUtils.isIndependentNode(clusterService, settings);
+        boolean isIndependentNode = RestActionUtils.isMultiTenant(clusterService, settings);
         Assert.assertTrue(isIndependentNode);
     }
 
     @Test
     public void testIsIndependentNode_False() {
-        Settings settings = Settings.builder().put(ML_COMMONS_INDEPENDENT_NODE.getKey(), false).build();
-        boolean isIndependentNode = RestActionUtils.isIndependentNode(clusterService, settings);
+        Settings settings = Settings.builder().put(ML_COMMONS_MULTI_TENANCY_ENABLED.getKey(), false).build();
+        boolean isIndependentNode = RestActionUtils.isMultiTenant(clusterService, settings);
         Assert.assertFalse(isIndependentNode);
     }
 
@@ -427,7 +428,7 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
 
     @Test
     public void testGetTenantID_NotIndependentNode() {
-        settings = Settings.builder().put(ML_COMMONS_INDEPENDENT_NODE.getKey(), false).build();
+        settings = Settings.builder().put(ML_COMMONS_MULTI_TENANCY_ENABLED.getKey(), false).build();
         String tenantId = "test-tenant";
         Map<String, List<String>> headers = new HashMap<>();
         headers.put(Constants.TENANT_ID, Collections.singletonList(tenantId));

--- a/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
@@ -387,14 +387,14 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
 
     @Test
     public void testIsIndependentNode() {
-        boolean isIndependentNode = RestActionUtils.IsIndependentNode(clusterService, settings);
+        boolean isIndependentNode = RestActionUtils.isIndependentNode(clusterService, settings);
         Assert.assertTrue(isIndependentNode);
     }
 
     @Test
     public void testIsIndependentNode_False() {
         Settings settings = Settings.builder().put(ML_COMMONS_INDEPENDENT_NODE.getKey(), false).build();
-        boolean isIndependentNode = RestActionUtils.IsIndependentNode(clusterService, settings);
+        boolean isIndependentNode = RestActionUtils.isIndependentNode(clusterService, settings);
         Assert.assertFalse(isIndependentNode);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED;
-
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
 import static org.opensearch.ml.utils.RestActionUtils.OPENSEARCH_DASHBOARDS_USER_AGENT;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_ALGORITHM;


### PR DESCRIPTION
### Description
[adding multi tenancy settings to distinguish if that's a multi-tenancy use case or not. IF this is multi-tenant, we expect tenant_id in the header. This tenant_id will give us way to make partition of the logical resources of tenants.

In this PR, I'm just adding `tenant_id` in get connector api to show how the overall flow look like depending on the multi-tenancy settings. 

Eventually I'll raise more PRs to cover other APIs (Connectors, Tasks, Models, Model groups etc)]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
