### PR TITLE
fix yaml test issue

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -24,6 +24,7 @@ ext {
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.pluginzip'
+apply plugin: 'opensearch.yaml-rest-test'
 ext {
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.txt')

--- a/plugin/src/yamlRestTest/java/org/opensearch/ml/plugin/PluginClientYamlTestSuiteIT.java
+++ b/plugin/src/yamlRestTest/java/org/opensearch/ml/plugin/PluginClientYamlTestSuiteIT.java
@@ -6,15 +6,15 @@
  */
 package org.opensearch.ml.plugin;
 
-import com.carrotsearch.randomizedtesting.annotations.Name;
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.opensearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.opensearch.test.rest.yaml.OpenSearchClientYamlSuiteTestCase;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 public class PluginClientYamlTestSuiteIT extends OpenSearchClientYamlSuiteTestCase {
 
-    public ConversationalClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+    public PluginClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
     }
 

--- a/plugin/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/plugin/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -5,4 +5,4 @@
         h: component
 
   - match:
-      $body: /^plugin\n$/
+      $body: /opensearch-ml\n$/

--- a/plugin/src/yamlRestTest/resources/rest-api-spec/test/20_inference_ingest_processor.yml
+++ b/plugin/src/yamlRestTest/resources/rest-api-spec/test/20_inference_ingest_processor.yml
@@ -6,7 +6,10 @@ teardown:
         ignore: 404
 
 ---
-"Test ML Inference Processor":
+"Test ML Inference Ingest Processor":
+  - skip:
+      version: " - 2.13.99"
+      reason: "Added in 2.14.0"
   - do:
       ingest.put_pipeline:
         id: "my_pipeline"


### PR DESCRIPTION
### Description
found out the yaml test was not run in 2.14 and 2.15. fixing the yaml test issue. 

This is the command to run yaml test locally `./gradlew ':rest-api-spec:yamlRestTest' --tests "org.opensearch.test.rest.ClientYamlTestSuiteIT.test`
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
