### PR TITLE
[Bug fix] Check if document exists before put operation

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -128,8 +128,8 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
                 item.put(SOURCE, AttributeValue.builder().m(sourceMap).build());
                 item.put(SEQ_NO_KEY, AttributeValue.builder().n(sequenceNumber.toString()).build());
                 Builder builder = PutItemRequest.builder().tableName(tableName).item(item);
-                if (!request.overwriteIfExists()) {
-                    builder.conditionExpression("attribute_not_exists(" + HASH_KEY + ") AND attribute_not_exists(" + RANGE_KEY + ")");
+                if (!request.overwriteIfExists() && getItemResponse != null && getItemResponse.item() != null) {
+                    throw new OpenSearchStatusException("Existing data object for ID: " + request.id(), RestStatus.CONFLICT);
                 }
                 final PutItemRequest putItemRequest = builder.build();
 


### PR DESCRIPTION
### Description
If `overwriteIfExists` flag is set to false, then `putDataObject` requests needs to throw an exception if the document already exists. Existing code has a bug which fails with error `nvalid ConditionExpression: Syntax error; token: \"_\", near: \"(_tenant_id\" (Service: DynamoDb, Status Code: 400, Request ID: P6GHA1O61AGC8DUCBJ1MUVIL9NVV4KQNSO5AEMVJF66Q9ASUAAJG)`

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
