### PR TITLE
enhance: support recursive_parameter_enabled in connector

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
@@ -108,18 +108,8 @@ public interface Connector extends ToXContentObject, Writeable {
     }
 
     default void validatePayload(String payload) {
-        if (payload != null && payload.contains("${parameters")) {
-            Pattern pattern = Pattern.compile("\\$\\{parameters\\.([^}]+)}");
-            Matcher matcher = pattern.matcher(payload);
-
-            StringBuilder errorBuilder = new StringBuilder();
-            while (matcher.find()) {
-                String parameter = matcher.group(1);
-                errorBuilder.append(parameter).append(", ");
-            }
-            String error = errorBuilder.substring(0, errorBuilder.length() - 2).toString();
-            throw new IllegalArgumentException("Some parameter placeholder not filled in payload: " + error);
-        }
+        Set<String> requiredParameters = getRequiredParameters(payload);
+        validateParameters(requiredParameters, Map.of());
     }
 
     static Connector fromStream(StreamInput in) throws IOException {

--- a/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
@@ -14,7 +14,6 @@ import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.ml.common.FunctionName;
 
 import java.io.IOException;
 import java.util.HashSet;

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -308,10 +309,18 @@ public class HttpConnector extends AbstractConnector {
     }
 
     @Override
-    public  <T> T createPayload(String action, Map<String, String> parameters) {
+    public <T> T createRawPayload(String action) {
         Optional<ConnectorAction> connectorAction = findAction(action);
         if (connectorAction.isPresent() && connectorAction.get().getRequestBody() != null) {
             String payload = connectorAction.get().getRequestBody();
+            return (T) payload;
+        }
+        return null;
+    }
+
+    @Override
+    public <T> T fillInPayload(String payload, Map<String, String> parameters) {
+        if (payload != null) {
             payload = fillNullParameters(parameters, payload);
             StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
             payload = substitutor.replace(payload);

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -168,7 +168,8 @@ public class HttpConnectorTest {
         HttpConnector connector = createHttpConnector();
         String rawPayload = connector.createRawPayload(PREDICT.name());
         String predictPayload = connector.fillInPayload(rawPayload, null);
-        connector.validatePayload(predictPayload);
+        Set<String> requiredParameters = connector.getRequiredParameters(predictPayload);
+        connector.validateParameters(requiredParameters, Map.of());
     }
 
     @Test
@@ -179,7 +180,8 @@ public class HttpConnectorTest {
         HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
         String rawPayload = connector.createRawPayload(PREDICT.name());
         String predictPayload = connector.fillInPayload(rawPayload, null);
-        connector.validatePayload(predictPayload);
+        Set<String> requiredParameters = connector.getRequiredParameters(predictPayload);
+        connector.validateParameters(requiredParameters, Map.of());
     }
 
     @Test
@@ -197,7 +199,8 @@ public class HttpConnectorTest {
         parameters.put("input", "test input value");
         String rawPayload = connector.createRawPayload(PREDICT.name());
         String predictPayload = connector.fillInPayload(rawPayload, parameters);
-        connector.validatePayload(predictPayload);
+        Set<String> requiredParameters = connector.getRequiredParameters(predictPayload);
+        connector.validateParameters(requiredParameters, Map.of());
         Assert.assertEquals("{\"input\": \"test input value\"}", predictPayload);
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -165,7 +165,8 @@ public class HttpConnectorTest {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("Some parameter placeholder not filled in payload: input");
         HttpConnector connector = createHttpConnector();
-        String predictPayload = connector.createPayload(PREDICT.name(), null);
+        String rawPayload = connector.createRawPayload(PREDICT.name());
+        String predictPayload = connector.fillInPayload(rawPayload, null);
         connector.validatePayload(predictPayload);
     }
 
@@ -175,7 +176,8 @@ public class HttpConnectorTest {
         exceptionRule.expectMessage("Invalid payload: {\"input\": ${parameters.input} }");
         String requestBody = "{\"input\": ${parameters.input} }";
         HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
-        String predictPayload = connector.createPayload(PREDICT.name(), null);
+        String rawPayload = connector.createRawPayload(PREDICT.name());
+        String predictPayload = connector.fillInPayload(rawPayload, null);
         connector.validatePayload(predictPayload);
     }
 
@@ -184,7 +186,8 @@ public class HttpConnectorTest {
         HttpConnector connector = createHttpConnector();
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test input value");
-        String predictPayload = connector.createPayload(PREDICT.name(), parameters);
+        String rawPayload = connector.createRawPayload(PREDICT.name());
+        String predictPayload = connector.fillInPayload(rawPayload, parameters);
         connector.validatePayload(predictPayload);
         Assert.assertEquals("{\"input\": \"test input value\"}", predictPayload);
     }

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
@@ -179,6 +180,14 @@ public class HttpConnectorTest {
         String rawPayload = connector.createRawPayload(PREDICT.name());
         String predictPayload = connector.fillInPayload(rawPayload, null);
         connector.validatePayload(predictPayload);
+    }
+
+    @Test
+    public void getRequiredParameters() {
+        HttpConnector connector = createHttpConnector();
+        String payload = connector.createRawPayload(PREDICT.name());
+        Set<String> requiredParameters = connector.getRequiredParameters(payload);;
+        Assert.assertEquals(Set.of("input"), requiredParameters);
     }
 
     @Test

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
@@ -58,6 +58,8 @@ import software.amazon.awssdk.regions.Region;
 public class ConnectorUtils {
 
     private static final Aws4Signer signer;
+    public static final String RECURSIVE_PARAMETER_ENABLED = "recursive_parameter_enabled";
+
     static {
         signer = Aws4Signer.create();
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -193,7 +193,7 @@ public interface RemoteConnectorExecutor {
         parameters.putAll(inputParameters);
 
         String payload = connector.createRawPayload(action);
-        if (Boolean.parseBoolean(parameters.getOrDefault(RECURSIVE_PARAMETER_ENABLED, "false"))) {
+        if (Boolean.parseBoolean(parameters.getOrDefault(RECURSIVE_PARAMETER_ENABLED, "true"))) {
             // recursively fill in parameters
             payload = connector.fillInPayload(payload, parameters);
             connector.validatePayload(payload);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -196,7 +196,8 @@ public interface RemoteConnectorExecutor {
         if (Boolean.parseBoolean(parameters.getOrDefault(RECURSIVE_PARAMETER_ENABLED, "true"))) {
             // recursively fill in parameters
             payload = connector.fillInPayload(payload, parameters);
-            connector.validatePayload(payload);
+            Set<String> requiredParameters = connector.getRequiredParameters(payload);
+            connector.validateParameters(requiredParameters, Map.of());
         } else {
             // only fill in required parameters
             Set<String> requiredParameters = connector.getRequiredParameters(payload);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.remote;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.connector.AbstractConnector.ACCESS_KEY_FIELD;
+import static org.opensearch.ml.common.connector.AbstractConnector.SECRET_KEY_FIELD;
+import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
+import static org.opensearch.ml.common.connector.HttpConnector.REGION_FIELD;
+import static org.opensearch.ml.common.connector.HttpConnector.SERVICE_NAME_FIELD;
+import static org.opensearch.ml.engine.algorithms.remote.ConnectorUtils.RECURSIVE_PARAMETER_ENABLED;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.client.Client;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ingest.TestTemplateService;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.connector.AwsConnector;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.ConnectorAction;
+import org.opensearch.ml.common.connector.ConnectorClientConfig;
+import org.opensearch.ml.common.connector.RetryBackoffPolicy;
+import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.engine.encryptor.Encryptor;
+import org.opensearch.ml.engine.encryptor.EncryptorImpl;
+import org.opensearch.script.ScriptService;
+import org.opensearch.threadpool.ThreadPool;
+
+import com.google.common.collect.ImmutableMap;
+
+public class RemoteConnectorExecutorTest {
+
+    Encryptor encryptor;
+
+    @Mock
+    Client client;
+
+    @Mock
+    ThreadPool threadPool;
+
+    @Mock
+    private ScriptService scriptService;
+
+    @Mock
+    ActionListener<Tuple<Integer, ModelTensors>> actionListener;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        encryptor = new EncryptorImpl("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
+        when(scriptService.compile(any(), any()))
+            .then(invocation -> new TestTemplateService.MockTemplateScript.Factory("{\"result\": \"hello world\"}"));
+    }
+
+    private Connector getConnector(Map<String, String> parameters) {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("http:///mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+        Map<String, String> credential = ImmutableMap
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key"), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key"));
+        return AwsConnector
+            .awsConnectorBuilder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .parameters(parameters)
+            .credential(credential)
+            .actions(Arrays.asList(predictAction))
+            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT))
+            .build();
+    }
+
+    private AwsConnectorExecutor getExecutor(Connector connector) {
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
+        Settings settings = Settings.builder().build();
+        ThreadContext threadContext = new ThreadContext(settings);
+        when(executor.getClient()).thenReturn(client);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        return executor;
+    }
+
+    @Test
+    public void executePreparePayloadAndInvoke_RecursiveDisabled() {
+        Map<String, String> parameters = ImmutableMap
+            .of(RECURSIVE_PARAMETER_ENABLED, "false", SERVICE_NAME_FIELD, "sagemaker", REGION_FIELD, "us-west-2");
+        Connector connector = getConnector(parameters);
+        AwsConnectorExecutor executor = getExecutor(connector);
+
+        RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
+            .builder()
+            .parameters(Map.of("input", "You are a ${parameters.role}", "role", "bot"))
+            .actionType(PREDICT)
+            .build();
+        String actionType = inputDataSet.getActionType().toString();
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build();
+
+        executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener);
+        Mockito
+            .verify(executor, times(1))
+            .invokeRemoteService(any(), any(), any(), argThat(argument -> argument.contains("You are a ${parameters.role}")), any(), any());
+    }
+
+    @Test
+    public void executePreparePayloadAndInvoke_RecursiveEnabled() {
+        Map<String, String> parameters = ImmutableMap
+            .of(RECURSIVE_PARAMETER_ENABLED, "true", SERVICE_NAME_FIELD, "sagemaker", REGION_FIELD, "us-west-2");
+        Connector connector = getConnector(parameters);
+        AwsConnectorExecutor executor = getExecutor(connector);
+
+        RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
+            .builder()
+            .parameters(Map.of("input", "You are a ${parameters.role}", "role", "bot"))
+            .actionType(PREDICT)
+            .build();
+        String actionType = inputDataSet.getActionType().toString();
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build();
+
+        executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener);
+        Mockito
+            .verify(executor, times(1))
+            .invokeRemoteService(any(), any(), any(), argThat(argument -> argument.contains("You are a bot")), any(), any());
+    }
+
+    @Test
+    public void executePreparePayloadAndInvoke_RecursiveDefault() {
+        Map<String, String> parameters = ImmutableMap.of(SERVICE_NAME_FIELD, "sagemaker", REGION_FIELD, "us-west-2");
+        Connector connector = getConnector(parameters);
+        AwsConnectorExecutor executor = getExecutor(connector);
+
+        RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
+            .builder()
+            .parameters(Map.of("input", "You are a ${parameters.role}", "role", "bot"))
+            .actionType(PREDICT)
+            .build();
+        String actionType = inputDataSet.getActionType().toString();
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build();
+
+        executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener);
+        Mockito
+            .verify(executor, times(1))
+            .invokeRemoteService(any(), any(), any(), argThat(argument -> argument.contains("You are a ${parameters.role}")), any(), any());
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
@@ -162,6 +162,6 @@ public class RemoteConnectorExecutorTest {
         executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener);
         Mockito
             .verify(executor, times(1))
-            .invokeRemoteService(any(), any(), any(), argThat(argument -> argument.contains("You are a ${parameters.role}")), any(), any());
+            .invokeRemoteService(any(), any(), any(), argThat(argument -> argument.contains("You are a bot")), any(), any());
     }
 }


### PR DESCRIPTION
### Description
When using LLM in ml-commons connector, the prompt may contains substring like `${parameters.xxxx} `. The PRs adds a parameter named `recursive_parameter_enabled` to enable users to configure whether to recursively replace the parameter in payload.

Here are an example to show why skipping parameter validation won't work. Suppose that the current parameter map is `{"prompt": "You are a ${parameters.role}", "role": "bot"}` the payload creation is ambiguous. The current connector creation consists of two steps:

`${parameters.prompt} ->  You are a ${parameters.role} ->  You are a bot.
`

The user might also wish to send the  `You are a ${parameters.role}` to the remote model. If we simply skip parameter validation, there would be no way for user to control the behavior.


We thus need a parameter `recursive_parameter_enabled` for users to configure the behavior of filling in parameters. The user can specify this parameter in the following manner:
```
POST /_plugins/_ml/connectors/_create
{
  "name": "BedRock test connector",
  "description": "The connector to BedRock service for claude model",
  "version": 1,
  "protocol": "aws_sigv4",
  "parameters": {
      "region": "us-east-1",
      "service_name": "bedrock",
      "anthropic_version": "bedrock-2023-05-31",
      "endpoint": "bedrock-runtime.us-east-1.amazonaws.com",
      "auth": "Sig_V4",
      "content_type": "application/json",
      "max_tokens_to_sample": 8000,
      "temperature": 0.00001,
      "recursive_parameter_enabled": true
  },
  "credential": {
    "access_key": "xxxx",
    "secret_key": "xxxx"
  },
  "actions": [
    {
      "action_type": "predict",
      "method": "POST",
      "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-instant-v1/invoke",
      "headers": { 
        "content-type": "application/json",
        "x-amz-content-sha256": "required"
      },
      "request_body": "{\"prompt\":\"${parameters.prompt}\", \"max_tokens_to_sample\":${parameters.max_tokens_to_sample}, \"temperature\":${parameters.temperature},  \"anthropic_version\":\"${parameters.anthropic_version}\" }"
    }
  ]
}
```

### Issues Resolved
Resolve https://github.com/opensearch-project/ml-commons/issues/2712
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
