### PR TITLE
update config index mappings to use correct field types

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -413,10 +413,10 @@ public class CommonValue {
                         + MASTER_KEY
                         + "\": {\"type\": \"keyword\"},\n"
                         + "      \""
-                        + MLConfig.TYPE_FIELD
+                        + MLConfig.CONFIG_TYPE_FIELD
                         + "\" : {\"type\":\"keyword\"},\n"
                         + "      \""
-                        + MLConfig.CONFIGURATION_FIELD
+                        + MLConfig.ML_CONFIGURATION_FIELD
                         + "\" : {\"type\": \"flat_object\"},\n"
                         + "      \""
                         + CREATE_TIME_FIELD

--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -13,6 +13,9 @@ import org.opensearch.ml.common.controller.MLController;
 
 import java.util.Set;
 
+import static org.opensearch.ml.common.MLConfig.CONFIG_TYPE_FIELD;
+import static org.opensearch.ml.common.MLConfig.LAST_UPDATED_TIME_FIELD;
+import static org.opensearch.ml.common.MLConfig.ML_CONFIGURATION_FIELD;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.APPLICATION_TYPE_FIELD;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_ADDITIONAL_INFO_FIELD;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_CONVERSATION_ID_FIELD;
@@ -407,22 +410,21 @@ public class CommonValue {
                         + "    \"_meta\": {\"schema_version\": "
                         + ML_CONFIG_INDEX_SCHEMA_VERSION
                         + "},\n"
-                        + "    \"dynamic\": \"strict\",\n"
                         + "    \"properties\": {\n"
                         + "      \""
                         + MASTER_KEY
                         + "\": {\"type\": \"keyword\"},\n"
                         + "      \""
-                        + MLConfig.CONFIG_TYPE_FIELD
+                        + CONFIG_TYPE_FIELD
                         + "\" : {\"type\":\"keyword\"},\n"
                         + "      \""
-                        + MLConfig.ML_CONFIGURATION_FIELD
+                        + ML_CONFIGURATION_FIELD
                         + "\" : {\"type\": \"flat_object\"},\n"
                         + "      \""
                         + CREATE_TIME_FIELD
                         + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"},\n"
                         + "      \""
-                        + LAST_UPDATE_TIME_FIELD
+                        + LAST_UPDATED_TIME_FIELD
                         + "\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"}\n"
                         + "    }\n"
                         + "}";

--- a/common/src/main/java/org/opensearch/ml/common/MLConfig.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLConfig.java
@@ -111,6 +111,7 @@ public class MLConfig implements ToXContentObject, Writeable {
         Configuration mlConfiguration = null;
         Instant createTime = null;
         Instant lastUpdateTime = null;
+        Instant lastUpdatedTime = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -136,6 +137,9 @@ public class MLConfig implements ToXContentObject, Writeable {
                 case LAST_UPDATE_TIME_FIELD:
                     lastUpdateTime = Instant.ofEpochMilli(parser.longValue());
                     break;
+                case LAST_UPDATED_TIME_FIELD:
+                    lastUpdatedTime = Instant.ofEpochMilli(parser.longValue());
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -145,7 +149,7 @@ public class MLConfig implements ToXContentObject, Writeable {
                 .type(configType == null ? type : configType)
                 .configuration(mlConfiguration == null ? configuration : mlConfiguration)
                 .createTime(createTime)
-                .lastUpdateTime(lastUpdateTime)
+                .lastUpdateTime(lastUpdatedTime == null ? lastUpdateTime : lastUpdatedTime)
                 .build();
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/MLConfig.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLConfig.java
@@ -27,10 +27,15 @@ public class MLConfig implements ToXContentObject, Writeable {
 
     public static final String TYPE_FIELD = "type";
 
+    public static final String CONFIG_TYPE_FIELD = "config_type";
+
     public static final String CONFIGURATION_FIELD = "configuration";
+
+    public static final String ML_CONFIGURATION_FIELD = "ml_configuration";
 
     public static final String CREATE_TIME_FIELD = "create_time";
     public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
+
 
     @Setter
     private String type;
@@ -78,10 +83,10 @@ public class MLConfig implements ToXContentObject, Writeable {
     public XContentBuilder toXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
         XContentBuilder builder = xContentBuilder.startObject();
         if (type != null) {
-            builder.field(TYPE_FIELD, type);
+            builder.field(CONFIG_TYPE_FIELD, type);
         }
         if (configuration != null) {
-            builder.field(CONFIGURATION_FIELD, configuration);
+            builder.field(ML_CONFIGURATION_FIELD, configuration);
         }
         if (createTime != null) {
             builder.field(CREATE_TIME_FIELD, createTime.toEpochMilli());
@@ -99,7 +104,9 @@ public class MLConfig implements ToXContentObject, Writeable {
 
     public static MLConfig parse(XContentParser parser) throws IOException {
         String type = null;
+        String configType = null;
         Configuration configuration = null;
+        Configuration mlConfiguration = null;
         Instant createTime = null;
         Instant lastUpdateTime = null;
 
@@ -112,8 +119,14 @@ public class MLConfig implements ToXContentObject, Writeable {
                 case TYPE_FIELD:
                     type = parser.text();
                     break;
+                case CONFIG_TYPE_FIELD:
+                    configType = parser.text();
+                    break;
                 case CONFIGURATION_FIELD:
                     configuration = Configuration.parse(parser);
+                    break;
+                case ML_CONFIGURATION_FIELD:
+                    mlConfiguration = Configuration.parse(parser);
                     break;
                 case CREATE_TIME_FIELD:
                     createTime = Instant.ofEpochMilli(parser.longValue());
@@ -127,8 +140,8 @@ public class MLConfig implements ToXContentObject, Writeable {
             }
         }
         return MLConfig.builder()
-                .type(type)
-                .configuration(configuration)
+                .type(configType == null ? type : configType)
+                .configuration(mlConfiguration == null ? configuration : mlConfiguration)
                 .createTime(createTime)
                 .lastUpdateTime(lastUpdateTime)
                 .build();

--- a/common/src/main/java/org/opensearch/ml/common/MLConfig.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLConfig.java
@@ -36,6 +36,8 @@ public class MLConfig implements ToXContentObject, Writeable {
     public static final String CREATE_TIME_FIELD = "create_time";
     public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
 
+    public static final String LAST_UPDATED_TIME_FIELD = "last_updated_time";
+
 
     @Setter
     private String type;


### PR DESCRIPTION
### Description
update config index mappings to use correct field types.

In 2.13, config index mapping was updated with three new fields `configuration`, `type`, and `last_update_time`but schema version was not bumped. Due to which, the domains which were upgraded to 2.13 from previous versions did not go through update index mapping as they did not detect a schema version bump. 

During indexing, these fields got created with wrong types not as specified in the mapping. Now when such domains are going to upgrade to 2.15, with schema_version bump, the index mapping tries to get updated but will throw exception since the field types for the three fields specified above are different. Hence the index initialization fails and indexing into the `config` index wouldn't be possible. 

Hence, the PR tries to add complete new fields(`ml_configuration`, `config_type`, `last_updated_time` while removing the old ones. So whenever mapping is getting updated, since there is no type-conflict for old fields, they get retained in the index as is while new fields get added. It is therefore suggested to start using these new fields from 2.15 while indexing into config index.
 
### Issues Resolved

https://github.com/opensearch-project/ml-commons/issues/2630
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
