### PR TITLE
[Feature/multi_tenancy] Simplify instantiating Data Object Request/Response builders

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/DeleteDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/DeleteDataObjectRequest.java
@@ -51,6 +51,14 @@ public class DeleteDataObjectRequest {
     public String tenantId() {
         return this.tenantId;
     }
+    
+    /**
+     * Instantiate a builder for this object
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
 
     /**
      * Class for constructing a Builder for this Request Object
@@ -63,7 +71,7 @@ public class DeleteDataObjectRequest {
         /**
          * Empty Constructor for the Builder object
          */
-        public Builder() {}
+        private Builder() {}
 
         /**
          * Add an index to this builder

--- a/common/src/main/java/org/opensearch/sdk/DeleteDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/DeleteDataObjectResponse.java
@@ -43,6 +43,14 @@ public class DeleteDataObjectResponse {
     }
     
     /**
+     * Instantiate a builder for this object
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
      * Class for constructing a Builder for this Response Object
      */
     public static class Builder {
@@ -52,7 +60,7 @@ public class DeleteDataObjectResponse {
         /**
          * Empty Constructor for the Builder object
          */
-        public Builder() {}
+        private Builder() {}
 
         /**
          * Add an id to this builder

--- a/common/src/main/java/org/opensearch/sdk/GetDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/GetDataObjectRequest.java
@@ -66,6 +66,14 @@ public class GetDataObjectRequest {
     }
 
     /**
+     * Instantiate a builder for this object
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
      * Class for constructing a Builder for this Request Object
      */
     public static class Builder {
@@ -77,7 +85,7 @@ public class GetDataObjectRequest {
         /**
          * Empty Constructor for the Builder object
          */
-        public Builder() {}
+        private Builder() {}
 
         /**
          * Add an index to this builder

--- a/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
@@ -57,6 +57,14 @@ public class GetDataObjectResponse {
     }
 
     /**
+     * Instantiate a builder for this object
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
      * Class for constructing a Builder for this Response Object
      */
     public static class Builder {
@@ -67,7 +75,7 @@ public class GetDataObjectResponse {
         /**
          * Empty Constructor for the Builder object
          */
-        public Builder() {}
+        private Builder() {}
 
         /**
          * Add an id to this builder

--- a/common/src/main/java/org/opensearch/sdk/PutDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/PutDataObjectRequest.java
@@ -64,6 +64,14 @@ public class PutDataObjectRequest {
     }
 
     /**
+     * Instantiate a builder for this object
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
      * Class for constructing a Builder for this Request Object
      */
     public static class Builder {
@@ -75,7 +83,7 @@ public class PutDataObjectRequest {
         /**
          * Empty Constructor for the Builder object
          */
-        public Builder() {}
+        private Builder() {}
 
         /**
          * Add an index to this builder

--- a/common/src/main/java/org/opensearch/sdk/PutDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/PutDataObjectResponse.java
@@ -43,6 +43,14 @@ public class PutDataObjectResponse {
     }
     
     /**
+     * Instantiate a builder for this object
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
      * Class for constructing a Builder for this Response Object
      */
     public static class Builder {
@@ -52,7 +60,7 @@ public class PutDataObjectResponse {
         /**
          * Empty Constructor for the Builder object
          */
-        public Builder() {}
+        private Builder() {}
 
         /**
          * Add an id to this builder

--- a/common/src/main/java/org/opensearch/sdk/SearchDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/SearchDataObjectRequest.java
@@ -56,6 +56,14 @@ public class SearchDataObjectRequest {
     }
 
     /**
+     * Instantiate a builder for this object
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
      * Class for constructing a Builder for this Request Object
      */
     public static class Builder {
@@ -66,7 +74,7 @@ public class SearchDataObjectRequest {
         /**
          * Empty Constructor for the Builder object
          */
-        public Builder() {}
+        private Builder() {}
 
         /**
          * Add a indices to this builder

--- a/common/src/main/java/org/opensearch/sdk/SearchDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/SearchDataObjectResponse.java
@@ -30,6 +30,14 @@ public class SearchDataObjectResponse {
     }
 
     /**
+     * Instantiate a builder for this object
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
      * Class for constructing a Builder for this Response Object
      */
     public static class Builder {
@@ -38,7 +46,7 @@ public class SearchDataObjectResponse {
         /**
          * Empty Constructor for the Builder object
          */
-        public Builder() {}
+        private Builder() {}
 
         /**
          * Add aparser to this builder

--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
@@ -70,6 +70,14 @@ public class UpdateDataObjectRequest {
     }
 
     /**
+     * Instantiate a builder for this object
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
      * Class for constructing a Builder for this Request Object
      */
     public static class Builder {
@@ -81,7 +89,7 @@ public class UpdateDataObjectRequest {
         /**
          * Empty Constructor for the Builder object
          */
-        public Builder() {}
+        private Builder() {}
 
         /**
          * Add an index to this builder

--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectResponse.java
@@ -43,6 +43,14 @@ public class UpdateDataObjectResponse {
     }
     
     /**
+     * Instantiate a builder for this object
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
      * Class for constructing a Builder for this Response Object
      */
     public static class Builder {
@@ -52,7 +60,7 @@ public class UpdateDataObjectResponse {
         /**
          * Empty Constructor for the Builder object
          */
-        public Builder() {}
+        private Builder() {}
 
         /**
          * Add an id to this builder

--- a/common/src/test/java/org/opensearch/sdk/DeleteDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/DeleteDataObjectRequestTests.java
@@ -27,7 +27,7 @@ public class DeleteDataObjectRequestTests {
 
     @Test
     public void testDeleteDataObjectRequest() {
-        DeleteDataObjectRequest request = new DeleteDataObjectRequest.Builder().index(testIndex).id(testId).tenantId(testTenantId).build();
+        DeleteDataObjectRequest request = DeleteDataObjectRequest.builder().index(testIndex).id(testId).tenantId(testTenantId).build();
 
         assertEquals(testIndex, request.index());
         assertEquals(testId, request.id());

--- a/common/src/test/java/org/opensearch/sdk/DeleteDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/DeleteDataObjectResponseTests.java
@@ -10,9 +10,6 @@ package org.opensearch.sdk;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.opensearch.action.support.replication.ReplicationResponse.ShardInfo;
-import org.opensearch.core.common.Strings;
-import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.XContentParser;
 
 import static org.junit.Assert.assertEquals;
@@ -31,7 +28,7 @@ public class DeleteDataObjectResponseTests {
 
     @Test
     public void testDeleteDataObjectResponse() {
-        DeleteDataObjectResponse response = new DeleteDataObjectResponse.Builder().id(testId).parser(testParser).build();
+        DeleteDataObjectResponse response = DeleteDataObjectResponse.builder().id(testId).parser(testParser).build();
 
         assertEquals(testId, response.id());
         assertEquals(testParser, response.parser());

--- a/common/src/test/java/org/opensearch/sdk/GetDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/GetDataObjectRequestTests.java
@@ -32,7 +32,7 @@ public class GetDataObjectRequestTests {
 
     @Test
     public void testGetDataObjectRequest() {
-        GetDataObjectRequest request = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest request = GetDataObjectRequest.builder()
             .index(testIndex)
             .id(testId)
             .tenantId(testTenantId)

--- a/common/src/test/java/org/opensearch/sdk/GetDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/GetDataObjectResponseTests.java
@@ -31,7 +31,7 @@ public class GetDataObjectResponseTests {
 
     @Test
     public void testGetDataObjectResponse() {
-        GetDataObjectResponse response = new GetDataObjectResponse.Builder().id(testId).parser(testParser).source(testSource).build();
+        GetDataObjectResponse response = GetDataObjectResponse.builder().id(testId).parser(testParser).source(testSource).build();
 
         assertEquals(testId, response.id());
         assertEquals(testParser, response.parser());

--- a/common/src/test/java/org/opensearch/sdk/PutDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/PutDataObjectRequestTests.java
@@ -30,7 +30,7 @@ public class PutDataObjectRequestTests {
 
     @Test
     public void testPutDataObjectRequest() {
-        PutDataObjectRequest request = new PutDataObjectRequest.Builder().index(testIndex).tenantId(testTenantId).dataObject(testDataObject).build();
+        PutDataObjectRequest request = PutDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).dataObject(testDataObject).build();
 
         assertEquals(testIndex, request.index());
         assertEquals(testTenantId, request.tenantId());

--- a/common/src/test/java/org/opensearch/sdk/PutDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/PutDataObjectResponseTests.java
@@ -28,7 +28,7 @@ public class PutDataObjectResponseTests {
 
     @Test
     public void testPutDataObjectResponse() {
-        PutDataObjectResponse response = new PutDataObjectResponse.Builder().id(testId).parser(testParser).build();
+        PutDataObjectResponse response = PutDataObjectResponse.builder().id(testId).parser(testParser).build();
 
         assertEquals(testId, response.id());
         assertEquals(testParser, response.parser());

--- a/common/src/test/java/org/opensearch/sdk/SearchDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SearchDataObjectRequestTests.java
@@ -30,7 +30,7 @@ public class SearchDataObjectRequestTests {
 
     @Test
     public void testGetDataObjectRequest() {
-        SearchDataObjectRequest request = new SearchDataObjectRequest.Builder()
+        SearchDataObjectRequest request = SearchDataObjectRequest.builder()
             .indices(testIndices)
             .tenantId(testTenantId)
             .searchSourceBuilder(testSearchSourceBuilder)

--- a/common/src/test/java/org/opensearch/sdk/SearchDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SearchDataObjectResponseTests.java
@@ -26,7 +26,7 @@ public class SearchDataObjectResponseTests {
 
     @Test
     public void testSearchDataObjectResponse() {
-        SearchDataObjectResponse response = new SearchDataObjectResponse.Builder().parser(testParser).build();
+        SearchDataObjectResponse response = SearchDataObjectResponse.builder().parser(testParser).build();
 
         assertEquals(testParser, response.parser());
     }

--- a/common/src/test/java/org/opensearch/sdk/UpdateDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/UpdateDataObjectRequestTests.java
@@ -40,7 +40,7 @@ public class UpdateDataObjectRequestTests {
 
     @Test
     public void testUpdateDataObjectRequest() {
-        UpdateDataObjectRequest request = new UpdateDataObjectRequest.Builder().index(testIndex).id(testId).tenantId(testTenantId).dataObject(testDataObject).build();
+        UpdateDataObjectRequest request = UpdateDataObjectRequest.builder().index(testIndex).id(testId).tenantId(testTenantId).dataObject(testDataObject).build();
 
         assertEquals(testIndex, request.index());
         assertEquals(testId, request.id());
@@ -50,7 +50,7 @@ public class UpdateDataObjectRequestTests {
 
     @Test
     public void testUpdateDataObjectMapRequest() {
-        UpdateDataObjectRequest request = new UpdateDataObjectRequest.Builder().index(testIndex).id(testId).tenantId(testTenantId).dataObject(testDataObjectMap).build();
+        UpdateDataObjectRequest request = UpdateDataObjectRequest.builder().index(testIndex).id(testId).tenantId(testTenantId).dataObject(testDataObjectMap).build();
 
         assertEquals(testIndex, request.index());
         assertEquals(testId, request.id());

--- a/common/src/test/java/org/opensearch/sdk/UpdateDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/UpdateDataObjectResponseTests.java
@@ -31,7 +31,7 @@ public class UpdateDataObjectResponseTests {
 
     @Test
     public void testUpdateDataObjectResponse() {
-        UpdateDataObjectResponse response = new UpdateDataObjectResponse.Builder().id(testId).parser(testParser).build();
+        UpdateDataObjectResponse response = UpdateDataObjectResponse.builder().id(testId).parser(testParser).build();
 
         assertEquals(testId, response.id());
         assertEquals(testParser, response.parser());

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/DeleteAgentTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/DeleteAgentTransportAction.java
@@ -83,7 +83,8 @@ public class DeleteAgentTransportAction extends HandledTransportAction<ActionReq
         boolean isSuperAdmin = isSuperAdminUserWrapper(clusterService, client);
 
         FetchSourceContext fetchSourceContext = new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
-        GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
             .index(ML_AGENT_INDEX)
             .id(agentId)
             .tenantId(tenantId)
@@ -131,7 +132,8 @@ public class DeleteAgentTransportAction extends HandledTransportAction<ActionReq
                                             try {
                                                 sdkClient
                                                     .deleteDataObjectAsync(
-                                                        new DeleteDataObjectRequest.Builder()
+                                                        DeleteDataObjectRequest
+                                                            .builder()
                                                             .index(deleteRequest.index())
                                                             .id(deleteRequest.id())
                                                             .tenantId(tenantId)

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/GetAgentTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/GetAgentTransportAction.java
@@ -83,7 +83,8 @@ public class GetAgentTransportAction extends HandledTransportAction<ActionReques
         boolean isSuperAdmin = isSuperAdminUserWrapper(clusterService, client);
 
         FetchSourceContext fetchSourceContext = new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
-        GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
             .index(ML_AGENT_INDEX)
             .id(agentId)
             .tenantId(tenantId)

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
@@ -86,7 +86,7 @@ public class TransportRegisterAgentAction extends HandledTransportAction<ActionR
 
                     sdkClient
                         .putDataObjectAsync(
-                            new PutDataObjectRequest.Builder().index(ML_AGENT_INDEX).dataObject(mlAgent).build(),
+                            PutDataObjectRequest.builder().index(ML_AGENT_INDEX).dataObject(mlAgent).build(),
                             client.threadPool().executor(GENERAL_THREAD_POOL)
                         )
                         .whenComplete((r, throwable) -> {

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
@@ -125,7 +125,8 @@ public class DeleteConnectorTransportAction extends HandledTransportAction<Actio
                 sourceBuilder.query(QueryBuilders.matchQuery(TENANT_ID, tenantId));
             }
 
-            SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+            SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+                .builder()
                 .indices(ML_MODEL_INDEX)
                 .searchSourceBuilder(sourceBuilder)
                 .build();
@@ -191,7 +192,7 @@ public class DeleteConnectorTransportAction extends HandledTransportAction<Actio
         try {
             sdkClient
                 .deleteDataObjectAsync(
-                    new DeleteDataObjectRequest.Builder().index(deleteRequest.index()).id(deleteRequest.id()).build(),
+                    DeleteDataObjectRequest.builder().index(deleteRequest.index()).id(deleteRequest.id()).build(),
                     client.threadPool().executor(GENERAL_THREAD_POOL)
                 )
                 .whenComplete((response, throwable) -> handleDeleteResponse(response, throwable, connectorId, actionListener));

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
@@ -72,7 +72,8 @@ public class GetConnectorTransportAction extends HandledTransportAction<ActionRe
             return;
         }
         FetchSourceContext fetchSourceContext = getFetchSourceContext(mlConnectorGetRequest.isReturnContent());
-        GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
             .index(ML_CONNECTOR_INDEX)
             .id(connectorId)
             .tenantId(tenantId)

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
@@ -103,7 +103,8 @@ public class SearchConnectorTransportAction extends HandledTransportAction<Searc
                 SearchSourceBuilder sourceBuilder = connectorAccessControlHelper.addUserBackendRolesFilter(user, request.source());
                 request.source(sourceBuilder);
             }
-            SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+            SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+                .builder()
                 .indices(request.indices())
                 .searchSourceBuilder(request.source())
                 .build();

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
@@ -144,7 +144,8 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
                 sdkClient
                     .putDataObjectAsync(
-                        new PutDataObjectRequest.Builder()
+                        PutDataObjectRequest
+                            .builder()
                             .tenantId(connector.getTenantId())
                             .index(ML_CONNECTOR_INDEX)
                             .dataObject(connector)

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
@@ -105,7 +105,8 @@ public class UpdateConnectorTransportAction extends HandledTransportAction<Actio
         }
         String connectorId = mlUpdateConnectorAction.getConnectorId();
         FetchSourceContext fetchSourceContext = new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
-        GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
             .index(ML_CONNECTOR_INDEX)
             .id(connectorId)
             .fetchSourceContext(fetchSourceContext)
@@ -125,7 +126,8 @@ public class UpdateConnectorTransportAction extends HandledTransportAction<Actio
                         if (Boolean.TRUE.equals(hasPermission)) {
                             connector.update(mlUpdateConnectorAction.getUpdateContent(), mlEngine::encrypt);
                             connector.validateConnectorURL(trustedConnectorEndpointsRegex);
-                            UpdateDataObjectRequest updateDataObjectRequest = new UpdateDataObjectRequest.Builder()
+                            UpdateDataObjectRequest updateDataObjectRequest = UpdateDataObjectRequest
+                                .builder()
                                 .index(ML_CONNECTOR_INDEX)
                                 .id(connectorId)
                                 .dataObject(connector)
@@ -162,7 +164,8 @@ public class UpdateConnectorTransportAction extends HandledTransportAction<Actio
         boolQueryBuilder.must(QueryBuilders.idsQuery().addIds(mlModelManager.getAllModelIds()));
         sourceBuilder.query(boolQueryBuilder);
 
-        SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+        SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+            .builder()
             .indices(ML_MODEL_INDEX)
             .searchSourceBuilder(sourceBuilder)
             .build();

--- a/plugin/src/main/java/org/opensearch/ml/action/handler/MLSearchHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/handler/MLSearchHandler.java
@@ -133,7 +133,8 @@ public class MLSearchHandler {
                 .wrap(wrappedListener::onResponse, e -> wrapListenerToHandleSearchIndexNotFound(e, wrappedListener));
             if (modelAccessControlHelper.skipModelAccessControl(user)
                 || !clusterService.state().metadata().hasIndex(CommonValue.ML_MODEL_GROUP_INDEX)) {
-                SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+                SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+                    .builder()
                     .indices(request.indices())
                     .searchSourceBuilder(request.source())
                     .build();
@@ -175,7 +176,8 @@ public class MLSearchHandler {
                         log.debug("No model group found");
                         request.source().query(rewriteQueryBuilder(request.source().query(), null));
                     }
-                    SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+                    SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+                        .builder()
                         .indices(request.indices())
                         .searchSourceBuilder(request.source())
                         .build();
@@ -199,7 +201,8 @@ public class MLSearchHandler {
                     log.error("Fail to search model groups!", e);
                     wrappedListener.onFailure(e);
                 });
-                SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+                SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+                    .builder()
                     .indices(modelGroupSearchRequest.indices())
                     .searchSourceBuilder(modelGroupSearchRequest.source())
                     .build();

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
@@ -106,7 +106,8 @@ public class DeleteModelGroupTransportAction extends HandledTransportAction<Acti
                     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(query);
                     SearchRequest searchRequest = new SearchRequest(ML_MODEL_INDEX).source(searchSourceBuilder);
 
-                    SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+                    SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+                        .builder()
                         .indices(ML_MODEL_INDEX)
                         .searchSourceBuilder(searchSourceBuilder)
                         .build();
@@ -157,7 +158,7 @@ public class DeleteModelGroupTransportAction extends HandledTransportAction<Acti
         try {
             sdkClient
                 .deleteDataObjectAsync(
-                    new DeleteDataObjectRequest.Builder().index(deleteRequest.index()).id(deleteRequest.id()).tenantId(tenantId).build(),
+                    DeleteDataObjectRequest.builder().index(deleteRequest.index()).id(deleteRequest.id()).tenantId(tenantId).build(),
                     client.threadPool().executor(GENERAL_THREAD_POOL)
                 )
                 .whenComplete((response, throwable) -> handleDeleteResponse(response, throwable, deleteRequest.id(), actionListener));

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/GetModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/GetModelGroupTransportAction.java
@@ -89,7 +89,8 @@ public class GetModelGroupTransportAction extends HandledTransportAction<ActionR
         }
 
         FetchSourceContext fetchSourceContext = new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
-        GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
             .index(ML_MODEL_GROUP_INDEX)
             .id(modelGroupId)
             .tenantId(tenantId)

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
@@ -77,7 +77,8 @@ public class SearchModelGroupTransportAction extends HandledTransportAction<Sear
                 modelAccessControlHelper.addUserBackendRolesFilter(user, request.source());
                 log.debug("Filtering result by " + user.getBackendRoles());
             }
-            SearchDataObjectRequest searchDataObjecRequest = new SearchDataObjectRequest.Builder()
+            SearchDataObjectRequest searchDataObjecRequest = SearchDataObjectRequest
+                .builder()
                 .indices(request.indices())
                 .searchSourceBuilder(request.source())
                 .build();

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupAction.java
@@ -108,7 +108,8 @@ public class TransportUpdateModelGroupAction extends HandledTransportAction<Acti
         }
         User user = RestActionUtils.getUserContext(client);
         FetchSourceContext fetchSourceContext = new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
-        GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
             .index(ML_MODEL_GROUP_INDEX)
             .id(modelGroupId)
             .tenantId(tenantId)

--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -114,7 +114,8 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
         }
         MLModelGetRequest mlModelGetRequest = new MLModelGetRequest(modelId, false, false, tenantId);
         FetchSourceContext fetchSourceContext = getFetchSourceContext(mlModelGetRequest.isReturnContent());
-        GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
             .index(ML_MODEL_INDEX)
             .id(modelId)
             .fetchSourceContext(fetchSourceContext)
@@ -263,7 +264,7 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
     }
 
     private void deleteModel(String modelId, Boolean isHidden, ActionListener<DeleteResponse> actionListener) {
-        DeleteDataObjectRequest deleteDataObjectRequest = new DeleteDataObjectRequest.Builder().index(ML_MODEL_INDEX).id(modelId).build();
+        DeleteDataObjectRequest deleteDataObjectRequest = DeleteDataObjectRequest.builder().index(ML_MODEL_INDEX).id(modelId).build();
         sdkClient
             .deleteDataObjectAsync(deleteDataObjectRequest, client.threadPool().executor(GENERAL_THREAD_POOL))
             .whenComplete((r, throwable) -> {
@@ -342,10 +343,7 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
      * @param modelId model ID
      */
     private void deleteController(String modelId, Boolean isHidden, ActionListener<Boolean> actionListener) {
-        DeleteDataObjectRequest deleteDataObjectRequest = new DeleteDataObjectRequest.Builder()
-            .index(ML_CONTROLLER_INDEX)
-            .id(modelId)
-            .build();
+        DeleteDataObjectRequest deleteDataObjectRequest = DeleteDataObjectRequest.builder().index(ML_CONTROLLER_INDEX).id(modelId).build();
         sdkClient
             .deleteDataObjectAsync(deleteDataObjectRequest, client.threadPool().executor(GENERAL_THREAD_POOL))
             .whenComplete((r, throwable) -> {

--- a/plugin/src/main/java/org/opensearch/ml/action/models/GetModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/GetModelTransportAction.java
@@ -99,7 +99,8 @@ public class GetModelTransportAction extends HandledTransportAction<ActionReques
             return;
         }
         FetchSourceContext fetchSourceContext = getFetchSourceContext(mlModelGetRequest.isReturnContent());
-        GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
             .index(ML_MODEL_INDEX)
             .id(modelId)
             .fetchSourceContext(fetchSourceContext)

--- a/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
@@ -424,7 +424,8 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         boolean isUpdateModelCache
     ) {
         updateModelInput.setLastUpdateTime(Instant.now());
-        UpdateDataObjectRequest updateDataObjectRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateDataObjectRequest = UpdateDataObjectRequest
+            .builder()
             .index(updateRequest.index())
             .id(updateRequest.id())
             .dataObject(updateModelInput)
@@ -476,7 +477,8 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
             newModelGroupResponse.getPrimaryTerm(),
             Integer.parseInt(updatedVersion)
         );
-        UpdateDataObjectRequest updateDataObjectRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateDataObjectRequest = UpdateDataObjectRequest
+            .builder()
             .index(updateRequest.index())
             .id(updateRequest.id())
             .dataObject(updateModelInput)
@@ -633,7 +635,7 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                 return builder.endObject();
             }
         };
-        return new UpdateDataObjectRequest.Builder().index(ML_MODEL_GROUP_INDEX).id(modelGroupId).dataObject(dataObject).build();
+        return UpdateDataObjectRequest.builder().index(ML_MODEL_GROUP_INDEX).id(modelGroupId).dataObject(dataObject).build();
     }
 
     private Boolean isModelDeployed(MLModelState mlModelState) {

--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/DeleteTaskTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/DeleteTaskTransportAction.java
@@ -81,7 +81,8 @@ public class DeleteTaskTransportAction extends HandledTransportAction<ActionRequ
             return;
         }
         FetchSourceContext fetchSourceContext = new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
-        GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
             .index(ML_TASK_INDEX)
             .id(taskId)
             .fetchSourceContext(fetchSourceContext)
@@ -124,7 +125,8 @@ public class DeleteTaskTransportAction extends HandledTransportAction<ActionRequ
                                         try {
                                             sdkClient
                                                 .deleteDataObjectAsync(
-                                                    new DeleteDataObjectRequest.Builder()
+                                                    DeleteDataObjectRequest
+                                                        .builder()
                                                         .index(deleteRequest.index())
                                                         .id(deleteRequest.id())
                                                         .build(),

--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
@@ -75,7 +75,8 @@ public class GetTaskTransportAction extends HandledTransportAction<ActionRequest
         }
 
         FetchSourceContext fetchSourceContext = new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
-        GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
             .index(ML_TASK_INDEX)
             .id(taskId)
             .fetchSourceContext(fetchSourceContext)

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
@@ -234,7 +234,8 @@ public class TransportUndeployModelsAction extends HandledTransportAction<Action
 
             SearchRequest searchRequest = new SearchRequest(ML_MODEL_INDEX).source(searchSourceBuilder);
 
-            SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+            SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+                .builder()
                 .indices(searchRequest.indices())
                 .searchSourceBuilder(searchRequest.source())
                 .build();

--- a/plugin/src/main/java/org/opensearch/ml/helper/ConnectorAccessControlHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/ConnectorAccessControlHelper.java
@@ -109,7 +109,8 @@ public class ConnectorAccessControlHelper {
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<Boolean> wrappedListener = ActionListener.runBefore(listener, context::restore);
             FetchSourceContext fetchSourceContext = getFetchSourceContext(true);
-            GetDataObjectRequest getDataObjectRequest = new GetDataObjectRequest.Builder()
+            GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+                .builder()
                 .index(ML_CONNECTOR_INDEX)
                 .id(connectorId)
                 .fetchSourceContext(fetchSourceContext)

--- a/plugin/src/main/java/org/opensearch/ml/helper/ModelAccessControlHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/ModelAccessControlHelper.java
@@ -164,7 +164,7 @@ public class ModelAccessControlHelper {
         }
 
         List<String> userBackendRoles = user.getBackendRoles();
-        GetDataObjectRequest getModelGroupRequest = new GetDataObjectRequest.Builder().index(ML_MODEL_GROUP_INDEX).id(modelGroupId).build();
+        GetDataObjectRequest getModelGroupRequest = GetDataObjectRequest.builder().index(ML_MODEL_GROUP_INDEX).id(modelGroupId).build();
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<Boolean> wrappedListener = ActionListener.runBefore(listener, () -> context.restore());
             sdkClient

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -130,7 +130,8 @@ public class MLModelGroupManager {
                         mlIndicesHandler.initModelGroupIndexIfAbsent(ActionListener.wrap(res -> {
                             sdkClient
                                 .putDataObjectAsync(
-                                    new PutDataObjectRequest.Builder()
+                                    PutDataObjectRequest
+                                        .builder()
                                         .tenantId(mlModelGroup.getTenantId())
                                         .index(ML_MODEL_GROUP_INDEX)
                                         .dataObject(mlModelGroup)
@@ -224,7 +225,8 @@ public class MLModelGroupManager {
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(query);
             SearchRequest searchRequest = new SearchRequest(ML_MODEL_GROUP_INDEX).source(searchSourceBuilder);
 
-            SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+            SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+                .builder()
                 .indices(searchRequest.indices())
                 .searchSourceBuilder(searchRequest.source())
                 .build();
@@ -267,7 +269,7 @@ public class MLModelGroupManager {
      * @param listener action listener
      */
     public void getModelGroupResponse(SdkClient sdkClient, String modelGroupId, ActionListener<GetResponse> listener) {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(ML_MODEL_GROUP_INDEX).id(modelGroupId).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(ML_MODEL_GROUP_INDEX).id(modelGroupId).build();
         sdkClient.getDataObjectAsync(getRequest, client.threadPool().executor(GENERAL_THREAD_POOL)).whenComplete((r, throwable) -> {
             if (throwable == null) {
                 try {

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -367,10 +367,7 @@ public class MLModelManager {
             mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
 
             String modelGroupId = mlRegisterModelInput.getModelGroupId();
-            GetDataObjectRequest getModelGroupRequest = new GetDataObjectRequest.Builder()
-                .index(ML_MODEL_GROUP_INDEX)
-                .id(modelGroupId)
-                .build();
+            GetDataObjectRequest getModelGroupRequest = GetDataObjectRequest.builder().index(ML_MODEL_GROUP_INDEX).id(modelGroupId).build();
             sdkClient
                 .getDataObjectAsync(getModelGroupRequest, client.threadPool().executor(GENERAL_THREAD_POOL))
                 .whenComplete((r, throwable) -> {
@@ -391,7 +388,8 @@ public class MLModelManager {
                                 */
                                 modelGroupSourceMap.put(MLModelGroup.LATEST_VERSION_FIELD, updatedVersion);
                                 modelGroupSourceMap.put(MLModelGroup.LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli());
-                                UpdateDataObjectRequest updateDataObjectRequest = new UpdateDataObjectRequest.Builder()
+                                UpdateDataObjectRequest updateDataObjectRequest = UpdateDataObjectRequest
+                                    .builder()
                                     .index(ML_MODEL_GROUP_INDEX)
                                     .id(modelGroupId)
                                     // TODO need to track these for concurrency
@@ -584,7 +582,8 @@ public class MLModelManager {
                     .tenantId(registerModelInput.getTenantId())
                     .build();
 
-                PutDataObjectRequest putModelMetaRequest = new PutDataObjectRequest.Builder()
+                PutDataObjectRequest putModelMetaRequest = PutDataObjectRequest
+                    .builder()
                     .index(ML_MODEL_INDEX)
                     .id(Boolean.TRUE.equals(registerModelInput.getIsHidden()) ? modelName : null)
                     .dataObject(mlModelMeta)
@@ -1647,7 +1646,8 @@ public class MLModelManager {
      * @param listener action listener
      */
     public void getModel(SdkClient sdkClient, String modelId, String[] includes, String[] excludes, ActionListener<MLModel> listener) {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder()
+        GetDataObjectRequest getRequest = GetDataObjectRequest
+            .builder()
             .index(ML_MODEL_INDEX)
             .id(modelId)
             .fetchSourceContext(new FetchSourceContext(true, includes, excludes))

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -116,7 +116,7 @@ public class DDBOpenSearchClient implements SdkClient {
                     source,
                     Map.of("result", "created")
                 );
-                return new PutDataObjectResponse.Builder().id(id).parser(createParser(simulatedIndexResponse)).build();
+                return PutDataObjectResponse.builder().id(id).parser(createParser(simulatedIndexResponse)).build();
             } catch (IOException e) {
                 // Rethrow unchecked exception on XContent parsing error
                 throw new OpenSearchStatusException("Failed to parse data object  " + request.id(), RestStatus.BAD_REQUEST);
@@ -165,7 +165,7 @@ public class DDBOpenSearchClient implements SdkClient {
                             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, simulatedGetResponse)
                     )
                     .getSourceAsMap();
-                return new GetDataObjectResponse.Builder().id(request.id()).parser(parser).source(sourceAsMap).build();
+                return GetDataObjectResponse.builder().id(request.id()).parser(parser).source(sourceAsMap).build();
             } catch (IOException e) {
                 // Rethrow unchecked exception on XContent parsing error
                 throw new OpenSearchStatusException("Failed to parse response", RestStatus.INTERNAL_SERVER_ERROR);
@@ -195,7 +195,7 @@ public class DDBOpenSearchClient implements SdkClient {
                 dynamoDbClient.updateItem(updateItemRequest);
 
                 String simulatedUpdateResponse = simulateOpenSearchResponse(request.index(), request.id(), source, Map.of("found", true));
-                return new UpdateDataObjectResponse.Builder().id(request.id()).parser(createParser(simulatedUpdateResponse)).build();
+                return UpdateDataObjectResponse.builder().id(request.id()).parser(createParser(simulatedUpdateResponse)).build();
             } catch (IOException e) {
                 log.error("Error updating {} in {}: {}", request.id(), request.index(), e.getMessage(), e);
                 // Rethrow unchecked exception on update IOException
@@ -234,7 +234,7 @@ public class DDBOpenSearchClient implements SdkClient {
                     null,
                     Map.of("result", "deleted")
                 );
-                return new DeleteDataObjectResponse.Builder().id(request.id()).parser(createParser(simulatedDeleteResponse)).build();
+                return DeleteDataObjectResponse.builder().id(request.id()).parser(createParser(simulatedDeleteResponse)).build();
             } catch (IOException e) {
                 // Rethrow unchecked exception on XContent parsing error
                 throw new OpenSearchStatusException("Failed to parse response", RestStatus.INTERNAL_SERVER_ERROR);

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClient.java
@@ -87,7 +87,7 @@ public class LocalClusterIndicesClient implements SdkClient {
                     )
                     .actionGet();
                 log.info("Creation status for id {}: {}", indexResponse.getId(), indexResponse.getResult());
-                return new PutDataObjectResponse.Builder().id(indexResponse.getId()).parser(createParser(indexResponse)).build();
+                return PutDataObjectResponse.builder().id(indexResponse.getId()).parser(createParser(indexResponse)).build();
             } catch (IOException e) {
                 // Rethrow unchecked exception on XContent parsing error
                 throw new OpenSearchStatusException(
@@ -108,10 +108,11 @@ public class LocalClusterIndicesClient implements SdkClient {
                     .actionGet();
                 if (getResponse == null) {
                     log.info("Null GetResponse");
-                    return new GetDataObjectResponse.Builder().id(request.id()).parser(null).build();
+                    return GetDataObjectResponse.builder().id(request.id()).parser(null).build();
                 }
                 log.info("Retrieved data object");
-                return new GetDataObjectResponse.Builder()
+                return GetDataObjectResponse
+                    .builder()
                     .id(getResponse.getId())
                     .parser(createParser(getResponse))
                     .source(getResponse.getSource())
@@ -138,10 +139,10 @@ public class LocalClusterIndicesClient implements SdkClient {
                     .actionGet();
                 if (updateResponse == null) {
                     log.info("Null UpdateResponse");
-                    return new UpdateDataObjectResponse.Builder().id(request.id()).parser(null).build();
+                    return UpdateDataObjectResponse.builder().id(request.id()).parser(null).build();
                 }
                 log.info("Update status for id {}: {}", updateResponse.getId(), updateResponse.getResult());
-                return new UpdateDataObjectResponse.Builder().id(updateResponse.getId()).parser(createParser(updateResponse)).build();
+                return UpdateDataObjectResponse.builder().id(updateResponse.getId()).parser(createParser(updateResponse)).build();
             } catch (IOException e) {
                 // Rethrow unchecked exception on XContent parsing error
                 throw new OpenSearchStatusException(
@@ -159,7 +160,7 @@ public class LocalClusterIndicesClient implements SdkClient {
                 log.info("Deleting {} from {}", request.id(), request.index());
                 DeleteResponse deleteResponse = client.delete(new DeleteRequest(request.index(), request.id())).actionGet();
                 log.info("Deletion status for id {}: {}", deleteResponse.getId(), deleteResponse.getResult());
-                return new DeleteDataObjectResponse.Builder().id(deleteResponse.getId()).parser(createParser(deleteResponse)).build();
+                return DeleteDataObjectResponse.builder().id(deleteResponse.getId()).parser(createParser(deleteResponse)).build();
             } catch (IOException e) {
                 // Rethrow unchecked exception on XContent parsing error
                 throw new OpenSearchStatusException(
@@ -177,7 +178,7 @@ public class LocalClusterIndicesClient implements SdkClient {
             SearchResponse searchResponse = client.search(new SearchRequest(request.indices(), request.searchSourceBuilder())).actionGet();
             log.info("Search returned {} hits", searchResponse.getHits().getTotalHits());
             try {
-                return new SearchDataObjectResponse.Builder().parser(createParser(searchResponse)).build();
+                return SearchDataObjectResponse.builder().parser(createParser(searchResponse)).build();
             } catch (IOException e) {
                 // Rethrow unchecked exception on XContent parsing error
                 throw new OpenSearchStatusException(

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
@@ -89,7 +89,7 @@ public class RemoteClusterIndicesClient implements SdkClient {
                 log.info("Indexing data object in {}", request.index());
                 IndexResponse indexResponse = openSearchClient.index(indexRequest);
                 log.info("Creation status for id {}: {}", indexResponse.id(), indexResponse.result());
-                return new PutDataObjectResponse.Builder().id(indexResponse.id()).parser(createParser(indexResponse)).build();
+                return PutDataObjectResponse.builder().id(indexResponse.id()).parser(createParser(indexResponse)).build();
             } catch (IOException e) {
                 log.error("Error putting data object in {}: {}", request.index(), e.getMessage(), e);
                 // Rethrow unchecked exception on XContent parsing error
@@ -110,7 +110,7 @@ public class RemoteClusterIndicesClient implements SdkClient {
                 GetResponse<Map<String, Object>> getResponse = openSearchClient.get(getRequest, MAP_DOCTYPE);
                 log.info("Get found status for id {}: {}", getResponse.id(), getResponse.found());
                 Map<String, Object> source = getResponse.source();
-                return new GetDataObjectResponse.Builder().id(getResponse.id()).parser(createParser(getResponse)).source(source).build();
+                return GetDataObjectResponse.builder().id(getResponse.id()).parser(createParser(getResponse)).source(source).build();
             } catch (IOException e) {
                 log.error("Error getting data object {} from {}: {}", request.id(), request.index(), e.getMessage(), e);
                 // Rethrow unchecked exception on XContent parser creation error
@@ -138,7 +138,7 @@ public class RemoteClusterIndicesClient implements SdkClient {
                 log.info("Updating {} in {}", request.id(), request.index());
                 UpdateResponse<Map<String, Object>> updateResponse = openSearchClient.update(updateRequest, MAP_DOCTYPE);
                 log.info("Update status for id {}: {}", updateResponse.id(), updateResponse.result());
-                return new UpdateDataObjectResponse.Builder().id(updateResponse.id()).parser(createParser(updateResponse)).build();
+                return UpdateDataObjectResponse.builder().id(updateResponse.id()).parser(createParser(updateResponse)).build();
             } catch (IOException e) {
                 log.error("Error updating {} in {}: {}", request.id(), request.index(), e.getMessage(), e);
                 // Rethrow unchecked exception on update IOException
@@ -158,7 +158,7 @@ public class RemoteClusterIndicesClient implements SdkClient {
                 log.info("Deleting {} from {}", request.id(), request.index());
                 DeleteResponse deleteResponse = openSearchClient.delete(deleteRequest);
                 log.info("Deletion status for id {}: {}", deleteResponse.id(), deleteResponse.result());
-                return new DeleteDataObjectResponse.Builder().id(deleteResponse.id()).parser(createParser(deleteResponse)).build();
+                return DeleteDataObjectResponse.builder().id(deleteResponse.id()).parser(createParser(deleteResponse)).build();
             } catch (IOException e) {
                 log.error("Error deleting {} from {}: {}", request.id(), request.index(), e.getMessage(), e);
                 // Rethrow unchecked exception on deletion IOException
@@ -180,7 +180,7 @@ public class RemoteClusterIndicesClient implements SdkClient {
                 searchRequest = searchRequest.toBuilder().index(Arrays.asList(request.indices())).build();
                 SearchResponse<?> searchResponse = openSearchClient.search(searchRequest, MAP_DOCTYPE);
                 log.info("Search returned {} hits", searchResponse.hits().total().value());
-                return new SearchDataObjectResponse.Builder().parser(createParser(searchResponse)).build();
+                return SearchDataObjectResponse.builder().parser(createParser(searchResponse)).build();
             } catch (IOException e) {
                 log.error("Error searching {}: {}", Arrays.toString(request.indices()), e.getMessage(), e);
                 // Rethrow unchecked exception on exception

--- a/plugin/src/test/java/org/opensearch/ml/helper/ConnectorAccessControlHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/ConnectorAccessControlHelperTests.java
@@ -439,10 +439,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
 
     @Test
     public void testGetConnectorHappyCase() throws IOException, InterruptedException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder()
-            .index(CommonValue.ML_CONNECTOR_INDEX)
-            .id("connectorId")
-            .build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(CommonValue.ML_CONNECTOR_INDEX).id("connectorId").build();
         GetResponse getResponse = prepareConnector();
 
         PlainActionFuture<GetResponse> future = PlainActionFuture.newFuture();
@@ -469,10 +466,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
 
     @Test
     public void testGetConnectorException() throws IOException, InterruptedException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder()
-            .index(CommonValue.ML_CONNECTOR_INDEX)
-            .id("connectorId")
-            .build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(CommonValue.ML_CONNECTOR_INDEX).id("connectorId").build();
 
         PlainActionFuture<GetResponse> future = PlainActionFuture.newFuture();
         future.onFailure(new RuntimeException("Failed to get connector"));
@@ -498,10 +492,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
 
     @Test
     public void testGetConnectorIndexNotFound() throws IOException, InterruptedException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder()
-            .index(CommonValue.ML_CONNECTOR_INDEX)
-            .id("connectorId")
-            .build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(CommonValue.ML_CONNECTOR_INDEX).id("connectorId").build();
 
         PlainActionFuture<GetResponse> future = PlainActionFuture.newFuture();
         future.onFailure(new IndexNotFoundException("Index not found"));

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -125,7 +125,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testPutDataObject_HappyCase() throws IOException {
-        PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder()
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
             .tenantId(TENANT_ID)
@@ -160,7 +161,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
             .testList(Arrays.asList("123", "hello", null))
             .testObject(testDataObject)
             .build();
-        PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder()
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
             .tenantId(TENANT_ID)
@@ -184,11 +186,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testPutDataObject_NullTenantId_SetsDefaultTenantId() throws IOException {
-        PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder()
-            .index(TEST_INDEX)
-            .id(TEST_ID)
-            .dataObject(testDataObject)
-            .build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).dataObject(testDataObject).build();
         Mockito.when(dynamoDbClient.putItem(Mockito.any(PutItemRequest.class))).thenReturn(PutItemResponse.builder().build());
         sdkClient.putDataObjectAsync(putRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
         Mockito.verify(dynamoDbClient).putItem(putItemRequestArgumentCaptor.capture());
@@ -199,7 +197,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testPutDataObject_NullId_SetsDefaultTenantId() throws IOException {
-        PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
         Mockito.when(dynamoDbClient.putItem(Mockito.any(PutItemRequest.class))).thenReturn(PutItemResponse.builder().build());
         PutDataObjectResponse response = sdkClient
             .putDataObjectAsync(putRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
@@ -214,11 +212,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testPutDataObject_DDBException_ThrowsException() {
-        PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder()
-            .index(TEST_INDEX)
-            .id(TEST_ID)
-            .dataObject(testDataObject)
-            .build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).dataObject(testDataObject).build();
         Mockito.when(dynamoDbClient.putItem(Mockito.any(PutItemRequest.class))).thenThrow(new RuntimeException("Test exception"));
         CompletableFuture<PutDataObjectResponse> future = sdkClient
             .putDataObjectAsync(putRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
@@ -230,7 +224,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testGetDataObject_HappyCase() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).tenantId(TENANT_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TENANT_ID).build();
         GetItemResponse getItemResponse = GetItemResponse
             .builder()
             .item(Map.ofEntries(Map.entry("data", AttributeValue.builder().s("foo").build())))
@@ -261,7 +255,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testGetDataObject_ComplexDataObject() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).tenantId(TENANT_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TENANT_ID).build();
         GetItemResponse getItemResponse = GetItemResponse
             .builder()
             .item(
@@ -305,7 +299,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testGetDataObject_NoExistingDoc() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).tenantId(TENANT_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TENANT_ID).build();
         GetItemResponse getItemResponse = GetItemResponse.builder().build();
         Mockito.when(dynamoDbClient.getItem(Mockito.any(GetItemRequest.class))).thenReturn(getItemResponse);
         GetDataObjectResponse response = sdkClient
@@ -319,7 +313,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testGetDataObject_UseDefaultTenantIdIfNull() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
         GetItemResponse getItemResponse = GetItemResponse.builder().build();
         Mockito.when(dynamoDbClient.getItem(Mockito.any(GetItemRequest.class))).thenReturn(getItemResponse);
         sdkClient.getDataObjectAsync(getRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
@@ -330,7 +324,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testGetDataObject_DDBException_ThrowsOSException() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).tenantId(TENANT_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TENANT_ID).build();
         Mockito.when(dynamoDbClient.getItem(Mockito.any(GetItemRequest.class))).thenThrow(new RuntimeException("Test exception"));
         CompletableFuture<GetDataObjectResponse> future = sdkClient
             .getDataObjectAsync(getRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
@@ -341,11 +335,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testDeleteDataObject_HappyCase() throws IOException {
-        DeleteDataObjectRequest deleteRequest = new DeleteDataObjectRequest.Builder()
-            .id(TEST_ID)
-            .index(TEST_INDEX)
-            .tenantId(TENANT_ID)
-            .build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID).index(TEST_INDEX).tenantId(TENANT_ID).build();
         Mockito.when(dynamoDbClient.deleteItem(deleteItemRequestArgumentCaptor.capture())).thenReturn(DeleteItemResponse.builder().build());
         DeleteDataObjectResponse deleteResponse = sdkClient
             .deleteDataObjectAsync(deleteRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
@@ -367,7 +357,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testDeleteDataObject_NullTenantId_UsesDefaultTenantId() {
-        DeleteDataObjectRequest deleteRequest = new DeleteDataObjectRequest.Builder().id(TEST_ID).index(TEST_INDEX).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID).index(TEST_INDEX).build();
         Mockito.when(dynamoDbClient.deleteItem(deleteItemRequestArgumentCaptor.capture())).thenReturn(DeleteItemResponse.builder().build());
         sdkClient.deleteDataObjectAsync(deleteRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
         DeleteItemRequest deleteItemRequest = deleteItemRequestArgumentCaptor.getValue();
@@ -376,7 +366,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void updateDataObjectAsync_HappyCase() {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .id(TEST_ID)
             .index(TEST_INDEX)
             .tenantId(TENANT_ID)
@@ -399,7 +390,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void updateDataObjectAsync_HappyCaseWithMap() {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .id(TEST_ID)
             .index(TEST_INDEX)
             .tenantId(TENANT_ID)
@@ -422,7 +414,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void updateDataObjectAsync_NullTenantId_UsesDefaultTenantId() {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .id(TEST_ID)
             .index(TEST_INDEX)
             .tenantId(TENANT_ID)
@@ -437,7 +430,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
     @Test
     public void searchDataObjectAsync_HappyCase() {
         SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.searchSource();
-        SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+        SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+            .builder()
             .indices(TEST_INDEX, TEST_INDEX_2)
             .tenantId(TENANT_ID)
             .searchSourceBuilder(searchSourceBuilder)
@@ -457,7 +451,8 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
     @Test
     public void searchDataObjectAsync_SystemIndex() {
         SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.searchSource();
-        SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest.Builder()
+        SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+            .builder()
             .indices(TEST_SYSTEM_INDEX)
             .tenantId(TENANT_ID)
             .searchSourceBuilder(searchSourceBuilder)

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClientTests.java
@@ -120,7 +120,7 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testPutDataObject() throws IOException {
-        PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
 
         IndexResponse indexResponse = new IndexResponse(new ShardId(TEST_INDEX, "_na_", 0), TEST_ID, 1, 0, 2, true);
         @SuppressWarnings("unchecked")
@@ -144,7 +144,7 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testPutDataObject_Exception() throws IOException {
-        PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
 
         when(mockedClient.index(any(IndexRequest.class))).thenThrow(new UnsupportedOperationException("test"));
 
@@ -165,7 +165,7 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
                 throw new IOException("test");
             }
         };
-        PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder().index(TEST_INDEX).dataObject(badDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(badDataObject).build();
 
         CompletableFuture<PutDataObjectResponse> future = sdkClient
             .putDataObjectAsync(putRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
@@ -178,7 +178,7 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testGetDataObject() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
 
         String json = testDataObject.toJson();
         GetResponse getResponse = new GetResponse(new GetResult(TEST_INDEX, TEST_ID, -2, 0, 1, true, new BytesArray(json), null, null));
@@ -210,7 +210,7 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testGetDataObject_NullResponse() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
 
         @SuppressWarnings("unchecked")
         ActionFuture<GetResponse> future = mock(ActionFuture.class);
@@ -231,7 +231,7 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testGetDataObject_NotFound() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
         GetResponse getResponse = new GetResponse(new GetResult(TEST_INDEX, TEST_ID, -2, 0, 1, false, null, null, null));
 
         @SuppressWarnings("unchecked")
@@ -253,7 +253,7 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testGetDataObject_Exception() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
 
         ArgumentCaptor<GetRequest> getRequestCaptor = ArgumentCaptor.forClass(GetRequest.class);
         when(mockedClient.get(getRequestCaptor.capture())).thenThrow(new UnsupportedOperationException("test"));
@@ -269,7 +269,8 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testUpdateDataObject() throws IOException {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
             .dataObject(testDataObject)
@@ -309,7 +310,8 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testUpdateDataObjectWithMap() throws IOException {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
             .dataObject(Map.of("foo", "bar"))
@@ -340,7 +342,8 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testUpdateDataObject_NotFound() throws IOException {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
             .dataObject(testDataObject)
@@ -380,7 +383,8 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testUpdateDataObject_Null() throws IOException {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
             .dataObject(testDataObject)
@@ -404,7 +408,8 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testUpdateDataObject_Exception() throws IOException {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
             .dataObject(testDataObject)
@@ -424,7 +429,7 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testDeleteDataObject() throws IOException {
-        DeleteDataObjectRequest deleteRequest = new DeleteDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
 
         DeleteResponse deleteResponse = new DeleteResponse(new ShardId(TEST_INDEX, "_na_", 0), TEST_ID, 1, 0, 2, true);
         PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
@@ -447,7 +452,7 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testDeleteDataObject_Exception() throws IOException {
-        DeleteDataObjectRequest deleteRequest = new DeleteDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
 
         ArgumentCaptor<DeleteRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
         when(mockedClient.delete(deleteRequestCaptor.capture())).thenThrow(new UnsupportedOperationException("test"));
@@ -464,7 +469,8 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
 
     public void testSearchDataObject() throws IOException {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        SearchDataObjectRequest searchRequest = new SearchDataObjectRequest.Builder()
+        SearchDataObjectRequest searchRequest = SearchDataObjectRequest
+            .builder()
             .indices(TEST_INDEX)
             .searchSourceBuilder(searchSourceBuilder)
             .build();
@@ -508,7 +514,8 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
 
     public void testSearchDataObject_Exception() throws IOException {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        SearchDataObjectRequest searchRequest = new SearchDataObjectRequest.Builder()
+        SearchDataObjectRequest searchRequest = SearchDataObjectRequest
+            .builder()
             .indices(TEST_INDEX)
             .searchSourceBuilder(searchSourceBuilder)
             .build();

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
@@ -126,7 +126,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testPutDataObject() throws IOException {
-        PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
 
         IndexResponse indexResponse = new IndexResponse.Builder()
             .id(TEST_ID)
@@ -159,7 +159,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testPutDataObject_Updated() throws IOException {
-        PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
 
         IndexResponse indexResponse = new IndexResponse.Builder()
             .id(TEST_ID)
@@ -192,7 +192,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testPutDataObject_Exception() throws IOException {
-        PutDataObjectRequest putRequest = new PutDataObjectRequest.Builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
 
         ArgumentCaptor<IndexRequest<?>> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
         when(mockedOpenSearchClient.index(indexRequestCaptor.capture())).thenThrow(new IOException("test"));
@@ -207,7 +207,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void testGetDataObject() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
 
         GetResponse<?> getResponse = new GetResponse.Builder<>()
             .index(TEST_INDEX)
@@ -242,7 +242,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void testGetDataObject_NotFound() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
 
         GetResponse<?> getResponse = new GetResponse.Builder<>().index(TEST_INDEX).id(TEST_ID).found(false).build();
 
@@ -263,7 +263,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void testGetDataObject_Exception() throws IOException {
-        GetDataObjectRequest getRequest = new GetDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
 
         ArgumentCaptor<GetRequest> getRequestCaptor = ArgumentCaptor.forClass(GetRequest.class);
         ArgumentCaptor<Class<Map>> mapClassCaptor = ArgumentCaptor.forClass(Class.class);
@@ -278,7 +278,8 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testUpdateDataObject() throws IOException {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
             .dataObject(testDataObject)
@@ -316,7 +317,8 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testUpdateDataObjectWithMap() throws IOException {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
             .dataObject(Map.of("foo", "bar"))
@@ -344,7 +346,8 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testUpdateDataObject_NotFound() throws IOException {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
             .dataObject(testDataObject)
@@ -382,7 +385,8 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testtUpdateDataObject_Exception() throws IOException {
-        UpdateDataObjectRequest updateRequest = new UpdateDataObjectRequest.Builder()
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
             .dataObject(testDataObject)
@@ -400,7 +404,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testDeleteDataObject() throws IOException {
-        DeleteDataObjectRequest deleteRequest = new DeleteDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
 
         DeleteResponse deleteResponse = new DeleteResponse.Builder()
             .id(TEST_ID)
@@ -433,7 +437,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testDeleteDataObject_NotFound() throws IOException {
-        DeleteDataObjectRequest deleteRequest = new DeleteDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
 
         DeleteResponse deleteResponse = new DeleteResponse.Builder()
             .id(TEST_ID)
@@ -463,7 +467,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testDeleteDataObject_Exception() throws IOException {
-        DeleteDataObjectRequest deleteRequest = new DeleteDataObjectRequest.Builder().index(TEST_INDEX).id(TEST_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
 
         ArgumentCaptor<DeleteRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
         when(mockedOpenSearchClient.delete(deleteRequestCaptor.capture())).thenThrow(new IOException("test"));
@@ -479,7 +483,8 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void testSearchDataObject() throws IOException {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        SearchDataObjectRequest searchRequest = new SearchDataObjectRequest.Builder()
+        SearchDataObjectRequest searchRequest = SearchDataObjectRequest
+            .builder()
             .indices(TEST_INDEX)
             .searchSourceBuilder(searchSourceBuilder)
             .build();
@@ -515,7 +520,8 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
     public void testSearchDataObject_Exception() throws IOException {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        SearchDataObjectRequest searchRequest = new SearchDataObjectRequest.Builder()
+        SearchDataObjectRequest searchRequest = SearchDataObjectRequest
+            .builder()
             .indices(TEST_INDEX)
             .searchSourceBuilder(searchSourceBuilder)
             .build();


### PR DESCRIPTION
### Description

Simplifies the syntax for creating builders, aligning with more common OpenSearch pattern.

Changes made via global regex search/replace.

Note: small overlap with #2605. Whichever one gets merged first let me rebase the other.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
