### PR TITLE
Prevents Locale Code build failures #2967

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -65,7 +65,7 @@ jobs:
                                export COHERE_KEY=`aws secretsmanager get-secret-value --secret-id github_cohere_key --query SecretString --output text` &&
                                echo "::add-mask::$OPENAI_KEY" &&
                                echo "::add-mask::$COHERE_KEY" &&
-                               echo "build and run tests" && ./gradlew build -Dtests.locale=en-US &&
+                               echo "build and run tests" && ./gradlew build &&
                                echo "Publish to Maven Local" && ./gradlew publishToMavenLocal &&
                                echo "Multi Nodes Integration Testing" && ./gradlew integTest -PnumNodes=3'
           plugin=`basename $(ls plugin/build/distributions/*.zip)`

--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -65,7 +65,7 @@ jobs:
                                export COHERE_KEY=`aws secretsmanager get-secret-value --secret-id github_cohere_key --query SecretString --output text` &&
                                echo "::add-mask::$OPENAI_KEY" &&
                                echo "::add-mask::$COHERE_KEY" &&
-                               echo "build and run tests" && ./gradlew build &&
+                               echo "build and run tests" && ./gradlew build -Dtests.locale=en-US &&
                                echo "Publish to Maven Local" && ./gradlew publishToMavenLocal &&
                                echo "Multi Nodes Integration Testing" && ./gradlew integTest -PnumNodes=3'
           plugin=`basename $(ls plugin/build/distributions/*.zip)`

--- a/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
@@ -208,7 +208,7 @@ public class ConnectorAction implements ToXContentObject, Writeable {
 
         public static boolean isValidAction(String action) {
             try {
-                ActionType.valueOf(action.toUpperCase());
+                ActionType.valueOf(action.toUpperCase(Locale.ROOT));
                 return true;
             } catch (IllegalArgumentException e) {
                 return false;

--- a/common/src/main/java/org/opensearch/ml/common/input/parameter/clustering/RCFSummarizeParams.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/parameter/clustering/RCFSummarizeParams.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.input.parameter.clustering;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
+import java.util.Locale;
 
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -97,7 +98,7 @@ public class RCFSummarizeParams implements MLAlgoParams {
                     parallel = parser.booleanValue();
                     break;
                 case DISTANCE_TYPE_FIELD:
-                    distanceType = DistanceType.from(parser.text().toUpperCase());
+                    distanceType = DistanceType.from(parser.text().toUpperCase(Locale.ROOT));
                     break;
                 default:
                     parser.skipChildren();

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
@@ -13,6 +13,7 @@ import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.opensearch.ResourceNotFoundException;
@@ -281,7 +282,7 @@ public class MLAgentExecutor implements Executable {
 
     @VisibleForTesting
     protected MLAgentRunner getAgentRunner(MLAgent mlAgent) {
-        final MLAgentType agentType = MLAgentType.from(mlAgent.getType().toUpperCase());
+        final MLAgentType agentType = MLAgentType.from(mlAgent.getType().toUpperCase(Locale.ROOT));
         switch (agentType) {
             case FLOW:
                 return new MLFlowAgentRunner(client, settings, clusterService, xContentRegistry, toolFactories, memoryFactoryMap);

--- a/plugin/src/main/java/org/opensearch/ml/action/batch/TransportBatchIngestionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/batch/TransportBatchIngestionAction.java
@@ -14,6 +14,7 @@ import static org.opensearch.ml.task.MLTaskManager.TASK_SEMAPHORE_TIMEOUT;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -93,7 +94,7 @@ public class TransportBatchIngestionAction extends HandledTransportAction<Action
                     mlTaskManager.add(mlTask);
                     listener.onResponse(new MLBatchIngestionResponse(taskId, MLTaskType.BATCH_INGEST, MLTaskState.CREATED.name()));
                     String ingestType = (String) mlBatchIngestionInput.getDataSources().get(TYPE);
-                    Ingestable ingestable = MLEngineClassLoader.initInstance(ingestType.toLowerCase(), client, Client.class);
+                    Ingestable ingestable = MLEngineClassLoader.initInstance(ingestType.toLowerCase(Locale.ROOT), client, Client.class);
                     threadPool.executor(INGEST_THREAD_POOL).execute(() -> {
                         executeWithErrorHandling(() -> {
                             double successRate = ingestable.ingest(mlBatchIngestionInput);
@@ -185,7 +186,7 @@ public class TransportBatchIngestionAction extends HandledTransportAction<Action
         if (dataSources.get(TYPE) == null || dataSources.get(SOURCE) == null) {
             throw new IllegalArgumentException("The batch ingest input data source is missing data type or source");
         }
-        if (((String) dataSources.get(TYPE)).toLowerCase() == "s3") {
+        if (((String) dataSources.get(TYPE)).equalsIgnoreCase("s3")) {
             List<String> s3Uris = (List<String>) dataSources.get(SOURCE);
             if (s3Uris == null || s3Uris.isEmpty()) {
                 throw new IllegalArgumentException("The batch ingest input s3Uris is empty");

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
@@ -129,7 +129,8 @@ public class RestMLPredictionAction extends BaseRestHandler {
         ActionType actionType = ActionType.from(getActionTypeFromRestRequest(request));
         if (FunctionName.REMOTE.name().equals(algorithm) && !mlFeatureEnabledSetting.isRemoteInferenceEnabled()) {
             throw new IllegalStateException(REMOTE_INFERENCE_DISABLED_ERR_MSG);
-        } else if (FunctionName.isDLModel(FunctionName.from(algorithm.toUpperCase())) && !mlFeatureEnabledSetting.isLocalModelEnabled()) {
+        } else if (FunctionName.isDLModel(FunctionName.from(algorithm.toUpperCase(Locale.ROOT)))
+            && !mlFeatureEnabledSetting.isLocalModelEnabled()) {
             throw new IllegalStateException(LOCAL_MODEL_DISABLED_ERR_MSG);
         } else if (!ActionType.isValidActionInModelPrediction(actionType)) {
             throw new IllegalArgumentException("Wrong action type in the rest request path!");


### PR DESCRIPTION

### Description
Depending on the GitHub CI workflow executes it will invoke ./gradlew build which will run tests on random parameters every time, there are locale-code's that will break a build one of them being **az-Cyrl**. The solution was to update the codebase that involved string operations such as `toUpperCase(), toLowerCase()` to `toUpperCase(Locale.Root), toLowerCase(Locale.Root)` In doing this we make the string operations language agnostic meaning it wont be affected on a computer that is set to a different language like Spanish or Turkish.  

#### Testing
- `./gradlew build -DTests.Locale=az-Cyrl` which previously failed now works
- `./gradlew build` builds successfully too.

**TLDR:**
- The change was to update String operations to use `Locale.Root` as a argument to avoid default Locale (which may depend on one that is not supported) you can see this [here](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html#getDefault--) . 

### Related Issues
Resolves #2967

### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
