### PR TITLE
[Feature/multi_tenancy] Handle controller index 404 on remote client

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -30,6 +30,7 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.client.Client;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
@@ -381,7 +382,9 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
                     }
                 } else {
                     Exception e = SdkClientUtils.unwrapAndConvertToException(throwable);
-                    if (e instanceof ResourceNotFoundException) {
+                    if (e instanceof ResourceNotFoundException // Local client
+                        || e instanceof OpenSearchException && // Remote client
+                            ((OpenSearchException) e).status() == RestStatus.NOT_FOUND.getStatus()) {
                         log
                             .info(
                                 getErrorMessage(


### PR DESCRIPTION
### Description

When deleting a model, its model controller must be deleted, but this is not required in multitenancy.

The `ResourceNotFound` exception was handled for the local (Node) client case. This PR handles the appropriate `OpenSearchException` with 404 status returned from the remote client.

It is likely a similar fix will be required for the DynamoDB client.

### Related Issues

Cherry-picked from #2818 

### Check List
- [x] New functionality includes testing. (Covered by #2818)
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
