### PR TITLE
Fix checkout action failure

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -38,6 +38,10 @@ jobs:
       # need to switch to root so that github actions can install runner binary on container without permission issues.
       options: --user root
 
+    # Allow using Node16 actions
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1
@@ -189,6 +193,10 @@ jobs:
     if: github.repository == 'opensearch-project/ml-commons'
     environment: ml-commons-cicd-env
     runs-on: windows-latest
+
+    # Allow using Node16 actions
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       - name: Setup Java ${{ matrix.java }}


### PR DESCRIPTION
### Description
CI is failing with 
```
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```
Added `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` variable to use Node16

PR in SQL repo where this was also addressed: https://github.com/opensearch-project/sql/pull/2807
 
### Issues Resolved
https://github.com/actions/checkout/issues/1809
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).