### PR TITLE
[Feature/multi_tenancy] Add source map to GetDataObjectResponse

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
@@ -10,22 +10,27 @@ package org.opensearch.sdk;
 
 import org.opensearch.core.xcontent.XContentParser;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 public class GetDataObjectResponse {
     private final String id;
     private final Optional<XContentParser> parser;
+    private final Map<String, Object> source;
 
     /**
-     * Instantiate this request with an id and parser used to recreate the data object.
+     * Instantiate this request with an id and parser/map used to recreate the data object.
      * <p>
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
      * @param id the document id
-     * @param parser an optional XContentParser that can be used to create the object if present.
+     * @param parser an optional XContentParser that can be used to create the data object if present.
+     * @param source the data object as a map
      */
-    public GetDataObjectResponse(String id, Optional<XContentParser> parser) {
+    public GetDataObjectResponse(String id, Optional<XContentParser> parser, Map<String, Object> source) {
         this.id = id;
         this.parser = parser;
+        this.source = source;
     }
 
     /**
@@ -37,11 +42,19 @@ public class GetDataObjectResponse {
     }
     
     /**
-     * Returns the parser optional
+     * Returns the parser optional. If present, is a representation of the data object that may be parsed.
      * @return the parser optional
      */
     public Optional<XContentParser> parser() {
         return this.parser;
+    }
+    
+    /**
+     * Returns the source map. This is a logical representation of the data object.
+     * @return the source map
+     */
+    public Map<String, Object> source() {
+        return this.source;
     }
 
     /**
@@ -50,6 +63,7 @@ public class GetDataObjectResponse {
     public static class Builder {
         private String id = null;
         private Optional<XContentParser> parser = Optional.empty();
+        private Map<String, Object> source = Collections.emptyMap();
 
         /**
          * Empty Constructor for the Builder object
@@ -68,7 +82,7 @@ public class GetDataObjectResponse {
         
         /**
          * Add an optional parser to this builder
-         * @param parser an {@link Optional} which may contain the parser
+         * @param parser an {@link Optional} which may contain the data object parser
          * @return the updated builder
          */
         public Builder parser(Optional<XContentParser> parser) {
@@ -77,11 +91,21 @@ public class GetDataObjectResponse {
         }
 
         /**
+         * Add a source map to this builder
+         * @param source the data object as a map
+         * @return the updated builder
+         */
+        public Builder source(Map<String, Object> source) {
+            this.source = source;
+            return this;
+        }
+        
+        /**
          * Builds the response
          * @return A {@link GetDataObjectResponse}
          */
         public GetDataObjectResponse build() {
-            return new GetDataObjectResponse(this.id, this.parser);
+            return new GetDataObjectResponse(this.id, this.parser, this.source);
         }
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/GetDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/GetDataObjectResponseTests.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.core.xcontent.XContentParser;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -21,18 +22,21 @@ public class GetDataObjectResponseTests {
 
     private String testId;
     private XContentParser testParser;
+    private Map<String, Object> testSource;
 
     @Before
     public void setUp() {
         testId = "test-id";
         testParser = mock(XContentParser.class);
+        testSource = Map.of("foo", "bar");
     }
 
     @Test
     public void testGetDataObjectResponse() {
-        GetDataObjectResponse response = new GetDataObjectResponse.Builder().id(testId).parser(Optional.of(testParser)).build();
+        GetDataObjectResponse response = new GetDataObjectResponse.Builder().id(testId).parser(Optional.of(testParser)).source(testSource).build();
 
         assertEquals(testId, response.id());
         assertEquals(testParser, response.parser().get());
+        assertEquals(testSource, response.source());
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClient.java
@@ -97,7 +97,11 @@ public class LocalClusterIndicesClient implements SdkClient {
                 XContentParser parser = jsonXContent
                     .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString());
                 log.info("Retrieved data object");
-                return new GetDataObjectResponse.Builder().id(getResponse.getId()).parser(Optional.of(parser)).build();
+                return new GetDataObjectResponse.Builder()
+                    .id(getResponse.getId())
+                    .parser(Optional.of(parser))
+                    .source(getResponse.getSource())
+                    .build();
             } catch (OpenSearchStatusException | IndexNotFoundException notFound) {
                 throw notFound;
             } catch (Exception e) {

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
@@ -87,11 +87,13 @@ public class RemoteClusterIndicesClient implements SdkClient {
                 if (!getResponse.found()) {
                     return new GetDataObjectResponse.Builder().id(getResponse.id()).build();
                 }
-                String json = new ObjectMapper().setSerializationInclusion(Include.NON_NULL).writeValueAsString(getResponse.source());
-                log.info("Retrieved data object");
+                // Since we use the JacksonJsonBMapper we know this is String-Object map
+                @SuppressWarnings("unchecked")
+                Map<String, Object> source = getResponse.source();
+                String json = new ObjectMapper().setSerializationInclusion(Include.NON_NULL).writeValueAsString(source);
                 XContentParser parser = JsonXContent.jsonXContent
                     .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
-                return new GetDataObjectResponse.Builder().id(getResponse.id()).parser(Optional.of(parser)).build();
+                return new GetDataObjectResponse.Builder().id(getResponse.id()).parser(Optional.of(parser)).source(source).build();
             } catch (Exception e) {
                 throw new OpenSearchException(e);
             }

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
@@ -173,6 +173,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
         assertEquals(TEST_INDEX, getRequestCaptor.getValue().index());
         assertEquals(TEST_ID, response.id());
+        assertEquals("foo", response.source().get("data"));
         assertTrue(response.parser().isPresent());
         XContentParser parser = response.parser().get();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);


### PR DESCRIPTION
### Description

Includes a String-Object source map alongside the parser for cases such as creating a model where its type and hidden status are needed prior to parsing.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
