### PR TITLE
Support null exception in ErrorMessage

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/utils/error/ErrorMessage.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/error/ErrorMessage.java
@@ -44,7 +44,7 @@ public class ErrorMessage {
     }
 
     private String fetchType() {
-        return exception == null ? "NULL" : exception.getClass().getSimpleName();
+        return exception == null ? "Unknown Exception" : exception.getClass().getSimpleName();
     }
 
     protected String fetchReason() {
@@ -53,7 +53,7 @@ public class ErrorMessage {
 
     protected String fetchDetails() {
         if (exception == null) {
-            return "NULL";
+            return "No Exception Details";
         }
 
         final String msg;

--- a/plugin/src/main/java/org/opensearch/ml/utils/error/ErrorMessage.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/error/ErrorMessage.java
@@ -44,7 +44,7 @@ public class ErrorMessage {
     }
 
     private String fetchType() {
-        return exception.getClass().getSimpleName();
+        return exception == null ? "NULL" : exception.getClass().getSimpleName();
     }
 
     protected String fetchReason() {
@@ -52,6 +52,10 @@ public class ErrorMessage {
     }
 
     protected String fetchDetails() {
+        if (exception == null) {
+            return "NULL";
+        }
+
         final String msg;
         // Prevent the method from exposing internal information such as internal ip address etc. that is a security concern.
         if (hasInternalInformation(exception)) {

--- a/plugin/src/test/java/org/opensearch/ml/utils/error/ErrorMessageTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/error/ErrorMessageTests.java
@@ -144,4 +144,12 @@ public class ErrorMessageTests {
 
         assertEquals(errorMessage.getDetails(), "illegal state");
     }
+
+    @Test
+    public void ConstructNullException() {
+        ErrorMessage errorMessage = new ErrorMessage(null, SERVICE_UNAVAILABLE.getStatus());
+
+        assertEquals(errorMessage.getType(), "NULL");
+        assertEquals(errorMessage.getDetails(), "NULL");
+    }
 }

--- a/plugin/src/test/java/org/opensearch/ml/utils/error/ErrorMessageTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/error/ErrorMessageTests.java
@@ -149,7 +149,7 @@ public class ErrorMessageTests {
     public void ConstructNullException() {
         ErrorMessage errorMessage = new ErrorMessage(null, SERVICE_UNAVAILABLE.getStatus());
 
-        assertEquals(errorMessage.getType(), "NULL");
-        assertEquals(errorMessage.getDetails(), "NULL");
+        assertEquals(errorMessage.getType(), "Unknown Exception");
+        assertEquals(errorMessage.getDetails(), "No Exception Details");
     }
 }


### PR DESCRIPTION
### Description
Support construct ErrorMessage object with null exception.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
