### PR TITLE
Support ML Inference Search Processor Writing to Search Extension 

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponse.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponse.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.ml.processor;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+public class MLInferenceSearchResponse extends SearchResponse {
+    private static final String EXT_SECTION_NAME = "ext";
+
+    private Map<String, Object> params;
+
+    public MLInferenceSearchResponse(
+        Map<String, Object> params,
+        SearchResponseSections internalResponse,
+        String scrollId,
+        int totalShards,
+        int successfulShards,
+        int skippedShards,
+        long tookInMillis,
+        ShardSearchFailure[] shardFailures,
+        Clusters clusters
+    ) {
+        super(internalResponse, scrollId, totalShards, successfulShards, skippedShards, tookInMillis, shardFailures, clusters);
+        this.params = params;
+    }
+
+    public void setParams(Map<String, Object> params) {
+        this.params = params;
+    }
+
+    public Map<String, Object> getParams() {
+        return this.params;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        innerToXContent(builder, params);
+
+        if (this.params != null) {
+            builder.startObject(EXT_SECTION_NAME);
+            builder.field(MLInferenceSearchResponseProcessor.TYPE, this.params);
+
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -84,6 +84,7 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
     // it can be overwritten using max_prediction_tasks when creating processor
     public static final int DEFAULT_MAX_PREDICTION_TASKS = 10;
     public static final String DEFAULT_OUTPUT_FIELD_NAME = "inference_results";
+    public static final String EXTENSION_PREFIX = "ext.ml_inference";
 
     protected MLInferenceSearchResponseProcessor(
         String modelId,
@@ -158,7 +159,19 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
 
             // if many to one, run rewriteResponseDocuments
             if (!oneToOne) {
-                rewriteResponseDocuments(response, responseListener);
+                // use MLInferenceSearchResponseProcessor to allow writing to extension
+                MLInferenceSearchResponse mLInferenceSearchResponse = new MLInferenceSearchResponse(
+                    null,
+                    response.getInternalResponse(),
+                    response.getScrollId(),
+                    response.getTotalShards(),
+                    response.getSuccessfulShards(),
+                    response.getSkippedShards(),
+                    response.getSuccessfulShards(),
+                    response.getShardFailures(),
+                    response.getClusters()
+                );
+                rewriteResponseDocuments(mLInferenceSearchResponse, responseListener);
             } else {
                 // if one to one, make one hit search response and run rewriteResponseDocuments
                 GroupedActionListener<SearchResponse> combineResponseListener = getCombineResponseGroupedActionListener(
@@ -545,22 +558,37 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                                         } else {
                                             modelOutputValuePerDoc = modelOutputValue;
                                         }
+                                        // writing to search response extension
+                                        if (newDocumentFieldName.startsWith(EXTENSION_PREFIX)) {
+                                            Map<String, Object> params = ((MLInferenceSearchResponse) response).getParams();
+                                            String paramsName = newDocumentFieldName.replaceFirst(EXTENSION_PREFIX + ".", "");
 
-                                        if (sourceAsMap.containsKey(newDocumentFieldName)) {
-                                            if (override) {
-                                                sourceAsMapWithInference.remove(newDocumentFieldName);
-                                                sourceAsMapWithInference.put(newDocumentFieldName, modelOutputValuePerDoc);
+                                            if (params != null) {
+                                                params.put(paramsName, modelOutputValuePerDoc);
+                                                ((MLInferenceSearchResponse) response).setParams(params);
                                             } else {
-                                                logger
-                                                    .debug(
-                                                        "{} already exists in the search response hit. Skip processing this field.",
-                                                        newDocumentFieldName
-                                                    );
-                                                // TODO when the response has the same field name, should it throw exception? currently,
-                                                // ingest processor quietly skip it
+                                                Map<String, Object> newParams = new HashMap<>();
+                                                newParams.put(paramsName, modelOutputValuePerDoc);
+                                                ((MLInferenceSearchResponse) response).setParams(newParams);
                                             }
                                         } else {
-                                            sourceAsMapWithInference.put(newDocumentFieldName, modelOutputValuePerDoc);
+                                            // writing to search response hits
+                                            if (sourceAsMap.containsKey(newDocumentFieldName)) {
+                                                if (override) {
+                                                    sourceAsMapWithInference.remove(newDocumentFieldName);
+                                                    sourceAsMapWithInference.put(newDocumentFieldName, modelOutputValuePerDoc);
+                                                } else {
+                                                    logger
+                                                        .debug(
+                                                            "{} already exists in the search response hit. Skip processing this field.",
+                                                            newDocumentFieldName
+                                                        );
+                                                    // TODO when the response has the same field name, should it throw exception? currently,
+                                                    // ingest processor quietly skip it
+                                                }
+                                            } else {
+                                                sourceAsMapWithInference.put(newDocumentFieldName, modelOutputValuePerDoc);
+                                            }
                                         }
                                     }
                                 }
@@ -773,6 +801,21 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                         + outputMaps.size()
                         + ". Please adjust mappings."
                 );
+            }
+            boolean writeToSearchExtension = false;
+
+            if (outputMaps != null) {
+                for (Map<String, String> outputMap : outputMaps) {
+                    for (String key : outputMap.keySet()) {
+                        if (key.startsWith(EXTENSION_PREFIX)) {
+                            writeToSearchExtension = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (writeToSearchExtension & oneToOne) {
+                throw new IllegalArgumentException("Writing model response to search extension does not support when one_to_one is true.");
             }
 
             return new MLInferenceSearchResponseProcessor(

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -804,18 +804,15 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
             }
             boolean writeToSearchExtension = false;
 
-            if (outputMaps != null) {
-                for (Map<String, String> outputMap : outputMaps) {
-                    for (String key : outputMap.keySet()) {
-                        if (key.startsWith(EXTENSION_PREFIX)) {
-                            writeToSearchExtension = true;
-                            break;
-                        }
-                    }
-                }
+            if (outputMaps != null
+                && outputMaps
+                    .stream()
+                    .anyMatch(outputMap -> outputMap.keySet().stream().anyMatch(key -> key.startsWith(EXTENSION_PREFIX)))) {
+                writeToSearchExtension = true;
             }
+
             if (writeToSearchExtension & oneToOne) {
-                throw new IllegalArgumentException("Writing model response to search extension does not support when one_to_one is true.");
+                throw new IllegalArgumentException("Write model response to search extension does not support when one_to_one is true.");
             }
 
             return new MLInferenceSearchResponseProcessor(

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -14,7 +14,14 @@ import static org.opensearch.ml.processor.InferenceProcessorAttributes.OUTPUT_MA
 import static org.opensearch.ml.processor.MLInferenceIngestProcessor.OVERRIDE;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.logging.log4j.LogManager;
@@ -156,18 +163,27 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
             // if many to one, run rewriteResponseDocuments
             if (!oneToOne) {
                 // use MLInferenceSearchResponseProcessor to allow writing to extension
-                MLInferenceSearchResponse mLInferenceSearchResponse = new MLInferenceSearchResponse(
-                    null,
-                    response.getInternalResponse(),
-                    response.getScrollId(),
-                    response.getTotalShards(),
-                    response.getSuccessfulShards(),
-                    response.getSkippedShards(),
-                    response.getSuccessfulShards(),
-                    response.getShardFailures(),
-                    response.getClusters()
-                );
-                rewriteResponseDocuments(mLInferenceSearchResponse, responseListener);
+                // check if the search response is in the type of MLInferenceSearchResponse
+                // if not, initiate a new one MLInferenceSearchResponse
+                MLInferenceSearchResponse mlInferenceSearchResponse;
+
+                if (response instanceof MLInferenceSearchResponse) {
+                    mlInferenceSearchResponse = (MLInferenceSearchResponse) response;
+                } else {
+                    mlInferenceSearchResponse = new MLInferenceSearchResponse(
+                        null,
+                        response.getInternalResponse(),
+                        response.getScrollId(),
+                        response.getTotalShards(),
+                        response.getSuccessfulShards(),
+                        response.getSkippedShards(),
+                        response.getSuccessfulShards(),
+                        response.getShardFailures(),
+                        response.getClusters()
+                    );
+                }
+
+                rewriteResponseDocuments(mlInferenceSearchResponse, responseListener);
             } else {
                 // if one to one, make one hit search response and run rewriteResponseDocuments
                 GroupedActionListener<SearchResponse> combineResponseListener = getCombineResponseGroupedActionListener(

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchParseException;
@@ -87,6 +88,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseException() throws Exception {
 
         MLInferenceSearchResponseProcessor responseProcessor = getMlInferenceSearchResponseProcessorSinglePairMapping(
@@ -115,6 +117,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseSuccess() throws Exception {
         String modelInputField = "inputs";
         String originalDocumentField = "text";
@@ -174,6 +177,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * with one to one prediction, 5 documents in hits are calling 5 prediction tasks
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithCustomPrompt() throws Exception {
 
         String newDocumentField = "context";
@@ -263,6 +267,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * with many to one prediction, 5 documents in hits are calling 1 prediction tasks
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseManyToOneWithCustomPrompt() throws Exception {
 
         String documentField = "text";
@@ -360,6 +365,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * with full response path false and no output mapping is provided
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseManyToOneWithCustomPromptFullResponsePathFalse() throws Exception {
 
         String documentField = "text";
@@ -436,6 +442,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * with full response path true and no output mapping is provided
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseManyToOneWithCustomPromptFullResponsePathTrue() throws Exception {
 
         String documentField = "text";
@@ -511,6 +518,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * with query extensions
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseSuccessWriteToExt() throws Exception {
         String documentField = "text";
         String modelInputField = "context";
@@ -586,6 +594,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * with one to one prediction, 5 documents in hits are calling 5 prediction tasks
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithNoMappings() throws Exception {
 
         MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
@@ -666,6 +675,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * with one to one prediction, 5 documents in hits are calling 5 prediction tasks
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithEmptyMappings() throws Exception {
         List<Map<String, String>> outputMap = new ArrayList<>();
         List<Map<String, String>> inputMap = new ArrayList<>();
@@ -747,6 +757,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * with one to one prediction, 5 documents in hits are calling 5 prediction tasks
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithOutputMappings() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -836,6 +847,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * when there is one document, the combinedResponseListener calls onFailure
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithOutputMappingsCombineResponseListenerFail() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -897,6 +909,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * when there is one document, the combinedResponseListener calls onFailure
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithOutputMappingsCombineResponseListenerException() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -953,6 +966,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * when there is one document and ignoreFailure, should return the original response
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithOutputMappingsCombineResponseListenerExceptionIgnoreFailure() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -1009,6 +1023,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * when there is one document and ignoreFailure, should return the original response
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseCreateRewriteResponseListenerExceptionIgnoreFailure() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -1099,6 +1114,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * createRewriteResponseListener should reach on Failure
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseCreateRewriteResponseListenerException() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -1185,6 +1201,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * test throwing OpenSearchStatusException
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOpenSearchStatusException() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -1268,6 +1285,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * test throwing MLResourceNotFoundException
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseMLResourceNotFoundException() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -1353,6 +1371,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * when there is one document, the combinedResponseListener calls onFailure
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithOutputMappingsIgnoreFailure() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -1414,6 +1433,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * when there is one document, the combinedResponseListener calls onFailure
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithOutputMappingsMLTaskResponseExceptionIgnoreFailure() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -1476,6 +1496,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * expect to run one prediction task and the rest 4 predictions tasks are not created
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithOutputMappingsPredictException() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -1532,6 +1553,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * expect to run one prediction task and the rest 4 predictions tasks are not created
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithOutputMappingsPredictFail() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -1594,6 +1616,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * then return original response
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneWithOutputMappingsPredictFailIgnoreFailure() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -1653,6 +1676,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * with one to one prediction, 5 documents in hits are calling 10 prediction tasks
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneTwoRoundsPredictions() throws Exception {
 
         String modelInputField = "inputs";
@@ -1783,6 +1807,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * expect to throw exception without further processing
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneTwoRoundsPredictionsOneException() throws Exception {
 
         String modelInputField = "inputs";
@@ -1883,6 +1908,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * expect to return document with second round prediction results
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneTwoRoundsPredictionsOneExceptionIgnoreMissing() throws Exception {
 
         String modelInputField = "inputs";
@@ -1993,6 +2019,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * expect to return document with second round prediction results
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneTwoRoundsPredictionsOneExceptionIgnoreFailure() throws Exception {
 
         String modelInputField = "inputs";
@@ -2086,6 +2113,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseNoMappingSuccess() throws Exception {
         MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
             "model1",
@@ -2163,6 +2191,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseEmptyMappingSuccess() throws Exception {
         List<Map<String, String>> inputMap = new ArrayList<>();
         Map<String, String> input = new HashMap<>();
@@ -2243,6 +2272,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseListOfEmbeddingsSuccess() throws Exception {
         /**
          * sample response before inference
@@ -2330,6 +2360,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOverrideSameField() throws Exception {
         /**
          * sample response before inference
@@ -2416,6 +2447,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOverrideSameFieldFalse() throws Exception {
         /**
          * sample response before inference
@@ -2504,6 +2536,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseListOfEmbeddingsMissingOneInputIgnoreMissingSuccess() throws Exception {
         /**
          * sample response before inference
@@ -2586,6 +2619,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseListOfEmbeddingsMissingOneInputException() throws Exception {
         /**
          * sample response before inference
@@ -2670,6 +2704,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseTwoRoundsOfPredictionSuccess() throws Exception {
         String modelInputField = "inputs";
         String modelOutputField = "response";
@@ -2767,6 +2802,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneModelInputMultipleModelOutputs() throws Exception {
         // one model input
         String modelInputField = "inputs";
@@ -2853,6 +2889,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponsePredictionException() throws Exception {
         MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
             "model1",
@@ -2898,6 +2935,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponsePredictionFailed() throws Exception {
         MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
             "model1",
@@ -2948,6 +2986,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponsePredictionExceptionIgnoreFailure() throws Exception {
         MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
             "model1",
@@ -2998,6 +3037,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseEmptyHit() throws Exception {
         MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
             "model1",
@@ -3042,6 +3082,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      *
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseHitWithNoSource() throws Exception {
         MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
             "model1",
@@ -3087,6 +3128,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * Exceptions happen when replaceHits to be one Hit Response
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneMadeOneHitResponseExceptions() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -3154,6 +3196,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * Exceptions happen when replaceHits  and ignoreFailure return original response
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneMadeOneHitResponseExceptionsIgnoreFailure() throws Exception {
 
         String newDocumentField = "text_embedding";
@@ -3220,6 +3263,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
      * Exceptions happen when replaceHits
      * @throws Exception if an error occurs during the test
      */
+    @Test
     public void testProcessResponseOneToOneCombinedHitsExceptions() throws Exception {
 
         String newDocumentField = "text_embedding";

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
@@ -3327,6 +3327,246 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         responseProcessor.processResponseAsync(request, mockResponse, responseContext, listener);
     }
 
+    /**
+     * Tests the processResponseAsync method when the input is a regular SearchResponse.
+     *
+     * This test verifies that when a regular SearchResponse is passed to the method,
+     * it attempts to create a new MLInferenceSearchResponse object.
+     */
+    @Test
+    public void testProcessResponseAsync_WithRegularSearchResponse() {
+        String modelInputField = "inputs";
+        String originalDocumentField = "text";
+        String newDocumentField = "text_embedding";
+        String modelOutputField = "response";
+
+        SearchResponse response = getSearchResponse(5, true, originalDocumentField);
+        Map<String, Object> params = new HashMap<>();
+        params.put("llm_response", "answer");
+        MLInferenceSearchResponse mLInferenceSearchResponse = new MLInferenceSearchResponse(
+            params,
+            response.getInternalResponse(),
+            response.getScrollId(),
+            response.getTotalShards(),
+            response.getSuccessfulShards(),
+            response.getSkippedShards(),
+            response.getSuccessfulShards(),
+            response.getShardFailures(),
+            response.getClusters()
+        );
+
+        MLInferenceSearchResponseProcessor responseProcessor = getMlInferenceSearchResponseProcessorSinglePairMapping(
+            modelOutputField,
+            modelInputField,
+            originalDocumentField,
+            newDocumentField,
+            false,
+            false,
+            false
+        );
+        SearchRequest request = getSearchRequest();
+        ModelTensor modelTensor = ModelTensor
+            .builder()
+            .dataAsMap(ImmutableMap.of("response", Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)))
+            .build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        ActionListener<SearchResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse newSearchResponse) {
+                MLInferenceSearchResponse responseAfterProcessor = (MLInferenceSearchResponse) newSearchResponse;
+                assertEquals(responseAfterProcessor.getHits().getHits().length, 5);
+                assertEquals(responseAfterProcessor.getHits().getHits()[0].getSourceAsMap().get("text_embedding"), 0.0);
+                assertEquals(responseAfterProcessor.getHits().getHits()[1].getSourceAsMap().get("text_embedding"), 1.0);
+                assertEquals(responseAfterProcessor.getHits().getHits()[2].getSourceAsMap().get("text_embedding"), 2.0);
+                assertEquals(responseAfterProcessor.getHits().getHits()[3].getSourceAsMap().get("text_embedding"), 3.0);
+                assertEquals(responseAfterProcessor.getHits().getHits()[4].getSourceAsMap().get("text_embedding"), 4.0);
+                assertEquals(responseAfterProcessor.getParams(), params);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        responseProcessor.processResponseAsync(request, mLInferenceSearchResponse, responseContext, listener);
+
+    }
+
+    /**
+     * Tests the processResponseAsync method when the input is already an MLInferenceSearchResponse.
+     *
+     * This test verifies that when an MLInferenceSearchResponse is passed to the method,
+     * and the params is being passed over
+     */
+    @Test
+    public void testProcessResponseAsync_WithMLInferenceSearchResponse() {
+        String modelInputField = "inputs";
+        String originalDocumentField = "text";
+        String newDocumentField = "text_embedding";
+        String modelOutputField = "response";
+
+        SearchResponse response = getSearchResponse(5, true, originalDocumentField);
+        Map<String, Object> params = new HashMap<>();
+        params.put("llm_response", "answer");
+        MLInferenceSearchResponse mLInferenceSearchResponse = new MLInferenceSearchResponse(
+            params,
+            response.getInternalResponse(),
+            response.getScrollId(),
+            response.getTotalShards(),
+            response.getSuccessfulShards(),
+            response.getSkippedShards(),
+            response.getSuccessfulShards(),
+            response.getShardFailures(),
+            response.getClusters()
+        );
+
+        MLInferenceSearchResponseProcessor responseProcessor = getMlInferenceSearchResponseProcessorSinglePairMapping(
+            modelOutputField,
+            modelInputField,
+            originalDocumentField,
+            newDocumentField,
+            false,
+            false,
+            false
+        );
+        SearchRequest request = getSearchRequest();
+        ModelTensor modelTensor = ModelTensor
+            .builder()
+            .dataAsMap(ImmutableMap.of("response", Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)))
+            .build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        ActionListener<SearchResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse newSearchResponse) {
+                MLInferenceSearchResponse responseAfterProcessor = (MLInferenceSearchResponse) newSearchResponse;
+                assertEquals(responseAfterProcessor.getHits().getHits().length, 5);
+                assertEquals(responseAfterProcessor.getHits().getHits()[0].getSourceAsMap().get("text_embedding"), 0.0);
+                assertEquals(responseAfterProcessor.getHits().getHits()[1].getSourceAsMap().get("text_embedding"), 1.0);
+                assertEquals(responseAfterProcessor.getHits().getHits()[2].getSourceAsMap().get("text_embedding"), 2.0);
+                assertEquals(responseAfterProcessor.getHits().getHits()[3].getSourceAsMap().get("text_embedding"), 3.0);
+                assertEquals(responseAfterProcessor.getHits().getHits()[4].getSourceAsMap().get("text_embedding"), 4.0);
+                assertEquals(responseAfterProcessor.getParams(), params);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        responseProcessor.processResponseAsync(request, mLInferenceSearchResponse, responseContext, listener);
+
+    }
+
+    /**
+     * Tests the processResponseAsync method when the input is already an MLInferenceSearchResponse.
+     *
+     * This test verifies that when an MLInferenceSearchResponse is passed to the method,
+     * and the params is being passed over and new params is added
+     */
+    @Test
+    public void testProcessResponseAsync_WriteExtensionToMLInferenceSearchResponse() {
+        String documentField = "text";
+        String modelInputField = "context";
+        List<Map<String, String>> inputMap = new ArrayList<>();
+        Map<String, String> input = new HashMap<>();
+        input.put(modelInputField, documentField);
+        inputMap.add(input);
+
+        String newDocumentField = "ext.ml_inference.summary";
+        String modelOutputField = "response";
+        List<Map<String, String>> outputMap = new ArrayList<>();
+        Map<String, String> output = new HashMap<>();
+        output.put(newDocumentField, modelOutputField);
+        outputMap.add(output);
+        Map<String, String> modelConfig = new HashMap<>();
+        modelConfig
+            .put(
+                "prompt",
+                "\\n\\nHuman: You are a professional data analyst. You will always answer question based on the given context first. If the answer is not directly shown in the context, you will analyze the data and find the answer. If you don't know the answer, just say I don't know. Context: ${parameters.context}. \\n\\n Human: please summarize the documents \\n\\n Assistant:"
+            );
+        MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
+            "model1",
+            inputMap,
+            outputMap,
+            modelConfig,
+            DEFAULT_MAX_PREDICTION_TASKS,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            false,
+            "remote",
+            false,
+            false,
+            false,
+            "{ \"parameters\": ${ml_inference.parameters} }",
+            client,
+            TEST_XCONTENT_REGISTRY_FOR_QUERY,
+            false
+        );
+        SearchResponse response = getSearchResponse(5, true, documentField);
+        Map<String, Object> params = new HashMap<>();
+        params.put("llm_response", "answer");
+        MLInferenceSearchResponse mLInferenceSearchResponse = new MLInferenceSearchResponse(
+            params,
+            response.getInternalResponse(),
+            response.getScrollId(),
+            response.getTotalShards(),
+            response.getSuccessfulShards(),
+            response.getSkippedShards(),
+            response.getSuccessfulShards(),
+            response.getShardFailures(),
+            response.getClusters()
+        );
+
+        SearchRequest request = getSearchRequest();
+        ModelTensor modelTensor = ModelTensor.builder().dataAsMap(ImmutableMap.of("response", "there is 1 value")).build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        ActionListener<SearchResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse newSearchResponse) {
+                MLInferenceSearchResponse responseAfterProcessor = (MLInferenceSearchResponse) newSearchResponse;
+                assertEquals(responseAfterProcessor.getHits().getHits().length, 5);
+                Map<String, Object> newParams = new HashMap<>();
+                newParams.put("llm_response", "answer");
+                newParams.put("summary", "there is 1 value");
+                assertEquals(responseAfterProcessor.getParams(), newParams);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        responseProcessor.processResponseAsync(request, mLInferenceSearchResponse, responseContext, listener);
+
+    }
+
     private static SearchRequest getSearchRequest() {
         QueryBuilder incomingQuery = new TermQueryBuilder("text", "foo");
         SearchSourceBuilder source = new SearchSourceBuilder().query(incomingQuery);

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseTests.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.ml.processor;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentGenerator;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class MLInferenceSearchResponseTests extends OpenSearchTestCase {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    /**
+     * Tests the toXContent method of MLInferenceSearchResponse with non-null parameters.
+     * This test ensures that the method correctly serializes the response when parameters are present.
+     *
+     * @throws IOException if an I/O error occurs during the test
+     */
+    @Test
+    public void testToXContent() throws IOException {
+        Map<String, Object> params = new HashMap<>();
+        params.put("key1", "value1");
+        params.put("key2", "value2");
+
+        SearchResponseSections internal = new SearchResponseSections(
+            new SearchHits(new SearchHit[0], null, 0),
+            null,
+            null,
+            false,
+            false,
+            null,
+            0
+        );
+        MLInferenceSearchResponse searchResponse = new MLInferenceSearchResponse(
+            params,
+            internal,
+            null,
+            0,
+            0,
+            0,
+            0,
+            new ShardSearchFailure[0],
+            MLInferenceSearchResponse.Clusters.EMPTY
+        );
+
+        XContent xc = mock(XContent.class);
+        OutputStream os = mock(OutputStream.class);
+        XContentGenerator generator = mock(XContentGenerator.class);
+        when(xc.createGenerator(any(), any(), any())).thenReturn(generator);
+        XContentBuilder builder = new XContentBuilder(xc, os);
+        XContentBuilder actual = searchResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(actual);
+    }
+
+    /**
+     * Tests the toXContent method of MLInferenceSearchResponse with null parameters.
+     * This test verifies that the method handles null parameters correctly during serialization.
+     *
+     * @throws IOException if an I/O error occurs during the test
+     */
+    @Test
+    public void testToXContentWithNullParams() throws IOException {
+        SearchResponseSections internal = new SearchResponseSections(
+            new SearchHits(new SearchHit[0], null, 0),
+            null,
+            null,
+            false,
+            false,
+            null,
+            0
+        );
+        MLInferenceSearchResponse searchResponse = new MLInferenceSearchResponse(
+            null,
+            internal,
+            null,
+            0,
+            0,
+            0,
+            0,
+            new ShardSearchFailure[0],
+            MLInferenceSearchResponse.Clusters.EMPTY
+        );
+
+        XContent xc = mock(XContent.class);
+        OutputStream os = mock(OutputStream.class);
+        XContentGenerator generator = mock(XContentGenerator.class);
+        when(xc.createGenerator(any(), any(), any())).thenReturn(generator);
+        XContentBuilder builder = new XContentBuilder(xc, os);
+        XContentBuilder actual = searchResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertNotNull(actual);
+    }
+
+    /**
+     * Tests the getParams method of MLInferenceSearchResponse.
+     * This test ensures that the method correctly returns the parameters that were set during object creation.
+     */
+    @Test
+    public void testGetParams() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("key1", "value1");
+        params.put("key2", "value2");
+
+        SearchResponseSections internal = new SearchResponseSections(
+            new SearchHits(new SearchHit[0], null, 0),
+            null,
+            null,
+            false,
+            false,
+            null,
+            0
+        );
+        MLInferenceSearchResponse searchResponse = new MLInferenceSearchResponse(
+            params,
+            internal,
+            null,
+            0,
+            0,
+            0,
+            0,
+            new ShardSearchFailure[0],
+            MLInferenceSearchResponse.Clusters.EMPTY
+        );
+
+        assertEquals(params, searchResponse.getParams());
+    }
+
+    /**
+     * Tests the setParams method of MLInferenceSearchResponse.
+     * This test verifies that the method correctly updates the parameters of the response object.
+     */
+    @Test
+    public void testSetParams() {
+        SearchResponseSections internal = new SearchResponseSections(
+            new SearchHits(new SearchHit[0], null, 0),
+            null,
+            null,
+            false,
+            false,
+            null,
+            0
+        );
+        MLInferenceSearchResponse searchResponse = new MLInferenceSearchResponse(
+            null,
+            internal,
+            null,
+            0,
+            0,
+            0,
+            0,
+            new ShardSearchFailure[0],
+            MLInferenceSearchResponse.Clusters.EMPTY
+        );
+
+        Map<String, Object> newParams = new HashMap<>();
+        newParams.put("key3", "value3");
+        searchResponse.setParams(newParams);
+
+        assertEquals(newParams, searchResponse.getParams());
+    }
+}


### PR DESCRIPTION
### Description
Previously, ml inference search processor only writing prediction results to the hits. Now, Support ML Inference Search Processor Writing to Search Extension when many to one inference. 

Note that it's not supported for one to one inference because the order of one to one inference matters and other processors might rerank the order and mess up the order to match one to one model input and prediction results 

### Related Issues
https://github.com/opensearch-project/ml-commons/issues/2878


### Sample Test Case

```

PUT /review_string_index/_doc/1
{
  "review": "Dr. Eric Goldberg is a fantastic doctor who has correctly diagnosed every issue that my wife and I have had. Unlike many of my past doctors, Dr. Goldberg is very accessible and we have been able to schedule appointments with him and his staff very quickly. We are happy to have him in the neighborhood and look forward to being his patients for many years to come." ,
  "label":"5 stars"
}

PUT /review_string_index/_doc/2
{
  "review": "happy visit" ,
  "label":"5 stars"
}


PUT /review_string_index/_doc/3
{
  "review": "sad place" ,
  "label":"1 stars"
}

PUT /_search/pipeline/my_pipeline_request_review_llm
{
  "response_processors": [
    {
      "ml_inference": {
        "tag": "ml_inference",
        "description": "This processor is going to run llm",
        "model_id": "uhkETJIB5-xYSMo_SPet",
        "function_name": "REMOTE",
        "input_map": [
          {
            "context": "review"
          }
        ],
        "output_map": [
          {
            "ext.ml_inference.params.model_response": "response" 
          }
        ],
        "model_config": {
          "prompt":"\n\nHuman: You are a professional data analysist. You will always answer question based on the given context first. If the answer is not directly shown in the context, you will analyze the data and find the answer. If you don't know the answer, just say I don't know. Context: ${parameters.context.toString()}. \n\n Human: please summarize the documents \n\n Assistant:"
        },
        "ignore_missing": false,
        "ignore_failure": false,
        "one_to_one":false
      }
    }
  ]
}

GET /review_string_index/_search?search_pipeline=my_pipeline_request_review_llm
{"query":{
  "match_all": {}
}
}
```
returnning 

```
{
  "took": 1,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 3,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "review_string_index",
        "_id": "1",
        "_score": 1,
        "_source": {
          "review": "Dr. Eric Goldberg is a fantastic doctor who has correctly diagnosed every issue that my wife and I have had. Unlike many of my past doctors, Dr. Goldberg is very accessible and we have been able to schedule appointments with him and his staff very quickly. We are happy to have him in the neighborhood and look forward to being his patients for many years to come.",
          "label": "5 stars"
        }
      },
      {
        "_index": "review_string_index",
        "_id": "2",
        "_score": 1,
        "_source": {
          "review": "happy visit",
          "label": "5 stars"
        }
      },
      {
        "_index": "review_string_index",
        "_id": "3",
        "_score": 1,
        "_source": {
          "review": "sad place",
          "label": "1 stars"
        }
      }
    ]
  },
  "ext": {
    "ml_inference": {
      "llm_response": """ Based on the context provided:

- The first document is a positive review of Dr. Eric Goldberg from a patient. It praises Dr. Goldberg for correctly diagnosing issues for the patient and their wife. It also notes that Dr. Goldberg is very accessible and appointments can be scheduled quickly with him and his staff. The patient expresses happiness that Dr. Goldberg is in their neighborhood and looks forward to being his patient for many years.

- The second document just says "happy visit". 

- The third document says "sad place".

- In summary, the first document positively reviews a doctor, Dr. Eric Goldberg. The other two documents don't provide much context on their own, just mentioning a "happy visit" and "sad place"."""
    }
  }
}
```


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
