### PR TITLE
Fix ml inference request processor when running terms query

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
@@ -251,7 +251,7 @@ public class MLInferenceSearchRequestProcessor extends AbstractProcessor impleme
                             requestListener.onResponse(request);
                         }
                     } catch (Exception e) {
-                        if (ignoreMissing || ignoreFailure) {
+                        if (ignoreFailure) {
                             logger.error("Failed in writing prediction outcomes to new query", e);
                             requestListener.onResponse(request);
 
@@ -348,7 +348,7 @@ public class MLInferenceSearchRequestProcessor extends AbstractProcessor impleme
             for (Map.Entry<String, String> entry : inputMap.entrySet()) {
                 // the inputMap takes in model input as keys and query fields as value
                 String queryField = entry.getValue();
-                String pathData = jsonData.read(queryField);
+                Object pathData = jsonData.read(queryField);
                 if (pathData == null) {
                     throw new IllegalArgumentException("cannot find field: " + queryField + " in query string: " + jsonData.jsonString());
                 }
@@ -358,7 +358,7 @@ public class MLInferenceSearchRequestProcessor extends AbstractProcessor impleme
             for (Map<String, String> outputMap : processOutputMap) {
                 for (Map.Entry<String, String> entry : outputMap.entrySet()) {
                     String queryField = entry.getKey();
-                    String pathData = jsonData.read(queryField);
+                    Object pathData = jsonData.read(queryField);
                     if (pathData == null) {
                         throw new IllegalArgumentException(
                             "cannot find field: " + queryField + " in query string: " + jsonData.jsonString()
@@ -402,7 +402,7 @@ public class MLInferenceSearchRequestProcessor extends AbstractProcessor impleme
                 // model field as key, query field name as value
                 String modelInputFieldName = entry.getKey();
                 String queryFieldName = entry.getValue();
-                String queryFieldValue = JsonPath.parse(newQuery).read(queryFieldName);
+                String queryFieldValue = StringUtils.toJson(JsonPath.parse(newQuery).read(queryFieldName));
                 modelParameters.put(modelInputFieldName, queryFieldValue);
             }
         }

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -478,7 +478,6 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
      */
     private boolean checkIsModelInputMissing(Map<String, Object> document, Map<String, String> inputMapping) {
         boolean isModelInputMissing = false;
-
         for (Map.Entry<String, String> inputMapEntry : inputMapping.entrySet()) {
             String oldDocumentFieldName = inputMapEntry.getValue();
             boolean checkSingleModelInputPresent = hasField(document, oldDocumentFieldName);


### PR DESCRIPTION
### Description
remove extra ignoreMissing and fix JsonArray Parsing Issue

when testing terms query on ml inference processor, found the bug when parsing list or other data type in queries are throw parsing exception, this PR will fix the exception while parsing list or object types in query body. 

Added unit tests for terms query when matching multiple keywords. 

example terms query: {"query":{"terms":{"text":["car","vehicle","truck"],"boost":1.0}}}

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
