### PR TITLE
add offline batch predict job ActionType in connector

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/PredictMode.java
+++ b/common/src/main/java/org/opensearch/ml/common/PredictMode.java
@@ -1,0 +1,18 @@
+package org.opensearch.ml.common;
+
+import java.util.Locale;
+
+public enum PredictMode {
+    PREDICT,
+    BATCH,
+    ASYNC,
+    STREAMING;
+
+    public static PredictMode from(String value) {
+        try {
+            return PredictMode.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Wrong Predict mode");
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/PredictMode.java
+++ b/common/src/main/java/org/opensearch/ml/common/PredictMode.java
@@ -4,9 +4,9 @@ import java.util.Locale;
 
 public enum PredictMode {
     PREDICT,
-    BATCH,
-    ASYNC,
-    STREAMING;
+    BATCH;
+    // ASYNC,
+    // STREAMING;
 
     public static PredictMode from(String value) {
         try {

--- a/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
@@ -183,6 +183,7 @@ public class ConnectorAction implements ToXContentObject, Writeable {
 
     public enum ActionType {
         PREDICT,
-        EXECUTE
+        EXECUTE,
+        BATCH
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/dataset/remote/RemoteInferenceInputDataSet.java
+++ b/common/src/main/java/org/opensearch/ml/common/dataset/remote/RemoteInferenceInputDataSet.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.ml.common.PredictMode;
 import org.opensearch.ml.common.annotation.InputDataSet;
 import org.opensearch.ml.common.dataset.MLInputDataType;
 import org.opensearch.ml.common.dataset.MLInputDataset;
@@ -23,11 +24,17 @@ public class RemoteInferenceInputDataSet extends MLInputDataset {
 
     @Setter
     private Map<String, String> parameters;
+    private PredictMode predictMode;
 
     @Builder(toBuilder = true)
-    public RemoteInferenceInputDataSet(Map<String, String> parameters) {
+    public RemoteInferenceInputDataSet(Map<String, String> parameters, PredictMode predictMode) {
         super(MLInputDataType.REMOTE);
         this.parameters = parameters;
+        this.predictMode = predictMode;
+    }
+
+    public RemoteInferenceInputDataSet(Map<String, String> parameters) {
+        this(parameters, null);
     }
 
     public RemoteInferenceInputDataSet(StreamInput streamInput) throws IOException {

--- a/common/src/main/java/org/opensearch/ml/common/input/MLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/MLInput.java
@@ -35,6 +35,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.input.remote.RemoteInferenceMLInput.PREDICT_MODE_FIELD;
 
 /**
  * ML input data: algorithm name, parameters and input data set.
@@ -196,6 +197,7 @@ public class MLInput implements Input {
                     RemoteInferenceInputDataSet remoteInferenceInputDataSet = (RemoteInferenceInputDataSet) this.inputDataset;
                     Map<String, String> parameters = remoteInferenceInputDataSet.getParameters();
                     builder.field(PARAMETERS_FIELD, parameters);
+                    builder.field(PREDICT_MODE_FIELD, remoteInferenceInputDataSet.getPredictMode());
                     break;
                 default:
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/input/remote/RemoteInferenceMLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/remote/RemoteInferenceMLInput.java
@@ -9,6 +9,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.PredictMode;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.utils.StringUtils;
@@ -21,6 +22,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 @org.opensearch.ml.common.annotation.MLInput(functionNames = {FunctionName.REMOTE})
 public class RemoteInferenceMLInput extends MLInput {
     public static final String PARAMETERS_FIELD = "parameters";
+    public static final String PREDICT_MODE_FIELD = "mode";
 
     public RemoteInferenceMLInput(StreamInput in) throws IOException {
         super(in);
@@ -34,6 +36,8 @@ public class RemoteInferenceMLInput extends MLInput {
     public RemoteInferenceMLInput(XContentParser parser, FunctionName functionName) throws IOException {
         super();
         this.algorithm = functionName;
+        Map<String, String> parameters = null;
+        PredictMode predictMode = null;
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
             String fieldName = parser.currentName();
@@ -41,14 +45,17 @@ public class RemoteInferenceMLInput extends MLInput {
 
             switch (fieldName) {
                 case PARAMETERS_FIELD:
-                    Map<String, String> parameters = StringUtils.getParameterMap(parser.map());
-                    inputDataset = new RemoteInferenceInputDataSet(parameters);
+                    parameters = StringUtils.getParameterMap(parser.map());
                     break;
+                case PREDICT_MODE_FIELD:
+                    predictMode = PredictMode.from(parser.text());
                 default:
                     parser.skipChildren();
                     break;
             }
         }
+        predictMode = predictMode == null? PredictMode.PREDICT:predictMode;
+        inputDataset = new RemoteInferenceInputDataSet(parameters, predictMode);
     }
 
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
@@ -17,7 +17,9 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.PredictMode;
 import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.model.MLGuard;
@@ -70,7 +72,12 @@ public class RemoteModel implements Predictable {
             return;
         }
         try {
-            connectorExecutor.executeAction(PREDICT.name(), mlInput, actionListener);
+            PredictMode predictMode = null;
+            if (mlInput.getInputDataset() instanceof RemoteInferenceInputDataSet) {
+                predictMode = ((RemoteInferenceInputDataSet) mlInput.getInputDataset()).getPredictMode();
+            }
+            predictMode = predictMode == null ? PredictMode.PREDICT : predictMode;
+            connectorExecutor.executeAction(predictMode.toString(), mlInput, actionListener);
         } catch (RuntimeException e) {
             log.error("Failed to call remote model.", e);
             actionListener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -132,6 +132,7 @@ public final class MLCommonsSettings {
             ImmutableList
                 .of(
                     "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                    "^https://api\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
                     "^https://api\\.openai\\.com/.*$",
                     "^https://api\\.cohere\\.ai/.*$",
                     "^https://bedrock-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"


### PR DESCRIPTION
### Description
Add batch jobs as new Action type in Connectors and allow model invocation through "batch" mode. Verified it works well with SageMaker Batch jobs.

Examples:
~~~
POST /_plugins/_ml/connectors/_create
{
...
  "actions": [
    {
      "action_type": "predict",
      "method": "POST",
      "headers": {
        "content-type": "application/json"
      },
      "url": "https://runtime.<your endpoint>/invocations",
      "request_body": "${parameters.input}",
      "pre_process_function": "connector.pre_process.default.embedding",
      "post_process_function": "connector.post_process.default.embedding"
    },
    {
        "action_type": "batch",
        "method": "POST",
        "headers": {
            "content-type": "application/json"
        },
        "url": "https://api.sagemaker.us-east-1.amazonaws.com/CreateTransformJob",
        "request_body": "{ \"ModelName\": \"${parameters.ModelName}\", \"TransformInput\": ${parameters.TransformInput}, \"TransformJobName\" : \"${parameters.TransformJobName}\", \"TransformOutput\" : ${parameters.TransformOutput}, \"TransformResources\" : ${parameters.TransformResources}}"
    }
  ]
}
~~~
 
~~~
POST /_plugins/_ml/models/dX2aLZABJS5LjL3lLCp2/_predict
{
    "mode" : "batch",
    "parameters": {... ... }
}
~~~
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/2488, https://github.com/opensearch-project/ml-commons/issues/2484
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
