### PR TITLE
fixing agent execution for multi-tenancy

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/settings/SettingsChangeListener.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/SettingsChangeListener.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.settings;
+
+public interface SettingsChangeListener {
+    void onMultiTenancyEnabledChanged(boolean isEnabled);
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/Executable.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/Executable.java
@@ -17,16 +17,5 @@ public interface Executable {
      * @param input input data
      * @return execution result
      */
-    default void execute(Input input, ActionListener<Output> listener) throws ExecuteException {
-        execute(input, null, listener);
-    }
-
-    /**
-     * Execute algorithm with given input data.
-     * @param input input data
-     * @param tenantId id of the tenant for multi-tenancy.
-     *                 For single tenant, it will be null
-     * @return execution result
-     */
-    void execute(Input input, String tenantId, ActionListener<Output> listener) throws ExecuteException;
+    void execute(Input input, ActionListener<Output> listener) throws ExecuteException;
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModelExecute.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModelExecute.java
@@ -52,7 +52,7 @@ public abstract class DLModelExecute implements MLExecutable {
     protected Device[] devices;
     protected AtomicInteger nextDevice = new AtomicInteger(0);
 
-    public abstract void execute(Input input, String tenantId, ActionListener<Output> listener);
+    public abstract void execute(Input input, ActionListener<Output> listener);
 
     protected Predictor<float[][], ai.djl.modality.Output> getPredictor() {
         int currentDevice = nextDevice.getAndIncrement();

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/anomalylocalization/AnomalyLocalizerImpl.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/anomalylocalization/AnomalyLocalizerImpl.java
@@ -524,7 +524,7 @@ public class AnomalyLocalizerImpl implements AnomalyLocalizer, Executable {
     }
 
     @Override
-    public void execute(Input input, String tenantId, ActionListener<Output> listener) {
+    public void execute(Input input, ActionListener<Output> listener) {
         getLocalizationResults(
             (AnomalyLocalizationInput) input,
             ActionListener.wrap(o -> listener.onResponse(o), e -> listener.onFailure(e))

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelation.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelation.java
@@ -114,7 +114,7 @@ public class MetricsCorrelation extends DLModelExecute {
      *  algorithm is a list of objects. Each object contains 3 properties  event_window, event_pattern and suspected_metrics
      */
     @Override
-    public void execute(Input input, String tenantId, ActionListener<org.opensearch.ml.common.output.Output> listener) {
+    public void execute(Input input, ActionListener<org.opensearch.ml.common.output.Output> listener) {
         if (!(input instanceof MetricsCorrelationInput)) {
             throw new ExecuteException("wrong input");
         }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/sample/LocalSampleCalculator.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/sample/LocalSampleCalculator.java
@@ -37,7 +37,7 @@ public class LocalSampleCalculator implements Executable {
     }
 
     @Override
-    public void execute(Input input, String tenantId, ActionListener<Output> listener) {
+    public void execute(Input input, ActionListener<Output> listener) {
         if (!(input instanceof LocalSampleCalculatorInput)) {
             throw new IllegalArgumentException("wrong input");
         }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -613,6 +613,9 @@ public class MachineLearningPlugin extends Plugin
             memoryFactoryMap,
             mlFeatureEnabledSetting.isMultiTenancyEnabled()
         );
+        // Register the agentExecutor as a listener
+        mlFeatureEnabledSetting.addListener(agentExecutor);
+
         MLEngineClassLoader.register(FunctionName.LOCAL_SAMPLE_CALCULATOR, localSampleCalculator);
         MLEngineClassLoader.register(FunctionName.AGENT, agentExecutor);
 

--- a/plugin/src/test/java/org/opensearch/ml/settings/MLFeatureEnabledSettingTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/settings/MLFeatureEnabledSettingTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.settings;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_LOCAL_MODEL_ENABLED;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED;
+
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.ml.common.settings.SettingsChangeListener;
+
+public class MLFeatureEnabledSettingTests {
+    @Mock
+    private ClusterService clusterService;
+    private Settings settings;
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+    private SettingsChangeListener listener;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        settings = Settings.builder().put(ML_COMMONS_MULTI_TENANCY_ENABLED.getKey(), false).build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        when(clusterService.getClusterSettings())
+            .thenReturn(
+                new ClusterSettings(
+                    settings,
+                    Set
+                        .of(
+                            ML_COMMONS_MULTI_TENANCY_ENABLED,
+                            ML_COMMONS_REMOTE_INFERENCE_ENABLED,
+                            ML_COMMONS_AGENT_FRAMEWORK_ENABLED,
+                            ML_COMMONS_LOCAL_MODEL_ENABLED
+                        )
+                )
+            );
+
+        mlFeatureEnabledSetting = new MLFeatureEnabledSetting(clusterService, settings);
+        listener = mock(SettingsChangeListener.class);
+    }
+
+    @Test
+    public void testAddListenerAndNotify() {
+        mlFeatureEnabledSetting.addListener(listener);
+
+        // Simulate settings change
+        mlFeatureEnabledSetting.notifyMultiTenancyListeners(false);
+
+        // Verify listener is notified
+        verify(listener, times(1)).onMultiTenancyEnabledChanged(false);
+    }
+}


### PR DESCRIPTION
### Description
[ `MLFeatureEnabledSetting` class is in `plugin` module and `algorithm` module doesn't have dependency on `plugin` module. So when we do `mlFeatureEnabledSetting.isMultiTenancyEnabled()` to the `MLAgentExecutor` class, it doesn't update the dynamic value of `ML_COMMONS_MULTI_TENANCY_ENABLED` settings. So we need a listener in algorithm module to get the update status of this settings.]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
