### PR TITLE
[ML Inference Search Processors] Always return list when using dollar symbol in input_maps

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -54,10 +54,6 @@ import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchResponseProcessor;
 
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
-
 public class MLInferenceSearchResponseProcessor extends AbstractProcessor implements SearchResponseProcessor, ModelExecutor {
 
     private final NamedXContentRegistry xContentRegistry;
@@ -350,13 +346,7 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                         String modelInputFieldName = entry.getKey();
                         String documentFieldName = entry.getValue();
 
-                        Object documentJson = JsonPath.parse(document).read("$");
-                        Configuration configuration = Configuration
-                            .builder()
-                            .options(Option.SUPPRESS_EXCEPTIONS, Option.DEFAULT_PATH_LEAF_TO_NULL)
-                            .build();
-
-                        Object documentValue = JsonPath.using(configuration).parse(documentJson).read(documentFieldName);
+                        Object documentValue = getMappedInputFromObject(document, documentFieldName);
                         if (documentValue != null) {
                             // when not existed in the map, add into the modelInputParameters map
                             updateModelInputParameters(modelInputParameters, modelInputFieldName, documentValue);
@@ -428,6 +418,7 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
      * simply put the document value in the map
      * If the setting is many-to-one,
      * create a new list and add the document value
+     *
      * @param modelInputParameters The map containing the model input parameters.
      * @param modelInputFieldName The name of the model input field.
      * @param documentValue The value from the document that needs to be added to the model input parameters.


### PR DESCRIPTION
### Description
fixing https://github.com/opensearch-project/ml-commons/issues/2974

by adding a helpful method `getMappedInputFromObject` when reading search query/ search response _source document, 

     * Retrieves the mapped input value from the object based on the provided field name.
     * when the field name start with a dollar symbol, which starts all path expressions in JSONPATH notation,
     * default to always return lists
     * otherwise, return the original format of elements retrieving from the fieldName
     

For example, 

in search processors:

for the same item index, if configuring input_map as` {"input": "$.item.text"}`,

the model input will be in list representation.

```
{
  "input": ["red shoes"]
}
```

for the same item index, if configuring input_map as `{"input": "item.text"}`,

the model input will be in list representation.

```
{
  "input": "red shoes"
}

```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
