### PR TITLE
[Feature/multi_tenancy] Fix DDB client tenant id handling

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -80,6 +80,7 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
     private static final Long DEFAULT_SEQUENCE_NUMBER = 0L;
     private static final Long DEFAULT_PRIMARY_TERM = 1L;
     private static final String RANGE_KEY = "_id";
+    private static final String HASH_KEY = "_tenant_id";
 
     private static final String SOURCE = "_source";
     private static final String SEQ_NO_KEY = "_seq_no";
@@ -130,7 +131,7 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
                     sourceMap.put(TENANT_ID, AttributeValue.builder().s(tenantId).build());
                 }
                 Map<String, AttributeValue> item = new HashMap<>();
-                item.put(TENANT_ID, AttributeValue.builder().s(tenantId).build());
+                item.put(HASH_KEY, AttributeValue.builder().s(tenantId).build());
                 item.put(RANGE_KEY, AttributeValue.builder().s(id).build());
                 item.put(SOURCE, AttributeValue.builder().m(sourceMap).build());
                 item.put(SEQ_NO_KEY, AttributeValue.builder().n(sequenceNumber.toString()).build());
@@ -232,10 +233,10 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
                 String source = Strings.toString(MediaTypeRegistry.JSON, request.dataObject());
                 JsonNode jsonNode = OBJECT_MAPPER.readTree(source);
                 Map<String, AttributeValue> updateItem = JsonTransformer.convertJsonObjectToDDBAttributeMap(jsonNode);
-                updateItem.remove(TENANT_ID);
+                updateItem.remove(HASH_KEY);
                 updateItem.remove(RANGE_KEY);
                 Map<String, AttributeValue> updateKey = new HashMap<>();
-                updateKey.put(TENANT_ID, AttributeValue.builder().s(tenantId).build());
+                updateKey.put(HASH_KEY, AttributeValue.builder().s(tenantId).build());
                 updateKey.put(RANGE_KEY, AttributeValue.builder().s(request.id()).build());
                 UpdateItemRequest.Builder updateItemRequestBuilder = UpdateItemRequest.builder().tableName(request.index()).key(updateKey);
                 Map<String, String> expressionAttributeNames = new HashMap<>();
@@ -305,7 +306,7 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
             .key(
                 Map
                     .ofEntries(
-                        Map.entry(TENANT_ID, AttributeValue.builder().s(tenantId).build()),
+                        Map.entry(HASH_KEY, AttributeValue.builder().s(tenantId).build()),
                         Map.entry(RANGE_KEY, AttributeValue.builder().s(request.id()).build())
                     )
             )
@@ -371,7 +372,7 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
             .key(
                 Map
                     .ofEntries(
-                        Map.entry(TENANT_ID, AttributeValue.builder().s(tenantId).build()),
+                        Map.entry(HASH_KEY, AttributeValue.builder().s(tenantId).build()),
                         Map.entry(RANGE_KEY, AttributeValue.builder().s(documentId).build())
                     )
             )

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -83,6 +83,7 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
 public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     private static final String RANGE_KEY = "_id";
+    private static final String HASH_KEY = "_tenant_id";
     private static final String SEQ_NUM = "_seq_no";
 
     private static final String TEST_ID = "123";
@@ -159,7 +160,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         PutItemRequest putItemRequest = putItemRequestArgumentCaptor.getValue();
         Assert.assertEquals(TEST_INDEX, putItemRequest.tableName());
         Assert.assertEquals(TEST_ID, putItemRequest.item().get(RANGE_KEY).s());
-        Assert.assertEquals(TENANT_ID, putItemRequest.item().get(CommonValue.TENANT_ID).s());
+        Assert.assertEquals(TENANT_ID, putItemRequest.item().get(HASH_KEY).s());
         Assert.assertEquals("0", putItemRequest.item().get(SEQ_NUM).n());
         Assert.assertEquals("foo", putItemRequest.item().get("_source").m().get("data").s());
     }
@@ -248,7 +249,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         Mockito.verify(dynamoDbClient).putItem(putItemRequestArgumentCaptor.capture());
 
         PutItemRequest putItemRequest = putItemRequestArgumentCaptor.getValue();
-        Assert.assertEquals("DEFAULT_TENANT", putItemRequest.item().get(CommonValue.TENANT_ID).s());
+        Assert.assertEquals("DEFAULT_TENANT", putItemRequest.item().get(HASH_KEY).s());
         Assert.assertNull(putItemRequest.item().get("_source").m().get(CommonValue.TENANT_ID));
     }
 
@@ -307,7 +308,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         Mockito.verify(dynamoDbClient).getItem(getItemRequestArgumentCaptor.capture());
         GetItemRequest getItemRequest = getItemRequestArgumentCaptor.getValue();
         Assert.assertEquals(TEST_INDEX, getItemRequest.tableName());
-        Assert.assertEquals(TENANT_ID, getItemRequest.key().get(CommonValue.TENANT_ID).s());
+        Assert.assertEquals(TENANT_ID, getItemRequest.key().get(HASH_KEY).s());
         Assert.assertEquals(TEST_ID, getItemRequest.key().get(RANGE_KEY).s());
         Assert.assertEquals(TEST_ID, response.id());
         Assert.assertEquals("foo", response.source().get("data"));
@@ -379,7 +380,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         sdkClient.getDataObjectAsync(getRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
         Mockito.verify(dynamoDbClient).getItem(getItemRequestArgumentCaptor.capture());
         GetItemRequest getItemRequest = getItemRequestArgumentCaptor.getValue();
-        Assert.assertEquals("DEFAULT_TENANT", getItemRequest.key().get(CommonValue.TENANT_ID).s());
+        Assert.assertEquals("DEFAULT_TENANT", getItemRequest.key().get(HASH_KEY).s());
     }
 
     @Test
@@ -405,7 +406,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
             .join();
         DeleteItemRequest deleteItemRequest = deleteItemRequestArgumentCaptor.getValue();
         Assert.assertEquals(TEST_INDEX, deleteItemRequest.tableName());
-        Assert.assertEquals(TENANT_ID, deleteItemRequest.key().get(CommonValue.TENANT_ID).s());
+        Assert.assertEquals(TENANT_ID, deleteItemRequest.key().get(HASH_KEY).s());
         Assert.assertEquals(TEST_ID, deleteItemRequest.key().get(RANGE_KEY).s());
         Assert.assertEquals(TEST_ID, deleteResponse.id());
 
@@ -425,7 +426,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         Mockito.when(dynamoDbClient.deleteItem(deleteItemRequestArgumentCaptor.capture())).thenReturn(DeleteItemResponse.builder().build());
         sdkClient.deleteDataObjectAsync(deleteRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
         DeleteItemRequest deleteItemRequest = deleteItemRequestArgumentCaptor.getValue();
-        Assert.assertEquals("DEFAULT_TENANT", deleteItemRequest.key().get(CommonValue.TENANT_ID).s());
+        Assert.assertEquals("DEFAULT_TENANT", deleteItemRequest.key().get(HASH_KEY).s());
     }
 
     @Test
@@ -447,7 +448,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         assertEquals(TEST_ID, updateRequest.id());
         assertEquals(TEST_INDEX, updateItemRequest.tableName());
         assertEquals(TEST_ID, updateItemRequest.key().get(RANGE_KEY).s());
-        assertEquals(TENANT_ID, updateItemRequest.key().get(CommonValue.TENANT_ID).s());
+        assertEquals(TENANT_ID, updateItemRequest.key().get(HASH_KEY).s());
         assertEquals("foo", updateItemRequest.expressionAttributeValues().get(":source").m().get("data").s());
 
     }
@@ -474,7 +475,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         UpdateItemRequest updateItemRequest = updateItemRequestArgumentCaptor.getValue();
         assertEquals(TEST_INDEX, updateItemRequest.tableName());
         assertEquals(TEST_ID, updateItemRequest.key().get(RANGE_KEY).s());
-        assertEquals(TENANT_ID, updateItemRequest.key().get(CommonValue.TENANT_ID).s());
+        assertEquals(TENANT_ID, updateItemRequest.key().get(HASH_KEY).s());
         assertTrue(updateItemRequest.expressionAttributeNames().containsKey("#seqNo"));
         assertTrue(updateItemRequest.expressionAttributeNames().containsKey("#source"));
         assertTrue(updateItemRequest.expressionAttributeValues().containsKey(":incr"));
@@ -498,7 +499,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
         Mockito.when(dynamoDbClient.updateItem(updateItemRequestArgumentCaptor.capture())).thenReturn(UpdateItemResponse.builder().build());
         sdkClient.updateDataObjectAsync(updateRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
         UpdateItemRequest updateItemRequest = updateItemRequestArgumentCaptor.getValue();
-        assertEquals(TENANT_ID, updateItemRequest.key().get(CommonValue.TENANT_ID).s());
+        assertEquals(TENANT_ID, updateItemRequest.key().get(HASH_KEY).s());
     }
 
     public void testUpdateDataObject_VersionCheck() throws IOException {


### PR DESCRIPTION
### Description

Since DynamoDB uses both the document id and tenant id as a combined primary key, both are necessary for the delete action; other clients only need the document ID.

Also fixes the DynamoDB client to use the HASH_KEY (`_tenant_id`) rather than TENANT_ID (`tenant_id`), a subtlety that was missed in a previous change to one but not the other.

### Check List
- [x] New functionality includes testing. (Part of #2818)
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
