### PR TITLE
[Feature/multi_tenancy] Add Tenant ID to Search API, refactor and add util methods

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -14,6 +14,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 
 import org.opensearch.OpenSearchException;
+import static org.opensearch.sdk.SdkClientUtils.unwrapAndConvertToRuntime;
 
 public interface SdkClient {
 
@@ -173,16 +174,5 @@ public interface SdkClient {
         } catch (CompletionException e) {
             throw unwrapAndConvertToRuntime(e);
         }
-    }
-
-    private static RuntimeException unwrapAndConvertToRuntime(CompletionException e) {
-        Throwable cause = e.getCause();
-        if (cause instanceof InterruptedException) {
-            Thread.currentThread().interrupt();
-        }
-        if (cause instanceof RuntimeException) {
-            return (RuntimeException) cause;
-        }
-        return new OpenSearchException(cause);
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/SdkClientUtils.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClientUtils.java
@@ -9,10 +9,15 @@
 package org.opensearch.sdk;
 
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
 import org.opensearch.OpenSearchException;
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.util.concurrent.FutureUtils;
+import org.opensearch.common.util.concurrent.UncategorizedExecutionException;
 
 public class SdkClientUtils {
-    
+
     /**
      * Unwraps the cause of a {@link CompletionException}. If the cause is a subclass of {@link RuntimeException}, rethrows the exception.
      * Otherwise wraps it in an {@link OpenSearchException}. Properly re-interrupts the thread on {@link InterruptedException}.
@@ -29,5 +34,18 @@ public class SdkClientUtils {
             return (RuntimeException) cause;
         }
         return new OpenSearchException(cause);
+    }
+
+    /**
+     * Get the original exception of an {@link UncategorizedExecutionException} with two levels of cause nesting.
+     * Intended to recreate the root cause of an exception thrown by {@link ActionFuture#actionGet}, which was handled by {@link FutureUtils#rethrowExecutionException}.
+     * @param throwable a throwable with possibly nested causes
+     * @return the root cause of an ExecutionException if it was not a RuntimeException, otherwise the original exception 
+     */
+    public static Throwable getRethrownExecutionExceptionRootCause(Throwable throwable) {
+        if (throwable instanceof UncategorizedExecutionException && throwable.getCause() instanceof ExecutionException) {
+            return throwable.getCause().getCause();
+        }
+        return throwable;
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/SdkClientUtils.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClientUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import java.util.concurrent.CompletionException;
+import org.opensearch.OpenSearchException;
+
+public class SdkClientUtils {
+    
+    /**
+     * Unwraps the cause of a {@link CompletionException}. If the cause is a subclass of {@link RuntimeException}, rethrows the exception.
+     * Otherwise wraps it in an {@link OpenSearchException}. Properly re-interrupts the thread on {@link InterruptedException}.
+     * @param e the CompletionException
+     * @return The wrapped cause of the completion exception if unchecked, otherwise an OpenSearchException wrapping it.
+     */
+    public static RuntimeException unwrapAndConvertToRuntime(CompletionException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+        }
+        // Below is the same as o.o.ExceptionsHelper.convertToRuntime but cause is a throwable
+        if (cause instanceof RuntimeException) {
+            return (RuntimeException) cause;
+        }
+        return new OpenSearchException(cause);
+    }
+}

--- a/common/src/main/java/org/opensearch/sdk/SearchDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/SearchDataObjectRequest.java
@@ -13,6 +13,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 public class SearchDataObjectRequest {
 
     private final String[] indices;
+    private final String tenantId;
     private final SearchSourceBuilder searchSourceBuilder;
 
     /**
@@ -20,11 +21,13 @@ public class SearchDataObjectRequest {
      * <p>
      * For data storage implementations other than OpenSearch, an index may be referred to as a table
      *
-     * @param indices             the indices to search for the object
+     * @param indices the indices to search for the object
+     * @param tenantId the tenant id
      * @param searchSourceBuilder the search body containing the query
      */
-    public SearchDataObjectRequest(String[] indices, SearchSourceBuilder searchSourceBuilder) {
+    public SearchDataObjectRequest(String[] indices, String tenantId, SearchSourceBuilder searchSourceBuilder) {
         this.indices = indices;
+        this.tenantId = tenantId;
         this.searchSourceBuilder = searchSourceBuilder;
     }
 
@@ -34,6 +37,14 @@ public class SearchDataObjectRequest {
      */
     public String[] indices() {
         return this.indices;
+    }
+
+    /**
+     * Returns the tenant id
+     * @return the tenantId
+     */
+    public String tenantId() {
+        return this.tenantId;
     }
 
     /**
@@ -49,6 +60,7 @@ public class SearchDataObjectRequest {
      */
     public static class Builder {
         private String[] indices = null;
+        private String tenantId = null;
         private SearchSourceBuilder searchSourceBuilder;
 
         /**
@@ -67,13 +79,22 @@ public class SearchDataObjectRequest {
         }
 
         /**
+         * Add a tenant ID to this builder
+         * @param tenantId the tenant id
+         * @return the updated builder
+         */
+        public Builder tenantId(String tenantId) {
+            this.tenantId = tenantId;
+            return this;
+        }
+
+        /**
          * Add a SearchSourceBuilder to this builder
          * @param searchSourceBuilder the searchSourceBuilder
          * @return the updated builder
          */
         public Builder searchSourceBuilder(SearchSourceBuilder searchSourceBuilder) {
             this.searchSourceBuilder = searchSourceBuilder;
-
             return this;
         }
 
@@ -82,7 +103,7 @@ public class SearchDataObjectRequest {
          * @return A {@link SearchDataObjectRequest}
          */
         public SearchDataObjectRequest build() {
-            return new SearchDataObjectRequest(this.indices, this.searchSourceBuilder);
+            return new SearchDataObjectRequest(this.indices, this.tenantId, this.searchSourceBuilder);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
@@ -99,7 +99,7 @@ public class UpdateDataObjectRequest {
             return this;
         }
 
-         /**
+        /**
          * Add a tenant ID to this builder
          * @param tenantId the tenant id
          * @return the updated builder

--- a/common/src/test/java/org/opensearch/sdk/SdkClientUtilsTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SdkClientUtilsTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
+import java.io.IOException;
+import java.util.concurrent.CompletionException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class SdkClientUtilsTests {
+
+    @Mock
+    private OpenSearchStatusException testException;
+    @Mock
+    private InterruptedException interruptedException;
+    @Mock
+    private IOException ioException;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testUnwrapAndConvertToRuntime() {
+        CompletionException ce = new CompletionException(testException);
+        RuntimeException rte = SdkClientUtils.unwrapAndConvertToRuntime(ce);
+        assertSame(testException, rte);
+
+        ce = new CompletionException(interruptedException);
+        rte = SdkClientUtils.unwrapAndConvertToRuntime(ce); // sets interrupted
+        assertTrue(Thread.interrupted()); // tests and resets interrupted
+        assertTrue(rte instanceof OpenSearchException);
+        assertSame(interruptedException, rte.getCause());
+
+        ce = new CompletionException(ioException);
+        rte = SdkClientUtils.unwrapAndConvertToRuntime(ce);
+        assertFalse(Thread.currentThread().isInterrupted());
+        assertTrue(rte instanceof OpenSearchException);
+        assertSame(ioException, rte.getCause());
+    }
+}


### PR DESCRIPTION
### Description

1. Adds tenant ID to SearchDataObjectRequest.  It was already added to the other requests in #2553 
2. Refactors `unwrapAndConvertToRuntime` static method from `SdkClient` interface to new `SdkClientUtils` class
3. Adds new `getRethrownExecutionExceptionRootCause` static method to `SdkClientUtils` class to handle common pattern of throwables from `actionGet()`.   (Have not yet migrated implementations; will do those as part of future PRs.)
 
### Issues Resolved

PR comments on multiple previous PRs.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
