### PR TITLE
Set tenant ID while creating connector and model group

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
@@ -75,6 +75,7 @@ public class GetConnectorTransportAction extends HandledTransportAction<ActionRe
         GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
             .index(ML_CONNECTOR_INDEX)
             .id(connectorId)
+            .tenantId(tenantId)
             .fetchSourceContext(fetchSourceContext)
             .build();
         User user = RestActionUtils.getUserContext(client);

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
@@ -144,7 +144,11 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
                 sdkClient
                     .putDataObjectAsync(
-                        new PutDataObjectRequest.Builder().index(ML_CONNECTOR_INDEX).dataObject(connector).build(),
+                        new PutDataObjectRequest.Builder()
+                            .tenantId(connector.getTenantId())
+                            .index(ML_CONNECTOR_INDEX)
+                            .dataObject(connector)
+                            .build(),
                         client.threadPool().executor(GENERAL_THREAD_POOL)
                     )
                     .whenComplete((r, throwable) -> {

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -124,7 +124,11 @@ public class MLModelGroupManager {
                         mlIndicesHandler.initModelGroupIndexIfAbsent(ActionListener.wrap(res -> {
                             sdkClient
                                 .putDataObjectAsync(
-                                    new PutDataObjectRequest.Builder().index(ML_MODEL_GROUP_INDEX).dataObject(mlModelGroup).build(),
+                                    new PutDataObjectRequest.Builder()
+                                        .tenantId(mlModelGroup.getTenantId())
+                                        .index(ML_MODEL_GROUP_INDEX)
+                                        .dataObject(mlModelGroup)
+                                        .build(),
                                     client.threadPool().executor(GENERAL_THREAD_POOL)
                                 )
                                 .whenComplete((r, throwable) -> {

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -15,11 +15,14 @@ import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.get.GetResponse;
@@ -249,7 +252,14 @@ public class DDBOpenSearchClient implements SdkClient {
      */
     @Override
     public CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(SearchDataObjectRequest request, Executor executor) {
-        return this.remoteClusterIndicesClient.searchDataObjectAsync(request, executor);
+        List<String> indices = Arrays.stream(request.indices()).map(this::getTableName).collect(Collectors.toList());
+
+        SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest(
+            indices.toArray(new String[0]),
+            request.tenantId(),
+            request.searchSourceBuilder()
+        );
+        return this.remoteClusterIndicesClient.searchDataObjectAsync(searchDataObjectRequest, executor);
     }
 
     private String getTableName(String index) {


### PR DESCRIPTION
### Description
Set tenant ID while creating connector and model group
 
DDB search implementation will modify index name to be same as table name.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
