### PR TITLE
Add feature enable setting for controller index

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/controller/DeleteControllerTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/controller/DeleteControllerTransportAction.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.action.controller;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.opensearch.ml.common.CommonValue.ML_CONTROLLER_INDEX;
 import static org.opensearch.ml.common.utils.StringUtils.getErrorMessage;
+import static org.opensearch.ml.utils.MLExceptionUtils.CONTROLLER_DISABLED_ERR_MSG;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,6 +42,7 @@ import org.opensearch.ml.common.transport.controller.MLUndeployControllerNodesRe
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -58,6 +60,7 @@ public class DeleteControllerTransportAction extends HandledTransportAction<Acti
     MLModelManager mlModelManager;
     MLModelCacheHelper mlModelCacheHelper;
     ModelAccessControlHelper modelAccessControlHelper;
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     @Inject
     public DeleteControllerTransportAction(
@@ -68,7 +71,8 @@ public class DeleteControllerTransportAction extends HandledTransportAction<Acti
         ClusterService clusterService,
         MLModelManager mlModelManager,
         MLModelCacheHelper mlModelCacheHelper,
-        ModelAccessControlHelper modelAccessControlHelper
+        ModelAccessControlHelper modelAccessControlHelper,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting
     ) {
         super(MLControllerDeleteAction.NAME, transportService, actionFilters, MLControllerDeleteRequest::new);
         this.client = client;
@@ -77,6 +81,7 @@ public class DeleteControllerTransportAction extends HandledTransportAction<Acti
         this.mlModelManager = mlModelManager;
         this.mlModelCacheHelper = mlModelCacheHelper;
         this.modelAccessControlHelper = modelAccessControlHelper;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
     }
 
     @Override
@@ -86,6 +91,9 @@ public class DeleteControllerTransportAction extends HandledTransportAction<Acti
         User user = RestActionUtils.getUserContext(client);
         String[] excludes = new String[] { MLModel.MODEL_CONTENT_FIELD, MLModel.OLD_MODEL_CONTENT_FIELD };
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            if (!mlFeatureEnabledSetting.isControllerEnabled()) {
+                throw new IllegalStateException(CONTROLLER_DISABLED_ERR_MSG);
+            }
             ActionListener<DeleteResponse> wrappedListener = ActionListener.runBefore(actionListener, context::restore);
             mlModelManager.getModel(modelId, null, excludes, ActionListener.wrap(mlModel -> {
                 Boolean isHidden = mlModel.getIsHidden();

--- a/plugin/src/main/java/org/opensearch/ml/action/controller/GetControllerTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/controller/GetControllerTransportAction.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.action.controller;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_CONTROLLER_INDEX;
 import static org.opensearch.ml.common.utils.StringUtils.getErrorMessage;
+import static org.opensearch.ml.utils.MLExceptionUtils.CONTROLLER_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
 import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
 
@@ -33,6 +34,7 @@ import org.opensearch.ml.common.transport.controller.MLControllerGetRequest;
 import org.opensearch.ml.common.transport.controller.MLControllerGetResponse;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.tasks.Task;
@@ -50,6 +52,7 @@ public class GetControllerTransportAction extends HandledTransportAction<ActionR
     ClusterService clusterService;
     MLModelManager mlModelManager;
     ModelAccessControlHelper modelAccessControlHelper;
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     @Inject
     public GetControllerTransportAction(
@@ -59,7 +62,8 @@ public class GetControllerTransportAction extends HandledTransportAction<ActionR
         NamedXContentRegistry xContentRegistry,
         ClusterService clusterService,
         MLModelManager mlModelManager,
-        ModelAccessControlHelper modelAccessControlHelper
+        ModelAccessControlHelper modelAccessControlHelper,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting
     ) {
         super(MLControllerGetAction.NAME, transportService, actionFilters, MLControllerGetRequest::new);
         this.client = client;
@@ -67,6 +71,7 @@ public class GetControllerTransportAction extends HandledTransportAction<ActionR
         this.clusterService = clusterService;
         this.mlModelManager = mlModelManager;
         this.modelAccessControlHelper = modelAccessControlHelper;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
     }
 
     @Override
@@ -79,6 +84,9 @@ public class GetControllerTransportAction extends HandledTransportAction<ActionR
         String[] excludes = new String[] { MLModel.MODEL_CONTENT_FIELD, MLModel.OLD_MODEL_CONTENT_FIELD };
 
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            if (!mlFeatureEnabledSetting.isControllerEnabled()) {
+                throw new IllegalStateException(CONTROLLER_DISABLED_ERR_MSG);
+            }
             ActionListener<MLControllerGetResponse> wrappedListener = ActionListener.runBefore(actionListener, context::restore);
             client.get(getRequest, ActionListener.wrap(r -> {
                 if (r != null && r.isExists()) {

--- a/plugin/src/main/java/org/opensearch/ml/action/controller/UpdateControllerTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/controller/UpdateControllerTransportAction.java
@@ -9,6 +9,7 @@ import static org.opensearch.ml.common.CommonValue.ML_CONTROLLER_INDEX;
 import static org.opensearch.ml.common.FunctionName.REMOTE;
 import static org.opensearch.ml.common.FunctionName.TEXT_EMBEDDING;
 import static org.opensearch.ml.common.utils.StringUtils.getErrorMessage;
+import static org.opensearch.ml.utils.MLExceptionUtils.CONTROLLER_DISABLED_ERR_MSG;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,6 +47,7 @@ import org.opensearch.ml.common.transport.controller.MLUpdateControllerRequest;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -62,6 +64,7 @@ public class UpdateControllerTransportAction extends HandledTransportAction<Acti
     MLModelCacheHelper mlModelCacheHelper;
     ClusterService clusterService;
     ModelAccessControlHelper modelAccessControlHelper;
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     @Inject
     public UpdateControllerTransportAction(
@@ -71,7 +74,8 @@ public class UpdateControllerTransportAction extends HandledTransportAction<Acti
         ClusterService clusterService,
         ModelAccessControlHelper modelAccessControlHelper,
         MLModelCacheHelper mlModelCacheHelper,
-        MLModelManager mlModelManager
+        MLModelManager mlModelManager,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting
     ) {
         super(MLUpdateControllerAction.NAME, transportService, actionFilters, MLUpdateControllerRequest::new);
         this.client = client;
@@ -79,6 +83,7 @@ public class UpdateControllerTransportAction extends HandledTransportAction<Acti
         this.clusterService = clusterService;
         this.mlModelCacheHelper = mlModelCacheHelper;
         this.modelAccessControlHelper = modelAccessControlHelper;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
     }
 
     @Override
@@ -90,6 +95,9 @@ public class UpdateControllerTransportAction extends HandledTransportAction<Acti
         String[] excludes = new String[] { MLModel.MODEL_CONTENT_FIELD, MLModel.OLD_MODEL_CONTENT_FIELD };
 
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            if (!mlFeatureEnabledSetting.isControllerEnabled()) {
+                throw new IllegalStateException(CONTROLLER_DISABLED_ERR_MSG);
+            }
             ActionListener<UpdateResponse> wrappedListener = ActionListener.runBefore(actionListener, context::restore);
             mlModelManager.getModel(modelId, null, excludes, ActionListener.wrap(mlModel -> {
                 FunctionName functionName = mlModel.getAlgorithm();

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -755,10 +755,10 @@ public class MachineLearningPlugin extends Plugin
         RestMemorySearchInteractionsAction restSearchInteractionsAction = new RestMemorySearchInteractionsAction();
         RestMemoryGetConversationAction restGetConversationAction = new RestMemoryGetConversationAction();
         RestMemoryGetInteractionAction restGetInteractionAction = new RestMemoryGetInteractionAction();
-        RestMLCreateControllerAction restMLCreateControllerAction = new RestMLCreateControllerAction();
-        RestMLGetControllerAction restMLGetControllerAction = new RestMLGetControllerAction();
-        RestMLUpdateControllerAction restMLUpdateControllerAction = new RestMLUpdateControllerAction();
-        RestMLDeleteControllerAction restMLDeleteControllerAction = new RestMLDeleteControllerAction();
+        RestMLCreateControllerAction restMLCreateControllerAction = new RestMLCreateControllerAction(mlFeatureEnabledSetting);
+        RestMLGetControllerAction restMLGetControllerAction = new RestMLGetControllerAction(mlFeatureEnabledSetting);
+        RestMLUpdateControllerAction restMLUpdateControllerAction = new RestMLUpdateControllerAction(mlFeatureEnabledSetting);
+        RestMLDeleteControllerAction restMLDeleteControllerAction = new RestMLDeleteControllerAction(mlFeatureEnabledSetting);
         RestMLGetAgentAction restMLGetAgentAction = new RestMLGetAgentAction(mlFeatureEnabledSetting);
         RestMLDeleteAgentAction restMLDeleteAgentAction = new RestMLDeleteAgentAction(mlFeatureEnabledSetting);
         RestMemoryUpdateConversationAction restMemoryUpdateConversationAction = new RestMemoryUpdateConversationAction();
@@ -969,7 +969,8 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_REMOTE_JOB_STATUS_COMPLETED_REGEX,
                 MLCommonsSettings.ML_COMMONS_REMOTE_JOB_STATUS_CANCELLED_REGEX,
                 MLCommonsSettings.ML_COMMONS_REMOTE_JOB_STATUS_CANCELLING_REGEX,
-                MLCommonsSettings.ML_COMMONS_REMOTE_JOB_STATUS_EXPIRED_REGEX
+                MLCommonsSettings.ML_COMMONS_REMOTE_JOB_STATUS_EXPIRED_REGEX,
+                MLCommonsSettings.ML_COMMONS_CONTROLLER_ENABLED
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLCreateControllerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLCreateControllerAction.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.rest;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.MLExceptionUtils.CONTROLLER_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
 import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
 
@@ -20,6 +21,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.controller.MLController;
 import org.opensearch.ml.common.transport.controller.MLCreateControllerAction;
 import org.opensearch.ml.common.transport.controller.MLCreateControllerRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestToXContentListener;
@@ -29,11 +31,14 @@ import com.google.common.collect.ImmutableList;
 public class RestMLCreateControllerAction extends BaseRestHandler {
 
     public final static String ML_CREATE_CONTROLLER_ACTION = "ml_create_controller_action";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     /**
      * Constructor
      */
-    public RestMLCreateControllerAction() {}
+    public RestMLCreateControllerAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
 
     @Override
     public String getName() {
@@ -61,6 +66,10 @@ public class RestMLCreateControllerAction extends BaseRestHandler {
      * @return MLCreateControllerRequest
      */
     private MLCreateControllerRequest getRequest(RestRequest request) throws IOException {
+        if (!mlFeatureEnabledSetting.isControllerEnabled()) {
+            throw new IllegalStateException(CONTROLLER_DISABLED_ERR_MSG);
+        }
+
         if (!request.hasContent()) {
             throw new OpenSearchParseException("Create model controller request has empty body");
         }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLDeleteControllerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLDeleteControllerAction.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.rest;
 
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.MLExceptionUtils.CONTROLLER_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
 
 import java.io.IOException;
@@ -15,6 +16,7 @@ import java.util.Locale;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.ml.common.transport.controller.MLControllerDeleteAction;
 import org.opensearch.ml.common.transport.controller.MLControllerDeleteRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestToXContentListener;
@@ -25,9 +27,13 @@ import com.google.common.collect.ImmutableList;
  * This class consists of the REST handler to delete ML Model.
  */
 public class RestMLDeleteControllerAction extends BaseRestHandler {
-    private static final String ML_DELETE_CONTROLLER_ACTION = "ml_delete_controller_action";
 
-    public void RestMLDeleteControllerAction() {}
+    private static final String ML_DELETE_CONTROLLER_ACTION = "ml_delete_controller_action";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    public RestMLDeleteControllerAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
 
     @Override
     public String getName() {
@@ -42,6 +48,9 @@ public class RestMLDeleteControllerAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (!mlFeatureEnabledSetting.isControllerEnabled()) {
+            throw new IllegalStateException(CONTROLLER_DISABLED_ERR_MSG);
+        }
         String modelId = request.param(PARAMETER_MODEL_ID);
 
         MLControllerDeleteRequest mlControllerDeleteRequest = new MLControllerDeleteRequest(modelId);

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetControllerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetControllerAction.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.rest;
 
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.MLExceptionUtils.CONTROLLER_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
 import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
 import static org.opensearch.ml.utils.RestActionUtils.returnContent;
@@ -17,6 +18,7 @@ import java.util.Locale;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.ml.common.transport.controller.MLControllerGetAction;
 import org.opensearch.ml.common.transport.controller.MLControllerGetRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestToXContentListener;
@@ -25,12 +27,16 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 public class RestMLGetControllerAction extends BaseRestHandler {
+
     private static final String ML_GET_CONTROLLER_ACTION = "ml_get_controller_action";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     /**
      * Constructor
      */
-    public RestMLGetControllerAction() {}
+    public RestMLGetControllerAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
 
     @Override
     public String getName() {
@@ -57,6 +63,10 @@ public class RestMLGetControllerAction extends BaseRestHandler {
      */
     @VisibleForTesting
     MLControllerGetRequest getRequest(RestRequest request) throws IOException {
+        if (!mlFeatureEnabledSetting.isControllerEnabled()) {
+            throw new IllegalStateException(CONTROLLER_DISABLED_ERR_MSG);
+        }
+
         String modelId = getParameterId(request, PARAMETER_MODEL_ID);
         boolean returnContent = returnContent(request);
 

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateControllerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateControllerAction.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.rest;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.MLExceptionUtils.CONTROLLER_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
 import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
 
@@ -20,6 +21,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.controller.MLController;
 import org.opensearch.ml.common.transport.controller.MLUpdateControllerAction;
 import org.opensearch.ml.common.transport.controller.MLUpdateControllerRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestToXContentListener;
@@ -29,11 +31,14 @@ import com.google.common.collect.ImmutableList;
 public class RestMLUpdateControllerAction extends BaseRestHandler {
 
     public final static String ML_UPDATE_CONTROLLER_ACTION = "ml_update_controller_action";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     /**
      * Constructor
      */
-    public RestMLUpdateControllerAction() {}
+    public RestMLUpdateControllerAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
 
     @Override
     public String getName() {
@@ -62,6 +67,10 @@ public class RestMLUpdateControllerAction extends BaseRestHandler {
      * @throws IOException if an error occurs while parsing the request
      */
     private MLUpdateControllerRequest getRequest(RestRequest request) throws IOException {
+        if (!mlFeatureEnabledSetting.isControllerEnabled()) {
+            throw new IllegalStateException(CONTROLLER_DISABLED_ERR_MSG);
+        }
+
         if (!request.hasContent()) {
             throw new OpenSearchParseException("Update model controller request has empty body");
         }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -243,4 +243,7 @@ public final class MLCommonsSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
+
+    public static final Setting<Boolean> ML_COMMONS_CONTROLLER_ENABLED = Setting
+        .boolSetting("plugins.ml_commons.controller_enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
@@ -9,6 +9,7 @@ package org.opensearch.ml.settings;
 
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_CONTROLLER_ENABLED;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_LOCAL_MODEL_ENABLED;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED;
 
@@ -25,11 +26,14 @@ public class MLFeatureEnabledSetting {
     private volatile Boolean isLocalModelEnabled;
     private volatile AtomicBoolean isConnectorPrivateIpEnabled;
 
+    private volatile Boolean isControllerEnabled;
+
     public MLFeatureEnabledSetting(ClusterService clusterService, Settings settings) {
         isRemoteInferenceEnabled = ML_COMMONS_REMOTE_INFERENCE_ENABLED.get(settings);
         isAgentFrameworkEnabled = ML_COMMONS_AGENT_FRAMEWORK_ENABLED.get(settings);
         isLocalModelEnabled = ML_COMMONS_LOCAL_MODEL_ENABLED.get(settings);
         isConnectorPrivateIpEnabled = new AtomicBoolean(ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED.get(settings));
+        isControllerEnabled = ML_COMMONS_CONTROLLER_ENABLED.get(settings);
 
         clusterService
             .getClusterSettings()
@@ -41,6 +45,7 @@ public class MLFeatureEnabledSetting {
         clusterService
             .getClusterSettings()
             .addSettingsUpdateConsumer(ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED, it -> isConnectorPrivateIpEnabled.set(it));
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_CONTROLLER_ENABLED, it -> isControllerEnabled = it);
     }
 
     /**
@@ -69,6 +74,14 @@ public class MLFeatureEnabledSetting {
 
     public AtomicBoolean isConnectorPrivateIpEnabled() {
         return isConnectorPrivateIpEnabled;
+    }
+
+    /**
+     * Whether the controller feature is enabled. If disabled, APIs in ml-commons will block controller.
+     * @return whether the controller is enabled.
+     */
+    public Boolean isControllerEnabled() {
+        return isControllerEnabled;
     }
 
 }

--- a/plugin/src/main/java/org/opensearch/ml/utils/MLExceptionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/MLExceptionUtils.java
@@ -24,6 +24,8 @@ public class MLExceptionUtils {
         "Local Model is currently disabled. To enable it, update the setting \"plugins.ml_commons.local_model.enabled\" to true.";
     public static final String AGENT_FRAMEWORK_DISABLED_ERR_MSG =
         "Agent Framework is currently disabled. To enable it, update the setting \"plugins.ml_commons.agent_framework_enabled\" to true.";
+    public static final String CONTROLLER_DISABLED_ERR_MSG =
+        "Controller is currently disabled. To enable it, update the setting \"plugins.ml_commons.controller_enabled\" to true.";
 
     public static String getRootCauseMessage(final Throwable throwable) {
         String message = ExceptionUtils.getRootCauseMessage(throwable);

--- a/plugin/src/test/java/org/opensearch/ml/action/controller/CreateControllerTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/controller/CreateControllerTransportActionTests.java
@@ -57,6 +57,7 @@ import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -104,6 +105,9 @@ public class CreateControllerTransportActionTests extends OpenSearchTestCase {
     @Mock
     MLDeployControllerNodesResponse mlDeployControllerNodesResponse;
 
+    @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
 
@@ -138,7 +142,7 @@ public class CreateControllerTransportActionTests extends OpenSearchTestCase {
 
         DiscoveryNodes nodes = DiscoveryNodes.builder().add(node1).add(node2).build();
         String[] targetNodeIds = new String[] { node1.getId(), node2.getId() };
-
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(true);
         createControllerTransportAction = spy(
             new CreateControllerTransportAction(
                 transportService,
@@ -148,7 +152,8 @@ public class CreateControllerTransportActionTests extends OpenSearchTestCase {
                 clusterService,
                 modelAccessControlHelper,
                 mlModelCacheHelper,
-                mlModelManager
+                mlModelManager,
+                mlFeatureEnabledSetting
             )
         );
 
@@ -204,6 +209,18 @@ public class CreateControllerTransportActionTests extends OpenSearchTestCase {
     public void testCreateControllerSuccess() {
         createControllerTransportAction.doExecute(null, createControllerRequest, actionListener);
         verify(actionListener).onResponse(any(MLCreateControllerResponse.class));
+    }
+
+    @Test
+    public void testCreateControllerFailedWithControllerFeatureFlagDisabled() {
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(false);
+        createControllerTransportAction.doExecute(null, createControllerRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+                "Controller is currently disabled. To enable it, update the setting \"plugins.ml_commons.controller_enabled\" to true.",
+                argumentCaptor.getValue().getMessage()
+        );
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/action/controller/DeleteControllerTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/controller/DeleteControllerTransportActionTests.java
@@ -54,6 +54,7 @@ import org.opensearch.ml.common.transport.controller.MLUndeployControllerNodesRe
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -104,6 +105,9 @@ public class DeleteControllerTransportActionTests extends OpenSearchTestCase {
     @Mock
     MLUndeployControllerNodesResponse mlUndeployControllerNodesResponse;
 
+    @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
 
@@ -137,7 +141,7 @@ public class DeleteControllerTransportActionTests extends OpenSearchTestCase {
         );
 
         DiscoveryNodes nodes = DiscoveryNodes.builder().add(node1).add(node2).build();
-
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(true);
         deleteControllerTransportAction = spy(
             new DeleteControllerTransportAction(
                 transportService,
@@ -147,7 +151,8 @@ public class DeleteControllerTransportActionTests extends OpenSearchTestCase {
                 clusterService,
                 mlModelManager,
                 mlModelCacheHelper,
-                modelAccessControlHelper
+                modelAccessControlHelper,
+                mlFeatureEnabledSetting
             )
         );
 
@@ -191,6 +196,18 @@ public class DeleteControllerTransportActionTests extends OpenSearchTestCase {
     public void testDeleteControllerSuccess() {
         deleteControllerTransportAction.doExecute(null, mlControllerDeleteRequest, actionListener);
         verify(actionListener).onResponse(deleteResponse);
+    }
+
+    @Test
+    public void testDeleteControllerFailedWithControllerFeatureFlagDisabled() {
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(false);
+        deleteControllerTransportAction.doExecute(null, mlControllerDeleteRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+                "Controller is currently disabled. To enable it, update the setting \"plugins.ml_commons.controller_enabled\" to true.",
+                argumentCaptor.getValue().getMessage()
+        );
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/action/controller/GetControllerTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/controller/GetControllerTransportActionTests.java
@@ -46,6 +46,7 @@ import org.opensearch.ml.common.transport.controller.MLControllerGetRequest;
 import org.opensearch.ml.common.transport.controller.MLControllerGetResponse;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -81,6 +82,9 @@ public class GetControllerTransportActionTests extends OpenSearchTestCase {
     @Mock
     MLModel mlModel;
 
+    @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
 
@@ -93,6 +97,7 @@ public class GetControllerTransportActionTests extends OpenSearchTestCase {
         MockitoAnnotations.openMocks(this);
 
         Settings settings = Settings.builder().build();
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(true);
         getControllerTransportAction = spy(
             new GetControllerTransportAction(
                 transportService,
@@ -101,7 +106,8 @@ public class GetControllerTransportActionTests extends OpenSearchTestCase {
                 xContentRegistry,
                 clusterService,
                 mlModelManager,
-                modelAccessControlHelper
+                modelAccessControlHelper,
+                mlFeatureEnabledSetting
             )
         );
         mlControllerGetRequest = MLControllerGetRequest.builder().modelId("testModelId").build();
@@ -134,6 +140,18 @@ public class GetControllerTransportActionTests extends OpenSearchTestCase {
     public void testGetControllerSuccess() {
         getControllerTransportAction.doExecute(null, mlControllerGetRequest, actionListener);
         verify(actionListener).onResponse(any(MLControllerGetResponse.class));
+    }
+
+    @Test
+    public void testGetControllerFailedWithControllerFeatureFlagDisabled() {
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(false);
+        getControllerTransportAction.doExecute(null, mlControllerGetRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+                "Controller is currently disabled. To enable it, update the setting \"plugins.ml_commons.controller_enabled\" to true.",
+                argumentCaptor.getValue().getMessage()
+        );
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/action/controller/UpdateControllerTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/controller/UpdateControllerTransportActionTests.java
@@ -58,6 +58,7 @@ import org.opensearch.ml.common.transport.controller.MLUpdateControllerRequest;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -105,6 +106,9 @@ public class UpdateControllerTransportActionTests extends OpenSearchTestCase {
     @Mock
     MLDeployControllerNodesResponse mlDeployControllerNodesResponse;
 
+    @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
 
@@ -141,7 +145,7 @@ public class UpdateControllerTransportActionTests extends OpenSearchTestCase {
 
         DiscoveryNodes nodes = DiscoveryNodes.builder().add(node1).add(node2).build();
         String[] targetNodeIds = new String[] { node1.getId(), node2.getId() };
-
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(true);
         updateControllerTransportAction = spy(
             new UpdateControllerTransportAction(
                 transportService,
@@ -150,7 +154,8 @@ public class UpdateControllerTransportActionTests extends OpenSearchTestCase {
                 clusterService,
                 modelAccessControlHelper,
                 mlModelCacheHelper,
-                mlModelManager
+                mlModelManager,
+                mlFeatureEnabledSetting
             )
         );
 
@@ -214,6 +219,18 @@ public class UpdateControllerTransportActionTests extends OpenSearchTestCase {
     public void testUpdateControllerSuccess() {
         updateControllerTransportAction.doExecute(null, updateControllerRequest, actionListener);
         verify(actionListener).onResponse(updateResponse);
+    }
+
+    @Test
+    public void testUpdateControllerFailedWithControllerFeatureFlagDisabled() {
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(false);
+        updateControllerTransportAction.doExecute(null, updateControllerRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+                "Controller is currently disabled. To enable it, update the setting \"plugins.ml_commons.controller_enabled\" to true.",
+                argumentCaptor.getValue().getMessage()
+        );
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -256,7 +256,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         threadContext = new ThreadContext(settings);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
-
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(true);
         when(mlFeatureEnabledSetting.isConnectorPrivateIpEnabled()).thenReturn(new AtomicBoolean(false));
 
         modelManager = spy(

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLCreateControllerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLCreateControllerActionTests.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +35,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.controller.MLController;
 import org.opensearch.ml.common.transport.controller.MLCreateControllerAction;
 import org.opensearch.ml.common.transport.controller.MLCreateControllerRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
@@ -51,6 +53,9 @@ public class RestMLCreateControllerActionTests extends OpenSearchTestCase {
     private ThreadPool threadPool;
 
     @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Mock
     RestChannel channel;
 
     @Before
@@ -58,7 +63,8 @@ public class RestMLCreateControllerActionTests extends OpenSearchTestCase {
         MockitoAnnotations.openMocks(this);
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
         client = spy(new NodeClient(Settings.EMPTY, threadPool));
-        restMLCreateControllerAction = new RestMLCreateControllerAction();
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(true);
+        restMLCreateControllerAction = new RestMLCreateControllerAction(mlFeatureEnabledSetting);
         doAnswer(invocation -> {
             invocation.getArgument(2);
             return null;
@@ -74,7 +80,7 @@ public class RestMLCreateControllerActionTests extends OpenSearchTestCase {
 
     @Test
     public void testConstructor() {
-        RestMLCreateControllerAction CreateModelAction = new RestMLCreateControllerAction();
+        RestMLCreateControllerAction CreateModelAction = new RestMLCreateControllerAction(mlFeatureEnabledSetting);
         assertNotNull(CreateModelAction);
     }
 
@@ -126,6 +132,18 @@ public class RestMLCreateControllerActionTests extends OpenSearchTestCase {
         exceptionRule.expect(ParsingException.class);
         exceptionRule.expectMessage("expecting token of type [START_OBJECT] but found [VALUE_NULL]");
         RestRequest request = getRestRequestWithNullField();
+        restMLCreateControllerAction.handleRequest(request, channel, client);
+    }
+
+    @Test
+    public void testCreateControllerRequestWithControllerDisabled() throws Exception {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule
+            .expectMessage(
+                "Controller is currently disabled. To enable it, update the setting \"plugins.ml_commons.controller_enabled\" to true."
+            );
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(false);
+        RestRequest request = getRestRequest();
         restMLCreateControllerAction.handleRequest(request, channel, client);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteControllerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteControllerActionTests.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
 
 import java.util.HashMap;
@@ -22,6 +23,7 @@ import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.settings.Settings;
@@ -30,6 +32,7 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.transport.controller.MLControllerDeleteAction;
 import org.opensearch.ml.common.transport.controller.MLControllerDeleteRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
@@ -49,11 +52,16 @@ public class RestMLDeleteControllerActionTests extends OpenSearchTestCase {
     private ThreadPool threadPool;
 
     @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Mock
     RestChannel channel;
 
     @Before
     public void setup() {
-        restMLDeleteControllerAction = new RestMLDeleteControllerAction();
+        MockitoAnnotations.openMocks(this);
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(true);
+        restMLDeleteControllerAction = new RestMLDeleteControllerAction(mlFeatureEnabledSetting);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
         client = spy(new NodeClient(Settings.EMPTY, threadPool));
@@ -73,7 +81,7 @@ public class RestMLDeleteControllerActionTests extends OpenSearchTestCase {
     }
 
     public void testConstructor() {
-        RestMLDeleteControllerAction mlDeleteControllerAction = new RestMLDeleteControllerAction();
+        RestMLDeleteControllerAction mlDeleteControllerAction = new RestMLDeleteControllerAction(mlFeatureEnabledSetting);
         assertNotNull(mlDeleteControllerAction);
     }
 
@@ -90,6 +98,17 @@ public class RestMLDeleteControllerActionTests extends OpenSearchTestCase {
         RestHandler.Route route = routes.get(0);
         assertEquals(RestRequest.Method.DELETE, route.getMethod());
         assertEquals("/_plugins/_ml/controllers/{model_id}", route.getPath());
+    }
+
+    public void testDeleteControllerRequestWithControllerDisabled() throws Exception {
+        thrown.expect(IllegalStateException.class);
+        thrown
+            .expectMessage(
+                "Controller is currently disabled. To enable it, update the setting \"plugins.ml_commons.controller_enabled\" to true."
+            );
+        when(mlFeatureEnabledSetting.isControllerEnabled()).thenReturn(false);
+        RestRequest request = getRestRequest();
+        restMLDeleteControllerAction.handleRequest(request, channel, client);
     }
 
     public void test_PrepareRequest() throws Exception {


### PR DESCRIPTION
### Description
This PR will add a feature enable setting for controller index, to support multi-tenancy
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
