### PR TITLE
[Backport 2.x] populate time fields for connectors on return (#2922)

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/AbstractConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/AbstractConnector.java
@@ -65,7 +65,9 @@ public abstract class AbstractConnector implements Connector {
     protected User owner;
     @Setter
     protected AccessMode access;
+    @Setter
     protected Instant createdTime;
+    @Setter
     protected Instant lastUpdateTime;
     @Setter
     protected ConnectorClientConfig connectorClientConfig;

--- a/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -43,6 +44,10 @@ public interface Connector extends ToXContentObject, Writeable {
     String getName();
 
     String getProtocol();
+
+    void setCreatedTime(Instant createdTime);
+
+    void setLastUpdateTime(Instant lastUpdateTime);
 
     User getOwner();
 

--- a/common/src/test/java/org/opensearch/ml/common/RemoteModelTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/RemoteModelTests.java
@@ -61,22 +61,22 @@ public class RemoteModelTests {
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         mlModel.toXContent(builder, EMPTY_PARAMS);
         String mlModelContent = TestHelper.xContentBuilderToString(builder);
-        assertEquals(
-            "{\"name\":\"test_model_name\",\"model_group_id\":\"test_group_id\","
-                + "\"algorithm\":\"REMOTE\",\"model_version\":\"1.0.0\",\"description\":\"test model\","
-                + "\"connector\":{\"name\":\"test_connector_name\",\"version\":\"1\","
-                + "\"description\":\"this is a test connector\",\"protocol\":\"http\","
-                + "\"parameters\":{\"input\":\"test input value\"},\"credential\":{\"key\":\"test_key_value\"},"
-                + "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\","
-                + "\"headers\":{\"api_key\":\"${credential.key}\"},"
-                + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
-                + "\"pre_process_function\":\"connector.pre_process.openai.embedding\","
-                + "\"post_process_function\":\"connector.post_process.openai.embedding\"}],"
-                + "\"backend_roles\":[\"role1\",\"role2\"],\"access\":\"public\","
-                + "\"client_config\":{\"max_connection\":30,\"connection_timeout\":30000,\"read_timeout\":30000,"
-                + "\"retry_backoff_millis\":10,\"retry_timeout_seconds\":10,\"max_retry_times\":-1,\"retry_backoff_policy\":\"constant\"}}}",
-            mlModelContent
-        );
+
+        String expectedConnectorResponse = "{\"name\":\"test_model_name\",\"model_group_id\":\"test_group_id\","
+            + "\"algorithm\":\"REMOTE\",\"model_version\":\"1.0.0\",\"description\":\"test model\","
+            + "\"connector\":{\"name\":\"test_connector_name\",\"version\":\"1\","
+            + "\"description\":\"this is a test connector\",\"protocol\":\"http\","
+            + "\"parameters\":{\"input\":\"test input value\"},\"credential\":{\"key\":\"test_key_value\"},"
+            + "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\","
+            + "\"headers\":{\"api_key\":\"${credential.key}\"},"
+            + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
+            + "\"pre_process_function\":\"connector.pre_process.openai.embedding\","
+            + "\"post_process_function\":\"connector.post_process.openai.embedding\"}],"
+            + "\"backend_roles\":[\"role1\",\"role2\"],\"access\":\"public\","
+            + "\"client_config\":{\"max_connection\":30,\"connection_timeout\":30000,\"read_timeout\":30000,"
+            + "\"retry_backoff_millis\":10,\"retry_timeout_seconds\":10,\"max_retry_times\":-1,\"retry_backoff_policy\":\"constant\"}}}";
+
+        assertEquals(expectedConnectorResponse, mlModelContent);
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -85,12 +85,12 @@ public class HttpConnectorTest {
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         connector.toXContent(builder, ToXContent.EMPTY_PARAMS);
         String content = TestHelper.xContentBuilderToString(builder);
+
         Assert.assertEquals(TEST_CONNECTOR_JSON_STRING, content);
     }
 
     @Test
     public void constructor_Parser() throws IOException {
-
         XContentParser parser = XContentType.JSON
             .xContent()
             .createParser(

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLConnectorGetResponseTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLConnectorGetResponseTests.java
@@ -58,21 +58,21 @@ public class MLConnectorGetResponseTests {
         mlConnectorGetResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertNotNull(builder);
         String jsonStr = builder.toString();
-        assertEquals(
-            "{\"name\":\"test_connector_name\",\"version\":\"1\","
-                + "\"description\":\"this is a test connector\",\"protocol\":\"http\","
-                + "\"parameters\":{\"input\":\"test input value\"},\"credential\":{\"key\":\"test_key_value\"},"
-                + "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\","
-                + "\"headers\":{\"api_key\":\"${credential.key}\"},"
-                + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
-                + "\"pre_process_function\":\"connector.pre_process.openai.embedding\","
-                + "\"post_process_function\":\"connector.post_process.openai.embedding\"}],"
-                + "\"backend_roles\":[\"role1\",\"role2\"],\"access\":\"public\","
-                + "\"client_config\":{\"max_connection\":30,"
-                + "\"connection_timeout\":30000,\"read_timeout\":30000,"
-                + "\"retry_backoff_millis\":10,\"retry_timeout_seconds\":10,\"max_retry_times\":-1,\"retry_backoff_policy\":\"constant\"}}",
-            jsonStr
-        );
+
+        String expectedControllerResponse = "{\"name\":\"test_connector_name\",\"version\":\"1\","
+            + "\"description\":\"this is a test connector\",\"protocol\":\"http\","
+            + "\"parameters\":{\"input\":\"test input value\"},\"credential\":{\"key\":\"test_key_value\"},"
+            + "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\","
+            + "\"headers\":{\"api_key\":\"${credential.key}\"},"
+            + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
+            + "\"pre_process_function\":\"connector.pre_process.openai.embedding\","
+            + "\"post_process_function\":\"connector.post_process.openai.embedding\"}],"
+            + "\"backend_roles\":[\"role1\",\"role2\"],\"access\":\"public\","
+            + "\"client_config\":{\"max_connection\":30,"
+            + "\"connection_timeout\":30000,\"read_timeout\":30000,"
+            + "\"retry_backoff_millis\":10,\"retry_timeout_seconds\":10,\"max_retry_times\":-1,\"retry_backoff_policy\":\"constant\"}}";
+
+        assertEquals(expectedControllerResponse, jsonStr);
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/model/MLUpdateModelInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/model/MLUpdateModelInputTest.java
@@ -64,8 +64,8 @@ public class MLUpdateModelInputTest {
             + "{\"name\":\"test\",\"version\":\"1\",\"protocol\":\"http\",\"parameters\":{\"param1\":\"value1\"},\"credential\":"
             + "{\"api_key\":\"credential_value\"},\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":"
             + "\"https://api.openai.com/v1/chat/completions\",\"headers\":{\"Authorization\":\"Bearer ${credential.api_key}\"},\"request_body\":"
-            + "\"{ \\\"model\\\": \\\"${parameters.model}\\\", \\\"messages\\\": ${parameters.messages} }\"}]},\"connector_id\":"
-            + "\"test-connector_id\",\"last_updated_time\":1}";
+            + "\"{ \\\"model\\\": \\\"${parameters.model}\\\", \\\"messages\\\": ${parameters.messages} }\"}]},"
+            + "\"connector_id\":\"test-connector_id\",\"last_updated_time\":1}";
 
     private final String expectedOutputStr = "{\"model_id\":null,\"name\":\"name\",\"description\":\"description\",\"model_group_id\":"
         + "\"modelGroupId\",\"is_enabled\":false,\"rate_limiter\":"
@@ -152,6 +152,7 @@ public class MLUpdateModelInputTest {
     @Test
     public void testToXContent() throws Exception {
         String jsonStr = serializationWithToXContent(updateModelInput);
+
         assertEquals(expectedOutputStrForUpdateRequestDoc, jsonStr);
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.action.connector;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
 
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 
@@ -133,6 +134,10 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
                     MLCreateConnectorResponse response = new MLCreateConnectorResponse(r.getId());
                     listener.onResponse(response);
                 }, listener::onFailure);
+
+                Instant currentTime = Instant.now();
+                connector.setCreatedTime(currentTime);
+                connector.setLastUpdateTime(currentTime);
 
                 IndexRequest indexRequest = new IndexRequest(ML_CONNECTOR_INDEX);
                 indexRequest.source(connector.toXContent(XContentBuilder.builder(XContentType.JSON.xContent()), ToXContent.EMPTY_PARAMS));

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
@@ -9,6 +9,7 @@ import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -93,6 +94,9 @@ public class UpdateConnectorTransportAction extends HandledTransportAction<Actio
                 if (Boolean.TRUE.equals(hasPermission)) {
                     connector.update(mlUpdateConnectorAction.getUpdateContent(), mlEngine::encrypt);
                     connector.validateConnectorURL(trustedConnectorEndpointsRegex);
+
+                    connector.setLastUpdateTime(Instant.now());
+
                     UpdateRequest updateRequest = new UpdateRequest(ML_CONNECTOR_INDEX, connectorId);
                     updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                     updateRequest.doc(connector.toXContent(XContentBuilder.builder(XContentType.JSON.xContent()), ToXContent.EMPTY_PARAMS));

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
@@ -14,6 +14,7 @@ import static org.opensearch.ml.utils.TestHelper.clusterSetting;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -200,6 +201,117 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
             listener.onResponse(connector);
             return null;
         }).when(connectorAccessControlHelper).getConnector(any(Client.class), any(String.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testUpdateConnectorDoesNotUpdateHttpConnectorTimeFields() {
+        HttpConnector connector = HttpConnector
+            .builder()
+            .name("test")
+            .protocol("http")
+            .version("1")
+            .credential(Map.of("api_key", "credential_value"))
+            .parameters(Map.of("param1", "value1"))
+            .actions(
+                Arrays
+                    .asList(
+                        ConnectorAction
+                            .builder()
+                            .actionType(ConnectorAction.ActionType.PREDICT)
+                            .method("POST")
+                            .url("https://api.openai.com/v1/chat/completions")
+                            .headers(Map.of("Authorization", "Bearer ${credential.api_key}"))
+                            .requestBody("{ \"model\": \"${parameters.model}\", \"messages\": ${parameters.messages} }")
+                            .build()
+                    )
+            )
+            .build();
+
+        assertNull(connector.getCreatedTime());
+        assertNull(connector.getLastUpdateTime());
+
+        doReturn(true).when(connectorAccessControlHelper).validateConnectorAccess(any(Client.class), any(Connector.class));
+
+        doAnswer(invocation -> {
+            ActionListener<Connector> listener = invocation.getArgument(2);
+            listener.onResponse(connector);
+            return null;
+        }).when(connectorAccessControlHelper).getConnector(any(Client.class), any(String.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), isA(ActionListener.class));
+
+        updateConnectorTransportAction.doExecute(task, updateRequest, actionListener);
+
+        assertNull(connector.getCreatedTime());
+        assertNotNull(connector.getLastUpdateTime());
+    }
+
+    @Test
+    public void testUpdateConnectorUpdatesHttpConnectorTimeFields() {
+        HttpConnector connector = HttpConnector
+            .builder()
+            .name("test")
+            .protocol("http")
+            .version("1")
+            .credential(Map.of("api_key", "credential_value"))
+            .parameters(Map.of("param1", "value1"))
+            .actions(
+                Arrays
+                    .asList(
+                        ConnectorAction
+                            .builder()
+                            .actionType(ConnectorAction.ActionType.PREDICT)
+                            .method("POST")
+                            .url("https://api.openai.com/v1/chat/completions")
+                            .headers(Map.of("Authorization", "Bearer ${credential.api_key}"))
+                            .requestBody("{ \"model\": \"${parameters.model}\", \"messages\": ${parameters.messages} }")
+                            .build()
+                    )
+            )
+            .build();
+
+        Instant testInitialTime = Instant.now();
+        connector.setCreatedTime(testInitialTime);
+        connector.setLastUpdateTime(testInitialTime);
+
+        assert (connector.getCreatedTime().toEpochMilli() == connector.getLastUpdateTime().toEpochMilli());
+
+        doReturn(true).when(connectorAccessControlHelper).validateConnectorAccess(any(Client.class), any(Connector.class));
+
+        doAnswer(invocation -> {
+            ActionListener<Connector> listener = invocation.getArgument(2);
+            listener.onResponse(connector);
+            return null;
+        }).when(connectorAccessControlHelper).getConnector(any(Client.class), any(String.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), isA(ActionListener.class));
+
+        updateConnectorTransportAction.doExecute(task, updateRequest, actionListener);
+
+        assertTrue(
+            "Last update time must be bigger than the creation time",
+            connector.getLastUpdateTime().toEpochMilli() >= connector.getCreatedTime().toEpochMilli()
+        );
     }
 
     @Test


### PR DESCRIPTION
### Description
Manual backport due to conflict #2922 (The commit that caused the backport merge conflict)

### Related Issues
Resolves #2890 (the initial PR that brought up the bug)
<!-- List any other related issues here -->
### Testing
- `./gradlew build` passes on the `backport/backport-2922-to-2.x`
### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
