### PR TITLE
feat: add bedrock runtime agent for knowledge base

### DIFF
--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorTest.java
@@ -65,7 +65,9 @@ public class ConnectorTest {
         HttpConnector connector = createHttpConnector();
         connector.validateConnectorURL(Arrays.asList("^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
                 "^https://api\\.openai\\.com/.*$",
-                "^https://api\\.cohere\\.ai/.*$"));
+                "^https://api\\.cohere\\.ai/.*$",
+                "^https://bedrock-agent-runtime\\\\..*[a-z0-9-]\\\\.amazonaws\\\\.com/.*$"
+            ));
     }
 
     @Test
@@ -73,6 +75,7 @@ public class ConnectorTest {
         HttpConnector connector = createHttpConnector();
         connector.validateConnectorURL(Arrays.asList("^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
                 "^https://api\\.openai\\.com/.*$",
+                "^https://bedrock-agent-runtime\\\\..*[a-z0-9-]\\\\.amazonaws\\\\.com/.*$",
                 "^" + connector.getActions().get(0).getUrl()));
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -144,7 +144,8 @@ public final class MLCommonsSettings {
                     "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
                     "^https://api\\.openai\\.com/.*$",
                     "^https://api\\.cohere\\.ai/.*$",
-                    "^https://bedrock-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"
+                    "^https://bedrock-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                    "^https://bedrock-agent-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"
                 ),
             Function.identity(),
             Setting.Property.NodeScope,


### PR DESCRIPTION
### Description
Enable users to register bedrock runtime agent for calling bedrock knowledge base.
 
### Issues Resolved

```
POST /_plugins/_ml/connectors/_create
{
  "name": "Amazon Bedrock Connector: knowledge",
  "description": "The connector to the Bedrock knowledge base",
  "version": 1,
  "protocol": "aws_sigv4",
  "parameters": {
    "region": "...",
    "service_name": "bedrock"
  },
  "credential": {
    "access_key": "...",
    "secret_key": "..."
  },
  "actions": [
    {
      "action_type": "predict",
      "method": "POST",
      "url": "...",
      "headers": {
        "content-type": "application/json",
        "x-amz-content-sha256": "required"
      },
      "request_body": "{\"retrievalQuery\": {\"text\": \"${parameters.text}\"}}"
    }
  ]
}

POST /_plugins/_ml/models/_register?deploy=true
{
  "name": "bedrock: knowledge base",
  "function_name": "remote",
  "description": "Test connector for bedrock knowledge base",
  "connector_id": <connector_id>
}

POST /_plugins/_ml/models/<model_id>/_predict/
{
  "parameters": {
    "text": "aws 2021"
  }
}
```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
