### PR TITLE
[Feature/multi_tenancy] Delay context restoring for initializing master key and deleting agent

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
@@ -187,7 +187,6 @@ public class EncryptorImpl implements Encryptor {
         AtomicReference<Exception> exceptionRef,
         CountDownLatch latch
     ) {
-        context.restore();
         log.debug("Completed Get MASTER_KEY Request, for tenant id:{}", tenantId);
 
         if (throwable != null) {
@@ -195,6 +194,7 @@ public class EncryptorImpl implements Encryptor {
         } else {
             handleGetDataObjectSuccess(response, tenantId, exceptionRef, latch, context);
         }
+        context.restore();
     }
 
     private void handleGetDataObjectFailure(Throwable throwable, AtomicReference<Exception> exceptionRef, CountDownLatch latch) {


### PR DESCRIPTION
### Description

Fixes too-eager restoring of context in cases where it needed to still be stashed

### Check List
- [x] New functionality includes testing. (Separately in #2818)
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
