### PR TITLE
[Feature/multi_tenancy] Remove strict version dependency to compile minimum compatible version

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.common;
 
+import org.opensearch.Version;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.connector.AbstractConnector;
 import org.opensearch.ml.common.controller.MLController;
@@ -541,4 +542,9 @@ public class CommonValue {
                         + "\": {\"type\": \"long\"}\n"
                         + "    }\n"
                         + "}";
+        // Calculate Versions independently of OpenSearch core version
+        public static final Version VERSION_2_11_0 = Version.fromString("2.11.0");
+        public static final Version VERSION_2_12_0 = Version.fromString("2.12.0");
+        public static final Version VERSION_2_13_0 = Version.fromString("2.13.0");
+        public static final Version VERSION_2_14_0 = Version.fromString("2.14.0");
 }

--- a/common/src/main/java/org/opensearch/ml/common/agent/MLAgent.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/MLAgent.java
@@ -15,6 +15,7 @@ import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.MLModel;
 
@@ -47,7 +48,7 @@ public class MLAgent implements ToXContentObject, Writeable {
     public static final String APP_TYPE_FIELD = "app_type";
     public static final String IS_HIDDEN_FIELD = "is_hidden";
 
-    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_HIDDEN_AGENT = Version.fromString("2.13.0");
+    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_HIDDEN_AGENT = CommonValue.VERSION_2_13_0;
 
     private String name;
     private String type;

--- a/common/src/main/java/org/opensearch/ml/common/agent/MLAgent.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/MLAgent.java
@@ -47,7 +47,7 @@ public class MLAgent implements ToXContentObject, Writeable {
     public static final String APP_TYPE_FIELD = "app_type";
     public static final String IS_HIDDEN_FIELD = "is_hidden";
 
-    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_HIDDEN_AGENT = Version.V_2_13_0;
+    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_HIDDEN_AGENT = Version.fromString("2.13.0");
 
     private String name;
     private String type;

--- a/common/src/main/java/org/opensearch/ml/common/dataset/TextDocsInputDataSet.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataset/TextDocsInputDataSet.java
@@ -29,7 +29,7 @@ public class TextDocsInputDataSet extends MLInputDataset{
 
     private List<String> docs;
 
-    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MULTI_MODAL = Version.V_2_11_0;
+    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MULTI_MODAL = Version.fromString("2.11.0");
 
     @Builder(toBuilder = true)
     public TextDocsInputDataSet(List<String> docs, ModelResultFilter resultFilter) {

--- a/common/src/main/java/org/opensearch/ml/common/dataset/TextDocsInputDataSet.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataset/TextDocsInputDataSet.java
@@ -12,6 +12,7 @@ import lombok.experimental.FieldDefaults;
 import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.annotation.InputDataSet;
 import org.opensearch.ml.common.output.model.ModelResultFilter;
 
@@ -29,7 +30,7 @@ public class TextDocsInputDataSet extends MLInputDataset{
 
     private List<String> docs;
 
-    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MULTI_MODAL = Version.fromString("2.11.0");
+    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MULTI_MODAL = CommonValue.VERSION_2_11_0;
 
     @Builder(toBuilder = true)
     public TextDocsInputDataSet(List<String> docs, ModelResultFilter resultFilter) {

--- a/common/src/main/java/org/opensearch/ml/common/model/MLDeploySetting.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/MLDeploySetting.java
@@ -27,7 +27,7 @@ public class MLDeploySetting implements ToXContentObject, Writeable {
     public static final String IS_AUTO_DEPLOY_ENABLED_FIELD = "is_auto_deploy_enabled";
     public static final String MODEL_TTL_MINUTES_FIELD = "model_ttl_minutes";
     private static final long DEFAULT_TTL_MINUTES = -1;
-    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL = Version.V_2_14_0;
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL = Version.fromString("2.14.0");
 
     private Boolean isAutoDeployEnabled;
     private Long modelTTLInMinutes; // in minutes

--- a/common/src/main/java/org/opensearch/ml/common/model/MLDeploySetting.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/MLDeploySetting.java
@@ -16,6 +16,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 
 import java.io.IOException;
 
@@ -27,7 +28,7 @@ public class MLDeploySetting implements ToXContentObject, Writeable {
     public static final String IS_AUTO_DEPLOY_ENABLED_FIELD = "is_auto_deploy_enabled";
     public static final String MODEL_TTL_MINUTES_FIELD = "model_ttl_minutes";
     private static final long DEFAULT_TTL_MINUTES = -1;
-    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL = Version.fromString("2.14.0");
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_TTL = CommonValue.VERSION_2_14_0;
 
     private Boolean isAutoDeployEnabled;
     private Long modelTTLInMinutes; // in minutes

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -48,7 +48,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
     public static final String ACCESS_MODE_FIELD = "access_mode";
     public static final String DRY_RUN_FIELD = "dry_run";
 
-    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_CLIENT_CONFIG = Version.V_2_13_0;
+    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_CLIENT_CONFIG = Version.fromString("2.13.0");
 
     public static final String DRY_RUN_CONNECTOR_NAME = "dryRunConnector";
 

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -17,6 +17,7 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.AccessMode;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.connector.AbstractConnector;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.ConnectorClientConfig;
@@ -48,7 +49,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
     public static final String ACCESS_MODE_FIELD = "access_mode";
     public static final String DRY_RUN_FIELD = "dry_run";
 
-    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_CLIENT_CONFIG = Version.fromString("2.13.0");
+    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_CLIENT_CONFIG = CommonValue.VERSION_2_13_0;
 
     public static final String DRY_RUN_CONNECTOR_NAME = "dryRunConnector";
 

--- a/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
@@ -69,10 +69,10 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
     public static final String DOES_VERSION_CREATE_MODEL_GROUP = "does_version_create_model_group";
     public static final String GUARDRAILS_FIELD = "guardrails";
 
-    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_DOES_VERSION_CREATE_MODEL_GROUP = Version.V_2_11_0;
-    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_AGENT_FRAMEWORK = Version.V_2_12_0;
-    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_GUARDRAILS_AND_AUTO_DEPLOY = Version.V_2_13_0;
-    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_INTERFACE = Version.V_2_14_0;
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_DOES_VERSION_CREATE_MODEL_GROUP = Version.fromString("2.11.0");
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_AGENT_FRAMEWORK = Version.fromString("2.12.0");
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_GUARDRAILS_AND_AUTO_DEPLOY = Version.fromString("2.13.0");
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_INTERFACE = Version.fromString("2.14.0");     
 
     private FunctionName functionName;
     private String modelName;

--- a/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
@@ -15,6 +15,7 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.AccessMode;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.connector.Connector;
@@ -69,10 +70,10 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
     public static final String DOES_VERSION_CREATE_MODEL_GROUP = "does_version_create_model_group";
     public static final String GUARDRAILS_FIELD = "guardrails";
 
-    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_DOES_VERSION_CREATE_MODEL_GROUP = Version.fromString("2.11.0");
-    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_AGENT_FRAMEWORK = Version.fromString("2.12.0");
-    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_GUARDRAILS_AND_AUTO_DEPLOY = Version.fromString("2.13.0");
-    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_INTERFACE = Version.fromString("2.14.0");     
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_DOES_VERSION_CREATE_MODEL_GROUP = CommonValue.VERSION_2_11_0;
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_AGENT_FRAMEWORK = CommonValue.VERSION_2_12_0;
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_GUARDRAILS_AND_AUTO_DEPLOY = CommonValue.VERSION_2_13_0;
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_INTERFACE = CommonValue.VERSION_2_14_0;
 
     private FunctionName functionName;
     private String modelName;

--- a/common/src/test/java/org/opensearch/ml/common/agent/MLAgentTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/MLAgentTest.java
@@ -206,10 +206,10 @@ public class MLAgentTest {
         assertNull(agentOldVersion.getIsHidden()); // Hidden should be null for old versions
 
         output = new BytesStreamOutput();
-        output.setVersion(Version.V_2_13_0); // Version at or after MINIMAL_SUPPORTED_VERSION_FOR_HIDDEN_AGENT
+        output.setVersion(Version.fromString("2.13.0")); // Version at or after MINIMAL_SUPPORTED_VERSION_FOR_HIDDEN_AGENT
         agent.writeTo(output);
         StreamInput streamInput1 = output.bytes().streamInput();
-        streamInput1.setVersion(Version.V_2_13_0);
+        streamInput1.setVersion(Version.fromString("2.13.0"));
         MLAgent agentNewVersion = new MLAgent(output.bytes().streamInput());
         assertEquals(Boolean.TRUE, agentNewVersion.getIsHidden()); // Hidden should be true for new versions
     }

--- a/common/src/test/java/org/opensearch/ml/common/agent/MLAgentTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/MLAgentTest.java
@@ -18,6 +18,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.TestHelper;
 import org.opensearch.search.SearchModule;
@@ -196,7 +197,7 @@ public class MLAgentTest {
     public void writeTo_ReadFrom_HiddenFlag_VersionCompatibility() throws IOException {
         MLAgent agent = new MLAgent("test", "FLOW", "test", null, null, null, null, Instant.EPOCH, Instant.EPOCH, "test", true);
         BytesStreamOutput output = new BytesStreamOutput();
-        Version oldVersion = Version.fromString("2.12.0");
+        Version oldVersion = CommonValue.VERSION_2_12_0;
         output.setVersion(oldVersion); // Version before MINIMAL_SUPPORTED_VERSION_FOR_HIDDEN_AGENT
         agent.writeTo(output);
 
@@ -206,10 +207,10 @@ public class MLAgentTest {
         assertNull(agentOldVersion.getIsHidden()); // Hidden should be null for old versions
 
         output = new BytesStreamOutput();
-        output.setVersion(Version.fromString("2.13.0")); // Version at or after MINIMAL_SUPPORTED_VERSION_FOR_HIDDEN_AGENT
+        output.setVersion(CommonValue.VERSION_2_13_0); // Version at or after MINIMAL_SUPPORTED_VERSION_FOR_HIDDEN_AGENT
         agent.writeTo(output);
         StreamInput streamInput1 = output.bytes().streamInput();
-        streamInput1.setVersion(Version.fromString("2.13.0"));
+        streamInput1.setVersion(CommonValue.VERSION_2_13_0);
         MLAgent agentNewVersion = new MLAgent(output.bytes().streamInput());
         assertEquals(Boolean.TRUE, agentNewVersion.getIsHidden()); // Hidden should be true for new versions
     }

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -21,6 +21,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.AccessMode;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.ConnectorClientConfig;
 import org.opensearch.ml.common.connector.MLPostProcessFunction;
@@ -254,7 +255,7 @@ public class MLCreateConnectorInputTests {
         MLCreateConnectorInput input = mlCreateConnectorInput; // Assuming mlCreateConnectorInput is already initialized
 
         // Simulate an older version of OpenSearch that does not support connectorClientConfig
-        Version oldVersion = Version.fromString("2.12.0"); // Change this as per your old version
+        Version oldVersion = CommonValue.VERSION_2_12_0; // Change this as per your old version
         BytesStreamOutput output = new BytesStreamOutput();
         output.setVersion(oldVersion);
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -69,6 +69,8 @@ dependencies {
         resolutionStrategy.force 'org.apache.httpcomponents.core5:httpcore5-h2:5.2.4'
         resolutionStrategy.force 'jakarta.json:jakarta.json-api:2.1.3'
         resolutionStrategy.force "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
+        resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+        resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     }
 }
 


### PR DESCRIPTION
### Description

Changes the Version compatibility constants to calculate independently of constants in those OpenSearch versions.
 
### Issues Resolved

Relates to #2483 (which can forward-port this commit to `main`)
 
### Check List
- ~[ ] New functionality includes testing.~
  - ~[ ] All tests pass~
- ~[ ] New functionality has been documented.~
  - ~[ ] New functionality has javadoc added~
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
