### PR TITLE
Make all Amazon managed LLM blueprints in a tidier format

### DIFF
--- a/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
@@ -47,7 +47,6 @@ POST /_plugins/_ml/connectors/_create
   "parameters": {
     "service_name": "comprehend",
     "region": "us-east-1",
-    "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
     "api_version": "20171127",
     "api_name": "DetectDominantLanguage",
     "api": "Comprehend_${parameters.api_version}.${parameters.api_name}",
@@ -57,7 +56,7 @@ POST /_plugins/_ml/connectors/_create
     {
       "action_type": "predict",
       "method": "POST",
-      "url": "${parameters.endpoint}",
+      "url": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
       "headers": {
         "X-Amz-Target": "${parameters.api}",
         "content-type": "application/x-amz-json-1.1"
@@ -87,7 +86,6 @@ POST /_plugins/_ml/connectors/_create
   "parameters": {
     "service_name": "comprehend",
     "region": "us-east-1",
-    "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
     "api_version": "20171127",
     "api_name": "DetectDominantLanguage",
     "api": "Comprehend_${parameters.api_version}.${parameters.api_name}",
@@ -97,7 +95,7 @@ POST /_plugins/_ml/connectors/_create
     {
       "action_type": "predict",
       "method": "POST",
-      "url": "${parameters.endpoint}",
+      "url": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
       "headers": {
         "X-Amz-Target": "${parameters.api}",
         "content-type": "application/x-amz-json-1.1"
@@ -400,7 +398,6 @@ POST /_plugins/_ml/connectors/_create
   "parameters": {
     "service_name": "comprehend",
     "region": "us-east-1",
-    "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
     "api_version": "20171127",
     "api_name": "DetectEntities",
     "api": "Comprehend_${parameters.api_version}.${parameters.api_name}",
@@ -410,7 +407,7 @@ POST /_plugins/_ml/connectors/_create
     {
       "action_type": "predict",
       "method": "POST",
-      "url": "${parameters.endpoint}",
+      "url": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
       "headers": {
         "X-Amz-Target": "${parameters.api}",
         "content-type": "application/x-amz-json-1.1"
@@ -440,7 +437,6 @@ POST /_plugins/_ml/connectors/_create
   "parameters": {
     "service_name": "comprehend",
     "region": "us-east-1",
-    "endpoint": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
     "api_version": "20171127",
     "api_name": "DetectEntities",
     "api": "Comprehend_${parameters.api_version}.${parameters.api_name}",
@@ -450,7 +446,7 @@ POST /_plugins/_ml/connectors/_create
     {
       "action_type": "predict",
       "method": "POST",
-      "url": "${parameters.endpoint}",
+      "url": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
       "headers": {
         "X-Amz-Target": "${parameters.api}",
         "content-type": "application/x-amz-json-1.1"

--- a/docs/remote_inference_blueprints/amazon_textract_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_textract_connector_blueprint.md
@@ -42,7 +42,9 @@ POST /_plugins/_ml/connectors/_create
   },
   "parameters": {
     "region": "<PLEASE ADD YOUR AWS REGION like us-west-2>",
-    "service_name": "textract"
+    "service_name": "textract",
+    "api_name": "DetectDocumentText",
+    "api": "Textract.${parameters.api_name}"
   },
   "actions": [
     {
@@ -50,7 +52,7 @@ POST /_plugins/_ml/connectors/_create
       "method": "POST",
       "headers": {
         "content-type": "application/x-amz-json-1.1",
-        "X-Amz-Target": "Textract.DetectDocumentText"
+        "X-Amz-Target": "${parameters.api}"
       },
       "url": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
       "request_body": "{  \"Document\": { \"Bytes\": \"${parameters.bytes}\" }  } "
@@ -77,7 +79,9 @@ POST /_plugins/_ml/connectors/_create
   },
   "parameters": {
     "region": "<PLEASE ADD YOUR AWS REGION like us-west-2>",
-    "service_name": "textract"
+    "service_name": "textract",
+    "api_name": "DetectDocumentText",
+    "api": "Textract.${parameters.api_name}"
   },
   "actions": [
     {
@@ -85,7 +89,7 @@ POST /_plugins/_ml/connectors/_create
       "method": "POST",
       "headers": {
         "content-type": "application/x-amz-json-1.1",
-        "X-Amz-Target": "Textract.DetectDocumentText"
+        "X-Amz-Target": "${parameters.api}"
       },
       "url": "https://${parameters.service_name}.${parameters.region}.amazonaws.com",
       "request_body": "{  \"Document\": { \"Bytes\": \"${parameters.bytes}\" }  } "

--- a/docs/remote_inference_blueprints/bedrock_connector_ai21labs_jurassic_blueprint.md
+++ b/docs/remote_inference_blueprints/bedrock_connector_ai21labs_jurassic_blueprint.md
@@ -28,7 +28,8 @@ POST /_plugins/_ml/connectors/_create
     "protocol": "aws_sigv4",
     "credential": {
         "access_key": "<PLEASE ADD YOUR AWS ACCESS KEY HERE>",
-        "secret_key": "<PLEASE ADD YOUR AWS SECRET KEY HERE>"
+        "secret_key": "<PLEASE ADD YOUR AWS SECRET KEY HERE>",
+        "session_token": "<PLEASE ADD YOUR AWS SECURITY TOKEN HERE>"
     },
     "parameters": {
         "region": "<PLEASE ADD YOUR AWS REGION HERE>",
@@ -42,7 +43,7 @@ POST /_plugins/_ml/connectors/_create
             "headers": {
                 "content-type": "application/json"
             },
-            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model_name}/invoke",
+            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke",
            "request_body": "{\"prompt\":\"${parameters.inputs}\",\"maxTokens\":200,\"temperature\":0.7,\"topP\":1,\"stopSequences\":[],\"countPenalty\":{\"scale\":0},\"presencePenalty\":{\"scale\":0},\"frequencyPenalty\":{\"scale\":0}}",
            "post_process_function": "\n  return params['completions'][0].data.text; \n"
         }
@@ -66,7 +67,7 @@ POST /_plugins/_ml/connectors/_create
     "parameters": {
         "region": "<PLEASE ADD YOUR AWS REGION HERE>",
         "service_name": "bedrock",
-        "model_name": "ai21.j2-mid-v1"
+        "model": "ai21.j2-mid-v1"
     },
     "actions": [
         {
@@ -75,7 +76,7 @@ POST /_plugins/_ml/connectors/_create
             "headers": {
                 "content-type": "application/json"
             },
-            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model_name}/invoke",
+            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke",
            "request_body": "{\"prompt\":\"${parameters.inputs}\",\"maxTokens\":200,\"temperature\":0.7,\"topP\":1,\"stopSequences\":[],\"countPenalty\":{\"scale\":0},\"presencePenalty\":{\"scale\":0},\"frequencyPenalty\":{\"scale\":0}}",
            "post_process_function": "\n  return params['completions'][0].data.text; \n"
         }

--- a/docs/remote_inference_blueprints/bedrock_connector_anthropic_claude3_blueprint.md
+++ b/docs/remote_inference_blueprints/bedrock_connector_anthropic_claude3_blueprint.md
@@ -73,7 +73,8 @@ POST /_plugins/_ml/connectors/_create
         "auth": "Sig_V4",
         "response_filter": "$.content[0].text",
         "max_tokens_to_sample": "8000",
-        "anthropic_version": "bedrock-2023-05-31"
+        "anthropic_version": "bedrock-2023-05-31",
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0"
     },
     "actions": [
         {
@@ -82,7 +83,7 @@ POST /_plugins/_ml/connectors/_create
             "headers": {
                 "content-type": "application/json"
             },
-            "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-sonnet-20240229-v1:0/invoke",
+            "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/${parameters.model}/invoke",
             "request_body": "{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"${parameters.prompt}\"}]}],\"anthropic_version\":\"${parameters.anthropic_version}\",\"max_tokens\":${parameters.max_tokens_to_sample}}"
         }
     ]

--- a/docs/remote_inference_blueprints/bedrock_connector_anthropic_claude_blueprint.md
+++ b/docs/remote_inference_blueprints/bedrock_connector_anthropic_claude_blueprint.md
@@ -65,7 +65,8 @@ POST /_plugins/_ml/connectors/_create
     },
     "parameters": {
         "region": "<PLEASE ADD YOUR AWS REGION HERE>",
-        "service_name": "bedrock"
+        "service_name": "bedrock",
+        "model": "anthropic.claude-v2"
     },
     "actions": [
         {
@@ -74,7 +75,7 @@ POST /_plugins/_ml/connectors/_create
             "headers": {
                 "content-type": "application/json"
             },
-            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/anthropic.claude-v2/invoke",
+            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke",
             "request_body": "{\"prompt\":\"\\n\\nHuman: ${parameters.inputs}\\n\\nAssistant:\",\"max_tokens_to_sample\":300,\"temperature\":0.5,\"top_k\":250,\"top_p\":1,\"stop_sequences\":[\"\\\\n\\\\nHuman:\"]}"
         }
     ]

--- a/docs/remote_inference_blueprints/bedrock_connector_titan_embedding_blueprint.md
+++ b/docs/remote_inference_blueprints/bedrock_connector_titan_embedding_blueprint.md
@@ -76,7 +76,7 @@ POST /_plugins/_ml/connectors/_create
     {
       "action_type": "predict",
       "method": "POST",
-      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/amazon.titan-embed-text-v1/invoke",
+      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke",
       "headers": {
         "content-type": "application/json",
         "x-amz-content-sha256": "required"

--- a/docs/remote_inference_blueprints/bedrock_connector_titan_multimodal_embedding_blueprint.md
+++ b/docs/remote_inference_blueprints/bedrock_connector_titan_multimodal_embedding_blueprint.md
@@ -67,6 +67,7 @@ POST /_plugins/_ml/connectors/_create
   "parameters": {
     "region": "<PLEASE ADD YOUR AWS REGION HERE>",
     "service_name": "bedrock",
+    "model": "amazon.titan-embed-image-v1",
     "input_docs_processed_step_size": 2
   },
   "credential": {
@@ -76,7 +77,7 @@ POST /_plugins/_ml/connectors/_create
     {
       "action_type": "predict",
       "method": "POST",
-      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/amazon.titan-embed-image-v1/invoke",
+      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke",
       "headers": {
         "content-type": "application/json",
         "x-amz-content-sha256": "required"


### PR DESCRIPTION
### Description
In order to conveniently enable the automated model interface, here we make Amazon managed LLM blueprints in a tidier format.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
