### PR TITLE
add setting to allow private IP

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.Client;
@@ -62,6 +63,8 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
     @Setter
     @Getter
     private MLGuard mlGuard;
+    @Setter
+    private volatile AtomicBoolean connectorPrivateIpEnabled;
 
     private SdkAsyncHttpClient httpClient;
 
@@ -136,6 +139,6 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
         String protocol = url.getProtocol();
         String host = url.getHost();
         int port = url.getPort();
-        MLHttpClientFactory.validate(protocol, host, port);
+        MLHttpClientFactory.validate(protocol, host, port, connectorPrivateIpEnabled);
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
@@ -149,6 +150,8 @@ public interface RemoteConnectorExecutor {
     ConnectorClientConfig getConnectorClientConfig();
 
     default void setClient(Client client) {}
+
+    default void setConnectorPrivateIpEnabled(AtomicBoolean connectorPrivateIpEnabled) {}
 
     default void setXContentRegistry(NamedXContentRegistry xContentRegistry) {}
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.engine.algorithms.remote;
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
@@ -43,6 +44,7 @@ public class RemoteModel implements Predictable {
     public static final String RATE_LIMITER = "rate_limiter";
     public static final String USER_RATE_LIMITER_MAP = "user_rate_limiter_map";
     public static final String GUARDRAILS = "guardrails";
+    public static final String CONNECTOR_PRIVATE_IP_ENABLED = "connectorPrivateIpEnabled";
 
     private RemoteConnectorExecutor connectorExecutor;
 
@@ -101,6 +103,7 @@ public class RemoteModel implements Predictable {
             this.connectorExecutor.setRateLimiter((TokenBucket) params.get(RATE_LIMITER));
             this.connectorExecutor.setUserRateLimiterMap((Map<String, TokenBucket>) params.get(USER_RATE_LIMITER_MAP));
             this.connectorExecutor.setMlGuard((MLGuard) params.get(GUARDRAILS));
+            this.connectorExecutor.setConnectorPrivateIpEnabled((AtomicBoolean) params.get(CONNECTOR_PRIVATE_IP_ENABLED));
         } catch (RuntimeException e) {
             log.error("Failed to init remote model.", e);
             throw e;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactory.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactory.java
@@ -14,6 +14,7 @@ import java.security.PrivilegedExceptionAction;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.extern.log4j.Log4j2;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -43,9 +44,11 @@ public class MLHttpClientFactory {
      * @param protocol The protocol supported in remote inference, currently only http and https are supported.
      * @param host The host name of the remote inference server, host must be a valid ip address or domain name and must not be localhost.
      * @param port The port number of the remote inference server, port number must be in range [0, 65536].
-     * @throws UnknownHostException
+     * @param connectorPrivateIpEnabled The port number of the remote inference server, port number must be in range [0, 65536].
+     * @throws UnknownHostException Allow to use private IP or not.
      */
-    public static void validate(String protocol, String host, int port) throws UnknownHostException {
+    public static void validate(String protocol, String host, int port, AtomicBoolean connectorPrivateIpEnabled)
+        throws UnknownHostException {
         if (protocol != null && !"http".equalsIgnoreCase(protocol) && !"https".equalsIgnoreCase(protocol)) {
             log.error("Remote inference protocol is not http or https: " + protocol);
             throw new IllegalArgumentException("Protocol is not http or https: " + protocol);
@@ -62,12 +65,12 @@ public class MLHttpClientFactory {
             log.error("Remote inference port out of range: " + port);
             throw new IllegalArgumentException("Port out of range: " + port);
         }
-        validateIp(host);
+        validateIp(host, connectorPrivateIpEnabled);
     }
 
-    private static void validateIp(String hostName) throws UnknownHostException {
+    private static void validateIp(String hostName, AtomicBoolean connectorPrivateIpEnabled) throws UnknownHostException {
         InetAddress[] addresses = InetAddress.getAllByName(hostName);
-        if (hasPrivateIpAddress(addresses)) {
+        if (!connectorPrivateIpEnabled.get() && hasPrivateIpAddress(addresses)) {
             log.error("Remote inference host name has private ip address: " + hostName);
             throw new IllegalArgumentException("Remote inference host name has private ip address: " + hostName);
         }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactory.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactory.java
@@ -70,7 +70,7 @@ public class MLHttpClientFactory {
 
     private static void validateIp(String hostName, AtomicBoolean connectorPrivateIpEnabled) throws UnknownHostException {
         InetAddress[] addresses = InetAddress.getAllByName(hostName);
-        if (!connectorPrivateIpEnabled.get() && hasPrivateIpAddress(addresses)) {
+        if ((connectorPrivateIpEnabled == null || !connectorPrivateIpEnabled.get()) && hasPrivateIpAddress(addresses)) {
             log.error("Remote inference host name has private ip address: " + hostName);
             throw new IllegalArgumentException("Remote inference host name has private ip address: " + hostName);
         }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactoryTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactoryTests.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.engine.httpclient;
 import static org.junit.Assert.assertNotNull;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,70 +29,84 @@ public class MLHttpClientFactoryTests {
 
     @Test
     public void test_validateIp_validIp_noException() throws Exception {
-        MLHttpClientFactory.validate("http", "api.openai.com", 80);
+        AtomicBoolean privateIpEnabled = new AtomicBoolean(false);
+        MLHttpClientFactory.validate("http", "api.openai.com", 80, privateIpEnabled);
     }
 
     @Test
     public void test_validateIp_rarePrivateIp_throwException() throws Exception {
+        AtomicBoolean privateIpEnabled = new AtomicBoolean(false);
         try {
-            MLHttpClientFactory.validate("http", "0254.020.00.01", 80);
+            MLHttpClientFactory.validate("http", "0254.020.00.01", 80, privateIpEnabled);
         } catch (IllegalArgumentException e) {
             assertNotNull(e);
         }
 
         try {
-            MLHttpClientFactory.validate("http", "172.1048577", 80);
+            MLHttpClientFactory.validate("http", "172.1048577", 80, privateIpEnabled);
         } catch (Exception e) {
             assertNotNull(e);
         }
 
         try {
-            MLHttpClientFactory.validate("http", "2886729729", 80);
+            MLHttpClientFactory.validate("http", "2886729729", 80, privateIpEnabled);
         } catch (IllegalArgumentException e) {
             assertNotNull(e);
         }
 
         try {
-            MLHttpClientFactory.validate("http", "192.11010049", 80);
+            MLHttpClientFactory.validate("http", "192.11010049", 80, privateIpEnabled);
         } catch (IllegalArgumentException e) {
             assertNotNull(e);
         }
 
         try {
-            MLHttpClientFactory.validate("http", "3232300545", 80);
+            MLHttpClientFactory.validate("http", "3232300545", 80, privateIpEnabled);
         } catch (IllegalArgumentException e) {
             assertNotNull(e);
         }
 
         try {
-            MLHttpClientFactory.validate("http", "0:0:0:0:0:ffff:127.0.0.1", 80);
+            MLHttpClientFactory.validate("http", "0:0:0:0:0:ffff:127.0.0.1", 80, privateIpEnabled);
         } catch (IllegalArgumentException e) {
             assertNotNull(e);
         }
 
         try {
-            MLHttpClientFactory.validate("http", "153.24.76.232", 80);
+            MLHttpClientFactory.validate("http", "153.24.76.232", 80, privateIpEnabled);
         } catch (IllegalArgumentException e) {
             assertNotNull(e);
         }
     }
 
     @Test
+    public void test_validateIp_rarePrivateIp_NotThrowException() throws Exception {
+        AtomicBoolean privateIpEnabled = new AtomicBoolean(true);
+        MLHttpClientFactory.validate("http", "0254.020.00.01", 80, privateIpEnabled);
+        MLHttpClientFactory.validate("http", "172.1048577", 80, privateIpEnabled);
+        MLHttpClientFactory.validate("http", "2886729729", 80, privateIpEnabled);
+        MLHttpClientFactory.validate("http", "192.11010049", 80, privateIpEnabled);
+        MLHttpClientFactory.validate("http", "3232300545", 80, privateIpEnabled);
+        MLHttpClientFactory.validate("http", "0:0:0:0:0:ffff:127.0.0.1", 80, privateIpEnabled);
+        MLHttpClientFactory.validate("http", "153.24.76.232", 80, privateIpEnabled);
+    }
+
+    @Test
     public void test_validateSchemaAndPort_success() throws Exception {
-        MLHttpClientFactory.validate("http", "api.openai.com", 80);
+        MLHttpClientFactory.validate("http", "api.openai.com", 80, new AtomicBoolean(false));
     }
 
     @Test
     public void test_validateSchemaAndPort_notAllowedSchema_throwException() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        MLHttpClientFactory.validate("ftp", "api.openai.com", 80);
+        MLHttpClientFactory.validate("ftp", "api.openai.com", 80, new AtomicBoolean(false));
     }
 
     @Test
     public void test_validateSchemaAndPort_portNotInRange_throwException() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Port out of range: 65537");
-        MLHttpClientFactory.validate("https", "api.openai.com", 65537);
+        MLHttpClientFactory.validate("https", "api.openai.com", 65537, new AtomicBoolean(false));
     }
 
 }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -27,6 +27,7 @@ import static org.opensearch.ml.engine.ModelHelper.MODEL_FILE_HASH;
 import static org.opensearch.ml.engine.ModelHelper.MODEL_SIZE_IN_BYTES;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.CLIENT;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.CLUSTER_SERVICE;
+import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.CONNECTOR_PRIVATE_IP_ENABLED;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.GUARDRAILS;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.RATE_LIMITER;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.SCRIPT_SERVICE;
@@ -128,6 +129,7 @@ import org.opensearch.ml.engine.Predictable;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.engine.utils.FileUtils;
 import org.opensearch.ml.profile.MLModelProfile;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.stats.ActionName;
 import org.opensearch.ml.stats.MLActionLevelStat;
 import org.opensearch.ml.stats.MLNodeLevelStat;
@@ -169,6 +171,7 @@ public class MLModelManager {
     private final MLTaskManager mlTaskManager;
     private final MLEngine mlEngine;
     private final DiscoveryNodeHelper nodeHelper;
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     private volatile Integer maxModelPerNode;
     private volatile Integer maxRegisterTasksPerNode;
@@ -198,7 +201,8 @@ public class MLModelManager {
         MLTaskManager mlTaskManager,
         MLModelCacheHelper modelCacheHelper,
         MLEngine mlEngine,
-        DiscoveryNodeHelper nodeHelper
+        DiscoveryNodeHelper nodeHelper,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting
     ) {
         this.client = client;
         this.threadPool = threadPool;
@@ -213,6 +217,7 @@ public class MLModelManager {
         this.mlTaskManager = mlTaskManager;
         this.mlEngine = mlEngine;
         this.nodeHelper = nodeHelper;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
 
         this.maxModelPerNode = ML_COMMONS_MAX_MODELS_PER_NODE.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_MAX_MODELS_PER_NODE, it -> maxModelPerNode = it);
@@ -1174,6 +1179,7 @@ public class MLModelManager {
             params.put(GUARDRAILS, mlGuard);
             log.info("Setting up ML guard parameter for ML predictor.");
         }
+        params.put(CONNECTOR_PRIVATE_IP_ENABLED, mlFeatureEnabledSetting.isConnectorPrivateIpEnabled());
         return Collections.unmodifiableMap(params);
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -495,6 +495,11 @@ public class MachineLearningPlugin extends Plugin
         mlIndicesHandler = new MLIndicesHandler(clusterService, client);
         mlTaskManager = new MLTaskManager(client, threadPool, mlIndicesHandler);
         modelHelper = new ModelHelper(mlEngine);
+
+        mlInputDatasetHandler = new MLInputDatasetHandler(client);
+        modelAccessControlHelper = new ModelAccessControlHelper(clusterService, settings);
+        connectorAccessControlHelper = new ConnectorAccessControlHelper(clusterService, settings);
+        mlFeatureEnabledSetting = new MLFeatureEnabledSetting(clusterService, settings);
         mlModelManager = new MLModelManager(
             clusterService,
             scriptService,
@@ -509,12 +514,9 @@ public class MachineLearningPlugin extends Plugin
             mlTaskManager,
             modelCacheHelper,
             mlEngine,
-            nodeHelper
+            nodeHelper,
+            mlFeatureEnabledSetting
         );
-        mlInputDatasetHandler = new MLInputDatasetHandler(client);
-        modelAccessControlHelper = new ModelAccessControlHelper(clusterService, settings);
-        connectorAccessControlHelper = new ConnectorAccessControlHelper(clusterService, settings);
-        mlFeatureEnabledSetting = new MLFeatureEnabledSetting(clusterService, settings);
 
         mlModelChunkUploader = new MLModelChunkUploader(mlIndicesHandler, client, xContentRegistry, modelAccessControlHelper);
 
@@ -928,7 +930,8 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_MEMORY_FEATURE_ENABLED,
                 MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED,
                 MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED,
-                MLCommonsSettings.ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE
+                MLCommonsSettings.ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE,
+                MLCommonsSettings.ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -184,4 +184,7 @@ public final class MLCommonsSettings {
     // This setting is to enable/disable agent related API register/execute/delete/get/search agent.
     public static final Setting<Boolean> ML_COMMONS_AGENT_FRAMEWORK_ENABLED = Setting
         .boolSetting("plugins.ml_commons.agent_framework_enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    public static final Setting<Boolean> ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED = Setting
+        .boolSetting("plugins.ml_commons.connector.private_ip_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
@@ -8,8 +8,11 @@
 package org.opensearch.ml.settings;
 
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_LOCAL_MODEL_ENABLED;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
@@ -20,11 +23,13 @@ public class MLFeatureEnabledSetting {
     private volatile Boolean isAgentFrameworkEnabled;
 
     private volatile Boolean isLocalModelEnabled;
+    private volatile AtomicBoolean isConnectorPrivateIpEnabled;
 
     public MLFeatureEnabledSetting(ClusterService clusterService, Settings settings) {
         isRemoteInferenceEnabled = ML_COMMONS_REMOTE_INFERENCE_ENABLED.get(settings);
         isAgentFrameworkEnabled = ML_COMMONS_AGENT_FRAMEWORK_ENABLED.get(settings);
         isLocalModelEnabled = ML_COMMONS_LOCAL_MODEL_ENABLED.get(settings);
+        isConnectorPrivateIpEnabled = new AtomicBoolean(ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED.get(settings));
 
         clusterService
             .getClusterSettings()
@@ -33,6 +38,9 @@ public class MLFeatureEnabledSetting {
             .getClusterSettings()
             .addSettingsUpdateConsumer(ML_COMMONS_AGENT_FRAMEWORK_ENABLED, it -> isAgentFrameworkEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_LOCAL_MODEL_ENABLED, it -> isLocalModelEnabled = it);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED, it -> isConnectorPrivateIpEnabled.set(it));
     }
 
     /**
@@ -57,6 +65,10 @@ public class MLFeatureEnabledSetting {
      */
     public boolean isLocalModelEnabled() {
         return isLocalModelEnabled;
+    }
+
+    public AtomicBoolean isConnectorPrivateIpEnabled() {
+        return isConnectorPrivateIpEnabled;
     }
 
 }

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -61,6 +61,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import org.junit.Before;
@@ -109,6 +110,7 @@ import org.opensearch.ml.engine.ModelHelper;
 import org.opensearch.ml.engine.encryptor.Encryptor;
 import org.opensearch.ml.engine.encryptor.EncryptorImpl;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.stats.ActionName;
 import org.opensearch.ml.stats.MLActionLevelStat;
 import org.opensearch.ml.stats.MLNodeLevelStat;
@@ -179,6 +181,8 @@ public class MLModelManagerTests extends OpenSearchTestCase {
 
     @Mock
     ClusterApplierService clusterApplierService;
+    @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     @Before
     public void setup() throws URISyntaxException {
@@ -253,6 +257,8 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
+        when(mlFeatureEnabledSetting.isConnectorPrivateIpEnabled()).thenReturn(new AtomicBoolean(false));
+
         modelManager = spy(
             new MLModelManager(
                 clusterService,
@@ -268,7 +274,8 @@ public class MLModelManagerTests extends OpenSearchTestCase {
                 mlTaskManager,
                 modelCacheHelper,
                 mlEngine,
-                nodeHelper
+                nodeHelper,
+                mlFeatureEnabledSetting
             )
         );
 


### PR DESCRIPTION
### Description
We have limited no private IP allowed in connector. Some user want to use private IP. Confirmed with security team, should be fine to have a setting to control allow private IP or not. By default it's disabled, user can enable it by update setting
```
PUT _cluster/settings
{
    "plugins.ml_commons.connector.private_ip_enabled": true
  }
}
```
 
### Issues Resolved
Resolve #2142
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
