### PR TITLE
Fix: import error on Backport/backport 2448 to 2.x

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLFlowAgentIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLFlowAgentIT.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hc.core5.http.ParseException;
+import java.text.ParseException;
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.client.Response;


### PR DESCRIPTION
### Description
Fix the error in https://github.com/opensearch-project/ml-commons/pull/2460 due to `import org.apache.hc.core5.http.ParseException; `
 
### Issues Resolved
Fix the error in https://github.com/opensearch-project/ml-commons/pull/2460 due to `import org.apache.hc.core5.http.ParseException; `
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
