### PR TITLE
[Feature/multi_tenancy] Implement retryOnConflict on UpdateDataObject

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/client/LocalClusterIndicesClient.java
+++ b/common/src/main/java/org/opensearch/sdk/client/LocalClusterIndicesClient.java
@@ -165,6 +165,9 @@ public class LocalClusterIndicesClient implements SdkClientDelegate {
                 if (request.ifPrimaryTerm() != null) {
                     updateRequest.setIfPrimaryTerm(request.ifPrimaryTerm());
                 }
+                if (request.retryOnConflict() > 0) {
+                    updateRequest.retryOnConflict(request.retryOnConflict());
+                }
                 UpdateResponse updateResponse = client.update(updateRequest).actionGet();
                 if (updateResponse == null) {
                     log.info("Null UpdateResponse");

--- a/common/src/test/java/org/opensearch/sdk/UpdateDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/UpdateDataObjectRequestTests.java
@@ -61,6 +61,7 @@ public class UpdateDataObjectRequestTests {
         assertEquals(testDataObject, request.dataObject());
         assertNull(request.ifSeqNo());
         assertNull(request.ifPrimaryTerm());
+        assertEquals(0, request.retryOnConflict());
     }
 
     @Test
@@ -92,6 +93,7 @@ public class UpdateDataObjectRequestTests {
             .dataObject(testDataObject)
             .ifSeqNo(testSeqNo)
             .ifPrimaryTerm(testPrimaryTerm)
+            .retryOnConflict(3)
             .build();
 
         assertEquals(testIndex, request.index());
@@ -100,6 +102,7 @@ public class UpdateDataObjectRequestTests {
         assertEquals(testDataObject, request.dataObject());
         assertEquals(testSeqNo, request.ifSeqNo());
         assertEquals(testPrimaryTerm, request.ifPrimaryTerm());
+        assertEquals(3, request.retryOnConflict());
 
         final Builder badSeqNoBuilder = UpdateDataObjectRequest.builder();
         assertThrows(IllegalArgumentException.class, () -> badSeqNoBuilder.ifSeqNo(-99));

--- a/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
@@ -301,6 +301,7 @@ public class LocalClusterIndicesClientTests {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .retryOnConflict(3)
             .dataObject(testDataObject)
             .build();
 
@@ -327,6 +328,7 @@ public class LocalClusterIndicesClientTests {
         ArgumentCaptor<UpdateRequest> requestCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
         verify(mockedClient, times(1)).update(requestCaptor.capture());
         assertEquals(TEST_INDEX, requestCaptor.getValue().index());
+        assertEquals(3, requestCaptor.getValue().retryOnConflict());
         assertEquals(TEST_ID, response.id());
 
         UpdateResponse updateActionResponse = UpdateResponse.fromXContent(response.parser());

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
@@ -175,6 +175,9 @@ public class RemoteClusterIndicesClient implements SdkClientDelegate {
                 if (request.ifPrimaryTerm() != null) {
                     updateRequestBuilder.ifPrimaryTerm(request.ifPrimaryTerm());
                 }
+                if (request.retryOnConflict() > 0) {
+                    updateRequestBuilder.retryOnConflict(request.retryOnConflict());
+                }
                 UpdateRequest<Map<String, Object>, ?> updateRequest = updateRequestBuilder.build();
                 log.info("Updating {} in {}", request.id(), request.index());
                 UpdateResponse<Map<String, Object>> updateResponse = openSearchClient.update(updateRequest, MAP_DOCTYPE);

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.ml.sdkclient;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -320,6 +321,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .join();
 
         assertEquals(TEST_INDEX, updateRequestCaptor.getValue().index());
+        assertNull(updateRequestCaptor.getValue().retryOnConflict());
         assertEquals(TEST_ID, response.id());
 
         org.opensearch.action.update.UpdateResponse updateActionResponse = org.opensearch.action.update.UpdateResponse
@@ -336,6 +338,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .retryOnConflict(3)
             .dataObject(Map.of("foo", "bar"))
             .build();
 
@@ -356,6 +359,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
         sdkClient.updateDataObjectAsync(updateRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
 
         assertEquals(TEST_INDEX, updateRequestCaptor.getValue().index());
+        assertEquals(3, updateRequestCaptor.getValue().retryOnConflict().intValue());
         assertEquals(TEST_ID, updateRequestCaptor.getValue().id());
         assertEquals("bar", ((Map<String, Object>) updateRequestCaptor.getValue().doc()).get("foo"));
     }


### PR DESCRIPTION
### Description

Implements `UpdateRequest.retryOnConflict()`
 - For local and remote OpenSearch client, simply passes through the setting
 - For DDB Client, implements the retry logic

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
