### PR TITLE
update tutorials for caching secrets for non-aws models

### DIFF
--- a/docs/tutorials/aws/AIConnectorHelper.ipynb
+++ b/docs/tutorials/aws/AIConnectorHelper.ipynb
@@ -375,6 +375,7 @@
     "                {\n",
     "                    \"Action\": [\n",
     "                        \"secretsmanager:GetSecretValue\"\n",
+    "                        \"secretsmanager:DescribeSecret\"\n",
     "                    ],\n",
     "                    \"Effect\": \"Allow\",\n",
     "                    \"Resource\": secret_arn\n",

--- a/docs/tutorials/aws/semantic_search_with_cohere_embedding_model.md
+++ b/docs/tutorials/aws/semantic_search_with_cohere_embedding_model.md
@@ -61,7 +61,8 @@ Go to IAM console, create IAM role `my_cohere_secret_role` with:
     "Statement": [
         {
             "Action": [
-                "secretsmanager:GetSecretValue"
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret"
             ],
             "Effect": "Allow",
             "Resource": "your_secret_arn_created_in_step1"

--- a/docs/tutorials/aws/semantic_search_with_openai_embedding_model.md
+++ b/docs/tutorials/aws/semantic_search_with_openai_embedding_model.md
@@ -54,7 +54,8 @@ Go to IAM console, create IAM role `my_openai_secret_role` with:
     "Statement": [
         {
             "Action": [
-                "secretsmanager:GetSecretValue"
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret"
             ],
             "Effect": "Allow",
             "Resource": "your_secret_arn_created_in_step1"


### PR DESCRIPTION
### Description
To add caching of secrets from client side to reduce API calls to secret manger in AOS, new permissions are required in the policy attached to the IAM role to fetch credentials from secret manager. 

This updates are validated using OpenAI and Cohere. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
