### PR TITLE
build is failing if the aws credentials aren't in the system

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -242,9 +242,16 @@ integTest {
 
 testClusters.integTest {
     // Replicate credential environment variables to cluster nodes    
-    environment "AWS_ACCESS_KEY_ID", System.getenv("AWS_ACCESS_KEY_ID");
-    environment "AWS_SECRET_ACCESS_KEY", System.getenv("AWS_SECRET_ACCESS_KEY");
-    environment "AWS_SESSION_TOKEN", System.getenv("AWS_SESSION_TOKEN");
+    // Set environment variables only if they are present
+    if (System.getenv("AWS_ACCESS_KEY_ID") != null) {
+        environment "AWS_ACCESS_KEY_ID", System.getenv("AWS_ACCESS_KEY_ID")
+    }
+    if (System.getenv("AWS_SECRET_ACCESS_KEY") != null) {
+        environment "AWS_SECRET_ACCESS_KEY", System.getenv("AWS_SECRET_ACCESS_KEY")
+    }
+    if (System.getenv("AWS_SESSION_TOKEN") != null) {
+        environment "AWS_SESSION_TOKEN", System.getenv("AWS_SESSION_TOKEN")
+    }
 
     testDistribution = "ARCHIVE"
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1


### PR DESCRIPTION
### Description
[build is failing if the aws credentials aren't in the system]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
