### PR TITLE
Fix removal of dot(.) from table name as DDB table name supports dot(.)

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -107,7 +107,7 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
     public CompletionStage<PutDataObjectResponse> putDataObjectAsync(PutDataObjectRequest request, Executor executor) {
         final String id = request.id() != null ? request.id() : UUID.randomUUID().toString();
         final String tenantId = request.tenantId() != null ? request.tenantId() : DEFAULT_TENANT;
-        final String tableName = getTableName(request.index());
+        final String tableName = request.index();
         return CompletableFuture.supplyAsync(() -> AccessController.doPrivileged((PrivilegedAction<PutDataObjectResponse>) () -> {
             try {
                 String source = Strings.toString(MediaTypeRegistry.JSON, request.dataObject());
@@ -145,7 +145,7 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
         final String tenantId = request.tenantId() != null ? request.tenantId() : DEFAULT_TENANT;
         final GetItemRequest getItemRequest = GetItemRequest
             .builder()
-            .tableName(getTableName(request.index()))
+            .tableName(request.index())
             .key(
                 Map
                     .ofEntries(
@@ -216,7 +216,7 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
                 updateKey.put(RANGE_KEY, AttributeValue.builder().s(request.id()).build());
                 UpdateItemRequest.Builder updateItemRequestBuilder = UpdateItemRequest
                     .builder()
-                    .tableName(getTableName(request.index()))
+                    .tableName(request.index())
                     .key(updateKey)
                     .attributeUpdates(updateAttributeValue);
                 if (request.ifSeqNo() != null) {
@@ -262,7 +262,7 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
         final String tenantId = request.tenantId() != null ? request.tenantId() : DEFAULT_TENANT;
         final DeleteItemRequest deleteItemRequest = DeleteItemRequest
             .builder()
-            .tableName(getTableName(request.index()))
+            .tableName(request.index())
             .key(
                 Map
                     .ofEntries(
@@ -301,7 +301,7 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
      */
     @Override
     public CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(SearchDataObjectRequest request, Executor executor) {
-        List<String> indices = Arrays.stream(request.indices()).map(this::getTableName).collect(Collectors.toList());
+        List<String> indices = Arrays.stream(request.indices()).collect(Collectors.toList());
 
         SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest(
             indices.toArray(new String[0]),
@@ -309,12 +309,6 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
             request.searchSourceBuilder()
         );
         return this.remoteClusterIndicesClient.searchDataObjectAsync(searchDataObjectRequest, executor);
-    }
-
-    private String getTableName(String index) {
-        // Table name will be same as index name. As DDB table name does not support dot(.)
-        // it will be removed from name.
-        return index.replaceAll("\\.", "");
     }
 
     private XContentParser createParser(String json) throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -494,7 +494,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
         assertEquals(searchDataObjectResponse, searchResponse);
         Mockito.verify(remoteClusterIndicesClient).searchDataObjectAsync(searchDataObjectRequestArgumentCaptor.capture(), Mockito.any());
-        Assert.assertEquals("test_index", searchDataObjectRequestArgumentCaptor.getValue().indices()[0]);
+        Assert.assertEquals(".test_index", searchDataObjectRequestArgumentCaptor.getValue().indices()[0]);
     }
 
 }


### PR DESCRIPTION
### Description
Previously dot(.) is manually removed from table name in DDB Client. This is no longer needed as DynamoDB table name supports dot(.)
ref:https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
