### PR TITLE
use local_regex as default type for guardrails

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/model/Guardrails.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/Guardrails.java
@@ -123,6 +123,9 @@ public class Guardrails implements ToXContentObject {
                     break;
             }
         }
+        if (type == null) {
+            type = "local_regex";
+        }
         if (!validateType(type)) {
             throw new IllegalArgumentException("The type of guardrails is required, can not be null.");
         }

--- a/common/src/test/java/org/opensearch/ml/common/model/GuardrailsTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/GuardrailsTests.java
@@ -83,4 +83,24 @@ public class GuardrailsTests {
         Assert.assertEquals(guardrails.getInputGuardrail(), inputLocalRegexGuardrail);
         Assert.assertEquals(guardrails.getOutputGuardrail(), outputLocalRegexGuardrail);
     }
+
+    @Test
+    public void parseNonType() throws IOException {
+        String jsonStr = "{"
+            + "\"input_guardrail\":{\"stop_words\":[{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}],\"regex\":[\"regex1\"]},"
+            + "\"output_guardrail\":{\"stop_words\":[{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}],\"regex\":[\"regex1\"]}}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+        Guardrails guardrails = Guardrails.parse(parser);
+
+        Assert.assertEquals(guardrails.getType(), "local_regex");
+        Assert.assertEquals(guardrails.getInputGuardrail(), inputLocalRegexGuardrail);
+        Assert.assertEquals(guardrails.getOutputGuardrail(), outputLocalRegexGuardrail);
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/model/GuardrailsTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/GuardrailsTests.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.model;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,6 +28,8 @@ public class GuardrailsTests {
     String[] regex;
     LocalRegexGuardrail inputLocalRegexGuardrail;
     LocalRegexGuardrail outputLocalRegexGuardrail;
+    ModelGuardrail inputModelGuardrail;
+    ModelGuardrail outputModelGuardrail;
 
     @Before
     public void setUp() {
@@ -34,6 +37,8 @@ public class GuardrailsTests {
         regex = List.of("regex1").toArray(new String[0]);
         inputLocalRegexGuardrail = new LocalRegexGuardrail(List.of(stopWords), regex);
         outputLocalRegexGuardrail = new LocalRegexGuardrail(List.of(stopWords), regex);
+        inputModelGuardrail = new ModelGuardrail(Map.of("model_id", "guardrail_model_id", "response_validation_regex", "accept"));
+        outputModelGuardrail = new ModelGuardrail(Map.of("model_id", "guardrail_model_id", "response_validation_regex", "accept"));
     }
 
     @Test
@@ -102,5 +107,25 @@ public class GuardrailsTests {
         Assert.assertEquals(guardrails.getType(), "local_regex");
         Assert.assertEquals(guardrails.getInputGuardrail(), inputLocalRegexGuardrail);
         Assert.assertEquals(guardrails.getOutputGuardrail(), outputLocalRegexGuardrail);
+    }
+
+    @Test
+    public void parseModelType() throws IOException {
+        String jsonStr = "{\"type\":\"model\","
+            + "\"input_guardrail\":{\"model_id\":\"guardrail_model_id\",\"response_validation_regex\":\"accept\"},"
+            + "\"output_guardrail\":{\"model_id\":\"guardrail_model_id\",\"response_validation_regex\":\"accept\"}}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+        Guardrails guardrails = Guardrails.parse(parser);
+
+        Assert.assertEquals(guardrails.getType(), "model");
+        Assert.assertEquals(guardrails.getInputGuardrail(), inputModelGuardrail);
+        Assert.assertEquals(guardrails.getOutputGuardrail(), outputModelGuardrail);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGuardrailsIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGuardrailsIT.java
@@ -177,6 +177,31 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
         predictRemoteModel(modelId, predictInput);
     }
 
+    public void testPredictRemoteModelFailedNonType() throws IOException, InterruptedException {
+        // Skip test if key is null
+        if (OPENAI_KEY == null) {
+            return;
+        }
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("guardrails triggered for user input");
+        Response response = createConnector(completionModelConnectorEntity);
+        Map responseMap = parseResponseToMap(response);
+        String connectorId = (String) responseMap.get("connector_id");
+        response = registerRemoteModelNonTypeGuardrails("openAI-GPT-3.5 completions", connectorId);
+        responseMap = parseResponseToMap(response);
+        String taskId = (String) responseMap.get("task_id");
+        waitForTask(taskId, MLTaskState.COMPLETED);
+        response = getTask(taskId);
+        responseMap = parseResponseToMap(response);
+        String modelId = (String) responseMap.get("model_id");
+        response = deployRemoteModel(modelId);
+        responseMap = parseResponseToMap(response);
+        taskId = (String) responseMap.get("task_id");
+        waitForTask(taskId, MLTaskState.COMPLETED);
+        String predictInput = "{\n" + "  \"parameters\": {\n" + "      \"prompt\": \"Say this is a test of stop word.\"\n" + "  }\n" + "}";
+        predictRemoteModel(modelId, predictInput);
+    }
+
     public void testPredictRemoteModelSuccessWithModelGuardrail() throws IOException, InterruptedException {
         // Skip test if key is null
         if (OPENAI_KEY == null) {
@@ -409,6 +434,66 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
             + "\",\n"
             + "  \"guardrails\": {\n"
             + "    \"type\": \"local_regex\",\n"
+            + "    \"input_guardrail\": {\n"
+            + "      \"stop_words\": [\n"
+            + "        {"
+            + "          \"index_name\": \"stop_words\",\n"
+            + "          \"source_fields\": [\"title\"]\n"
+            + "        }"
+            + "      ],\n"
+            + "      \"regex\": [\"regex1\", \"regex2\"]\n"
+            + "    },\n"
+            + "    \"output_guardrail\": {\n"
+            + "      \"stop_words\": [\n"
+            + "        {"
+            + "          \"index_name\": \"stop_words\",\n"
+            + "          \"source_fields\": [\"title\"]\n"
+            + "        }"
+            + "      ],\n"
+            + "      \"regex\": [\"regex1\", \"regex2\"]\n"
+            + "    }\n"
+            + "},\n"
+            + "  \"interface\": {\n"
+            + "    \"input\": {},\n"
+            + "    \"output\": {}\n"
+            + "    }\n"
+            + "}";
+        return TestHelper
+            .makeRequest(client(), "POST", "/_plugins/_ml/models/_register", null, TestHelper.toHttpEntity(registerModelEntity), null);
+    }
+
+    protected Response registerRemoteModelNonTypeGuardrails(String name, String connectorId) throws IOException {
+        String registerModelGroupEntity = "{\n"
+            + "  \"name\": \"remote_model_group\",\n"
+            + "  \"description\": \"This is an example description\"\n"
+            + "}";
+        Response response = TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                "/_plugins/_ml/model_groups/_register",
+                null,
+                TestHelper.toHttpEntity(registerModelGroupEntity),
+                null
+            );
+        Map responseMap = parseResponseToMap(response);
+        assertEquals((String) responseMap.get("status"), "CREATED");
+        String modelGroupId = (String) responseMap.get("model_group_id");
+
+        String registerModelEntity = "{\n"
+            + "  \"name\": \""
+            + name
+            + "\",\n"
+            + "  \"function_name\": \"remote\",\n"
+            + "  \"model_group_id\": \""
+            + modelGroupId
+            + "\",\n"
+            + "  \"version\": \"1.0.0\",\n"
+            + "  \"description\": \"test model\",\n"
+            + "  \"connector_id\": \""
+            + connectorId
+            + "\",\n"
+            + "  \"guardrails\": {\n"
             + "    \"input_guardrail\": {\n"
             + "      \"stop_words\": [\n"
             + "        {"


### PR DESCRIPTION
### Description
When the guardrails type is not setup, we use local_regex as default type.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
