### PR TITLE
[Feature/multi_tenancy] Make tenant awareness setting static

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -19,18 +19,14 @@ import org.opensearch.ml.common.settings.SettingsChangeListener;
 
 import static org.opensearch.sdk.SdkClientUtils.unwrapAndConvertToException;
 
-public class SdkClient implements SettingsChangeListener {
+public class SdkClient {
     
     private final SdkClientDelegate delegate;
-    private volatile Boolean isMultiTenancyEnabled;
+    private final Boolean isMultiTenancyEnabled;
     
-    public SdkClient(SdkClientDelegate delegate) {
+    public SdkClient(SdkClientDelegate delegate, Boolean multiTenancy) {
         this.delegate = delegate;
-    }
-
-    @Override
-    public void onMultiTenancyEnabledChanged(boolean isEnabled) {
-        this.isMultiTenancyEnabled = isEnabled;
+        this.isMultiTenancyEnabled = multiTenancy;
     }
 
     /**

--- a/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
@@ -108,8 +108,7 @@ public class SdkClientTests {
                 return CompletableFuture.completedFuture(searchResponse);
             }
         });
-        sdkClient = new SdkClient(sdkClientImpl);
-        sdkClient.onMultiTenancyEnabledChanged(true);
+        sdkClient = new SdkClient(sdkClientImpl, true);
         testException = new OpenSearchStatusException("Test", RestStatus.BAD_REQUEST);
         interruptedException = new InterruptedException();
     }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutorTest.java
@@ -168,7 +168,7 @@ public class MLAgentExecutorTest {
         when(threadPool.executor(anyString())).thenReturn(testThreadPool.executor("opensearch_ml_general"));
 
         settings = Settings.builder().build();
-        sdkClient = new SdkClient(new LocalClusterIndicesClient(client, xContentRegistry));
+        sdkClient = new SdkClient(new LocalClusterIndicesClient(client, xContentRegistry), true);
         mlAgentExecutor = Mockito
             .spy(new MLAgentExecutor(client, sdkClient, settings, clusterService, xContentRegistry, toolFactories, memoryMap, false));
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
@@ -104,7 +104,7 @@ public class EncryptorImplTest {
         MockitoAnnotations.openMocks(this);
         masterKey = new ConcurrentHashMap<>();
         masterKey.put(DEFAULT_TENANT_ID, "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
-        sdkClient = new SdkClient(new LocalClusterIndicesClient(client, xContentRegistry));
+        sdkClient = new SdkClient(new LocalClusterIndicesClient(client, xContentRegistry), true);
 
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = invocation.getArgument(1);

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     implementation("software.amazon.awssdk:utils:2.25.40")
     // AWS OpenSearch Service dependency
     implementation("software.amazon.awssdk:apache-client:2.25.40")
-    
+
     configurations.all {
         resolutionStrategy.force 'org.apache.httpcomponents.core5:httpcore5:5.2.4'
         resolutionStrategy.force 'org.apache.httpcomponents.core5:httpcore5-h2:5.2.4'
@@ -104,7 +104,8 @@ dependencies {
 
 publishing {
     publications {
-        pluginZip(MavenPublication) { publication ->
+        pluginZip(MavenPublication) {
+            publication ->
             pom {
                 name = opensearchplugin.name
                 description = opensearchplugin.description
@@ -173,7 +174,9 @@ task integTest(type: RestIntegTestTask) {
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
 }
-tasks.named("check").configure { dependsOn(integTest) }
+tasks.named("check").configure {
+    dependsOn(integTest)
+}
 
 integTest {
     dependsOn "bundlePlugin"
@@ -245,6 +248,10 @@ testClusters.integTest {
     environment "AWS_ACCESS_KEY_ID", System.getenv("AWS_ACCESS_KEY_ID");
     environment "AWS_SECRET_ACCESS_KEY", System.getenv("AWS_SECRET_ACCESS_KEY");
     environment "AWS_SESSION_TOKEN", System.getenv("AWS_SESSION_TOKEN");
+
+    if (System.getProperty("tests.rest.tenantaware") != null) {
+        environment "plugins.ml_commons.multi_tenancy_enabled", "true"
+    }
 
     testDistribution = "ARCHIVE"
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -613,8 +613,6 @@ public class MachineLearningPlugin extends Plugin
             memoryFactoryMap,
             mlFeatureEnabledSetting.isMultiTenancyEnabled()
         );
-        // Register the sdkClient as a listener
-        mlFeatureEnabledSetting.addListener(sdkClient);
         // Register the agentExecutor as a listener
         mlFeatureEnabledSetting.addListener(agentExecutor);
 

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -357,7 +357,7 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
 
     private String getIndexName(String index) {
         // System index is not supported in remote index. Replacing '.' from index name.
-        return index.replaceAll("\\.", "");
+        return (index.length() > 1 && index.charAt(0) == '.') ? index.substring(1) : index;
     }
 
     private XContentParser createParser(String json) throws IOException {

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
@@ -231,7 +231,7 @@ public class RemoteClusterIndicesClient implements SdkClientDelegate {
     ) {
         return CompletableFuture.supplyAsync(() -> AccessController.doPrivileged((PrivilegedAction<SearchDataObjectResponse>) () -> {
             try {
-                log.info("Searching {}", Arrays.toString(request.indices()), null);
+                log.info("Searching {}", Arrays.toString(request.indices()));
                 // work around https://github.com/opensearch-project/opensearch-java/issues/1150
                 String json = SdkClientUtils
                     .lowerCaseEnumValues(
@@ -254,6 +254,8 @@ public class RemoteClusterIndicesClient implements SdkClientDelegate {
                         .filter(tenantIdFilterQuery.toQuery())
                         .build();
                     searchRequest = searchRequest.toBuilder().index(Arrays.asList(request.indices())).query(boolQuery.toQuery()).build();
+                } else {
+                    searchRequest = searchRequest.toBuilder().index(Arrays.asList(request.indices())).build();
                 }
                 SearchResponse<?> searchResponse = openSearchClient.search(searchRequest, MAP_DOCTYPE);
                 log.info("Search returned {} hits", searchResponse.hits().total().value());

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -185,6 +185,18 @@ public final class MLCommonsSettings {
     public static final Setting<Boolean> ML_COMMONS_AGENT_FRAMEWORK_ENABLED = Setting
         .boolSetting("plugins.ml_commons.agent_framework_enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
+    // Whether multi-tenancy is enabled in ML Commons.
+    // This is a static setting which must be set before starting OpenSearch by (in priority order):
+    // 1. As a command-line argument using the -E flag (overrides other options):
+    // ./bin/opensearch -Eplugins.ml_commons.multi_tenancy_enabled=true
+    // 2. As a system property using OPENSEARCH_JAVA_OPTS (overrides opensearch.yml):
+    // export OPENSEARCH_JAVA_OPTS="-Dplugins.ml_commons.multi_tenancy_enabled=true"
+    // ./bin/opensearch
+    // Or inline when starting OpenSearch:
+    // OPENSEARCH_JAVA_OPTS="-Dplugins.ml_commons.multi_tenancy_enabled=true" ./bin/opensearch
+    // 3. In the opensearch.yml configuration file:
+    // plugins.ml_commons.multi_tenancy_enabled: true
+    // After setting it, a full cluster restart is required for the changes to take effect.
     public static final Setting<Boolean> ML_COMMONS_MULTI_TENANCY_ENABLED = Setting
-        .boolSetting("plugins.ml_commons.multi_tenancy_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .boolSetting("plugins.ml_commons.multi_tenancy_enabled", false, Setting.Property.NodeScope);
 }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLFeatureEnabledSetting.java
@@ -46,10 +46,6 @@ public class MLFeatureEnabledSetting {
             .getClusterSettings()
             .addSettingsUpdateConsumer(ML_COMMONS_AGENT_FRAMEWORK_ENABLED, it -> isAgentFrameworkEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_LOCAL_MODEL_ENABLED, it -> isLocalModelEnabled = it);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_MULTI_TENANCY_ENABLED, it -> {
-            isMultiTenancyEnabled = it;
-            notifyMultiTenancyListeners(it);
-        });
     }
 
     /**

--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -176,16 +176,6 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
         response = TestHelper
             .makeRequest(client(), "PUT", "_cluster/settings", ImmutableMap.of(), TestHelper.toHttpEntity(jsonEntity), null);
         assertEquals(200, response.getStatusLine().getStatusCode());
-
-        String multiTenancyEntity = "{\n"
-            + "  \"persistent\" : {\n"
-            + "    \"plugins.ml_commons.multi_tenancy_enabled\" : false \n"
-            + "  }\n"
-            + "}";
-
-        response = TestHelper
-            .makeRequest(client(), "PUT", "_cluster/settings", ImmutableMap.of(), TestHelper.toHttpEntity(multiTenancyEntity), null);
-        assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
     @Override

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -129,8 +129,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
     public void setup() {
         MockitoAnnotations.openMocks(this);
 
-        sdkClient = SdkClientFactory.wrapSdkClientDelegate(new DDBOpenSearchClient(dynamoDbClient, remoteClusterIndicesClient));
-        sdkClient.onMultiTenancyEnabledChanged(true);
+        sdkClient = SdkClientFactory.wrapSdkClientDelegate(new DDBOpenSearchClient(dynamoDbClient, remoteClusterIndicesClient), true);
         testDataObject = new TestDataObject("foo");
     }
 


### PR DESCRIPTION
### Description

Removes the ability to change the value of the mutiTenancy setting: it must be initialized in `opensearch.yml`.

Two other small changes:
 - When multiTenancy was false (which is was while I was figuring out how to set it), Remote client search didn't include the index name, thus returning every document in the cluster/collection.
 - improved performance of removing the dot from a system index name from a match-all regex to substring, since I briefly thought this could be a problem when debugging the bug above

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
