### PR TITLE
[Feature/multi_tenancy] Add SearchDataObject interface, Client, and Connector Implementations 

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -59,8 +59,8 @@ public interface SdkClient {
      * @param request A request identifying the data object to retrieve
      * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
      */
-    default CompletionStage<GetDataObjectResponse> getDataObjectAsync(GetDataObjectRequest request){
-        return getDataObjectAsync(request, ForkJoinPool.commonPool());        
+    default CompletionStage<GetDataObjectResponse> getDataObjectAsync(GetDataObjectRequest request) {
+        return getDataObjectAsync(request, ForkJoinPool.commonPool());
     }
 
     /**
@@ -90,7 +90,7 @@ public interface SdkClient {
      * @return A completion stage encapsulating the response or exception
      */
     default CompletionStage<UpdateDataObjectResponse> updateDataObjectAsync(UpdateDataObjectRequest request) {
-        return updateDataObjectAsync(request, ForkJoinPool.commonPool());        
+        return updateDataObjectAsync(request, ForkJoinPool.commonPool());
     }
 
     /**
@@ -120,7 +120,7 @@ public interface SdkClient {
      * @return A completion stage encapsulating the response or exception
      */
     default CompletionStage<DeleteDataObjectResponse> deleteDataObjectAsync(DeleteDataObjectRequest request) {
-        return deleteDataObjectAsync(request, ForkJoinPool.commonPool());        
+        return deleteDataObjectAsync(request, ForkJoinPool.commonPool());
     }
 
     /**
@@ -135,7 +135,37 @@ public interface SdkClient {
             throw unwrapAndConvertToRuntime(e);
         }
     }
-    
+
+    /**
+     * Search for a data object/document in a table/index.
+     * @param request A request identifying the data object to retrieve
+     * @param executor the executor to use for asynchronous execution
+     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     */
+    public CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(SearchDataObjectRequest request, Executor executor);
+
+    /**
+     * Search for a data object/document in a table/index.
+     * @param request A request identifying the data object to retrieve
+     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     */
+    default CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(SearchDataObjectRequest request) {
+        return searchDataObjectAsync(request, ForkJoinPool.commonPool());
+    }
+
+    /**
+     * Search for a data object/document in a table/index.
+     * @param request A request identifying the data object to retrieve
+     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     */
+    default SearchDataObjectResponse searchDataObject(SearchDataObjectRequest request) {
+        try {
+            return searchDataObjectAsync(request).toCompletableFuture().join();
+        } catch (CompletionException e) {
+            throw unwrapAndConvertToRuntime(e);
+        }
+    }
+
     private static RuntimeException unwrapAndConvertToRuntime(CompletionException e) {
         Throwable cause = e.getCause();
         if (cause instanceof InterruptedException) {

--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -8,11 +8,12 @@
  */
 package org.opensearch.sdk;
 
-import org.opensearch.OpenSearchException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
+
+import org.opensearch.OpenSearchException;
 
 public interface SdkClient {
 
@@ -36,7 +37,7 @@ public interface SdkClient {
     /**
      * Create/Put/Index a data object/document into a table/index.
      * @param request A request encapsulating the data object to store
-     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     * @return A response on success. Throws unchecked exceptions or {@link OpenSearchException} wrapping the cause on checked exception.
      */
     default PutDataObjectResponse putDataObject(PutDataObjectRequest request) {
         try {
@@ -48,16 +49,18 @@ public interface SdkClient {
 
     /**
      * Read/Get a data object/document from a table/index.
-     * @param request A request identifying the data object to retrieve
+     *
+     * @param request  A request identifying the data object to retrieve
      * @param executor the executor to use for asynchronous execution
-     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<GetDataObjectResponse> getDataObjectAsync(GetDataObjectRequest request, Executor executor);
 
     /**
      * Read/Get a data object/document from a table/index.
+     *
      * @param request A request identifying the data object to retrieve
-     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     * @return A completion stage encapsulating the response or exception
      */
     default CompletionStage<GetDataObjectResponse> getDataObjectAsync(GetDataObjectRequest request) {
         return getDataObjectAsync(request, ForkJoinPool.commonPool());
@@ -66,7 +69,7 @@ public interface SdkClient {
     /**
      * Read/Get a data object/document from a table/index.
      * @param request A request identifying the data object to retrieve
-     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     * @return A response on success. Throws unchecked exceptions or {@link OpenSearchException} wrapping the cause on checked exception.
      */
     default GetDataObjectResponse getDataObject(GetDataObjectRequest request) {
         try {
@@ -78,7 +81,8 @@ public interface SdkClient {
 
     /**
      * Update a data object/document in a table/index.
-     * @param request A request identifying the data object to update
+     *
+     * @param request  A request identifying the data object to update
      * @param executor the executor to use for asynchronous execution
      * @return A completion stage encapsulating the response or exception
      */
@@ -86,6 +90,7 @@ public interface SdkClient {
 
     /**
      * Update a data object/document in a table/index.
+     *
      * @param request A request identifying the data object to update
      * @return A completion stage encapsulating the response or exception
      */
@@ -96,7 +101,7 @@ public interface SdkClient {
     /**
      * Update a data object/document in a table/index.
      * @param request A request identifying the data object to update
-     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     * @return A response on success. Throws unchecked exceptions or {@link OpenSearchException} wrapping the cause on checked exception.
      */
     default UpdateDataObjectResponse updateDataObject(UpdateDataObjectRequest request) {
         try {
@@ -108,7 +113,8 @@ public interface SdkClient {
 
     /**
      * Delete a data object/document from a table/index.
-     * @param request A request identifying the data object to delete
+     *
+     * @param request  A request identifying the data object to delete
      * @param executor the executor to use for asynchronous execution
      * @return A completion stage encapsulating the response or exception
      */
@@ -116,6 +122,7 @@ public interface SdkClient {
 
     /**
      * Delete a data object/document from a table/index.
+     *
      * @param request A request identifying the data object to delete
      * @return A completion stage encapsulating the response or exception
      */
@@ -126,7 +133,7 @@ public interface SdkClient {
     /**
      * Delete a data object/document from a table/index.
      * @param request A request identifying the data object to delete
-     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     * @return A response on success. Throws unchecked exceptions or {@link OpenSearchException} wrapping the cause on checked exception.
      */
     default DeleteDataObjectResponse deleteDataObject(DeleteDataObjectRequest request) {
         try {
@@ -137,26 +144,28 @@ public interface SdkClient {
     }
 
     /**
-     * Search for a data object/document in a table/index.
-     * @param request A request identifying the data object to retrieve
+     * Search for data objects/documents in a table/index.
+     *
+     * @param request  A request identifying the data objects to search for
      * @param executor the executor to use for asynchronous execution
-     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(SearchDataObjectRequest request, Executor executor);
 
     /**
-     * Search for a data object/document in a table/index.
-     * @param request A request identifying the data object to retrieve
-     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     * Search for data objects/documents in a table/index.
+     *
+     * @param request A request identifying the data objects to search for
+     * @return A completion stage encapsulating the response or exception
      */
     default CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(SearchDataObjectRequest request) {
         return searchDataObjectAsync(request, ForkJoinPool.commonPool());
     }
 
     /**
-     * Search for a data object/document in a table/index.
-     * @param request A request identifying the data object to retrieve
-     * @return A response on success. Throws {@link OpenSearchException} wrapping the cause on exception.
+     * Search for data objects/documents in a table/index.
+     * @param request A request identifying the data objects to search for
+     * @return A response on success. Throws unchecked exceptions or {@link OpenSearchException} wrapping the cause on checked exception.
      */
     default SearchDataObjectResponse searchDataObject(SearchDataObjectRequest request) {
         try {

--- a/common/src/main/java/org/opensearch/sdk/SearchDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/SearchDataObjectRequest.java
@@ -16,11 +16,12 @@ public class SearchDataObjectRequest {
     private final SearchSourceBuilder searchSourceBuilder;
 
     /**
-     * Instantiate this request with an index and id
+     * Instantiate this request with an optional list of indices and search source
      * <p>
-     * For data storage implementations other than OpenSearch, an index may be referred to as a table and the id may be referred to as a primary key.
-     * @param indices the indices to search for the object
-     * @param searchSourceBuilder the context to use when fetching _source
+     * For data storage implementations other than OpenSearch, an index may be referred to as a table
+     *
+     * @param indices             the indices to search for the object
+     * @param searchSourceBuilder the search body containing the query
      */
     public SearchDataObjectRequest(String[] indices, SearchSourceBuilder searchSourceBuilder) {
         this.indices = indices;
@@ -72,7 +73,7 @@ public class SearchDataObjectRequest {
          */
         public Builder searchSourceBuilder(SearchSourceBuilder searchSourceBuilder) {
             this.searchSourceBuilder = searchSourceBuilder;
-            
+
             return this;
         }
 

--- a/common/src/main/java/org/opensearch/sdk/SearchDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/SearchDataObjectRequest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+public class SearchDataObjectRequest {
+
+    private final String[] indices;
+    private final SearchSourceBuilder searchSourceBuilder;
+
+    /**
+     * Instantiate this request with an index and id
+     * <p>
+     * For data storage implementations other than OpenSearch, an index may be referred to as a table and the id may be referred to as a primary key.
+     * @param indices the indices to search for the object
+     * @param searchSourceBuilder the context to use when fetching _source
+     */
+    public SearchDataObjectRequest(String[] indices, SearchSourceBuilder searchSourceBuilder) {
+        this.indices = indices;
+        this.searchSourceBuilder = searchSourceBuilder;
+    }
+
+    /**
+     * Returns the indices
+     * @return the indices
+     */
+    public String[] indices() {
+        return this.indices;
+    }
+
+    /**
+     * Returns the builder for searching
+     * @return the SearchSourceBuilder
+     */
+    public SearchSourceBuilder searchSourceBuilder() {
+        return this.searchSourceBuilder;
+    }
+
+    /**
+     * Class for constructing a Builder for this Request Object
+     */
+    public static class Builder {
+        private String[] indices = null;
+        private SearchSourceBuilder searchSourceBuilder;
+
+        /**
+         * Empty Constructor for the Builder object
+         */
+        public Builder() {}
+
+        /**
+         * Add a indices to this builder
+         * @param indices the index to put the object
+         * @return the updated builder
+         */
+        public Builder indices(String... indices) {
+            this.indices = indices;
+            return this;
+        }
+
+        /**
+         * Add a SearchSourceBuilder to this builder
+         * @param searchSourceBuilder the searchSourceBuilder
+         * @return the updated builder
+         */
+        public Builder searchSourceBuilder(SearchSourceBuilder searchSourceBuilder) {
+            this.searchSourceBuilder = searchSourceBuilder;
+            
+            return this;
+        }
+
+        /**
+         * Builds the request
+         * @return A {@link SearchDataObjectRequest}
+         */
+        public SearchDataObjectRequest build() {
+            return new SearchDataObjectRequest(this.indices, this.searchSourceBuilder);
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/sdk/SearchDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/SearchDataObjectResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.opensearch.core.xcontent.XContentParser;
+
+
+public class SearchDataObjectResponse {
+    private final XContentParser parser;
+
+    /**
+     * Instantiate this request with a parser used to recreate the response.
+     * @param parser an XContentParser that can be used to create the response.
+     */
+    public SearchDataObjectResponse(XContentParser parser) {
+        this.parser = parser;
+    }
+    
+    /**
+     * Returns the parser
+     * @return the parser
+     */
+    public XContentParser parser() {
+        return this.parser;
+    }
+
+    /**
+     * Class for constructing a Builder for this Response Object
+     */
+    public static class Builder {
+        private XContentParser parser = null;
+
+        /**
+         * Empty Constructor for the Builder object
+         */
+        public Builder() {}
+
+        /**
+         * Add aparser to this builder
+         * @param parser a parser
+         * @return the updated builder
+         */
+        public Builder parser(XContentParser parser) {
+            this.parser = parser;
+            return this;
+        }
+
+        /**
+         * Builds the response
+         * @return A {@link SearchDataObjectResponse}
+         */
+        public SearchDataObjectResponse build() {
+            return new SearchDataObjectResponse(this.parser);
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/sdk/SearchDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/SearchDataObjectResponse.java
@@ -10,7 +10,6 @@ package org.opensearch.sdk;
 
 import org.opensearch.core.xcontent.XContentParser;
 
-
 public class SearchDataObjectResponse {
     private final XContentParser parser;
 
@@ -21,7 +20,7 @@ public class SearchDataObjectResponse {
     public SearchDataObjectResponse(XContentParser parser) {
         this.parser = parser;
     }
-    
+
     /**
      * Returns the parser
      * @return the parser

--- a/common/src/test/java/org/opensearch/sdk/SearchDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SearchDataObjectRequestTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class SearchDataObjectRequestTests {
+
+    private String[] testIndices;
+    private SearchSourceBuilder testSearchSourceBuilder;
+
+    @Before
+    public void setUp() {
+        testIndices = new String[] {"test-index"};
+        testSearchSourceBuilder = new SearchSourceBuilder();
+    }
+
+    @Test
+    public void testGetDataObjectRequest() {
+        SearchDataObjectRequest request = new SearchDataObjectRequest.Builder()
+            .indices(testIndices)
+            .searchSourceBuilder(testSearchSourceBuilder)
+            .build();
+
+        assertArrayEquals(testIndices, request.indices());
+        assertEquals(testSearchSourceBuilder, request.searchSourceBuilder());
+    }
+}

--- a/common/src/test/java/org/opensearch/sdk/SearchDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SearchDataObjectResponseTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.core.xcontent.XContentParser;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class SearchDataObjectResponseTests {
+
+    private XContentParser testParser;
+
+    @Before
+    public void setUp() {
+        testParser = mock(XContentParser.class);
+    }
+
+    @Test
+    public void testSearchDataObjectResponse() {
+        SearchDataObjectResponse response = new SearchDataObjectResponse.Builder().parser(testParser).build();
+
+        assertEquals(testParser, response.parser());
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.action.connector;
 
+import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleSearchIndexNotFound;
 
 import java.util.ArrayList;
@@ -14,6 +15,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.ShardSearchFailure;
@@ -24,12 +27,15 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.utils.RestActionUtils;
+import org.opensearch.sdk.SdkClient;
+import org.opensearch.sdk.SearchDataObjectRequest;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.search.internal.InternalSearchResponse;
@@ -44,6 +50,7 @@ import lombok.extern.log4j.Log4j2;
 public class SearchConnectorTransportAction extends HandledTransportAction<SearchRequest, SearchResponse> {
 
     private final Client client;
+    private final SdkClient sdkClient;
 
     private final ConnectorAccessControlHelper connectorAccessControlHelper;
 
@@ -52,10 +59,12 @@ public class SearchConnectorTransportAction extends HandledTransportAction<Searc
         TransportService transportService,
         ActionFilters actionFilters,
         Client client,
+        SdkClient sdkClient,
         ConnectorAccessControlHelper connectorAccessControlHelper
     ) {
         super(MLConnectorSearchAction.NAME, transportService, actionFilters, SearchRequest::new);
         this.client = client;
+        this.sdkClient = sdkClient;
         this.connectorAccessControlHelper = connectorAccessControlHelper;
     }
 
@@ -90,13 +99,39 @@ public class SearchConnectorTransportAction extends HandledTransportAction<Searc
             final ActionListener<SearchResponse> doubleWrappedListener = ActionListener
                 .wrap(wrappedListener::onResponse, e -> wrapListenerToHandleSearchIndexNotFound(e, wrappedListener));
 
-            if (connectorAccessControlHelper.skipConnectorAccessControl(user)) {
-                client.search(request, doubleWrappedListener);
-            } else {
+            if (!connectorAccessControlHelper.skipConnectorAccessControl(user)) {
                 SearchSourceBuilder sourceBuilder = connectorAccessControlHelper.addUserBackendRolesFilter(user, request.source());
                 request.source(sourceBuilder);
-                client.search(request, doubleWrappedListener);
             }
+            SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+                .indices(request.indices())
+                .searchSourceBuilder(request.source())
+                .build();
+            sdkClient
+                .searchDataObjectAsync(searchDataObjectRequest, client.threadPool().executor(GENERAL_THREAD_POOL))
+                .whenComplete((r, throwable) -> {
+                    if (throwable != null) {
+                        Throwable cause = throwable.getCause() == null ? throwable : throwable.getCause();
+                        log.error("Failed to search connector", cause);
+                        if (cause instanceof Exception) {
+                            doubleWrappedListener.onFailure((Exception) cause);
+                        } else {
+                            doubleWrappedListener.onFailure(new OpenSearchException(cause));
+                        }
+                    } else {
+                        try {
+                            SearchResponse searchResponse = SearchResponse.fromXContent(r.parser());
+                            log.info("Connector search complete: {}", searchResponse.getHits().getTotalHits());
+                            doubleWrappedListener.onResponse(searchResponse);
+                        } catch (Exception e) {
+                            log.error("Failed to parse search response", e);
+                            doubleWrappedListener
+                                .onFailure(
+                                    new OpenSearchStatusException("Failed to parse search response", RestStatus.INTERNAL_SERVER_ERROR)
+                                );
+                        }
+                    }
+                });
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             actionListener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/SdkClientModule.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/SdkClientModule.java
@@ -19,6 +19,7 @@ import org.opensearch.common.inject.AbstractModule;
 import org.opensearch.core.common.Strings;
 import org.opensearch.sdk.SdkClient;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
@@ -75,7 +76,9 @@ public class SdkClientModule extends AbstractModule {
                     }
                 })
                 .build();
-            ObjectMapper objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+            ObjectMapper objectMapper = new ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
             return new OpenSearchClient(new RestClientTransport(restClient, new JacksonJsonpMapper(objectMapper)));
         } catch (Exception e) {
             throw new OpenSearchException(e);

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/DeleteConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/DeleteConnectorTransportActionTests.java
@@ -33,6 +33,7 @@ import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
@@ -172,11 +173,9 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
         }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
         SearchResponse searchResponse = getEmptySearchResponse();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onResponse(searchResponse);
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
@@ -201,11 +200,9 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
-        doAnswer(invocation -> {
-            ActionListener<Exception> actionListener = invocation.getArgument(1);
-            actionListener.onFailure(new IndexNotFoundException("ml_model index not found!"));
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onFailure(new IndexNotFoundException("ml_model index not found!"));
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
@@ -232,11 +229,9 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
         }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
         SearchResponse searchResponse = getEmptySearchResponse();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onResponse(searchResponse);
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
@@ -261,11 +256,9 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
         }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
         SearchResponse searchResponse = getNonEmptySearchResponse();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onResponse(searchResponse);
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
@@ -293,7 +286,7 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
         assertEquals("You are not allowed to delete this connector", argumentCaptor.getValue().getMessage());
     }
 
-    public void testDeleteConnector_SearchFailure() throws IOException {
+    public void testDeleteConnector_SearchFailure() throws IOException, InterruptedException {
 
         doAnswer(invocation -> {
             ActionListener<Boolean> listener = invocation.getArgument(5);
@@ -301,13 +294,15 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onFailure(new RuntimeException("Search Failed!"));
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onFailure(new RuntimeException("Search Failed!"));
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
 
-        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, latchedActionListener);
+        latch.await();
+
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Search Failed!", argumentCaptor.getValue().getMessage());
@@ -322,7 +317,6 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
             listener.onResponse(true);
             return null;
         }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
-
 
         deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
@@ -339,13 +333,10 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
-
         SearchResponse searchResponse = getEmptySearchResponse();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onResponse(searchResponse);
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
@@ -9,12 +9,15 @@
 package org.opensearch.ml.sdkclient;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -26,6 +29,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.Result;
 import org.opensearch.client.opensearch._types.ShardStatistics;
@@ -35,8 +39,14 @@ import org.opensearch.client.opensearch.core.GetRequest;
 import org.opensearch.client.opensearch.core.GetResponse;
 import org.opensearch.client.opensearch.core.IndexRequest;
 import org.opensearch.client.opensearch.core.IndexResponse;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.UpdateRequest;
 import org.opensearch.client.opensearch.core.UpdateResponse;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.TotalHits;
+import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
+import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
@@ -48,12 +58,19 @@ import org.opensearch.sdk.GetDataObjectResponse;
 import org.opensearch.sdk.PutDataObjectRequest;
 import org.opensearch.sdk.PutDataObjectResponse;
 import org.opensearch.sdk.SdkClient;
+import org.opensearch.sdk.SearchDataObjectRequest;
+import org.opensearch.sdk.SearchDataObjectResponse;
 import org.opensearch.sdk.UpdateDataObjectRequest;
 import org.opensearch.sdk.UpdateDataObjectResponse;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
@@ -75,11 +92,24 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     private OpenSearchClient mockedOpenSearchClient;
     private SdkClient sdkClient;
 
+    @Mock
+    private OpenSearchTransport transport;
+
     private TestDataObject testDataObject;
 
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
+
+        when(mockedOpenSearchClient._transport()).thenReturn(transport);
+        when(transport.jsonpMapper())
+            .thenReturn(
+                new JacksonJsonpMapper(
+                    new ObjectMapper()
+                        .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                )
+            );
 
         sdkClient = new RemoteClusterIndicesClient(mockedOpenSearchClient);
         testDataObject = new TestDataObject("foo");
@@ -371,5 +401,61 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
         assertEquals(OpenSearchStatusException.class, ce.getCause().getClass());
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void testSearchDataObject() throws IOException {
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        SearchDataObjectRequest searchRequest = new SearchDataObjectRequest.Builder()
+            .indices(TEST_INDEX)
+            .searchSourceBuilder(searchSourceBuilder)
+            .build();
+
+        TotalHits totalHits = new TotalHits.Builder().value(0).relation(TotalHitsRelation.Eq).build();
+        HitsMetadata<Object> hits = new HitsMetadata.Builder<>().hits(Collections.emptyList()).total(totalHits).build();
+        ShardStatistics shards = new ShardStatistics.Builder().failed(0).successful(1).total(1).build();
+        SearchResponse<?> searchResponse = new SearchResponse.Builder<>().hits(hits).took(1).timedOut(false).shards(shards).build();
+
+        ArgumentCaptor<SearchRequest> getRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        ArgumentCaptor<Class<Map>> mapClassCaptor = ArgumentCaptor.forClass(Class.class);
+        when(mockedOpenSearchClient.search(getRequestCaptor.capture(), mapClassCaptor.capture()))
+            .thenReturn((SearchResponse<Map>) searchResponse);
+
+        SearchDataObjectResponse response = sdkClient
+            .searchDataObjectAsync(searchRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
+            .toCompletableFuture()
+            .join();
+
+        ArgumentCaptor<SearchRequest> requestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        verify(mockedOpenSearchClient, times(1)).search(requestCaptor.capture(), any());
+        assertEquals(1, requestCaptor.getValue().index().size());
+        assertEquals(TEST_INDEX, requestCaptor.getValue().index().get(0));
+
+        org.opensearch.action.search.SearchResponse searchActionResponse = org.opensearch.action.search.SearchResponse
+            .fromXContent(response.parser());
+        assertEquals(TimeValue.timeValueMillis(1), searchActionResponse.getTook());
+        assertFalse(searchActionResponse.isTimedOut());
+        assertEquals(0, searchActionResponse.getFailedShards());
+        assertEquals(1, searchActionResponse.getSuccessfulShards());
+        assertEquals(1, searchActionResponse.getTotalShards());
+    }
+
+    public void testSearchDataObject_Exception() throws IOException {
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        SearchDataObjectRequest searchRequest = new SearchDataObjectRequest.Builder()
+            .indices(TEST_INDEX)
+            .searchSourceBuilder(searchSourceBuilder)
+            .build();
+
+        ArgumentCaptor<SearchRequest> searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        when(mockedOpenSearchClient.search(searchRequestCaptor.capture(), any())).thenThrow(new UnsupportedOperationException("test"));
+        CompletableFuture<SearchDataObjectResponse> future = sdkClient
+            .searchDataObjectAsync(searchRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
+            .toCompletableFuture();
+
+        CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
+        Throwable cause = ce.getCause();
+        assertEquals(UnsupportedOperationException.class, cause.getClass());
+        assertEquals("test", cause.getMessage());
     }
 }


### PR DESCRIPTION
### Description

 - Adds search method to SdkClient interface
 - Implements search method on Local and Remote clients
 - Migrates Connector Search action to use SdkClient for the searching
 - Updates Delete and Update connector actions which search model index to use new API
 
### Issues Resolved

Continuation of PR https://github.com/opensearch-project/ml-commons/pull/2459
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
