### PR TITLE
Add retry to model delete API

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/model/MLModelDeleteRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model/MLModelDeleteRequest.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.InputStreamStreamInput;
 import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -21,24 +22,40 @@ import java.io.UncheckedIOException;
 
 import static org.opensearch.action.ValidateActions.addValidationError;
 
+@Getter
 public class MLModelDeleteRequest extends ActionRequest {
-    @Getter
     String modelId;
+    Boolean retry;
+    Integer maxRetry;
+    TimeValue retryDelay;
+    TimeValue retryTimeout;
 
     @Builder
-    public MLModelDeleteRequest(String modelId) {
+    public MLModelDeleteRequest(String modelId, Boolean retry, Integer maxRetry, TimeValue retryDelay, TimeValue retryTimeout) {
         this.modelId = modelId;
+        this.retry = retry;
+        this.maxRetry = maxRetry;
+        this.retryDelay = retryDelay;
+        this.retryTimeout = retryTimeout;
     }
 
     public MLModelDeleteRequest(StreamInput input) throws IOException {
         super(input);
         this.modelId = input.readString();
+        this.retry = input.readOptionalBoolean();
+        this.maxRetry = input.readOptionalVInt();
+        this.retryDelay = input.readOptionalTimeValue();
+        this.retryTimeout = input.readOptionalTimeValue();
     }
 
     @Override
     public void writeTo(StreamOutput output) throws IOException {
         super.writeTo(output);
         output.writeString(modelId);
+        output.writeOptionalBoolean(retry);
+        output.writeOptionalVInt(maxRetry);
+        output.writeOptionalTimeValue(retryDelay);
+        output.writeOptionalTimeValue(retryTimeout);
     }
 
     @Override
@@ -47,6 +64,17 @@ public class MLModelDeleteRequest extends ActionRequest {
 
         if (this.modelId == null) {
             exception = addValidationError("ML model id can't be null", exception);
+        }
+        if (this.maxRetry != null && (this.maxRetry < 0 || this.maxRetry > 5)) {
+            exception = addValidationError("Retry count should be greater than or equal to 0 and less than 5", exception);
+        }
+
+        if (this.retryDelay != null && (this.retryDelay.getMillis() < 0 || this.retryDelay.getMillis() > 30000)) {
+            exception = addValidationError("Retry delay should be greater than or equal to 0 or less than 30000 milliseconds", exception);
+        }
+
+        if (this.retryTimeout != null && (this.retryTimeout.getMillis() < 0 || this.retryTimeout.getMillis() > 30000)) {
+            exception = addValidationError("Retry delay should be greater than or equal to 0 or less than 30000 milliseconds", exception);
         }
 
         return exception;
@@ -58,7 +86,7 @@ public class MLModelDeleteRequest extends ActionRequest {
         }
 
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
             actionRequest.writeTo(osso);
             try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
                 return new MLModelDeleteRequest(input);

--- a/common/src/test/java/org/opensearch/ml/common/transport/model/MLModelDeleteRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/model/MLModelDeleteRequestTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -19,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class MLModelDeleteRequestTest {
     private String modelId;
@@ -52,6 +54,62 @@ public class MLModelDeleteRequestTest {
 
         ActionRequestValidationException exception = mlModelDeleteRequest.validate();
         assertEquals("Validation Failed: 1: ML model id can't be null;", exception.getMessage());
+    }
+
+    @Test
+    public void validate_Exception_NegativeMaxRetry() {
+        MLModelDeleteRequest mlModelDeleteRequest = MLModelDeleteRequest.builder()
+                .modelId(modelId).maxRetry(-1).build();
+
+        ActionRequestValidationException exception = mlModelDeleteRequest.validate();
+        assertEquals("Validation Failed: 1: Retry count should be greater than or equal to 0 and less than 5;", exception.getMessage());
+    }
+
+    @Test
+    public void validate_Exception_ExceedMaxRetry() {
+        MLModelDeleteRequest mlModelDeleteRequest = MLModelDeleteRequest.builder()
+                .modelId(modelId).maxRetry(6).build();
+
+        ActionRequestValidationException exception = mlModelDeleteRequest.validate();
+        assertEquals("Validation Failed: 1: Retry count should be greater than or equal to 0 and less than 5;", exception.getMessage());
+    }
+
+    @Test
+    public void validate_Exception_NegativeRetryDelay() {
+        MLModelDeleteRequest mlModelDeleteRequest = MLModelDeleteRequest.builder()
+                .modelId(modelId).retryDelay(TimeValue.timeValueMillis(-1)).build();
+
+        ActionRequestValidationException exception = mlModelDeleteRequest.validate();
+        assertEquals("Validation Failed: 1: Retry delay should be greater than or equal to 0 or less than 30000 milliseconds;", exception.getMessage());
+    }
+
+
+    @Test
+    public void validate_Exception_ExceedRetryDelay() {
+        MLModelDeleteRequest mlModelDeleteRequest = MLModelDeleteRequest.builder()
+                .modelId(modelId).retryDelay(TimeValue.timeValueMillis(50000)).build();
+
+        ActionRequestValidationException exception = mlModelDeleteRequest.validate();
+        assertEquals("Validation Failed: 1: Retry delay should be greater than or equal to 0 or less than 30000 milliseconds;", exception.getMessage());
+    }
+
+    @Test
+    public void validate_Exception_NegativeRetryTimeout() {
+        MLModelDeleteRequest mlModelDeleteRequest = MLModelDeleteRequest.builder()
+                .modelId(modelId).retryTimeout(TimeValue.timeValueMillis(-1)).build();
+
+        ActionRequestValidationException exception = mlModelDeleteRequest.validate();
+        assertEquals("Validation Failed: 1: Retry delay should be greater than or equal to 0 or less than 30000 milliseconds;", exception.getMessage());
+    }
+
+
+    @Test
+    public void validate_Exception_ExceedRetryTimeout() {
+        MLModelDeleteRequest mlModelDeleteRequest = MLModelDeleteRequest.builder()
+                .modelId(modelId).retryTimeout(TimeValue.timeValueSeconds(60)).build();
+
+        ActionRequestValidationException exception = mlModelDeleteRequest.validate();
+        assertEquals("Validation Failed: 1: Retry delay should be greater than or equal to 0 or less than 30000 milliseconds;", exception.getMessage());
     }
 
     @Test

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -1690,6 +1690,20 @@ public class MLModelManager {
     }
 
     /**
+     * Get model state with model id.
+     *
+     * @param modelId  model id
+     * @param listener action listener
+     */
+    public void getModelState(String modelId, ActionListener<MLModelState> listener) {
+        String[] excludes = new String[] { MLModel.MODEL_CONTENT_FIELD, MLModel.OLD_MODEL_CONTENT_FIELD };
+        getModel(modelId, null, excludes, ActionListener.wrap(mlModel -> { listener.onResponse(mlModel.getModelState()); }, e -> {
+            log.error("Failed to get model state for model: " + modelId, e);
+            listener.onFailure(e);
+        }));
+    }
+
+    /**
      * Update model with build-in listener.
      *
      * @param modelId       model id

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLDeleteModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLDeleteModelAction.java
@@ -6,13 +6,18 @@
 package org.opensearch.ml.rest;
 
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MAX_RETRY;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_RETRY;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_RETRY_DELAY;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_RETRY_TIMEOUT;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.ml.common.transport.model.MLModelDeleteAction;
 import org.opensearch.ml.common.transport.model.MLModelDeleteRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -43,8 +48,12 @@ public class RestMLDeleteModelAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String modelId = request.param(PARAMETER_MODEL_ID);
+        boolean retry = request.paramAsBoolean(PARAMETER_RETRY, true);
+        int maxRetry = request.paramAsInt(PARAMETER_MAX_RETRY, 1);
+        TimeValue retryDelay = request.paramAsTime(PARAMETER_RETRY_DELAY, TimeValue.timeValueMillis(100));
+        TimeValue retryTimeout = request.paramAsTime(PARAMETER_RETRY_TIMEOUT, TimeValue.timeValueSeconds(30));
 
-        MLModelDeleteRequest mlModelDeleteRequest = new MLModelDeleteRequest(modelId);
+        MLModelDeleteRequest mlModelDeleteRequest = new MLModelDeleteRequest(modelId, retry, maxRetry, retryDelay, retryTimeout);
         return channel -> client.execute(MLModelDeleteAction.INSTANCE, mlModelDeleteRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -70,6 +70,10 @@ public class RestActionUtils {
     public static final String PARAMETER_VERSION = "version";
     public static final String PARAMETER_MODEL_GROUP_ID = "model_group_id";
     public static final String PARAMETER_CONFIG_ID = "config_id";
+    public static final String PARAMETER_RETRY = "retry";
+    public static final String PARAMETER_MAX_RETRY = "max_retry";
+    public static final String PARAMETER_RETRY_DELAY = "retry_delay";
+    public static final String PARAMETER_RETRY_TIMEOUT = "retry_timeout";
     public static final String OPENSEARCH_DASHBOARDS_USER_AGENT = "OpenSearch Dashboards";
     public static final String[] UI_METADATA_EXCLUDE = new String[] { "ui_metadata" };
 

--- a/plugin/src/test/java/org/opensearch/ml/action/models/DeleteModelTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/DeleteModelTransportActionTests.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.action.models;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -23,9 +24,9 @@ import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
@@ -40,6 +41,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
@@ -95,6 +97,9 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
     @Mock
     ClusterService clusterService;
 
+    @Mock
+    ExecutorService executorService;
+
     DeleteModelTransportAction deleteModelTransportAction;
     MLModelDeleteRequest mlModelDeleteRequest;
     ThreadContext threadContext;
@@ -107,7 +112,14 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
     public void setup() throws IOException {
         MockitoAnnotations.openMocks(this);
 
-        mlModelDeleteRequest = MLModelDeleteRequest.builder().modelId("test_id").build();
+        mlModelDeleteRequest = MLModelDeleteRequest
+            .builder()
+            .modelId("test_id")
+            .retry(false)
+            .maxRetry(1)
+            .retryDelay(TimeValue.timeValueMillis(100))
+            .retryTimeout(TimeValue.timeValueSeconds(30))
+            .build();
 
         Settings settings = Settings.builder().build();
         deleteModelTransportAction = spy(
@@ -115,10 +127,10 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
                 transportService,
                 actionFilters,
                 client,
-                settings,
                 xContentRegistry,
                 clusterService,
-                modelAccessControlHelper
+                modelAccessControlHelper,
+                mlModelManager
             )
         );
 
@@ -132,6 +144,18 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
         when(clusterService.getSettings()).thenReturn(settings);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(threadPool.executor(any())).thenReturn(executorService);
+
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(threadPool).schedule(any(), any(), any());
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(executorService).execute(any());
     }
 
     public void testDeleteModel_Success() throws IOException {
@@ -148,12 +172,18 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, null, false);
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, null, false);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         verify(actionListener).onResponse(deleteResponse);
@@ -173,12 +203,18 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        GetResponse getResponse = prepareModelWithFunction(MLModelState.REGISTERED, null, false, FunctionName.REMOTE);
+        MLModel mlModel = prepareModelWithFunction(MLModelState.REGISTERED, null, false, FunctionName.REMOTE);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         verify(actionListener).onResponse(deleteResponse);
@@ -202,12 +238,18 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        GetResponse getResponse = prepareModelWithFunction(MLModelState.REGISTERED, null, false, FunctionName.REMOTE);
+        MLModel mlModel = prepareModelWithFunction(MLModelState.REGISTERED, null, false, FunctionName.REMOTE);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -233,12 +275,18 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        GetResponse getResponse = prepareModelWithFunction(MLModelState.REGISTERED, null, false, FunctionName.TEXT_EMBEDDING);
+        MLModel mlModel = prepareModelWithFunction(MLModelState.REGISTERED, null, false, FunctionName.TEXT_EMBEDDING);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -259,12 +307,18 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(), any());
 
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, null, false);
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, null, false);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -286,12 +340,18 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, null, true);
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, null, true);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         doReturn(true).when(deleteModelTransportAction).isSuperAdminUserWrapper(clusterService, client);
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
@@ -312,12 +372,24 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, null, true);
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, null, true);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         doReturn(false).when(deleteModelTransportAction).isSuperAdminUserWrapper(clusterService, client);
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
@@ -340,24 +412,48 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, null, false);
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, null, false);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         verify(actionListener).onResponse(deleteResponse);
     }
 
     public void test_UserHasNoAccessException() throws IOException {
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, "modelGroupID", false);
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, "modelGroupID", false);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         doAnswer(invocation -> {
             ActionListener<Boolean> listener = invocation.getArgument(3);
@@ -371,13 +467,25 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
         assertEquals("User doesn't have privilege to perform this operation on this model", argumentCaptor.getValue().getMessage());
     }
 
-    public void testDeleteModel_CheckModelState() throws IOException {
-        GetResponse getResponse = prepareMLModel(MLModelState.DEPLOYING, null, false);
+    public void testDeleteModel_CheckModelStateDeploying() throws IOException {
+        MLModel mlModel = prepareMLModel(MLModelState.DEPLOYING, null, false);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.DEPLOYING);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -388,12 +496,166 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
         );
     }
 
+    public void testDeleteModel_CheckModelStateLoading() throws IOException {
+        MLModel mlModel = prepareMLModel(MLModelState.LOADING, null, false);
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.LOADING);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
+
+        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "Model cannot be deleted in deploying or deployed state. Try undeploy model first then delete",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    public void testDeleteModel_CheckModelStateDeployed() throws IOException {
+        MLModel mlModel = prepareMLModel(MLModelState.DEPLOYED, null, false);
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.DEPLOYED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
+
+        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "Model cannot be deleted in deploying or deployed state. Try undeploy model first then delete",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    public void testDeleteModel_CheckModelStateLoaded() throws IOException {
+        MLModel mlModel = prepareMLModel(MLModelState.LOADED, null, false);
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.LOADED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
+
+        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "Model cannot be deleted in deploying or deployed state. Try undeploy model first then delete",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    public void testDeleteModel_CheckModelStatePartiallyDeployed() throws IOException {
+        MLModel mlModel = prepareMLModel(MLModelState.PARTIALLY_DEPLOYED, null, false);
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.PARTIALLY_DEPLOYED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
+
+        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "Model cannot be deleted in deploying or deployed state. Try undeploy model first then delete",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    public void testDeleteModel_CheckModelStatePartiallyLoaded() throws IOException {
+        MLModel mlModel = prepareMLModel(MLModelState.PARTIALLY_LOADED, null, false);
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.PARTIALLY_LOADED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
+
+        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "Model cannot be deleted in deploying or deployed state. Try undeploy model first then delete",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    public void testDeleteModel_CheckModelStateNotFound() throws IOException {
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, null, false);
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(null);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
+
+        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+    }
+
+    public void testDeleteModel_CheckModelStateOtherException() throws IOException {
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, null, false);
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException("Some Exception occurred. Please check log for more details."));
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
+
+        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Some Exception occurred. Please check log for more details.", argumentCaptor.getValue().getMessage());
+    }
+
     public void testDeleteModel_ModelNotFoundException() throws IOException {
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onFailure(new Exception("Fail to find model"));
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onFailure(new Exception("Fail to find model"));
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -419,12 +681,18 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, null, false);
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, null, false);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         ArgumentCaptor<DeleteResponse> argumentCaptor = ArgumentCaptor.forClass(DeleteResponse.class);
@@ -432,12 +700,18 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
     }
 
     public void test_ValidationFailedException() throws IOException {
-        GetResponse getResponse = prepareMLModel(MLModelState.REGISTERED, null, false);
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, null, false);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         doAnswer(invocation -> {
             ActionListener<Boolean> listener = invocation.getArgument(3);
@@ -469,12 +743,18 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        GetResponse getResponse = prepareModelWithFunction(MLModelState.REGISTERED, null, false, FunctionName.REMOTE);
+        MLModel mlModel = prepareModelWithFunction(MLModelState.REGISTERED, null, false, FunctionName.REMOTE);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         ArgumentCaptor<OpenSearchStatusException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
@@ -500,12 +780,18 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        GetResponse getResponse = prepareModelWithFunction(MLModelState.REGISTERED, null, false, FunctionName.REMOTE);
+        MLModel mlModel = prepareModelWithFunction(MLModelState.REGISTERED, null, false, FunctionName.REMOTE);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
 
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
         ArgumentCaptor<RuntimeException> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
@@ -515,10 +801,10 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
 
     public void testModelNotFound_modelChunks_modelController_delete_success() throws IOException {
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(null);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(null);
             return null;
-        }).when(client).get(any(), any());
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
 
         doAnswer(invocation -> {
             ActionListener<DeleteResponse> listener = invocation.getArgument(1);
@@ -550,13 +836,11 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
         verify(deleteChunksListener).onResponse(true);
     }
 
-    @Ignore
     public void testDeleteModel_ThreadContextError() {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage("thread context error");
         when(threadPool.getThreadContext()).thenThrow(new RuntimeException("thread context error"));
         deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
-        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals("thread context error", argumentCaptor.getValue().getMessage());
     }
 
     public void test_FailToDeleteModel() {
@@ -625,7 +909,98 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
         assertEquals(OS_STATUS_EXCEPTION_MESSAGE + ", " + SEARCH_FAILURE_MSG + "test_id", argumentCaptor.getValue().getMessage());
     }
 
-    public GetResponse prepareMLModel(MLModelState mlModelState, String modelGroupID, boolean isHidden) throws IOException {
+    public void testDeleteModel_FailedWithMaxRetry() throws IOException {
+        mlModelDeleteRequest = MLModelDeleteRequest
+            .builder()
+            .modelId("test_id")
+            .retry(true)
+            .maxRetry(1)
+            .retryDelay(TimeValue.timeValueMillis(100))
+            .retryTimeout(TimeValue.timeValueSeconds(30))
+            .build();
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
+            listener.onResponse(deleteResponse);
+            return null;
+        }).when(client).delete(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            BulkByScrollResponse response = new BulkByScrollResponse(new ArrayList<>(), null);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, null, false);
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.DEPLOYED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
+
+        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
+        verify(mlModelManager, times(2)).getModelState(any(), any());
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "Model cannot be deleted in deploying or deployed state. Try undeploy model first then delete",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    public void testDeleteModel_SuccessWithMaxRetry() throws IOException {
+        mlModelDeleteRequest = MLModelDeleteRequest
+            .builder()
+            .modelId("test_id")
+            .retry(true)
+            .maxRetry(1)
+            .retryDelay(TimeValue.timeValueMillis(100))
+            .retryTimeout(TimeValue.timeValueSeconds(30))
+            .build();
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
+            listener.onResponse(deleteResponse);
+            return null;
+        }).when(client).delete(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            BulkByScrollResponse response = new BulkByScrollResponse(new ArrayList<>(), null);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        MLModel mlModel = prepareMLModel(MLModelState.REGISTERED, null, false);
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(3);
+            listener.onResponse(mlModel);
+            return null;
+        }).when(mlModelManager).getModel(eq("test_id"), any(), any(), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.DEPLOYED);
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<MLModelState> listener = invocation.getArgument(1);
+            listener.onResponse(MLModelState.REGISTERED);
+            return null;
+        }).when(mlModelManager).getModelState(eq("test_id"), isA(ActionListener.class));
+
+        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
+        verify(mlModelManager, times(2)).getModelState(any(), any());
+        verify(actionListener).onResponse(deleteResponse);
+    }
+
+    private MLModel prepareMLModel(MLModelState mlModelState, String modelGroupID, boolean isHidden) {
         MLModel mlModel = MLModel
             .builder()
             .modelId("test_id")
@@ -633,11 +1008,10 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             .modelGroupId(modelGroupID)
             .isHidden(isHidden)
             .build();
-        return buildResponse(mlModel);
+        return mlModel;
     }
 
-    public GetResponse prepareModelWithFunction(MLModelState mlModelState, String modelGroupID, boolean isHidden, FunctionName functionName)
-        throws IOException {
+    private MLModel prepareModelWithFunction(MLModelState mlModelState, String modelGroupID, boolean isHidden, FunctionName functionName) {
         MLModel mlModel = MLModel
             .builder()
             .modelId("test_id")
@@ -646,7 +1020,7 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             .modelGroupId(modelGroupID)
             .isHidden(isHidden)
             .build();
-        return buildResponse(mlModel);
+        return mlModel;
     }
 
     private GetResponse buildResponse(MLModel mlModel) throws IOException {


### PR DESCRIPTION
### Description
Adding a retry parameter in model delete API, with retry times and delay time interval
 
### Issues Resolved
This PR should resolve https://github.com/opensearch-project/ml-commons/issues/2419
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
