### PR TITLE
[Backport 2.x] Temp use of older nodejs version before moving to Almalinux8

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -24,6 +24,8 @@ jobs:
     strategy:
       matrix:
         java: [11, 17, 21]
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     name: Build and Test MLCommons Plugin on linux
     if: github.repository == 'opensearch-project/ml-commons'


### PR DESCRIPTION


### Description
[Backport 2.x] Temp use of older nodejs version before moving to Almalinux8
 
### Issues Resolved
Backport https://github.com/opensearch-project/ml-commons/pull/2627
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
