### PR TITLE
feat: allow user specify region when calling connector

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -146,7 +146,8 @@ public final class MLCommonsSettings {
                     "^https://api\\.openai\\.com/.*$",
                     "^https://api\\.cohere\\.ai/.*$",
                     "^https://bedrock-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
-                    "^https://bedrock-agent-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"
+                    "^https://bedrock-agent-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                    "^https://bedrock-agent-runtime\\.\\$\\{[^}]+\\}\\.amazonaws\\.com/.*$"
                 ),
             Function.identity(),
             Setting.Property.NodeScope,


### PR DESCRIPTION
### Description
Users can create connector like

```
POST /_plugins/_ml/connectors/_create
{
  "name": "Amazon Bedrock Connector: knowledge",
  "description": "The connector to the Bedrock knowledge base",
  "version": 1,
  "protocol": "aws_sigv4",
  "parameters": {
    "region": "${parameters.knowledgeBaseRegion}",
    "service_name": "bedrock",
    "knowledgeBaseId": "${parameters.knowledgeBaseId}",
    "model_arn": "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0",
    "skip_validating_missing_parameters": true
  },
  "credential": {
    "access_key": "xxx",
    "secret_key": "xxx"
  },
  "actions": [
    {
      "action_type": "predict",
      "method": "POST",
      "url": "https://bedrock-agent-runtime.${parameters.region}.amazonaws.com/retrieveAndGenerate",
      "headers": {
        "content-type": "application/json"
      },
      "request_body": """{"input": {"text": "${parameters.text}"}, "retrieveAndGenerateConfiguration": {"type": "KNOWLEDGE_BASE", "knowledgeBaseConfiguration": {"knowledgeBaseId": "${parameters.knowledgeBaseId}", "modelArn": "${parameters.model_arn}"}}}""",
      "post_process_function": "return params.output.text;"
    }
  ]
}
```

Then, we can predict the ml model like:

```
POST /_plugins/_ml/models/4JfpaZEBiWPupK-hPgqH/_predict
{
  "parameters": {
    "knowledgeBaseRegion": "us-west-2",
    "knowledgeBaseId": "JRQ0RNLOQK",
    "text": """xxxx"""
  }
}
```


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
