### PR TITLE
add a connector blueprint for Amazon Comprehend APIs

### DIFF
--- a/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
@@ -390,7 +390,7 @@ POST /_plugins/_ml/connectors/_create
       "url": "${parameters.endpoint}",
       "headers": {
         "X-Amz-Target": "${parameters.api}",
-        "content-type": "application/x-amz-json-1.1",
+        "content-type": "application/x-amz-json-1.1"
       },
       "request_body": "{ \"Text\": \"${parameters.Text}\", \"LanguageCode\": \"${parameters.LanguageCode}\"}"
     }

--- a/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
@@ -1,14 +1,14 @@
-# Amazon Comprehend connector blueprint example for metadata embedding:
+# Amazon Comprehend connector blueprint example for metadata embedding
 
-Amazon Comprehend uses natural language processing (NLP) to extract insights about the content of documents without the need of any special preprocessing. You can get details of Amazon Comprehend from [Amazon Comprehend Documentation](https://docs.aws.amazon.com/comprehend/).
+Amazon Comprehend uses natural language processing (NLP) to extract insights about the content of documents without the need for any special preprocessing. For more information about Amazon Comprehend, see  [Amazon Comprehend](https://docs.aws.amazon.com/comprehend/).
 
-## Language detection with [DetectDominantLanguage](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectDominantLanguage.html) API
+## Language detection with DetectDominantLanguage API
 
-This instruction shows how to create OpenSearch connector having capability to set detected language code based on input text using Amazon Comrehend DetectDominantLanguage API.
+This tutorial shows how to create an OpenSearch connector for an Amazon Comprehend model. The model examines the input text, detects the language using the Amazon Comrehend [DetectDominantLanguage API](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectDominantLanguage.html), and sets a corresponding language code.
 
-Note: Need to do this on 2.14.0 or later.
+Note: This functionality is available in OpenSearch 2.14.0 or later.
 
-### 1. Add connector endpoint to trusted URLs:
+### Step 1: Add the connector endpoint to trusted URLs
 
 ```json
 PUT /_cluster/settings
@@ -21,9 +21,9 @@ PUT /_cluster/settings
 }
 ```
 
-### 2. Create connector for Amazon Bedrock:
+### Step 2: Create a connector for Amazon Bedrock
 
-If you are using self-managed Opensearch, you should supply AWS credentials:
+If you are using self-managed Opensearch, provide your AWS credentials:
 
 ```json
 POST /_plugins/_ml/connectors/_create
@@ -59,8 +59,8 @@ POST /_plugins/_ml/connectors/_create
 }
 ```
 
-If using the AWS Opensearch Service, you can provide an IAM role arn that allows access to the bedrock service.
-Refer to this [AWS doc](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
+If using the AWS Opensearch Service, you can provide an IAM role ARN that allows access to the Amazon Bedrock service.
+For more information, see [AWS documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
 
 ```json
 POST /_plugins/_ml/connectors/_create
@@ -101,7 +101,7 @@ Sample response:
 }
 ```
 
-### 3. Create model group:
+### Step 3: Create a model group
 
 ```json
 POST /_plugins/_ml/model_groups/_register
@@ -119,7 +119,7 @@ Sample response:
 }
 ```
 
-### 4. Register model to model group & deploy model:
+### Step 4: Register and deploy the model
 
 ```json
 POST /_plugins/_ml/models/_register?deploy=true
@@ -140,7 +140,7 @@ Sample response:
   "model_id": "mNBeno8Bk4Evvk2c4lRF"
 }
 ```
-### 5. Test model inference:
+### Step 5: Test the model inference
 
 ```json
 POST /_plugins/_ml/models/mNBeno8Bk4Evvk2c4lRF/_predict
@@ -181,15 +181,15 @@ Sample response:
 }
 ```
 
-### 6. Create ingest pipeline with ml_inference processor:
+### Step 6: Create an ingest pipeline with an `ml_inference` processor
 
-[ML inference processor](https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/) passes source field to a model, extracts model output and insert into target field. 
+The [ML inference processor](https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/) passes a source field to a model, extracts the model output, and inserts it into a target field. 
 
 This example processor works as follows:
-1. Extract values from `message` field and pass values to `Text` parameter.
-1. Invoke Amazon Comprehend DetectDominantLanguage API with `Text` parameter.
-1. Extract values from DetectDominantLanguage result.
-1. Insert extracted values into `detected_dominant_language`.
+1. Extracts values from the `message` field and passes the values to the `Text` parameter.
+1. Invokes the Amazon Comprehend DetectDominantLanguage API providing the `Text` parameter.
+1. Extracts values from the DetectDominantLanguage API response.
+1. Inserts the extracted values into the `detected_dominant_language` field.
 
 ```json
 PUT /_ingest/pipeline/detect_dominant_language_pipeline
@@ -197,7 +197,7 @@ PUT /_ingest/pipeline/detect_dominant_language_pipeline
   "processors": [
     {
       "ml_inference": {
-        "model_id": comprehend_model_id,
+        "model_id": "mNBeno8Bk4Evvk2c4lRF",
         "input_map": [
           {
             "Text": "message" 
@@ -221,7 +221,7 @@ Sample response:
 }
 ```
 
-### 7. Test ingest pipeline processor
+### Step 7: Test the ingest pipeline processor
 
 ```json
 POST /_ingest/pipeline/detect_dominant_language_pipeline/_simulate
@@ -339,30 +339,30 @@ Sample response:
 }
 ```
 
-Congratulations! You've successfully created Amazon Comprehend DetectDominantLanguage connector and ingest pipeline.
+You have now successfully created an Amazon Comprehend Detect Dominant Language connector and ingest pipeline.
 
-## Entity detection with [DetectEntities](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectEntities.html) API
+## Entity detection with the DetectEntities API
 
-This instruction shows how to create OpenSearch connector having capability to extract entities from input text.
+This tutorial shows how to create an OpenSearch connector that can extract entities from input text using the [DetectEntities API](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectEntities.html).
 
-Note: Need to do this on 2.14.0 or later.
+Note: This functionality is available in OpenSearch 2.14.0 or later.
 
-### 1. Add connector endpoint to trusted URLs:
+### Step 1: Add the connector endpoint to trusted URLs
 
 ```json
 PUT /_cluster/settings
 {
     "persistent": {
         "plugins.ml_commons.trusted_connector_endpoints_regex": [
-            "^https://comprehend\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"
+            "^https://comprehend\\..*[a-z0-9-]\\.amazonaws\\.com$"
         ]
     }
 }
 ```
 
-### 2. Create connector for Amazon Bedrock:
+### Step 2: Create a connector for Amazon Bedrock
 
-If you are using self-managed Opensearch, you should supply AWS credentials:
+If you are using self-managed Opensearch, supply your AWS credentials:
 
 ```json
 POST /_plugins/_ml/connectors/_create
@@ -398,8 +398,8 @@ POST /_plugins/_ml/connectors/_create
 }
 ```
 
-If using the AWS Opensearch Service, you can provide an IAM role arn that allows access to the bedrock service.
-Refer to this [AWS doc](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
+If using the AWS Opensearch Service, you can provide an IAM role ARN that allows access to the Amazon Bedrock service.
+For more information, see [AWS documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
 
 ```json
 POST /_plugins/_ml/connectors/_create
@@ -425,7 +425,7 @@ POST /_plugins/_ml/connectors/_create
       "url": "${parameters.endpoint}",
       "headers": {
         "X-Amz-Target": "${parameters.api}",
-        "content-type": "application/x-amz-json-1.1",
+        "content-type": "application/x-amz-json-1.1"
       },
       "request_body": "{ \"Text\": \"${parameters.Text}\", \"LanguageCode\": \"${parameters.LanguageCode}\"}"
     }
@@ -440,7 +440,7 @@ Sample response:
 }
 ```
 
-### 3. Create model group:
+### Step 3: Create a model group
 
 ```json
 POST /_plugins/_ml/model_groups/_register
@@ -458,7 +458,7 @@ Sample response:
 }
 ```
 
-### 4. Register model to model group & deploy model:
+### Step 4: Register and deploy the model:
 
 ```json
 POST /_plugins/_ml/models/_register?deploy=true
@@ -479,7 +479,7 @@ Sample response:
   "model_id": "mNBeno8Bk4Evvk2c4lRF"
 }
 ```
-### 5. Test model inference:
+### Step 5: Test the model inference
 
 ```json
 POST /_plugins/_ml/models/mNBeno8Bk4Evvk2c4lRF/_predict
@@ -548,15 +548,15 @@ Sample response:
 }
 ```
 
-### 6. Create ingest pipeline with ml_inference processor:
+### Step 6: Create an ingest pipeline with an `ml_inference` processor
 
-ml_inference passes source field to a model, extracts model output and insert into target field. Read more details on https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/
+The [ML inference processor](https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/) passes a source field to a model, extracts the model output, and inserts it into a target field. 
 
 This example processor works as follows:
-1. Extract values from `message` field and pass values to `Text` parameter.
-1. Invoke Amazon Comprehend DetectEntities API with `Text` parameter and `LanguageCode` parameter. LanguageCode is specified in model_config section.
-1. Extract values from DetectEntities result.
-1. Insert extracted values into `detected_entities`.
+1. Extracts values from the `message` field and passes the values to the `Text` parameter.
+1. Invokes the Amazon Comprehend DetectEntities API providing the `Text` parameter and the `LanguageCode` parameter. The `LanguageCode` is specified in the `model_config` section.
+1. Extracts values from the Detect Entities API response.
+1. Insert extracted values into the `detected_entities` field.
 
 ```json
 PUT /_ingest/pipeline/detect_entities_pipeline
@@ -564,7 +564,7 @@ PUT /_ingest/pipeline/detect_entities_pipeline
   "processors": [
     {
       "ml_inference": {
-        "model_id": mNBeno8Bk4Evvk2c4lRF,
+        "model_id": "mNBeno8Bk4Evvk2c4lRF",
         "input_map": [
           {
             "Text": "message"

--- a/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
@@ -86,7 +86,7 @@ POST /_plugins/_ml/connectors/_create
       "url": "${parameters.endpoint}",
       "headers": {
         "X-Amz-Target": "${parameters.api}",
-        "content-type": "application/x-amz-json-1.1",
+        "content-type": "application/x-amz-json-1.1"
       },
       "request_body": "{ \"Text\": \"${parameters.Text}\"}"
     }

--- a/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
@@ -15,7 +15,7 @@ PUT /_cluster/settings
 {
     "persistent": {
         "plugins.ml_commons.trusted_connector_endpoints_regex": [
-            "^https://comprehend\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"
+            "^https://comprehend\\..*[a-z0-9-]\\.amazonaws\\.com$"
         ]
     }
 }

--- a/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
@@ -51,7 +51,7 @@ POST /_plugins/_ml/connectors/_create
       "url": "${parameters.endpoint}",
       "headers": {
         "X-Amz-Target": "${parameters.api}",
-        "content-type": "application/x-amz-json-1.1",
+        "content-type": "application/x-amz-json-1.1"
       },
       "request_body": "{ \"Text\": \"${parameters.Text}\"}"
     }

--- a/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
@@ -1,0 +1,668 @@
+# Amazon Comprehend connector blueprint example for metadata embedding:
+
+Amazon Comprehend uses natural language processing (NLP) to extract insights about the content of documents without the need of any special preprocessing. You can get details of Amazon Comprehend from [Amazon Comprehend Documentation](https://docs.aws.amazon.com/comprehend/).
+
+## Language detection with [DetectDominantLanguage](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectDominantLanguage.html) API
+
+This instruction shows how to create OpenSearch connector having capability to set detected language code based on input text using Amazon Comrehend DetectDominantLanguage API.
+
+Note: Need to do this on 2.14.0 or later.
+
+### 1. Add connector endpoint to trusted URLs:
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.trusted_connector_endpoints_regex": [
+            "^https://comprehend\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"
+        ]
+    }
+}
+```
+
+### 2. Create connector for Amazon Bedrock:
+
+If you are using self-managed Opensearch, you should supply AWS credentials:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Amazon Comprehend",
+  "description": "Test connector for Amazon Comprehend",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "credential": {
+    "access_key": "<PLEASE ADD YOUR AWS ACCESS KEY HERE>",
+    "secret_key": "<PLEASE ADD YOUR AWS SECRET KEY HERE>",
+    "session_token": "<PLEASE ADD YOUR AWS SECURITY TOKEN HERE>"
+  },
+  "parameters": {
+    "service_name": "comprehend",
+    "region": "ap-northeast-1",
+    "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
+    "api": "Comprehend_20171127.DetectDominantLanguage",
+    "response_filter": "$"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "${parameters.endpoint}",
+      "headers": {
+        "X-Amz-Target": "${parameters.api}",
+        "content-type": "application/x-amz-json-1.1",
+      },
+      "request_body": "{ \"Text\": \"${parameters.Text}\"}"
+    }
+  ]
+}
+```
+
+If using the AWS Opensearch Service, you can provide an IAM role arn that allows access to the bedrock service.
+Refer to this [AWS doc](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Amazon Comprehend",
+  "description": "Test connector for Amazon Comprehend",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "credential": {
+      "roleArn": "<PLEASE ADD YOUR AWS ROLE ARN HERE>"
+  },
+  "parameters": {
+    "service_name": "comprehend",
+    "region": "ap-northeast-1",
+    "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
+    "api": "Comprehend_20171127.DetectDominantLanguage",
+    "response_filter": "$"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "${parameters.endpoint}",
+      "headers": {
+        "X-Amz-Target": "${parameters.api}",
+        "content-type": "application/x-amz-json-1.1",
+      },
+      "request_body": "{ \"Text\": \"${parameters.Text}\"}"
+    }
+  ]
+}
+```
+
+Sample response:
+```json
+{
+  "connector_id": "k9Agno8Bk4Evvk2cEVR1"
+}
+```
+
+### 3. Create model group:
+
+```json
+POST /_plugins/_ml/model_groups/_register
+{
+    "name": "amazon_comprehend_model_group",
+    "description": "This is an example description"
+}
+```
+
+Sample response:
+```json
+{
+  "model_group_id": "c9AVno8Bk4Evvk2cz1Sf",
+  "status": "CREATED"
+}
+```
+
+### 4. Register model to model group & deploy model:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+    "name": "amazon_comprehend_detect_dominant_language",
+    "function_name": "remote",
+    "model_group_id": "c9AVno8Bk4Evvk2cz1Sf",
+    "description": "test model",
+    "connector_id": "k9Agno8Bk4Evvk2cEVR1"
+}
+```
+
+Sample response:
+```json
+{
+  "task_id": "l9Beno8Bk4Evvk2c4lQm",
+  "status": "CREATED",
+  "model_id": "mNBeno8Bk4Evvk2c4lRF"
+}
+```
+### 5. Test model inference:
+
+```json
+POST /_plugins/_ml/models/mNBeno8Bk4Evvk2c4lRF/_predict
+{
+  "parameters": {
+    "Text": "Bonjour"
+  }
+}
+```
+
+Sample response:
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": {
+              "Languages": [
+                {
+                  "LanguageCode": "fr", 
+                  "Score": 0.6898566484451294
+                },
+                {
+                  "LanguageCode": "en",
+                  "Score": 0.29757627844810486
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```
+
+### 6. Create ingest pipeline with ml_inference processor:
+
+[ML inference processor](https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/) passes source field to a model, extracts model output and insert into target field. 
+
+This example processor works as follows:
+1. Extract values from `message` field and pass values to `Text` parameter.
+1. Invoke Amazon Comprehend DetectDominantLanguage API with `Text` parameter.
+1. Extract values from DetectDominantLanguage result.
+1. Insert extracted values into `detected_dominant_language`.
+
+```json
+PUT /_ingest/pipeline/detect_dominant_language_pipeline
+{
+  "processors": [
+    {
+      "ml_inference": {
+        "model_id": comprehend_model_id,
+        "input_map": [
+          {
+            "Text": "message" 
+          }
+        ],
+        "output_map": [
+          {
+            "detected_dominant_language": "$.response.Languages[0].LanguageCode"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Sample response:
+```json
+{
+  "acknowledged": true
+}
+```
+
+### 7. Test ingest pipeline processor
+
+```json
+POST /_ingest/pipeline/detect_dominant_language_pipeline/_simulate
+{
+  "docs": [
+    {
+      "_index": "testindex1",
+      "_id": "1",
+      "_source":{
+         "message": "Bonjour"
+      }
+    },
+    {
+      "_index": "testindex1",
+      "_id": "2",
+      "_source":{
+         "message": "你好"
+      }
+    },
+    {
+      "_index": "testindex1",
+      "_id": "3",
+      "_source":{
+         "message": "Hello"
+      }
+    },
+    {
+      "_index": "testindex1",
+      "_id": "4",
+      "_source":{
+         "message": "안녕하세요"
+      }
+    },
+    {
+      "_index": "testindex1",
+      "_id": "5",
+      "_source":{
+         "message": "こんにちは"
+      }
+    }
+  ]
+}
+```
+
+Sample response:
+```json
+{
+  "docs": [
+    {
+      "doc": {
+        "_index": "testindex1",
+        "_id": "1",
+        "_source": {
+          "detected_dominant_language": "fr",
+          "message": "Bonjour"
+        },
+        "_ingest": {
+          "timestamp": "2024-05-22T07:52:18.257268252Z"
+        }
+      }
+    },
+    {
+      "doc": {
+        "_index": "testindex1",
+        "_id": "2",
+        "_source": {
+          "detected_dominant_language": "zh",
+          "message": "你好"
+        },
+        "_ingest": {
+          "timestamp": "2024-05-22T07:52:18.257271404Z"
+        }
+      }
+    },
+    {
+      "doc": {
+        "_index": "testindex1",
+        "_id": "3",
+        "_source": {
+          "detected_dominant_language": "en",
+          "message": "Hello"
+        },
+        "_ingest": {
+          "timestamp": "2024-05-22T07:52:18.25727557Z"
+        }
+      }
+    },
+    {
+      "doc": {
+        "_index": "testindex1",
+        "_id": "4",
+        "_source": {
+          "detected_dominant_language": "ko",
+          "message": "안녕하세요"
+        },
+        "_ingest": {
+          "timestamp": "2024-05-22T07:52:18.257276936Z"
+        }
+      }
+    },
+    {
+      "doc": {
+        "_index": "testindex1",
+        "_id": "5",
+        "_source": {
+          "detected_dominant_language": "ja",
+          "message": "こんにちは"
+        },
+        "_ingest": {
+          "timestamp": "2024-05-22T07:52:18.257278224Z"
+        }
+      }
+    }
+  ]
+}
+```
+
+Congratulations! You've successfully created Amazon Comprehend DetectDominantLanguage connector and ingest pipeline.
+
+## Entity detection with [DetectEntities](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectEntities.html) API
+
+This instruction shows how to create OpenSearch connector having capability to extract entities from input text.
+
+Note: Need to do this on 2.14.0 or later.
+
+### 1. Add connector endpoint to trusted URLs:
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.trusted_connector_endpoints_regex": [
+            "^https://comprehend\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"
+        ]
+    }
+}
+```
+
+### 2. Create connector for Amazon Bedrock:
+
+If you are using self-managed Opensearch, you should supply AWS credentials:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Amazon Comprehend",
+  "description": "Test connector for Amazon Comprehend",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "credential": {
+    "access_key": "<PLEASE ADD YOUR AWS ACCESS KEY HERE>",
+    "secret_key": "<PLEASE ADD YOUR AWS SECRET KEY HERE>",
+    "session_token": "<PLEASE ADD YOUR AWS SECURITY TOKEN HERE>"
+  },
+  "parameters": {
+    "service_name": "comprehend",
+    "region": "ap-northeast-1",
+    "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
+    "api": "Comprehend_20171127.DetectEntities",
+    "response_filter": "$"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "${parameters.endpoint}",
+      "headers": {
+        "X-Amz-Target": "${parameters.api}",
+        "content-type": "application/x-amz-json-1.1",
+      },
+      "request_body": "{ \"Text\": \"${parameters.Text}\", \"LanguageCode\": \"${parameters.LanguageCode}\"}"
+    }
+  ]
+}
+```
+
+If using the AWS Opensearch Service, you can provide an IAM role arn that allows access to the bedrock service.
+Refer to this [AWS doc](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Amazon Comprehend",
+  "description": "Test connector for Amazon Comprehend",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "credential": {
+      "roleArn": "<PLEASE ADD YOUR AWS ROLE ARN HERE>"
+  },
+  "parameters": {
+    "service_name": "comprehend",
+    "region": "ap-northeast-1",
+    "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
+    "api": "Comprehend_20171127.DetectEntities",
+    "response_filter": "$"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "${parameters.endpoint}",
+      "headers": {
+        "X-Amz-Target": "${parameters.api}",
+        "content-type": "application/x-amz-json-1.1",
+      },
+      "request_body": "{ \"Text\": \"${parameters.Text}\", \"LanguageCode\": \"${parameters.LanguageCode}\"}"
+    }
+  ]
+}
+```
+
+Sample response:
+```json
+{
+  "connector_id": "k9Agno8Bk4Evvk2cEVR1"
+}
+```
+
+### 3. Create model group:
+
+```json
+POST /_plugins/_ml/model_groups/_register
+{
+    "name": "amazon_comprehend_model_group",
+    "description": "This is an example description"
+}
+```
+
+Sample response:
+```json
+{
+  "model_group_id": "c9AVno8Bk4Evvk2cz1Sf",
+  "status": "CREATED"
+}
+```
+
+### 4. Register model to model group & deploy model:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+    "name": "amazon_comprehend_detect_entities",
+    "function_name": "remote",
+    "model_group_id": "c9AVno8Bk4Evvk2cz1Sf",
+    "description": "test model",
+    "connector_id": "k9Agno8Bk4Evvk2cEVR1"
+}
+```
+
+Sample response:
+```json
+{
+  "task_id": "l9Beno8Bk4Evvk2c4lQm",
+  "status": "CREATED",
+  "model_id": "mNBeno8Bk4Evvk2c4lRF"
+}
+```
+### 5. Test model inference:
+
+```json
+POST /_plugins/_ml/models/mNBeno8Bk4Evvk2c4lRF/_predict
+{
+  "parameters": {
+    "Text": "Bob ordered two sandwiches and three ice cream cones today from a store in Seattle.",
+    "LanguageCode": "en"
+  }
+}
+```
+
+Sample response:
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": {
+              "Entities": [
+                {
+                  "BeginOffset": 0,
+                  "EndOffset": 3,
+                  "Score": 0.9987996816635132,
+                  "Text": "Bob",
+                  "Type": "PERSON"
+                },
+                {
+                  "BeginOffset": 12,
+                  "EndOffset": 26,
+                  "Score": 0.9984013438224792,
+                  "Text": "two sandwiches",
+                  "Type": "QUANTITY"
+                },
+                {
+                  "BeginOffset": 31,
+                  "EndOffset": 52,
+                  "Score": 0.9882009625434875,
+                  "Text": "three ice cream cones",
+                  "Type": "QUANTITY"
+                },
+                {
+                  "BeginOffset": 53,
+                  "EndOffset": 58,
+                  "Score": 0.9878937602043152,
+                  "Text": "today",
+                  "Type": "DATE"
+                },
+                {
+                  "BeginOffset": 75,
+                  "EndOffset": 82,
+                  "Score": 0.9978049397468567,
+                  "Text": "Seattle",
+                  "Type": "LOCATION"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```
+
+### 6. Create ingest pipeline with ml_inference processor:
+
+ml_inference passes source field to a model, extracts model output and insert into target field. Read more details on https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/
+
+This example processor works as follows:
+1. Extract values from `message` field and pass values to `Text` parameter.
+1. Invoke Amazon Comprehend DetectEntities API with `Text` parameter and `LanguageCode` parameter. LanguageCode is specified in model_config section.
+1. Extract values from DetectEntities result.
+1. Insert extracted values into `detected_entities`.
+
+```json
+PUT /_ingest/pipeline/detect_entities_pipeline
+{
+  "processors": [
+    {
+      "ml_inference": {
+        "model_id": mNBeno8Bk4Evvk2c4lRF,
+        "input_map": [
+          {
+            "Text": "message"
+          }
+        ],
+        "output_map": [
+          {
+            "detected_entities": "$.response.Entities"
+          }
+        ],
+        "model_config":{
+          "LanguageCode": "en"
+        }
+      }
+    }
+  ]
+}
+```
+
+Sample response:
+```json
+{
+  "acknowledged": true
+}
+```
+
+### 7. Test ingest pipeline processor
+
+```json
+POST /_ingest/pipeline/detect_entities_pipeline/_simulate
+{
+  "docs": [
+    {
+      "_index": "testindex1",
+      "_id": "1",
+      "_source":{
+         "message": "Bob ordered two sandwiches and three ice cream cones today from a store in Seattle."
+      }
+    }
+  ]
+}
+```
+
+Sample response:
+```json
+{
+  "docs": [
+    {
+      "doc": {
+        "_index": "testindex1",
+        "_id": "1",
+        "_source": {
+          "message": "Bob ordered two sandwiches and three ice cream cones today from a store in Seattle.",
+          "detected_entities": [
+            {
+              "EndOffset": 3,
+              "BeginOffset": 0,
+              "Score": 0.9987996816635132,
+              "Type": "PERSON",
+              "Text": "Bob"
+            },
+            {
+              "EndOffset": 26,
+              "BeginOffset": 12,
+              "Score": 0.9984013438224792,
+              "Type": "QUANTITY",
+              "Text": "two sandwiches"
+            },
+            {
+              "EndOffset": 52,
+              "BeginOffset": 31,
+              "Score": 0.9882009625434875,
+              "Type": "QUANTITY",
+              "Text": "three ice cream cones"
+            },
+            {
+              "EndOffset": 58,
+              "BeginOffset": 53,
+              "Score": 0.9878937602043152,
+              "Type": "DATE",
+              "Text": "today"
+            },
+            {
+              "EndOffset": 82,
+              "BeginOffset": 75,
+              "Score": 0.9978049397468567,
+              "Type": "LOCATION",
+              "Text": "Seattle"
+            }
+          ]
+        },
+        "_ingest": {
+          "timestamp": "2024-05-22T08:18:16.014633507Z"
+        }
+      }
+    }
+  ]
+}
+```
+
+Congratulations! You've successfully created Amazon Comprehend DetectEntities connector and ingest pipeline.

--- a/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
@@ -21,9 +21,16 @@ PUT /_cluster/settings
 }
 ```
 
-### Step 2: Create a connector for Amazon Bedrock
+### Step 2: Create a connector for Amazon Comprehend
 
-If you are using self-managed Opensearch, provide your AWS credentials:
+- If you are using self-managed Opensearch, supply your AWS credentials. Credential owner has to have a permission to access Amazon Comprehend [DetectDominantLanguage API](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectDominantLanguage.html) API. For more information, see [AWS documentation](https://docs.aws.amazon.com/comprehend/latest/dg/security-iam-awsmanpol.html)
+
+- You can choose any region from [supported regions](https://docs.aws.amazon.com/general/latest/gr/comprehend.html)
+
+- AWS recommends to lock API version for production to avoid disruption by new API version released [1]. You can find the latest API version from SDK reference [2] or botocore code [3].
+  - [1] https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/locking-api-versions.html
+  - [2] https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Comprehend.html
+  - [3] https://github.com/boto/botocore/tree/master/botocore/data
 
 ```json
 POST /_plugins/_ml/connectors/_create
@@ -39,9 +46,11 @@ POST /_plugins/_ml/connectors/_create
   },
   "parameters": {
     "service_name": "comprehend",
-    "region": "ap-northeast-1",
+    "region": "us-east-1",
     "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
-    "api": "Comprehend_20171127.DetectDominantLanguage",
+    "api_version": "20171127",
+    "api_name": "DetectDominantLanguage",
+    "api": "Comprehend_${parameters.api_version}.${parameters.api_name}",
     "response_filter": "$"
   },
   "actions": [
@@ -59,7 +68,7 @@ POST /_plugins/_ml/connectors/_create
 }
 ```
 
-If using the AWS Opensearch Service, you can provide an IAM role ARN that allows access to the Amazon Bedrock service.
+If using the AWS Opensearch Service, you can provide an IAM role ARN that allows access to the Amazon Comprehend service.
 For more information, see [AWS documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
 
 ```json
@@ -74,9 +83,11 @@ POST /_plugins/_ml/connectors/_create
   },
   "parameters": {
     "service_name": "comprehend",
-    "region": "ap-northeast-1",
+    "region": "us-east-1",
     "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
-    "api": "Comprehend_20171127.DetectDominantLanguage",
+    "api_version": "20171127",
+    "api_name": "DetectDominantLanguage",
+    "api": "Comprehend_${parameters.api_version}.${parameters.api_name}",
     "response_filter": "$"
   },
   "actions": [
@@ -360,9 +371,16 @@ PUT /_cluster/settings
 }
 ```
 
-### Step 2: Create a connector for Amazon Bedrock
+### Step 2: Create a connector for Amazon Comprehend
 
-If you are using self-managed Opensearch, supply your AWS credentials:
+- If you are using self-managed Opensearch, supply your AWS credentials. Credential owner has to have a permission to access Amazon Comprehend [DetectEntities API](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectEntities.html) API. For more information, see [AWS documentation](https://docs.aws.amazon.com/comprehend/latest/dg/security-iam-awsmanpol.html)
+
+- You can choose any region from [supported regions](https://docs.aws.amazon.com/general/latest/gr/comprehend.html)
+
+- AWS recommends to lock API version for production to avoid disruption by new API version released [1]. You can find the latest API version from SDK reference [2] or botocore code [3].
+  - [1] https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/locking-api-versions.html
+  - [2] https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Comprehend.html
+  - [3] https://github.com/boto/botocore/tree/master/botocore/data
 
 ```json
 POST /_plugins/_ml/connectors/_create
@@ -378,9 +396,11 @@ POST /_plugins/_ml/connectors/_create
   },
   "parameters": {
     "service_name": "comprehend",
-    "region": "ap-northeast-1",
+    "region": "us-east-1",
     "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
-    "api": "Comprehend_20171127.DetectEntities",
+    "api_version": "20171127",
+    "api_name": "DetectEntities",
+    "api": "Comprehend_${parameters.api_version}.${parameters.api_name}",
     "response_filter": "$"
   },
   "actions": [
@@ -398,7 +418,7 @@ POST /_plugins/_ml/connectors/_create
 }
 ```
 
-If using the AWS Opensearch Service, you can provide an IAM role ARN that allows access to the Amazon Bedrock service.
+If using the AWS Opensearch Service, you can provide an IAM role ARN that allows access to the Amazon Comprehend service.
 For more information, see [AWS documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
 
 ```json
@@ -413,9 +433,11 @@ POST /_plugins/_ml/connectors/_create
   },
   "parameters": {
     "service_name": "comprehend",
-    "region": "ap-northeast-1",
+    "region": "us-east-1",
     "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
-    "api": "Comprehend_20171127.DetectEntities",
+    "api_version": "20171127",
+    "api_name": "DetectEntities",
+    "api": "Comprehend_${parameters.api_version}.${parameters.api_name}",
     "response_filter": "$"
   },
   "actions": [

--- a/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
@@ -665,4 +665,4 @@ Sample response:
 }
 ```
 
-Congratulations! You've successfully created Amazon Comprehend DetectEntities connector and ingest pipeline.
+You have now successfully created an Amazon Comprehend Detect Entities connector and ingest pipeline.

--- a/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
@@ -68,8 +68,11 @@ POST /_plugins/_ml/connectors/_create
 }
 ```
 
-If using the AWS Opensearch Service, you can provide an IAM role ARN that allows access to the Amazon Comprehend service.
-For more information, see [AWS documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
+If using the AWS Opensearch Service, you can provide an IAM role ARN that allows access to the Amazon Comprehend service. For more information, see following documents:
+- [AWS documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
+- [AIConnectorHelper tutorial](https://github.com/opensearch-project/ml-commons/blob/2.x/docs/tutorials/aws/AIConnectorHelper.ipynb)
+- [Semantic search with Amazon Bedrock Titan embedding text model](https://github.com/opensearch-project/ml-commons/blob/2.x/docs/tutorials/aws/semantic_search_with_bedrock_titan_embedding_model.md)
+
 
 ```json
 POST /_plugins/_ml/connectors/_create
@@ -418,8 +421,11 @@ POST /_plugins/_ml/connectors/_create
 }
 ```
 
-If using the AWS Opensearch Service, you can provide an IAM role ARN that allows access to the Amazon Comprehend service.
-For more information, see [AWS documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
+If using the AWS Opensearch Service, you can provide an IAM role ARN that allows access to the Amazon Comprehend service. For more information, see following documents:
+- [AWS documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html)
+- [AIConnectorHelper tutorial](https://github.com/opensearch-project/ml-commons/blob/2.x/docs/tutorials/aws/AIConnectorHelper.ipynb)
+- [Semantic search with Amazon Bedrock Titan embedding text model](https://github.com/opensearch-project/ml-commons/blob/2.x/docs/tutorials/aws/semantic_search_with_bedrock_titan_embedding_model.md)
+
 
 ```json
 POST /_plugins/_ml/connectors/_create


### PR DESCRIPTION
### Description
Add a connector blueprint for Amazon Comprehend. This shows how to create custom connector used by ML Inference processor.

### Issues Resolved
- https://github.com/opensearch-project/ml-commons/issues/2467
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
