### PR TITLE
[Feature/multi_tenancy] Make model group access control checks tenant aware

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/MLModelGroup.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModelGroup.java
@@ -203,6 +203,7 @@ public class MLModelGroup implements ToXContentObject {
                     break;
                 case TENANT_ID:
                     tenantId = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;

--- a/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
@@ -618,8 +618,7 @@ public class LocalClusterIndicesClientTests {
         verify(mockedClient, times(1)).search(requestCaptor.capture());
         assertEquals(1, requestCaptor.getValue().indices().length);
         assertEquals(TEST_INDEX, requestCaptor.getValue().indices()[0]);
-        assertTrue(requestCaptor.getValue().source().toString().contains("\"query\":{\"bool\":{\"must\":"));
-        assertTrue(requestCaptor.getValue().source().toString().contains("\"filter\":[{\"term\":{\"tenant_id\":{\"value\":\"xyz\""));
+        assertTrue(requestCaptor.getValue().source().toString().contains("{\"term\":{\"tenant_id\":{\"value\":\"xyz\""));
 
         SearchResponse searchActionResponse = SearchResponse.fromXContent(response.parser());
         assertEquals(0, searchActionResponse.getFailedShards());

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
@@ -96,7 +96,7 @@ public class DeleteModelGroupTransportAction extends HandledTransportAction<Acti
         User user = RestActionUtils.getUserContext(client);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<DeleteResponse> wrappedListener = ActionListener.runBefore(actionListener, context::restore);
-            modelAccessControlHelper.validateModelGroupAccess(user, modelGroupId, client, ActionListener.wrap(access -> {
+            modelAccessControlHelper.validateModelGroupAccess(user, modelGroupId, client, sdkClient, ActionListener.wrap(access -> {
                 if (!access) {
                     wrappedListener.onFailure(new MLValidationException("User doesn't have privilege to delete this model group"));
                 } else {
@@ -109,6 +109,7 @@ public class DeleteModelGroupTransportAction extends HandledTransportAction<Acti
                     SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
                         .builder()
                         .indices(ML_MODEL_INDEX)
+                        .tenantId(tenantId)
                         .searchSourceBuilder(searchSourceBuilder)
                         .build();
 

--- a/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
@@ -160,6 +160,8 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                                 modelAccessControlHelper
                                     .validateModelGroupAccess(
                                         user,
+                                        mlFeatureEnabledSetting,
+                                        tenantId,
                                         mlModel.getModelGroupId(),
                                         client,
                                         sdkClient,

--- a/plugin/src/test/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportActionTests.java
@@ -134,10 +134,10 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
         );
 
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(3);
+            ActionListener<Boolean> listener = invocation.getArgument(6);
             listener.onResponse(true);
             return null;
-        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any());
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
 
         threadContext = new ThreadContext(settings);
         when(client.threadPool()).thenReturn(threadPool);
@@ -255,10 +255,10 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
     @Test
     public void test_UserHasNoAccessException() throws IOException {
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(3);
+            ActionListener<Boolean> listener = invocation.getArgument(6);
             listener.onResponse(false);
             return null;
-        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any());
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
 
         deleteModelGroupTransportAction.doExecute(null, mlModelGroupDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -269,10 +269,10 @@ public class DeleteModelGroupTransportActionTests extends OpenSearchTestCase {
     @Test
     public void test_ValidationFailedException() {
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(3);
+            ActionListener<Boolean> listener = invocation.getArgument(6);
             listener.onFailure(new Exception("Failed to validate access"));
             return null;
-        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any());
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
 
         deleteModelGroupTransportAction.doExecute(null, mlModelGroupDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);

--- a/plugin/src/test/java/org/opensearch/ml/action/models/UpdateModelTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/UpdateModelTransportActionTests.java
@@ -318,12 +318,20 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
         }).when(modelAccessControlHelper).validateModelGroupAccess(any(), eq("test_model_group_id"), any(), isA(ActionListener.class));
 
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(4);
+            ActionListener<Boolean> listener = invocation.getArgument(6);
             listener.onResponse(true);
             return null;
         })
             .when(modelAccessControlHelper)
-            .validateModelGroupAccess(any(), eq("test_model_group_id"), any(), any(SdkClient.class), isA(ActionListener.class));
+            .validateModelGroupAccess(
+                any(),
+                any(),
+                any(),
+                eq("test_model_group_id"),
+                any(),
+                any(SdkClient.class),
+                isA(ActionListener.class)
+            );
 
         // TODO eventually remove if migrated to sdkClient
         doAnswer(invocation -> {
@@ -335,12 +343,20 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
             .validateModelGroupAccess(any(), eq("updated_test_model_group_id"), any(), isA(ActionListener.class));
 
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(4);
+            ActionListener<Boolean> listener = invocation.getArgument(6);
             listener.onResponse(true);
             return null;
         })
             .when(modelAccessControlHelper)
-            .validateModelGroupAccess(any(), eq("updated_test_model_group_id"), any(), any(SdkClient.class), isA(ActionListener.class));
+            .validateModelGroupAccess(
+                any(),
+                any(),
+                any(),
+                eq("updated_test_model_group_id"),
+                any(),
+                any(SdkClient.class),
+                isA(ActionListener.class)
+            );
 
         doAnswer(invocation -> {
             ActionListener<Boolean> listener = invocation.getArgument(5);
@@ -605,10 +621,12 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
     @Test
     public void testUpdateModelWithModelAccessControlNoPermission() throws InterruptedException {
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(4);
+            ActionListener<Boolean> listener = invocation.getArgument(6);
             listener.onResponse(false);
             return null;
-        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(SdkClient.class), isA(ActionListener.class));
+        })
+            .when(modelAccessControlHelper)
+            .validateModelGroupAccess(any(), any(), any(), any(), any(), any(SdkClient.class), isA(ActionListener.class));
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<UpdateResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
@@ -808,12 +826,12 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
         doReturn("mockUpdateModelGroupId").when(mockUpdateModelInput).getModelGroupId();
 
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(4);
+            ActionListener<Boolean> listener = invocation.getArgument(46);
             listener.onResponse(true);
             return null;
         })
             .when(modelAccessControlHelper)
-            .validateModelGroupAccess(any(), eq("mockUpdateModelGroupId"), any(), eq(sdkClient), isA(ActionListener.class));
+            .validateModelGroupAccess(any(), any(), any(), eq("mockUpdateModelGroupId"), any(), eq(sdkClient), isA(ActionListener.class));
 
         MLModelGroup modelGroup = MLModelGroup
             .builder()

--- a/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/register/TransportRegisterModelActionTests.java
@@ -227,10 +227,10 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
         assertNotNull(transportRegisterModelAction);
 
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(4);
+            ActionListener<Boolean> listener = invocation.getArgument(6);
             listener.onResponse(true);
             return null;
-        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any());
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
 
         MLStat mlStat = mock(MLStat.class);
         when(mlStats.getStat(eq(MLNodeLevelStat.ML_REQUEST_COUNT))).thenReturn(mlStat);
@@ -310,10 +310,10 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
 
     public void testDoExecute_userHasNoAccessException() throws InterruptedException {
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(4);
+            ActionListener<Boolean> listener = invocation.getArgument(6);
             listener.onResponse(false);
             return null;
-        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any());
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLRegisterModelResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
@@ -469,10 +469,10 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
 
     public void test_ValidationFailedException() throws InterruptedException {
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(4);
+            ActionListener<Boolean> listener = invocation.getArgument(6);
             listener.onFailure(new Exception("Failed to validate access"));
             return null;
-        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any());
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLRegisterModelResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
@@ -644,10 +644,10 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
         }).when(mlModelGroupManager).validateUniqueModelGroupName(any(), any(), any());
 
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(4);
+            ActionListener<Boolean> listener = invocation.getArgument(6);
             listener.onResponse(false);
             return null;
-        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any());
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
 
         MLRegisterModelInput registerModelInput = MLRegisterModelInput
             .builder()
@@ -694,10 +694,10 @@ public class TransportRegisterModelActionTests extends OpenSearchTestCase {
         }).when(mlModelGroupManager).validateUniqueModelGroupName(any(), any(), any());
 
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(4);
+            ActionListener<Boolean> listener = invocation.getArgument(6);
             listener.onResponse(false);
             return null;
-        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any());
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<MLRegisterModelResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);

--- a/plugin/src/test/java/org/opensearch/ml/helper/ModelAccessControlHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/ModelAccessControlHelperTests.java
@@ -51,6 +51,7 @@ import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.MLModelGroup;
 import org.opensearch.ml.common.MLModelGroup.MLModelGroupBuilder;
 import org.opensearch.ml.sdkclient.SdkClientFactory;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.sdk.SdkClient;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
@@ -73,6 +74,9 @@ public class ModelAccessControlHelperTests extends OpenSearchTestCase {
 
     @Mock
     ClusterService clusterService;
+
+    @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     @Mock
     Client client;
@@ -141,7 +145,7 @@ public class ModelAccessControlHelperTests extends OpenSearchTestCase {
     }
 
     public void test_UndefinedModelGroupID() {
-        modelAccessControlHelper.validateModelGroupAccess(null, null, client, sdkClient, actionListener);
+        modelAccessControlHelper.validateModelGroupAccess(null, mlFeatureEnabledSetting, null, null, client, sdkClient, actionListener);
         ArgumentCaptor<Boolean> argumentCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
         assertTrue(argumentCaptor.getValue());
@@ -158,7 +162,8 @@ public class ModelAccessControlHelperTests extends OpenSearchTestCase {
 
     public void test_UndefinedOwner() throws IOException {
         getResponse = modelGroupBuilder(null, null, null);
-        modelAccessControlHelper.validateModelGroupAccess(null, "testGroupID", client, sdkClient, actionListener);
+        modelAccessControlHelper
+            .validateModelGroupAccess(null, mlFeatureEnabledSetting, null, "testGroupID", client, sdkClient, actionListener);
         ArgumentCaptor<Boolean> argumentCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
         assertTrue(argumentCaptor.getValue());
@@ -186,7 +191,8 @@ public class ModelAccessControlHelperTests extends OpenSearchTestCase {
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<Boolean> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
-        modelAccessControlHelper.validateModelGroupAccess(user, "testGroupID", client, sdkClient, latchedActionListener);
+        modelAccessControlHelper
+            .validateModelGroupAccess(user, mlFeatureEnabledSetting, null, "testGroupID", client, sdkClient, latchedActionListener);
         latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -218,7 +224,8 @@ public class ModelAccessControlHelperTests extends OpenSearchTestCase {
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<Boolean> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
-        modelAccessControlHelper.validateModelGroupAccess(user, "testGroupID", client, sdkClient, latchedActionListener);
+        modelAccessControlHelper
+            .validateModelGroupAccess(user, mlFeatureEnabledSetting, null, "testGroupID", client, sdkClient, latchedActionListener);
         latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Boolean> argumentCaptor = ArgumentCaptor.forClass(Boolean.class);
@@ -250,7 +257,8 @@ public class ModelAccessControlHelperTests extends OpenSearchTestCase {
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<Boolean> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
-        modelAccessControlHelper.validateModelGroupAccess(user, "testGroupID", client, sdkClient, latchedActionListener);
+        modelAccessControlHelper
+            .validateModelGroupAccess(user, mlFeatureEnabledSetting, null, "testGroupID", client, sdkClient, latchedActionListener);
         latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Boolean> argumentCaptor = ArgumentCaptor.forClass(Boolean.class);
@@ -282,7 +290,8 @@ public class ModelAccessControlHelperTests extends OpenSearchTestCase {
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<Boolean> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
-        modelAccessControlHelper.validateModelGroupAccess(user, "testGroupID", client, sdkClient, latchedActionListener);
+        modelAccessControlHelper
+            .validateModelGroupAccess(user, mlFeatureEnabledSetting, null, "testGroupID", client, sdkClient, latchedActionListener);
         latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Boolean> argumentCaptor = ArgumentCaptor.forClass(Boolean.class);
@@ -314,7 +323,8 @@ public class ModelAccessControlHelperTests extends OpenSearchTestCase {
 
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<Boolean> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
-        modelAccessControlHelper.validateModelGroupAccess(user, "testGroupID", client, sdkClient, latchedActionListener);
+        modelAccessControlHelper
+            .validateModelGroupAccess(user, mlFeatureEnabledSetting, null, "testGroupID", client, sdkClient, latchedActionListener);
         latch.await(500, TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Boolean> argumentCaptor = ArgumentCaptor.forClass(Boolean.class);


### PR DESCRIPTION
### Description

Prevents one tenant from registering a model to a model group created by a different tenant, and deleting a model group created by a different tenant.

### Check List
- [x] New functionality includes testing. (Separately in #2818)
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
