### PR TITLE
Fix RestMLInferenceSearchResponseProcessorIT: add skip when aws key is null

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLInferenceSearchResponseProcessorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLInferenceSearchResponseProcessorIT.java
@@ -257,6 +257,10 @@ public class RestMLInferenceSearchResponseProcessorIT extends MLCommonsRestTestC
      * @throws Exception if any error occurs during the test
      */
     public void testMLInferenceProcessorRemoteModelStringField() throws Exception {
+        // Skip test if key is null
+        if (AWS_ACCESS_KEY_ID == null) {
+            return;
+        }
         String createPipelineRequestBody = "{\n"
             + "  \"response_processors\": [\n"
             + "    {\n"


### PR DESCRIPTION
### Description
Fix RestMLInferenceSearchResponseProcessorIT: add skip when aws key is null

### Related Issues
https://github.com/opensearch-project/ml-commons/issues/2857#issuecomment-2341768217
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
