### PR TITLE
[Backport to 2.17] add rate limiting for offline batch jobs, set default bulk size to 50…

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/Ingestable.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/Ingestable.java
@@ -13,7 +13,7 @@ public interface Ingestable {
      * @param mlBatchIngestionInput batch ingestion input data
      * @return successRate (0 - 100)
      */
-    default double ingest(MLBatchIngestionInput mlBatchIngestionInput) {
+    default double ingest(MLBatchIngestionInput mlBatchIngestionInput, int bulkSize) {
         throw new IllegalStateException("Ingest is not implemented");
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestion.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ingest/OpenAIDataIngestion.java
@@ -39,7 +39,7 @@ public class OpenAIDataIngestion extends AbstractIngestion {
     }
 
     @Override
-    public double ingest(MLBatchIngestionInput mlBatchIngestionInput) {
+    public double ingest(MLBatchIngestionInput mlBatchIngestionInput, int bulkSize) {
         List<String> sources = (List<String>) mlBatchIngestionInput.getDataSources().get(SOURCE);
         if (Objects.isNull(sources) || sources.isEmpty()) {
             return 100;
@@ -48,13 +48,19 @@ public class OpenAIDataIngestion extends AbstractIngestion {
         boolean isSoleSource = sources.size() == 1;
         List<Double> successRates = Collections.synchronizedList(new ArrayList<>());
         for (int sourceIndex = 0; sourceIndex < sources.size(); sourceIndex++) {
-            successRates.add(ingestSingleSource(sources.get(sourceIndex), mlBatchIngestionInput, sourceIndex, isSoleSource));
+            successRates.add(ingestSingleSource(sources.get(sourceIndex), mlBatchIngestionInput, sourceIndex, isSoleSource, bulkSize));
         }
 
         return calculateSuccessRate(successRates);
     }
 
-    private double ingestSingleSource(String fileId, MLBatchIngestionInput mlBatchIngestionInput, int sourceIndex, boolean isSoleSource) {
+    private double ingestSingleSource(
+        String fileId,
+        MLBatchIngestionInput mlBatchIngestionInput,
+        int sourceIndex,
+        boolean isSoleSource,
+        int bulkSize
+    ) {
         double successRate = 0;
         try {
             String apiKey = mlBatchIngestionInput.getCredential().get(API_KEY);
@@ -82,8 +88,8 @@ public class OpenAIDataIngestion extends AbstractIngestion {
                     linesBuffer.add(line);
                     lineCount++;
 
-                    // Process every 100 lines
-                    if (lineCount % 100 == 0) {
+                    // Process every bulkSize lines
+                    if (lineCount % bulkSize == 0) {
                         // Create a CompletableFuture that will be completed by the bulkResponseListener
                         CompletableFuture<Void> future = new CompletableFuture<>();
                         batchIngest(

--- a/plugin/src/main/java/org/opensearch/ml/action/batch/TransportBatchIngestionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/batch/TransportBatchIngestionAction.java
@@ -10,6 +10,7 @@ import static org.opensearch.ml.common.MLTask.STATE_FIELD;
 import static org.opensearch.ml.common.MLTaskState.COMPLETED;
 import static org.opensearch.ml.common.MLTaskState.FAILED;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.INGEST_THREAD_POOL;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_BATCH_INGESTION_BULK_SIZE;
 import static org.opensearch.ml.task.MLTaskManager.TASK_SEMAPHORE_TIMEOUT;
 import static org.opensearch.ml.utils.MLExceptionUtils.OFFLINE_BATCH_INGESTION_DISABLED_ERR_MSG;
 
@@ -24,7 +25,9 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.MLTask;
@@ -60,16 +63,19 @@ public class TransportBatchIngestionAction extends HandledTransportAction<Action
     private final Client client;
     private ThreadPool threadPool;
     private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+    private volatile Integer batchIngestionBulkSize;
 
     @Inject
     public TransportBatchIngestionAction(
+        ClusterService clusterService,
         TransportService transportService,
         ActionFilters actionFilters,
         Client client,
         MLTaskManager mlTaskManager,
         ThreadPool threadPool,
         MLModelManager mlModelManager,
-        MLFeatureEnabledSetting mlFeatureEnabledSetting
+        MLFeatureEnabledSetting mlFeatureEnabledSetting,
+        Settings settings
     ) {
         super(MLBatchIngestionAction.NAME, transportService, actionFilters, MLBatchIngestionRequest::new);
         this.transportService = transportService;
@@ -78,6 +84,12 @@ public class TransportBatchIngestionAction extends HandledTransportAction<Action
         this.threadPool = threadPool;
         this.mlModelManager = mlModelManager;
         this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+
+        batchIngestionBulkSize = ML_COMMONS_BATCH_INGESTION_BULK_SIZE.get(settings);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_BATCH_INGESTION_BULK_SIZE, it -> batchIngestionBulkSize = it);
+
     }
 
     @Override
@@ -131,33 +143,45 @@ public class TransportBatchIngestionAction extends HandledTransportAction<Action
             .state(MLTaskState.CREATED)
             .build();
 
-        mlTaskManager.createMLTask(mlTask, ActionListener.wrap(response -> {
-            String taskId = response.getId();
-            try {
-                mlTask.setTaskId(taskId);
-                mlTaskManager.add(mlTask);
-                listener.onResponse(new MLBatchIngestionResponse(taskId, MLTaskType.BATCH_INGEST, MLTaskState.CREATED.name()));
-                String ingestType = (String) mlBatchIngestionInput.getDataSources().get(TYPE);
-                Ingestable ingestable = MLEngineClassLoader.initInstance(ingestType.toLowerCase(), client, Client.class);
-                threadPool.executor(INGEST_THREAD_POOL).execute(() -> {
-                    executeWithErrorHandling(() -> {
-                        double successRate = ingestable.ingest(mlBatchIngestionInput);
-                        handleSuccessRate(successRate, taskId);
-                    }, taskId);
-                });
-            } catch (Exception ex) {
-                log.error("Failed in batch ingestion", ex);
-                mlTaskManager
-                    .updateMLTask(
-                        taskId,
-                        Map.of(STATE_FIELD, FAILED, ERROR_FIELD, MLExceptionUtils.getRootCauseMessage(ex)),
-                        TASK_SEMAPHORE_TIMEOUT,
-                        true
-                    );
-                listener.onFailure(ex);
+        mlModelManager.checkMaxBatchJobTask(mlTask, ActionListener.wrap(exceedLimits -> {
+            if (exceedLimits) {
+                String error =
+                    "Exceeded maximum limit for BATCH_INGEST tasks. To increase the limit, update the plugins.ml_commons.max_batch_ingestion_tasks setting.";
+                log.warn(error + " in task " + mlTask.getTaskId());
+                listener.onFailure(new OpenSearchStatusException(error, RestStatus.TOO_MANY_REQUESTS));
+            } else {
+                mlTaskManager.createMLTask(mlTask, ActionListener.wrap(response -> {
+                    String taskId = response.getId();
+                    try {
+                        mlTask.setTaskId(taskId);
+                        mlTaskManager.add(mlTask);
+                        listener.onResponse(new MLBatchIngestionResponse(taskId, MLTaskType.BATCH_INGEST, MLTaskState.CREATED.name()));
+                        String ingestType = (String) mlBatchIngestionInput.getDataSources().get(TYPE);
+                        Ingestable ingestable = MLEngineClassLoader.initInstance(ingestType.toLowerCase(), client, Client.class);
+                        threadPool.executor(INGEST_THREAD_POOL).execute(() -> {
+                            executeWithErrorHandling(() -> {
+                                double successRate = ingestable.ingest(mlBatchIngestionInput, batchIngestionBulkSize);
+                                handleSuccessRate(successRate, taskId);
+                            }, taskId);
+                        });
+                    } catch (Exception ex) {
+                        log.error("Failed in batch ingestion", ex);
+                        mlTaskManager
+                            .updateMLTask(
+                                taskId,
+                                Map.of(STATE_FIELD, FAILED, ERROR_FIELD, MLExceptionUtils.getRootCauseMessage(ex)),
+                                TASK_SEMAPHORE_TIMEOUT,
+                                true
+                            );
+                        listener.onFailure(ex);
+                    }
+                }, exception -> {
+                    log.error("Failed to create batch ingestion task", exception);
+                    listener.onFailure(exception);
+                }));
             }
         }, exception -> {
-            log.error("Failed to create batch ingestion task", exception);
+            log.error("Failed to check the maximum BATCH_INGEST Task limits", exception);
             listener.onFailure(exception);
         }));
     }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -973,7 +973,10 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_REMOTE_JOB_STATUS_EXPIRED_REGEX,
                 MLCommonsSettings.ML_COMMONS_CONTROLLER_ENABLED,
                 MLCommonsSettings.ML_COMMONS_OFFLINE_BATCH_INGESTION_ENABLED,
-                MLCommonsSettings.ML_COMMONS_OFFLINE_BATCH_INFERENCE_ENABLED
+                MLCommonsSettings.ML_COMMONS_OFFLINE_BATCH_INFERENCE_ENABLED,
+                MLCommonsSettings.ML_COMMONS_MAX_BATCH_INFERENCE_TASKS,
+                MLCommonsSettings.ML_COMMONS_MAX_BATCH_INGESTION_TASKS,
+                MLCommonsSettings.ML_COMMONS_BATCH_INGESTION_BULK_SIZE
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -34,6 +34,15 @@ public final class MLCommonsSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
+
+    public static final Setting<Integer> ML_COMMONS_MAX_BATCH_INFERENCE_TASKS = Setting
+        .intSetting("plugins.ml_commons.max_batch_inference_tasks", 10, 0, 500, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    public static final Setting<Integer> ML_COMMONS_MAX_BATCH_INGESTION_TASKS = Setting
+        .intSetting("plugins.ml_commons.max_batch_ingestion_tasks", 10, 0, 500, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    public static final Setting<Integer> ML_COMMONS_BATCH_INGESTION_BULK_SIZE = Setting
+        .intSetting("plugins.ml_commons.batch_ingestion_bulk_size", 500, 100, 100000, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Integer> ML_COMMONS_MAX_DEPLOY_MODEL_TASKS_PER_NODE = Setting
         .intSetting("plugins.ml_commons.max_deploy_model_tasks_per_node", 10, 0, 10, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final Setting<Integer> ML_COMMONS_MAX_ML_TASK_PER_NODE = Setting

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -253,6 +253,33 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
             .lastUpdateTime(now)
             .async(false)
             .build();
+        if (actionType.equals(ActionType.BATCH_PREDICT)) {
+            mlModelManager.checkMaxBatchJobTask(mlTask, ActionListener.wrap(exceedLimits -> {
+                if (exceedLimits) {
+                    String error =
+                        "Exceeded maximum limit for BATCH_PREDICTION tasks. To increase the limit, update the plugins.ml_commons.max_batch_inference_tasks setting.";
+                    log.warn(error + " in task " + mlTask.getTaskId());
+                    listener.onFailure(new OpenSearchStatusException(error, RestStatus.TOO_MANY_REQUESTS));
+                } else {
+                    executePredictionByInputDataType(inputDataType, modelId, mlInput, mlTask, functionName, listener);
+                }
+            }, exception -> {
+                log.error("Failed to check the maximum BATCH_PREDICTION Task limits", exception);
+                listener.onFailure(exception);
+            }));
+            return;
+        }
+        executePredictionByInputDataType(inputDataType, modelId, mlInput, mlTask, functionName, listener);
+    }
+
+    private void executePredictionByInputDataType(
+        MLInputDataType inputDataType,
+        String modelId,
+        MLInput mlInput,
+        MLTask mlTask,
+        FunctionName functionName,
+        ActionListener<MLTaskResponse> listener
+    ) {
         switch (inputDataType) {
             case SEARCH_QUERY:
                 ActionListener<MLInputDataset> dataFrameActionListener = ActionListener.wrap(dataSet -> {

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -28,6 +28,9 @@ import static org.opensearch.ml.engine.ModelHelper.MODEL_SIZE_IN_BYTES;
 import static org.opensearch.ml.model.MLModelManager.TIMEOUT_IN_MILLIS;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.DEPLOY_THREAD_POOL;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.REGISTER_THREAD_POOL;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_BATCH_INGESTION_BULK_SIZE;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MAX_BATCH_INFERENCE_TASKS;
+import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MAX_BATCH_INGESTION_TASKS;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MAX_DEPLOY_MODEL_TASKS_PER_NODE;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MAX_MODELS_PER_NODE;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MAX_REGISTER_MODEL_TASKS_PER_NODE;
@@ -194,12 +197,18 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         settings = Settings.builder().put(ML_COMMONS_MAX_REGISTER_MODEL_TASKS_PER_NODE.getKey(), 10).build();
         settings = Settings.builder().put(ML_COMMONS_MONITORING_REQUEST_COUNT.getKey(), 10).build();
         settings = Settings.builder().put(ML_COMMONS_MAX_DEPLOY_MODEL_TASKS_PER_NODE.getKey(), 10).build();
+        settings = Settings.builder().put(ML_COMMONS_MAX_BATCH_INFERENCE_TASKS.getKey(), 10).build();
+        settings = Settings.builder().put(ML_COMMONS_MAX_BATCH_INGESTION_TASKS.getKey(), 10).build();
+        settings = Settings.builder().put(ML_COMMONS_BATCH_INGESTION_BULK_SIZE.getKey(), 100).build();
         ClusterSettings clusterSettings = clusterSetting(
             settings,
             ML_COMMONS_MAX_MODELS_PER_NODE,
             ML_COMMONS_MAX_REGISTER_MODEL_TASKS_PER_NODE,
             ML_COMMONS_MONITORING_REQUEST_COUNT,
-            ML_COMMONS_MAX_DEPLOY_MODEL_TASKS_PER_NODE
+            ML_COMMONS_MAX_DEPLOY_MODEL_TASKS_PER_NODE,
+            ML_COMMONS_MAX_BATCH_INFERENCE_TASKS,
+            ML_COMMONS_MAX_BATCH_INGESTION_TASKS,
+            ML_COMMONS_BATCH_INGESTION_BULK_SIZE
         );
         clusterService = spy(new ClusterService(settings, clusterSettings, null, clusterApplierService));
         xContentRegistry = NamedXContentRegistry.EMPTY;

--- a/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
@@ -229,6 +229,11 @@ public class MLPredictTaskRunnerTests extends OpenSearchTestCase {
 
         GetResult getResult = new GetResult(indexName, "1.1.1", 111l, 111l, 111l, true, bytesReference, null, null);
         getResponse = new GetResponse(getResult);
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(1);
+            listener.onResponse(false);
+            return null;
+        }).when(mlModelManager).checkMaxBatchJobTask(any(MLTask.class), isA(ActionListener.class));
     }
 
     public void testExecuteTask_OnLocalNode() {


### PR DESCRIPTION
The backport PR from https://github.com/opensearch-project/ml-commons/pull/3116

* add rate limiting for offline batch jobs, set default bulk size to 500
* update error code to 429 for rate limiting and update logs



---------

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
