### PR TITLE
Filter out remote model auto redeployment

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/autoredeploy/MLModelAutoReDeployer.java
+++ b/plugin/src/main/java/org/opensearch/ml/autoredeploy/MLModelAutoReDeployer.java
@@ -260,19 +260,16 @@ public class MLModelAutoReDeployer {
         String modelId = modelAutoRedeployArrangement.getSearchResponse().getId();
         List<String> addedNodes = modelAutoRedeployArrangement.getAddedNodes();
         Map<String, Object> sourceAsMap = modelAutoRedeployArrangement.getSearchResponse().getSourceAsMap();
-        String functionName = (String) Optional.ofNullable(sourceAsMap.get(MLModel.FUNCTION_NAME_FIELD))
+        String functionName = (String) Optional
+            .ofNullable(sourceAsMap.get(MLModel.FUNCTION_NAME_FIELD))
             .orElse(sourceAsMap.get(MLModel.ALGORITHM_FIELD));
         if (FunctionName.REMOTE == FunctionName.from(functionName)) {
             log.info("Skipping redeploying remote model {} as remote model deployment can be done at prediction time.", modelId);
             return;
         }
-        List<String> planningWorkerNodes = (List<String>) sourceAsMap
-            .get(MLModel.PLANNING_WORKER_NODES_FIELD);
-        Integer autoRedeployRetryTimes = (Integer) sourceAsMap
-            .get(MLModel.AUTO_REDEPLOY_RETRY_TIMES_FIELD);
-        Boolean deployToAllNodes = (Boolean) Optional
-            .ofNullable(sourceAsMap.get(MLModel.DEPLOY_TO_ALL_NODES_FIELD))
-            .orElse(false);
+        List<String> planningWorkerNodes = (List<String>) sourceAsMap.get(MLModel.PLANNING_WORKER_NODES_FIELD);
+        Integer autoRedeployRetryTimes = (Integer) sourceAsMap.get(MLModel.AUTO_REDEPLOY_RETRY_TIMES_FIELD);
+        Boolean deployToAllNodes = (Boolean) Optional.ofNullable(sourceAsMap.get(MLModel.DEPLOY_TO_ALL_NODES_FIELD)).orElse(false);
         // calculate node ids.
         String[] nodeIds = null;
         if (deployToAllNodes || !allowCustomDeploymentPlan) {

--- a/plugin/src/main/java/org/opensearch/ml/autoredeploy/MLModelAutoReDeployer.java
+++ b/plugin/src/main/java/org/opensearch/ml/autoredeploy/MLModelAutoReDeployer.java
@@ -12,6 +12,7 @@ import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -30,6 +31,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.common.transport.deploy.MLDeployModelAction;
@@ -257,16 +259,19 @@ public class MLModelAutoReDeployer {
     private void triggerModelRedeploy(ModelAutoRedeployArrangement modelAutoRedeployArrangement) {
         String modelId = modelAutoRedeployArrangement.getSearchResponse().getId();
         List<String> addedNodes = modelAutoRedeployArrangement.getAddedNodes();
-        List<String> planningWorkerNodes = (List<String>) modelAutoRedeployArrangement
-            .getSearchResponse()
-            .getSourceAsMap()
+        Map<String, Object> sourceAsMap = modelAutoRedeployArrangement.getSearchResponse().getSourceAsMap();
+        String functionName = (String) Optional.ofNullable(sourceAsMap.get(MLModel.FUNCTION_NAME_FIELD))
+            .orElse(sourceAsMap.get(MLModel.ALGORITHM_FIELD));
+        if (FunctionName.REMOTE == FunctionName.from(functionName)) {
+            log.info("Skipping redeploying remote model {} as remote model deployment can be done at prediction time.", modelId);
+            return;
+        }
+        List<String> planningWorkerNodes = (List<String>) sourceAsMap
             .get(MLModel.PLANNING_WORKER_NODES_FIELD);
-        Integer autoRedeployRetryTimes = (Integer) modelAutoRedeployArrangement
-            .getSearchResponse()
-            .getSourceAsMap()
+        Integer autoRedeployRetryTimes = (Integer) sourceAsMap
             .get(MLModel.AUTO_REDEPLOY_RETRY_TIMES_FIELD);
         Boolean deployToAllNodes = (Boolean) Optional
-            .ofNullable(modelAutoRedeployArrangement.getSearchResponse().getSourceAsMap().get(MLModel.DEPLOY_TO_ALL_NODES_FIELD))
+            .ofNullable(sourceAsMap.get(MLModel.DEPLOY_TO_ALL_NODES_FIELD))
             .orElse(false);
         // calculate node ids.
         String[] nodeIds = null;

--- a/plugin/src/test/resources/org/opensearch/ml/autoredeploy/RemoteModelResult.json
+++ b/plugin/src/test/resources/org/opensearch/ml/autoredeploy/RemoteModelResult.json
@@ -1,0 +1,20 @@
+{
+  "last_deployed_time": 1722954415807,
+  "model_version": "619",
+  "created_time": 1722954415642,
+  "deploy_to_all_nodes": true,
+  "is_hidden": false,
+  "description": "This is a test model",
+  "model_state": "DEPLOYED",
+  "planning_worker_node_count": 1,
+  "auto_redeploy_retry_times": 0,
+  "last_updated_time": 1723691017054,
+  "name": "my sagemaker model",
+  "connector_id": "z3kVKJEBAfFjoGUT_Ui7",
+  "current_worker_node_count": 0,
+  "model_group_id": "MiJPJ5EBQM-QzppeWrTJ",
+  "planning_worker_nodes": [
+    "DecGG5pDQYaqelLMLcIV9Q"
+  ],
+  "algorithm": "REMOTE"
+}


### PR DESCRIPTION
### Description
Currently, ml-commons supports remote model auto deployment when first prediction request comes, so in MLModelAutoRedeplyer remote model auto redeployment can be  filtered out.

### Related Issues
NA

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
