### PR TITLE
[Feature/multi_tenancy] Add ifSeqNo and ifPrimaryTerm for update concurrency

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
@@ -8,8 +8,6 @@
  */
 package org.opensearch.sdk;
 
-import org.opensearch.OpenSearchStatusException;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;

--- a/common/src/test/java/org/opensearch/sdk/SdkClientUtilsTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SdkClientUtilsTests.java
@@ -10,7 +10,6 @@ package org.opensearch.sdk;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.core.rest.RestStatus;

--- a/common/src/test/java/org/opensearch/sdk/UpdateDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/UpdateDataObjectRequestTests.java
@@ -69,7 +69,7 @@ public class UpdateDataObjectRequestTests {
     
     @Test
     public void testUpdateDataObjectRequestConcurrency() {
-        UpdateDataObjectRequest request = new UpdateDataObjectRequest.Builder().index(testIndex).id(testId).tenantId(testTenantId).dataObject(testDataObject)
+        UpdateDataObjectRequest request = UpdateDataObjectRequest.builder().index(testIndex).id(testId).tenantId(testTenantId).dataObject(testDataObject)
             .ifSeqNo(testSeqNo).ifPrimaryTerm(testPrimaryTerm).build();
 
         assertEquals(testIndex, request.index());
@@ -79,13 +79,13 @@ public class UpdateDataObjectRequestTests {
         assertEquals(testSeqNo, request.ifSeqNo());
         assertEquals(testPrimaryTerm, request.ifPrimaryTerm());
 
-        final Builder badSeqNoBuilder = new UpdateDataObjectRequest.Builder();
+        final Builder badSeqNoBuilder = UpdateDataObjectRequest.builder();
         assertThrows(IllegalArgumentException.class, () -> badSeqNoBuilder.ifSeqNo(-99));
-        final Builder badPrimaryTermBuilder = new UpdateDataObjectRequest.Builder();
+        final Builder badPrimaryTermBuilder = UpdateDataObjectRequest.builder();
         assertThrows(IllegalArgumentException.class, () -> badPrimaryTermBuilder.ifPrimaryTerm(-99));
-        final Builder onlySeqNoBuilder = new UpdateDataObjectRequest.Builder().ifSeqNo(testSeqNo);
+        final Builder onlySeqNoBuilder = UpdateDataObjectRequest.builder().ifSeqNo(testSeqNo);
         assertThrows(IllegalArgumentException.class, () -> onlySeqNoBuilder.build());
-        final Builder onlyPrimaryTermBuilder = new UpdateDataObjectRequest.Builder().ifPrimaryTerm(testPrimaryTerm);
+        final Builder onlyPrimaryTermBuilder = UpdateDataObjectRequest.builder().ifPrimaryTerm(testPrimaryTerm);
         assertThrows(IllegalArgumentException.class, () -> onlyPrimaryTermBuilder.build());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/UpdateDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/UpdateDataObjectResponseTests.java
@@ -10,9 +10,6 @@ package org.opensearch.sdk;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.opensearch.action.support.replication.ReplicationResponse.ShardInfo;
-import org.opensearch.core.common.Strings;
-import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.XContentParser;
 
 import static org.junit.Assert.assertEquals;

--- a/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
@@ -615,16 +615,6 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
     ) {
         modelGroupSourceMap.put(MLModelGroup.LATEST_VERSION_FIELD, updatedVersion);
         modelGroupSourceMap.put(MLModelGroup.LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli());
-        /* Old code here. TODO investigate if we need to add seqNo and primaryTerm to data object request
-        UpdateRequest updateModelGroupRequest = new UpdateRequest();        
-        updateModelGroupRequest
-            .index(ML_MODEL_GROUP_INDEX)
-            .id(modelGroupId)
-            .setIfSeqNo(seqNo)
-            .setIfPrimaryTerm(primaryTerm)
-            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .doc(modelGroupSourceMap);
-        */
         ToXContentObject dataObject = new ToXContentObject() {
             @Override
             public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -635,7 +625,13 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                 return builder.endObject();
             }
         };
-        return UpdateDataObjectRequest.builder().index(ML_MODEL_GROUP_INDEX).id(modelGroupId).dataObject(dataObject).build();
+        return UpdateDataObjectRequest.builder()
+            .index(ML_MODEL_GROUP_INDEX)
+            .id(modelGroupId)
+            .ifSeqNo(seqNo)
+            .ifPrimaryTerm(primaryTerm)
+            .dataObject(dataObject)
+            .build();
     }
 
     private Boolean isModelDeployed(MLModelState mlModelState) {

--- a/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
@@ -625,7 +625,8 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                 return builder.endObject();
             }
         };
-        return UpdateDataObjectRequest.builder()
+        return UpdateDataObjectRequest
+            .builder()
             .index(ML_MODEL_GROUP_INDEX)
             .id(modelGroupId)
             .ifSeqNo(seqNo)

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -377,25 +377,14 @@ public class MLModelManager {
                             if (getModelGroupResponse.isExists()) {
                                 Map<String, Object> modelGroupSourceMap = getModelGroupResponse.getSourceAsMap();
                                 int updatedVersion = incrementLatestVersion(modelGroupSourceMap);
-                                /* TODO UpdateDataObjectRequest needs to track response seqNo + primary term
-                                UpdateRequest updateModelGroupRequest = createUpdateModelGroupRequest(
-                                modelGroupSourceMap,
-                                modelGroupId,
-                                getModelGroupResponse.getSeqNo(),
-                                getModelGroupResponse.getPrimaryTerm(),
-                                updatedVersion
-                                );
-                                */
                                 modelGroupSourceMap.put(MLModelGroup.LATEST_VERSION_FIELD, updatedVersion);
                                 modelGroupSourceMap.put(MLModelGroup.LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli());
                                 UpdateDataObjectRequest updateDataObjectRequest = UpdateDataObjectRequest
                                     .builder()
                                     .index(ML_MODEL_GROUP_INDEX)
                                     .id(modelGroupId)
-                                    // TODO need to track these for concurrency
-                                    // .setIfSeqNo(seqNo)
-                                    // .setIfPrimaryTerm(primaryTerm)
-                                    // .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                                    .ifSeqNo(getModelGroupResponse.getSeqNo())
+                                    .ifPrimaryTerm(getModelGroupResponse.getPrimaryTerm())
                                     .dataObject(modelGroupSourceMap)
                                     .build();
                                 sdkClient.updateDataObjectAsync(updateDataObjectRequest).whenComplete((ur, ut) -> {

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClient.java
@@ -132,11 +132,15 @@ public class LocalClusterIndicesClient implements SdkClient {
         return CompletableFuture.supplyAsync(() -> AccessController.doPrivileged((PrivilegedAction<UpdateDataObjectResponse>) () -> {
             try (XContentBuilder sourceBuilder = XContentFactory.jsonBuilder()) {
                 log.info("Updating {} from {}", request.id(), request.index());
-                UpdateResponse updateResponse = client
-                    .update(
-                        new UpdateRequest(request.index(), request.id()).doc(request.dataObject().toXContent(sourceBuilder, EMPTY_PARAMS))
-                    )
-                    .actionGet();
+                UpdateRequest updateRequest = new UpdateRequest(request.index(), request.id())
+                    .doc(request.dataObject().toXContent(sourceBuilder, EMPTY_PARAMS));
+                if (request.ifSeqNo() != null) {
+                    updateRequest.setIfSeqNo(request.ifSeqNo());
+                }
+                if (request.ifPrimaryTerm() != null) {
+                    updateRequest.setIfPrimaryTerm(request.ifPrimaryTerm());
+                }
+                UpdateResponse updateResponse = client.update(updateRequest).actionGet();
                 if (updateResponse == null) {
                     log.info("Null UpdateResponse");
                     return UpdateDataObjectResponse.builder().id(request.id()).parser(null).build();

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
@@ -34,6 +34,7 @@ import org.opensearch.client.opensearch.core.IndexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.UpdateRequest;
+import org.opensearch.client.opensearch.core.UpdateRequest.Builder;
 import org.opensearch.client.opensearch.core.UpdateResponse;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -130,11 +131,18 @@ public class RemoteClusterIndicesClient implements SdkClient {
                 Map<String, Object> docMap = JsonXContent.jsonXContent
                     .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, builder.toString())
                     .map();
-                UpdateRequest<Map<String, Object>, ?> updateRequest = new UpdateRequest.Builder<Map<String, Object>, Map<String, Object>>()
-                    .index(request.index())
-                    .id(request.id())
-                    .doc(docMap)
-                    .build();
+                Builder<Map<String, Object>, Map<String, Object>> updateRequestBuilder =
+                    new UpdateRequest.Builder<Map<String, Object>, Map<String, Object>>()
+                        .index(request.index())
+                        .id(request.id())
+                        .doc(docMap);
+                if (request.ifSeqNo() != null) {
+                    updateRequestBuilder.ifSeqNo(request.ifSeqNo());
+                }
+                if (request.ifPrimaryTerm() != null) {
+                    updateRequestBuilder.ifPrimaryTerm(request.ifPrimaryTerm());
+                }
+                UpdateRequest<Map<String, Object>, ?> updateRequest = updateRequestBuilder.build();
                 log.info("Updating {} in {}", request.id(), request.index());
                 UpdateResponse<Map<String, Object>> updateResponse = openSearchClient.update(updateRequest, MAP_DOCTYPE);
                 log.info("Update status for id {}: {}", updateResponse.id(), updateResponse.result());

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -9,6 +9,7 @@
 
 package org.opensearch.ml.sdkclient;
 
+import static org.mockito.Mockito.when;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
@@ -30,6 +31,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetResponse;
@@ -41,6 +43,7 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
@@ -65,6 +68,7 @@ import com.google.common.collect.ImmutableMap;
 
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
@@ -75,6 +79,9 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
 
 public class DDBOpenSearchClientTests extends OpenSearchTestCase {
+
+    private static final String HASH_KEY = "_tenant_id";
+    private static final String RANGE_KEY = "_id";
 
     private static final String TEST_ID = "123";
     private static final String TENANT_ID = "TEST_TENANT_ID";
@@ -146,8 +153,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
         PutItemRequest putItemRequest = putItemRequestArgumentCaptor.getValue();
         Assert.assertEquals(TEST_INDEX, putItemRequest.tableName());
-        Assert.assertEquals(TEST_ID, putItemRequest.item().get("id").s());
-        Assert.assertEquals(TENANT_ID, putItemRequest.item().get("tenant_id").s());
+        Assert.assertEquals(TEST_ID, putItemRequest.item().get(RANGE_KEY).s());
+        Assert.assertEquals(TENANT_ID, putItemRequest.item().get(HASH_KEY).s());
         Assert.assertEquals("foo", putItemRequest.item().get("data").s());
     }
 
@@ -192,7 +199,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         Mockito.verify(dynamoDbClient).putItem(putItemRequestArgumentCaptor.capture());
 
         PutItemRequest putItemRequest = putItemRequestArgumentCaptor.getValue();
-        Assert.assertEquals("DEFAULT_TENANT", putItemRequest.item().get("tenant_id").s());
+        Assert.assertEquals("DEFAULT_TENANT", putItemRequest.item().get(HASH_KEY).s());
     }
 
     @Test
@@ -206,7 +213,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         Mockito.verify(dynamoDbClient).putItem(putItemRequestArgumentCaptor.capture());
 
         PutItemRequest putItemRequest = putItemRequestArgumentCaptor.getValue();
-        Assert.assertNotNull(putItemRequest.item().get("id").s());
+        Assert.assertNotNull(putItemRequest.item().get(RANGE_KEY).s());
         Assert.assertNotNull(response.id());
     }
 
@@ -237,8 +244,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         Mockito.verify(dynamoDbClient).getItem(getItemRequestArgumentCaptor.capture());
         GetItemRequest getItemRequest = getItemRequestArgumentCaptor.getValue();
         Assert.assertEquals(TEST_INDEX, getItemRequest.tableName());
-        Assert.assertEquals(TENANT_ID, getItemRequest.key().get("tenant_id").s());
-        Assert.assertEquals(TEST_ID, getItemRequest.key().get("id").s());
+        Assert.assertEquals(TENANT_ID, getItemRequest.key().get(HASH_KEY).s());
+        Assert.assertEquals(TEST_ID, getItemRequest.key().get(RANGE_KEY).s());
         Assert.assertEquals(TEST_ID, response.id());
         Assert.assertEquals("foo", response.source().get("data"));
         XContentParser parser = response.parser();
@@ -319,7 +326,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         sdkClient.getDataObjectAsync(getRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
         Mockito.verify(dynamoDbClient).getItem(getItemRequestArgumentCaptor.capture());
         GetItemRequest getItemRequest = getItemRequestArgumentCaptor.getValue();
-        Assert.assertEquals("DEFAULT_TENANT", getItemRequest.key().get("tenant_id").s());
+        Assert.assertEquals("DEFAULT_TENANT", getItemRequest.key().get(HASH_KEY).s());
     }
 
     @Test
@@ -343,8 +350,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
             .join();
         DeleteItemRequest deleteItemRequest = deleteItemRequestArgumentCaptor.getValue();
         Assert.assertEquals(TEST_INDEX, deleteItemRequest.tableName());
-        Assert.assertEquals(TENANT_ID, deleteItemRequest.key().get("tenant_id").s());
-        Assert.assertEquals(TEST_ID, deleteItemRequest.key().get("id").s());
+        Assert.assertEquals(TENANT_ID, deleteItemRequest.key().get(HASH_KEY).s());
+        Assert.assertEquals(TEST_ID, deleteItemRequest.key().get(RANGE_KEY).s());
         Assert.assertEquals(TEST_ID, deleteResponse.id());
 
         DeleteResponse deleteActionResponse = DeleteResponse.fromXContent(deleteResponse.parser());
@@ -361,7 +368,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         Mockito.when(dynamoDbClient.deleteItem(deleteItemRequestArgumentCaptor.capture())).thenReturn(DeleteItemResponse.builder().build());
         sdkClient.deleteDataObjectAsync(deleteRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
         DeleteItemRequest deleteItemRequest = deleteItemRequestArgumentCaptor.getValue();
-        Assert.assertEquals("DEFAULT_TENANT", deleteItemRequest.key().get("tenant_id").s());
+        Assert.assertEquals("DEFAULT_TENANT", deleteItemRequest.key().get(HASH_KEY).s());
     }
 
     @Test
@@ -382,8 +389,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         UpdateItemRequest updateItemRequest = updateItemRequestArgumentCaptor.getValue();
         assertEquals(TEST_ID, updateRequest.id());
         assertEquals(TEST_INDEX, updateItemRequest.tableName());
-        assertEquals(TEST_ID, updateItemRequest.key().get("id").s());
-        assertEquals(TENANT_ID, updateItemRequest.key().get("tenant_id").s());
+        assertEquals(TEST_ID, updateItemRequest.key().get(RANGE_KEY).s());
+        assertEquals(TENANT_ID, updateItemRequest.key().get(HASH_KEY).s());
         assertEquals("foo", updateItemRequest.key().get("data").s());
 
     }
@@ -406,8 +413,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         UpdateItemRequest updateItemRequest = updateItemRequestArgumentCaptor.getValue();
         assertEquals(TEST_ID, updateRequest.id());
         assertEquals(TEST_INDEX, updateItemRequest.tableName());
-        assertEquals(TEST_ID, updateItemRequest.key().get("id").s());
-        assertEquals(TENANT_ID, updateItemRequest.key().get("tenant_id").s());
+        assertEquals(TEST_ID, updateItemRequest.key().get(RANGE_KEY).s());
+        assertEquals(TENANT_ID, updateItemRequest.key().get(HASH_KEY).s());
         assertEquals("bar", updateItemRequest.key().get("foo").s());
 
     }
@@ -424,7 +431,30 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         Mockito.when(dynamoDbClient.updateItem(updateItemRequestArgumentCaptor.capture())).thenReturn(UpdateItemResponse.builder().build());
         sdkClient.updateDataObjectAsync(updateRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
         UpdateItemRequest updateItemRequest = updateItemRequestArgumentCaptor.getValue();
-        assertEquals(TENANT_ID, updateItemRequest.key().get("tenant_id").s());
+        assertEquals(TENANT_ID, updateItemRequest.key().get(HASH_KEY).s());
+    }
+
+    public void testUpdateDataObject_VersionCheck() throws IOException {
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .dataObject(testDataObject)
+            .ifSeqNo(5)
+            .ifPrimaryTerm(2)
+            .build();
+
+        ConditionalCheckFailedException conflictException = ConditionalCheckFailedException.builder().build();
+        when(dynamoDbClient.updateItem(updateItemRequestArgumentCaptor.capture())).thenThrow(conflictException);
+
+        CompletableFuture<UpdateDataObjectResponse> future = sdkClient
+            .updateDataObjectAsync(updateRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
+            .toCompletableFuture();
+
+        CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
+        Throwable cause = ce.getCause();
+        assertEquals(OpenSearchStatusException.class, cause.getClass());
+        assertEquals(RestStatus.CONFLICT, ((OpenSearchStatusException) cause).status());
     }
 
     @Test


### PR DESCRIPTION
### Description

Tracks SeqNo and PrimaryTerm used for strong concurrency for updates.
 - Adds to update requests
 - Implements tracking of this version in DynamoDB

Still TODO (@arjunkumargiri  will do in another PR):
 - DDB: Initialize SeqNo to 0 for new documents, but increment on overwrite
 - DDB: Increment on successful update
 - DDB: Return -2 on delete
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
