### PR TITLE
output only old fields in get config API

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/MLConfig.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLConfig.java
@@ -121,26 +121,17 @@ public class MLConfig implements ToXContentObject, Writeable {
     @Override
     public XContentBuilder toXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
         XContentBuilder builder = xContentBuilder.startObject();
-        if (type != null) {
-            builder.field(TYPE_FIELD, type);
+        if (configType != null || type != null) {
+            builder.field(TYPE_FIELD, configType == null ? type : configType);
         }
-        if (configType != null) {
-            builder.field(CONFIG_TYPE_FIELD, configType);
-        }
-        if (configuration != null) {
-            builder.field(CONFIGURATION_FIELD, configuration);
-        }
-        if (mlConfiguration != null) {
-            builder.field(ML_CONFIGURATION_FIELD, mlConfiguration);
+        if (configuration != null || mlConfiguration != null) {
+            builder.field(CONFIGURATION_FIELD, mlConfiguration == null ? configuration : mlConfiguration);
         }
         if (createTime != null) {
             builder.field(CREATE_TIME_FIELD, createTime.toEpochMilli());
         }
-        if (lastUpdateTime != null) {
-            builder.field(LAST_UPDATE_TIME_FIELD, lastUpdateTime.toEpochMilli());
-        }
-        if (lastUpdatedTime != null) {
-            builder.field(LAST_UPDATED_TIME_FIELD, lastUpdatedTime.toEpochMilli());
+        if (lastUpdateTime != null || lastUpdatedTime != null) {
+            builder.field(LAST_UPDATE_TIME_FIELD, lastUpdatedTime == null ? lastUpdateTime.toEpochMilli() : lastUpdatedTime.toEpochMilli());
         }
         return builder.endObject();
     }


### PR DESCRIPTION
### Description
output only old fields in get config API

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
