### PR TITLE
support customized conversation name

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
@@ -25,6 +25,7 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
@@ -64,6 +65,7 @@ public class MLAgentExecutor implements Executable {
 
     public static final String MEMORY_ID = "memory_id";
     public static final String QUESTION = "question";
+    public static final String CONVERSATION_NAME = "conversation_name";
     public static final String PARENT_INTERACTION_ID = "parent_interaction_id";
     public static final String REGENERATE_INTERACTION_ID = "regenerate_interaction_id";
     public static final String MESSAGE_HISTORY_LIMIT = "message_history_limit";
@@ -121,6 +123,7 @@ public class MLAgentExecutor implements Executable {
                             String regenerateInteractionId = inputDataSet.getParameters().get(REGENERATE_INTERACTION_ID);
                             String appType = mlAgent.getAppType();
                             String question = inputDataSet.getParameters().get(QUESTION);
+                            String conversationName = inputDataSet.getParameters().get(CONVERSATION_NAME);
 
                             if (memoryId == null && regenerateInteractionId != null) {
                                 throw new IllegalArgumentException("A memory ID must be provided to regenerate.");
@@ -132,7 +135,8 @@ public class MLAgentExecutor implements Executable {
                                 && (memoryId == null || parentInteractionId == null)) {
                                 ConversationIndexMemory.Factory conversationIndexMemoryFactory =
                                     (ConversationIndexMemory.Factory) memoryFactoryMap.get(memorySpec.getType());
-                                conversationIndexMemoryFactory.create(question, memoryId, appType, ActionListener.wrap(memory -> {
+                                String title = Strings.isEmpty(conversationName) ? question : conversationName;
+                                conversationIndexMemoryFactory.create(title, memoryId, appType, ActionListener.wrap(memory -> {
                                     inputDataSet.getParameters().put(MEMORY_ID, memory.getConversationId());
                                     ActionListener<Object> agentActionListener = createAgentActionListener(listener, outputs, modelTensors);
                                     // get question for regenerate


### PR DESCRIPTION
### Description

Add a new parameter `conversation_name` to support customize conversation name
 
### Issues Resolved

https://github.com/opensearch-project/ml-commons/issues/2623
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
