### PR TITLE
[Backport 2.x] Fix MLModelTool returns null if the response of LLM is a pure json object

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
@@ -69,7 +69,7 @@ public class MLModelTool implements Tool {
         outputParser = o -> {
             try {
                 List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
-                Map<String, ?> dataAsMap = mlModelOutputs.getFirst().getMlModelTensors().getFirst().getDataAsMap();
+                Map<String, ?> dataAsMap = mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap();
                 // Return the response field if it exists, otherwise return the whole response as json string.
                 if (dataAsMap.containsKey(responseField)) {
                     return dataAsMap.get(responseField);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/MLModelToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/MLModelToolTests.java
@@ -124,7 +124,7 @@ public class MLModelToolTests {
         tool.run(null, listener);
 
         future.join();
-        assertEquals(null, future.get());
+        assertEquals("{\"response\":\"response 1\",\"action\":\"action1\"}", future.get());
     }
 
     @Test
@@ -168,6 +168,26 @@ public class MLModelToolTests {
 
         // Assert that the result matches the expected response
         assertEquals("testResponse", result);
+    }
+
+    @Test
+    public void testOutputParserWithJsonResponse() {
+        Parser outputParser = new MLModelTool(client, "modelId", "response").getOutputParser();
+        String expectedJson = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
+
+        // Create a mock ModelTensors with json object
+        ModelTensor modelTensor = ModelTensor.builder().dataAsMap(ImmutableMap.of("key1", "value1", "key2", "value2")).build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+        Object result = outputParser.parse(mlModelTensorOutput.getMlModelOutputs());
+        assertEquals(expectedJson, result);
+
+        // Create a mock ModelTensors with response string
+        modelTensor = ModelTensor.builder().dataAsMap(ImmutableMap.of("response", "{\"key1\":\"value1\",\"key2\":\"value2\"}")).build();
+        modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+        result = outputParser.parse(mlModelTensorOutput.getMlModelOutputs());
+        assertEquals(expectedJson, result);
     }
 
     @Test


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/ml-commons/commit/007b914b74850e6faec3645b6f3d8db2dc772563 from https://github.com/opensearch-project/ml-commons/pull/2655 

And fix compiling failure by removing java21 API. (main use java 21 while 2.x use java17)

### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/2654
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
