### PR TITLE
Support list in response body

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -324,16 +324,15 @@ public class HttpConnector extends AbstractConnector {
             payload = fillNullParameters(parameters, payload);
             StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
             payload = substitutor.replace(payload);
-            boolean isJson = isJson(payload);
-            if (!isJson) {
-                String manuallyFixedJson = connectorAction.get().getRequestBody();
+            if (!isJson(payload)) {
+                String payloadAfterEscape = connectorAction.get().getRequestBody();
                 Map<String, String> escapedParameters = escapeMapValues(parameters);
                 StringSubstitutor escapedSubstitutor = new StringSubstitutor(escapedParameters, "${parameters.", "}");
-                manuallyFixedJson = escapedSubstitutor.replace(manuallyFixedJson);
-                if (!isJson(manuallyFixedJson)) {
+                payloadAfterEscape = escapedSubstitutor.replace(payloadAfterEscape);
+                if (!isJson(payloadAfterEscape)) {
                     throw new IllegalArgumentException("Invalid payload: " + payload);
                 } else {
-                    payload = manuallyFixedJson;
+                    payload = payloadAfterEscape;
                 }
             }
             return (T) payload;

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -184,6 +184,33 @@ public class HttpConnectorTest {
     }
 
     @Test
+    public void createPayloadWithString() {
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+
+        parameters.put("prompt", "answer question based on context: ${parameters.context}");
+        parameters.put("context", "document1");
+        String predictPayload = connector.createPayload(PREDICT.name(), parameters);
+        connector.validatePayload(predictPayload);
+        Assert.assertEquals("{\"prompt\": \"answer question based on context: document1\"}", predictPayload);
+    }
+
+    @Test
+    public void createPayloadWithList() {
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("prompt", "answer question based on context: ${parameters.context}");
+        ArrayList<String> listOfDocuments= new ArrayList<>();
+        listOfDocuments.add("document1");
+        listOfDocuments.add("document2");
+        parameters.put("context", toJson(listOfDocuments));
+        String predictPayload = connector.createPayload(PREDICT.name(), parameters);
+        connector.validatePayload(predictPayload);
+    }
+
+    @Test
     public void createPayload() {
         HttpConnector connector = createHttpConnector();
         Map<String, String> parameters = new HashMap<>();

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -212,6 +212,87 @@ public class HttpConnectorTest {
     }
 
     @Test
+    public void createPayloadWithNestedList() {
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("prompt", "answer question based on context: ${parameters.context}");
+        ArrayList<String> listOfDocuments = new ArrayList<>();
+        listOfDocuments.add("document1");
+        ArrayList<String> NestedListOfDocuments = new ArrayList<>();
+        NestedListOfDocuments.add("document2");
+        listOfDocuments.add(toJson(NestedListOfDocuments));
+        parameters.put("context", toJson(listOfDocuments));
+        String predictPayload = connector.createPayload(PREDICT.name(), parameters);
+        connector.validatePayload(predictPayload);
+    }
+
+    @Test
+    public void createPayloadWithMap() {
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("prompt", "answer question based on context: ${parameters.context}");
+        Map<String, String> mapOfDocuments = new HashMap<>();
+        mapOfDocuments.put("name", "John");
+        parameters.put("context", toJson(mapOfDocuments));
+        String predictPayload = connector.createPayload(PREDICT.name(), parameters);
+        connector.validatePayload(predictPayload);
+    }
+
+    @Test
+    public void createPayloadWithNestedMapOfString() {
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("prompt", "answer question based on context: ${parameters.context}");
+        Map<String, String> mapOfDocuments = new HashMap<>();
+        mapOfDocuments.put("name", "John");
+        Map<String, String> nestedMapOfDocuments = new HashMap<>();
+        nestedMapOfDocuments.put("city", "New York");
+        mapOfDocuments.put("hometown", toJson(nestedMapOfDocuments));
+        parameters.put("context", toJson(mapOfDocuments));
+        String predictPayload = connector.createPayload(PREDICT.name(), parameters);
+        connector.validatePayload(predictPayload);
+    }
+
+    @Test
+    public void createPayloadWithNestedMapOfObject() {
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("prompt", "answer question based on context: ${parameters.context}");
+        Map<String, Object> mapOfDocuments = new HashMap<>();
+        mapOfDocuments.put("name", "John");
+        Map<String, String> nestedMapOfDocuments = new HashMap<>();
+        nestedMapOfDocuments.put("city", "New York");
+        mapOfDocuments.put("hometown", nestedMapOfDocuments);
+        parameters.put("context", toJson(mapOfDocuments));
+        String predictPayload = connector.createPayload(PREDICT.name(), parameters);
+        connector.validatePayload(predictPayload);
+    }
+
+    @Test
+    public void createPayloadWithNestedListOfMapOfObject() {
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("prompt", "answer question based on context: ${parameters.context}");
+        ArrayList<String> listOfDocuments = new ArrayList<>();
+        listOfDocuments.add("document1");
+        ArrayList<Object> NestedListOfDocuments = new ArrayList<>();
+        Map<String, Object> mapOfDocuments = new HashMap<>();
+        mapOfDocuments.put("name", "John");
+        Map<String, String> nestedMapOfDocuments = new HashMap<>();
+        nestedMapOfDocuments.put("city", "New York");
+        mapOfDocuments.put("hometown", nestedMapOfDocuments);
+        listOfDocuments.add(toJson(NestedListOfDocuments));
+        parameters.put("context", toJson(listOfDocuments));
+        String predictPayload = connector.createPayload(PREDICT.name(), parameters);
+        connector.validatePayload(predictPayload);
+    }
+
+    @Test
     public void createPayload() {
         HttpConnector connector = createHttpConnector();
         Map<String, String> parameters = new HashMap<>();

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.connector;
 
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
+import static org.opensearch.ml.common.utils.StringUtils.toJson;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -202,7 +203,7 @@ public class HttpConnectorTest {
         HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("prompt", "answer question based on context: ${parameters.context}");
-        ArrayList<String> listOfDocuments= new ArrayList<>();
+        ArrayList<String> listOfDocuments = new ArrayList<>();
         listOfDocuments.add("document1");
         listOfDocuments.add("document2");
         parameters.put("context", toJson(listOfDocuments));


### PR DESCRIPTION
### Description

When an array as a string in parameter, the string in list are not escaped. 

This PR will escape the string when it's a json array. 

for example, before this change: 
```
POST /_plugins/_ml/connectors/_create
{
  "name": "Amazon Bedrock Connector: Claude Instant V1",
  "version": "1",
  "description": "The connector to bedrock Claude model",
  "protocol": "aws_sigv4",
  "parameters": {
    "max_tokens_to_sample": "8000",
    "service_name": "bedrock",
    "temperature": "1.0E-4",
    "response_filter": "$.completion",
    "region": "us-west-2",
    "anthropic_version": "bedrock-2023-05-31",
    "inputs":"please summerize the documents"
  },
  "credential": {
    "access_key": " ",
        "secret_key": " ",
        "session_token": "" },
  "actions": [
    {
      "action_type": "PREDICT",
      "method": "POST",
      "url": "https://bedrock-runtime.us-west-2.amazonaws.com/model/anthropic.claude-instant-v1/invoke",
      "headers": {
        "x-amz-content-sha256": "required",
        "content-type": "application/json"
      },
      "request_body":  "{\"prompt\":\"${parameters.prompt}\",\"max_tokens_to_sample\":300,\"temperature\":0.5,\"top_k\":250,\"top_p\":1,\"stop_sequences\":[\"\\n\\nHuman:\"]}"
    }
  ]
}


POST /_plugins/_ml/models/_register
{
  "name": "Bedrock agent model with prompt",
  "function_name": "remote",
  "description": "test model",
  "connector_id": "0CwoD5EB6KAJXDLxYDvd"}
  
POST /_plugins/_ml/models/2SwoD5EB6KAJXDLxezto/_deploy

## success with string
POST /_plugins/_ml/models/2SwoD5EB6KAJXDLxezto/_predict  
{
  "parameters": {
    "prompt":"\n\nHuman: You are a professional data analysist. You will always answer question based on the given context first. If the answer is not directly shown in the context, you will analyze the data and find the answer. If you don't know the answer, just say I don't know. Context: ${parameters.context}. \n\n Human: please summarize the documents \n\n Assistant:",
    "context":"Dr. Eric Goldberg is a fantastic doctor who has correctly diagnosed every issue that my wife and I have had. Unlike many of my past doctors, Dr. Goldberg is very accessible and we have been able to schedule appointments with him and his staff very quickly. We are happy to have him in the neighborhood and look forward to being his patients for many years to come."
  }
}


##failed with list 

POST /_plugins/_ml/models/2SwoD5EB6KAJXDLxezto/_predict  
{
  "parameters": {
    "prompt":"\n\nHuman: You are a professional data analysist. You will always answer question based on the given context first. If the answer is not directly shown in the context, you will analyze the data and find the answer. If you don't know the answer, just say I don't know. Context: ${parameters.context}. \n\n Human: please summarize the documents \n\n Assistant:",
    "context":["Dr. Eric Goldberg is a fantastic doctor who has correctly diagnosed every issue that my wife and I have had. Unlike many of my past doctors, Dr. Goldberg is very accessible and we have been able to schedule appointments with him and his staff very quickly. We are happy to have him in the neighborhood and look forward to being his patients for many years to come."]
  }
}

```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
