### PR TITLE
[Feature/multi_tenancy] Add UpdateDataObject interface, Client, and Connector Implementations

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -46,7 +46,12 @@ public interface SdkClient {
             if (cause instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            throw new OpenSearchException(cause);
+            // Rethrow unchecked Exceptions
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else {
+                throw new OpenSearchException(cause);                
+            }
         }
     }
 
@@ -80,7 +85,12 @@ public interface SdkClient {
             if (cause instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            throw new OpenSearchException(cause);
+            // Rethrow unchecked Exceptions
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else {
+                throw new OpenSearchException(cause);                
+            }
         }
     }
 
@@ -114,7 +124,12 @@ public interface SdkClient {
             if (cause instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            throw new OpenSearchException(cause);
+            // Rethrow unchecked Exceptions
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else {
+                throw new OpenSearchException(cause);                
+            }
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -42,16 +42,7 @@ public interface SdkClient {
         try {
             return putDataObjectAsync(request).toCompletableFuture().join();
         } catch (CompletionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            // Rethrow unchecked Exceptions
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            } else {
-                throw new OpenSearchException(cause);                
-            }
+            throw unwrapAndConvertToRuntime(e);
         }
     }
 
@@ -81,16 +72,7 @@ public interface SdkClient {
         try {
             return getDataObjectAsync(request).toCompletableFuture().join();
         } catch (CompletionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            // Rethrow unchecked Exceptions
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            } else {
-                throw new OpenSearchException(cause);                
-            }
+            throw unwrapAndConvertToRuntime(e);
         }
     }
 
@@ -120,16 +102,7 @@ public interface SdkClient {
         try {
             return updateDataObjectAsync(request).toCompletableFuture().join();
         } catch (CompletionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            // Rethrow unchecked Exceptions
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            } else {
-                throw new OpenSearchException(cause);                
-            }
+            throw unwrapAndConvertToRuntime(e);
         }
     }
 
@@ -159,16 +132,18 @@ public interface SdkClient {
         try {
             return deleteDataObjectAsync(request).toCompletableFuture().join();
         } catch (CompletionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            // Rethrow unchecked Exceptions
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            } else {
-                throw new OpenSearchException(cause);                
-            }
+            throw unwrapAndConvertToRuntime(e);
         }
+    }
+    
+    private static RuntimeException unwrapAndConvertToRuntime(CompletionException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+        }
+        if (cause instanceof RuntimeException) {
+            return (RuntimeException) cause;
+        }
+        return new OpenSearchException(cause);
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -95,6 +95,45 @@ public interface SdkClient {
     }
 
     /**
+     * Update a data object/document in a table/index.
+     * @param request A request identifying the data object to update
+     * @param executor the executor to use for asynchronous execution
+     * @return A completion stage encapsulating the response or exception
+     */
+    public CompletionStage<UpdateDataObjectResponse> updateDataObjectAsync(UpdateDataObjectRequest request, Executor executor);
+
+    /**
+     * Update a data object/document in a table/index.
+     * @param request A request identifying the data object to update
+     * @return A completion stage encapsulating the response or exception
+     */
+    default CompletionStage<UpdateDataObjectResponse> updateDataObjectAsync(UpdateDataObjectRequest request) {
+        return updateDataObjectAsync(request, ForkJoinPool.commonPool());        
+    }
+
+    /**
+     * Update a data object/document in a table/index.
+     * @param request A request identifying the data object to update
+     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     */
+    default UpdateDataObjectResponse updateDataObject(UpdateDataObjectRequest request) {
+        try {
+            return updateDataObjectAsync(request).toCompletableFuture().join();
+        } catch (CompletionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            // Rethrow unchecked Exceptions
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else {
+                throw new OpenSearchException(cause);                
+            }
+        }
+    }
+
+    /**
      * Delete a data object/document from a table/index.
      * @param request A request identifying the data object to delete
      * @param executor the executor to use for asynchronous execution

--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.opensearch.core.xcontent.ToXContentObject;
+
+public class UpdateDataObjectRequest {
+
+    private final String index;
+    private final String id;
+    private final ToXContentObject dataObject;
+
+    /**
+     * Instantiate this request with an index and data object.
+     * <p>
+     * For data storage implementations other than OpenSearch, an index may be referred to as a table and the data object may be referred to as an item.
+     * @param index the index location to update the object
+     * @param id the document id
+     * @param dataObject the data object
+     */
+    public UpdateDataObjectRequest(String index, String id, ToXContentObject dataObject) {
+        this.index = index;
+        this.id = id;
+        this.dataObject = dataObject;
+    }
+
+    /**
+     * Returns the index
+     * @return the index
+     */
+    public String index() {
+        return this.index;
+    }
+
+    /**
+     * Returns the document id
+     * @return the id
+     */
+    public String id() {
+        return this.id;
+    }
+    
+    /**
+     * Returns the data object
+     * @return the data object
+     */
+    public ToXContentObject dataObject() {
+        return this.dataObject;
+    }
+
+    /**
+     * Class for constructing a Builder for this Request Object
+     */
+    public static class Builder {
+        private String index = null;
+        private String id = null;
+        private ToXContentObject dataObject = null;
+
+        /**
+         * Empty Constructor for the Builder object
+         */
+        public Builder() {}
+
+        /**
+         * Add an index to this builder
+         * @param index the index to put the object
+         * @return the updated builder
+         */
+        public Builder index(String index) {
+            this.index = index;
+            return this;
+        }
+        
+        /**
+         * Add an id to this builder
+         * @param id the document id
+         * @return the updated builder
+         */
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * Add a data object to this builder
+         * @param dataObject the data object
+         * @return the updated builder
+         */
+        public Builder dataObject(ToXContentObject dataObject) {
+            this.dataObject = dataObject;
+            return this;
+        }
+
+        /**
+         * Builds the request
+         * @return A {@link UpdateDataObjectRequest}
+         */
+        public UpdateDataObjectRequest build() {
+            return new UpdateDataObjectRequest(this.index, this.id, this.dataObject);
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectResponse.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.opensearch.action.support.replication.ReplicationResponse.ShardInfo;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.index.shard.ShardId;
+
+public class UpdateDataObjectResponse {
+    private final String id;
+    private final ShardId shardId;
+    private final ShardInfo shardInfo;
+    private final boolean updated;
+
+    /**
+     * Instantiate this request with an id and update status.
+     * <p>
+     * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
+     * @param id the document id
+     * @param shardId the shard id
+     * @param shardInfo the shard info
+     * @param updated Whether the object was updated.
+     */
+    public UpdateDataObjectResponse(String id, ShardId shardId, ShardInfo shardInfo, boolean updated) {
+        this.id = id;
+        this.shardId = shardId;
+        this.shardInfo = shardInfo;
+        this.updated = updated;
+    }
+
+    /**
+     * Returns the document id
+     * @return the id
+     */
+    public String id() {
+        return id;
+    }
+
+    /**
+     * Returns the shard id.
+     * @return the shard id, or a generated id if shards are not applicable
+     */
+    public ShardId shardId() {
+        return shardId;
+    }
+
+    /**
+     * Returns the shard info.
+     * @return the shard info, or generated info if shards are not applicable
+     */
+    public ShardInfo shardInfo() {
+        return shardInfo;
+    }
+
+    /**
+     * Returns whether update was successful
+     * @return true if update was successful
+     */
+    public boolean updated() {
+        return updated;
+    }
+
+    /**
+     * Class for constructing a Builder for this Response Object
+     */
+    public static class Builder {
+        private String id = null;
+        private ShardId shardId = null;
+        private ShardInfo shardInfo = null;
+        private boolean updated = false;
+
+        /**
+         * Empty Constructor for the Builder object
+         */
+        public Builder() {}
+
+        /**
+         * Add an id to this builder
+         * @param id the id to add
+         * @return the updated builder
+         */
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * Adds a shard id to this builder
+         * @param shardId the shard id to add
+         * @return the updated builder
+         */
+        public Builder shardId(ShardId shardId) {
+            this.shardId = shardId;
+            return this;
+        }
+
+        /**
+         * Adds a generated shard id to this builder
+         * @param indexName the index name to generate a shard id
+         * @return the updated builder
+         */
+        public Builder shardId(String indexName) {
+            this.shardId = new ShardId(indexName, Strings.UNKNOWN_UUID_VALUE, 0);
+            return this;
+        }
+
+        /**
+         * Adds shard information (statistics) to this builder
+         * @param shardInfo the shard info to add
+         * @return the updated builder
+         */
+        public Builder shardInfo(ShardInfo shardInfo) {
+            this.shardInfo = shardInfo;
+            return this;
+        }
+        /**
+         * Add a updated status to this builder
+         * @param updated the updated status to add
+         * @return the updated builder
+         */
+        public Builder updated(boolean updated) {
+            this.updated = updated;
+            return this;
+        }
+
+        /**
+         * Builds the object
+         * @return A {@link UpdateDataObjectResponse}
+         */
+        public UpdateDataObjectResponse build() {
+            return new UpdateDataObjectResponse(this.id, this.shardId, this.shardInfo, this.updated);
+        }
+    }
+}

--- a/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
@@ -42,6 +42,10 @@ public class SdkClientTests {
     @Mock
     private GetDataObjectResponse getResponse;
     @Mock
+    private UpdateDataObjectRequest updateRequest;
+    @Mock
+    private UpdateDataObjectResponse updateResponse;
+    @Mock
     private DeleteDataObjectRequest deleteRequest;
     @Mock
     private DeleteDataObjectResponse deleteResponse;
@@ -61,6 +65,11 @@ public class SdkClientTests {
             @Override
             public CompletionStage<GetDataObjectResponse> getDataObjectAsync(GetDataObjectRequest request, Executor executor) {
                 return CompletableFuture.completedFuture(getResponse);
+            }
+
+            @Override
+            public CompletionStage<UpdateDataObjectResponse> updateDataObjectAsync(UpdateDataObjectRequest request, Executor executor) {
+                return CompletableFuture.completedFuture(updateResponse);
             }
 
             @Override
@@ -136,6 +145,37 @@ public class SdkClientTests {
         verify(sdkClient).getDataObjectAsync(any(GetDataObjectRequest.class), any(Executor.class));
     }
 
+
+    @Test
+    public void testUpdateDataObjectSuccess() {
+        assertEquals(updateResponse, sdkClient.updateDataObject(updateRequest));
+        verify(sdkClient).updateDataObjectAsync(any(UpdateDataObjectRequest.class), any(Executor.class));
+    }
+
+    @Test
+    public void testUpdateDataObjectException() {
+        when(sdkClient.updateDataObjectAsync(any(UpdateDataObjectRequest.class), any(Executor.class)))
+                .thenReturn(CompletableFuture.failedFuture(testException));
+        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
+            sdkClient.updateDataObject(updateRequest);
+        });
+        assertEquals(testException, exception);
+        assertFalse(Thread.interrupted());        
+        verify(sdkClient).updateDataObjectAsync(any(UpdateDataObjectRequest.class), any(Executor.class));
+    }
+
+    @Test
+    public void testUpdateDataObjectInterrupted() {
+        when(sdkClient.updateDataObjectAsync(any(UpdateDataObjectRequest.class), any(Executor.class)))
+        .thenReturn(CompletableFuture.failedFuture(interruptedException));
+        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
+            sdkClient.updateDataObject(updateRequest);
+        });
+        assertEquals(interruptedException, exception.getCause());
+        assertTrue(Thread.interrupted());        
+        verify(sdkClient).updateDataObjectAsync(any(UpdateDataObjectRequest.class), any(Executor.class));
+    }
+    
     @Test
     public void testDeleteDataObjectSuccess() {
         assertEquals(deleteResponse, sdkClient.deleteDataObject(deleteRequest));

--- a/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.rest.RestStatus;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -44,7 +46,7 @@ public class SdkClientTests {
     @Mock
     private DeleteDataObjectResponse deleteResponse;
 
-    private RuntimeException testException;
+    private OpenSearchStatusException testException;
     private InterruptedException interruptedException;
 
     @Before
@@ -66,7 +68,7 @@ public class SdkClientTests {
                 return CompletableFuture.completedFuture(deleteResponse);
             }
         });
-        testException = new RuntimeException();
+        testException = new OpenSearchStatusException("Test", RestStatus.BAD_REQUEST);
         interruptedException = new InterruptedException();
     }
 
@@ -81,10 +83,10 @@ public class SdkClientTests {
         when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class), any(Executor.class)))
                 .thenReturn(CompletableFuture.failedFuture(testException));
 
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
+        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
             sdkClient.putDataObject(putRequest);
         });
-        assertEquals(testException, exception.getCause());
+        assertEquals(testException, exception);
         assertFalse(Thread.interrupted());        
         verify(sdkClient).putDataObjectAsync(any(PutDataObjectRequest.class), any(Executor.class));
     }
@@ -113,10 +115,10 @@ public class SdkClientTests {
         when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class), any(Executor.class)))
                 .thenReturn(CompletableFuture.failedFuture(testException));
 
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
+        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
             sdkClient.getDataObject(getRequest);
         });
-        assertEquals(testException, exception.getCause());
+        assertEquals(testException, exception);
         assertFalse(Thread.interrupted());        
         verify(sdkClient).getDataObjectAsync(any(GetDataObjectRequest.class), any(Executor.class));
     }
@@ -144,10 +146,10 @@ public class SdkClientTests {
     public void testDeleteDataObjectException() {
         when(sdkClient.deleteDataObjectAsync(any(DeleteDataObjectRequest.class), any(Executor.class)))
                 .thenReturn(CompletableFuture.failedFuture(testException));
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
+        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
             sdkClient.deleteDataObject(deleteRequest);
         });
-        assertEquals(testException, exception.getCause());
+        assertEquals(testException, exception);
         assertFalse(Thread.interrupted());        
         verify(sdkClient).deleteDataObjectAsync(any(DeleteDataObjectRequest.class), any(Executor.class));
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
@@ -93,7 +93,6 @@ public class GetConnectorTransportAction extends HandledTransportAction<ActionRe
                             e -> handleConnectorAccessValidationFailure(connectorId, e, actionListener)
                         )
                 );
-
         } catch (Exception e) {
             log.error("Failed to get ML connector {}", connectorId, e);
             actionListener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/helper/ConnectorAccessControlHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/ConnectorAccessControlHelper.java
@@ -14,6 +14,7 @@ import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_
 import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
 
 import org.apache.lucene.search.join.ScoreMode;
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.client.Client;
@@ -176,8 +177,12 @@ public class ConnectorAccessControlHelper {
                         log.error("Failed to get connector index", cause);
                         listener.onFailure(new OpenSearchStatusException("Failed to find connector", RestStatus.NOT_FOUND));
                     } else {
-                        log.error("Failed to find connector {}", connectorId, cause);
-                        listener.onFailure(new RuntimeException(cause));
+                        log.error("Failed to get ML connector " + connectorId, cause);
+                        if (cause instanceof Exception) {
+                            listener.onFailure((Exception) cause);
+                        } else {
+                            listener.onFailure(new OpenSearchException(cause));
+                        }
                     }
                 } else {
                     if (r != null && r.parser().isPresent()) {

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
@@ -11,6 +11,7 @@ package org.opensearch.ml.sdkclient;
 import static org.opensearch.client.opensearch._types.Result.Created;
 import static org.opensearch.client.opensearch._types.Result.Deleted;
 
+import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Map;
@@ -19,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 
-import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.support.replication.ReplicationResponse.ShardInfo;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.core.DeleteRequest;
@@ -30,6 +31,7 @@ import org.opensearch.client.opensearch.core.IndexRequest;
 import org.opensearch.client.opensearch.core.IndexResponse;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.sdk.DeleteDataObjectRequest;
@@ -70,8 +72,12 @@ public class RemoteClusterIndicesClient implements SdkClient {
                 IndexResponse indexResponse = openSearchClient.index(indexRequest);
                 log.info("Creation status for id {}: {}", indexResponse.id(), indexResponse.result());
                 return new PutDataObjectResponse.Builder().id(indexResponse.id()).created(indexResponse.result() == Created).build();
-            } catch (Exception e) {
-                throw new OpenSearchException("Error occurred while indexing data object", e);
+            } catch (IOException e) {
+                // Rethrow unchecked exception on XContent parsing error
+                throw new OpenSearchStatusException(
+                    "Failed to parse data object to put in index " + request.index(),
+                    RestStatus.BAD_REQUEST
+                );
             }
         }), executor);
     }
@@ -94,8 +100,12 @@ public class RemoteClusterIndicesClient implements SdkClient {
                 XContentParser parser = JsonXContent.jsonXContent
                     .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
                 return new GetDataObjectResponse.Builder().id(getResponse.id()).parser(Optional.of(parser)).source(source).build();
-            } catch (Exception e) {
-                throw new OpenSearchException(e);
+            } catch (IOException e) {
+                // Rethrow unchecked exception on XContent parser creation error
+                throw new OpenSearchStatusException(
+                    "Failed to create parser for data object retrieved from index " + request.index(),
+                    RestStatus.INTERNAL_SERVER_ERROR
+                );
             }
         }), executor);
     }
@@ -118,8 +128,12 @@ public class RemoteClusterIndicesClient implements SdkClient {
                     .shardInfo(shardInfo)
                     .deleted(deleteResponse.result() == Deleted)
                     .build();
-            } catch (Exception e) {
-                throw new OpenSearchException("Error occurred while deleting data object", e);
+            } catch (IOException e) {
+                // Rethrow unchecked exception on deletion IOException
+                throw new OpenSearchStatusException(
+                    "IOException occurred while deleting data object " + request.id() + " from index " + request.index(),
+                    RestStatus.INTERNAL_SERVER_ERROR
+                );
             }
         }), executor);
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/DeleteConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/DeleteConnectorTransportActionTests.java
@@ -354,9 +354,7 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
-        // TODO: fix all this exception nesting
-        // java.util.concurrent.CompletionException: OpenSearchException[ResourceNotFoundException[errorMessage]]; nested: ResourceNotFoundException[errorMessage];
-        assertEquals("errorMessage", argumentCaptor.getValue().getCause().getCause().getCause().getMessage());
+        assertEquals("errorMessage", argumentCaptor.getValue().getMessage());
     }
 
     public void test_ValidationFailedException() throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/GetConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/GetConnectorTransportActionTests.java
@@ -42,7 +42,6 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.HttpConnector;
@@ -185,36 +184,6 @@ public class GetConnectorTransportActionTests extends OpenSearchTestCase {
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Failed to find connector with the provided connector id: connector_id", argumentCaptor.getValue().getMessage());
-    }
-
-    public void testGetConnector_IndexNotFoundException() throws InterruptedException {
-        PlainActionFuture<GetResponse> future = PlainActionFuture.newFuture();
-        future.onFailure(new IndexNotFoundException("Fail to find model"));
-        when(client.get(any(GetRequest.class))).thenReturn(future);
-
-        CountDownLatch latch = new CountDownLatch(1);
-        LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
-        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
-        latch.await();
-
-        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals("Failed to find connector", argumentCaptor.getValue().getMessage());
-    }
-
-    public void testGetConnector_RuntimeException() throws InterruptedException {
-        PlainActionFuture<GetResponse> future = PlainActionFuture.newFuture();
-        future.onFailure(new RuntimeException("errorMessage"));
-        when(client.get(any(GetRequest.class))).thenReturn(future);
-
-        CountDownLatch latch = new CountDownLatch(1);
-        LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
-        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
-        latch.await();
-
-        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals("errorMessage", argumentCaptor.getValue().getMessage());
     }
 
     public void testGetConnector_MultiTenancyEnabled_Success() throws IOException, InterruptedException {

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/GetConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/GetConnectorTransportActionTests.java
@@ -42,6 +42,7 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.HttpConnector;
@@ -186,7 +187,36 @@ public class GetConnectorTransportActionTests extends OpenSearchTestCase {
         assertEquals("Failed to find connector with the provided connector id: connector_id", argumentCaptor.getValue().getMessage());
     }
 
-    @Test
+    public void testGetConnector_IndexNotFoundException() throws InterruptedException {
+        PlainActionFuture<GetResponse> future = PlainActionFuture.newFuture();
+        future.onFailure(new IndexNotFoundException("Fail to find model"));
+        when(client.get(any(GetRequest.class))).thenReturn(future);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
+        latch.await();
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Failed to find connector", argumentCaptor.getValue().getMessage());
+    }
+
+    public void testGetConnector_RuntimeException() throws InterruptedException {
+        PlainActionFuture<GetResponse> future = PlainActionFuture.newFuture();
+        future.onFailure(new RuntimeException("errorMessage"));
+        when(client.get(any(GetRequest.class))).thenReturn(future);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
+        latch.await();
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("errorMessage", argumentCaptor.getValue().getMessage());
+    }
+
     public void testGetConnector_MultiTenancyEnabled_Success() throws IOException, InterruptedException {
         when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
         when(connectorAccessControlHelper.hasPermission(any(), any())).thenReturn(true);

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClientTests.java
@@ -9,7 +9,6 @@
 package org.opensearch.ml.sdkclient;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,7 +27,6 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.OpenSearchException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
@@ -45,8 +43,6 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.json.JsonXContent;
-import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.sdk.DeleteDataObjectRequest;
@@ -125,18 +121,17 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     public void testPutDataObject_Exception() throws IOException {
         PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder().index(TEST_INDEX).dataObject(testDataObject).build();
 
-        doAnswer(invocation -> {
-            ActionListener<ActionResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new IOException("test"));
-            return null;
-        }).when(mockedClient).index(any(IndexRequest.class), any());
+        ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        when(mockedClient.index(indexRequestCaptor.capture())).thenThrow(new UnsupportedOperationException("test"));
 
         CompletableFuture<PutDataObjectResponse> future = sdkClient
             .putDataObjectAsync(putRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        Throwable cause = ce.getCause();
+        assertEquals(UnsupportedOperationException.class, cause.getClass());
+        assertEquals("test", cause.getMessage());
     }
 
     public void testGetDataObject() throws IOException {
@@ -194,18 +189,17 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     public void testGetDataObject_Exception() throws IOException {
         GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
 
-        doAnswer(invocation -> {
-            ActionListener<ActionResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new IOException("test"));
-            return null;
-        }).when(mockedClient).get(any(GetRequest.class), any());
+        ArgumentCaptor<GetRequest> getRequestCaptor = ArgumentCaptor.forClass(GetRequest.class);
+        when(mockedClient.get(getRequestCaptor.capture())).thenThrow(new UnsupportedOperationException("test"));
 
         CompletableFuture<GetDataObjectResponse> future = sdkClient
             .getDataObjectAsync(getRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        Throwable cause = ce.getCause();
+        assertEquals(UnsupportedOperationException.class, cause.getClass());
+        assertEquals("test", cause.getMessage());
     }
 
     public void testDeleteDataObject() throws IOException {
@@ -236,17 +230,16 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     public void testDeleteDataObject_Exception() throws IOException {
         DeleteDataObjectRequest deleteRequest = new DeleteDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
 
-        doAnswer(invocation -> {
-            ActionListener<ActionResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new IOException("test"));
-            return null;
-        }).when(mockedClient).delete(any(DeleteRequest.class), any());
+        ArgumentCaptor<DeleteRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
+        when(mockedClient.delete(deleteRequestCaptor.capture())).thenThrow(new UnsupportedOperationException("test"));
 
         CompletableFuture<DeleteDataObjectResponse> future = sdkClient
             .deleteDataObjectAsync(deleteRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        Throwable cause = ce.getCause();
+        assertEquals(UnsupportedOperationException.class, cause.getClass());
+        assertEquals("test", cause.getMessage());
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.Result;
 import org.opensearch.client.opensearch._types.ShardStatistics;
@@ -148,7 +148,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        assertEquals(OpenSearchStatusException.class, ce.getCause().getClass());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -213,7 +213,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        assertEquals(OpenSearchStatusException.class, ce.getCause().getClass());
     }
 
     public void testDeleteDataObject() throws IOException {
@@ -285,6 +285,6 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .toCompletableFuture();
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        assertEquals(OpenSearchException.class, ce.getCause().getClass());
+        assertEquals(OpenSearchStatusException.class, ce.getCause().getClass());
     }
 }


### PR DESCRIPTION
### Description

- Adds update method to SdkClient interface (full document update, does not do scripts)
- Implements update method on Local and Remote clients
- Migrates Connector Update action to use SdkClient for the updates

NOTE: this PR builds on commit 22a0ce53d8e494e269203b4de7937db122c241fa which represents PR #2507 .  Reviewers may want to focus attention on commits 100d71a19556047c6e23625bdb4229d01fe86a44 and e90b553742d124e54dfd834f863adc4edb2ad24d

Will rebase this PR against the branch when #2507 is merged.

### Issues Resolved

Continuation of PR #2459

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
