### PR TITLE
remove java21 API for aligning with BackPort PR

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java
@@ -69,7 +69,7 @@ public class MLModelTool implements Tool {
         outputParser = o -> {
             try {
                 List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
-                Map<String, ?> dataAsMap = mlModelOutputs.getFirst().getMlModelTensors().getFirst().getDataAsMap();
+                Map<String, ?> dataAsMap = mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap();
                 // Return the response field if it exists, otherwise return the whole response as json string.
                 if (dataAsMap.containsKey(responseField)) {
                     return dataAsMap.get(responseField);


### PR DESCRIPTION
### Description
The previous PR https://github.com/opensearch-project/ml-commons/pull/2655 includes java21 API and will block backport PR.

After fixing with this backport PR https://github.com/opensearch-project/ml-commons/pull/2675 and avoid diverge with it, this PR will remove the java 21 API as well.
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/2654
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
