### PR TITLE
Fix MLModelTool returns null if the response of LLM is a pure json object

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
@@ -8,7 +8,6 @@ package org.opensearch.ml.engine.tools;
 import java.util.List;
 import java.util.Map;
 
-import java.util.NoSuchElementException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.client.Client;
 import org.opensearch.core.action.ActionListener;
@@ -70,8 +69,7 @@ public class MLModelTool implements Tool {
         outputParser = o -> {
             try {
                 List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
-                Map<String, ?> dataAsMap = mlModelOutputs.getFirst().getMlModelTensors().getFirst()
-                    .getDataAsMap();
+                Map<String, ?> dataAsMap = mlModelOutputs.getFirst().getMlModelTensors().getFirst().getDataAsMap();
                 // Return the response field if it exists, otherwise return the whole response as json string.
                 if (dataAsMap.containsKey(responseField)) {
                     return dataAsMap.get(responseField);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
@@ -69,7 +69,8 @@ public class MLModelTool implements Tool {
         outputParser = o -> {
             List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
             Map<String, ?> dataAsMap = mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap();
-            if (dataAsMap.size() == 1 && dataAsMap.containsKey(responseField)) {
+            // Return the response field if it exists, otherwise return the whole response a json string.
+            if (dataAsMap.containsKey(responseField)) {
                 return dataAsMap.get(responseField);
             } else {
                 return StringUtils.toJson(dataAsMap);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
@@ -21,6 +21,7 @@ import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
+import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.repackage.com.google.common.annotations.VisibleForTesting;
 
 import lombok.Getter;
@@ -54,6 +55,7 @@ public class MLModelTool implements Tool {
     private Parser inputParser;
     @Setter
     @Getter
+    @VisibleForTesting
     private Parser outputParser;
     @Setter
     @Getter
@@ -66,7 +68,12 @@ public class MLModelTool implements Tool {
 
         outputParser = o -> {
             List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
-            return mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap().get(responseField);
+            Map<String, ?> dataAsMap = mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap();
+            if (dataAsMap.size() == 1 && dataAsMap.containsKey(responseField)) {
+                return dataAsMap.get(responseField);
+            } else {
+                return StringUtils.toJson(dataAsMap);
+            }
         };
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/MLModelToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/MLModelToolTests.java
@@ -171,6 +171,26 @@ public class MLModelToolTests {
     }
 
     @Test
+    public void testOutputParserWithJsonResponse() {
+        Parser outputParser = new MLModelTool(client, "modelId", "response").getOutputParser();
+        String expectedJson = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
+
+        // Create a mock ModelTensors with json object
+        ModelTensor modelTensor = ModelTensor.builder().dataAsMap(ImmutableMap.of("key1", "value1", "key2", "value2")).build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+        Object result = outputParser.parse(mlModelTensorOutput.getMlModelOutputs());
+        assertEquals(expectedJson, result);
+
+        // Create a mock ModelTensors with response string
+        modelTensor = ModelTensor.builder().dataAsMap(ImmutableMap.of("response", "{\"key1\":\"value1\",\"key2\":\"value2\"}")).build();
+        modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+        result = outputParser.parse(mlModelTensorOutput.getMlModelOutputs());
+        assertEquals(expectedJson, result);
+    }
+
+    @Test
     public void testRunWithError() {
         // Mocking the client.execute to simulate an error
         doAnswer(invocation -> {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/MLModelToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/MLModelToolTests.java
@@ -124,7 +124,7 @@ public class MLModelToolTests {
         tool.run(null, listener);
 
         future.join();
-        assertEquals(null, future.get());
+        assertEquals("{\"response\":\"response 1\",\"action\":\"action1\"}", future.get());
     }
 
     @Test


### PR DESCRIPTION
### Description
Fix MLModelTool returns null if the response of LLM is a pure json object. It will detect wether the LLM response is a pure json object or a response string, and parse in different way.

There is similar logic in [AgentUtils.java](https://github.com/opensearch-project/ml-commons/blob/b6618b2bcd18ab7070a8b8923074d365efe89dd9/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java#L193) for MLChatAgentRunner

https://github.com/opensearch-project/ml-commons/blob/b6618b2bcd18ab7070a8b8923074d365efe89dd9/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java#L193
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/2654
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
