### PR TITLE
increase execute thread pool size

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -842,8 +842,8 @@ public class MachineLearningPlugin extends Plugin
         FixedExecutorBuilder executeThreadPool = new FixedExecutorBuilder(
             settings,
             EXECUTE_THREAD_POOL,
-            Math.max(1, OpenSearchExecutors.allocatedProcessors(settings) - 1),
-            10,
+            OpenSearchExecutors.allocatedProcessors(settings) * 4,
+            10000,
             ML_THREAD_POOL_PREFIX + EXECUTE_THREAD_POOL,
             false
         );


### PR DESCRIPTION
### Description
Agent will use execute thread pool. The current pool size is too small. Increase it to the same with remote predict.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
