### PR TITLE
upgrading bounty castle version

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -65,7 +65,10 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.25.40')
     api 'software.amazon.awssdk:auth:2.25.40'
     implementation 'software.amazon.awssdk:apache-client'
-    implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
+    implementation ('com.amazonaws:aws-encryption-sdk-java:2.4.1') {
+        exclude group: 'org.bouncycastle', module: 'bcprov-ext-jdk18on'
+    }
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
     implementation group: 'software.amazon.awssdk', name: 'aws-core', version: '2.25.40'
     implementation group: 'software.amazon.awssdk', name: 's3', version: '2.25.40'
     implementation group: 'software.amazon.awssdk', name: 'regions', version: '2.25.40'


### PR DESCRIPTION
### Description
[In OpenSearch 2.16 specifically OpenSearch-ML, Bouncy Castle is still at version 1.75 and has 4 medium vulnerabilities listed against it in Black Duck:
BDSA-2023-3876/ CVE-2024-30171
BDSA-2024-1960/ CVE-2024-29857
BDSA-2023-3876/ CVE-2024-30171
BDSA-2024-2378/ CVE-2024-34447]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
