### PR TITLE
Use full DocWriteResponse json for Put/Update/Delete responses

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/DeleteDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/DeleteDataObjectResponse.java
@@ -8,30 +8,22 @@
  */
 package org.opensearch.sdk;
 
-import org.opensearch.action.support.replication.ReplicationResponse.ShardInfo;
-import org.opensearch.core.common.Strings;
-import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.xcontent.XContentParser;
 
 public class DeleteDataObjectResponse {
     private final String id;
-    private final ShardId shardId;
-    private final ShardInfo shardInfo;
-    private final boolean deleted;
+    private final XContentParser parser;
 
     /**
-     * Instantiate this request.
+     * Instantiate this request with an id and parser representing a DeleteResponse
      * <p>
-     * For data storage implementations other than OpenSearch, an index may be referred to as a table and the id may be referred to as a primary key.
+     * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
      * @param id the document id
-     * @param shardId the shard id
-     * @param shardInfo the shard info
-     * @param deleted Whether the object was deleted. Use {@code false} if the object was not found.
+     * @param parser a parser that can be used to create a DeleteResponse
      */
-    public DeleteDataObjectResponse(String id, ShardId shardId, ShardInfo shardInfo, boolean deleted) {
+    public DeleteDataObjectResponse(String id, XContentParser parser) {
         this.id = id;
-        this.shardId = shardId;
-        this.shardInfo = shardInfo;
-        this.deleted = deleted;
+        this.parser = parser;
     }
 
     /**
@@ -39,41 +31,23 @@ public class DeleteDataObjectResponse {
      * @return the id
      */
     public String id() {
-        return id;
+        return this.id;
     }
-
+    
     /**
-     * Returns the shard id.
-     * @return the shard id, or a generated id if shards are not applicable
+     * Returns the parser that can be used to create a DeleteResponse
+     * @return the parser
      */
-    public ShardId shardId() {
-        return shardId;
+    public XContentParser parser() {
+        return this.parser;
     }
-
-    /**
-     * Returns the shard info.
-     * @return the shard info, or generated info if shards are not applicable
-     */
-    public ShardInfo shardInfo() {
-        return shardInfo;
-    }
-
-    /**
-     * Returns whether deletion was successful
-     * @return true if deletion was successful, false if the object was not found
-     */
-    public boolean deleted() {
-        return deleted;
-    }
-
+    
     /**
      * Class for constructing a Builder for this Response Object
      */
     public static class Builder {
         private String id = null;
-        private ShardId shardId = null;
-        private ShardInfo shardInfo = null;
-        private boolean deleted = false;
+        private XContentParser parser = null;
 
         /**
          * Empty Constructor for the Builder object
@@ -89,53 +63,23 @@ public class DeleteDataObjectResponse {
             this.id = id;
             return this;
         }
-
+        
         /**
-         * Adds a shard id to this builder
-         * @param shardId the shard id to add
+         * Add a parser to this builder
+         * @param parser a parser that can be used to create a DeleteResponse
          * @return the updated builder
          */
-        public Builder shardId(ShardId shardId) {
-            this.shardId = shardId;
+        public Builder parser(XContentParser parser) {
+            this.parser = parser;
             return this;
         }
-
+        
         /**
-         * Adds a generated shard id to this builder
-         * @param indexName the index name to generate a shard id
-         * @return the updated builder
-         */
-        public Builder shardId(String indexName) {
-            this.shardId = new ShardId(indexName, Strings.UNKNOWN_UUID_VALUE, 0);
-            return this;
-        }
-
-        /**
-         * Adds shard information (statistics) to this builder
-         * @param shardInfo the shard info to add
-         * @return the updated builder
-         */
-        public Builder shardInfo(ShardInfo shardInfo) {
-            this.shardInfo = shardInfo;
-            return this;
-        }
-
-        /**
-         * Add a deleted status to this builder
-         * @param deleted the deleted status to add
-         * @return the updated builder
-         */
-        public Builder deleted(boolean deleted) {
-            this.deleted = deleted;
-            return this;
-        }
-
-        /**
-         * Builds the object
+         * Builds the response
          * @return A {@link DeleteDataObjectResponse}
          */
         public DeleteDataObjectResponse build() {
-            return new DeleteDataObjectResponse(this.id, this.shardId, this.shardInfo, this.deleted);
+            return new DeleteDataObjectResponse(this.id, this.parser);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/PutDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/PutDataObjectResponse.java
@@ -8,20 +8,22 @@
  */
 package org.opensearch.sdk;
 
+import org.opensearch.core.xcontent.XContentParser;
+
 public class PutDataObjectResponse {
     private final String id;
-    private final boolean created;
+    private final XContentParser parser;
 
     /**
-     * Instantiate this request with an id and creation status.
+     * Instantiate this request with an id and parser representing an IndexResponse
      * <p>
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
      * @param id the document id
-     * @param created Whether the object was created.
+     * @param parser a parser that can be used to create an IndexResponse
      */
-    public PutDataObjectResponse(String id, boolean created) {
+    public PutDataObjectResponse(String id, XContentParser parser) {
         this.id = id;
-        this.created = created;
+        this.parser = parser;
     }
 
     /**
@@ -29,23 +31,23 @@ public class PutDataObjectResponse {
      * @return the id
      */
     public String id() {
-        return id;
+        return this.id;
     }
-
+    
     /**
-     * Returns whether creation was successful
-     * @return true if creation was successful
+     * Returns the parser that can be used to create an IndexResponse
+     * @return the parser
      */
-    public boolean created() {
-        return created;
+    public XContentParser parser() {
+        return this.parser;
     }
-
+    
     /**
      * Class for constructing a Builder for this Response Object
      */
     public static class Builder {
         private String id = null;
-        private boolean created = false;
+        private XContentParser parser = null;
 
         /**
          * Empty Constructor for the Builder object
@@ -61,23 +63,23 @@ public class PutDataObjectResponse {
             this.id = id;
             return this;
         }
-
+        
         /**
-         * Add a created status to this builder
-         * @param created the created status to add
+         * Add a parser to this builder
+         * @param parser a parser that can be used to create an IndexResponse
          * @return the updated builder
          */
-        public Builder created(boolean created) {
-            this.created = created;
+        public Builder parser(XContentParser parser) {
+            this.parser = parser;
             return this;
         }
-
+        
         /**
-         * Builds the object
+         * Builds the response
          * @return A {@link PutDataObjectResponse}
          */
         public PutDataObjectResponse build() {
-            return new PutDataObjectResponse(this.id, this.created);
+            return new PutDataObjectResponse(this.id, this.parser);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectResponse.java
@@ -8,30 +8,22 @@
  */
 package org.opensearch.sdk;
 
-import org.opensearch.action.support.replication.ReplicationResponse.ShardInfo;
-import org.opensearch.core.common.Strings;
-import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.xcontent.XContentParser;
 
 public class UpdateDataObjectResponse {
     private final String id;
-    private final ShardId shardId;
-    private final ShardInfo shardInfo;
-    private final boolean updated;
+    private final XContentParser parser;
 
     /**
-     * Instantiate this request with an id and update status.
+     * Instantiate this request with an id and parser representing an UpdateResponse
      * <p>
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
      * @param id the document id
-     * @param shardId the shard id
-     * @param shardInfo the shard info
-     * @param updated Whether the object was updated.
+     * @param parser a parser that can be used to create an UpdateResponse
      */
-    public UpdateDataObjectResponse(String id, ShardId shardId, ShardInfo shardInfo, boolean updated) {
+    public UpdateDataObjectResponse(String id, XContentParser parser) {
         this.id = id;
-        this.shardId = shardId;
-        this.shardInfo = shardInfo;
-        this.updated = updated;
+        this.parser = parser;
     }
 
     /**
@@ -39,41 +31,23 @@ public class UpdateDataObjectResponse {
      * @return the id
      */
     public String id() {
-        return id;
+        return this.id;
     }
-
+    
     /**
-     * Returns the shard id.
-     * @return the shard id, or a generated id if shards are not applicable
+     * Returns the parser that can be used to create an UpdateResponse
+     * @return the parser
      */
-    public ShardId shardId() {
-        return shardId;
+    public XContentParser parser() {
+        return this.parser;
     }
-
-    /**
-     * Returns the shard info.
-     * @return the shard info, or generated info if shards are not applicable
-     */
-    public ShardInfo shardInfo() {
-        return shardInfo;
-    }
-
-    /**
-     * Returns whether update was successful
-     * @return true if update was successful
-     */
-    public boolean updated() {
-        return updated;
-    }
-
+    
     /**
      * Class for constructing a Builder for this Response Object
      */
     public static class Builder {
         private String id = null;
-        private ShardId shardId = null;
-        private ShardInfo shardInfo = null;
-        private boolean updated = false;
+        private XContentParser parser = null;
 
         /**
          * Empty Constructor for the Builder object
@@ -89,52 +63,23 @@ public class UpdateDataObjectResponse {
             this.id = id;
             return this;
         }
-
+        
         /**
-         * Adds a shard id to this builder
-         * @param shardId the shard id to add
+         * Add a parser to this builder
+         * @param parser a parser that can be used to create an UpdateResponse
          * @return the updated builder
          */
-        public Builder shardId(ShardId shardId) {
-            this.shardId = shardId;
+        public Builder parser(XContentParser parser) {
+            this.parser = parser;
             return this;
         }
-
+        
         /**
-         * Adds a generated shard id to this builder
-         * @param indexName the index name to generate a shard id
-         * @return the updated builder
-         */
-        public Builder shardId(String indexName) {
-            this.shardId = new ShardId(indexName, Strings.UNKNOWN_UUID_VALUE, 0);
-            return this;
-        }
-
-        /**
-         * Adds shard information (statistics) to this builder
-         * @param shardInfo the shard info to add
-         * @return the updated builder
-         */
-        public Builder shardInfo(ShardInfo shardInfo) {
-            this.shardInfo = shardInfo;
-            return this;
-        }
-        /**
-         * Add a updated status to this builder
-         * @param updated the updated status to add
-         * @return the updated builder
-         */
-        public Builder updated(boolean updated) {
-            this.updated = updated;
-            return this;
-        }
-
-        /**
-         * Builds the object
+         * Builds the response
          * @return A {@link UpdateDataObjectResponse}
          */
         public UpdateDataObjectResponse build() {
-            return new UpdateDataObjectResponse(this.id, this.shardId, this.shardInfo, this.updated);
+            return new UpdateDataObjectResponse(this.id, this.parser);
         }
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/DeleteDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/DeleteDataObjectResponseTests.java
@@ -13,48 +13,27 @@ import org.junit.Test;
 import org.opensearch.action.support.replication.ReplicationResponse.ShardInfo;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.xcontent.XContentParser;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class DeleteDataObjectResponseTests {
+
     private String testId;
-    private String testIndex;
-    private ShardId testShardId;
-    private ShardInfo testShardInfo;
-    private boolean testDeleted;
+    private XContentParser testParser;
 
     @Before
     public void setUp() {
         testId = "test-id";
-        testIndex = "test-index";
-        testShardId = new ShardId("test-index", Strings.UNKNOWN_UUID_VALUE, 0);
-        testShardInfo = mock(ShardInfo.class);
-        testDeleted = true;
+        testParser = mock(XContentParser.class);
     }
 
     @Test
     public void testDeleteDataObjectResponse() {
-        DeleteDataObjectResponse response = new DeleteDataObjectResponse.Builder()
-            .id(testId)
-            .shardId(testShardId)
-            .shardInfo(testShardInfo)
-            .deleted(testDeleted)
-            .build();
+        DeleteDataObjectResponse response = new DeleteDataObjectResponse.Builder().id(testId).parser(testParser).build();
 
         assertEquals(testId, response.id());
-        assertEquals(testShardId, response.shardId());
-        assertEquals(testShardInfo, response.shardInfo());
-        assertEquals(testDeleted, response.deleted());
-    }
-
-    @Test
-    public void testDeleteDataObjectResponseWithIndexName() {
-        DeleteDataObjectResponse response = new DeleteDataObjectResponse.Builder().id(testId).shardId(testIndex).shardInfo(testShardInfo).deleted(testDeleted).build();
-
-        assertEquals(testId, response.id());
-        assertEquals(testShardId, response.shardId());
-        assertEquals(testShardInfo, response.shardInfo());
-        assertEquals(testDeleted, response.deleted());
+        assertEquals(testParser, response.parser());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/UpdateDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/UpdateDataObjectResponseTests.java
@@ -10,12 +10,15 @@ package org.opensearch.sdk;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.action.support.replication.ReplicationResponse.ShardInfo;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.XContentParser;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
-public class PutDataObjectResponseTests {
+public class UpdateDataObjectResponseTests {
 
     private String testId;
     private XContentParser testParser;
@@ -27,8 +30,8 @@ public class PutDataObjectResponseTests {
     }
 
     @Test
-    public void testPutDataObjectResponse() {
-        PutDataObjectResponse response = new PutDataObjectResponse.Builder().id(testId).parser(testParser).build();
+    public void testUpdateDataObjectResponse() {
+        UpdateDataObjectResponse response = new UpdateDataObjectResponse.Builder().id(testId).parser(testParser).build();
 
         assertEquals(testId, response.id());
         assertEquals(testParser, response.parser());

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionRequest;
+import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.client.Client;
@@ -95,9 +96,14 @@ public class TransportRegisterAgentAction extends HandledTransportAction<ActionR
                                 log.error("Failed to index ML agent", cause);
                                 listener.onFailure(cause);
                             } else {
-                                log.info("Agent creation result: {}, Agent id: {}", r.created(), r.id());
-                                MLRegisterAgentResponse response = new MLRegisterAgentResponse(r.id());
-                                listener.onResponse(response);
+                                try {
+                                    IndexResponse indexResponse = IndexResponse.fromXContent(r.parser());
+                                    log.info("Agent creation result: {}, Agent id: {}", indexResponse.getResult(), indexResponse.getId());
+                                    MLRegisterAgentResponse response = new MLRegisterAgentResponse(r.id());
+                                    listener.onResponse(response);
+                                } catch (Exception e) {
+                                    listener.onFailure(e);
+                                }
                             }
                         });
                 } catch (Exception e) {

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
@@ -132,8 +133,18 @@ public class MLModelGroupManager {
                                         log.error("Failed to index model group", cause);
                                         wrappedListener.onFailure(cause);
                                     } else {
-                                        log.info("Model group creation result: {}, model group id: {}", r.created(), r.id());
-                                        wrappedListener.onResponse(r.id());
+                                        try {
+                                            IndexResponse indexResponse = IndexResponse.fromXContent(r.parser());
+                                            log
+                                                .info(
+                                                    "Model group creation result: {}, model group id: {}",
+                                                    indexResponse.getResult(),
+                                                    indexResponse.getId()
+                                                );
+                                            wrappedListener.onResponse(r.id());
+                                        } catch (Exception e) {
+                                            wrappedListener.onFailure(e);
+                                        }
                                     }
                                 });
 

--- a/plugin/src/test/java/org/opensearch/ml/action/agents/DeleteAgentTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agents/DeleteAgentTransportActionTests.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.opensearch.action.DocWriteResponse.Result.DELETED;
+import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 
@@ -35,7 +36,6 @@ import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.PlainActionFuture;
-import org.opensearch.action.support.replication.ReplicationResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
@@ -82,7 +82,6 @@ public class DeleteAgentTransportActionTests {
     @Mock
     ClusterService clusterService;
 
-    @Mock
     DeleteResponse deleteResponse;
 
     @Mock
@@ -129,9 +128,7 @@ public class DeleteAgentTransportActionTests {
         when(threadPool.getThreadContext()).thenReturn(threadContext);
         when(threadPool.executor(anyString())).thenReturn(testThreadPool.executor(GENERAL_THREAD_POOL));
 
-        when(deleteResponse.getId()).thenReturn("AGENT_ID");
-        when(deleteResponse.getShardId()).thenReturn(mock(ShardId.class));
-        when(deleteResponse.getShardInfo()).thenReturn(mock(ReplicationResponse.ShardInfo.class));
+        deleteResponse = new DeleteResponse(new ShardId(ML_AGENT_INDEX, "_na_", 0), "AGENT_ID", 1, 0, 2, true);
     }
 
     @AfterClass
@@ -162,7 +159,6 @@ public class DeleteAgentTransportActionTests {
         getFuture.onResponse(getResponse);
         when(client.get(any(GetRequest.class))).thenReturn(getFuture);
 
-        when(deleteResponse.getResult()).thenReturn(DELETED);
         PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
         future.onResponse(deleteResponse);
         when(client.delete(any(DeleteRequest.class))).thenReturn(future);
@@ -170,7 +166,7 @@ public class DeleteAgentTransportActionTests {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteAgentTransportAction.doExecute(task, deleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<DeleteResponse> captor = ArgumentCaptor.forClass(DeleteResponse.class);
         verify(actionListener).onResponse(captor.capture());
@@ -193,7 +189,6 @@ public class DeleteAgentTransportActionTests {
         getFuture.onResponse(getResponse);
         when(client.get(any(GetRequest.class))).thenReturn(getFuture);
 
-        when(deleteResponse.getResult()).thenReturn(DELETED);
         PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
         future.onFailure(new NullPointerException("Failed to delete ML Agent " + agentId));
         when(client.delete(any(DeleteRequest.class))).thenReturn(future);
@@ -201,7 +196,7 @@ public class DeleteAgentTransportActionTests {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteAgentTransportAction.doExecute(task, deleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -226,7 +221,7 @@ public class DeleteAgentTransportActionTests {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteAgentTransportAction.doExecute(task, deleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<OpenSearchException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -251,7 +246,7 @@ public class DeleteAgentTransportActionTests {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteAgentTransportAction.doExecute(task, deleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<OpenSearchStatusException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -272,7 +267,6 @@ public class DeleteAgentTransportActionTests {
         getFuture.onResponse(getResponse);
         when(client.get(any(GetRequest.class))).thenReturn(getFuture);
 
-        when(deleteResponse.getResult()).thenReturn(DELETED);
         PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
         future.onResponse(deleteResponse);
         when(client.delete(any(DeleteRequest.class))).thenReturn(future);
@@ -282,7 +276,7 @@ public class DeleteAgentTransportActionTests {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteAgentTransportAction.doExecute(task, deleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<DeleteResponse> captor = ArgumentCaptor.forClass(DeleteResponse.class);
         verify(actionListener).onResponse(captor.capture());
@@ -306,7 +300,7 @@ public class DeleteAgentTransportActionTests {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteAgentTransportAction.doExecute(task, deleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -329,7 +323,6 @@ public class DeleteAgentTransportActionTests {
         getFuture.onResponse(getResponse);
         when(client.get(any(GetRequest.class))).thenReturn(getFuture);
 
-        when(deleteResponse.getResult()).thenReturn(DELETED);
         PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
         future.onFailure(expectedException);
         when(client.delete(any(DeleteRequest.class))).thenReturn(future);
@@ -338,7 +331,7 @@ public class DeleteAgentTransportActionTests {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteAgentTransportAction.doExecute(task, deleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         // Verify that actionListener.onFailure() was called with the expected exception
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
@@ -353,7 +346,7 @@ public class DeleteAgentTransportActionTests {
             MLAgentType.CONVERSATIONAL.name(),
             "test",
             new LLMSpec("test_model", Map.of("test_key", "test_value")),
-            List.of(new MLToolSpec("test", "test", "test", Collections.EMPTY_MAP, false)),
+            List.of(new MLToolSpec("test", "test", "test", Collections.emptyMap(), false)),
             Map.of("test", "test"),
             new MLMemorySpec("test", "123", 0),
             Instant.EPOCH,

--- a/plugin/src/test/java/org/opensearch/ml/action/agents/GetAgentTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agents/GetAgentTransportActionTests.java
@@ -159,7 +159,7 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLAgentGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getAgentTransportAction.doExecute(task, getRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -185,7 +185,7 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLAgentGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getAgentTransportAction.doExecute(task, getRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -214,7 +214,7 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLAgentGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getAgentTransportAction.doExecute(task, getRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -236,7 +236,7 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLAgentGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getAgentTransportAction.doExecute(task, getRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -257,7 +257,7 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLAgentGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getAgentTransportAction.doExecute(task, getRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -291,7 +291,7 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
             CountDownLatch latch = new CountDownLatch(1);
             LatchedActionListener<MLAgentGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
             getAgentTransportActionNullContext.doExecute(task, getRequest, latchedActionListener);
-            latch.await();
+            latch.await(500, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             assertEquals(e.getClass(), RuntimeException.class);
         }
@@ -316,7 +316,7 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
             CountDownLatch latch = new CountDownLatch(1);
             LatchedActionListener<MLAgentGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
             getAgentTransportAction.doExecute(task, getRequest, latchedActionListener);
-            latch.await();
+            latch.await(500, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             assertEquals(e.getClass(), IllegalArgumentException.class);
         }
@@ -338,7 +338,7 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLAgentGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getAgentTransportAction.doExecute(task, getRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         verify(actionListener).onResponse(any(MLAgentGetResponse.class));
 
@@ -364,7 +364,7 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLAgentGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getAgentTransportAction.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -389,7 +389,7 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLAgentGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getAgentTransportAction.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<MLAgentGetResponse> captor = ArgumentCaptor.forClass(MLAgentGetResponse.class);
         verify(actionListener, times(1)).onResponse(captor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/action/agents/RegisterAgentTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agents/RegisterAgentTransportActionTests.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 
@@ -39,6 +40,7 @@ import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.agent.LLMSpec;
@@ -80,6 +82,8 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
 
     @Mock
     private ActionListener<MLRegisterAgentResponse> actionListener;
+
+    IndexResponse indexResponse;
 
     @Mock
     private NamedXContentRegistry xContentRegistry;
@@ -127,6 +131,7 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
             clusterService,
             mlFeatureEnabledSetting
         );
+        indexResponse = new IndexResponse(new ShardId(ML_AGENT_INDEX, "_na_", 0), "AGENT_ID", 1, 0, 2, true);
     }
 
     @AfterClass
@@ -153,13 +158,13 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
         }).when(mlIndicesHandler).initMLAgentIndex(any());
 
         PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
-        future.onResponse(mock(IndexResponse.class));
+        future.onResponse(indexResponse);
         when(client.index(any(IndexRequest.class))).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLRegisterAgentResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportRegisterAgentAction.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<MLRegisterAgentResponse> argumentCaptor = ArgumentCaptor.forClass(MLRegisterAgentResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -185,7 +190,7 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLRegisterAgentResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportRegisterAgentAction.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<OpenSearchException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Failed to create ML agent index", argumentCaptor.getValue().getMessage());
@@ -216,7 +221,7 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLRegisterAgentResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportRegisterAgentAction.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<RuntimeException> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
 
@@ -244,7 +249,7 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLRegisterAgentResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportRegisterAgentAction.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<RuntimeException> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -270,13 +275,13 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
         }).when(mlIndicesHandler).initMLAgentIndex(any());
 
         PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
-        future.onResponse(mock(IndexResponse.class));
+        future.onResponse(indexResponse);
         when(client.index(any(IndexRequest.class))).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLRegisterAgentResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportRegisterAgentAction.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<MLRegisterAgentResponse> argumentCaptor = ArgumentCaptor.forClass(MLRegisterAgentResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
@@ -297,13 +302,13 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
         }).when(mlIndicesHandler).initMLAgentIndex(any());
 
         PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
-        future.onResponse(mock(IndexResponse.class));
+        future.onResponse(indexResponse);
         when(client.index(any(IndexRequest.class))).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLRegisterAgentResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportRegisterAgentAction.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<MLRegisterAgentResponse> argumentCaptor = ArgumentCaptor.forClass(MLRegisterAgentResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/GetConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/GetConnectorTransportActionTests.java
@@ -155,7 +155,7 @@ public class GetConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -179,7 +179,7 @@ public class GetConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -203,7 +203,7 @@ public class GetConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<MLConnectorGetResponse> argumentCaptor = ArgumentCaptor.forClass(MLConnectorGetResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
@@ -228,7 +228,7 @@ public class GetConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/SearchConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/SearchConnectorTransportActionTests.java
@@ -168,7 +168,7 @@ public class SearchConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<SearchResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         searchConnectorTransportAction.doExecute(task, searchRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         verify(actionListener).onResponse(any(SearchResponse.class));
     }
@@ -183,7 +183,7 @@ public class SearchConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<SearchResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);        
         searchConnectorTransportAction.doExecute(task, searchRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         verify(actionListener).onResponse(any(SearchResponse.class));
     }
@@ -196,7 +196,7 @@ public class SearchConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<SearchResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         searchConnectorTransportAction.doExecute(task, searchRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         verify(actionListener).onFailure(any(RuntimeException.class));
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.action.DocWriteResponse.Result.CREATED;
+import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED;
@@ -46,6 +46,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.connector.ConnectorAction;
@@ -114,7 +115,6 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
     @Mock
     ActionListener<MLCreateConnectorResponse> actionListener;
 
-    @Mock
     IndexResponse indexResponse;
 
     @Mock
@@ -141,7 +141,7 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
         MockitoAnnotations.openMocks(this);
 
         sdkClient = new LocalClusterIndicesClient(client, xContentRegistry);
-        when(indexResponse.getId()).thenReturn(CONNECTOR_ID);
+        indexResponse = new IndexResponse(new ShardId(ML_CONNECTOR_INDEX, "_na_", 0), CONNECTOR_ID, 1, 0, 2, true);
 
         settings = Settings
             .builder()
@@ -218,16 +218,14 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
-        when(indexResponse.getResult()).thenReturn(CREATED);
-
         PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
-        future.onResponse(mock(IndexResponse.class));
+        future.onResponse(indexResponse);
         when(client.index(any(IndexRequest.class))).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLCreateConnectorResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         action.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         verify(actionListener).onResponse(any(MLCreateConnectorResponse.class));
     }
@@ -244,16 +242,14 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
-        when(indexResponse.getResult()).thenReturn(CREATED);
-
         PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
-        future.onResponse(mock(IndexResponse.class));
+        future.onResponse(indexResponse);
         when(client.index(any(IndexRequest.class))).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLCreateConnectorResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         action.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -281,7 +277,7 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLCreateConnectorResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         action.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -303,13 +299,13 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
         PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
-        future.onResponse(mock(IndexResponse.class));
+        future.onResponse(indexResponse);
         when(client.index(any(IndexRequest.class))).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLCreateConnectorResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         action.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         verify(actionListener).onResponse(any(MLCreateConnectorResponse.class));
     }
@@ -326,13 +322,13 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
         PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
-        future.onResponse(mock(IndexResponse.class));
+        future.onResponse(indexResponse);
         when(client.index(any(IndexRequest.class))).thenReturn(future);
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLCreateConnectorResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         action.doExecute(task, request, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         verify(actionListener).onResponse(any(MLCreateConnectorResponse.class));
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
@@ -263,7 +263,7 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         ActionListener<UpdateResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         updateConnectorTransportAction.doExecute(task, updateRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         verify(actionListener).onResponse(any(UpdateResponse.class));
     }
@@ -321,7 +321,7 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         ActionListener<UpdateResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         updateConnectorTransportAction.doExecute(task, updateRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<UpdateResponse> argumentCaptor = ArgumentCaptor.forClass(UpdateResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
@@ -341,7 +341,7 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         ActionListener<UpdateResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         updateConnectorTransportAction.doExecute(task, updateRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -359,7 +359,7 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         ActionListener<UpdateResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         updateConnectorTransportAction.doExecute(task, updateRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -379,7 +379,7 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         ActionListener<UpdateResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         updateConnectorTransportAction.doExecute(task, updateRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -430,7 +430,7 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         ActionListener<UpdateResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         updateConnectorTransportAction.doExecute(task, updateRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<UpdateResponse> argumentCaptor = ArgumentCaptor.forClass(UpdateResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportActionTests.java
@@ -8,11 +8,11 @@ package org.opensearch.ml.action.model_group;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.action.DocWriteResponse.Result.DELETED;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 
@@ -39,7 +39,6 @@ import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.PlainActionFuture;
-import org.opensearch.action.support.replication.ReplicationResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
@@ -83,9 +82,6 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
 
     @Mock
     ActionListener<DeleteResponse> actionListener;
-
-    @Mock
-    DeleteResponse deleteResponse;
 
     @Mock
     ClusterService clusterService;
@@ -147,10 +143,6 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
         when(threadPool.executor(anyString())).thenReturn(testThreadPool.executor(GENERAL_THREAD_POOL));
-
-        when(deleteResponse.getId()).thenReturn("test_id");
-        when(deleteResponse.getShardId()).thenReturn(mock(ShardId.class));
-        when(deleteResponse.getShardInfo()).thenReturn(mock(ReplicationResponse.ShardInfo.class));
     }
 
     @AfterClass
@@ -167,7 +159,7 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
         future.onResponse(searchResponse);
         when(client.search(any(SearchRequest.class))).thenReturn(future);
 
-        when(deleteResponse.getResult()).thenReturn(DELETED);
+        DeleteResponse deleteResponse = new DeleteResponse(new ShardId(ML_MODEL_GROUP_INDEX, "_na_", 0), "test_id", 1, 0, 2, true);
         PlainActionFuture<DeleteResponse> deleteFuture = PlainActionFuture.newFuture();
         deleteFuture.onResponse(deleteResponse);
         when(client.delete(any(DeleteRequest.class))).thenReturn(deleteFuture);
@@ -175,7 +167,7 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteModelGroupTransportAction.doExecute(null, mlModelGroupDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<DeleteResponse> captor = ArgumentCaptor.forClass(DeleteResponse.class);
         verify(actionListener).onResponse(captor.capture());
         assertEquals("test_id", captor.getValue().getId());
@@ -193,7 +185,7 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteModelGroupTransportAction.doExecute(null, mlModelGroupDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Cannot delete the model group when it has associated model versions", argumentCaptor.getValue().getMessage());
@@ -206,7 +198,7 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
         future.onFailure(new IndexNotFoundException("index_not_found"));
         when(client.search(any(SearchRequest.class))).thenReturn(future);
 
-        when(deleteResponse.getResult()).thenReturn(DELETED);
+        DeleteResponse deleteResponse = new DeleteResponse(new ShardId(ML_MODEL_GROUP_INDEX, "_na_", 0), "test_id", 1, 0, 2, true);
         PlainActionFuture<DeleteResponse> deleteFuture = PlainActionFuture.newFuture();
         deleteFuture.onResponse(deleteResponse);
         when(client.delete(any(DeleteRequest.class))).thenReturn(deleteFuture);
@@ -214,7 +206,7 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteModelGroupTransportAction.doExecute(null, mlModelGroupDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<DeleteResponse> captor = ArgumentCaptor.forClass(DeleteResponse.class);
         verify(actionListener).onResponse(captor.capture());
@@ -232,7 +224,7 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteModelGroupTransportAction.doExecute(null, mlModelGroupDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -253,7 +245,7 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteModelGroupTransportAction.doExecute(null, mlModelGroupDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -295,7 +287,6 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
         future.onResponse(searchResponse);
         when(client.search(any(SearchRequest.class))).thenReturn(future);
 
-        when(deleteResponse.getResult()).thenReturn(DELETED);
         PlainActionFuture<DeleteResponse> deleteFuture = PlainActionFuture.newFuture();
         deleteFuture.onFailure(new Exception("errorMessage"));
         when(client.delete(any(DeleteRequest.class))).thenReturn(deleteFuture);
@@ -303,7 +294,7 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteModelGroupTransportAction.doExecute(null, mlModelGroupDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/action/model_group/GetModelGroupTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/model_group/GetModelGroupTransportActionTests.java
@@ -152,7 +152,7 @@ public class GetModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLModelGroupGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<MLModelGroupGetResponse> argumentCaptor = ArgumentCaptor.forClass(MLModelGroupGetResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -172,7 +172,7 @@ public class GetModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLModelGroupGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -194,7 +194,7 @@ public class GetModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLModelGroupGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -209,7 +209,7 @@ public class GetModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLModelGroupGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -225,7 +225,7 @@ public class GetModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLModelGroupGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -241,7 +241,7 @@ public class GetModelGroupTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLModelGroupGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupActionTests.java
@@ -205,7 +205,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -221,7 +221,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -241,7 +241,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -259,7 +259,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("You can specify backend roles only for a model group with the restricted access mode.", argumentCaptor.getValue().getMessage());
@@ -276,7 +276,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("You can specify backend roles only for a model group with the restricted access mode.", argumentCaptor.getValue().getMessage());
@@ -291,7 +291,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Admin users cannot add all backend roles to a model group.", argumentCaptor.getValue().getMessage());
@@ -308,7 +308,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("You don't have any backend roles.", argumentCaptor.getValue().getMessage());
@@ -325,7 +325,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("You have to specify backend roles when add all backend roles is set to false.", argumentCaptor.getValue().getMessage());
@@ -342,7 +342,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
@@ -364,7 +364,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("You don't have the backend roles specified.", argumentCaptor.getValue().getMessage());
@@ -380,7 +380,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<MLUpdateModelGroupResponse> argumentCaptor = ArgumentCaptor.forClass(MLUpdateModelGroupResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -396,7 +396,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<MLUpdateModelGroupResponse> argumentCaptor = ArgumentCaptor.forClass(MLUpdateModelGroupResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -411,7 +411,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<MLUpdateModelGroupResponse> argumentCaptor = ArgumentCaptor.forClass(MLUpdateModelGroupResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -425,7 +425,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<MLUpdateModelGroupResponse> argumentCaptor = ArgumentCaptor.forClass(MLUpdateModelGroupResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -441,7 +441,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<MLUpdateModelGroupResponse> argumentCaptor = ArgumentCaptor.forClass(MLUpdateModelGroupResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -456,7 +456,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -473,7 +473,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -490,7 +490,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -511,7 +511,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Failed to update Model Group", argumentCaptor.getValue().getMessage());
@@ -525,7 +525,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<MLUpdateModelGroupResponse> argumentCaptor = ArgumentCaptor.forClass(MLUpdateModelGroupResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -545,7 +545,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -563,7 +563,7 @@ public class TransportUpdateModelGroupActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLUpdateModelGroupResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         transportUpdateModelGroupAction.doExecute(task, actionRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/action/tasks/DeleteTaskTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/tasks/DeleteTaskTransportActionTests.java
@@ -7,11 +7,11 @@ package org.opensearch.ml.action.tasks;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.action.DocWriteResponse.Result.DELETED;
+import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 
@@ -35,7 +35,6 @@ import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.PlainActionFuture;
-import org.opensearch.action.support.replication.ReplicationResponse;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -82,9 +81,6 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
     ActionListener<DeleteResponse> actionListener;
 
     @Mock
-    DeleteResponse deleteResponse;
-
-    @Mock
     NamedXContentRegistry xContentRegistry;
 
     @Mock
@@ -123,10 +119,6 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
         when(threadPool.executor(anyString())).thenReturn(testThreadPool.executor(GENERAL_THREAD_POOL));
-
-        when(deleteResponse.getId()).thenReturn("TASK_ID");
-        when(deleteResponse.getShardId()).thenReturn(mock(ShardId.class));
-        when(deleteResponse.getShardInfo()).thenReturn(mock(ReplicationResponse.ShardInfo.class));
     }
 
     @AfterClass
@@ -136,7 +128,7 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
 
     @Test
     public void testDeleteTask_Success() throws IOException, InterruptedException {
-        when(deleteResponse.getResult()).thenReturn(DELETED);
+        DeleteResponse deleteResponse = new DeleteResponse(new ShardId(ML_TASK_INDEX, "_na_", 0), "TASK_ID", 1, 0, 2, true);
         PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
         future.onResponse(deleteResponse);
         when(client.delete(any(DeleteRequest.class))).thenReturn(future);
@@ -150,7 +142,7 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteTaskTransportAction.doExecute(null, mlTaskDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<DeleteResponse> captor = ArgumentCaptor.forClass(DeleteResponse.class);
         verify(actionListener).onResponse(captor.capture());
@@ -169,7 +161,7 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteTaskTransportAction.doExecute(null, mlTaskDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -185,7 +177,7 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteTaskTransportAction.doExecute(null, mlTaskDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -201,7 +193,7 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteTaskTransportAction.doExecute(null, mlTaskDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -217,7 +209,7 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteTaskTransportAction.doExecute(null, mlTaskDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -226,8 +218,6 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
 
     @Test
     public void testDeleteTask_RuntimeException() throws IOException, InterruptedException {
-
-        when(deleteResponse.getResult()).thenReturn(DELETED);
         PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
         future.onFailure(new RuntimeException("errorMessage"));
         when(client.delete(any(DeleteRequest.class))).thenReturn(future);
@@ -241,7 +231,7 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteTaskTransportAction.doExecute(null, mlTaskDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -255,7 +245,7 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteTaskTransportAction.doExecute(null, mlTaskDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -271,7 +261,7 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteTaskTransportAction.doExecute(null, mlTaskDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -288,7 +278,7 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteTaskTransportAction.doExecute(null, mlTaskDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -302,7 +292,7 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         deleteTaskTransportAction.doExecute(null, mlTaskDeleteRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         verify(actionListener).onFailure(any(Exception.class));
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/tasks/GetTaskTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/tasks/GetTaskTransportActionTests.java
@@ -120,7 +120,7 @@ public class GetTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLTaskGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getTaskTransportAction.doExecute(null, mlTaskGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -135,7 +135,7 @@ public class GetTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLTaskGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getTaskTransportAction.doExecute(null, mlTaskGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("errorMessage", argumentCaptor.getValue().getMessage());
@@ -149,7 +149,7 @@ public class GetTaskTransportActionTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLTaskGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         getTaskTransportAction.doExecute(null, mlTaskGetRequest, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/helper/ConnectorAccessControlHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/ConnectorAccessControlHelperTests.java
@@ -460,7 +460,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
                 "connectorId",
                 latchedActionListener
             );
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<GetRequest> requestCaptor = ArgumentCaptor.forClass(GetRequest.class);
         verify(client, times(1)).get(requestCaptor.capture());
@@ -489,7 +489,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
                 "connectorId",
                 latchedActionListener
             );
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getConnectorActionListener).onFailure(argumentCaptor.capture());
@@ -518,7 +518,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
                 "connectorId",
                 latchedActionListener
             );
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<OpenSearchStatusException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
         verify(getConnectorActionListener).onFailure(argumentCaptor.capture());

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelGroupManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelGroupManagerTests.java
@@ -10,7 +10,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.action.DocWriteResponse.Result.CREATED;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 
@@ -50,6 +50,7 @@ import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -95,7 +96,6 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
     @Mock
     private ActionListener<GetResponse> modelGroupListener;
 
-    @Mock
     private IndexResponse indexResponse;
 
     ThreadContext threadContext;
@@ -142,9 +142,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         );
         assertNotNull(mlModelGroupManager);
 
-        when(indexResponse.getId()).thenReturn("model_group_ID");
-
-        when(indexResponse.getResult()).thenReturn(CREATED);
+        indexResponse = new IndexResponse(new ShardId(ML_MODEL_GROUP_INDEX, "_na_", 0), "model_group_ID", 1, 0, 2, true);
 
         PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
         future.onResponse(indexResponse);
@@ -181,7 +179,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -198,7 +196,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
@@ -217,7 +215,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -230,7 +228,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -244,7 +242,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -258,7 +256,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -271,7 +269,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("You can specify backend roles only for a model group with the restricted access mode.", argumentCaptor.getValue().getMessage());
@@ -285,7 +283,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("You cannot specify backend roles and add all backend roles at the same time.", argumentCaptor.getValue().getMessage());
@@ -299,7 +297,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("You can specify backend roles only for a model group with the restricted access mode.", argumentCaptor.getValue().getMessage());
@@ -315,7 +313,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Admin users cannot add all backend roles to a model group.", argumentCaptor.getValue().getMessage());
@@ -330,7 +328,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
@@ -348,7 +346,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
@@ -366,7 +364,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
@@ -386,7 +384,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("You don't have the backend roles specified.", argumentCaptor.getValue().getMessage());
@@ -400,7 +398,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
     }
@@ -413,7 +411,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
@@ -430,7 +428,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
     }
@@ -446,7 +444,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Index Not Found", argumentCaptor.getValue().getMessage());
@@ -465,7 +463,7 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<String> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
         mlModelGroupManager.createModelGroup(mlRegisterModelGroupInput, latchedActionListener);
-        latch.await();
+        latch.await(500, TimeUnit.MILLISECONDS);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Index Not Found", argumentCaptor.getValue().getMessage());

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
@@ -29,6 +29,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.DocWriteResponse;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.Result;
@@ -147,7 +148,14 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
         assertEquals(TEST_INDEX, indexRequestCaptor.getValue().index());
         assertEquals(TEST_ID, response.id());
-        assertTrue(response.created());
+
+        org.opensearch.action.index.IndexResponse indexActionResponse = org.opensearch.action.index.IndexResponse
+            .fromXContent(response.parser());
+        assertEquals(TEST_ID, indexActionResponse.getId());
+        assertEquals(DocWriteResponse.Result.CREATED, indexActionResponse.getResult());
+        assertEquals(0, indexActionResponse.getShardInfo().getFailed());
+        assertEquals(1, indexActionResponse.getShardInfo().getSuccessful());
+        assertEquals(1, indexActionResponse.getShardInfo().getTotal());
     }
 
     public void testPutDataObject_Updated() throws IOException {
@@ -173,7 +181,14 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
         assertEquals(TEST_INDEX, indexRequestCaptor.getValue().index());
         assertEquals(TEST_ID, response.id());
-        assertFalse(response.created());
+
+        org.opensearch.action.index.IndexResponse indexActionResponse = org.opensearch.action.index.IndexResponse
+            .fromXContent(response.parser());
+        assertEquals(TEST_ID, indexActionResponse.getId());
+        assertEquals(DocWriteResponse.Result.UPDATED, indexActionResponse.getResult());
+        assertEquals(0, indexActionResponse.getShardInfo().getFailed());
+        assertEquals(1, indexActionResponse.getShardInfo().getSuccessful());
+        assertEquals(1, indexActionResponse.getShardInfo().getTotal());
     }
 
     public void testPutDataObject_Exception() throws IOException {
@@ -290,7 +305,14 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
         assertEquals(TEST_INDEX, updateRequestCaptor.getValue().index());
         assertEquals(TEST_ID, response.id());
-        assertTrue(response.updated());
+
+        org.opensearch.action.update.UpdateResponse updateActionResponse = org.opensearch.action.update.UpdateResponse
+            .fromXContent(response.parser());
+        assertEquals(TEST_ID, updateActionResponse.getId());
+        assertEquals(DocWriteResponse.Result.UPDATED, updateActionResponse.getResult());
+        assertEquals(0, updateActionResponse.getShardInfo().getFailed());
+        assertEquals(1, updateActionResponse.getShardInfo().getSuccessful());
+        assertEquals(1, updateActionResponse.getShardInfo().getTotal());
     }
 
     public void testUpdateDataObject_NotFound() throws IOException {
@@ -321,7 +343,14 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
         assertEquals(TEST_INDEX, updateRequestCaptor.getValue().index());
         assertEquals(TEST_ID, response.id());
-        assertFalse(response.updated());
+
+        org.opensearch.action.update.UpdateResponse updateActionResponse = org.opensearch.action.update.UpdateResponse
+            .fromXContent(response.parser());
+        assertEquals(TEST_ID, updateActionResponse.getId());
+        assertEquals(DocWriteResponse.Result.CREATED, updateActionResponse.getResult());
+        assertEquals(0, updateActionResponse.getShardInfo().getFailed());
+        assertEquals(1, updateActionResponse.getShardInfo().getSuccessful());
+        assertEquals(1, updateActionResponse.getShardInfo().getTotal());
     }
 
     public void testtUpdateDataObject_Exception() throws IOException {
@@ -365,10 +394,14 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
         assertEquals(TEST_INDEX, deleteRequestCaptor.getValue().index());
         assertEquals(TEST_ID, response.id());
-        assertEquals(2, response.shardInfo().getTotal());
-        assertEquals(2, response.shardInfo().getSuccessful());
-        assertEquals(0, response.shardInfo().getFailed());
-        assertTrue(response.deleted());
+
+        org.opensearch.action.delete.DeleteResponse deleteActionResponse = org.opensearch.action.delete.DeleteResponse
+            .fromXContent(response.parser());
+        assertEquals(TEST_ID, deleteActionResponse.getId());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteActionResponse.getResult());
+        assertEquals(0, deleteActionResponse.getShardInfo().getFailed());
+        assertEquals(2, deleteActionResponse.getShardInfo().getSuccessful());
+        assertEquals(2, deleteActionResponse.getShardInfo().getTotal());
     }
 
     public void testDeleteDataObject_NotFound() throws IOException {
@@ -392,12 +425,13 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .toCompletableFuture()
             .join();
 
-        assertEquals(TEST_INDEX, deleteRequestCaptor.getValue().index());
-        assertEquals(TEST_ID, response.id());
-        assertEquals(2, response.shardInfo().getTotal());
-        assertEquals(2, response.shardInfo().getSuccessful());
-        assertEquals(0, response.shardInfo().getFailed());
-        assertFalse(response.deleted());
+        org.opensearch.action.delete.DeleteResponse deleteActionResponse = org.opensearch.action.delete.DeleteResponse
+            .fromXContent(response.parser());
+        assertEquals(TEST_ID, deleteActionResponse.getId());
+        assertEquals(DocWriteResponse.Result.NOT_FOUND, deleteActionResponse.getResult());
+        assertEquals(0, deleteActionResponse.getShardInfo().getFailed());
+        assertEquals(2, deleteActionResponse.getShardInfo().getSuccessful());
+        assertEquals(2, deleteActionResponse.getShardInfo().getTotal());
     }
 
     public void testDeleteDataObject_Exception() throws IOException {


### PR DESCRIPTION
### Description

Updates the SDKClient to use the full IndexResponse, UpdateResponse, and DeleteResponse objects.

Parallel of similar work on GetResponse in #2587 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
