### PR TITLE
Fix master key2

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
@@ -8,29 +8,36 @@ package org.opensearch.ml.engine.encryptor;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.opensearch.ml.common.CommonValue.MASTER_KEY;
 import static org.opensearch.ml.common.CommonValue.ML_CONFIG_INDEX;
+import static org.opensearch.ml.common.MLConfig.CREATE_TIME_FIELD;
 
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.crypto.spec.SecretKeySpec;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.opensearch.ResourceNotFoundException;
-import org.opensearch.action.LatchedActionListener;
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.get.GetRequest;
-import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.ml.common.exception.MLException;
+import org.opensearch.ml.engine.indices.MLIndicesHandler;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
 import com.amazonaws.encryptionsdk.CommitmentPolicy;
 import com.amazonaws.encryptionsdk.CryptoResult;
 import com.amazonaws.encryptionsdk.jce.JceMasterKey;
+import com.google.common.collect.ImmutableMap;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -42,11 +49,13 @@ public class EncryptorImpl implements Encryptor {
     private ClusterService clusterService;
     private Client client;
     private volatile String masterKey;
+    private MLIndicesHandler mlIndicesHandler;
 
-    public EncryptorImpl(ClusterService clusterService, Client client) {
+    public EncryptorImpl(ClusterService clusterService, Client client, MLIndicesHandler mlIndicesHandler) {
         this.masterKey = null;
         this.clusterService = clusterService;
         this.client = client;
+        this.mlIndicesHandler = mlIndicesHandler;
     }
 
     public EncryptorImpl(String masterKey) {
@@ -104,28 +113,63 @@ public class EncryptorImpl implements Encryptor {
         AtomicReference<Exception> exceptionRef = new AtomicReference<>();
 
         CountDownLatch latch = new CountDownLatch(1);
-        if (clusterService.state().metadata().hasIndex(ML_CONFIG_INDEX)) {
+        mlIndicesHandler.initMLConfigIndex(ActionListener.wrap(r -> {
+            GetRequest getRequest = new GetRequest(ML_CONFIG_INDEX).id(MASTER_KEY);
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-                GetRequest getRequest = new GetRequest(ML_CONFIG_INDEX).id(MASTER_KEY);
-                client.get(getRequest, ActionListener.runBefore(new LatchedActionListener(ActionListener.<GetResponse>wrap(r -> {
-                    if (r.isExists()) {
-                        String masterKey = (String) r.getSourceAsMap().get(MASTER_KEY);
-                        this.masterKey = masterKey;
+                client.get(getRequest, ActionListener.wrap(getResponse -> {
+                    if (getResponse == null || !getResponse.isExists()) {
+                        IndexRequest indexRequest = new IndexRequest(ML_CONFIG_INDEX).id(MASTER_KEY);
+                        final String generatedMasterKey = generateMasterKey();
+                        indexRequest
+                            .source(ImmutableMap.of(MASTER_KEY, generatedMasterKey, CREATE_TIME_FIELD, Instant.now().toEpochMilli()));
+                        indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                        indexRequest.opType(DocWriteRequest.OpType.CREATE);
+                        client.index(indexRequest, ActionListener.wrap(indexResponse -> {
+                            this.masterKey = generatedMasterKey;
+                            log.info("ML encryption master key initialized successfully");
+                            latch.countDown();
+                        }, e -> {
+                            if (ExceptionUtils.getRootCause(e) instanceof VersionConflictEngineException) {
+                                GetRequest getMasterKeyRequest = new GetRequest(ML_CONFIG_INDEX).id(MASTER_KEY);
+                                try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
+                                    client.get(getMasterKeyRequest, ActionListener.wrap(getMasterKey -> {
+                                        if (getMasterKey.isExists()) {
+                                            final String masterKey = (String) getMasterKey.getSourceAsMap().get(MASTER_KEY);
+                                            this.masterKey = masterKey;
+                                            log.info("ML encryption master key already initialized, no action needed");
+                                            latch.countDown();
+                                        }
+                                    }, error -> {
+                                        log.debug("Failed to get ML encryption master key", e);
+                                        exceptionRef.set(new ResourceNotFoundException(MASTER_KEY_NOT_READY_ERROR));
+                                        latch.countDown();
+                                    }));
+                                }
+                            } else {
+                                log.debug("Failed to index ML encryption master key", e);
+                                exceptionRef.set(new ResourceNotFoundException(MASTER_KEY_NOT_READY_ERROR));
+                                latch.countDown();
+                            }
+                        }));
                     } else {
-                        exceptionRef.set(new ResourceNotFoundException(MASTER_KEY_NOT_READY_ERROR));
+                        final String masterKey = (String) getResponse.getSourceAsMap().get(MASTER_KEY);
+                        this.masterKey = masterKey;
+                        log.info("ML encryption master key already initialized, no action needed");
+                        latch.countDown();
                     }
                 }, e -> {
-                    log.error("Failed to get ML encryption master key", e);
-                    exceptionRef.set(e);
-                }), latch), () -> context.restore()));
+                    log.debug("Failed to get ML encryption master key from config index", e);
+                    exceptionRef.set(new ResourceNotFoundException(MASTER_KEY_NOT_READY_ERROR));
+                    latch.countDown();
+                }));
             }
-        } else {
-            exceptionRef.set(new ResourceNotFoundException(MASTER_KEY_NOT_READY_ERROR));
+        }, e -> {
+            log.debug("Failed to init ML config index", e);
             latch.countDown();
-        }
+        }));
 
         try {
-            latch.await(5, SECONDS);
+            latch.await(1, SECONDS);
         } catch (InterruptedException e) {
             throw new IllegalStateException(e);
         }
@@ -142,4 +186,5 @@ public class EncryptorImpl implements Encryptor {
             throw new ResourceNotFoundException(MASTER_KEY_NOT_READY_ERROR);
         }
     }
+
 }

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.index.IndexRequest;
@@ -231,6 +232,7 @@ public class MLSyncUpCron implements Runnable {
                         final String masterKey = encryptor.generateMasterKey();
                         indexRequest.source(ImmutableMap.of(MASTER_KEY, masterKey, CREATE_TIME_FIELD, Instant.now().toEpochMilli()));
                         indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                        indexRequest.opType(DocWriteRequest.OpType.CREATE);
                         client.index(indexRequest, ActionListener.wrap(indexResponse -> {
                             log.info("ML configuration initialized successfully");
                             encryptor.setMasterKey(masterKey);

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -458,7 +458,8 @@ public class MachineLearningPlugin extends Plugin
         Settings settings = environment.settings();
         Path dataPath = environment.dataFiles()[0];
 
-        encryptor = new EncryptorImpl(clusterService, client);
+        mlIndicesHandler = new MLIndicesHandler(clusterService, client);
+        encryptor = new EncryptorImpl(clusterService, client, mlIndicesHandler);
 
         mlEngine = new MLEngine(dataPath, encryptor);
         nodeHelper = new DiscoveryNodeHelper(clusterService, settings);
@@ -492,7 +493,6 @@ public class MachineLearningPlugin extends Plugin
         stats.put(MLNodeLevelStat.ML_CIRCUIT_BREAKER_TRIGGER_COUNT, new MLStat<>(false, new CounterSupplier()));
         this.mlStats = new MLStats(stats);
 
-        mlIndicesHandler = new MLIndicesHandler(clusterService, client);
         mlTaskManager = new MLTaskManager(client, threadPool, mlIndicesHandler);
         modelHelper = new ModelHelper(mlEngine);
 


### PR DESCRIPTION
### Description
1. reduce latch wait timeout from 5 seconds to 1 seconds when init encryption master key
2. create new encryption master key if not found
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
