### PR TITLE
Temp use of older nodejs version before moving to Almalinux8

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -24,6 +24,8 @@ jobs:
     strategy:
       matrix:
         java: [21]
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     name: Build and Test MLCommons Plugin on linux
     if: github.repository == 'opensearch-project/ml-commons'


### PR DESCRIPTION
### Description
As we are using the AL2 image for OS plugin for linux now.
We need to fall back with older nodejs versions until AL2 deprecation next year.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
