### PR TITLE
offline batch ingestion API actions and data ingesters 

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/MLTaskType.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLTaskType.java
@@ -15,5 +15,6 @@ public enum MLTaskType {
     @Deprecated
     LOAD_MODEL,
     REGISTER_MODEL,
-    DEPLOY_MODEL
+    DEPLOY_MODEL,
+    BATCH_INGEST
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionAction.java
@@ -1,0 +1,13 @@
+package org.opensearch.ml.common.transport.batch;
+
+import org.opensearch.action.ActionType;
+
+public class MLBatchIngestionAction extends ActionType<MLBatchIngestionResponse> {
+    public static MLBatchIngestionAction INSTANCE = new MLBatchIngestionAction();
+    public static final String NAME = "cluster:admin/opensearch/ml/batch_ingestion";
+
+    private MLBatchIngestionAction() {
+        super(NAME, MLBatchIngestionResponse::new);
+    }
+
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.batch;
 
 import org.opensearch.action.ActionType;

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInput.java
@@ -47,10 +47,14 @@ public class MLBatchIngestionInput implements ToXContentObject, Writeable {
         Map<String, String> credential
     ) {
         if (indexName == null) {
-            throw new IllegalArgumentException("index name for ingestion is null");
+            throw new IllegalArgumentException(
+                "The index name for data ingestion is missing. Please provide a valid index name to proceed."
+            );
         }
         if (dataSources == null) {
-            throw new IllegalArgumentException("dataSources for ingestion is null");
+            throw new IllegalArgumentException(
+                "No data sources were provided for ingestion. Please specify at least one valid data source to proceed."
+            );
         }
         this.indexName = indexName;
         this.fieldMapping = fieldMapping;

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInput.java
@@ -35,7 +35,7 @@ public class MLBatchIngestionInput implements ToXContentObject, Writeable {
     @Getter
     private Map<String, Object> fieldMapping;
     @Getter
-    private Map<String, String> dataSources;
+    private Map<String, Object> dataSources;
     @Getter
     private Map<String, String> credential;
 
@@ -43,7 +43,7 @@ public class MLBatchIngestionInput implements ToXContentObject, Writeable {
     public MLBatchIngestionInput(
         String indexName,
         Map<String, Object> fieldMapping,
-        Map<String, String> dataSources,
+        Map<String, Object> dataSources,
         Map<String, String> credential
     ) {
         if (indexName == null) {
@@ -61,7 +61,7 @@ public class MLBatchIngestionInput implements ToXContentObject, Writeable {
     public static MLBatchIngestionInput parse(XContentParser parser) throws IOException {
         String indexName = null;
         Map<String, Object> fieldMapping = null;
-        Map<String, String> dataSources = null;
+        Map<String, Object> dataSources = null;
         Map<String, String> credential = new HashMap<>();
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -80,7 +80,7 @@ public class MLBatchIngestionInput implements ToXContentObject, Writeable {
                     credential = parser.mapStrings();
                     break;
                 case DATA_SOURCE_FIELD:
-                    dataSources = parser.mapStrings();
+                    dataSources = parser.map();
                     break;
                 default:
                     parser.skipChildren();
@@ -99,11 +99,11 @@ public class MLBatchIngestionInput implements ToXContentObject, Writeable {
         if (fieldMapping != null) {
             builder.field(FIELD_MAP_FIELD, fieldMapping);
         }
-        if (dataSources != null) {
-            builder.field(DATA_SOURCE_FIELD, dataSources);
-        }
         if (credential != null) {
             builder.field(CONNECTOR_CREDENTIAL_FIELD, credential);
+        }
+        if (dataSources != null) {
+            builder.field(DATA_SOURCE_FIELD, dataSources);
         }
         builder.endObject();
         return builder;
@@ -118,17 +118,15 @@ public class MLBatchIngestionInput implements ToXContentObject, Writeable {
         } else {
             output.writeBoolean(false);
         }
-
-        if (dataSources != null) {
-            output.writeBoolean(true);
-            output.writeMap(dataSources, StreamOutput::writeString, StreamOutput::writeString);
-        } else {
-            output.writeBoolean(false);
-        }
-
         if (credential != null) {
             output.writeBoolean(true);
             output.writeMap(credential, StreamOutput::writeString, StreamOutput::writeString);
+        } else {
+            output.writeBoolean(false);
+        }
+        if (dataSources != null) {
+            output.writeBoolean(true);
+            output.writeMap(dataSources, StreamOutput::writeString, StreamOutput::writeGenericValue);
         } else {
             output.writeBoolean(false);
         }
@@ -140,10 +138,10 @@ public class MLBatchIngestionInput implements ToXContentObject, Writeable {
             fieldMapping = input.readMap(s -> s.readString(), s -> s.readGenericValue());
         }
         if (input.readBoolean()) {
-            dataSources = input.readMap(s -> s.readString(), s -> s.readString());
+            credential = input.readMap(s -> s.readString(), s -> s.readString());
         }
         if (input.readBoolean()) {
-            credential = input.readMap(s -> s.readString(), s -> s.readString());
+            dataSources = input.readMap(s -> s.readString(), s -> s.readGenericValue());
         }
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInput.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.batch;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.utils.StringUtils.getOrderedMap;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * ML batch ingestion data: index, field mapping and input and out files.
+ */
+public class MLBatchIngestionInput implements ToXContentObject, Writeable {
+
+    public static final String INDEX_NAME_FIELD = "index_name";
+    public static final String TEXT_EMBEDDING_FIELD_MAP_FIELD = "text_embedding_field_map";
+    public static final String DATA_SOURCE_FIELD = "data_source";
+    public static final String CONNECTOR_CREDENTIAL_FIELD = "credential";
+    @Getter
+    private String indexName;
+    @Getter
+    private Map<String, String> fieldMapping;
+    @Getter
+    private Map<String, String> dataSources;
+    @Getter
+    private Map<String, String> credential;
+
+    @Builder(toBuilder = true)
+    public MLBatchIngestionInput(
+        String indexName,
+        Map<String, String> fieldMapping,
+        Map<String, String> dataSources,
+        Map<String, String> credential
+    ) {
+        this.indexName = indexName;
+        this.fieldMapping = fieldMapping;
+        this.dataSources = dataSources;
+        this.credential = credential;
+    }
+
+    public static MLBatchIngestionInput parse(XContentParser parser) throws IOException {
+        String indexName = null;
+        Map<String, String> fieldMapping = null;
+        Map<String, String> dataSources = null;
+        Map<String, String> credential = new HashMap<>();
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case INDEX_NAME_FIELD:
+                    indexName = parser.text();
+                    break;
+                case TEXT_EMBEDDING_FIELD_MAP_FIELD:
+                    fieldMapping = getOrderedMap(parser.mapOrdered());
+                    break;
+                case CONNECTOR_CREDENTIAL_FIELD:
+                    credential = parser.mapStrings();
+                    break;
+                case DATA_SOURCE_FIELD:
+                    dataSources = parser.mapStrings();
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return new MLBatchIngestionInput(indexName, fieldMapping, dataSources, credential);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (indexName != null) {
+            builder.field(INDEX_NAME_FIELD, indexName);
+        }
+        if (fieldMapping != null) {
+            builder.field(TEXT_EMBEDDING_FIELD_MAP_FIELD, fieldMapping);
+        }
+        if (dataSources != null) {
+            builder.field(DATA_SOURCE_FIELD, dataSources);
+        }
+        if (credential != null) {
+            builder.field(CONNECTOR_CREDENTIAL_FIELD, credential);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput output) throws IOException {
+        output.writeOptionalString(indexName);
+        if (fieldMapping != null) {
+            output.writeBoolean(true);
+            output.writeMap(fieldMapping, StreamOutput::writeString, StreamOutput::writeString);
+        } else {
+            output.writeBoolean(false);
+        }
+
+        if (dataSources != null) {
+            output.writeBoolean(true);
+            output.writeMap(dataSources, StreamOutput::writeString, StreamOutput::writeString);
+        } else {
+            output.writeBoolean(false);
+        }
+
+        if (credential != null) {
+            output.writeBoolean(true);
+            output.writeMap(credential, StreamOutput::writeString, StreamOutput::writeString);
+        } else {
+            output.writeBoolean(false);
+        }
+    }
+
+    public MLBatchIngestionInput(StreamInput input) throws IOException {
+        indexName = input.readOptionalString();
+        if (input.readBoolean()) {
+            fieldMapping = input.readMap(s -> s.readString(), s -> s.readString());
+        }
+        if (input.readBoolean()) {
+            dataSources = input.readMap(s -> s.readString(), s -> s.readString());
+        }
+        if (input.readBoolean()) {
+            credential = input.readMap(s -> s.readString(), s -> s.readString());
+        }
+    }
+
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequest.java
@@ -52,13 +52,13 @@ public class MLBatchIngestionRequest extends ActionRequest {
     public ActionRequestValidationException validate() {
         ActionRequestValidationException exception = null;
         if (mlBatchIngestionInput == null) {
-            exception = addValidationError("ML batch ingestion input can't be null", exception);
+            exception = addValidationError("The input for ML batch ingestion cannot be null.", exception);
         }
         if (mlBatchIngestionInput != null && mlBatchIngestionInput.getCredential() == null) {
-            exception = addValidationError("ML batch ingestion credentials can't be null", exception);
+            exception = addValidationError("The credential for ML batch ingestion cannot be null", exception);
         }
         if (mlBatchIngestionInput != null && mlBatchIngestionInput.getDataSources() == null) {
-            exception = addValidationError("ML batch ingestion data sources can't be null", exception);
+            exception = addValidationError("The data sources for ML batch ingestion cannot be null", exception);
         }
 
         return exception;

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.batch;
 
 import static org.opensearch.action.ValidateActions.addValidationError;

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequest.java
@@ -1,0 +1,70 @@
+package org.opensearch.ml.common.transport.batch;
+
+import static org.opensearch.action.ValidateActions.addValidationError;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@ToString
+public class MLBatchIngestionRequest extends ActionRequest {
+
+    private MLBatchIngestionInput mlBatchIngestionInput;
+
+    @Builder
+    public MLBatchIngestionRequest(MLBatchIngestionInput mlBatchIngestionInput) {
+        this.mlBatchIngestionInput = mlBatchIngestionInput;
+    }
+
+    public MLBatchIngestionRequest(StreamInput in) throws IOException {
+        super(in);
+        this.mlBatchIngestionInput = new MLBatchIngestionInput(in);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException exception = null;
+        if (mlBatchIngestionInput == null) {
+            exception = addValidationError("ML batch ingestion input can't be null", exception);
+        }
+        if (mlBatchIngestionInput.getCredential() == null) {
+            exception = addValidationError("ML batch ingestion credentials can't be null", exception);
+        }
+        if (mlBatchIngestionInput.getDataSources() == null) {
+            exception = addValidationError("ML batch ingestion data sources can't be null", exception);
+        }
+
+        return exception;
+    }
+
+    public static MLBatchIngestionRequest fromActionRequest(ActionRequest actionRequest) {
+        if (actionRequest instanceof MLBatchIngestionRequest) {
+            return (MLBatchIngestionRequest) actionRequest;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionRequest.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLBatchIngestionRequest(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionRequest into MLBatchIngestionRequest", e);
+        }
+
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequest.java
@@ -17,6 +17,7 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.core.common.io.stream.InputStreamStreamInput;
 import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -42,15 +43,21 @@ public class MLBatchIngestionRequest extends ActionRequest {
     }
 
     @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        this.mlBatchIngestionInput.writeTo(out);
+    }
+
+    @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException exception = null;
         if (mlBatchIngestionInput == null) {
             exception = addValidationError("ML batch ingestion input can't be null", exception);
         }
-        if (mlBatchIngestionInput.getCredential() == null) {
+        if (mlBatchIngestionInput != null && mlBatchIngestionInput.getCredential() == null) {
             exception = addValidationError("ML batch ingestion credentials can't be null", exception);
         }
-        if (mlBatchIngestionInput.getDataSources() == null) {
+        if (mlBatchIngestionInput != null && mlBatchIngestionInput.getDataSources() == null) {
             exception = addValidationError("ML batch ingestion data sources can't be null", exception);
         }
 

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionResponse.java
@@ -1,0 +1,73 @@
+package org.opensearch.ml.common.transport.batch;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.MLTaskType;
+
+public class MLBatchIngestionResponse extends ActionResponse implements ToXContentObject {
+    public static final String TASK_ID_FIELD = "task_id";
+    public static final String TASK_TYPE_FIELD = "task_type";
+    public static final String STATUS_FIELD = "status";
+
+    private String taskId;
+    private MLTaskType taskType;
+    private String status;
+
+    public MLBatchIngestionResponse(StreamInput in) throws IOException {
+        super(in);
+        this.taskId = in.readString();
+        this.taskType = in.readEnum(MLTaskType.class);
+        this.status = in.readString();
+    }
+
+    public MLBatchIngestionResponse(String taskId, MLTaskType mlTaskType, String status) {
+        this.taskId = taskId;
+        this.taskType = mlTaskType;
+        this.status = status;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(taskId);
+        out.writeEnum(taskType);
+        out.writeString(status);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field(TASK_ID_FIELD, taskId);
+        if (taskType != null) {
+            builder.field(TASK_TYPE_FIELD, taskType);
+        }
+        builder.field(STATUS_FIELD, status);
+        builder.endObject();
+        return builder;
+    }
+
+    public static MLBatchIngestionResponse fromActionResponse(ActionResponse actionResponse) {
+        if (actionResponse instanceof MLBatchIngestionResponse) {
+            return (MLBatchIngestionResponse) actionResponse;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionResponse.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLBatchIngestionResponse(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionResponse into MLBatchIngestionResponse", e);
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionResponse.java
@@ -20,6 +20,9 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.MLTaskType;
 
+import lombok.Getter;
+
+@Getter
 public class MLBatchIngestionResponse extends ActionResponse implements ToXContentObject {
     public static final String TASK_ID_FIELD = "task_id";
     public static final String TASK_TYPE_FIELD = "task_type";

--- a/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionResponse.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.batch;
 
 import java.io.ByteArrayInputStream;

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -13,6 +13,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -125,6 +126,27 @@ public class StringUtils {
     @SuppressWarnings("removal")
     public static Map<String, String> getParameterMap(Map<String, ?> parameterObjs) {
         Map<String, String> parameters = new HashMap<>();
+        for (String key : parameterObjs.keySet()) {
+            Object value = parameterObjs.get(key);
+            try {
+                AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                    if (value instanceof String) {
+                        parameters.put(key, (String) value);
+                    } else {
+                        parameters.put(key, gson.toJson(value));
+                    }
+                    return null;
+                });
+            } catch (PrivilegedActionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameters;
+    }
+
+    @SuppressWarnings("removal")
+    public static LinkedHashMap<String, String> getOrderedMap(Map<String, ?> parameterObjs) {
+        LinkedHashMap<String, String> parameters = new LinkedHashMap<>();
         for (String key : parameterObjs.keySet()) {
             Object value = parameterObjs.get(key);
             try {

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -301,4 +301,10 @@ public class StringUtils {
         return parameters;
     }
 
+    public static String obtainFieldNameFromJsonPath(String jsonPath) {
+        String[] parts = jsonPath.split("\\.");
+
+        // Get the last part which is the field name
+        return parts[parts.length - 1];
+    }
 }

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -13,7 +13,6 @@ import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -126,27 +125,6 @@ public class StringUtils {
     @SuppressWarnings("removal")
     public static Map<String, String> getParameterMap(Map<String, ?> parameterObjs) {
         Map<String, String> parameters = new HashMap<>();
-        for (String key : parameterObjs.keySet()) {
-            Object value = parameterObjs.get(key);
-            try {
-                AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                    if (value instanceof String) {
-                        parameters.put(key, (String) value);
-                    } else {
-                        parameters.put(key, gson.toJson(value));
-                    }
-                    return null;
-                });
-            } catch (PrivilegedActionException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return parameters;
-    }
-
-    @SuppressWarnings("removal")
-    public static LinkedHashMap<String, String> getOrderedMap(Map<String, ?> parameterObjs) {
-        LinkedHashMap<String, String> parameters = new LinkedHashMap<>();
         for (String key : parameterObjs.keySet()) {
             Object value = parameterObjs.get(key);
             try {
@@ -306,5 +284,13 @@ public class StringUtils {
 
         // Get the last part which is the field name
         return parts[parts.length - 1];
+    }
+
+    public static String getJsonPath(String jsonPathWithSource) {
+        // Find the index of the first occurrence of "$."
+        int startIndex = jsonPathWithSource.indexOf("$.");
+
+        // Extract the substring from the startIndex to the end of the input string
+        return (startIndex != -1) ? jsonPathWithSource.substring(startIndex) : jsonPathWithSource;
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/input/nlp/TextDocsMLInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/nlp/TextDocsMLInputTest.java
@@ -57,7 +57,6 @@ public class TextDocsMLInputTest {
         XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
         input.toXContent(builder, ToXContent.EMPTY_PARAMS);
         String jsonStr = builder.toString();
-        System.out.println(jsonStr);
         parseMLInput(jsonStr, 2);
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInputTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.batch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.search.SearchModule;
+
+public class MLBatchIngestionInputTests {
+
+    private MLBatchIngestionInput mlBatchIngestionInput;
+
+    private Map<String, String> dataSource;
+
+    @Rule
+    public final ExpectedException exceptionRule = ExpectedException.none();
+
+    private final String expectedInputStr = "{"
+        + "\"index_name\":\"test index\","
+        + "\"text_embedding_field_map\":{"
+        + "\"chapter\":\"chapter_embedding\""
+        + "},"
+        + "\"data_source\":{"
+        + "\"source\":\"s3://samplebucket/output/sampleresults.json.out\","
+        + "\"type\":\"s3\""
+        + "},"
+        + "\"credential\":{"
+        + "\"region\":\"test region\""
+        + "}"
+        + "}";
+
+    @Before
+    public void setUp() {
+        dataSource = new HashMap<>();
+        dataSource.put("type", "s3");
+        dataSource.put("source", "s3://samplebucket/output/sampleresults.json.out");
+
+        Map<String, String> credentials = Map.of("region", "test region");
+        Map<String, String> fieldMapping = Map.of("chapter", "chapter_embedding");
+
+        mlBatchIngestionInput = MLBatchIngestionInput
+            .builder()
+            .indexName("test index")
+            .credential(credentials)
+            .fieldMapping(fieldMapping)
+            .dataSources(dataSource)
+            .build();
+    }
+
+    @Test
+    public void constructorMLBatchIngestionInput_NullName() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("index name for ingestion is null");
+
+        MLBatchIngestionInput.builder().indexName(null).dataSources(dataSource).build();
+    }
+
+    @Test
+    public void constructorMLBatchIngestionInput_NullSource() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("dataSources for ingestion is null");
+        MLBatchIngestionInput.builder().indexName("test index").dataSources(null).build();
+    }
+
+    @Test
+    public void testToXContent_FullFields() throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        mlBatchIngestionInput.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(builder);
+        String jsonStr = builder.toString();
+        assertEquals(expectedInputStr, jsonStr);
+    }
+
+    @Test
+    public void testParse() throws Exception {
+        testParseFromJsonString(expectedInputStr, parsedInput -> {
+            assertEquals("test index", parsedInput.getIndexName());
+            assertEquals("test region", parsedInput.getCredential().get("region"));
+            assertEquals("chapter_embedding", parsedInput.getFieldMapping().get("chapter"));
+            assertEquals("s3", parsedInput.getDataSources().get("type"));
+        });
+    }
+
+    private void testParseFromJsonString(String expectedInputString, Consumer<MLBatchIngestionInput> verify) throws Exception {
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                LoggingDeprecationHandler.INSTANCE,
+                expectedInputString
+            );
+        parser.nextToken();
+        MLBatchIngestionInput parsedInput = MLBatchIngestionInput.parse(parser);
+        verify.accept(parsedInput);
+    }
+
+    @Test
+    public void readInputStream_Success() throws IOException {
+        readInputStream(
+            mlBatchIngestionInput,
+            parsedInput -> assertEquals(mlBatchIngestionInput.getIndexName(), parsedInput.getIndexName())
+        );
+    }
+
+    private void readInputStream(MLBatchIngestionInput input, Consumer<MLBatchIngestionInput> verify) throws IOException {
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        input.writeTo(bytesStreamOutput);
+        StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+        MLBatchIngestionInput parsedInput = new MLBatchIngestionInput(streamInput);
+        verify.accept(parsedInput);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInputTests.java
@@ -75,7 +75,7 @@ public class MLBatchIngestionInputTests {
     @Test
     public void constructorMLBatchIngestionInput_NullName() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("index name for ingestion is null");
+        exceptionRule.expectMessage("The index name for data ingestion is missing. Please provide a valid index name to proceed.");
 
         MLBatchIngestionInput.builder().indexName(null).dataSources(dataSource).build();
     }
@@ -83,7 +83,8 @@ public class MLBatchIngestionInputTests {
     @Test
     public void constructorMLBatchIngestionInput_NullSource() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("dataSources for ingestion is null");
+        exceptionRule
+            .expectMessage("No data sources were provided for ingestion. Please specify at least one valid data source to proceed.");
         MLBatchIngestionInput.builder().indexName("test index").dataSources(null).build();
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInputTests.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,22 +35,22 @@ public class MLBatchIngestionInputTests {
 
     private MLBatchIngestionInput mlBatchIngestionInput;
 
-    private Map<String, String> dataSource;
+    private Map<String, Object> dataSource;
 
     @Rule
     public final ExpectedException exceptionRule = ExpectedException.none();
 
     private final String expectedInputStr = "{"
         + "\"index_name\":\"test index\","
-        + "\"text_embedding_field_map\":{"
+        + "\"field_map\":{"
         + "\"chapter\":\"chapter_embedding\""
-        + "},"
-        + "\"data_source\":{"
-        + "\"source\":\"s3://samplebucket/output/sampleresults.json.out\","
-        + "\"type\":\"s3\""
         + "},"
         + "\"credential\":{"
         + "\"region\":\"test region\""
+        + "},"
+        + "\"data_source\":{"
+        + "\"source\":[\"s3://samplebucket/output/sampleresults.json.out\"],"
+        + "\"type\":\"s3\""
         + "}"
         + "}";
 
@@ -57,10 +58,10 @@ public class MLBatchIngestionInputTests {
     public void setUp() {
         dataSource = new HashMap<>();
         dataSource.put("type", "s3");
-        dataSource.put("source", "s3://samplebucket/output/sampleresults.json.out");
+        dataSource.put("source", Arrays.asList("s3://samplebucket/output/sampleresults.json.out"));
 
         Map<String, String> credentials = Map.of("region", "test region");
-        Map<String, String> fieldMapping = Map.of("chapter", "chapter_embedding");
+        Map<String, Object> fieldMapping = Map.of("chapter", "chapter_embedding");
 
         mlBatchIngestionInput = MLBatchIngestionInput
             .builder()

--- a/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequestTests.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.batch;
+
+public class MLBatchIngestionRequestTests {}

--- a/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequestTests.java
@@ -5,4 +5,109 @@
 
 package org.opensearch.ml.common.transport.batch;
 
-public class MLBatchIngestionRequestTests {}
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+public class MLBatchIngestionRequestTests {
+    private MLBatchIngestionInput mlBatchIngestionInput;
+    private MLBatchIngestionRequest mlBatchIngestionRequest;
+
+    @Before
+    public void setUp() {
+        mlBatchIngestionInput = MLBatchIngestionInput
+            .builder()
+            .indexName("test_index_name")
+            .credential(Map.of("region", "test region"))
+            .fieldMapping(Map.of("chapter", "chapter_embedding"))
+            .dataSources(Map.of("type", "s3"))
+            .build();
+        mlBatchIngestionRequest = MLBatchIngestionRequest.builder().mlBatchIngestionInput(mlBatchIngestionInput).build();
+    }
+
+    @Test
+    public void writeToSuccess() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        mlBatchIngestionRequest.writeTo(output);
+        MLBatchIngestionRequest parsedRequest = new MLBatchIngestionRequest(output.bytes().streamInput());
+        assertEquals(
+            mlBatchIngestionRequest.getMlBatchIngestionInput().getIndexName(),
+            parsedRequest.getMlBatchIngestionInput().getIndexName()
+        );
+        assertEquals(
+            mlBatchIngestionRequest.getMlBatchIngestionInput().getCredential(),
+            parsedRequest.getMlBatchIngestionInput().getCredential()
+        );
+        assertEquals(
+            mlBatchIngestionRequest.getMlBatchIngestionInput().getFieldMapping(),
+            parsedRequest.getMlBatchIngestionInput().getFieldMapping()
+        );
+        assertEquals(
+            mlBatchIngestionRequest.getMlBatchIngestionInput().getDataSources(),
+            parsedRequest.getMlBatchIngestionInput().getDataSources()
+        );
+    }
+
+    @Test
+    public void validateSuccess() {
+        assertNull(mlBatchIngestionRequest.validate());
+    }
+
+    @Test
+    public void validateWithNullInputException() {
+        MLBatchIngestionRequest mlBatchIngestionRequest1 = MLBatchIngestionRequest.builder().build();
+        ActionRequestValidationException exception = mlBatchIngestionRequest1.validate();
+        assertEquals("Validation Failed: 1: ML batch ingestion input can't be null;", exception.getMessage());
+    }
+
+    @Test
+    public void fromActionRequestWithBatchRequestSuccess() {
+        assertSame(MLBatchIngestionRequest.fromActionRequest(mlBatchIngestionRequest), mlBatchIngestionRequest);
+    }
+
+    @Test
+    public void fromActionRequestWithNonRequestSuccess() {
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                mlBatchIngestionRequest.writeTo(out);
+            }
+        };
+        MLBatchIngestionRequest result = MLBatchIngestionRequest.fromActionRequest(actionRequest);
+        assertNotSame(result, mlBatchIngestionRequest);
+        assertEquals(mlBatchIngestionRequest.getMlBatchIngestionInput().getIndexName(), result.getMlBatchIngestionInput().getIndexName());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void fromActionRequestIOException() {
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException();
+            }
+        };
+        MLBatchIngestionRequest.fromActionRequest(actionRequest);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionRequestTests.java
@@ -69,7 +69,7 @@ public class MLBatchIngestionRequestTests {
     public void validateWithNullInputException() {
         MLBatchIngestionRequest mlBatchIngestionRequest1 = MLBatchIngestionRequest.builder().build();
         ActionRequestValidationException exception = mlBatchIngestionRequest1.validate();
-        assertEquals("Validation Failed: 1: ML batch ingestion input can't be null;", exception.getMessage());
+        assertEquals("Validation Failed: 1: The input for ML batch ingestion cannot be null.;", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionResponseTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionResponseTests.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.batch;
+
+public class MLBatchIngestionResponseTests {}

--- a/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionResponseTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionResponseTests.java
@@ -5,4 +5,79 @@
 
 package org.opensearch.ml.common.transport.batch;
 
-public class MLBatchIngestionResponseTests {}
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.MLTaskType;
+import org.opensearch.ml.common.TestHelper;
+
+public class MLBatchIngestionResponseTests {
+
+    MLBatchIngestionResponse mlBatchIngestionResponse;
+
+    @Before
+    public void setUp() {
+        mlBatchIngestionResponse = new MLBatchIngestionResponse("testId", MLTaskType.BATCH_INGEST, "Created");
+    }
+
+    @Test
+    public void toXContent() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        mlBatchIngestionResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+        assertEquals("{\"task_id\":\"testId\",\"task_type\":\"BATCH_INGEST\",\"status\":\"Created\"}", content);
+    }
+
+    @Test
+    public void readFromStream() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        mlBatchIngestionResponse.writeTo(output);
+
+        MLBatchIngestionResponse response2 = new MLBatchIngestionResponse(output.bytes().streamInput());
+        assertEquals("testId", response2.getTaskId());
+        assertEquals("Created", response2.getStatus());
+    }
+
+    @Test
+    public void fromActionResponseWithMLBatchIngestionResponseSuccess() {
+        MLBatchIngestionResponse responseFromActionResponse = MLBatchIngestionResponse.fromActionResponse(mlBatchIngestionResponse);
+        assertSame(mlBatchIngestionResponse, responseFromActionResponse);
+        assertEquals(mlBatchIngestionResponse.getTaskType(), responseFromActionResponse.getTaskType());
+    }
+
+    @Test
+    public void fromActionResponseSuccess() {
+        ActionResponse actionResponse = new ActionResponse() {
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                mlBatchIngestionResponse.writeTo(out);
+            }
+        };
+        MLBatchIngestionResponse responseFromActionResponse = MLBatchIngestionResponse.fromActionResponse(actionResponse);
+        assertNotSame(mlBatchIngestionResponse, responseFromActionResponse);
+        assertEquals(mlBatchIngestionResponse.getTaskType(), responseFromActionResponse.getTaskType());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void fromActionResponseIOException() {
+        ActionResponse actionResponse = new ActionResponse() {
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException();
+            }
+        };
+        MLBatchIngestionResponse.fromActionResponse(actionResponse);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
@@ -8,10 +8,10 @@ package org.opensearch.ml.common.utils;
 import static org.junit.Assert.assertEquals;
 import static org.opensearch.ml.common.utils.StringUtils.TO_STRING_FUNCTION_NAME;
 import static org.opensearch.ml.common.utils.StringUtils.collectToStringPrefixes;
-import static org.opensearch.ml.common.utils.StringUtils.parseParameters;
-import static org.opensearch.ml.common.utils.StringUtils.toJson;
 import static org.opensearch.ml.common.utils.StringUtils.getJsonPath;
 import static org.opensearch.ml.common.utils.StringUtils.obtainFieldNameFromJsonPath;
+import static org.opensearch.ml.common.utils.StringUtils.parseParameters;
+import static org.opensearch.ml.common.utils.StringUtils.toJson;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -401,10 +401,10 @@ public class StringUtilsTest {
     public void testParseParametersNestedMapToString() {
         Map<String, String> parameters = new HashMap<>();
         parameters
-                .put(
-                        "prompt",
-                        "answer question based on context: ${parameters.context.toString()} and conversation history based on history: ${parameters.history.toString()}"
-                );
+            .put(
+                "prompt",
+                "answer question based on context: ${parameters.context.toString()} and conversation history based on history: ${parameters.history.toString()}"
+            );
         Map<String, String> mapOfDocuments = new HashMap<>();
         mapOfDocuments.put("name", "John");
         Map<String, String> nestedMapOfDocuments = new HashMap<>();
@@ -414,15 +414,15 @@ public class StringUtilsTest {
         parameters.put("history", "hello\n");
         parseParameters(parameters);
         assertEquals(
-                parameters.get("context" + TO_STRING_FUNCTION_NAME),
-                "{\\\"hometown\\\":\\\"{\\\\\\\"city\\\\\\\":\\\\\\\"New York\\\\\\\"}\\\",\\\"name\\\":\\\"John\\\"}"
+            parameters.get("context" + TO_STRING_FUNCTION_NAME),
+            "{\\\"hometown\\\":\\\"{\\\\\\\"city\\\\\\\":\\\\\\\"New York\\\\\\\"}\\\",\\\"name\\\":\\\"John\\\"}"
         );
         String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
         StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
         requestBody = substitutor.replace(requestBody);
         assertEquals(
-                requestBody,
-                "{\"prompt\": \"answer question based on context: {\\\"hometown\\\":\\\"{\\\\\\\"city\\\\\\\":\\\\\\\"New York\\\\\\\"}\\\",\\\"name\\\":\\\"John\\\"} and conversation history based on history: hello\\n\"}"
+            requestBody,
+            "{\"prompt\": \"answer question based on context: {\\\"hometown\\\":\\\"{\\\\\\\"city\\\\\\\":\\\\\\\"New York\\\\\\\"}\\\",\\\"name\\\":\\\"John\\\"} and conversation history based on history: hello\\n\"}"
         );
     }
 

--- a/memory/src/test/java/org/opensearch/ml/memory/index/InteractionsIndexTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/index/InteractionsIndexTests.java
@@ -750,7 +750,6 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         interactionsIndex.getInteraction("iid", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
-        System.out.println(argCaptor.getValue().getMessage());
         assert (argCaptor
             .getValue()
             .getMessage()

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -7,6 +7,7 @@ import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
 plugins {
     id 'java'
+    id 'java-library'
     id 'jacoco'
     id "io.freefair.lombok"
     id 'com.diffplug.spotless' version '6.25.0'
@@ -62,9 +63,12 @@ dependencies {
     }
 
     implementation platform('software.amazon.awssdk:bom:2.25.40')
-    implementation 'software.amazon.awssdk:auth'
+    api 'software.amazon.awssdk:auth:2.25.40'
     implementation 'software.amazon.awssdk:apache-client'
     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
+    implementation group: 'software.amazon.awssdk', name: 'aws-core', version: '2.25.40'
+    implementation group: 'software.amazon.awssdk', name: 's3', version: '2.25.40'
+    implementation group: 'software.amazon.awssdk', name: 'regions', version: '2.25.40'
     implementation 'com.jayway.jsonpath:json-path:2.9.0'
     implementation group: 'org.json', name: 'json', version: '20231013'
     implementation group: 'software.amazon.awssdk', name: 'netty-nio-client', version: '2.25.40'

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -86,7 +86,6 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
         ActionListener<Tuple<Integer, ModelTensors>> actionListener
     ) {
         try {
-            connector.getDecryptedCredential();
             SdkHttpFullRequest request = ConnectorUtils.buildSdkRequest(action, connector, parameters, payload, POST);
             AsyncExecuteRequest executeRequest = AsyncExecuteRequest
                 .builder()

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -86,6 +86,7 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
         ActionListener<Tuple<Integer, ModelTensors>> actionListener
     ) {
         try {
+            connector.getDecryptedCredential();
             SdkHttpFullRequest request = ConnectorUtils.buildSdkRequest(action, connector, parameters, payload, POST);
             AsyncExecuteRequest executeRequest = AsyncExecuteRequest
                 .builder()

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/annotation/Ingester.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/annotation/Ingester.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Ingester {
+    String value();
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/AbstractIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/AbstractIngestion.java
@@ -36,10 +36,10 @@ import lombok.extern.log4j.Log4j2;
 public class AbstractIngestion implements Ingestable {
     public static final String OUTPUT = "output";
     public static final String INPUT = "input";
-    public static final String OUTPUTIELDS = "output_names";
-    public static final String INPUTFIELDS = "input_names";
-    public static final String INGESTFIELDS = "ingest_fields";
-    public static final String IDFIELD = "id_field";
+    public static final String OUTPUT_FIELD_NAMES = "output_names";
+    public static final String INPUT_FIELD_NAMES = "input_names";
+    public static final String INGEST_FIELDS = "ingest_fields";
+    public static final String ID_FIELD = "id_field";
 
     private final Client client;
 
@@ -112,10 +112,10 @@ public class AbstractIngestion implements Ingestable {
         }));
 
         if (filteredFieldMap.containsKey(OUTPUT)) {
-            filteredFieldMap.put(OUTPUTIELDS, fieldMap.get(OUTPUTIELDS));
+            filteredFieldMap.put(OUTPUT_FIELD_NAMES, fieldMap.get(OUTPUT_FIELD_NAMES));
         }
         if (filteredFieldMap.containsKey(INPUT)) {
-            filteredFieldMap.put(INPUTFIELDS, fieldMap.get(INPUTFIELDS));
+            filteredFieldMap.put(INPUT_FIELD_NAMES, fieldMap.get(INPUT_FIELD_NAMES));
         }
         return filteredFieldMap;
     }
@@ -130,14 +130,14 @@ public class AbstractIngestion implements Ingestable {
     protected Map<String, Object> processFieldMapping(String jsonStr, Map<String, Object> fieldMapping) {
         String inputJsonPath = fieldMapping.containsKey(INPUT) ? getJsonPath((String) fieldMapping.get(INPUT)) : null;
         List<String> remoteModelInput = inputJsonPath != null ? (List<String>) JsonPath.read(jsonStr, inputJsonPath) : null;
-        List<String> inputFieldNames = inputJsonPath != null ? (List<String>) fieldMapping.get(INPUTFIELDS) : null;
+        List<String> inputFieldNames = inputJsonPath != null ? (List<String>) fieldMapping.get(INPUT_FIELD_NAMES) : null;
 
         String outputJsonPath = fieldMapping.containsKey(OUTPUT) ? getJsonPath((String) fieldMapping.get(OUTPUT)) : null;
         List<List> remoteModelOutput = outputJsonPath != null ? (List<List>) JsonPath.read(jsonStr, outputJsonPath) : null;
-        List<String> outputFieldNames = outputJsonPath != null ? (List<String>) fieldMapping.get(OUTPUTIELDS) : null;
+        List<String> outputFieldNames = outputJsonPath != null ? (List<String>) fieldMapping.get(OUTPUT_FIELD_NAMES) : null;
 
         List<String> ingestFieldsJsonPath = Optional
-            .ofNullable((List<String>) fieldMapping.get(INGESTFIELDS))
+            .ofNullable((List<String>) fieldMapping.get(INGEST_FIELDS))
             .stream()
             .flatMap(Collection::stream)
             .map(StringUtils::getJsonPath)
@@ -152,9 +152,9 @@ public class AbstractIngestion implements Ingestable {
             jsonMap.put(obtainFieldNameFromJsonPath(fieldPath), JsonPath.read(jsonStr, fieldPath));
         }
 
-        if (fieldMapping.containsKey(IDFIELD)) {
+        if (fieldMapping.containsKey(ID_FIELD)) {
             List<String> docIdJsonPath = Optional
-                .ofNullable((List<String>) fieldMapping.get(IDFIELD))
+                .ofNullable((List<String>) fieldMapping.get(ID_FIELD))
                 .stream()
                 .flatMap(Collection::stream)
                 .map(StringUtils::getJsonPath)

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/AbstractIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/AbstractIngestion.java
@@ -57,6 +57,7 @@ public class AbstractIngestion implements Ingestable {
                 failedBatches.incrementAndGet();
                 future.completeExceptionally(new RuntimeException(bulkResponse.buildFailureMessage()));  // Mark the future as completed
                 // with an exception
+                return;
             }
             log.debug("Batch Ingestion successfully");
             successfulBatches.incrementAndGet();
@@ -68,7 +69,7 @@ public class AbstractIngestion implements Ingestable {
         });
     }
 
-    protected double calcualteSuccessRate(List<Double> successRates) {
+    protected double calculateSuccessRate(List<Double> successRates) {
         return successRates
             .stream()
             .min(Double::compare)
@@ -152,8 +153,10 @@ public class AbstractIngestion implements Ingestable {
         }
 
         if (fieldMapping.containsKey(IDFIELD)) {
-            List<String> docIdJsonPath = ((List<String>) fieldMapping.get(IDFIELD))
+            List<String> docIdJsonPath = Optional
+                .ofNullable((List<String>) fieldMapping.get(IDFIELD))
                 .stream()
+                .flatMap(Collection::stream)
                 .map(StringUtils::getJsonPath)
                 .collect(Collectors.toList());
             if (docIdJsonPath.size() != 1) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/AbstractIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/AbstractIngestion.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.ingest;
+
+import static org.opensearch.ml.common.utils.StringUtils.getJsonPath;
+import static org.opensearch.ml.common.utils.StringUtils.obtainFieldNameFromJsonPath;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
+import org.opensearch.ml.common.utils.StringUtils;
+
+import com.jayway.jsonpath.JsonPath;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class AbstractIngestion implements Ingestable {
+    public static final String OUTPUT = "output";
+    public static final String INPUT = "input";
+    public static final String OUTPUTIELDS = "output_names";
+    public static final String INPUTFIELDS = "input_names";
+    public static final String INGESTFIELDS = "ingest_fields";
+    public static final String IDFIELD = "id_field";
+
+    private final Client client;
+
+    public AbstractIngestion(Client client) {
+        this.client = client;
+    }
+
+    protected ActionListener<BulkResponse> getBulkResponseListener(
+        AtomicInteger successfulBatches,
+        AtomicInteger failedBatches,
+        CompletableFuture<Void> future
+    ) {
+        return ActionListener.wrap(bulkResponse -> {
+            if (bulkResponse.hasFailures()) {
+                failedBatches.incrementAndGet();
+                future.completeExceptionally(new RuntimeException(bulkResponse.buildFailureMessage()));  // Mark the future as completed
+                // with an exception
+            }
+            log.debug("Batch Ingestion successfully");
+            successfulBatches.incrementAndGet();
+            future.complete(null); // Mark the future as completed successfully
+        }, e -> {
+            log.error("Failed to Batch Ingestion", e);
+            failedBatches.incrementAndGet();
+            future.completeExceptionally(e);  // Mark the future as completed with an exception
+        });
+    }
+
+    protected double calcualteSuccessRate(List<Double> successRates) {
+        return successRates
+            .stream()
+            .min(Double::compare)
+            .orElseThrow(
+                () -> new OpenSearchStatusException(
+                    "Failed to batch ingest data as not success rate is returned",
+                    RestStatus.INTERNAL_SERVER_ERROR
+                )
+            );
+    }
+
+    /**
+     * Filters fields in the map where the value contains the specified source index as a prefix.
+     *
+     * @param mlBatchIngestionInput The MLBatchIngestionInput.
+     * @param index    The source index to filter by.
+     * @return A new map with only the entries that match the specified source index.
+     */
+    protected Map<String, Object> filterFieldMapping(MLBatchIngestionInput mlBatchIngestionInput, int index) {
+        Map<String, Object> fieldMap = mlBatchIngestionInput.getFieldMapping();
+        int indexInFieldMap = index + 1;
+        String prefix = "source[" + indexInFieldMap + "]";
+
+        Map<String, Object> filteredFieldMap = fieldMap.entrySet().stream().filter(entry -> {
+            Object value = entry.getValue();
+            if (value instanceof String) {
+                return ((String) value).contains(prefix);
+            } else if (value instanceof List) {
+                return ((List<String>) value).stream().anyMatch(val -> val.contains(prefix));
+            }
+            return false;
+        }).collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+            Object value = entry.getValue();
+            if (value instanceof String) {
+                return value;
+            } else if (value instanceof List) {
+                return ((List<String>) value).stream().filter(val -> val.contains(prefix)).collect(Collectors.toList());
+            }
+            return null;
+        }));
+
+        if (filteredFieldMap.containsKey(OUTPUT)) {
+            filteredFieldMap.put(OUTPUTIELDS, fieldMap.get(OUTPUTIELDS));
+        }
+        if (filteredFieldMap.containsKey(INPUT)) {
+            filteredFieldMap.put(INPUTFIELDS, fieldMap.get(INPUTFIELDS));
+        }
+        return filteredFieldMap;
+    }
+
+    /**
+     * Produce the source as a Map to be ingested in to OpenSearch.
+     *
+     * @param jsonStr The MLBatchIngestionInput.
+     * @param fieldMapping  The field mapping that includes all the field name and Json Path for the data.
+     * @return A new map that contains all the fields and data for ingestion.
+     */
+    protected Map<String, Object> processFieldMapping(String jsonStr, Map<String, Object> fieldMapping) {
+        String inputJsonPath = fieldMapping.containsKey(INPUT) ? getJsonPath((String) fieldMapping.get(INPUT)) : null;
+        List<String> remoteModelInput = inputJsonPath != null ? (List<String>) JsonPath.read(jsonStr, inputJsonPath) : null;
+        List<String> inputFieldNames = inputJsonPath != null ? (List<String>) fieldMapping.get(INPUTFIELDS) : null;
+
+        String outputJsonPath = fieldMapping.containsKey(OUTPUT) ? getJsonPath((String) fieldMapping.get(OUTPUT)) : null;
+        List<List> remoteModelOutput = outputJsonPath != null ? (List<List>) JsonPath.read(jsonStr, outputJsonPath) : null;
+        List<String> outputFieldNames = outputJsonPath != null ? (List<String>) fieldMapping.get(OUTPUTIELDS) : null;
+
+        List<String> ingestFieldsJsonPath = Optional
+            .ofNullable((List<String>) fieldMapping.get(INGESTFIELDS))
+            .stream()
+            .flatMap(Collection::stream)
+            .map(StringUtils::getJsonPath)
+            .collect(Collectors.toList());
+
+        Map<String, Object> jsonMap = new HashMap<>();
+
+        populateJsonMap(jsonMap, inputFieldNames, remoteModelInput);
+        populateJsonMap(jsonMap, outputFieldNames, remoteModelOutput);
+
+        for (String fieldPath : ingestFieldsJsonPath) {
+            jsonMap.put(obtainFieldNameFromJsonPath(fieldPath), JsonPath.read(jsonStr, fieldPath));
+        }
+
+        if (fieldMapping.containsKey(IDFIELD)) {
+            List<String> docIdJsonPath = ((List<String>) fieldMapping.get(IDFIELD))
+                .stream()
+                .map(StringUtils::getJsonPath)
+                .collect(Collectors.toList());
+            if (docIdJsonPath.size() != 1) {
+                throw new IllegalArgumentException("The Id field must contains only 1 jsonPath for each source");
+            }
+            jsonMap.put("_id", JsonPath.read(jsonStr, docIdJsonPath.get(0)));
+        }
+        return jsonMap;
+    }
+
+    protected void batchIngest(
+        List<String> sourceLines,
+        MLBatchIngestionInput mlBatchIngestionInput,
+        ActionListener<BulkResponse> bulkResponseListener,
+        int sourceIndex,
+        boolean isSoleSource
+    ) {
+        BulkRequest bulkRequest = new BulkRequest();
+        sourceLines.stream().forEach(jsonStr -> {
+            Map<String, Object> filteredMapping = isSoleSource
+                ? mlBatchIngestionInput.getFieldMapping()
+                : filterFieldMapping(mlBatchIngestionInput, sourceIndex);
+            Map<String, Object> jsonMap = processFieldMapping(jsonStr, filteredMapping);
+            if (isSoleSource || sourceIndex == 0) {
+                IndexRequest indexRequest = new IndexRequest(mlBatchIngestionInput.getIndexName());
+                if (jsonMap.containsKey("_id")) {
+                    String id = (String) jsonMap.remove("_id");
+                    indexRequest.id(id);
+                }
+                indexRequest.source(jsonMap);
+                bulkRequest.add(indexRequest);
+            } else {
+                // bulk update docs as they were partially ingested
+                if (!jsonMap.containsKey("_id")) {
+                    throw new IllegalArgumentException("The id filed must be provided to match documents for multiple sources");
+                }
+                String id = (String) jsonMap.remove("_id");
+                UpdateRequest updateRequest = new UpdateRequest(mlBatchIngestionInput.getIndexName(), id).doc(jsonMap).upsert(jsonMap);
+                bulkRequest.add(updateRequest);
+            }
+        });
+        client.bulk(bulkRequest, bulkResponseListener);
+    }
+
+    private void populateJsonMap(Map<String, Object> jsonMap, List<String> fieldNames, List<?> modelData) {
+        if (modelData != null) {
+            if (modelData.size() != fieldNames.size()) {
+                throw new IllegalArgumentException("The fieldMapping and source data do not match");
+            }
+
+            for (int index = 0; index < modelData.size(); index++) {
+                jsonMap.put(fieldNames.get(index), modelData.get(index));
+            }
+        }
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/Ingestable.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/Ingestable.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.ingest;
+
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
+
+public interface Ingestable {
+    /**
+     * offline ingest data with given input.
+     * @param mlBatchIngestionInput batch ingestion input data
+     * @return successRate (0 - 100)
+     */
+    default double ingest(MLBatchIngestionInput mlBatchIngestionInput) {
+        throw new IllegalStateException("Ingest is not implemented");
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestion.java
@@ -51,7 +51,7 @@ public class OpenAIDataIngestion extends AbstractIngestion {
             successRates.add(ingestSingleSource(sources.get(sourceIndex), mlBatchIngestionInput, sourceIndex, isSoleSource));
         }
 
-        return calcualteSuccessRate(successRates);
+        return calculateSuccessRate(successRates);
     }
 
     private double ingestSingleSource(String fildId, MLBatchIngestionInput mlBatchIngestionInput, int sourceIndex, boolean isSoleSource) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestion.java
@@ -54,11 +54,11 @@ public class OpenAIDataIngestion extends AbstractIngestion {
         return calculateSuccessRate(successRates);
     }
 
-    private double ingestSingleSource(String fildId, MLBatchIngestionInput mlBatchIngestionInput, int sourceIndex, boolean isSoleSource) {
+    private double ingestSingleSource(String fileId, MLBatchIngestionInput mlBatchIngestionInput, int sourceIndex, boolean isSoleSource) {
         double successRate = 0;
         try {
             String apiKey = mlBatchIngestionInput.getCredential().get(API_KEY);
-            URL url = new URL(API_URL + fildId + "/content");
+            URL url = new URL(API_URL + fileId + "/content");
 
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestion.java
@@ -5,11 +5,6 @@
 
 package org.opensearch.ml.engine.ingest;
 
-import static org.opensearch.ml.common.utils.StringUtils.obtainFieldNameFromJsonPath;
-import static org.opensearch.ml.engine.ingest.S3DataIngestion.INGESTFIELDS;
-import static org.opensearch.ml.engine.ingest.S3DataIngestion.OUTPUT;
-import static org.opensearch.ml.engine.ingest.S3DataIngestion.OUTPUTIELDS;
-
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
@@ -18,46 +13,52 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.action.bulk.BulkRequest;
-import org.opensearch.action.bulk.BulkResponse;
-import org.opensearch.action.index.IndexRequest;
 import org.opensearch.client.Client;
-import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
 import org.opensearch.ml.engine.annotation.Ingester;
-
-import com.jayway.jsonpath.JsonPath;
 
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 @Ingester("openai")
-public class OpenAIDataIngestion implements Ingestable {
+public class OpenAIDataIngestion extends AbstractIngestion {
     private static final String API_KEY = "openAI_key";
     private static final String API_URL = "https://api.openai.com/v1/files/";
-
     public static final String SOURCE = "source";
-    private final Client client;
 
     public OpenAIDataIngestion(Client client) {
-        this.client = client;
+        super(client);
     }
 
     @Override
     public double ingest(MLBatchIngestionInput mlBatchIngestionInput) {
+        List<String> sources = (List<String>) mlBatchIngestionInput.getDataSources().get(SOURCE);
+        if (Objects.isNull(sources) || sources.isEmpty()) {
+            return 100;
+        }
+
+        boolean isSoleSource = sources.size() == 1;
+        List<Double> successRates = Collections.synchronizedList(new ArrayList<>());
+        for (int sourceIndex = 0; sourceIndex < sources.size(); sourceIndex++) {
+            successRates.add(ingestSingleSource(sources.get(sourceIndex), mlBatchIngestionInput, sourceIndex, isSoleSource));
+        }
+
+        return calcualteSuccessRate(successRates);
+    }
+
+    private double ingestSingleSource(String fildId, MLBatchIngestionInput mlBatchIngestionInput, int sourceIndex, boolean isSoleSource) {
         double successRate = 0;
         try {
             String apiKey = mlBatchIngestionInput.getCredential().get(API_KEY);
-            String fileId = mlBatchIngestionInput.getDataSources().get(SOURCE);
-            URL url = new URL(API_URL + fileId + "/content");
+            URL url = new URL(API_URL + fildId + "/content");
 
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
@@ -84,7 +85,13 @@ public class OpenAIDataIngestion implements Ingestable {
                 if (lineCount == 100) {
                     // Create a CompletableFuture that will be completed by the bulkResponseListener
                     CompletableFuture<Void> future = new CompletableFuture<>();
-                    batchIngest(linesBuffer, mlBatchIngestionInput, getBulkResponseListener(successfulBatches, failedBatches, future));
+                    batchIngest(
+                        linesBuffer,
+                        mlBatchIngestionInput,
+                        getBulkResponseListener(successfulBatches, failedBatches, future),
+                        sourceIndex,
+                        isSoleSource
+                    );
 
                     futures.add(future);
                     linesBuffer.clear();
@@ -94,7 +101,13 @@ public class OpenAIDataIngestion implements Ingestable {
             // Process any remaining lines in the buffer
             if (!linesBuffer.isEmpty()) {
                 CompletableFuture<Void> future = new CompletableFuture<>();
-                batchIngest(linesBuffer, mlBatchIngestionInput, getBulkResponseListener(successfulBatches, failedBatches, future));
+                batchIngest(
+                    linesBuffer,
+                    mlBatchIngestionInput,
+                    getBulkResponseListener(successfulBatches, failedBatches, future),
+                    sourceIndex,
+                    isSoleSource
+                );
                 futures.add(future);
             }
 
@@ -113,62 +126,5 @@ public class OpenAIDataIngestion implements Ingestable {
         }
 
         return successRate;
-    }
-
-    private ActionListener<BulkResponse> getBulkResponseListener(
-        AtomicInteger successfulBatches,
-        AtomicInteger failedBatches,
-        CompletableFuture<Void> future
-    ) {
-        return ActionListener.wrap(bulkResponse -> {
-            if (bulkResponse.hasFailures()) {
-                failedBatches.incrementAndGet();
-                future.completeExceptionally(new RuntimeException(bulkResponse.buildFailureMessage()));  // Mark the future as completed
-                // with an exception
-            }
-            log.debug("Batch Ingestion successfully");
-            successfulBatches.incrementAndGet();
-            future.complete(null); // Mark the future as completed successfully
-        }, e -> {
-            log.error("Failed to bulk update model state", e);
-            failedBatches.incrementAndGet();
-            future.completeExceptionally(e);  // Mark the future as completed with an exception
-        });
-    }
-
-    private void batchIngest(
-        List<String> sourceLines,
-        MLBatchIngestionInput mlBatchIngestionInput,
-        ActionListener<BulkResponse> bulkResponseListener
-    ) {
-        BulkRequest bulkRequest = new BulkRequest();
-        sourceLines.stream().forEach(jsonStr -> {
-            Map<String, Object> jsonMap = processFieldMapping(jsonStr, mlBatchIngestionInput.getFieldMapping());
-            IndexRequest indexRequest = new IndexRequest(mlBatchIngestionInput.getIndexName()).source(jsonMap);
-
-            bulkRequest.add(indexRequest);
-        });
-        client.bulk(bulkRequest, bulkResponseListener);
-    }
-
-    private Map<String, Object> processFieldMapping(String jsonStr, Map<String, Object> fieldMapping) {
-        String outputJsonPath = (String) fieldMapping.get(OUTPUT);
-        List<List> outputs = (List<List>) JsonPath.read(jsonStr, outputJsonPath);
-        List<String> outputFields = (List<String>) fieldMapping.get(OUTPUTIELDS);
-        List<String> ingestFieldsJsonPath = (List<String>) fieldMapping.get(INGESTFIELDS);
-
-        Map<String, Object> jsonMap = new HashMap<>();
-        if (outputs.size() != outputFields.size()) {
-            throw new IllegalArgumentException("the fieldMapping and source data do not match");
-        }
-        for (int index = 0; index < outputs.size(); index++) {
-            jsonMap.put(outputFields.get(index), outputs.get(index));
-        }
-
-        for (String fieldPath : ingestFieldsJsonPath) {
-            jsonMap.put(obtainFieldNameFromJsonPath(fieldPath), JsonPath.read(jsonStr, fieldPath));
-        }
-
-        return jsonMap;
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/S3DataIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/S3DataIngestion.java
@@ -29,6 +29,8 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
 import org.opensearch.ml.engine.annotation.Ingester;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import lombok.extern.log4j.Log4j2;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
@@ -64,10 +66,10 @@ public class S3DataIngestion extends AbstractIngestion {
             successRates.add(ingestSingleSource(s3, s3Uris.get(sourceIndex), mlBatchIngestionInput, sourceIndex, isSoleSource));
         }
 
-        return calcualteSuccessRate(successRates);
+        return calculateSuccessRate(successRates);
     }
 
-    private double ingestSingleSource(
+    public double ingestSingleSource(
         S3Client s3,
         String s3Uri,
         MLBatchIngestionInput mlBatchIngestionInput,
@@ -177,7 +179,8 @@ public class S3DataIngestion extends AbstractIngestion {
         return uriWithoutPrefix.substring(slashIndex + 1);
     }
 
-    private S3Client initS3Client(MLBatchIngestionInput mlBatchIngestionInput) {
+    @VisibleForTesting
+    public S3Client initS3Client(MLBatchIngestionInput mlBatchIngestionInput) {
         String accessKey = mlBatchIngestionInput.getCredential().get(ACCESS_KEY_FIELD);
         String secretKey = mlBatchIngestionInput.getCredential().get(SECRET_KEY_FIELD);
         String sessionToken = mlBatchIngestionInput.getCredential().get(SESSION_TOKEN_FIELD);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/S3DataIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/S3DataIngestion.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.ingest;
+
+import static org.opensearch.ml.common.connector.AbstractConnector.ACCESS_KEY_FIELD;
+import static org.opensearch.ml.common.connector.AbstractConnector.SECRET_KEY_FIELD;
+import static org.opensearch.ml.common.connector.AbstractConnector.SESSION_TOKEN_FIELD;
+import static org.opensearch.ml.common.connector.HttpConnector.REGION_FIELD;
+import static org.opensearch.ml.common.utils.StringUtils.fromJson;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
+import org.opensearch.ml.engine.annotation.Ingester;
+
+import lombok.extern.log4j.Log4j2;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Log4j2
+@Ingester("s3")
+public class S3DataIngestion implements Ingestable {
+    public static final String SOURCE = "source";
+    private final Client client;
+
+    public S3DataIngestion(Client client) {
+        this.client = client;
+    }
+
+    @Override
+    public double ingest(MLBatchIngestionInput mlBatchIngestionInput) {
+        S3Client s3 = initS3Client(mlBatchIngestionInput);
+        double successRate = 0;
+
+        String s3Uri = mlBatchIngestionInput.getDataSources().get(SOURCE);
+        String bucketName = getS3BucketName(s3Uri);
+        String keyName = getS3KeyName(s3Uri);
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(bucketName).key(keyName).build();
+
+        try {
+            ResponseInputStream<GetObjectResponse> s3is = AccessController
+                .doPrivileged((PrivilegedExceptionAction<ResponseInputStream<GetObjectResponse>>) () -> s3.getObject(getObjectRequest));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(s3is, StandardCharsets.UTF_8));
+
+            List<String> linesBuffer = new ArrayList<>();
+            String line;
+            int lineCount = 0;
+            // Atomic counters for tracking success and failure
+            AtomicInteger successfulBatches = new AtomicInteger(0);
+            AtomicInteger failedBatches = new AtomicInteger(0);
+            // List of CompletableFutures to track batch ingestion operations
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+            while ((line = reader.readLine()) != null) {
+                linesBuffer.add(line);
+                lineCount++;
+
+                // Process every 100 lines
+                if (lineCount == 100) {
+                    // Create a CompletableFuture that will be completed by the bulkResponseListener
+                    CompletableFuture<Void> future = new CompletableFuture<>();
+                    batchIngest(linesBuffer, mlBatchIngestionInput, getBulkResponseListener(successfulBatches, failedBatches, future));
+
+                    futures.add(future);
+                    linesBuffer.clear();
+                    lineCount = 0;
+                }
+            }
+            // Process any remaining lines in the buffer
+            if (!linesBuffer.isEmpty()) {
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                batchIngest(linesBuffer, mlBatchIngestionInput, getBulkResponseListener(successfulBatches, failedBatches, future));
+                futures.add(future);
+            }
+
+            reader.close();
+
+            // Combine all futures and wait for completion
+            CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+
+            // Wait for all tasks to complete
+            allFutures.join();
+
+            int totalBatches = successfulBatches.get() + failedBatches.get();
+            successRate = (double) successfulBatches.get() / totalBatches * 100;
+        } catch (S3Exception e) {
+            log.error("Error reading from S3: " + e.awsErrorDetails().errorMessage());
+            throw e;
+        } catch (PrivilegedActionException e) {
+            throw new RuntimeException("Failed to get S3 Object: ", e);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            throw new OpenSearchStatusException("Failed to batch ingest: " + e.getMessage(), RestStatus.INTERNAL_SERVER_ERROR);
+        } finally {
+            s3.close();
+        }
+
+        return successRate;
+    }
+
+    private ActionListener<BulkResponse> getBulkResponseListener(
+        AtomicInteger successfulBatches,
+        AtomicInteger failedBatches,
+        CompletableFuture<Void> future
+    ) {
+        return ActionListener.wrap(bulkResponse -> {
+            if (bulkResponse.hasFailures()) {
+                failedBatches.incrementAndGet();
+                future.completeExceptionally(new RuntimeException(bulkResponse.buildFailureMessage()));  // Mark the future as completed
+                                                                                                         // with an exception
+            }
+            log.debug("Batch Ingestion successfully");
+            successfulBatches.incrementAndGet();
+            future.complete(null); // Mark the future as completed successfully
+        }, e -> {
+            log.error("Failed to bulk update model state", e);
+            failedBatches.incrementAndGet();
+            future.completeExceptionally(e);  // Mark the future as completed with an exception
+        });
+    }
+
+    private void batchIngest(
+        List<String> sourceLines,
+        MLBatchIngestionInput mlBatchIngestionInput,
+        ActionListener<BulkResponse> bulkResponseListener
+    ) {
+        BulkRequest bulkRequest = new BulkRequest();
+        sourceLines.stream().forEach(jsonStr -> {
+            Map<String, Object> jsonMap = fromJson(jsonStr, "SageMakerOutput");
+            processFieldMapping(jsonMap, mlBatchIngestionInput.getFieldMapping());
+            IndexRequest indexRequest = new IndexRequest(mlBatchIngestionInput.getIndexName()).source(jsonMap);
+
+            bulkRequest.add(indexRequest);
+        });
+        client.bulk(bulkRequest, bulkResponseListener);
+    }
+
+    private void processFieldMapping(Map<String, Object> jsonMap, Map<String, String> fieldMapping) {
+        List<List> smOutput = (List<List>) jsonMap.get("SageMakerOutput");
+        List<String> smInput = (List<String>) jsonMap.get("content");
+        if (smInput.size() == smInput.size() && smInput.size() == fieldMapping.size()) {
+            int index = 0;
+            for (Map.Entry<String, String> mapping : fieldMapping.entrySet()) {
+                // key is the field name for input String, value is the field name for embedded output
+                jsonMap.put(mapping.getKey(), smInput.get(index));
+                jsonMap.put(mapping.getValue(), smOutput.get(index));
+                index++;
+            }
+            jsonMap.remove("content");
+            jsonMap.remove("SageMakerOutput");
+        } else {
+            throw new IllegalArgumentException("the fieldMapping and source data do not match");
+        }
+    }
+
+    private String getS3BucketName(String s3Uri) {
+        // Remove the "s3://" prefix
+        String uriWithoutPrefix = s3Uri.substring(5);
+        // Find the first slash after the bucket name
+        int slashIndex = uriWithoutPrefix.indexOf('/');
+        // If there is no slash, the entire remaining string is the bucket name
+        if (slashIndex == -1) {
+            return uriWithoutPrefix;
+        }
+        // Otherwise, the bucket name is the substring up to the first slash
+        return uriWithoutPrefix.substring(0, slashIndex);
+    }
+
+    private String getS3KeyName(String s3Uri) {
+        String uriWithoutPrefix = s3Uri.substring(5);
+        // Find the first slash after the bucket name
+        int slashIndex = uriWithoutPrefix.indexOf('/');
+        // If there is no slash, it means there is no key, return an empty string or handle as needed
+        if (slashIndex == -1) {
+            return "";
+        }
+        // The key name is the substring after the first slash
+        return uriWithoutPrefix.substring(slashIndex + 1);
+    }
+
+    private S3Client initS3Client(MLBatchIngestionInput mlBatchIngestionInput) {
+        String accessKey = mlBatchIngestionInput.getCredential().get(ACCESS_KEY_FIELD);
+        String secretKey = mlBatchIngestionInput.getCredential().get(SECRET_KEY_FIELD);
+        String sessionToken = mlBatchIngestionInput.getCredential().get(SESSION_TOKEN_FIELD);
+        String region = mlBatchIngestionInput.getCredential().get(REGION_FIELD);
+
+        AwsCredentials credentials = sessionToken == null
+            ? AwsBasicCredentials.create(accessKey, secretKey)
+            : AwsSessionCredentials.create(accessKey, secretKey, sessionToken);
+
+        try {
+            S3Client s3 = AccessController
+                .doPrivileged(
+                    (PrivilegedExceptionAction<S3Client>) () -> S3Client
+                        .builder()
+                        .region(Region.of(region))  // Specify the region here
+                        .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                        .build()
+                );
+            return s3;
+        } catch (PrivilegedActionException e) {
+            throw new RuntimeException("Can't load credentials", e);
+        }
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/S3DataIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/S3DataIngestion.java
@@ -166,7 +166,7 @@ public class S3DataIngestion implements Ingestable {
     private void processFieldMapping(Map<String, Object> jsonMap, Map<String, String> fieldMapping) {
         List<List> smOutput = (List<List>) jsonMap.get("SageMakerOutput");
         List<String> smInput = (List<String>) jsonMap.get("content");
-        if (smInput.size() == smInput.size() && smInput.size() == fieldMapping.size()) {
+        if (smInput.size() == smOutput.size() && smInput.size() == fieldMapping.size()) {
             int index = 0;
             for (Map.Entry<String, String> mapping : fieldMapping.entrySet()) {
                 // key is the field name for input String, value is the field name for embedded output

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/openAIDataIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/openAIDataIngestion.java
@@ -1,0 +1,25 @@
+package org.opensearch.ml.engine.ingest;
+
+import org.opensearch.client.Client;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
+import org.opensearch.ml.engine.annotation.Ingester;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@Ingester("openai")
+public class openAIDataIngestion implements Ingestable {
+    public static final String SOURCE = "source";
+    private final Client client;
+
+    public openAIDataIngestion(Client client) {
+        this.client = client;
+    }
+
+    @Override
+    public double ingest(MLBatchIngestionInput mlBatchIngestionInput) {
+        double successRate = 0;
+
+        return successRate;
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/openAIDataIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/openAIDataIngestion.java
@@ -1,6 +1,28 @@
 package org.opensearch.ml.engine.ingest;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
 import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
 import org.opensearch.ml.engine.annotation.Ingester;
 
@@ -9,6 +31,9 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 @Ingester("openai")
 public class openAIDataIngestion implements Ingestable {
+    private static final String API_KEY = "openAI_key";
+    private static final String API_URL = "https://api.openai.com/v1/files/";
+
     public static final String SOURCE = "source";
     private final Client client;
 
@@ -19,7 +44,121 @@ public class openAIDataIngestion implements Ingestable {
     @Override
     public double ingest(MLBatchIngestionInput mlBatchIngestionInput) {
         double successRate = 0;
+        try {
+            String apiKey = mlBatchIngestionInput.getCredential().get(API_KEY);
+            String fileId = mlBatchIngestionInput.getDataSources().get(SOURCE);
+            URL url = new URL(API_URL + fileId + "/content");
+
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Authorization", "Bearer " + apiKey);
+
+            InputStreamReader inputStreamReader = AccessController
+                .doPrivileged((PrivilegedExceptionAction<InputStreamReader>) () -> new InputStreamReader(connection.getInputStream()));
+            BufferedReader reader = new BufferedReader(inputStreamReader);
+
+            List<String> linesBuffer = new ArrayList<>();
+            String line;
+            int lineCount = 0;
+            // Atomic counters for tracking success and failure
+            AtomicInteger successfulBatches = new AtomicInteger(0);
+            AtomicInteger failedBatches = new AtomicInteger(0);
+            // List of CompletableFutures to track batch ingestion operations
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+            while ((line = reader.readLine()) != null) {
+                linesBuffer.add(line);
+                lineCount++;
+
+                // Process every 100 lines
+                if (lineCount == 100) {
+                    // Create a CompletableFuture that will be completed by the bulkResponseListener
+                    CompletableFuture<Void> future = new CompletableFuture<>();
+                    batchIngest(linesBuffer, mlBatchIngestionInput, getBulkResponseListener(successfulBatches, failedBatches, future));
+
+                    futures.add(future);
+                    linesBuffer.clear();
+                    lineCount = 0;
+                }
+            }
+            // Process any remaining lines in the buffer
+            if (!linesBuffer.isEmpty()) {
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                batchIngest(linesBuffer, mlBatchIngestionInput, getBulkResponseListener(successfulBatches, failedBatches, future));
+                futures.add(future);
+            }
+
+            reader.close();
+            // Combine all futures and wait for completion
+            CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            // Wait for all tasks to complete
+            allFutures.join();
+            int totalBatches = successfulBatches.get() + failedBatches.get();
+            successRate = (double) successfulBatches.get() / totalBatches * 100;
+        } catch (PrivilegedActionException e) {
+            throw new RuntimeException("Failed to read from OpenAI file API: ", e);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            throw new OpenSearchStatusException("Failed to batch ingest: " + e.getMessage(), RestStatus.INTERNAL_SERVER_ERROR);
+        }
 
         return successRate;
+    }
+
+    private ActionListener<BulkResponse> getBulkResponseListener(
+        AtomicInteger successfulBatches,
+        AtomicInteger failedBatches,
+        CompletableFuture<Void> future
+    ) {
+        return ActionListener.wrap(bulkResponse -> {
+            if (bulkResponse.hasFailures()) {
+                failedBatches.incrementAndGet();
+                future.completeExceptionally(new RuntimeException(bulkResponse.buildFailureMessage()));  // Mark the future as completed
+                // with an exception
+            }
+            log.debug("Batch Ingestion successfully");
+            successfulBatches.incrementAndGet();
+            future.complete(null); // Mark the future as completed successfully
+        }, e -> {
+            log.error("Failed to bulk update model state", e);
+            failedBatches.incrementAndGet();
+            future.completeExceptionally(e);  // Mark the future as completed with an exception
+        });
+    }
+
+    private void batchIngest(
+        List<String> sourceLines,
+        MLBatchIngestionInput mlBatchIngestionInput,
+        ActionListener<BulkResponse> bulkResponseListener
+    ) {
+        BulkRequest bulkRequest = new BulkRequest();
+        sourceLines.stream().forEach(jsonStr -> {
+            JSONObject jsonObject = new JSONObject(jsonStr);
+            String customId = jsonObject.getString("custom_id");
+            JSONObject responseBody = jsonObject.getJSONObject("response").getJSONObject("body");
+            JSONArray dataArray = responseBody.getJSONArray("data");
+            Map<String, Object> jsonMap = processFieldMapping(customId, dataArray, mlBatchIngestionInput.getFieldMapping());
+            IndexRequest indexRequest = new IndexRequest(mlBatchIngestionInput.getIndexName()).source(jsonMap);
+
+            bulkRequest.add(indexRequest);
+        });
+        client.bulk(bulkRequest, bulkResponseListener);
+    }
+
+    private Map<String, Object> processFieldMapping(String customId, JSONArray dataArray, Map<String, String> fieldMapping) {
+        Map<String, Object> jsonMap = new HashMap<>();
+        if (dataArray.length() == fieldMapping.size()) {
+            int index = 0;
+            for (Map.Entry<String, String> mapping : fieldMapping.entrySet()) {
+                // key is the field name for input String, value is the field name for embedded output
+                JSONObject dataItem = dataArray.getJSONObject(index);
+                jsonMap.put(mapping.getValue(), dataItem.getJSONArray("embedding"));
+                index++;
+            }
+            jsonMap.put("id", customId);
+        } else {
+            throw new IllegalArgumentException("the fieldMapping and source data do not match");
+        }
+        return jsonMap;
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
@@ -326,7 +326,6 @@ public class MLSdkAsyncHttpResponseHandlerTest {
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener, times(1)).onFailure(captor.capture());
         assert captor.getValue() instanceof OpenSearchStatusException;
-        System.out.println(captor.getValue().getMessage());
         assert captor.getValue().getMessage().contains("runtime error");
     }
 
@@ -350,7 +349,6 @@ public class MLSdkAsyncHttpResponseHandlerTest {
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener, times(1)).onFailure(captor.capture());
         assert captor.getValue() instanceof OpenSearchStatusException;
-        System.out.println(captor.getValue().getMessage());
         assert captor.getValue().getMessage().contains(REMOTE_SERVICE_ERROR);
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/AbstractIngestionTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/AbstractIngestionTests.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.ingest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.IDFIELD;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INGESTFIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUT;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUTFIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUT;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUTIELDS;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
+
+public class AbstractIngestionTests {
+    @Mock
+    Client client;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    S3DataIngestion s3DataIngestion = new S3DataIngestion(client);
+
+    Map<String, Object> fieldMap;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        s3DataIngestion = new S3DataIngestion(client);
+
+        fieldMap = new HashMap<>();
+        fieldMap.put(INPUT, "source[1].$.content");
+        fieldMap.put(OUTPUT, "source[1].$.SageMakerOutput");
+        fieldMap.put(INPUTFIELDS, Arrays.asList("chapter", "title"));
+        fieldMap.put(OUTPUTIELDS, Arrays.asList("chapter_embedding", "title_embedding"));
+        fieldMap.put(INGESTFIELDS, Arrays.asList("source[1].$.id"));
+    }
+
+    @Test
+    public void testBulkResponseListener_Success() {
+        // Arrange
+        AtomicInteger successfulBatches = new AtomicInteger(0);
+        AtomicInteger failedBatches = new AtomicInteger(0);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        // Mock BulkResponse
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+        when(bulkResponse.hasFailures()).thenReturn(false);
+
+        S3DataIngestion instance = new S3DataIngestion(client);
+
+        // Act
+        ActionListener<BulkResponse> listener = instance.getBulkResponseListener(successfulBatches, failedBatches, future);
+        listener.onResponse(bulkResponse);
+
+        // Assert
+        assertFalse(future.isCompletedExceptionally());
+        assertEquals(1, successfulBatches.get());
+        assertEquals(0, failedBatches.get());
+    }
+
+    @Test
+    public void testBulkResponseListener_Failure() {
+        // Arrange
+        AtomicInteger successfulBatches = new AtomicInteger(0);
+        AtomicInteger failedBatches = new AtomicInteger(0);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        // Mock BulkResponse
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+        when(bulkResponse.hasFailures()).thenReturn(true);
+        when(bulkResponse.buildFailureMessage()).thenReturn("Failure message");
+
+        S3DataIngestion instance = new S3DataIngestion(client);
+
+        // Act
+        ActionListener<BulkResponse> listener = instance.getBulkResponseListener(successfulBatches, failedBatches, future);
+        listener.onResponse(bulkResponse);
+
+        // Assert
+        assertTrue(future.isCompletedExceptionally());
+        assertEquals(0, successfulBatches.get());
+        assertEquals(1, failedBatches.get());
+    }
+
+    @Test
+    public void testBulkResponseListener_Exception() {
+        // Arrange
+        AtomicInteger successfulBatches = new AtomicInteger(0);
+        AtomicInteger failedBatches = new AtomicInteger(0);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        // Create an exception
+        RuntimeException exception = new RuntimeException("Test exception");
+
+        S3DataIngestion instance = new S3DataIngestion(client);
+
+        // Act
+        ActionListener<BulkResponse> listener = instance.getBulkResponseListener(successfulBatches, failedBatches, future);
+        listener.onFailure(exception);
+
+        // Assert
+        assertTrue(future.isCompletedExceptionally());
+        assertEquals(0, successfulBatches.get());
+        assertEquals(1, failedBatches.get());
+        assertThrows(Exception.class, () -> future.join());  // Ensure that future throws exception
+    }
+
+    @Test
+    public void testCalculateSuccessRate_MultipleValues() {
+        // Arrange
+        List<Double> successRates = Arrays.asList(90.0, 85.5, 92.0, 88.0);
+
+        // Act
+        double result = s3DataIngestion.calculateSuccessRate(successRates);
+
+        // Assert
+        assertEquals(85.5, result, 0.0001);
+    }
+
+    @Test
+    public void testCalculateSuccessRate_SingleValue() {
+        // Arrange
+        List<Double> successRates = Collections.singletonList(99.9);
+
+        // Act
+        double result = s3DataIngestion.calculateSuccessRate(successRates);
+
+        // Assert
+        assertEquals(99.9, result, 0.0001);
+    }
+
+    @Test
+    public void testFilterFieldMapping_ValidInput_MatchingPrefix() {
+        // Arrange
+        MLBatchIngestionInput mlBatchIngestionInput = new MLBatchIngestionInput("indexName", fieldMap, new HashMap<>(), new HashMap<>());
+        Map<String, Object> result = s3DataIngestion.filterFieldMapping(mlBatchIngestionInput, 0);
+
+        // Assert
+        assertEquals(5, result.size());
+        assertEquals("source[1].$.content", result.get(INPUT));
+        assertEquals("source[1].$.SageMakerOutput", result.get(OUTPUT));
+        assertEquals(Arrays.asList("chapter", "title"), result.get(INPUTFIELDS));
+        assertEquals(Arrays.asList("chapter_embedding", "title_embedding"), result.get(OUTPUTIELDS));
+        assertEquals(Arrays.asList("source[1].$.id"), result.get(INGESTFIELDS));
+    }
+
+    @Test
+    public void testFilterFieldMapping_NoMatchingPrefix() {
+        // Arrange
+        Map<String, Object> fieldMap = new HashMap<>();
+        fieldMap.put("field1", "source[3].$.response.body.data[*].embedding");
+        fieldMap.put("field2", "source[4].$.body.input");
+
+        MLBatchIngestionInput mlBatchIngestionInput = new MLBatchIngestionInput("indexName", fieldMap, new HashMap<>(), new HashMap<>());
+
+        // Act
+        Map<String, Object> result = s3DataIngestion.filterFieldMapping(mlBatchIngestionInput, 0);
+
+        // Assert
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testProcessFieldMapping_ValidInput() {
+        String jsonStr =
+            "{\"SageMakerOutput\":[[-0.017166402, 0.055771016],[-0.004301484,-0.042826906]],\"content\":[\"this is chapter 1\",\"harry potter\"],\"id\":1}";
+        // Arrange
+
+        // Act
+        Map<String, Object> processedFieldMapping = s3DataIngestion.processFieldMapping(jsonStr, fieldMap);
+
+        // Assert
+        assertEquals("this is chapter 1", processedFieldMapping.get("chapter"));
+        assertEquals("harry potter", processedFieldMapping.get("title"));
+        assertEquals(1, processedFieldMapping.get("id"));
+    }
+
+    @Test
+    public void testProcessFieldMapping_NoIdFieldInput() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("The Id field must contains only 1 jsonPath for each source");
+
+        String jsonStr =
+            "{\"SageMakerOutput\":[[-0.017166402, 0.055771016],[-0.004301484,-0.042826906]],\"content\":[\"this is chapter 1\",\"harry potter\"],\"id\":1}";
+        // Arrange
+        fieldMap.put(IDFIELD, null);
+
+        // Act
+        s3DataIngestion.processFieldMapping(jsonStr, fieldMap);
+    }
+
+    @Test
+    public void testBatchIngestSuccess_SoleSource() {
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> bulkResponseListener = invocation.getArgument(1);
+            bulkResponseListener.onResponse(mock(BulkResponse.class));
+            return null;
+        }).when(client).bulk(any(), any());
+
+        List<String> sourceLines = Arrays
+            .asList(
+                "{\"SageMakerOutput\":[[-0.017166402, 0.055771016],[-0.004301484,-0.042826906]],\"content\":[\"this is chapter 1\",\"harry potter\"],\"id\":1}"
+            );
+        MLBatchIngestionInput mlBatchIngestionInput = new MLBatchIngestionInput("indexName", fieldMap, new HashMap<>(), new HashMap<>());
+        ActionListener<BulkResponse> bulkResponseListener = mock(ActionListener.class);
+        s3DataIngestion.batchIngest(sourceLines, mlBatchIngestionInput, bulkResponseListener, 0, true);
+
+        verify(client).bulk(isA(BulkRequest.class), isA(ActionListener.class));
+        verify(bulkResponseListener).onResponse(isA(BulkResponse.class));
+    }
+
+    @Test
+    public void testBatchIngestSuccess_NoIdError() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("The id filed must be provided to match documents for multiple sources");
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> bulkResponseListener = invocation.getArgument(1);
+            bulkResponseListener.onResponse(mock(BulkResponse.class));
+            return null;
+        }).when(client).bulk(any(), any());
+
+        List<String> sourceLines = Arrays
+            .asList(
+                "{\"SageMakerOutput\":[[-0.017166402, 0.055771016],[-0.004301484,-0.042826906]],\"content\":[\"this is chapter 1\",\"harry potter\"],\"id\":1}"
+            );
+        MLBatchIngestionInput mlBatchIngestionInput = new MLBatchIngestionInput("indexName", fieldMap, new HashMap<>(), new HashMap<>());
+        ActionListener<BulkResponse> bulkResponseListener = mock(ActionListener.class);
+        s3DataIngestion.batchIngest(sourceLines, mlBatchIngestionInput, bulkResponseListener, 1, false);
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/AbstractIngestionTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/AbstractIngestionTests.java
@@ -15,12 +15,12 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ml.engine.ingest.AbstractIngestion.IDFIELD;
-import static org.opensearch.ml.engine.ingest.AbstractIngestion.INGESTFIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.ID_FIELD;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INGEST_FIELDS;
 import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUT;
-import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUTFIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUT_FIELD_NAMES;
 import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUT;
-import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUTIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUT_FIELD_NAMES;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,9 +61,9 @@ public class AbstractIngestionTests {
         fieldMap = new HashMap<>();
         fieldMap.put(INPUT, "source[1].$.content");
         fieldMap.put(OUTPUT, "source[1].$.SageMakerOutput");
-        fieldMap.put(INPUTFIELDS, Arrays.asList("chapter", "title"));
-        fieldMap.put(OUTPUTIELDS, Arrays.asList("chapter_embedding", "title_embedding"));
-        fieldMap.put(INGESTFIELDS, Arrays.asList("source[1].$.id"));
+        fieldMap.put(INPUT_FIELD_NAMES, Arrays.asList("chapter", "title"));
+        fieldMap.put(OUTPUT_FIELD_NAMES, Arrays.asList("chapter_embedding", "title_embedding"));
+        fieldMap.put(INGEST_FIELDS, Arrays.asList("source[1].$.id"));
     }
 
     @Test
@@ -170,9 +170,9 @@ public class AbstractIngestionTests {
         assertEquals(5, result.size());
         assertEquals("source[1].$.content", result.get(INPUT));
         assertEquals("source[1].$.SageMakerOutput", result.get(OUTPUT));
-        assertEquals(Arrays.asList("chapter", "title"), result.get(INPUTFIELDS));
-        assertEquals(Arrays.asList("chapter_embedding", "title_embedding"), result.get(OUTPUTIELDS));
-        assertEquals(Arrays.asList("source[1].$.id"), result.get(INGESTFIELDS));
+        assertEquals(Arrays.asList("chapter", "title"), result.get(INPUT_FIELD_NAMES));
+        assertEquals(Arrays.asList("chapter_embedding", "title_embedding"), result.get(OUTPUT_FIELD_NAMES));
+        assertEquals(Arrays.asList("source[1].$.id"), result.get(INGEST_FIELDS));
     }
 
     @Test
@@ -214,7 +214,7 @@ public class AbstractIngestionTests {
         String jsonStr =
             "{\"SageMakerOutput\":[[-0.017166402, 0.055771016],[-0.004301484,-0.042826906]],\"content\":[\"this is chapter 1\",\"harry potter\"],\"id\":1}";
         // Arrange
-        fieldMap.put(IDFIELD, null);
+        fieldMap.put(ID_FIELD, null);
 
         // Act
         s3DataIngestion.processFieldMapping(jsonStr, fieldMap);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestionTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestionTests.java
@@ -1,8 +1,0 @@
-/*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
- */
-
-package org.opensearch.ml.engine.ingest;
-
-public class OpenAIDataIngestionTests {}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestionTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestionTests.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.ingest;
+
+public class OpenAIDataIngestionTests {}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/S3DataIngestionTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/S3DataIngestionTests.java
@@ -5,9 +5,9 @@
 
 package org.opensearch.ml.engine.ingest;
 
-import static org.opensearch.ml.engine.ingest.AbstractIngestion.INGESTFIELDS;
-import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUTFIELDS;
-import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUTIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INGEST_FIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUT_FIELD_NAMES;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUT_FIELD_NAMES;
 import static org.opensearch.ml.engine.ingest.S3DataIngestion.SOURCE;
 
 import java.util.Arrays;
@@ -41,9 +41,9 @@ public class S3DataIngestionTests {
         Map<String, Object> fieldMap = new HashMap<>();
         fieldMap.put("input", "$.content");
         fieldMap.put("output", "$.SageMakerOutput");
-        fieldMap.put(INPUTFIELDS, Arrays.asList("chapter", "title"));
-        fieldMap.put(OUTPUTIELDS, Arrays.asList("chapter_embedding", "title_embedding"));
-        fieldMap.put(INGESTFIELDS, Arrays.asList("$.id"));
+        fieldMap.put(INPUT_FIELD_NAMES, Arrays.asList("chapter", "title"));
+        fieldMap.put(OUTPUT_FIELD_NAMES, Arrays.asList("chapter_embedding", "title_embedding"));
+        fieldMap.put(INGEST_FIELDS, Arrays.asList("$.id"));
 
         Map<String, String> credential = Map
             .of("region", "us-east-1", "access_key", "some accesskey", "secret_key", "some secret", "session_token", "some token");

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/S3DataIngestionTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/S3DataIngestionTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.ingest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INGESTFIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUTFIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUTIELDS;
+import static org.opensearch.ml.engine.ingest.S3DataIngestion.SOURCE;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.client.Client;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
+
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+public class S3DataIngestionTests {
+
+    private MLBatchIngestionInput mlBatchIngestionInput;
+    private S3DataIngestion s3DataIngestion;
+
+    @Mock
+    Client client;
+
+    @Mock
+    S3Client s3Client;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        s3DataIngestion = new S3DataIngestion(client);
+
+        Map<String, Object> fieldMap = new HashMap<>();
+        fieldMap.put("input", "$.content");
+        fieldMap.put("output", "$.SageMakerOutput");
+        fieldMap.put(INPUTFIELDS, Arrays.asList("chapter", "title"));
+        fieldMap.put(OUTPUTIELDS, Arrays.asList("chapter_embedding", "title_embedding"));
+        fieldMap.put(INGESTFIELDS, Arrays.asList("$.id"));
+
+        Map<String, String> credential = Map
+            .of("region", "us-east-1", "access_key", "some accesskey", "secret_key", "some secret", "session_token", "some token");
+        Map<String, Object> dataSource = new HashMap<>();
+        dataSource.put("type", "s3");
+        dataSource.put(SOURCE, Arrays.asList("s3://offlinebatch/output/sagemaker_djl_batch_input.json.out"));
+
+        mlBatchIngestionInput = MLBatchIngestionInput
+            .builder()
+            .indexName("testIndex")
+            .fieldMapping(fieldMap)
+            .credential(credential)
+            .dataSources(dataSource)
+            .build();
+    }
+
+    @Test
+    public void testInitS3Client_WithSessionToken() {
+        // Mock the S3Client and its builder
+        S3Client mockS3Client = mock(S3Client.class);
+        S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
+
+        // Mock the builder method chain
+        when(mockBuilder.region(Region.of("us-east-1"))).thenReturn(mockBuilder);
+        // Correctly handle the credentialsProvider method
+        when(mockBuilder.credentialsProvider(any(StaticCredentialsProvider.class))).thenReturn(mockBuilder);
+        when(mockBuilder.build()).thenReturn(mockS3Client);
+
+        // try (MockedStatic<S3Client> s3ClientStaticMock = mockStatic(S3Client.class)) {
+        // s3ClientStaticMock.when(S3Client::builder).thenReturn(mockBuilder);
+        //
+        // AwsCredentials credentials = AwsSessionCredentials.create("some accesskey", "some secret", "some token");
+        //
+        // // Act
+        // S3Client s3 = S3Client
+        // .builder()
+        // .region(Region.of("us-east-1"))
+        // .credentialsProvider(StaticCredentialsProvider.create(credentials))
+        // .build();
+        //
+        // // Assert
+        // assertEquals(mockS3Client, s3);
+        //
+        // // Verify the interactions
+        // verify(mockBuilder).region(Region.of("us-east-1"));
+        // verify(mockBuilder).credentialsProvider(any(StaticCredentialsProvider.class));
+        // verify(mockBuilder).build();
+        // }
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/S3DataIngestionTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/ingest/S3DataIngestionTests.java
@@ -5,9 +5,6 @@
 
 package org.opensearch.ml.engine.ingest;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.opensearch.ml.engine.ingest.AbstractIngestion.INGESTFIELDS;
 import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUTFIELDS;
 import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUTIELDS;
@@ -18,16 +15,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.client.Client;
 import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
 
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
 public class S3DataIngestionTests {
 
@@ -65,39 +58,5 @@ public class S3DataIngestionTests {
             .credential(credential)
             .dataSources(dataSource)
             .build();
-    }
-
-    @Test
-    public void testInitS3Client_WithSessionToken() {
-        // Mock the S3Client and its builder
-        S3Client mockS3Client = mock(S3Client.class);
-        S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
-
-        // Mock the builder method chain
-        when(mockBuilder.region(Region.of("us-east-1"))).thenReturn(mockBuilder);
-        // Correctly handle the credentialsProvider method
-        when(mockBuilder.credentialsProvider(any(StaticCredentialsProvider.class))).thenReturn(mockBuilder);
-        when(mockBuilder.build()).thenReturn(mockS3Client);
-
-        // try (MockedStatic<S3Client> s3ClientStaticMock = mockStatic(S3Client.class)) {
-        // s3ClientStaticMock.when(S3Client::builder).thenReturn(mockBuilder);
-        //
-        // AwsCredentials credentials = AwsSessionCredentials.create("some accesskey", "some secret", "some token");
-        //
-        // // Act
-        // S3Client s3 = S3Client
-        // .builder()
-        // .region(Region.of("us-east-1"))
-        // .credentialsProvider(StaticCredentialsProvider.create(credentials))
-        // .build();
-        //
-        // // Assert
-        // assertEquals(mockS3Client, s3);
-        //
-        // // Verify the interactions
-        // verify(mockBuilder).region(Region.of("us-east-1"));
-        // verify(mockBuilder).credentialsProvider(any(StaticCredentialsProvider.class));
-        // verify(mockBuilder).build();
-        // }
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/batch/TransportBatchIngestionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/batch/TransportBatchIngestionAction.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.batch;
+
+import static org.opensearch.ml.common.MLTask.ERROR_FIELD;
+import static org.opensearch.ml.common.MLTask.STATE_FIELD;
+import static org.opensearch.ml.common.MLTaskState.COMPLETED;
+import static org.opensearch.ml.common.MLTaskState.FAILED;
+import static org.opensearch.ml.task.MLTaskManager.TASK_SEMAPHORE_TIMEOUT;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.client.Client;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.common.MLTaskType;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionAction;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionRequest;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionResponse;
+import org.opensearch.ml.engine.MLEngineClassLoader;
+import org.opensearch.ml.engine.ingest.Ingestable;
+import org.opensearch.ml.task.MLTaskManager;
+import org.opensearch.ml.utils.MLExceptionUtils;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class TransportBatchIngestionAction extends HandledTransportAction<ActionRequest, MLBatchIngestionResponse> {
+    private static final String S3_URI_REGEX = "^s3://([a-zA-Z0-9.-]+)(/.*)?$";
+    private static final Pattern S3_URI_PATTERN = Pattern.compile(S3_URI_REGEX);
+    public static final String TYPE = "type";
+    public static final String SOURCE = "source";
+    TransportService transportService;
+    MLTaskManager mlTaskManager;
+    private final Client client;
+
+    @Inject
+    public TransportBatchIngestionAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client,
+        MLTaskManager mlTaskManager
+    ) {
+        super(MLBatchIngestionAction.NAME, transportService, actionFilters, MLBatchIngestionRequest::new);
+        this.transportService = transportService;
+        this.client = client;
+        this.mlTaskManager = mlTaskManager;
+    }
+
+    @Override
+    protected void doExecute(Task task, ActionRequest request, ActionListener<MLBatchIngestionResponse> listener) {
+        MLBatchIngestionRequest mlBatchIngestionRequest = MLBatchIngestionRequest.fromActionRequest(request);
+        MLBatchIngestionInput mlBatchIngestionInput = mlBatchIngestionRequest.getMlBatchIngestionInput();
+        try {
+            validateBatchIngestInput(mlBatchIngestionInput);
+            MLTask mlTask = MLTask
+                .builder()
+                .async(true)
+                .taskType(MLTaskType.BATCH_INGEST)
+                .createTime(Instant.now())
+                .lastUpdateTime(Instant.now())
+                .state(MLTaskState.CREATED)
+                .build();
+
+            mlTaskManager.createMLTask(mlTask, ActionListener.wrap(response -> {
+                String taskId = response.getId();
+                try {
+                    mlTask.setTaskId(taskId);
+                    mlTaskManager.add(mlTask);
+                    listener.onResponse(new MLBatchIngestionResponse(taskId, MLTaskType.BATCH_INGEST, MLTaskState.CREATED.name()));
+                    Ingestable ingestable = MLEngineClassLoader
+                        .initInstance(mlBatchIngestionInput.getDataSources().get(TYPE).toLowerCase(), client, Client.class);
+                    double successRate = ingestable.ingest(mlBatchIngestionInput);
+                    if (successRate == 100) {
+                        mlTaskManager.updateMLTask(taskId, Map.of(STATE_FIELD, COMPLETED), 5000, true);
+                    } else if (successRate > 0) {
+                        mlTaskManager
+                            .updateMLTask(
+                                taskId,
+                                Map.of(STATE_FIELD, FAILED, ERROR_FIELD, "batch ingestion successful rate is " + successRate),
+                                TASK_SEMAPHORE_TIMEOUT,
+                                true
+                            );
+                    } else {
+                        mlTaskManager
+                            .updateMLTask(
+                                taskId,
+                                Map.of(STATE_FIELD, FAILED, ERROR_FIELD, "batch ingestion successful rate is 0"),
+                                TASK_SEMAPHORE_TIMEOUT,
+                                true
+                            );
+                    }
+                } catch (Exception ex) {
+                    log.error("Failed in batch ingestion", ex);
+                    mlTaskManager
+                        .updateMLTask(
+                            taskId,
+                            Map.of(STATE_FIELD, FAILED, ERROR_FIELD, MLExceptionUtils.getRootCauseMessage(ex)),
+                            TASK_SEMAPHORE_TIMEOUT,
+                            true
+                        );
+                    listener.onFailure(ex);
+                }
+            }, exception -> {
+                log.error("Failed to create batch ingestion task", exception);
+                listener.onFailure(exception);
+            }));
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            listener
+                .onFailure(
+                    new OpenSearchStatusException(
+                        "IllegalArgumentException in the batch ingestion input: " + e.getMessage(),
+                        RestStatus.BAD_REQUEST
+                    )
+                );
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private void validateBatchIngestInput(MLBatchIngestionInput mlBatchIngestionInput) {
+        if (mlBatchIngestionInput == null
+            || mlBatchIngestionInput.getDataSources() == null
+            || mlBatchIngestionInput.getDataSources().isEmpty()) {
+            throw new IllegalArgumentException("The batch ingest input data source cannot be null");
+        }
+        Map<String, String> dataSources = mlBatchIngestionInput.getDataSources();
+        if (dataSources.get(TYPE) == null || dataSources.get(SOURCE) == null) {
+            throw new IllegalArgumentException("The batch ingest input data source is missing data type or source");
+        }
+        if (dataSources.get(TYPE).toLowerCase() == "s3") {
+            String s3Uri = dataSources.get(SOURCE);
+            if (s3Uri == null || s3Uri.isEmpty()) {
+                throw new IllegalArgumentException("The batch ingest input s3Uri is empty");
+            }
+
+            if (!S3_URI_PATTERN.matcher(s3Uri).matches()) {
+                throw new IllegalArgumentException("The batch ingest input s3Uri is invalid");
+            }
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -48,6 +48,7 @@ import org.opensearch.ml.action.agents.DeleteAgentTransportAction;
 import org.opensearch.ml.action.agents.GetAgentTransportAction;
 import org.opensearch.ml.action.agents.TransportRegisterAgentAction;
 import org.opensearch.ml.action.agents.TransportSearchAgentAction;
+import org.opensearch.ml.action.batch.TransportBatchIngestionAction;
 import org.opensearch.ml.action.config.GetConfigTransportAction;
 import org.opensearch.ml.action.connector.DeleteConnectorTransportAction;
 import org.opensearch.ml.action.connector.ExecuteConnectorTransportAction;
@@ -120,6 +121,7 @@ import org.opensearch.ml.common.transport.agent.MLAgentDeleteAction;
 import org.opensearch.ml.common.transport.agent.MLAgentGetAction;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentAction;
 import org.opensearch.ml.common.transport.agent.MLSearchAgentAction;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionAction;
 import org.opensearch.ml.common.transport.config.MLConfigGetAction;
 import org.opensearch.ml.common.transport.connector.MLConnectorDeleteAction;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetAction;
@@ -216,6 +218,7 @@ import org.opensearch.ml.processor.MLInferenceIngestProcessor;
 import org.opensearch.ml.processor.MLInferenceSearchRequestProcessor;
 import org.opensearch.ml.processor.MLInferenceSearchResponseProcessor;
 import org.opensearch.ml.repackage.com.google.common.collect.ImmutableList;
+import org.opensearch.ml.rest.RestMLBatchIngestAction;
 import org.opensearch.ml.rest.RestMLCreateConnectorAction;
 import org.opensearch.ml.rest.RestMLCreateControllerAction;
 import org.opensearch.ml.rest.RestMLDeleteAgentAction;
@@ -440,7 +443,8 @@ public class MachineLearningPlugin extends Plugin
                 new ActionHandler<>(GetTracesAction.INSTANCE, GetTracesTransportAction.class),
                 new ActionHandler<>(MLListToolsAction.INSTANCE, ListToolsTransportAction.class),
                 new ActionHandler<>(MLGetToolAction.INSTANCE, GetToolTransportAction.class),
-                new ActionHandler<>(MLConfigGetAction.INSTANCE, GetConfigTransportAction.class)
+                new ActionHandler<>(MLConfigGetAction.INSTANCE, GetConfigTransportAction.class),
+                new ActionHandler<>(MLBatchIngestionAction.INSTANCE, TransportBatchIngestionAction.class)
             );
     }
 
@@ -759,6 +763,7 @@ public class MachineLearningPlugin extends Plugin
         RestMLListToolsAction restMLListToolsAction = new RestMLListToolsAction(toolFactories);
         RestMLGetToolAction restMLGetToolAction = new RestMLGetToolAction(toolFactories);
         RestMLGetConfigAction restMLGetConfigAction = new RestMLGetConfigAction();
+        RestMLBatchIngestAction restMLBatchIngestAction = new RestMLBatchIngestAction();
         return ImmutableList
             .of(
                 restMLStatsAction,
@@ -811,7 +816,8 @@ public class MachineLearningPlugin extends Plugin
                 restMLSearchAgentAction,
                 restMLListToolsAction,
                 restMLGetToolAction,
-                restMLGetConfigAction
+                restMLGetConfigAction,
+                restMLBatchIngestAction
             );
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLBatchIngestAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLBatchIngestAction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionAction;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class RestMLBatchIngestAction extends BaseRestHandler {
+    private static final String ML_BATCH_INGESTION_ACTION = "ml_batch_ingestion_action";
+
+    @Override
+    public String getName() {
+        return ML_BATCH_INGESTION_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList.of(new Route(RestRequest.Method.POST, String.format(Locale.ROOT, "%s/_batch_ingestion", ML_BASE_URI)));
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        MLBatchIngestionRequest mlBatchIngestTaskRequest = getRequest(request);
+        return channel -> client.execute(MLBatchIngestionAction.INSTANCE, mlBatchIngestTaskRequest, new RestToXContentListener<>(channel));
+    }
+
+    /**
+     * Creates a MLBatchIngestTaskRequest from a RestRequest
+     *
+     * @param request RestRequest
+     * @return MLBatchIngestTaskRequest
+     */
+    @VisibleForTesting
+    MLBatchIngestionRequest getRequest(RestRequest request) throws IOException {
+        if (!request.hasContent()) {
+            throw new IOException("Batch Ingestion request has empty body");
+        }
+        XContentParser parser = request.contentParser();
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        MLBatchIngestionInput mlBatchIngestionInput = MLBatchIngestionInput.parse(parser);
+        return new MLBatchIngestionRequest(mlBatchIngestionInput);
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
@@ -127,13 +127,11 @@ public class RestMLPredictionAction extends BaseRestHandler {
     @VisibleForTesting
     MLPredictionTaskRequest getRequest(String modelId, String algorithm, RestRequest request) throws IOException {
         ActionType actionType = ActionType.from(getActionTypeFromRestRequest(request));
-        System.out.println("actionType is " + actionType);
         if (FunctionName.REMOTE.name().equals(algorithm) && !mlFeatureEnabledSetting.isRemoteInferenceEnabled()) {
             throw new IllegalStateException(REMOTE_INFERENCE_DISABLED_ERR_MSG);
         } else if (FunctionName.isDLModel(FunctionName.from(algorithm.toUpperCase())) && !mlFeatureEnabledSetting.isLocalModelEnabled()) {
             throw new IllegalStateException(LOCAL_MODEL_DISABLED_ERR_MSG);
         } else if (!ActionType.isValidActionInModelPrediction(actionType)) {
-            System.out.println(actionType.toString());
             throw new IllegalArgumentException("Wrong action type in the rest request path!");
         }
 

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -319,7 +319,6 @@ public class RestActionUtils {
      */
     public static String getActionTypeFromRestRequest(RestRequest request) {
         String path = request.path();
-        System.out.println("path is " + path);
         String[] segments = path.split("/");
         String methodName = segments[segments.length - 1];
         methodName = methodName.startsWith("_") ? methodName.substring(1) : methodName;

--- a/plugin/src/main/plugin-metadata/plugin-security.policy
+++ b/plugin/src/main/plugin-metadata/plugin-security.policy
@@ -24,4 +24,10 @@ grant {
 
     // Circuit Breaker
     permission java.lang.RuntimePermission "getFileSystemAttributes";
+
+    // s3 client opens socket connections for to access repository
+    permission java.net.SocketPermission "*", "connect,resolve";
+
+    // aws credential file access
+    permission java.io.FilePermission "<<ALL FILES>>", "read";
 };

--- a/plugin/src/test/java/org/opensearch/ml/action/batch/TransportBatchIngestionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/batch/TransportBatchIngestionActionTests.java
@@ -15,9 +15,9 @@ import static org.opensearch.ml.common.MLTask.ERROR_FIELD;
 import static org.opensearch.ml.common.MLTask.STATE_FIELD;
 import static org.opensearch.ml.common.MLTaskState.COMPLETED;
 import static org.opensearch.ml.common.MLTaskState.FAILED;
-import static org.opensearch.ml.engine.ingest.AbstractIngestion.INGESTFIELDS;
-import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUTFIELDS;
-import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUTIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INGEST_FIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUT_FIELD_NAMES;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUT_FIELD_NAMES;
 import static org.opensearch.ml.engine.ingest.S3DataIngestion.SOURCE;
 import static org.opensearch.ml.task.MLTaskManager.TASK_SEMAPHORE_TIMEOUT;
 
@@ -74,9 +74,9 @@ public class TransportBatchIngestionActionTests extends OpenSearchTestCase {
         Map<String, Object> fieldMap = new HashMap<>();
         fieldMap.put("input", "$.content");
         fieldMap.put("output", "$.SageMakerOutput");
-        fieldMap.put(INPUTFIELDS, Arrays.asList("chapter", "title"));
-        fieldMap.put(OUTPUTIELDS, Arrays.asList("chapter_embedding", "title_embedding"));
-        fieldMap.put(INGESTFIELDS, Arrays.asList("$.id"));
+        fieldMap.put(INPUT_FIELD_NAMES, Arrays.asList("chapter", "title"));
+        fieldMap.put(OUTPUT_FIELD_NAMES, Arrays.asList("chapter_embedding", "title_embedding"));
+        fieldMap.put(INGEST_FIELDS, Arrays.asList("$.id"));
 
         Map<String, String> credential = Map
             .of("region", "us-east-1", "access_key", "some accesskey", "secret_key", "some secret", "session_token", "some token");

--- a/plugin/src/test/java/org/opensearch/ml/action/batch/TransportBatchIngestionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/batch/TransportBatchIngestionActionTests.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.batch;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.MLTask.ERROR_FIELD;
+import static org.opensearch.ml.common.MLTask.STATE_FIELD;
+import static org.opensearch.ml.common.MLTaskState.COMPLETED;
+import static org.opensearch.ml.common.MLTaskState.FAILED;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INGESTFIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.INPUTFIELDS;
+import static org.opensearch.ml.engine.ingest.AbstractIngestion.OUTPUTIELDS;
+import static org.opensearch.ml.engine.ingest.S3DataIngestion.SOURCE;
+import static org.opensearch.ml.task.MLTaskManager.TASK_SEMAPHORE_TIMEOUT;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.MLTask;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionRequest;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionResponse;
+import org.opensearch.ml.task.MLTaskManager;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.TransportService;
+
+public class TransportBatchIngestionActionTests extends OpenSearchTestCase {
+    @Mock
+    private Client client;
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private MLTaskManager mlTaskManager;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private MLBatchIngestionRequest mlBatchIngestionRequest;
+    @Mock
+    private Task task;
+    @Mock
+    ActionListener<MLBatchIngestionResponse> actionListener;
+
+    private TransportBatchIngestionAction batchAction;
+    private MLBatchIngestionInput batchInput;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        batchAction = new TransportBatchIngestionAction(transportService, actionFilters, client, mlTaskManager);
+
+        Map<String, Object> fieldMap = new HashMap<>();
+        fieldMap.put("input", "$.content");
+        fieldMap.put("output", "$.SageMakerOutput");
+        fieldMap.put(INPUTFIELDS, Arrays.asList("chapter", "title"));
+        fieldMap.put(OUTPUTIELDS, Arrays.asList("chapter_embedding", "title_embedding"));
+        fieldMap.put(INGESTFIELDS, Arrays.asList("$.id"));
+
+        Map<String, String> credential = Map
+            .of("region", "us-east-1", "access_key", "some accesskey", "secret_key", "some secret", "session_token", "some token");
+        Map<String, Object> dataSource = new HashMap<>();
+        dataSource.put("type", "s3");
+        dataSource.put(SOURCE, Arrays.asList("s3://offlinebatch/output/sagemaker_djl_batch_input.json.out"));
+
+        batchInput = MLBatchIngestionInput
+            .builder()
+            .indexName("testIndex")
+            .fieldMapping(fieldMap)
+            .credential(credential)
+            .dataSources(dataSource)
+            .build();
+        when(mlBatchIngestionRequest.getMlBatchIngestionInput()).thenReturn(batchInput);
+    }
+
+    public void test_doExecute_success() {
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            ShardId shardId = new ShardId(new Index("indexName", "uuid"), 1);
+            IndexResponse indexResponse = new IndexResponse(shardId, "taskId", 1, 1, 1, true);
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(mlTaskManager).createMLTask(isA(MLTask.class), isA(ActionListener.class));
+        batchAction.doExecute(task, mlBatchIngestionRequest, actionListener);
+
+        verify(actionListener).onResponse(any(MLBatchIngestionResponse.class));
+    }
+
+    public void test_doExecute_handleSuccessRate100() {
+        batchAction.handleSuccessRate(100, "taskid");
+        verify(mlTaskManager).updateMLTask("taskid", Map.of(STATE_FIELD, COMPLETED), 5000, true);
+    }
+
+    public void test_doExecute_handleSuccessRate50() {
+        batchAction.handleSuccessRate(50, "taskid");
+        verify(mlTaskManager)
+            .updateMLTask(
+                "taskid",
+                Map.of(STATE_FIELD, FAILED, ERROR_FIELD, "batch ingestion successful rate is 50.0"),
+                TASK_SEMAPHORE_TIMEOUT,
+                true
+            );
+    }
+
+    public void test_doExecute_handleSuccessRate0() {
+        batchAction.handleSuccessRate(0, "taskid");
+        verify(mlTaskManager)
+            .updateMLTask(
+                "taskid",
+                Map.of(STATE_FIELD, FAILED, ERROR_FIELD, "batch ingestion successful rate is 0"),
+                TASK_SEMAPHORE_TIMEOUT,
+                true
+            );
+    }
+
+    public void test_doExecute_noDataSource() {
+        MLBatchIngestionInput batchInput = MLBatchIngestionInput
+            .builder()
+            .indexName("testIndex")
+            .fieldMapping(new HashMap<>())
+            .credential(new HashMap<>())
+            .dataSources(new HashMap<>())
+            .build();
+        when(mlBatchIngestionRequest.getMlBatchIngestionInput()).thenReturn(batchInput);
+        batchAction.doExecute(task, mlBatchIngestionRequest, actionListener);
+
+        ArgumentCaptor<OpenSearchStatusException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "IllegalArgumentException in the batch ingestion input: The batch ingest input data source cannot be null",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    public void test_doExecute_noTypeInDataSource() {
+        MLBatchIngestionInput batchInput = MLBatchIngestionInput
+            .builder()
+            .indexName("testIndex")
+            .fieldMapping(new HashMap<>())
+            .credential(new HashMap<>())
+            .dataSources(Map.of("source", "some url"))
+            .build();
+        when(mlBatchIngestionRequest.getMlBatchIngestionInput()).thenReturn(batchInput);
+        batchAction.doExecute(task, mlBatchIngestionRequest, actionListener);
+
+        ArgumentCaptor<OpenSearchStatusException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "IllegalArgumentException in the batch ingestion input: The batch ingest input data source is missing data type or source",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    public void test_doExecute_invalidS3DataSource() {
+        Map<String, Object> dataSource = new HashMap<>();
+        dataSource.put("type", "s3");
+        dataSource.put(SOURCE, Arrays.asList("s3://offlinebatch/output/sagemaker_djl_batch_input.json.out", "invalid s3"));
+
+        MLBatchIngestionInput batchInput = MLBatchIngestionInput
+            .builder()
+            .indexName("testIndex")
+            .fieldMapping(new HashMap<>())
+            .credential(new HashMap<>())
+            .dataSources(dataSource)
+            .build();
+        when(mlBatchIngestionRequest.getMlBatchIngestionInput()).thenReturn(batchInput);
+        batchAction.doExecute(task, mlBatchIngestionRequest, actionListener);
+
+        ArgumentCaptor<OpenSearchStatusException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "IllegalArgumentException in the batch ingestion input: The following batch ingest input S3 URIs are invalid: [invalid s3]",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    public void test_doExecute_emptyS3DataSource() {
+        Map<String, Object> dataSource = new HashMap<>();
+        dataSource.put("type", "s3");
+        dataSource.put(SOURCE, new ArrayList<>());
+
+        MLBatchIngestionInput batchInput = MLBatchIngestionInput
+            .builder()
+            .indexName("testIndex")
+            .fieldMapping(new HashMap<>())
+            .credential(new HashMap<>())
+            .dataSources(dataSource)
+            .build();
+        when(mlBatchIngestionRequest.getMlBatchIngestionInput()).thenReturn(batchInput);
+        batchAction.doExecute(task, mlBatchIngestionRequest, actionListener);
+
+        ArgumentCaptor<OpenSearchStatusException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "IllegalArgumentException in the batch ingestion input: The batch ingest input s3Uris is empty",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    public void test_doExecute_mlTaskCreateException() {
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException("Failed to create ML Task"));
+            return null;
+        }).when(mlTaskManager).createMLTask(isA(MLTask.class), isA(ActionListener.class));
+        batchAction.doExecute(task, mlBatchIngestionRequest, actionListener);
+
+        ArgumentCaptor<RuntimeException> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Failed to create ML Task", argumentCaptor.getValue().getMessage());
+    }
+
+    public void test_doExecute_batchIngestionFailed() {
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            ShardId shardId = new ShardId(new Index("indexName", "uuid"), 1);
+            IndexResponse indexResponse = new IndexResponse(shardId, "taskId", 1, 1, 1, true);
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(mlTaskManager).createMLTask(isA(MLTask.class), isA(ActionListener.class));
+
+        doThrow(new OpenSearchStatusException("some error", RestStatus.INTERNAL_SERVER_ERROR)).when(mlTaskManager).add(isA(MLTask.class));
+        batchAction.doExecute(task, mlBatchIngestionRequest, actionListener);
+
+        ArgumentCaptor<OpenSearchStatusException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("some error", argumentCaptor.getValue().getMessage());
+        verify(mlTaskManager).updateMLTask("taskId", Map.of(STATE_FIELD, FAILED, ERROR_FIELD, "some error"), TASK_SEMAPHORE_TIMEOUT, true);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/batch/TransportBatchIngestionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/batch/TransportBatchIngestionActionTests.java
@@ -45,6 +45,7 @@ import org.opensearch.ml.common.transport.batch.MLBatchIngestionResponse;
 import org.opensearch.ml.task.MLTaskManager;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 public class TransportBatchIngestionActionTests extends OpenSearchTestCase {
@@ -62,6 +63,8 @@ public class TransportBatchIngestionActionTests extends OpenSearchTestCase {
     private Task task;
     @Mock
     ActionListener<MLBatchIngestionResponse> actionListener;
+    @Mock
+    ThreadPool threadPool;
 
     private TransportBatchIngestionAction batchAction;
     private MLBatchIngestionInput batchInput;
@@ -69,7 +72,7 @@ public class TransportBatchIngestionActionTests extends OpenSearchTestCase {
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        batchAction = new TransportBatchIngestionAction(transportService, actionFilters, client, mlTaskManager);
+        batchAction = new TransportBatchIngestionAction(transportService, actionFilters, client, mlTaskManager, threadPool);
 
         Map<String, Object> fieldMap = new HashMap<>();
         fieldMap.put("input", "$.content");

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLBatchIngestionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLBatchIngestionActionTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.ml.utils.TestHelper.getBatchIngestionRestRequest;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionAction;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionInput;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionRequest;
+import org.opensearch.ml.common.transport.batch.MLBatchIngestionResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+public class RestMLBatchIngestionActionTests extends OpenSearchTestCase {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private RestMLBatchIngestAction restMLBatchIngestAction;
+    private ThreadPool threadPool;
+    NodeClient client;
+
+    @Mock
+    RestChannel channel;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        restMLBatchIngestAction = new RestMLBatchIngestAction();
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+        doAnswer(invocation -> {
+            ActionListener<MLBatchIngestionResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLBatchIngestionAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
+    }
+
+    public void testConstructor() {
+        RestMLBatchIngestAction mlBatchIngestAction = new RestMLBatchIngestAction();
+        assertNotNull(mlBatchIngestAction);
+    }
+
+    public void testGetName() {
+        String actionName = restMLBatchIngestAction.getName();
+        assertFalse(Strings.isNullOrEmpty(actionName));
+        assertEquals("ml_batch_ingestion_action", actionName);
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = restMLBatchIngestAction.routes();
+        assertNotNull(routes);
+        assertFalse(routes.isEmpty());
+        RestHandler.Route route = routes.get(0);
+        assertEquals(RestRequest.Method.POST, route.getMethod());
+        assertEquals("/_plugins/_ml/_batch_ingestion", route.getPath());
+    }
+
+    public void testGetRequest() throws IOException {
+        RestRequest request = getBatchIngestionRestRequest();
+        MLBatchIngestionRequest mlBatchIngestionRequest = restMLBatchIngestAction.getRequest(request);
+
+        MLBatchIngestionInput mlBatchIngestionInput = mlBatchIngestionRequest.getMlBatchIngestionInput();
+        assertEquals("test batch index", mlBatchIngestionInput.getIndexName());
+        assertEquals("$.content", mlBatchIngestionInput.getFieldMapping().get("input"));
+        assertNotNull(mlBatchIngestionInput.getDataSources().get("source"));
+        assertNotNull(mlBatchIngestionInput.getCredential());
+    }
+
+    public void testPrepareRequest() throws Exception {
+        RestRequest request = getBatchIngestionRestRequest();
+        restMLBatchIngestAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLBatchIngestionRequest> argumentCaptor = ArgumentCaptor.forClass(MLBatchIngestionRequest.class);
+        verify(client, times(1)).execute(eq(MLBatchIngestionAction.INSTANCE), argumentCaptor.capture(), any());
+        MLBatchIngestionInput mlBatchIngestionInput = argumentCaptor.getValue().getMlBatchIngestionInput();
+        assertEquals("test batch index", mlBatchIngestionInput.getIndexName());
+        assertEquals("$.content", mlBatchIngestionInput.getFieldMapping().get("input"));
+        assertNotNull(mlBatchIngestionInput.getDataSources().get("source"));
+        assertNotNull(mlBatchIngestionInput.getCredential());
+    }
+
+    public void testPrepareRequest_EmptyContent() throws Exception {
+        thrown.expect(IOException.class);
+        thrown.expectMessage("Batch Ingestion request has empty body");
+        Map<String, String> params = new HashMap<>();
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).build();
+
+        restMLBatchIngestAction.handleRequest(request, channel, client);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -523,4 +523,27 @@ public class TestHelper {
         FileUtils.copyFile(new File(sourceFile), new File(destFile));
     }
 
+    public static RestRequest getBatchIngestionRestRequest() {
+        final String requestContent = "{\n"
+            + "    \"index_name\": \"test batch index\",\n"
+            + "    \"field_map\": {\n"
+            + "        \"input\": \"$.content\",\n"
+            + "        \"output\": \"$.SageMakerOutput\",\n"
+            + "        \"input_names\": [\"chapter\", \"title\"],\n"
+            + "        \"output_names\": [\"chapter_embedding\", \"title_embedding\"],\n"
+            + "        \"ingest_fields\": [\"$.id\"]\n"
+            + "    },\n"
+            + "    \"credential\": {\n"
+            + "        \"region\": \"xxxxxxxx\"\n"
+            + "    },\n"
+            + "    \"data_source\": {\n"
+            + "        \"type\": \"s3\",\n"
+            + "        \"source\": [\"s3://offlinebatch/output/sagemaker_djl_batch_input.json.out\"]\n"
+            + "    }\n"
+            + "}";
+        RestRequest request = new FakeRestRequest.Builder(getXContentRegistry())
+            .withContent(new BytesArray(requestContent), XContentType.JSON)
+            .build();
+        return request;
+    }
 }


### PR DESCRIPTION
### Description
Add a new API to offline ingest data in batch mode from different sources (starting with sageMaker). This is to collaborate with the offline batch inference released in 2.16.

Example of batch ingestion request from SageMaker:
1. Create the knn index
```
PUT /my-nlp-index
{
  "settings": {
    "index.knn": true
  },
  "mappings": {
    "properties": {
      "id": {
        "type": "text"
      },
      "chapter_embedding": {
        "type": "knn_vector",
        "dimension": 384,
        "method": {
          "engine": "nmslib",
          "space_type": "cosinesimil",
          "name": "hnsw",
          "parameters": {
            "ef_construction": 512,
            "m": 16
          }
        }
      },
      "chapter": {
        "type": "text"
      },
      "title_embedding": {
        "type": "knn_vector",
        "dimension": 384,
        "method": {
          "engine": "nmslib",
          "space_type": "cosinesimil",
          "name": "hnsw",
          "parameters": {
            "ef_construction": 512,
            "m": 16
          }
        }
      },
      "title": {
        "type": "text"
      }
    }
  }
}

```
2. run the new batch ingestion API
```
POST /_plugins/_ml/_batch_ingestion
{
  "index_name": "my-nlp-index",
  "field_map": {
    "input": "$.content",   // input is a reserved name to indicate llm input 
    "output": "$.SageMakerOutput", // output is a reserved name to indicate llm output
    "input_names": ["chapter", "title"], 
    "output_names": ["chapter_embedding", "title_embedding"],
    "ingest_fields": ["$.id"]
  },
  "credential": {
    "region": "us-east-1",
    "access_key": "xxxx",
    "secret_key": "xxxx",
    "session_token": "xxxx"
  },
  "data_source": {
    "type": "s3",
    "source": ["s3://offlinebatch/output/sagemaker_djl_batch_input.json.out"]
  }
}

```

Example of batch ingestion request from OpenAI:
1. Create the knn index
```
PUT /my-nlp-index-openai
{
  "settings": {
    "index.knn": true
  },
  "mappings": {
    "properties": {
      "custom_id": {
        "type": "text"
      },
      "question_embedding": {
        "type": "knn_vector",
        "dimension": 1536,
        "method": {
          "engine": "nmslib",
          "space_type": "cosinesimil",
          "name": "hnsw",
          "parameters": {
            "ef_construction": 512,
            "m": 16
          }
        }
      },
      "answer_embedding": {
        "type": "knn_vector",
        "dimension": 1536,
        "method": {
          "engine": "nmslib",
          "space_type": "cosinesimil",
          "name": "hnsw",
          "parameters": {
            "ef_construction": 512,
            "m": 16
          }
        }
      },
      "question": {
        "type": "text"
      },
      "answer": {
        "type": "text"
      }
    }
  }
}
```

2. run the new batch ingestion API using OpenAI file
```
POST /_plugins/_ml/_batch_ingestion
{
  "index_name": "my-nlp-index-openai",
  "field_map": {
    "output": "source[1].$.response.body.data[*].embedding", 
    "output_names": ["question_embedding", "answer_embedding"],
    "input": "source[2].$.body.input",
    "input_names": ["question", "answer"],
    "id_field": ["source[1].$.custom_id", "source[2].$.custom_id"],
    "ingest_fields": ["source[1].$.custom_id"]
  },
  "credential": {
    "openAI_key": "<your key>"
  },
  "data_source": {
    "type": "openAI",
    "source": ["file-wbu2zvKKAaqpSzRNWiN3Ia2y", "file-5gXEtbKjHnYrKrdtv69IeRN2"]. // [output file id, input file id]
  }
}
```
### Related Issues
https://github.com/opensearch-project/ml-commons/issues/2840

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
