### PR TITLE
adding immediate refresh to delete model group request

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
@@ -69,7 +69,8 @@ public class DeleteModelGroupTransportAction extends HandledTransportAction<Acti
     protected void doExecute(Task task, ActionRequest request, ActionListener<DeleteResponse> actionListener) {
         MLModelGroupDeleteRequest mlModelGroupDeleteRequest = MLModelGroupDeleteRequest.fromActionRequest(request);
         String modelGroupId = mlModelGroupDeleteRequest.getModelGroupId();
-        DeleteRequest deleteRequest = new DeleteRequest(ML_MODEL_GROUP_INDEX, modelGroupId).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);;
+        DeleteRequest deleteRequest = new DeleteRequest(ML_MODEL_GROUP_INDEX, modelGroupId)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         User user = RestActionUtils.getUserContext(client);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<DeleteResponse> wrappedListener = ActionListener.runBefore(actionListener, () -> context.restore());

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
@@ -15,6 +15,7 @@ import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -68,7 +69,7 @@ public class DeleteModelGroupTransportAction extends HandledTransportAction<Acti
     protected void doExecute(Task task, ActionRequest request, ActionListener<DeleteResponse> actionListener) {
         MLModelGroupDeleteRequest mlModelGroupDeleteRequest = MLModelGroupDeleteRequest.fromActionRequest(request);
         String modelGroupId = mlModelGroupDeleteRequest.getModelGroupId();
-        DeleteRequest deleteRequest = new DeleteRequest(ML_MODEL_GROUP_INDEX, modelGroupId);
+        DeleteRequest deleteRequest = new DeleteRequest(ML_MODEL_GROUP_INDEX, modelGroupId).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);;
         User user = RestActionUtils.getUserContext(client);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<DeleteResponse> wrappedListener = ActionListener.runBefore(actionListener, () -> context.restore());

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteModelGroupActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteModelGroupActionIT.java
@@ -37,12 +37,11 @@ public class RestMLDeleteModelGroupActionIT extends MLCommonsRestTestCase {
         assertEquals(RestStatus.OK, TestHelper.restStatus(deleteModelGroupResponse));
     }
 
-    public void testDeleteAndRegisterModelGroup_Success() throws IOException, InterruptedException {
+    public void testDeleteAndRegisterModelGroup_Success() throws IOException {
 
         Response deleteModelGroupResponse = TestHelper
             .makeRequest(client(), "DELETE", "/_plugins/_ml/model_groups/" + modelGroupId, null, "", null);
 
-        Thread.sleep(50);
         if (TestHelper.restStatus(deleteModelGroupResponse).equals(RestStatus.OK)) {
             MLRegisterModelGroupInput newMlRegisterModelGroupInput = MLRegisterModelGroupInput
                 .builder()

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteModelGroupActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteModelGroupActionIT.java
@@ -6,32 +6,54 @@
 package org.opensearch.ml.rest;
 
 import java.io.IOException;
-import java.util.Map;
 
-import org.apache.hc.core5.http.HttpEntity;
-import org.junit.Ignore;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.opensearch.client.Response;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput;
 import org.opensearch.ml.utils.TestHelper;
 
 public class RestMLDeleteModelGroupActionIT extends MLCommonsRestTestCase {
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
+    private MLRegisterModelGroupInput mlRegisterModelGroupInput;
+    private String modelGroupId;
 
-    @Ignore
+    @Before
+    public void setup() throws IOException {
+        mlRegisterModelGroupInput = MLRegisterModelGroupInput.builder().name("testGroupID").description("This is test Group").build();
+        registerModelGroup(client(), TestHelper.toJsonString(mlRegisterModelGroupInput), registerModelGroupResult -> {
+            this.modelGroupId = (String) registerModelGroupResult.get("model_group_id");
+        });
+    }
+
     public void testDeleteModelGroupAPI_Success() throws IOException {
-        Response trainModelGroupResponse = ingestModelData();
-        HttpEntity entity = trainModelGroupResponse.getEntity();
-        assertNotNull(trainModelGroupResponse);
-        String entityString = TestHelper.httpEntityToString(entity);
-        Map map = gson.fromJson(entityString, Map.class);
-        String model_group_id = (String) map.get("model_group_id");
 
-        Response deleteModelResponse = TestHelper
-            .makeRequest(client(), "DELETE", "/_plugins/_ml/model_groups/" + model_group_id, null, "", null);
-        assertNotNull(deleteModelResponse);
-        assertEquals(RestStatus.OK, TestHelper.restStatus(deleteModelResponse));
+        Response deleteModelGroupResponse = TestHelper
+            .makeRequest(client(), "DELETE", "/_plugins/_ml/model_groups/" + modelGroupId, null, "", null);
+        assertNotNull(deleteModelGroupResponse);
+        assertEquals(RestStatus.OK, TestHelper.restStatus(deleteModelGroupResponse));
+    }
+
+    public void testDeleteAndRegisterModelGroup_Success() throws IOException, InterruptedException {
+
+        Response deleteModelGroupResponse = TestHelper
+            .makeRequest(client(), "DELETE", "/_plugins/_ml/model_groups/" + modelGroupId, null, "", null);
+
+        Thread.sleep(50);
+        if (TestHelper.restStatus(deleteModelGroupResponse).equals(RestStatus.OK)) {
+            MLRegisterModelGroupInput newMlRegisterModelGroupInput = MLRegisterModelGroupInput
+                .builder()
+                .name("testGroupID")
+                .description("This is a new test Group")
+                .build();
+
+            registerModelGroup(client(), TestHelper.toJsonString(newMlRegisterModelGroupInput), registerModelGroupResponse -> {
+                assertNotNull(registerModelGroupResponse);
+                assertEquals("CREATED", registerModelGroupResponse.get("status"));
+            });
+        }
     }
 }


### PR DESCRIPTION
### Description
On successful deletion of a model group, when trying to register a new model group with same name within a few milli seconds, it gives the error "The name you provided is already being used by a model group..". Setting the refresh policy to immediate to resolve the issue.
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
