### PR TITLE
Support index.auto_expand_replicas 0-all for .plugins-ml-config

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -69,7 +69,7 @@ public class CommonValue {
     public static final Integer ML_TASK_INDEX_SCHEMA_VERSION = 3;
     public static final Integer ML_CONNECTOR_SCHEMA_VERSION = 3;
     public static final String ML_CONFIG_INDEX = ".plugins-ml-config";
-    public static final Integer ML_CONFIG_INDEX_SCHEMA_VERSION = 3;
+    public static final Integer ML_CONFIG_INDEX_SCHEMA_VERSION = 4;
     public static final String ML_CONTROLLER_INDEX = ".plugins-ml-controller";
     public static final Integer ML_CONTROLLER_INDEX_SCHEMA_VERSION = 1;
     public static final String ML_MAP_RESPONSE_KEY = "response";

--- a/common/src/main/java/org/opensearch/ml/common/utils/IndexUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/IndexUtils.java
@@ -12,9 +12,24 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class IndexUtils {
 
-    // This setting is for index creation.
-    public static final Map<String, Object> INDEX_SETTINGS = Map.of("index.number_of_shards", "1", "index.auto_expand_replicas", "0-1");
+    /**
+     * Default settings for index creation with a single shard and one replica.
+     * - Sets the number of shards to 1 for better performance in small indices.
+     * - Uses auto-expand replicas (0-1) to ensure high availability while minimizing resource usage.
+     */
+    public static final Map<String, Object> DEFAULT_INDEX_SETTINGS = Map
+        .of("index.number_of_shards", "1", "index.auto_expand_replicas", "0-1");
+    /**
+     * Default settings for index creation with replicas on all nodes.
+     * - Sets the number of shards to 1 for better performance in small indices.
+     * - Uses auto-expand replicas (0-all) to ensure a replica on every node, maximizing availability.
+     * - Caution: This can significantly increase storage requirements and indexing load.
+     * - Suitable for small, critical indices where maximum redundancy is required.
+     */
+    public static final Map<String, Object> ALL_NODES_REPLICA_INDEX_SETTINGS = Map
+        .of("index.number_of_shards", "1", "index.auto_expand_replicas", "0-all");
 
-    // This setting is for index update only, so only dynamic settings should be contained!
-    public static final Map<String, Object> UPDATED_INDEX_SETTINGS = Map.of("index.auto_expand_replicas", "0-1");
+    // Note: This does not include static settings like number of shards, which can't be changed after index creation.
+    public static final Map<String, Object> UPDATED_DEFAULT_INDEX_SETTINGS = Map.of("index.auto_expand_replicas", "0-1");
+    public static final Map<String, Object> UPDATED_ALL_NODES_REPLICA_INDEX_SETTINGS = Map.of("index.auto_expand_replicas", "0-all");
 }

--- a/common/src/test/java/org/opensearch/ml/common/utils/IndexUtilsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/IndexUtilsTest.java
@@ -14,18 +14,32 @@ import org.junit.Test;
 public class IndexUtilsTest {
 
     @Test
-    public void testIndexSettingsContainsExpectedValues() {
-        Map<String, Object> indexSettings = IndexUtils.INDEX_SETTINGS;
+    public void testDefaultIndexSettingsContainsExpectedValues() {
+        Map<String, Object> indexSettings = IndexUtils.DEFAULT_INDEX_SETTINGS;
         assertEquals("index.number_of_shards should be 1", indexSettings.get("index.number_of_shards"), "1");
         assertEquals("index.auto_expand_replicas should be 0-1", indexSettings.get("index.auto_expand_replicas"), "0-1");
         assertEquals("INDEX_SETTINGS should contain exactly 2 settings", 2, indexSettings.size());
     }
 
     @Test
-    public void testUpdatedIndexSettingsContainsExpectedValues() {
-        Map<String, Object> updatedIndexSettings = IndexUtils.UPDATED_INDEX_SETTINGS;
+    public void testAllNodesReplicaIndexSettingsContainsExpectedValues() {
+        Map<String, Object> indexSettings = IndexUtils.ALL_NODES_REPLICA_INDEX_SETTINGS;
+        assertEquals("index.number_of_shards should be 1", indexSettings.get("index.number_of_shards"), "1");
+        assertEquals("index.auto_expand_replicas should be 0-all", indexSettings.get("index.auto_expand_replicas"), "0-all");
+        assertEquals("INDEX_SETTINGS should contain exactly 2 settings", 2, indexSettings.size());
+    }
+
+    @Test
+    public void testUpdatedDefaultIndexSettingsContainsExpectedValues() {
+        Map<String, Object> updatedIndexSettings = IndexUtils.UPDATED_DEFAULT_INDEX_SETTINGS;
         assertEquals("index.auto_expand_replicas should be 0-1", updatedIndexSettings.get("index.auto_expand_replicas"), "0-1");
         assertEquals("INDEX_SETTINGS should contain exactly 1 settings", 1, updatedIndexSettings.size());
     }
 
+    @Test
+    public void testUpdatedAllNodesReplicaIndexSettingsContainsExpectedValues() {
+        Map<String, Object> updatedIndexSettings = IndexUtils.UPDATED_ALL_NODES_REPLICA_INDEX_SETTINGS;
+        assertEquals("index.auto_expand_replicas should be 0-all", updatedIndexSettings.get("index.auto_expand_replicas"), "0-all");
+        assertEquals("INDEX_SETTINGS should contain exactly 1 settings", 1, updatedIndexSettings.size());
+    }
 }

--- a/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/ConversationMetaIndex.java
@@ -18,7 +18,7 @@
 package org.opensearch.ml.memory.index;
 
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.META_INDEX_NAME;
-import static org.opensearch.ml.common.utils.IndexUtils.INDEX_SETTINGS;
+import static org.opensearch.ml.common.utils.IndexUtils.DEFAULT_INDEX_SETTINGS;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -90,7 +90,7 @@ public class ConversationMetaIndex {
             CreateIndexRequest request = Requests
                 .createIndexRequest(META_INDEX_NAME)
                 .mapping(ConversationalIndexConstants.META_MAPPING, XContentType.JSON)
-                .settings(INDEX_SETTINGS);
+                .settings(DEFAULT_INDEX_SETTINGS);
             try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
                 ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());
                 ActionListener<CreateIndexResponse> al = ActionListener.wrap(createIndexResponse -> {

--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -18,7 +18,7 @@
 package org.opensearch.ml.memory.index;
 
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_INDEX_NAME;
-import static org.opensearch.ml.common.utils.IndexUtils.INDEX_SETTINGS;
+import static org.opensearch.ml.common.utils.IndexUtils.DEFAULT_INDEX_SETTINGS;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -93,7 +93,7 @@ public class InteractionsIndex {
             CreateIndexRequest request = Requests
                 .createIndexRequest(INTERACTIONS_INDEX_NAME)
                 .mapping(ConversationalIndexConstants.INTERACTIONS_MAPPINGS, XContentType.JSON)
-                .settings(INDEX_SETTINGS);
+                .settings(DEFAULT_INDEX_SETTINGS);
             try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
                 ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());
                 ActionListener<CreateIndexResponse> al = ActionListener.wrap(r -> {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
@@ -7,8 +7,10 @@ package org.opensearch.ml.engine.indices;
 
 import static org.opensearch.ml.common.CommonValue.META;
 import static org.opensearch.ml.common.CommonValue.SCHEMA_VERSION_FIELD;
-import static org.opensearch.ml.common.utils.IndexUtils.INDEX_SETTINGS;
-import static org.opensearch.ml.common.utils.IndexUtils.UPDATED_INDEX_SETTINGS;
+import static org.opensearch.ml.common.utils.IndexUtils.ALL_NODES_REPLICA_INDEX_SETTINGS;
+import static org.opensearch.ml.common.utils.IndexUtils.DEFAULT_INDEX_SETTINGS;
+import static org.opensearch.ml.common.utils.IndexUtils.UPDATED_ALL_NODES_REPLICA_INDEX_SETTINGS;
+import static org.opensearch.ml.common.utils.IndexUtils.UPDATED_DEFAULT_INDEX_SETTINGS;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -108,7 +110,9 @@ public class MLIndicesHandler {
                         internalListener.onFailure(e);
                     }
                 });
-                CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping, XContentType.JSON).settings(INDEX_SETTINGS);
+                CreateIndexRequest request = new CreateIndexRequest(indexName)
+                    .mapping(mapping, XContentType.JSON)
+                    .settings(indexName.equals(MLIndex.CONFIG.getIndexName()) ? ALL_NODES_REPLICA_INDEX_SETTINGS : DEFAULT_INDEX_SETTINGS);
                 client.admin().indices().create(request, actionListener);
             } else {
                 log.debug("index:{} is already created", indexName);
@@ -124,7 +128,13 @@ public class MLIndicesHandler {
                                     ActionListener.wrap(response -> {
                                         if (response.isAcknowledged()) {
                                             UpdateSettingsRequest updateSettingRequest = new UpdateSettingsRequest();
-                                            updateSettingRequest.indices(indexName).settings(UPDATED_INDEX_SETTINGS);
+                                            updateSettingRequest
+                                                .indices(indexName)
+                                                .settings(
+                                                    indexName.equals(MLIndex.CONFIG.getIndexName())
+                                                        ? UPDATED_ALL_NODES_REPLICA_INDEX_SETTINGS
+                                                        : UPDATED_DEFAULT_INDEX_SETTINGS
+                                                );
                                             client
                                                 .admin()
                                                 .indices()


### PR DESCRIPTION
### Description
Support for `.plugins-ml-config` to be available on all nodes, maximizing availability. This is because config index are small but critical.

### Related Issues
Resolves #3002

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
