### PR TITLE
Prepare for setting ml-commons plugin 3.0.0 baseline JDK version to JDK-21

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -23,7 +23,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     name: Build and Test MLCommons Plugin on linux
     if: github.repository == 'opensearch-project/ml-commons'
@@ -88,7 +88,7 @@ jobs:
     needs: Build-ml-linux
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     name: Test MLCommons Plugin on linux docker
     if: github.repository == 'opensearch-project/ml-commons'
@@ -179,7 +179,7 @@ jobs:
   Build-ml-windows:
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [21]
     name: Build and Test MLCommons Plugin on Windows
     if: github.repository == 'opensearch-project/ml-commons'
     environment: ml-commons-cicd-env


### PR DESCRIPTION
### Description
Prepare for setting ml-commons plugin 3.0.0 baseline JDK version to JDK-21 (seems like the GA should be updated separately to take an effect)
 
### Issues Resolved
See please https://github.com/opensearch-project/ml-commons/pull/2583
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
