### PR TITLE
[Backport 2.16] Fix custom prompt substitute with List issue in ml inference search response processor

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -17,6 +17,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.AccessMode;
+import static org.opensearch.ml.common.utils.StringUtils.parseParameters;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -308,20 +309,21 @@ public class HttpConnector extends AbstractConnector {
     }
 
     @Override
-    public  <T> T createPayload(String action, Map<String, String> parameters) {
+    public <T> T createPayload(String action, Map<String, String> parameters) {
         Optional<ConnectorAction> connectorAction = findAction(action);
         if (connectorAction.isPresent() && connectorAction.get().getRequestBody() != null) {
             String payload = connectorAction.get().getRequestBody();
             payload = fillNullParameters(parameters, payload);
+            parseParameters(parameters);
             StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
             payload = substitutor.replace(payload);
-
             if (!isJson(payload)) {
                 throw new IllegalArgumentException("Invalid payload: " + payload);
             }
             return (T) payload;
         }
         return (T) parameters.get("http_body");
+
     }
 
     protected String fillNullParameters(Map<String, String> parameters, String payload) {

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -34,19 +34,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_ADDITIONAL_INFO_FIELD;
-import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_RESPONSE_FIELD;
-import org.apache.commons.lang3.BooleanUtils;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonSyntaxException;
-
-import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class StringUtils {

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -36,6 +36,17 @@ import java.util.stream.Collectors;
 
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_ADDITIONAL_INFO_FIELD;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_RESPONSE_FIELD;
+import org.apache.commons.lang3.BooleanUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+
+import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class StringUtils {
@@ -56,6 +67,7 @@ public class StringUtils {
     static {
         gson = new Gson();
     }
+    public static final String TO_STRING_FUNCTION_NAME = ".toString()";
 
     public static boolean isValidJsonString(String Json) {
         try {
@@ -239,4 +251,49 @@ public class StringUtils {
             return errorMessage + " Model ID: " + modelId;
         }
     }
+
+    /**
+     * Collects the prefixes of the toString() method calls present in the values of the given map.
+     *
+     * @param map A map containing key-value pairs where the values may contain toString() method calls.
+     * @return A list of prefixes for the toString() method calls found in the map values.
+     */
+    public static List<String> collectToStringPrefixes(Map<String, String> map) {
+        List<String> prefixes = new ArrayList<>();
+        for (String key : map.keySet()) {
+            String value = map.get(key);
+            if (value != null) {
+                Pattern pattern = Pattern.compile("\\$\\{parameters\\.(.+?)\\.toString\\(\\)\\}");
+                Matcher matcher = pattern.matcher(value);
+                while (matcher.find()) {
+                    String prefix = matcher.group(1);
+                    prefixes.add(prefix);
+                }
+            }
+        }
+        return prefixes;
+    }
+
+    /**
+     * Parses the given parameters map and processes the values containing toString() method calls.
+     *
+     * @param parameters A map containing key-value pairs where the values may contain toString() method calls.
+     * @return A new map with the processed values for the toString() method calls.
+     */
+    public static Map<String, String> parseParameters(Map<String, String> parameters) {
+        if (parameters != null) {
+            List<String> toStringParametersPrefixes = collectToStringPrefixes(parameters);
+
+            if (!toStringParametersPrefixes.isEmpty()) {
+                for (String prefix : toStringParametersPrefixes) {
+                    String value = parameters.get(prefix);
+                    if (value != null) {
+                        parameters.put(prefix + TO_STRING_FUNCTION_NAME, processTextDoc(value));
+                    }
+                }
+            }
+        }
+        return parameters;
+    }
+
 }

--- a/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
@@ -5,9 +5,13 @@
 
 package org.opensearch.ml.common.utils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.opensearch.ml.common.utils.StringUtils.TO_STRING_FUNCTION_NAME;
+import static org.opensearch.ml.common.utils.StringUtils.collectToStringPrefixes;
+import static org.opensearch.ml.common.utils.StringUtils.parseParameters;
+import static org.opensearch.ml.common.utils.StringUtils.toJson;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -15,8 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
+import org.apache.commons.text.StringSubstitutor;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class StringUtilsTest {
 
@@ -217,5 +222,204 @@ public class StringUtilsTest {
 
         // Assert
         assertEquals(expected, result);
+    }
+
+    /**
+     * Tests the collectToStringPrefixes method with a map containing toString() method calls
+     * in the values. Verifies that the method correctly extracts the prefixes of the toString()
+     * method calls.
+     */
+    @Test
+    public void testGetToStringPrefix() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters
+            .put(
+                "prompt",
+                "answer question based on context: ${parameters.context.toString()} and conversation history based on history: ${parameters.history.toString()}"
+            );
+        parameters.put("context", "${parameters.text.toString()}");
+
+        List<String> prefixes = collectToStringPrefixes(parameters);
+        List<String> expectPrefixes = new ArrayList<>();
+        expectPrefixes.add("text");
+        expectPrefixes.add("context");
+        expectPrefixes.add("history");
+        assertEquals(prefixes, expectPrefixes);
+    }
+
+    /**
+     * Tests the parseParameters method with a map containing a list of strings as the value
+     * for the "context" key. Verifies that the method correctly processes the list and adds
+     * the processed value to the map with the expected key. Also tests the string substitution
+     * using the processed values.
+     */
+    @Test
+    public void testParseParametersListToString() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("prompt", "answer question based on context: ${parameters.context.toString()}");
+        ArrayList<String> listOfDocuments = new ArrayList<>();
+        listOfDocuments.add("document1");
+        parameters.put("context", toJson(listOfDocuments));
+
+        parseParameters(parameters);
+        assertEquals(parameters.get("context" + TO_STRING_FUNCTION_NAME), "[\\\"document1\\\"]");
+
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
+        requestBody = substitutor.replace(requestBody);
+        assertEquals(requestBody, "{\"prompt\": \"answer question based on context: [\\\"document1\\\"]\"}");
+    }
+
+    /**
+     * Tests the parseParameters method with a map containing a list of strings as the value
+     * for the "context" key, and the "prompt" value containing escaped characters. Verifies
+     * that the method correctly processes the list and adds the processed value to the map
+     * with the expected key. Also tests the string substitution using the processed values.
+     */
+    @Test
+    public void testParseParametersListToStringWithEscapedPrompt() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters
+            .put(
+                "prompt",
+                "\\n\\nHuman: You are a professional data analyst. You will always answer question based on the given context first. If the answer is not directly shown in the context, you will analyze the data and find the answer. If you don't know the answer, just say I don't know. Context: ${parameters.context.toString()}. \\n\\n Human: please summarize the documents \\n\\n Assistant:"
+            );
+        ArrayList<String> listOfDocuments = new ArrayList<>();
+        listOfDocuments.add("document1");
+        parameters.put("context", toJson(listOfDocuments));
+
+        parseParameters(parameters);
+        assertEquals(parameters.get("context" + TO_STRING_FUNCTION_NAME), "[\\\"document1\\\"]");
+
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
+        requestBody = substitutor.replace(requestBody);
+        assertEquals(
+            requestBody,
+            "{\"prompt\": \"\\n\\nHuman: You are a professional data analyst. You will always answer question based on the given context first. If the answer is not directly shown in the context, you will analyze the data and find the answer. If you don't know the answer, just say I don't know. Context: [\\\"document1\\\"]. \\n\\n Human: please summarize the documents \\n\\n Assistant:\"}"
+        );
+    }
+
+    /**
+     * Tests the parseParameters method with a map containing a list of strings as the value
+     * for the "context" key, and the "prompt" value containing escaped characters. Verifies
+     * that the method correctly processes the list and adds the processed value to the map
+     * with the expected key. Also tests the string substitution using the processed values.
+     */
+    @Test
+    public void testParseParametersListToStringModelConfig() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters
+            .put(
+                "prompt",
+                "\\n\\nHuman: You are a professional data analyst. You will always answer question based on the given context first. If the answer is not directly shown in the context, you will analyze the data and find the answer. If you don't know the answer, just say I don't know. Context: ${parameters.model_config.context.toString()}. \\n\\n Human: please summarize the documents \\n\\n Assistant:"
+            );
+        ArrayList<String> listOfDocuments = new ArrayList<>();
+        listOfDocuments.add("document1");
+        parameters.put("model_config.context", toJson(listOfDocuments));
+
+        parseParameters(parameters);
+        assertEquals(parameters.get("model_config.context" + TO_STRING_FUNCTION_NAME), "[\\\"document1\\\"]");
+
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
+        requestBody = substitutor.replace(requestBody);
+        assertEquals(
+            requestBody,
+            "{\"prompt\": \"\\n\\nHuman: You are a professional data analyst. You will always answer question based on the given context first. If the answer is not directly shown in the context, you will analyze the data and find the answer. If you don't know the answer, just say I don't know. Context: [\\\"document1\\\"]. \\n\\n Human: please summarize the documents \\n\\n Assistant:\"}"
+        );
+    }
+
+    /**
+     * Tests the parseParameters method with a map containing a nested list of strings as the
+     * value for the "context" key. Verifies that the method correctly processes the nested
+     * list and adds the processed value to the map with the expected key. Also tests the
+     * string substitution using the processed values.
+     */
+    @Test
+    public void testParseParametersNestedListToString() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("prompt", "answer question based on context: ${parameters.context.toString()}");
+        ArrayList<String> listOfDocuments = new ArrayList<>();
+        listOfDocuments.add("document1");
+        ArrayList<String> NestedListOfDocuments = new ArrayList<>();
+        NestedListOfDocuments.add("document2");
+        listOfDocuments.add(toJson(NestedListOfDocuments));
+        parameters.put("context", toJson(listOfDocuments));
+
+        parseParameters(parameters);
+        assertEquals(parameters.get("context" + TO_STRING_FUNCTION_NAME), "[\\\"document1\\\",\\\"[\\\\\\\"document2\\\\\\\"]\\\"]");
+
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
+        requestBody = substitutor.replace(requestBody);
+        assertEquals(
+            requestBody,
+            "{\"prompt\": \"answer question based on context: [\\\"document1\\\",\\\"[\\\\\\\"document2\\\\\\\"]\\\"]\"}"
+        );
+    }
+
+    /**
+     * Tests the parseParameters method with a map containing a map of strings as the value
+     * for the "context" key. Verifies that the method correctly processes the map and adds
+     * the processed value to the map with the expected key. Also tests the string substitution
+     * using the processed values.
+     */
+    @Test
+    public void testParseParametersMapToString() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters
+            .put(
+                "prompt",
+                "answer question based on context: ${parameters.context.toString()} and conversation history based on history: ${parameters.history.toString()}"
+            );
+        Map<String, String> mapOfDocuments = new HashMap<>();
+        mapOfDocuments.put("name", "John");
+        parameters.put("context", toJson(mapOfDocuments));
+        parameters.put("history", "hello\n");
+        parseParameters(parameters);
+        assertEquals(parameters.get("context" + TO_STRING_FUNCTION_NAME), "{\\\"name\\\":\\\"John\\\"}");
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
+        requestBody = substitutor.replace(requestBody);
+        assertEquals(
+            requestBody,
+            "{\"prompt\": \"answer question based on context: {\\\"name\\\":\\\"John\\\"} and conversation history based on history: hello\\n\"}"
+        );
+    }
+
+    /**
+     * Tests the parseParameters method with a map containing a nested map of strings as the
+     * value for the "context" key. Verifies that the method correctly processes the nested
+     * map and adds the processed value to the map with the expected key. Also tests the
+     * string substitution using the processed values.
+     */
+    @Test
+    public void testParseParametersNestedMapToString() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters
+            .put(
+                "prompt",
+                "answer question based on context: ${parameters.context.toString()} and conversation history based on history: ${parameters.history.toString()}"
+            );
+        Map<String, String> mapOfDocuments = new HashMap<>();
+        mapOfDocuments.put("name", "John");
+        Map<String, String> nestedMapOfDocuments = new HashMap<>();
+        nestedMapOfDocuments.put("city", "New York");
+        mapOfDocuments.put("hometown", toJson(nestedMapOfDocuments));
+        parameters.put("context", toJson(mapOfDocuments));
+        parameters.put("history", "hello\n");
+        parseParameters(parameters);
+        assertEquals(
+            parameters.get("context" + TO_STRING_FUNCTION_NAME),
+            "{\\\"hometown\\\":\\\"{\\\\\\\"city\\\\\\\":\\\\\\\"New York\\\\\\\"}\\\",\\\"name\\\":\\\"John\\\"}"
+        );
+        String requestBody = "{\"prompt\": \"${parameters.prompt}\"}";
+        StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
+        requestBody = substitutor.replace(requestBody);
+        assertEquals(
+            requestBody,
+            "{\"prompt\": \"answer question based on context: {\\\"hometown\\\":\\\"{\\\\\\\"city\\\\\\\":\\\\\\\"New York\\\\\\\"}\\\",\\\"name\\\":\\\"John\\\"} and conversation history based on history: hello\\n\"}"
+        );
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -268,8 +268,8 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                 }
             }
         }
-
-        modelParameters = StringUtils.getParameterMap(modelInputParameters);
+        Map<String, String> modelParametersInString = StringUtils.getParameterMap(modelInputParameters);
+        modelParameters.putAll(modelParametersInString);
 
         Set<String> inputMapKeys = new HashSet<>(modelParameters.keySet());
         inputMapKeys.removeAll(modelConfigs.keySet());


### PR DESCRIPTION
### Description
Manual Backport from https://github.com/opensearch-project/ml-commons/pull/2871

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
