### PR TITLE
Modify tenant ID header naming to x-tenant-id

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.connector.ConnectorProtocols.HTTP;
 import static org.opensearch.ml.common.connector.ConnectorProtocols.validateProtocol;
-import static org.opensearch.ml.common.input.Constants.TENANT_ID;
+import static org.opensearch.ml.common.CommonValue.TENANT_ID;
 import static org.opensearch.ml.common.utils.StringUtils.getParameterMap;
 import static org.opensearch.ml.common.utils.StringUtils.isJson;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;

--- a/common/src/main/java/org/opensearch/ml/common/input/Constants.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/Constants.java
@@ -37,5 +37,5 @@ public class Constants {
     public static final String AD_ANOMALY_SCORE_THRESHOLD = "anomalyScoreThreshold";
     public static final String AD_DATE_FORMAT = "dateFormat";
 
-    public static final String TENANT_ID = "tenant_id";
+    public static final String TENANT_ID = "x-tenant-id";
 }

--- a/common/src/main/java/org/opensearch/ml/common/input/Constants.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/Constants.java
@@ -37,5 +37,5 @@ public class Constants {
     public static final String AD_ANOMALY_SCORE_THRESHOLD = "anomalyScoreThreshold";
     public static final String AD_DATE_FORMAT = "dateFormat";
 
-    public static final String TENANT_ID = "x-tenant-id";
+    public static final String TENANT_ID_HEADER = "x-tenant-id";
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.MLModel.allowedInterfaceFieldKeys;
 import static org.opensearch.ml.common.connector.Connector.createConnector;
-import static org.opensearch.ml.common.input.Constants.TENANT_ID;
+import static org.opensearch.ml.common.CommonValue.TENANT_ID;
 import static org.opensearch.ml.common.utils.StringUtils.filteredParameterMap;
 
 

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
@@ -7,7 +7,7 @@ package org.opensearch.ml.action.connector;
 
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
-import static org.opensearch.ml.common.input.Constants.TENANT_ID;
+import static org.opensearch.ml.common.CommonValue.TENANT_ID;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 
 import java.util.ArrayList;

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -315,8 +315,8 @@ public class RestActionUtils {
         if (isMultiTenancyEnabled) {
             Map<String, List<String>> headers = restRequest.getHeaders();
             if (headers != null) {
-                if (headers.containsKey(Constants.TENANT_ID)) {
-                    List<String> tenantIdList = headers.get(Constants.TENANT_ID);
+                if (headers.containsKey(Constants.TENANT_ID_HEADER)) {
+                    List<String> tenantIdList = headers.get(Constants.TENANT_ID_HEADER);
                     if (tenantIdList != null && !tenantIdList.isEmpty()) {
                         String tenantId = tenantIdList.get(0);
                         if (tenantId != null) {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteConnectorActionTests.java
@@ -27,6 +27,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.input.Constants;
 import org.opensearch.ml.common.transport.connector.MLConnectorDeleteAction;
 import org.opensearch.ml.common.transport.connector.MLConnectorDeleteRequest;
 import org.opensearch.ml.settings.MLFeatureEnabledSetting;
@@ -124,7 +125,7 @@ public class RestMLDeleteConnectorActionTests extends OpenSearchTestCase {
 
         Map<String, List<String>> headers = new HashMap<>();
         if (tenantId != null) {
-            headers.put("tenant_id", Collections.singletonList(tenantId));
+            headers.put(Constants.TENANT_ID_HEADER, Collections.singletonList(tenantId));
         }
 
         return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).withHeaders(headers).build();

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetConnectorActionTests.java
@@ -35,6 +35,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.input.Constants;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetAction;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetRequest;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetResponse;
@@ -157,7 +158,7 @@ public class RestMLGetConnectorActionTests extends OpenSearchTestCase {
 
         Map<String, List<String>> headers = new HashMap<>();
         if (tenantId != null) {
-            headers.put("tenant_id", Collections.singletonList(tenantId));
+            headers.put(Constants.TENANT_ID_HEADER, Collections.singletonList(tenantId));
         }
 
         return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).withHeaders(headers).build();

--- a/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
@@ -389,7 +389,7 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
     public void testGetTenantID_IndependentNode() {
         String tenantId = "test-tenant";
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put(Constants.TENANT_ID, Collections.singletonList(tenantId));
+        headers.put(Constants.TENANT_ID_HEADER, Collections.singletonList(tenantId));
         RestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(headers).build();
 
         String actualTenantID = RestActionUtils.getTenantID(Boolean.TRUE, restRequest);
@@ -399,7 +399,7 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
     @Test
     public void testGetTenantID_IndependentNode_NullTenantID() {
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put(Constants.TENANT_ID, Collections.singletonList(null));
+        headers.put(Constants.TENANT_ID_HEADER, Collections.singletonList(null));
         RestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(headers).build();
 
         try {
@@ -417,7 +417,7 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
         settings = Settings.builder().put(ML_COMMONS_MULTI_TENANCY_ENABLED.getKey(), false).build();
         String tenantId = "test-tenant";
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put(Constants.TENANT_ID, Collections.singletonList(tenantId));
+        headers.put(Constants.TENANT_ID_HEADER, Collections.singletonList(tenantId));
         RestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(headers).build();
 
         String tenantID = RestActionUtils.getTenantID(Boolean.FALSE, restRequest);

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -75,6 +75,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.MLInputDataType;
 import org.opensearch.ml.common.dataset.SearchQueryInputDataset;
+import org.opensearch.ml.common.input.Constants;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.input.execute.metricscorrelation.MetricsCorrelationInput;
 import org.opensearch.ml.common.input.execute.samplecalculator.LocalSampleCalculatorInput;
@@ -220,7 +221,7 @@ public class TestHelper {
     public static RestRequest getCreateConnectorRestRequest(String tenantId) {
         Map<String, List<String>> headers = new HashMap<>();
         if (tenantId != null) {
-            headers.put("tenant_id", Collections.singletonList(tenantId));
+            headers.put(Constants.TENANT_ID_HEADER, Collections.singletonList(tenantId));
         }
         final String requestContent = "{\n"
             + "    \"name\": \"OpenAI Connector\",\n"


### PR DESCRIPTION
### Description
Modify tenant ID header naming to x-tenant-id
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/2594
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
