### PR TITLE
Add application_type into get ConversationMeta API response

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -537,4 +537,5 @@ public class CommonValue {
         public static final Version VERSION_2_12_0 = Version.fromString("2.12.0");
         public static final Version VERSION_2_13_0 = Version.fromString("2.13.0");
         public static final Version VERSION_2_14_0 = Version.fromString("2.14.0");
+        public static final Version VERSION_2_16_0 = Version.fromString("2.16.0");
 }

--- a/common/src/main/java/org/opensearch/ml/common/conversation/ConversationMeta.java
+++ b/common/src/main/java/org/opensearch/ml/common/conversation/ConversationMeta.java
@@ -22,7 +22,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 
-import org.opensearch.action.index.IndexRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -49,6 +48,8 @@ public class ConversationMeta implements Writeable, ToXContentObject {
     private String name;
     @Getter
     private String user;
+    @Getter
+    private String applicationType;
 
     /**
      * Creates a conversationMeta object from a SearchHit object
@@ -71,7 +72,8 @@ public class ConversationMeta implements Writeable, ToXContentObject {
         Instant updated = Instant.parse((String) docFields.get(ConversationalIndexConstants.META_UPDATED_TIME_FIELD));
         String name = (String) docFields.get(ConversationalIndexConstants.META_NAME_FIELD);
         String user = (String) docFields.get(ConversationalIndexConstants.USER_FIELD);
-        return new ConversationMeta(id, created, updated, name, user);
+        String applicationType = (String) docFields.get(ConversationalIndexConstants.APPLICATION_TYPE_FIELD);
+        return new ConversationMeta(id, created, updated, name, user, applicationType);
     }
 
     /**
@@ -87,7 +89,8 @@ public class ConversationMeta implements Writeable, ToXContentObject {
         Instant updated = in.readInstant();
         String name = in.readString();
         String user = in.readOptionalString();
-        return new ConversationMeta(id, created, updated, name, user);
+        String applicationType = in.readOptionalString();
+        return new ConversationMeta(id, created, updated, name, user, applicationType);
     }
 
     @Override
@@ -97,6 +100,7 @@ public class ConversationMeta implements Writeable, ToXContentObject {
         out.writeInstant(updatedTime);
         out.writeString(name);
         out.writeOptionalString(user);
+        out.writeOptionalString(applicationType);
     }
 
     @Override
@@ -106,6 +110,7 @@ public class ConversationMeta implements Writeable, ToXContentObject {
             + ", created=" + createdTime.toString()
             + ", updated=" + updatedTime.toString()
             + ", user=" + user
+            + ", applicationType=" + applicationType
             + "}";
     }
 
@@ -116,8 +121,11 @@ public class ConversationMeta implements Writeable, ToXContentObject {
         builder.field(ConversationalIndexConstants.META_CREATED_TIME_FIELD, this.createdTime);
         builder.field(ConversationalIndexConstants.META_UPDATED_TIME_FIELD, this.updatedTime);
         builder.field(ConversationalIndexConstants.META_NAME_FIELD, this.name);
-        if(this.user != null) {
+        if (this.user != null) {
             builder.field(ConversationalIndexConstants.USER_FIELD, this.user);
+        }
+        if (this.applicationType != null) {
+            builder.field(ConversationalIndexConstants.APPLICATION_TYPE_FIELD, this.applicationType);
         }
         builder.endObject();
         return builder;
@@ -131,6 +139,7 @@ public class ConversationMeta implements Writeable, ToXContentObject {
         ConversationMeta otherConversation = (ConversationMeta) other;
         return Objects.equals(this.id, otherConversation.id) &&
             Objects.equals(this.user, otherConversation.user) &&
+            Objects.equals(this.applicationType, otherConversation.applicationType) &&
             Objects.equals(this.createdTime, otherConversation.createdTime) &&
             Objects.equals(this.updatedTime, otherConversation.updatedTime) &&
             Objects.equals(this.name, otherConversation.name);

--- a/common/src/test/java/org/opensearch/ml/common/conversation/ConversationMetaTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/conversation/ConversationMetaTests.java
@@ -30,7 +30,7 @@ public class ConversationMetaTests {
     @Before
     public void setUp() {
         time = Instant.now();
-        conversationMeta = new ConversationMeta("test_id", time, time, "test_name", "admin");
+        conversationMeta = new ConversationMeta("test_id", time, time, "test_name", "admin", "testApp");
     }
 
     @Test
@@ -41,6 +41,7 @@ public class ConversationMetaTests {
         content.field(ConversationalIndexConstants.META_UPDATED_TIME_FIELD, time);
         content.field(ConversationalIndexConstants.META_NAME_FIELD, "meta name");
         content.field(ConversationalIndexConstants.USER_FIELD, "admin");
+        content.field(ConversationalIndexConstants.APPLICATION_TYPE_FIELD, "testApp");
         content.endObject();
 
         SearchHit[] hits = new SearchHit[1];
@@ -50,6 +51,7 @@ public class ConversationMetaTests {
         assertEquals(conversationMeta.getId(), "cId");
         assertEquals(conversationMeta.getName(), "meta name");
         assertEquals(conversationMeta.getUser(), "admin");
+        assertEquals(conversationMeta.getApplicationType(), "testApp");
     }
 
     @Test
@@ -63,12 +65,15 @@ public class ConversationMetaTests {
                         ConversationalIndexConstants.META_NAME_FIELD,
                         "meta name",
                         ConversationalIndexConstants.USER_FIELD,
-                        "admin"
+                        "admin",
+                        ConversationalIndexConstants.APPLICATION_TYPE_FIELD,
+                        "testApp"
                 );
         ConversationMeta conversationMeta = ConversationMeta.fromMap("test-conversation-meta", params);
         assertEquals(conversationMeta.getId(), "test-conversation-meta");
         assertEquals(conversationMeta.getName(), "meta name");
         assertEquals(conversationMeta.getUser(), "admin");
+        assertEquals(conversationMeta.getApplicationType(), "testApp");
     }
 
     @Test
@@ -81,26 +86,27 @@ public class ConversationMetaTests {
         assertEquals(meta.getId(), conversationMeta.getId());
         assertEquals(meta.getName(), conversationMeta.getName());
         assertEquals(meta.getUser(), conversationMeta.getUser());
+        assertEquals(meta.getApplicationType(), conversationMeta.getApplicationType());
     }
 
     @Test
     public void test_ToXContent() throws IOException {
-        ConversationMeta conversationMeta = new ConversationMeta("test_id", Instant.ofEpochMilli(123), Instant.ofEpochMilli(123), "test meta", "admin");
+        ConversationMeta conversationMeta = new ConversationMeta("test_id", Instant.ofEpochMilli(123), Instant.ofEpochMilli(123), "test meta", "admin", "testApp");
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         conversationMeta.toXContent(builder, EMPTY_PARAMS);
         String content = TestHelper.xContentBuilderToString(builder);
-        assertEquals(content, "{\"memory_id\":\"test_id\",\"create_time\":\"1970-01-01T00:00:00.123Z\",\"updated_time\":\"1970-01-01T00:00:00.123Z\",\"name\":\"test meta\",\"user\":\"admin\"}");
+        assertEquals(content, "{\"memory_id\":\"test_id\",\"create_time\":\"1970-01-01T00:00:00.123Z\",\"updated_time\":\"1970-01-01T00:00:00.123Z\",\"name\":\"test meta\",\"user\":\"admin\",\"application_type\":\"testApp\"}");
     }
 
     @Test
     public void test_toString() {
-        ConversationMeta conversationMeta = new ConversationMeta("test_id", Instant.ofEpochMilli(123), Instant.ofEpochMilli(123), "test meta", "admin");
-        assertEquals("{id=test_id, name=test meta, created=1970-01-01T00:00:00.123Z, updated=1970-01-01T00:00:00.123Z, user=admin}", conversationMeta.toString());
+        ConversationMeta conversationMeta = new ConversationMeta("test_id", Instant.ofEpochMilli(123), Instant.ofEpochMilli(123), "test meta", "admin", "testApp");
+        assertEquals("{id=test_id, name=test meta, created=1970-01-01T00:00:00.123Z, updated=1970-01-01T00:00:00.123Z, user=admin, applicationType=testApp}", conversationMeta.toString());
     }
 
     @Test
     public void test_equal() {
-        ConversationMeta meta = new ConversationMeta("test_id", Instant.ofEpochMilli(123), Instant.ofEpochMilli(123), "test meta", "admin");
+        ConversationMeta meta = new ConversationMeta("test_id", Instant.ofEpochMilli(123), Instant.ofEpochMilli(123), "test meta", "admin", "testApp");
         assertEquals(meta.equals(conversationMeta), false);
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/conversation/ConversationMetaTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/conversation/ConversationMetaTests.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 
 public class ConversationMetaTests {
@@ -87,6 +88,21 @@ public class ConversationMetaTests {
         assertEquals(meta.getName(), conversationMeta.getName());
         assertEquals(meta.getUser(), conversationMeta.getUser());
         assertEquals(meta.getApplicationType(), conversationMeta.getApplicationType());
+    }
+
+    @Test
+    public void test_fromStream_empty_applicationType() throws IOException {
+        ConversationMeta conversationMeta = new ConversationMeta("test_id", time, time, "test_name", "admin", null);
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+
+        conversationMeta.writeTo(bytesStreamOutput);
+
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        ConversationMeta meta = ConversationMeta.fromStream(streamInput);
+        assertEquals(meta.getId(), conversationMeta.getId());
+        assertEquals(meta.getName(), conversationMeta.getName());
+        assertEquals(meta.getUser(), conversationMeta.getUser());
+        assertNull(meta.getApplicationType());
     }
 
     @Test

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationResponseTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationResponseTests.java
@@ -36,7 +36,7 @@ import org.opensearch.test.OpenSearchTestCase;
 public class GetConversationResponseTests extends OpenSearchTestCase {
 
     public void testGetConversationResponseStreaming() throws IOException {
-        ConversationMeta convo = new ConversationMeta("cid", Instant.now(), Instant.now(), "name", null);
+        ConversationMeta convo = new ConversationMeta("cid", Instant.now(), Instant.now(), "name", null, null);
         GetConversationResponse response = new GetConversationResponse(convo);
         assert (response.getConversation().equals(convo));
 
@@ -49,7 +49,7 @@ public class GetConversationResponseTests extends OpenSearchTestCase {
     }
 
     public void testToXContent() throws IOException {
-        ConversationMeta convo = new ConversationMeta("cid", Instant.now(), Instant.now(), "name", null);
+        ConversationMeta convo = new ConversationMeta("cid", Instant.now(), Instant.now(), "name", null, null);
         GetConversationResponse response = new GetConversationResponse(convo);
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationTransportActionTests.java
@@ -107,7 +107,7 @@ public class GetConversationTransportActionTests extends OpenSearchTestCase {
     }
 
     public void testGetConversation() {
-        ConversationMeta result = new ConversationMeta("test-cid", Instant.now(), Instant.now(), "name", null);
+        ConversationMeta result = new ConversationMeta("test-cid", Instant.now(), Instant.now(), "name", null, null);
         doAnswer(invocation -> {
             ActionListener<ConversationMeta> listener = invocation.getArgument(1);
             listener.onResponse(result);

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsResponseTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsResponseTests.java
@@ -46,9 +46,9 @@ public class GetConversationsResponseTests extends OpenSearchTestCase {
     public void setup() {
         conversations = List
             .of(
-                new ConversationMeta("0", Instant.now(), Instant.now(), "name0", "user0"),
-                new ConversationMeta("1", Instant.now(), Instant.now(), "name1", "user0"),
-                new ConversationMeta("2", Instant.now(), Instant.now(), "name2", "user2")
+                new ConversationMeta("0", Instant.now(), Instant.now(), "name0", "user0", null),
+                new ConversationMeta("1", Instant.now(), Instant.now(), "name1", "user0", null),
+                new ConversationMeta("2", Instant.now(), Instant.now(), "name2", "user2", null)
             );
     }
 

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsTransportActionTests.java
@@ -114,8 +114,8 @@ public class GetConversationsTransportActionTests extends OpenSearchTestCase {
         log.info("testing get conversations transport");
         List<ConversationMeta> testResult = List
             .of(
-                new ConversationMeta("testcid1", Instant.now(), Instant.now(), "", null),
-                new ConversationMeta("testcid2", Instant.now(), Instant.now(), "testname", null)
+                new ConversationMeta("testcid1", Instant.now(), Instant.now(), "", null, null),
+                new ConversationMeta("testcid2", Instant.now(), Instant.now(), "testname", null, null)
             );
         doAnswer(invocation -> {
             ActionListener<List<ConversationMeta>> listener = invocation.getArgument(2);
@@ -132,9 +132,9 @@ public class GetConversationsTransportActionTests extends OpenSearchTestCase {
     public void testPagination() {
         List<ConversationMeta> testResult = List
             .of(
-                new ConversationMeta("testcid1", Instant.now(), Instant.now(), "", null),
-                new ConversationMeta("testcid2", Instant.now(), Instant.now(), "testname", null),
-                new ConversationMeta("testcid3", Instant.now(), Instant.now(), "testname", null)
+                new ConversationMeta("testcid1", Instant.now(), Instant.now(), "", null, null),
+                new ConversationMeta("testcid2", Instant.now(), Instant.now(), "testname", null, null),
+                new ConversationMeta("testcid3", Instant.now(), Instant.now(), "testname", null, null)
             );
         doAnswer(invocation -> {
             ActionListener<List<ConversationMeta>> listener = invocation.getArgument(2);

--- a/memory/src/test/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandlerTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandlerTests.java
@@ -301,7 +301,7 @@ public class OpenSearchConversationalMemoryHandlerTests extends OpenSearchTestCa
     }
 
     public void testGetAConversation_Future() {
-        ConversationMeta response = new ConversationMeta("cid", Instant.now(), Instant.now(), "boring name", null);
+        ConversationMeta response = new ConversationMeta("cid", Instant.now(), Instant.now(), "boring name", null, null);
         doAnswer(invocation -> {
             ActionListener<ConversationMeta> listener = invocation.getArgument(1);
             listener.onResponse(response);


### PR DESCRIPTION
### Description
Add application_type into get ConversationMeta

An example
```
GET /_plugins/_ml/memory/xJkym5ABZevb6ngQphzz


{
  "memory_id": "xJkym5ABZevb6ngQphzz",
  "create_time": "2024-07-10T05:51:46.418785Z",
  "updated_time": "2024-07-10T05:52:06.657124Z",
  "name": "Summarise the alert 'Revenue is low'",
  "user": "admin",
  "application_type": "alert_analysis"
}

```
 
### Issues Resolved
#2632 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
