### PR TITLE
[Feature/multi_tenancy] Add tenant ID field to DDB object

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -126,6 +126,9 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
                 String source = Strings.toString(MediaTypeRegistry.JSON, request.dataObject());
                 JsonNode jsonNode = OBJECT_MAPPER.readTree(source);
                 Map<String, AttributeValue> sourceMap = JsonTransformer.convertJsonObjectToDDBAttributeMap(jsonNode);
+                if (request.tenantId() != null) {
+                    sourceMap.put(TENANT_ID, AttributeValue.builder().s(tenantId).build());
+                }
                 Map<String, AttributeValue> item = new HashMap<>();
                 item.put(TENANT_ID, AttributeValue.builder().s(tenantId).build());
                 item.put(RANGE_KEY, AttributeValue.builder().s(id).build());

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -237,6 +237,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         Assert.assertEquals("hello", putItemRequest.item().get("_source").m().get("testList").l().get(1).s());
         Assert.assertEquals(null, putItemRequest.item().get("_source").m().get("testList").l().get(2).s());
         Assert.assertEquals("foo", putItemRequest.item().get("_source").m().get("testObject").m().get("data").s());
+        Assert.assertEquals(TENANT_ID, putItemRequest.item().get("_source").m().get(CommonValue.TENANT_ID).s());
     }
 
     @Test
@@ -248,6 +249,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
         PutItemRequest putItemRequest = putItemRequestArgumentCaptor.getValue();
         Assert.assertEquals("DEFAULT_TENANT", putItemRequest.item().get(CommonValue.TENANT_ID).s());
+        Assert.assertNull(putItemRequest.item().get("_source").m().get(CommonValue.TENANT_ID));
     }
 
     @Test


### PR DESCRIPTION
### Description

Adds the `tenant_id` field to the DynamoDB Item source so that it will be available for search when replicated.

### Related Issues

Cherry-picked from #2818

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
