### PR TITLE
[Feature/multi_tenancy] Adds missing break statements following tenant ID parsing

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/MLConfig.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLConfig.java
@@ -134,6 +134,7 @@ public class MLConfig implements ToXContentObject, Writeable {
                     break;
                 case TENANT_ID:
                     tenantId = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/MLModelGroup.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModelGroup.java
@@ -203,6 +203,7 @@ public class MLModelGroup implements ToXContentObject {
                     break;
                 case TENANT_ID:
                     tenantId = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/MLTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLTask.java
@@ -288,6 +288,7 @@ public class MLTask implements ToXContentObject, Writeable {
                     break;
                 case TENANT_ID:
                     tenantId = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/agent/MLAgent.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/MLAgent.java
@@ -317,6 +317,7 @@ public class MLAgent implements ToXContentObject, Writeable {
                     break;
                 case TENANT_ID:
                     tenantId = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -132,6 +132,7 @@ public class HttpConnector extends AbstractConnector {
                     break;
                 case TENANT_ID:
                     tenantId = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -186,6 +186,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
                     break;
                 case TENANT_ID:
                     tenantId = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/transport/model_group/MLRegisterModelGroupInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/model_group/MLRegisterModelGroupInput.java
@@ -140,6 +140,7 @@ public class MLRegisterModelGroupInput implements ToXContentObject, Writeable{
                     break;
                 case TENANT_ID:
                     tenantId = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelsRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelsRequest.java
@@ -96,6 +96,7 @@ public class MLUndeployModelsRequest extends MLTaskRequest {
                     break;
                 case TENANT_ID:
                     tenantId = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;


### PR DESCRIPTION
### Description

Several of the XContent parsers were missing a break statement after getting the tenant ID, causing them to continue to also execute the default.

### Related Issues

Fixed one of these in #2867, saw another one and did a search for other copy-pasted victims, and this fixes the rest.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
