### PR TITLE
Add XContentType to wrap the CreateIndexRequest mappings in _doc key to fix v1 templates issue

### DIFF
--- a/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
@@ -87,7 +87,7 @@ public class ConversationMetaIndex {
             log.debug("No conversational meta index found. Adding it");
             CreateIndexRequest request = Requests
                 .createIndexRequest(META_INDEX_NAME)
-                .mapping(ConversationalIndexConstants.META_MAPPING)
+                .mapping("{\"_doc\":" + ConversationalIndexConstants.META_MAPPING + "}")
                 .settings(INDEX_SETTINGS);
             try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
                 ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());

--- a/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
@@ -46,6 +46,7 @@ import org.opensearch.client.Client;
 import org.opensearch.client.Requests;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
@@ -87,7 +88,7 @@ public class ConversationMetaIndex {
             log.debug("No conversational meta index found. Adding it");
             CreateIndexRequest request = Requests
                 .createIndexRequest(META_INDEX_NAME)
-                .mapping("{\"_doc\":" + ConversationalIndexConstants.META_MAPPING + "}")
+                .mapping(ConversationalIndexConstants.META_MAPPING, XContentType.JSON)
                 .settings(INDEX_SETTINGS);
             try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
                 ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());

--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -46,6 +46,7 @@ import org.opensearch.client.Client;
 import org.opensearch.client.Requests;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
@@ -90,7 +91,7 @@ public class InteractionsIndex {
             log.debug("No messages index found. Adding it");
             CreateIndexRequest request = Requests
                 .createIndexRequest(INTERACTIONS_INDEX_NAME)
-                .mapping("{\"_doc\":" + ConversationalIndexConstants.INTERACTIONS_MAPPINGS + "}")
+                .mapping(ConversationalIndexConstants.INTERACTIONS_MAPPINGS, XContentType.JSON)
                 .settings(INDEX_SETTINGS);
             try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
                 ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());

--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -90,7 +90,7 @@ public class InteractionsIndex {
             log.debug("No messages index found. Adding it");
             CreateIndexRequest request = Requests
                 .createIndexRequest(INTERACTIONS_INDEX_NAME)
-                .mapping(ConversationalIndexConstants.INTERACTIONS_MAPPINGS)
+                .mapping("{\"_doc\":" + ConversationalIndexConstants.INTERACTIONS_MAPPINGS + "}")
                 .settings(INDEX_SETTINGS);
             try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
                 ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelation.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelation.java
@@ -131,7 +131,7 @@ public class MetricsCorrelation extends DLModelExecute {
             if (!hasModelGroupIndex) { // Create model group index if it doesn't exist
                 try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
                     CreateIndexRequest request = new CreateIndexRequest(ML_MODEL_GROUP_INDEX)
-                        .mapping("{\"_doc\":" + ML_MODEL_GROUP_INDEX_MAPPING + "}");
+                        .mapping(ML_MODEL_GROUP_INDEX_MAPPING, XContentType.JSON);
                     CreateIndexResponse createIndexResponse = client.admin().indices().create(request).actionGet(1000);
                     if (!createIndexResponse.isAcknowledged()) {
                         throw new MLException("Failed to create model group index");

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelation.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelation.java
@@ -130,7 +130,8 @@ public class MetricsCorrelation extends DLModelExecute {
             boolean hasModelGroupIndex = clusterService.state().getMetadata().hasIndex(ML_MODEL_GROUP_INDEX);
             if (!hasModelGroupIndex) { // Create model group index if it doesn't exist
                 try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-                    CreateIndexRequest request = new CreateIndexRequest(ML_MODEL_GROUP_INDEX).mapping(ML_MODEL_GROUP_INDEX_MAPPING);
+                    CreateIndexRequest request = new CreateIndexRequest(ML_MODEL_GROUP_INDEX)
+                        .mapping("{\"_doc\":" + ML_MODEL_GROUP_INDEX_MAPPING + "}");
                     CreateIndexResponse createIndexResponse = client.admin().indices().create(request).actionGet(1000);
                     if (!createIndexResponse.isAcknowledged()) {
                         throw new MLException("Failed to create model group index");

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
@@ -108,7 +108,9 @@ public class MLIndicesHandler {
                         internalListener.onFailure(e);
                     }
                 });
-                CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping).settings(INDEX_SETTINGS);
+                CreateIndexRequest request = new CreateIndexRequest(indexName)
+                    .mapping("{\"_doc\":" + mapping + "}")
+                    .settings(INDEX_SETTINGS);
                 client.admin().indices().create(request, actionListener);
             } else {
                 log.debug("index:{} is already created", indexName);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
@@ -108,9 +108,7 @@ public class MLIndicesHandler {
                         internalListener.onFailure(e);
                     }
                 });
-                CreateIndexRequest request = new CreateIndexRequest(indexName)
-                    .mapping("{\"_doc\":" + mapping + "}")
-                    .settings(INDEX_SETTINGS);
+                CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping, XContentType.JSON).settings(INDEX_SETTINGS);
                 client.admin().indices().create(request, actionListener);
             } else {
                 log.debug("index:{} is already created", indexName);

--- a/release-notes/opensearch-ml-common.release-notes-2.16.0.0.md
+++ b/release-notes/opensearch-ml-common.release-notes-2.16.0.0.md
@@ -26,7 +26,6 @@ Compatible with OpenSearch 2.16.0
 * Fix yaml test issue (#2700)[https://github.com/opensearch-project/ml-commons/pull/2700]
 * Fix MLModelTool returns null if the response of LLM is a pure json object (#2675)[https://github.com/opensearch-project/ml-commons/pull/2675]
 * Bump ml config index schema version (#2656)[https://github.com/opensearch-project/ml-commons/pull/2656]
-* Wrap CreateIndexRequest mappings in _doc key in ml-commons (#2759)[https://github.com/opensearch-project/ml-commons/pull/2759]
 
 ### Maintenance
 * Upgrade djl version to 0.28.0 (#2578)[https://github.com/opensearch-project/ml-commons/pull/2578]

--- a/release-notes/opensearch-ml-common.release-notes-2.16.0.0.md
+++ b/release-notes/opensearch-ml-common.release-notes-2.16.0.0.md
@@ -26,6 +26,7 @@ Compatible with OpenSearch 2.16.0
 * Fix yaml test issue (#2700)[https://github.com/opensearch-project/ml-commons/pull/2700]
 * Fix MLModelTool returns null if the response of LLM is a pure json object (#2675)[https://github.com/opensearch-project/ml-commons/pull/2675]
 * Bump ml config index schema version (#2656)[https://github.com/opensearch-project/ml-commons/pull/2656]
+* Wrap CreateIndexRequest mappings in _doc key in ml-commons (#2759)[https://github.com/opensearch-project/ml-commons/pull/2759]
 
 ### Maintenance
 * Upgrade djl version to 0.28.0 (#2578)[https://github.com/opensearch-project/ml-commons/pull/2578]


### PR DESCRIPTION
### Description
Adds the _doc key wrapper around index mapping as required by CreateIndexRequest javadoc.

### Related Issues
See also https://github.com/opensearch-project/OpenSearch/issues/14984

### Testing Details
When the cluster has v1 templates with patterns matching the index, without the _doc wrapper, dynamic mappings are getting enabled for the index. From below, created_time is being created as long (dynamically picked) instead of `timestamp` type which is defined in the [mapping definition](https://github.com/opensearch-project/ml-commons/blob/main/common/src/main/java/org/opensearch/ml/common/CommonValue.java#L138).

<img width="1042" alt="Screenshot 2024-07-26 at 1 54 05 PM" src="https://github.com/user-attachments/assets/0bd2608b-b614-4ae3-a605-0b692215c8d2">



With changes in this PR by adding `_doc` wrapper, even if cluster has v1 templates, indices are getting created with expected mappings.


<img width="1122" alt="Screenshot 2024-07-26 at 2 17 26 PM" src="https://github.com/user-attachments/assets/ebea5c1f-b042-41b3-ba70-4d92efbae80f">



### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
