### PR TITLE
chat agent runner supports passing chat history to tool if needed

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -461,7 +461,8 @@ public class AgentUtils {
         String question,
         AtomicReference<String> lastActionInput,
         String action,
-        String actionInput
+        String actionInput,
+        Map<String, String> parameters
     ) {
         Map<String, String> toolParams = new HashMap<>();
         Map<String, String> toolSpecParams = toolSpecMap.get(action).getParameters();
@@ -477,6 +478,9 @@ public class AgentUtils {
                 Map<String, String> params = getParameterMap(gson.fromJson(actionInput, Map.class));
                 toolParams.putAll(params);
             }
+        }
+        if (tools.get(action).needHistory()) {
+            toolParams.put(CHAT_HISTORY, parameters.getOrDefault(CHAT_HISTORY, ""));
         }
         return toolParams;
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -290,7 +290,8 @@ public class MLChatAgentRunner implements MLAgentRunner {
                             question,
                             lastActionInput,
                             action,
-                            actionInput
+                            actionInput,
+                            parameters
                         );
                         runTool(
                             tools,

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -618,14 +618,21 @@ public class AgentUtilsTest {
         verifyConstructToolParams(question, actionInput, Collections.emptyMap(), false, verify);
     }
 
-    private void verifyConstructToolParams(String question, String actionInput, Map<String, String> params, boolean needHistory, Consumer<Map<String, String>> verify) {
+    private void verifyConstructToolParams(
+        String question,
+        String actionInput,
+        Map<String, String> params,
+        boolean needHistory,
+        Consumer<Map<String, String>> verify
+    ) {
         Map<String, Tool> tools = Map.of("tool1", tool1);
         when(tool1.needHistory()).thenReturn(needHistory);
         Map<String, MLToolSpec> toolSpecMap = Map
             .of("tool1", MLToolSpec.builder().type("tool1").parameters(Map.of("key1", "value1")).build());
         AtomicReference<String> lastActionInput = new AtomicReference<>();
         String action = "tool1";
-        Map<String, String> toolParams = AgentUtils.constructToolParams(tools, toolSpecMap, question, lastActionInput, action, actionInput, params);
+        Map<String, String> toolParams = AgentUtils
+            .constructToolParams(tools, toolSpecMap, question, lastActionInput, action, actionInput, params);
         verify.accept(toolParams);
     }
 }

--- a/spi/src/main/java/org/opensearch/ml/common/spi/tools/Tool.java
+++ b/spi/src/main/java/org/opensearch/ml/common/spi/tools/Tool.java
@@ -98,6 +98,14 @@ public interface Tool {
     }
 
     /**
+     * Whether the tool needs the history of the conversation.
+     * @return if true, agent runner should pass history information as input parameter to this tool
+     */
+    default boolean needHistory() {
+        return false;
+    }
+
+    /**
      * Tool factory which can create instance of {@link Tool}.
      * @param <T> The subclass this factory produces
      */


### PR DESCRIPTION
### Description
Some tools may need CHAT_HISTORY as its input parameters, this PR make ChatAgentRunner supports passing CHAT_HISTORY to tools if needed.

### Related Issues
original issue: https://github.com/opensearch-project/ml-commons/issues/2645
issue has dependency on this: https://github.com/opensearch-project/skills/issues/338

### Check List
- [x] New functionality includes testing.
- [ ] All tests pass
- [ ] New functionality has been documented.
- [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
