### PR TITLE
[Feature/multi_tenancy] Update GetDataObjectResponse to include full GetResponse parser

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
@@ -12,11 +12,10 @@ import org.opensearch.core.xcontent.XContentParser;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 
 public class GetDataObjectResponse {
     private final String id;
-    private final Optional<XContentParser> parser;
+    private final XContentParser parser;
     private final Map<String, Object> source;
 
     /**
@@ -24,10 +23,10 @@ public class GetDataObjectResponse {
      * <p>
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
      * @param id the document id
-     * @param parser an optional XContentParser that can be used to create the data object if present.
+     * @param parser a parser that can be used to create a GetResponse
      * @param source the data object as a map
      */
-    public GetDataObjectResponse(String id, Optional<XContentParser> parser, Map<String, Object> source) {
+    public GetDataObjectResponse(String id, XContentParser parser, Map<String, Object> source) {
         this.id = id;
         this.parser = parser;
         this.source = source;
@@ -42,10 +41,10 @@ public class GetDataObjectResponse {
     }
     
     /**
-     * Returns the parser optional. If present, is a representation of the data object that may be parsed.
-     * @return the parser optional
+     * Returns the parser that can be used to create a GetResponse
+     * @return the parser
      */
-    public Optional<XContentParser> parser() {
+    public XContentParser parser() {
         return this.parser;
     }
     
@@ -62,7 +61,7 @@ public class GetDataObjectResponse {
      */
     public static class Builder {
         private String id = null;
-        private Optional<XContentParser> parser = Optional.empty();
+        private XContentParser parser = null;
         private Map<String, Object> source = Collections.emptyMap();
 
         /**
@@ -81,11 +80,11 @@ public class GetDataObjectResponse {
         }
         
         /**
-         * Add an optional parser to this builder
-         * @param parser an {@link Optional} which may contain the data object parser
+         * Add a parser to this builder
+         * @param parser a parser that can be used to create a GetResponse
          * @return the updated builder
          */
-        public Builder parser(Optional<XContentParser> parser) {
+        public Builder parser(XContentParser parser) {
             this.parser = parser;
             return this;
         }
@@ -96,7 +95,7 @@ public class GetDataObjectResponse {
          * @return the updated builder
          */
         public Builder source(Map<String, Object> source) {
-            this.source = source;
+            this.source = source == null ? Collections.emptyMap() : source;
             return this;
         }
         

--- a/common/src/test/java/org/opensearch/sdk/GetDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/GetDataObjectResponseTests.java
@@ -13,8 +13,6 @@ import org.junit.Test;
 import org.opensearch.core.xcontent.XContentParser;
 
 import java.util.Map;
-import java.util.Optional;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -33,10 +31,10 @@ public class GetDataObjectResponseTests {
 
     @Test
     public void testGetDataObjectResponse() {
-        GetDataObjectResponse response = new GetDataObjectResponse.Builder().id(testId).parser(Optional.of(testParser)).source(testSource).build();
+        GetDataObjectResponse response = new GetDataObjectResponse.Builder().id(testId).parser(testParser).source(testSource).build();
 
         assertEquals(testId, response.id());
-        assertEquals(testParser, response.parser().get());
+        assertEquals(testParser, response.parser());
         assertEquals(testSource, response.source());
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
@@ -5,17 +5,20 @@
 
 package org.opensearch.ml.action.tasks;
 
+import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
+import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.client.Client;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
@@ -95,22 +98,29 @@ public class GetTaskTransportAction extends HandledTransportAction<ActionRequest
                             actionListener.onFailure(cause);
                         }
                     } else {
-                        if (r != null && r.parser().isPresent()) {
-                            try {
-                                XContentParser parser = r.parser().get();
-                                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-                                MLTask mlTask = MLTask.parse(parser);
-                                if (!TenantAwareHelper
-                                    .validateTenantResource(mlFeatureEnabledSetting, tenantId, mlTask.getTenantId(), actionListener)) {
-                                    return;
+                        try {
+                            GetResponse gr = GetResponse.fromXContent(r.parser());
+                            if (gr != null && gr.isExists()) {
+                                try (
+                                    XContentParser parser = jsonXContent
+                                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, gr.getSourceAsString())
+                                ) {
+                                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                                    MLTask mlTask = MLTask.parse(parser);
+                                    if (!TenantAwareHelper
+                                        .validateTenantResource(mlFeatureEnabledSetting, tenantId, mlTask.getTenantId(), actionListener)) {
+                                        return;
+                                    }
+                                    actionListener.onResponse(MLTaskGetResponse.builder().mlTask(mlTask).build());
+                                } catch (Exception e) {
+                                    log.error("Failed to parse ml task {}", r.id(), e);
+                                    actionListener.onFailure(e);
                                 }
-                                actionListener.onResponse(MLTaskGetResponse.builder().mlTask(mlTask).build());
-                            } catch (Exception e) {
-                                log.error("Failed to parse ml task {}", r.id(), e);
-                                actionListener.onFailure(e);
+                            } else {
+                                actionListener.onFailure(new OpenSearchStatusException("Fail to find task", RestStatus.NOT_FOUND));
                             }
-                        } else {
-                            actionListener.onFailure(new OpenSearchStatusException("Fail to find task", RestStatus.NOT_FOUND));
+                        } catch (Exception e) {
+                            actionListener.onFailure(e);
                         }
                     }
                 });

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -123,7 +123,7 @@ public class DDBOpenSearchClient implements SdkClient {
                     + request.index()
                     + "\",\"_id\":\""
                     + request.id()
-                    + "\",\"_version\":1,\"_seq_no\":-2,\"_primary_term\":0,\"found\":"
+                    + "\",\"found\":"
                     + found
                     + ",\"_source\":"
                     + source


### PR DESCRIPTION
### Description

Some APIs (get model group) require the full `GetResponse` object from the API.

This changes the GetDataObjectResponse to use the full `GetResponse` as the `parser`.  Since there will always be a response, there is no longer a need for `Optional`, and the `isExists()` checks are available again.

It retains the source map as-is.

This parallels the implementation in the SearchDataObjectResponse (and probably would have done it that way if I'd done search first).

This allows for even closer-to-original migration of code expecting a GetResponse.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
