### PR TITLE
Fixed the bug of sequence error during merging files

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -1705,7 +1705,9 @@ public class MLModelManager {
                 chunkFiles.put(currentChunk, new File(chunkPath.toUri()));
                 retrievedChunks.getAndIncrement();
                 if (retrievedChunks.get() == totalChunks) {
-                   Queue<File> orderedChunkFiles = chunkFiles.entrySet().stream()
+                   Queue<File> orderedChunkFiles = chunkFiles
+                           .entrySet()
+                           .stream()
                            .sorted(Map.Entry.comparingByKey())
                            .map(Map.Entry::getValue)
                            .collect(Collectors.toCollection(LinkedList::new));

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -58,11 +58,14 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -1687,7 +1690,7 @@ public class MLModelManager {
         Semaphore semaphore = new Semaphore(1);
         AtomicBoolean stopNow = new AtomicBoolean(false);
         String modelZip = mlEngine.getDeployModelZipPath(modelId, modelName);
-        ConcurrentLinkedDeque<File> chunkFiles = new ConcurrentLinkedDeque();
+        ConcurrentHashMap<Integer, File> chunkFiles = new ConcurrentHashMap<>();
         AtomicInteger retrievedChunks = new AtomicInteger(0);
         for (int i = 0; i < totalChunks; i++) {
             semaphore.tryAcquire(10, TimeUnit.SECONDS);
@@ -1699,11 +1702,15 @@ public class MLModelManager {
             this.getModel(modelChunkId, threadedActionListener(DEPLOY_THREAD_POOL, ActionListener.wrap(model -> {
                 Path chunkPath = mlEngine.getDeployModelChunkPath(modelId, currentChunk);
                 FileUtils.write(Base64.getDecoder().decode(model.getContent()), chunkPath.toString());
-                chunkFiles.add(new File(chunkPath.toUri()));
+                chunkFiles.put(currentChunk, new File(chunkPath.toUri()));
                 retrievedChunks.getAndIncrement();
                 if (retrievedChunks.get() == totalChunks) {
+                   Queue<File> orderedChunkFiles = chunkFiles.entrySet().stream()
+                           .sorted(Map.Entry.comparingByKey())
+                           .map(Map.Entry::getValue)
+                           .collect(Collectors.toCollection(LinkedList::new));
                     File modelZipFile = new File(modelZip);
-                    FileUtils.mergeFiles(chunkFiles, modelZipFile);
+                    FileUtils.mergeFiles(orderedChunkFiles, modelZipFile);
                     listener.onResponse(modelZipFile);
                 }
                 semaphore.release();

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -66,7 +66,6 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1705,12 +1704,12 @@ public class MLModelManager {
                 chunkFiles.put(currentChunk, new File(chunkPath.toUri()));
                 retrievedChunks.getAndIncrement();
                 if (retrievedChunks.get() == totalChunks) {
-                   Queue<File> orderedChunkFiles = chunkFiles
-                           .entrySet()
-                           .stream()
-                           .sorted(Map.Entry.comparingByKey())
-                           .map(Map.Entry::getValue)
-                           .collect(Collectors.toCollection(LinkedList::new));
+                    Queue<File> orderedChunkFiles = chunkFiles
+                        .entrySet()
+                        .stream()
+                        .sorted(Map.Entry.comparingByKey())
+                        .map(Map.Entry::getValue)
+                        .collect(Collectors.toCollection(LinkedList::new));
                     File modelZipFile = new File(modelZip);
                     FileUtils.mergeFiles(orderedChunkFiles, modelZipFile);
                     listener.onResponse(modelZipFile);


### PR DESCRIPTION
### Description
Ensure that model files are executed in the expected order during merging to maintain hash consistency.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
[([BUG]Model content hash can't match original hash value #2819)](https://github.com/opensearch-project/ml-commons/issues/2819)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
