### PR TITLE
Merge the existing parameters when updating connectors

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -287,7 +287,7 @@ public class HttpConnector extends AbstractConnector {
             this.protocol = updateContent.getProtocol();
         }
         if (updateContent.getParameters() != null && updateContent.getParameters().size() > 0) {
-            this.parameters = updateContent.getParameters();
+            getParameters().putAll(updateContent.getParameters());
         }
         if (updateContent.getCredential() != null && updateContent.getCredential().size() > 0) {
             this.credential = updateContent.getCredential();

--- a/docs/remote_inference_blueprints/batch_inference_sagemaker_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/batch_inference_sagemaker_connector_blueprint.md
@@ -5,6 +5,18 @@ Read more details on https://opensearch.org/docs/latest/ml-commons-plugin/remote
 Integrate the SageMaker Batch Transform API using the connector below with a new action type "batch_predict". 
 For more details to use batch transform to run inference with Amazon SageMaker, please refer to https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html.
 
+SageMaker uses your pre-created model to execute the batch transform job. For creating your model in SageMaker
+that supports batch transform, please refer to https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateModel.html. In this example, the following primary 
+container is used to create the text-embedding DJL model in SageMaker.
+```json
+"ModelName": "DJL-Text-Embedding-Model-imageforjsonlines",
+"PrimaryContainer": {
+"Environment": {
+"SERVING_LOAD_MODELS" : "djl://ai.djl.huggingface.pytorch/sentence-transformers/all-MiniLM-L6-v2"
+},
+"Image": "763104351884.dkr.ecr.us-east-1.amazonaws.com/djl-inference:0.22.1-cpu-full"
+}
+```
 #### 1. Create your Model connector and Model group
 
 ##### 1a. Register Model group


### PR DESCRIPTION
### Description
This PR fixes the issue reported in https://github.com/opensearch-project/ml-commons/issues/2502. This is not a bug since the issue was an expected behavior based on the initial design of the Update Connector API. However, over time we think that, in the Update APIs, it's a better CX experience to merge the updated parameters with the existing ones. 

Also, some details of the sagemaker model for batch inference is added in this PR.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
