### PR TITLE
[Feature/multi_tenancy] Delay restoring thread context until after all client calls

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/helper/ConnectorAccessControlHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/ConnectorAccessControlHelper.java
@@ -162,6 +162,15 @@ public class ConnectorAccessControlHelper {
         }));
     }
 
+    /**
+     * Gets a connector with the provided clients. 
+     * @param sdkClient The SDKClient
+     * @param client The OpenSearch client for thread pool management
+     * @param context The Stored Context.  Executing this method will restore this context.
+     * @param getDataObjectRequest The get request
+     * @param connectorId The connector Id
+     * @param listener the action listener to complete with the GetResponse or Exception
+     */
     public void getConnector(
         SdkClient sdkClient,
         Client client,


### PR DESCRIPTION
### Description

Fixes Delete Connector and Update Connector transport action handling of thread context.   Context was being restored too soon when there were multiple chained calls, and this caused subsequent calls to fail.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
