### PR TITLE
[Feature/multi_tenancy] Support forbidding upserts in PutDataObjectRequest

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/PutDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/PutDataObjectRequest.java
@@ -15,6 +15,7 @@ public class PutDataObjectRequest {
     private final String index;
     private final String id;
     private final String tenantId;
+    private final boolean overwriteIfExists;
     private final ToXContentObject dataObject;
 
     /**
@@ -24,10 +25,11 @@ public class PutDataObjectRequest {
      * @param index the index location to put the object
      * @param dataObject the data object
      */
-    public PutDataObjectRequest(String index, String id, String tenantId, ToXContentObject dataObject) {
+    public PutDataObjectRequest(String index, String id, String tenantId, boolean overwriteIfExists, ToXContentObject dataObject) {
         this.index = index;
         this.id = id;
         this.tenantId = tenantId;
+        this.overwriteIfExists = overwriteIfExists;
         this.dataObject = dataObject;
     }
 
@@ -54,6 +56,14 @@ public class PutDataObjectRequest {
     public String tenantId() {
         return this.tenantId;
     }
+    
+    /**
+     * Returns whether to overwrite an existing document (upsert)
+     * @return true if this request should overwrite
+     */
+    public boolean overwriteIfExists() {
+        return this.overwriteIfExists;
+    }
 
     /**
      * Returns the data object
@@ -78,6 +88,7 @@ public class PutDataObjectRequest {
         private String index = null;
         private String id = null;
         private String tenantId = null;
+        private boolean overwriteIfExists = true;
         private ToXContentObject dataObject = null;
 
         /**
@@ -116,6 +127,15 @@ public class PutDataObjectRequest {
         }
 
         /**
+         * Specify whether to overwrite an existing document/item (upsert). True by default. 
+         * @param overwriteIfExists whether to overwrite an existing document/item
+         * @return the updated builder
+         */
+        public Builder overwriteIfExists(boolean overwriteIfExists) {
+            this.overwriteIfExists = overwriteIfExists;
+            return this;
+        }
+        /**
          * Add a data object to this builder
          * @param dataObject the data object
          * @return the updated builder
@@ -130,7 +150,7 @@ public class PutDataObjectRequest {
          * @return A {@link PutDataObjectRequest}
          */
         public PutDataObjectRequest build() {
-            return new PutDataObjectRequest(this.index, this.id, this.tenantId, this.dataObject);
+            return new PutDataObjectRequest(this.index, this.id, this.tenantId, this.overwriteIfExists, this.dataObject);
         }
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/PutDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/PutDataObjectRequestTests.java
@@ -11,29 +11,42 @@ package org.opensearch.sdk;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.sdk.PutDataObjectRequest.Builder;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class PutDataObjectRequestTests {
 
     private String testIndex;
+    private String testId;
     private String testTenantId;
     private ToXContentObject testDataObject;
 
     @Before
     public void setUp() {
         testIndex = "test-index";
+        testId = "test-id";
         testTenantId = "test-tenant-id";
         testDataObject = mock(ToXContentObject.class);
     }
 
     @Test
     public void testPutDataObjectRequest() {
-        PutDataObjectRequest request = PutDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).dataObject(testDataObject).build();
+        Builder builder = PutDataObjectRequest.builder().index(testIndex).id(testId).tenantId(testTenantId).dataObject(testDataObject);
+        PutDataObjectRequest request = builder.build();
 
         assertEquals(testIndex, request.index());
+        assertEquals(testId, request.id());
         assertEquals(testTenantId, request.tenantId());
-        assertEquals(testDataObject, request.dataObject());
+        assertTrue(request.overwriteIfExists());
+        assertSame(testDataObject, request.dataObject());
+        
+        builder.overwriteIfExists(false);
+        request = builder.build();
+        assertFalse(request.overwriteIfExists());
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -60,6 +60,7 @@ import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest.Builder;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
 /**
@@ -109,7 +110,11 @@ public class DDBOpenSearchClient implements SdkClient {
                 Map<String, AttributeValue> item = JsonTransformer.convertJsonObjectToDDBAttributeMap(jsonNode);
                 item.put(HASH_KEY, AttributeValue.builder().s(tenantId).build());
                 item.put(RANGE_KEY, AttributeValue.builder().s(id).build());
-                final PutItemRequest putItemRequest = PutItemRequest.builder().tableName(tableName).item(item).build();
+                Builder builder = PutItemRequest.builder().tableName(tableName).item(item);
+                if (!request.overwriteIfExists()) {
+                    builder.conditionExpression("attribute_not_exists(" + HASH_KEY + ") AND attribute_not_exists(" + RANGE_KEY + ")");
+                }
+                final PutItemRequest putItemRequest = builder.build();
 
                 // TODO need to initialize/return SEQ_NO here
                 // If document doesn't exist, return 0

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -136,6 +136,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .overwriteIfExists(false)
             .tenantId(TENANT_ID)
             .dataObject(testDataObject)
             .build();
@@ -155,6 +156,11 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         Assert.assertEquals(TEST_INDEX, putItemRequest.tableName());
         Assert.assertEquals(TEST_ID, putItemRequest.item().get(RANGE_KEY).s());
         Assert.assertEquals(TENANT_ID, putItemRequest.item().get(HASH_KEY).s());
+        Assert
+            .assertEquals(
+                "attribute_not_exists(" + HASH_KEY + ") AND attribute_not_exists(" + RANGE_KEY + ")",
+                putItemRequest.conditionExpression()
+            );
         Assert.assertEquals("foo", putItemRequest.item().get("data").s());
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/LocalClusterIndicesClientTests.java
@@ -31,6 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.DocWriteRequest.OpType;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.DocWriteResponse.Result;
 import org.opensearch.action.delete.DeleteRequest;
@@ -121,7 +122,13 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testPutDataObject() throws IOException {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .overwriteIfExists(false)
+            .dataObject(testDataObject)
+            .build();
 
         IndexResponse indexResponse = new IndexResponse(new ShardId(TEST_INDEX, "_na_", 0), TEST_ID, 1, 0, 2, true);
         @SuppressWarnings("unchecked")
@@ -137,6 +144,9 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
         ArgumentCaptor<IndexRequest> requestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
         verify(mockedClient, times(1)).index(requestCaptor.capture());
         assertEquals(TEST_INDEX, requestCaptor.getValue().index());
+        assertEquals(TEST_ID, requestCaptor.getValue().id());
+        assertEquals(OpType.CREATE, requestCaptor.getValue().opType());
+
         assertEquals(TEST_ID, response.id());
 
         IndexResponse indexActionResponse = IndexResponse.fromXContent(response.parser());

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
@@ -34,6 +34,7 @@ import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.ErrorCause;
 import org.opensearch.client.opensearch._types.ErrorResponse;
+import org.opensearch.client.opensearch._types.OpType;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Result;
 import org.opensearch.client.opensearch._types.ShardStatistics;
@@ -163,7 +164,13 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testPutDataObject_Updated() throws IOException {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .overwriteIfExists(false)
+            .dataObject(testDataObject)
+            .build();
 
         IndexResponse indexResponse = new IndexResponse.Builder()
             .id(TEST_ID)
@@ -184,6 +191,8 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .join();
 
         assertEquals(TEST_INDEX, indexRequestCaptor.getValue().index());
+        assertEquals(TEST_ID, indexRequestCaptor.getValue().id());
+        assertEquals(OpType.Create, indexRequestCaptor.getValue().opType());
         assertEquals(TEST_ID, response.id());
 
         org.opensearch.action.index.IndexResponse indexActionResponse = org.opensearch.action.index.IndexResponse


### PR DESCRIPTION
### Description

Adds an `overwriteIfExists` boolean to the `PutDataObjectRequest`, defaulting to `true`.  This replicates current default `IndexRequest` behavior using `OpType.INDEX`.   If set false, uses `OpType.CREATE`.
 
### Issues Resolved

https://github.com/opensearch-project/ml-commons/pull/2605#issuecomment-2214777743
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
