### PR TITLE
Implement SdkClient in TransportRegisterModelAction

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
@@ -9,6 +9,10 @@
 package org.opensearch.sdk;
 
 import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
 
 public class UpdateDataObjectRequest {
 
@@ -116,6 +120,20 @@ public class UpdateDataObjectRequest {
          */
         public Builder dataObject(ToXContentObject dataObject) {
             this.dataObject = dataObject;
+            return this;
+        }
+        
+        /**
+         * Add a data object as a map to this builder
+         * @param dataObjectMap the data object as a map of fields
+         * @return the updated builder
+         */
+        public Builder dataObject(Map<String, Object> dataObjectMap) {
+            this.dataObject = new ToXContentObject() {
+                @Override
+                public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                    return builder.map(dataObjectMap);
+                }};
             return this;
         }
 

--- a/common/src/test/java/org/opensearch/sdk/DeleteDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/DeleteDataObjectRequestTests.java
@@ -16,18 +16,21 @@ import static org.junit.Assert.assertEquals;
 public class DeleteDataObjectRequestTests {
     private String testIndex;
     private String testId;
+    private String testTenantId;
 
     @Before
     public void setUp() {
         testIndex = "test-index";
         testId = "test-id";
+        testTenantId = "test-tenant-id";
     }
 
     @Test
     public void testDeleteDataObjectRequest() {
-        DeleteDataObjectRequest request = new DeleteDataObjectRequest.Builder().index(testIndex).id(testId).build();
+        DeleteDataObjectRequest request = new DeleteDataObjectRequest.Builder().index(testIndex).id(testId).tenantId(testTenantId).build();
 
         assertEquals(testIndex, request.index());
         assertEquals(testId, request.id());
+        assertEquals(testTenantId, request.tenantId());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/GetDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/GetDataObjectRequestTests.java
@@ -19,12 +19,14 @@ public class GetDataObjectRequestTests {
 
     private String testIndex;
     private String testId;
+    private String testTenantId;    
     private FetchSourceContext testFetchSourceContext;
 
     @Before
     public void setUp() {
         testIndex = "test-index";
         testId = "test-id";
+        testTenantId = "test-tenant-id";
         testFetchSourceContext = mock(FetchSourceContext.class);
     }
 
@@ -33,11 +35,13 @@ public class GetDataObjectRequestTests {
         GetDataObjectRequest request = new GetDataObjectRequest.Builder()
             .index(testIndex)
             .id(testId)
+            .tenantId(testTenantId)
             .fetchSourceContext(testFetchSourceContext)
             .build();
 
         assertEquals(testIndex, request.index());
         assertEquals(testId, request.id());
+        assertEquals(testTenantId, request.tenantId());
         assertEquals(testFetchSourceContext, request.fetchSourceContext());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/PutDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/PutDataObjectRequestTests.java
@@ -18,19 +18,22 @@ import static org.mockito.Mockito.mock;
 public class PutDataObjectRequestTests {
 
     private String testIndex;
+    private String testTenantId;
     private ToXContentObject testDataObject;
 
     @Before
     public void setUp() {
         testIndex = "test-index";
+        testTenantId = "test-tenant-id";
         testDataObject = mock(ToXContentObject.class);
     }
 
     @Test
     public void testPutDataObjectRequest() {
-        PutDataObjectRequest request = new PutDataObjectRequest.Builder().index(testIndex).dataObject(testDataObject).build();
+        PutDataObjectRequest request = new PutDataObjectRequest.Builder().index(testIndex).tenantId(testTenantId).dataObject(testDataObject).build();
 
         assertEquals(testIndex, request.index());
+        assertEquals(testTenantId, request.tenantId());
         assertEquals(testDataObject, request.dataObject());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/SearchDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SearchDataObjectRequestTests.java
@@ -18,11 +18,13 @@ import static org.junit.Assert.assertEquals;
 public class SearchDataObjectRequestTests {
 
     private String[] testIndices;
+    private String testTenantId;
     private SearchSourceBuilder testSearchSourceBuilder;
 
     @Before
     public void setUp() {
         testIndices = new String[] {"test-index"};
+        testTenantId = "test-tenant-id";
         testSearchSourceBuilder = new SearchSourceBuilder();
     }
 
@@ -30,10 +32,12 @@ public class SearchDataObjectRequestTests {
     public void testGetDataObjectRequest() {
         SearchDataObjectRequest request = new SearchDataObjectRequest.Builder()
             .indices(testIndices)
+            .tenantId(testTenantId)
             .searchSourceBuilder(testSearchSourceBuilder)
             .build();
 
         assertArrayEquals(testIndices, request.indices());
+        assertEquals(testTenantId, request.tenantId());
         assertEquals(testSearchSourceBuilder, request.searchSourceBuilder());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/UpdateDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/UpdateDataObjectRequestTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.ToXContentObject;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class UpdateDataObjectRequestTests {
+
+    private String testIndex;
+    private String testId;
+    private String testTenantId;
+    private ToXContentObject testDataObject;
+    private Map<String, Object> testDataObjectMap;
+
+    @Before
+    public void setUp() {
+        testIndex = "test-index";
+        testId = "test-id";
+        testTenantId = "test-tenant-id";
+        testDataObject = mock(ToXContentObject.class);
+        testDataObjectMap = Map.of("foo", "bar");
+    }
+
+    @Test
+    public void testUpdateDataObjectRequest() {
+        UpdateDataObjectRequest request = new UpdateDataObjectRequest.Builder().index(testIndex).id(testId).tenantId(testTenantId).dataObject(testDataObject).build();
+
+        assertEquals(testIndex, request.index());
+        assertEquals(testId, request.id());
+        assertEquals(testTenantId, request.tenantId());
+        assertEquals(testDataObject, request.dataObject());
+    }
+
+    @Test
+    public void testUpdateDataObjectMapRequest() {
+        UpdateDataObjectRequest request = new UpdateDataObjectRequest.Builder().index(testIndex).id(testId).tenantId(testTenantId).dataObject(testDataObjectMap).build();
+
+        assertEquals(testIndex, request.index());
+        assertEquals(testId, request.id());
+        assertEquals(testTenantId, request.tenantId());
+        assertEquals(testDataObjectMap, XContentHelper.convertToMap(JsonXContent.jsonXContent, Strings.toString(XContentType.JSON, request.dataObject()), false));        
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
@@ -377,7 +377,7 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
             modelAccessControlHelper
                 .validateModelGroupAccess(user, newModelGroupId, client, ActionListener.wrap(hasNewModelGroupPermission -> {
                     if (hasNewModelGroupPermission) {
-                        mlModelGroupManager.getModelGroupResponse(newModelGroupId, ActionListener.wrap(newModelGroupResponse -> {
+                        mlModelGroupManager.getModelGroupResponse(sdkClient, newModelGroupId, ActionListener.wrap(newModelGroupResponse -> {
                             buildUpdateRequest(
                                 modelId,
                                 newModelGroupId,

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -196,7 +196,7 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
     ) {
         User user = RestActionUtils.getUserContext(client);
         modelAccessControlHelper
-            .validateModelGroupAccess(user, registerModelInput.getModelGroupId(), client, ActionListener.wrap(access -> {
+            .validateModelGroupAccess(user, registerModelInput.getModelGroupId(), client, sdkClient, ActionListener.wrap(access -> {
                 if (access) {
                     doRegister(registerModelInput, listener);
                     return;
@@ -351,7 +351,7 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
             mlTaskManager.createMLTask(mlTask, ActionListener.wrap(response -> {
                 String taskId = response.getId();
                 mlTask.setTaskId(taskId);
-                mlModelManager.registerMLRemoteModel(registerModelInput, mlTask, listener);
+                mlModelManager.registerMLRemoteModel(sdkClient, registerModelInput, mlTask, listener);
             }, e -> {
                 logException("Failed to register model", e, log);
                 listener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -13,7 +13,6 @@ import java.time.Instant;
 import java.util.HashSet;
 
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
@@ -255,25 +254,6 @@ public class MLModelGroupManager {
             log.error("Failed to search model group index", e);
             listener.onFailure(e);
         }
-    }
-
-    // TODO Remove when all calls migrated to SDKClient version
-    /**
-     * Get model group from model group index.
-     *
-     * @param modelGroupId  model group id
-     * @param listener action listener
-     */
-    public void getModelGroupResponse(String modelGroupId, ActionListener<GetResponse> listener) {
-        GetRequest getRequest = new GetRequest();
-        getRequest.index(ML_MODEL_GROUP_INDEX).id(modelGroupId);
-        client.get(getRequest, ActionListener.wrap(r -> {
-            if (r != null && r.isExists()) {
-                listener.onResponse(r);
-            } else {
-                listener.onFailure(new MLResourceNotFoundException("Failed to find model group with ID: " + modelGroupId));
-            }
-        }, listener::onFailure));
     }
 
     /**

--- a/plugin/src/test/java/org/opensearch/ml/action/models/UpdateModelTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/UpdateModelTransportActionTests.java
@@ -311,7 +311,7 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
             )
             .build();
 
-        // TODO eventually remove
+        // TODO eventually remove if migrated to sdkClient
         doAnswer(invocation -> {
             ActionListener<Boolean> listener = invocation.getArgument(3);
             listener.onResponse(true);
@@ -326,7 +326,7 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
             .when(modelAccessControlHelper)
             .validateModelGroupAccess(any(), eq("test_model_group_id"), any(), any(SdkClient.class), isA(ActionListener.class));
 
-        // TODO eventually remove
+        // TODO eventually remove if migrated to sdkClient
         doAnswer(invocation -> {
             ActionListener<Boolean> listener = invocation.getArgument(3);
             listener.onResponse(true);
@@ -359,12 +359,12 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
         future.onResponse(updateResponse);
         when(client.update(any(UpdateRequest.class))).thenReturn(future);
 
-        // TODO eventually remove
+        // TODO eventually remove if migrated to sdkClient
         doAnswer(invocation -> {
-            ActionListener<MLModel> listener = invocation.getArgument(4);
+            ActionListener<MLModel> listener = invocation.getArgument(3);
             listener.onResponse(localModel);
             return null;
-        }).when(mlModelManager).getModel(any(SdkClient.class), eq("test_model_id"), any(), any(), isA(ActionListener.class));
+        }).when(mlModelManager).getModel(eq("test_model_id"), any(), any(), isA(ActionListener.class));
 
         doAnswer(invocation -> {
             ActionListener<MLModel> listener = invocation.getArgument(4);
@@ -386,10 +386,10 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
         GetResponse getResponse = prepareGetResponse(modelGroup);
 
         doAnswer(invocation -> {
-            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
             listener.onResponse(getResponse);
             return null;
-        }).when(mlModelGroupManager).getModelGroupResponse(eq("updated_test_model_group_id"), isA(ActionListener.class));
+        }).when(mlModelGroupManager).getModelGroupResponse(eq(sdkClient), eq("updated_test_model_group_id"), isA(ActionListener.class));
     }
 
     @AfterClass
@@ -692,10 +692,10 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
     @Test
     public void testUpdateModelWithRegisterToNewModelGroupNotFound() {
         doAnswer(invocation -> {
-            ActionListener<MLModelGroup> listener = invocation.getArgument(1);
+            ActionListener<MLModelGroup> listener = invocation.getArgument(2);
             listener.onFailure(new MLResourceNotFoundException("Model group not found with MODEL_GROUP_ID: updated_test_model_group_id"));
             return null;
-        }).when(mlModelGroupManager).getModelGroupResponse(eq("updated_test_model_group_id"), isA(ActionListener.class));
+        }).when(mlModelGroupManager).getModelGroupResponse(eq(sdkClient), eq("updated_test_model_group_id"), isA(ActionListener.class));
 
         transportUpdateModelAction.doExecute(task, updateLocalModelRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -800,7 +800,7 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
             ActionListener<MLModel> listener = invocation.getArgument(4);
             listener.onResponse(mockModel);
             return null;
-        }).when(mlModelManager).getModel(any(SdkClient.class), eq("mockId"), any(), any(), isA(ActionListener.class));
+        }).when(mlModelManager).getModel(eq(sdkClient), eq("mockId"), any(), any(), isA(ActionListener.class));
 
         doReturn("test_model_group_id").when(mockModel).getModelGroupId();
         doReturn(FunctionName.TEXT_EMBEDDING).when(mockModel).getAlgorithm();
@@ -809,10 +809,12 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
         doReturn("mockUpdateModelGroupId").when(mockUpdateModelInput).getModelGroupId();
 
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(3);
+            ActionListener<Boolean> listener = invocation.getArgument(4);
             listener.onResponse(true);
             return null;
-        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), eq("mockUpdateModelGroupId"), any(), isA(ActionListener.class));
+        })
+            .when(modelAccessControlHelper)
+            .validateModelGroupAccess(any(), eq("mockUpdateModelGroupId"), any(), eq(sdkClient), isA(ActionListener.class));
 
         MLModelGroup modelGroup = MLModelGroup
             .builder()
@@ -828,10 +830,10 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
         GetResponse getResponse = prepareGetResponse(modelGroup);
 
         doAnswer(invocation -> {
-            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
             listener.onResponse(getResponse);
             return null;
-        }).when(mlModelGroupManager).getModelGroupResponse(eq("mockUpdateModelGroupId"), isA(ActionListener.class));
+        }).when(mlModelGroupManager).getModelGroupResponse(eq(sdkClient), eq("mockUpdateModelGroupId"), isA(ActionListener.class));
 
         doThrow(new IOException("Exception occurred during building update request.")).when(mockUpdateModelInput).toXContent(any(), any());
 

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -393,6 +393,29 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
     }
 
     @Test
+    public void updateDataObjectAsync_HappyCaseWithMap() {
+        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+            .id(TEST_ID)
+            .index(TEST_INDEX)
+            .tenantId(TENANT_ID)
+            .dataObject(Map.of("foo", "bar"))
+            .build();
+        Mockito.when(dynamoDbClient.updateItem(updateItemRequestArgumentCaptor.capture())).thenReturn(UpdateItemResponse.builder().build());
+        UpdateDataObjectResponse updateResponse = sdkClient
+            .updateDataObjectAsync(updateRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
+            .toCompletableFuture()
+            .join();
+        assertEquals(TEST_ID, updateResponse.id());
+        UpdateItemRequest updateItemRequest = updateItemRequestArgumentCaptor.getValue();
+        assertEquals(TEST_ID, updateRequest.id());
+        assertEquals(TEST_INDEX, updateItemRequest.tableName());
+        assertEquals(TEST_ID, updateItemRequest.key().get("id").s());
+        assertEquals(TENANT_ID, updateItemRequest.key().get("tenant_id").s());
+        assertEquals("bar", updateItemRequest.key().get("foo").s());
+
+    }
+
+    @Test
     public void updateDataObjectAsync_NullTenantId_UsesDefaultTenantId() {
         UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
             .id(TEST_ID)


### PR DESCRIPTION
### Description

Implements needed methods in MLModelManager for the TransportRegisterModelAction when the model is remote.

Migrates all code calling non-sdk MLModelGroupManager methods and removes old method/test.

Also updates SDK request tests to include Tenant ID and creates the missing UpdateRequest test.
 
Still TODO:  Concurrency guarantee on update request.  Still considering the best way to do that, will follow up with another PR for that, probably tomorrow.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
