### PR TITLE
[Backport] use local_regex as default type for guardrails (#2853) (#2856)

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/model/Guardrails.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/Guardrails.java
@@ -122,6 +122,9 @@ public class Guardrails implements ToXContentObject {
                     break;
             }
         }
+        if (type == null) {
+            type = "local_regex";
+        }
         if (!validateType(type)) {
             throw new IllegalArgumentException("The type of guardrails is required, can not be null.");
         }

--- a/common/src/test/java/org/opensearch/ml/common/model/GuardrailsTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/GuardrailsTests.java
@@ -5,6 +5,11 @@
 
 package org.opensearch.ml.common.model;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,15 +23,13 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.TestHelper;
 import org.opensearch.search.SearchModule;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-
 public class GuardrailsTests {
     StopWords stopWords;
     String[] regex;
     LocalRegexGuardrail inputLocalRegexGuardrail;
     LocalRegexGuardrail outputLocalRegexGuardrail;
+    ModelGuardrail inputModelGuardrail;
+    ModelGuardrail outputModelGuardrail;
 
     @Before
     public void setUp() {
@@ -34,6 +37,8 @@ public class GuardrailsTests {
         regex = List.of("regex1").toArray(new String[0]);
         inputLocalRegexGuardrail = new LocalRegexGuardrail(List.of(stopWords), regex);
         outputLocalRegexGuardrail = new LocalRegexGuardrail(List.of(stopWords), regex);
+        inputModelGuardrail = new ModelGuardrail(Map.of("model_id", "guardrail_model_id", "response_validation_regex", "accept"));
+        outputModelGuardrail = new ModelGuardrail(Map.of("model_id", "guardrail_model_id", "response_validation_regex", "accept"));
     }
 
     @Test
@@ -74,5 +79,45 @@ public class GuardrailsTests {
         Assert.assertEquals(guardrails.getType(), "local_regex");
         Assert.assertEquals(guardrails.getInputGuardrail(), inputLocalRegexGuardrail);
         Assert.assertEquals(guardrails.getOutputGuardrail(), outputLocalRegexGuardrail);
+    }
+
+    @Test
+    public void parseNonType() throws IOException {
+        String jsonStr = "{"
+            + "\"input_guardrail\":{\"stop_words\":[{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}],\"regex\":[\"regex1\"]},"
+            + "\"output_guardrail\":{\"stop_words\":[{\"index_name\":\"test_index\",\"source_fields\":[\"test_field\"]}],\"regex\":[\"regex1\"]}}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+        Guardrails guardrails = Guardrails.parse(parser);
+
+        Assert.assertEquals(guardrails.getType(), "local_regex");
+        Assert.assertEquals(guardrails.getInputGuardrail(), inputLocalRegexGuardrail);
+        Assert.assertEquals(guardrails.getOutputGuardrail(), outputLocalRegexGuardrail);
+    }
+
+    @Test
+    public void parseModelType() throws IOException {
+        String jsonStr = "{\"type\":\"model\","
+            + "\"input_guardrail\":{\"model_id\":\"guardrail_model_id\",\"response_validation_regex\":\"accept\"},"
+            + "\"output_guardrail\":{\"model_id\":\"guardrail_model_id\",\"response_validation_regex\":\"accept\"}}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+        Guardrails guardrails = Guardrails.parse(parser);
+
+        Assert.assertEquals(guardrails.getType(), "model");
+        Assert.assertEquals(guardrails.getInputGuardrail(), inputModelGuardrail);
+        Assert.assertEquals(guardrails.getOutputGuardrail(), outputModelGuardrail);
     }
 }


### PR DESCRIPTION
* use local_regex as default type for guardrails



* add UT for model type



---------


(cherry picked from commit 7ecff1aaa17d8ee04fc0a408b49384624db0b93b)

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
