### PR TITLE
[Feature/multi_tenancy] Move the LocalClusterIndicesClient to ml-common module

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/client/LocalClusterIndicesClient.java
+++ b/common/src/main/java/org/opensearch/sdk/client/LocalClusterIndicesClient.java
@@ -6,7 +6,7 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package org.opensearch.ml.sdkclient;
+package org.opensearch.sdk.client;
 
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;

--- a/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
@@ -6,17 +6,19 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package org.opensearch.ml.sdkclient;
+package org.opensearch.sdk.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
-import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
-
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Map;
@@ -78,13 +80,16 @@ import org.opensearch.sdk.UpdateDataObjectRequest;
 import org.opensearch.sdk.UpdateDataObjectResponse;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.internal.InternalSearchResponse;
-import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
-public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
+public class LocalClusterIndicesClientTests {
 
+    // Copied constants from MachineLearningPlugin.java
+    private static final String ML_THREAD_POOL_PREFIX = "thread_pool.ml_commons.";
+    private static final String GENERAL_THREAD_POOL = "opensearch_ml_general";
+    
     private static final String TEST_ID = "123";
     private static final String TEST_INDEX = "test_index";
 
@@ -112,8 +117,7 @@ public class LocalClusterIndicesClientTests extends OpenSearchTestCase {
     public void setup() {
         MockitoAnnotations.openMocks(this);
 
-        Settings settings = Settings.builder().build();
-        sdkClient = SdkClientFactory.createSdkClient(mockedClient, xContentRegistry, settings);
+        sdkClient = new SdkClient(new LocalClusterIndicesClient(mockedClient, xContentRegistry));
         testDataObject = new TestDataObject("foo");
     }
 

--- a/common/src/test/java/org/opensearch/sdk/client/TestDataObject.java
+++ b/common/src/test/java/org/opensearch/sdk/client/TestDataObject.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk.client;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.io.IOException;
+
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+public class TestDataObject implements ToXContentObject {
+    private static final String DATA_FIELD = "data";
+
+    private final String data;
+
+    public TestDataObject(String data) {
+        this.data = data;
+    }
+
+    public String data() {
+        return this.data;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        XContentBuilder xContentBuilder = builder.startObject();
+        xContentBuilder.field(DATA_FIELD, this.data);
+        return xContentBuilder.endObject();
+    }
+
+    public static TestDataObject parse(XContentParser parser) throws IOException {
+        String data = null;
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+            if (DATA_FIELD.equals(fieldName)) {
+                data = parser.text();
+            }
+        }
+        return new TestDataObject(data);
+    }
+
+    public String toJson() throws IOException {
+        return this.toXContent(JsonXContent.contentBuilder(), EMPTY_PARAMS).toString();
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/SdkClientFactory.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/SdkClientFactory.java
@@ -28,6 +28,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.sdk.SdkClient;
 import org.opensearch.sdk.SdkClientDelegate;
 import org.opensearch.sdk.SdkClientSettings;
+import org.opensearch.sdk.client.LocalClusterIndicesClient;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -107,7 +107,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
     private TestDataObject testDataObject;
 
     private static TestThreadPool testThreadPool = new TestThreadPool(
-        LocalClusterIndicesClientTests.class.getName(),
+        DDBOpenSearchClientTests.class.getName(),
         new ScalingExecutorBuilder(
             GENERAL_THREAD_POOL,
             1,

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/SdkClientFactoryTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/SdkClientFactoryTests.java
@@ -16,6 +16,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.sdk.SdkClient;
 import org.opensearch.sdk.SdkClientSettings;
+import org.opensearch.sdk.client.LocalClusterIndicesClient;
 import org.opensearch.test.OpenSearchTestCase;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;


### PR DESCRIPTION
### Description

Moves the default client (LocalClusterIndicesClient) to the `ml-common` module.  This will make it accessible to tests which cannot depend on the `ml-plugin` module using:
```java
SdkClient sdkClient = new SdkClient(new LocalClusterIndicesClient(client, xContentRegistry));
```

Some changes needed to make this work:
 - thread pool name constants from `MachineLearningPlugin.java` needed to be manually defined
 - no dependency available (yet) to extend `OpenSearchTestCase`.  We weren't using its functionality anyway other than needing to use mocks directly.
 - I had to make a copy of the `TestDataObject` class, as the `ml-plugin` test classes couldn't access it from the `ml-common` test classes.

Blockers for me moving either of the other clients:
 - they required jackson dependencies (remote client uses annotations, databind, dataformat, DDB uses others)
 - the existing dependencies caused java class version issues with ShadowJar.  These were fixable with the `asm` version and shadow plugin changes from https://github.com/opensearch-project/ml-commons/pull/2583/files
 - I could not figure out how to access `${versions.jackson}` from the OpenSearch version library.  This may be part of the opensearchplugin dependency but that assumes you're setting up a plugin and imposes other requirements, so I'm not sure how it would work with the `ml-common` module.
   - I tried matching up the version based on gradle dependencies, but ended up with jar hell in too many different combinations

I'm sure these are all solvable problems, but if this current fix unblocks local tests I think it's a good compromise until we properly put all these classes somewhere outside of ML Commons repo.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
