### PR TITLE
[Feature/multi_tenancy] Restore original exception handling expectations

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -46,7 +46,12 @@ public interface SdkClient {
             if (cause instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            throw new OpenSearchException(cause);
+            // Rethrow unchecked Exceptions
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else {
+                throw new OpenSearchException(cause);                
+            }
         }
     }
 
@@ -80,7 +85,12 @@ public interface SdkClient {
             if (cause instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            throw new OpenSearchException(cause);
+            // Rethrow unchecked Exceptions
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else {
+                throw new OpenSearchException(cause);                
+            }
         }
     }
 
@@ -114,7 +124,12 @@ public interface SdkClient {
             if (cause instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            throw new OpenSearchException(cause);
+            // Rethrow unchecked Exceptions
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else {
+                throw new OpenSearchException(cause);                
+            }
         }
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.rest.RestStatus;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -44,7 +46,7 @@ public class SdkClientTests {
     @Mock
     private DeleteDataObjectResponse deleteResponse;
 
-    private RuntimeException testException;
+    private OpenSearchStatusException testException;
     private InterruptedException interruptedException;
 
     @Before
@@ -66,7 +68,7 @@ public class SdkClientTests {
                 return CompletableFuture.completedFuture(deleteResponse);
             }
         });
-        testException = new RuntimeException();
+        testException = new OpenSearchStatusException("Test", RestStatus.BAD_REQUEST);
         interruptedException = new InterruptedException();
     }
 
@@ -81,10 +83,10 @@ public class SdkClientTests {
         when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class), any(Executor.class)))
                 .thenReturn(CompletableFuture.failedFuture(testException));
 
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
+        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
             sdkClient.putDataObject(putRequest);
         });
-        assertEquals(testException, exception.getCause());
+        assertEquals(testException, exception);
         assertFalse(Thread.interrupted());        
         verify(sdkClient).putDataObjectAsync(any(PutDataObjectRequest.class), any(Executor.class));
     }
@@ -113,10 +115,10 @@ public class SdkClientTests {
         when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class), any(Executor.class)))
                 .thenReturn(CompletableFuture.failedFuture(testException));
 
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
+        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
             sdkClient.getDataObject(getRequest);
         });
-        assertEquals(testException, exception.getCause());
+        assertEquals(testException, exception);
         assertFalse(Thread.interrupted());        
         verify(sdkClient).getDataObjectAsync(any(GetDataObjectRequest.class), any(Executor.class));
     }
@@ -144,10 +146,10 @@ public class SdkClientTests {
     public void testDeleteDataObjectException() {
         when(sdkClient.deleteDataObjectAsync(any(DeleteDataObjectRequest.class), any(Executor.class)))
                 .thenReturn(CompletableFuture.failedFuture(testException));
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
+        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
             sdkClient.deleteDataObject(deleteRequest);
         });
-        assertEquals(testException, exception.getCause());
+        assertEquals(testException, exception);
         assertFalse(Thread.interrupted());        
         verify(sdkClient).deleteDataObjectAsync(any(DeleteDataObjectRequest.class), any(Executor.class));
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.delete.DeleteRequest;
@@ -125,7 +126,7 @@ public class DeleteConnectorTransportAction extends HandledTransportAction<Actio
                 sourceBuilder.query(QueryBuilders.matchQuery(TENANT_ID, tenantId));
             }
             searchRequest.source(sourceBuilder);
-            // TODO: User SDK client not client.
+            // TODO: Use SDK client not client.
             client.search(searchRequest, ActionListener.runBefore(ActionListener.wrap(searchResponse -> {
                 SearchHit[] searchHits = searchResponse.getHits().getHits();
                 if (searchHits.length == 0) {
@@ -213,8 +214,13 @@ public class DeleteConnectorTransportAction extends HandledTransportAction<Actio
         ActionListener<DeleteResponse> actionListener
     ) {
         if (throwable != null) {
-            log.error("Failed to delete ML connector: {}", connectorId, throwable);
-            actionListener.onFailure(new RuntimeException(throwable));
+            Throwable cause = throwable.getCause() == null ? throwable : throwable.getCause();
+            log.error("Failed to delete ML connector: {}", connectorId, cause);
+            if (cause instanceof Exception) {
+                actionListener.onFailure((Exception) cause);
+            } else {
+                actionListener.onFailure(new OpenSearchException(cause));
+            }
         } else {
             log.info("Connector deletion result: {}, connector id: {}", response.deleted(), response.id());
             DeleteResponse deleteResponse = new DeleteResponse(response.shardId(), response.id(), 0, 0, 0, response.deleted());

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
@@ -10,6 +10,7 @@ import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
@@ -95,8 +96,12 @@ public class GetConnectorTransportAction extends HandledTransportAction<ActionRe
                             log.error("Failed to get connector index", cause);
                             actionListener.onFailure(new OpenSearchStatusException("Failed to find connector", RestStatus.NOT_FOUND));
                         } else {
-                            log.error("Failed to get ML connector {}", connectorId, cause);
-                            actionListener.onFailure(new RuntimeException(cause));
+                            log.error("Failed to get ML connector " + connectorId, cause);
+                            if (cause instanceof Exception) {
+                                actionListener.onFailure((Exception) cause);
+                            } else {
+                                actionListener.onFailure(new OpenSearchException(cause));
+                            }
                         }
                     } else {
                         if (r != null && r.parser().isPresent()) {
@@ -140,6 +145,5 @@ public class GetConnectorTransportAction extends HandledTransportAction<ActionRe
             log.error("Failed to get ML connector " + connectorId, e);
             actionListener.onFailure(e);
         }
-
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClient.java
@@ -14,6 +14,7 @@ import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE
 import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 
+import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Optional;
@@ -21,7 +22,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 
-import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
@@ -32,10 +32,10 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.sdk.DeleteDataObjectRequest;
 import org.opensearch.sdk.DeleteDataObjectResponse;
 import org.opensearch.sdk.GetDataObjectRequest;
@@ -79,8 +79,12 @@ public class LocalClusterIndicesClient implements SdkClient {
                     .actionGet();
                 log.info("Creation status for id {}: {}", indexResponse.getId(), indexResponse.getResult());
                 return new PutDataObjectResponse.Builder().id(indexResponse.getId()).created(indexResponse.getResult() == CREATED).build();
-            } catch (Exception e) {
-                throw new OpenSearchException(e);
+            } catch (IOException e) {
+                // Rethrow unchecked exception on XContent parsing error
+                throw new OpenSearchStatusException(
+                    "Failed to parse data object to put in index " + request.index(),
+                    RestStatus.BAD_REQUEST
+                );
             }
         }), executor);
     }
@@ -90,7 +94,9 @@ public class LocalClusterIndicesClient implements SdkClient {
         return CompletableFuture.supplyAsync(() -> AccessController.doPrivileged((PrivilegedAction<GetDataObjectResponse>) () -> {
             try {
                 log.info("Getting {} from {}", request.id(), request.index());
-                GetResponse getResponse = client.get(new GetRequest(request.index(), request.id())).actionGet();
+                GetResponse getResponse = client
+                    .get(new GetRequest(request.index(), request.id()).fetchSourceContext(request.fetchSourceContext()))
+                    .actionGet();
                 if (getResponse == null || !getResponse.isExists()) {
                     return new GetDataObjectResponse.Builder().id(request.id()).build();
                 }
@@ -98,10 +104,12 @@ public class LocalClusterIndicesClient implements SdkClient {
                     .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString());
                 log.info("Retrieved data object");
                 return new GetDataObjectResponse.Builder().id(getResponse.getId()).parser(Optional.of(parser)).build();
-            } catch (OpenSearchStatusException | IndexNotFoundException notFound) {
-                throw notFound;
-            } catch (Exception e) {
-                throw new OpenSearchException(e);
+            } catch (IOException e) {
+                // Rethrow unchecked exception on XContent parser creation error
+                throw new OpenSearchStatusException(
+                    "Failed to create parser for data object retrieved from index " + request.index(),
+                    RestStatus.INTERNAL_SERVER_ERROR
+                );
             }
         }), executor);
     }
@@ -109,19 +117,15 @@ public class LocalClusterIndicesClient implements SdkClient {
     @Override
     public CompletionStage<DeleteDataObjectResponse> deleteDataObjectAsync(DeleteDataObjectRequest request, Executor executor) {
         return CompletableFuture.supplyAsync(() -> AccessController.doPrivileged((PrivilegedAction<DeleteDataObjectResponse>) () -> {
-            try {
-                log.info("Deleting {} from {}", request.id(), request.index());
-                DeleteResponse deleteResponse = client.delete(new DeleteRequest(request.index(), request.id())).actionGet();
-                log.info("Deletion status for id {}: {}", deleteResponse.getId(), deleteResponse.getResult());
-                return new DeleteDataObjectResponse.Builder()
-                    .id(deleteResponse.getId())
-                    .shardId(deleteResponse.getShardId())
-                    .shardInfo(deleteResponse.getShardInfo())
-                    .deleted(deleteResponse.getResult() == DELETED)
-                    .build();
-            } catch (Exception e) {
-                throw new OpenSearchException(e);
-            }
+            log.info("Deleting {} from {}", request.id(), request.index());
+            DeleteResponse deleteResponse = client.delete(new DeleteRequest(request.index(), request.id())).actionGet();
+            log.info("Deletion status for id {}: {}", deleteResponse.getId(), deleteResponse.getResult());
+            return new DeleteDataObjectResponse.Builder()
+                .id(deleteResponse.getId())
+                .shardId(deleteResponse.getShardId())
+                .shardInfo(deleteResponse.getShardInfo())
+                .deleted(deleteResponse.getResult() == DELETED)
+                .build();
         }), executor);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/DeleteConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/DeleteConnectorTransportActionTests.java
@@ -310,9 +310,7 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
-        // TODO: fix all this exception nesting
-        // java.util.concurrent.CompletionException: OpenSearchException[ResourceNotFoundException[errorMessage]]; nested: ResourceNotFoundException[errorMessage];
-        assertEquals("errorMessage", argumentCaptor.getValue().getCause().getCause().getCause().getMessage());
+        assertEquals("errorMessage", argumentCaptor.getValue().getMessage());
     }
 
     public void test_ValidationFailedException() throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/GetConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/GetConnectorTransportActionTests.java
@@ -226,9 +226,7 @@ public class GetConnectorTransportActionTests extends OpenSearchTestCase {
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
-        // TODO: Fix this nesting
-        // [OpenSearchException[java.lang.RuntimeException: errorMessage]; nested: RuntimeException[errorMessage];
-        assertEquals("errorMessage", argumentCaptor.getValue().getCause().getCause().getMessage());
+        assertEquals("errorMessage", argumentCaptor.getValue().getMessage());
     }
 
     public void testGetConnector_MultiTenancyEnabled_Success() throws IOException, InterruptedException {

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClientTests.java
@@ -9,7 +9,6 @@
 package org.opensearch.ml.sdkclient;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,7 +27,6 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.OpenSearchException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
@@ -43,8 +41,6 @@ import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
-import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.sdk.DeleteDataObjectRequest;
@@ -123,18 +119,17 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     public void testPutDataObject_Exception() throws IOException {
         PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder().index(TEST_INDEX).dataObject(testDataObject).build();
 
-        doAnswer(invocation -> {
-            ActionListener<ActionResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new IOException("test"));
-            return null;
-        }).when(mockedClient).index(any(IndexRequest.class), any());
+        ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        when(mockedClient.index(indexRequestCaptor.capture())).thenThrow(new UnsupportedOperationException("test"));
 
         CompletableFuture<PutDataObjectResponse> future = sdkClient
             .putDataObjectAsync(putRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        Throwable cause = ce.getCause();
+        assertEquals(UnsupportedOperationException.class, cause.getClass());
+        assertEquals("test", cause.getMessage());
     }
 
     public void testGetDataObject() throws IOException {
@@ -189,18 +184,17 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     public void testGetDataObject_Exception() throws IOException {
         GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
 
-        doAnswer(invocation -> {
-            ActionListener<ActionResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new IOException("test"));
-            return null;
-        }).when(mockedClient).get(any(GetRequest.class), any());
+        ArgumentCaptor<GetRequest> getRequestCaptor = ArgumentCaptor.forClass(GetRequest.class);
+        when(mockedClient.get(getRequestCaptor.capture())).thenThrow(new UnsupportedOperationException("test"));
 
         CompletableFuture<GetDataObjectResponse> future = sdkClient
             .getDataObjectAsync(getRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        Throwable cause = ce.getCause();
+        assertEquals(UnsupportedOperationException.class, cause.getClass());
+        assertEquals("test", cause.getMessage());
     }
 
     public void testDeleteDataObject() throws IOException {
@@ -231,17 +225,16 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     public void testDeleteDataObject_Exception() throws IOException {
         DeleteDataObjectRequest deleteRequest = new DeleteDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
 
-        doAnswer(invocation -> {
-            ActionListener<ActionResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new IOException("test"));
-            return null;
-        }).when(mockedClient).delete(any(DeleteRequest.class), any());
+        ArgumentCaptor<DeleteRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
+        when(mockedClient.delete(deleteRequestCaptor.capture())).thenThrow(new UnsupportedOperationException("test"));
 
         CompletableFuture<DeleteDataObjectResponse> future = sdkClient
             .deleteDataObjectAsync(deleteRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        Throwable cause = ce.getCause();
+        assertEquals(UnsupportedOperationException.class, cause.getClass());
+        assertEquals("test", cause.getMessage());
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.Result;
 import org.opensearch.client.opensearch._types.ShardStatistics;
@@ -148,7 +148,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        assertEquals(OpenSearchStatusException.class, ce.getCause().getClass());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -212,7 +212,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        assertEquals(OpenSearchStatusException.class, ce.getCause().getClass());
     }
 
     public void testDeleteDataObject() throws IOException {
@@ -284,6 +284,6 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        assertEquals(OpenSearchStatusException.class, ce.getCause().getClass());
     }
 }


### PR DESCRIPTION
### Description

Restores the original exception handling behavior for connector transport actions
 
### Issues Resolved

Resolves TODO from #2459

Open question: should the non-runtime exceptions be wrapped in an `UndeclaredThrowableException` rather than an `OpenSearchStatusException`?  I'm thinking probably.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
