### PR TITLE
[Feature/multi_tenancy] Validate non-null or empty tenant ID in requests when multitenancy enabled

### DIFF
--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ForkJoinPool;
 
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
+import org.opensearch.core.common.Strings;
 
 import static org.opensearch.sdk.SdkClientUtils.unwrapAndConvertToException;
 
@@ -214,7 +215,7 @@ public class SdkClient {
      * @param tenantId The tenantId from the request
      */
     private void validateTenantId(String tenantId) {
-        if (Boolean.TRUE.equals(isMultiTenancyEnabled) && tenantId == null) {
+        if (Boolean.TRUE.equals(isMultiTenancyEnabled) && Strings.isNullOrEmpty(tenantId)) {
             throw new IllegalArgumentException("A tenant ID is required when multitenancy is enabled.");
         }
     }

--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -15,7 +15,6 @@ import java.util.concurrent.ForkJoinPool;
 
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
-import org.opensearch.ml.common.settings.SettingsChangeListener;
 
 import static org.opensearch.sdk.SdkClientUtils.unwrapAndConvertToException;
 
@@ -36,6 +35,7 @@ public class SdkClient {
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<PutDataObjectResponse> putDataObjectAsync(PutDataObjectRequest request, Executor executor) {
+        validateTenantId(request.tenantId());
         return delegate.putDataObjectAsync(request, executor, isMultiTenancyEnabled);
     }
 
@@ -79,6 +79,7 @@ public class SdkClient {
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<GetDataObjectResponse> getDataObjectAsync(GetDataObjectRequest request) {
+        validateTenantId(request.tenantId());
         return getDataObjectAsync(request, ForkJoinPool.commonPool());
     }
 
@@ -103,6 +104,7 @@ public class SdkClient {
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<UpdateDataObjectResponse> updateDataObjectAsync(UpdateDataObjectRequest request, Executor executor) {
+        validateTenantId(request.tenantId());
         return delegate.updateDataObjectAsync(request, executor, isMultiTenancyEnabled);
     }
 
@@ -137,6 +139,7 @@ public class SdkClient {
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<DeleteDataObjectResponse> deleteDataObjectAsync(DeleteDataObjectRequest request, Executor executor) {
+        validateTenantId(request.tenantId());
         return delegate.deleteDataObjectAsync(request, executor, isMultiTenancyEnabled);
     }
 
@@ -171,6 +174,7 @@ public class SdkClient {
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(SearchDataObjectRequest request, Executor executor) {
+        validateTenantId(request.tenantId());
         return delegate.searchDataObjectAsync(request, executor, isMultiTenancyEnabled);
     }
 
@@ -203,5 +207,15 @@ public class SdkClient {
      */
     public SdkClientDelegate getDelegate() {
         return delegate;
+    }
+
+    /**
+     * Throw exception if tenantId is null and multitenancy is enabled
+     * @param tenantId The tenantId from the request
+     */
+    private void validateTenantId(String tenantId) {
+        if (Boolean.TRUE.equals(isMultiTenancyEnabled) && tenantId == null) {
+            throw new IllegalArgumentException("A tenant ID is required when multitenancy is enabled.");
+        }
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 
 public class SdkClientTests {
 
+    private static final String TENANT_ID = "test_id";
     private SdkClient sdkClient;
     private SdkClientDelegate sdkClientImpl;
 
@@ -62,6 +63,12 @@ public class SdkClientTests {
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+        when(putRequest.tenantId()).thenReturn(TENANT_ID);
+        when(getRequest.tenantId()).thenReturn(TENANT_ID);
+        when(updateRequest.tenantId()).thenReturn(TENANT_ID);
+        when(deleteRequest.tenantId()).thenReturn(TENANT_ID);
+        when(searchRequest.tenantId()).thenReturn(TENANT_ID);
+
         sdkClientImpl = spy(new SdkClientDelegate() {
             @Override
             public CompletionStage<PutDataObjectResponse> putDataObjectAsync(
@@ -120,6 +127,12 @@ public class SdkClientTests {
     }
 
     @Test
+    public void testPutDataObjectNullTenantId() {
+        when(putRequest.tenantId()).thenReturn(null);
+        assertThrows(IllegalArgumentException.class, () -> sdkClient.putDataObject(putRequest));
+    }
+    
+    @Test
     public void testPutDataObjectException() {
         when(sdkClientImpl.putDataObjectAsync(any(PutDataObjectRequest.class), any(Executor.class), anyBoolean()))
                 .thenReturn(CompletableFuture.failedFuture(testException));
@@ -152,6 +165,12 @@ public class SdkClientTests {
     }
 
     @Test
+    public void testGetDataObjectNullTenantId() {
+        when(getRequest.tenantId()).thenReturn(null);
+        assertThrows(IllegalArgumentException.class, () -> sdkClient.getDataObject(getRequest));
+    }
+    
+    @Test
     public void testGetDataObjectException() {
         when(sdkClientImpl.getDataObjectAsync(any(GetDataObjectRequest.class), any(Executor.class), anyBoolean()))
                 .thenReturn(CompletableFuture.failedFuture(testException));
@@ -181,6 +200,11 @@ public class SdkClientTests {
     public void testUpdateDataObjectSuccess() {
         assertEquals(updateResponse, sdkClient.updateDataObject(updateRequest));
         verify(sdkClientImpl).updateDataObjectAsync(any(UpdateDataObjectRequest.class), any(Executor.class), anyBoolean());
+    }
+    @Test
+    public void testUpdateDataObjectNullTenantId() {
+        when(updateRequest.tenantId()).thenReturn(null);
+        assertThrows(IllegalArgumentException.class, () -> sdkClient.updateDataObject(updateRequest));
     }
 
     @Test
@@ -214,6 +238,12 @@ public class SdkClientTests {
     }
 
     @Test
+    public void testDeleteDataObjectNullTenantId() {
+        when(deleteRequest.tenantId()).thenReturn(null);
+        assertThrows(IllegalArgumentException.class, () -> sdkClient.deleteDataObject(deleteRequest));
+    }
+
+    @Test
     public void testDeleteDataObjectException() {
         when(sdkClientImpl.deleteDataObjectAsync(any(DeleteDataObjectRequest.class), any(Executor.class), anyBoolean()))
                 .thenReturn(CompletableFuture.failedFuture(testException));
@@ -242,6 +272,12 @@ public class SdkClientTests {
         assertEquals(searchResponse, sdkClient.searchDataObject(searchRequest));
         verify(sdkClientImpl).searchDataObjectAsync(any(SearchDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
+    @Test
+    public void testSearchDataObjectNullTenantId() {
+        when(searchRequest.tenantId()).thenReturn(null);
+        assertThrows(IllegalArgumentException.class, () -> sdkClient.searchDataObject(searchRequest));
+    }
+
 
     @Test
     public void testSearchDataObjectException() {

--- a/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
@@ -135,7 +135,7 @@ public class LocalClusterIndicesClientTests {
         PutDataObjectRequest putRequest = PutDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID)
+            .id(TEST_ID).tenantId(TEST_TENANT_ID)
             .overwriteIfExists(false)
             .dataObject(testDataObject)
             .build();
@@ -166,7 +166,7 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testPutDataObject_Exception() throws IOException {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).tenantId(TEST_TENANT_ID).dataObject(testDataObject).build();
 
         when(mockedClient.index(any(IndexRequest.class))).thenThrow(new UnsupportedOperationException("test"));
 
@@ -188,7 +188,7 @@ public class LocalClusterIndicesClientTests {
                 throw new IOException("test");
             }
         };
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(badDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).tenantId(TEST_TENANT_ID).dataObject(badDataObject).build();
 
         CompletableFuture<PutDataObjectResponse> future = sdkClient
             .putDataObjectAsync(putRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
@@ -202,7 +202,7 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testGetDataObject() throws IOException {
-        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
 
         String json = testDataObject.toJson();
         GetResponse getResponse = new GetResponse(new GetResult(TEST_INDEX, TEST_ID, -2, 0, 1, true, new BytesArray(json), null, null));
@@ -235,7 +235,7 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testGetDataObject_NullResponse() throws IOException {
-        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
 
         @SuppressWarnings("unchecked")
         ActionFuture<GetResponse> future = mock(ActionFuture.class);
@@ -257,7 +257,7 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testGetDataObject_NotFound() throws IOException {
-        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
         GetResponse getResponse = new GetResponse(new GetResult(TEST_INDEX, TEST_ID, -2, 0, 1, false, null, null, null));
 
         @SuppressWarnings("unchecked")
@@ -280,7 +280,7 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testGetDataObject_Exception() throws IOException {
-        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
 
         ArgumentCaptor<GetRequest> getRequestCaptor = ArgumentCaptor.forClass(GetRequest.class);
         when(mockedClient.get(getRequestCaptor.capture())).thenThrow(new UnsupportedOperationException("test"));
@@ -300,7 +300,7 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID)
+            .id(TEST_ID).tenantId(TEST_TENANT_ID)
             .retryOnConflict(3)
             .dataObject(testDataObject)
             .build();
@@ -344,7 +344,7 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID)
+            .id(TEST_ID).tenantId(TEST_TENANT_ID)
             .dataObject(Map.of("foo", "bar"))
             .build();
 
@@ -377,7 +377,7 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID)
+            .id(TEST_ID).tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .build();
 
@@ -419,7 +419,7 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID)
+            .id(TEST_ID).tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .build();
 
@@ -445,7 +445,7 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID)
+            .id(TEST_ID).tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .build();
 
@@ -467,7 +467,7 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID)
+            .id(TEST_ID).tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .ifSeqNo(5)
             .ifPrimaryTerm(2)
@@ -493,7 +493,7 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testDeleteDataObject() throws IOException {
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
 
         DeleteResponse deleteResponse = new DeleteResponse(new ShardId(TEST_INDEX, "_na_", 0), TEST_ID, 1, 0, 2, true);
         PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
@@ -517,7 +517,7 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testDeleteDataObject_Exception() throws IOException {
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
 
         ArgumentCaptor<DeleteRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
         when(mockedClient.delete(deleteRequestCaptor.capture())).thenThrow(new UnsupportedOperationException("test"));
@@ -651,27 +651,6 @@ public class LocalClusterIndicesClientTests {
         Throwable cause = ce.getCause();
         assertEquals(UnsupportedOperationException.class, cause.getClass());
         assertEquals("test", cause.getMessage());
-    }
-    
-    @Test
-    public void testSearchDataObject_NullTenantId() throws IOException {
-        // Tests exception if multitenancy enabled        
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        SearchDataObjectRequest searchRequest = SearchDataObjectRequest
-            .builder()
-            .indices(TEST_INDEX)
-            // null tenant Id
-            .searchSourceBuilder(searchSourceBuilder)
-            .build();
-        
-        CompletableFuture<SearchDataObjectResponse> future = sdkClient
-            .searchDataObjectAsync(searchRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
-            .toCompletableFuture();
-
-        CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        Throwable cause = ce.getCause();
-        assertEquals(OpenSearchStatusException.class, cause.getClass());
-        assertEquals("Tenant ID is required when multitenancy is enabled.", cause.getMessage());
     }
     
     @Test

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
@@ -340,10 +340,13 @@ public class EncryptorImpl implements Encryptor {
                 createGetDataObjectRequest(tenantId, new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY)),
                 client.threadPool().executor("opensearch_ml_general")
             )
-            .whenComplete((response, throwable) -> handleVersionConflictResponse(context, response, throwable, exceptionRef, latch));
+            .whenComplete(
+                (response, throwable) -> handleVersionConflictResponse(tenantId, context, response, throwable, exceptionRef, latch)
+            );
     }
 
     private void handleVersionConflictResponse(
+        String tenantId,
         ThreadContext.StoredContext context,
         GetDataObjectResponse response1,
         Throwable throwable2,
@@ -359,7 +362,7 @@ public class EncryptorImpl implements Encryptor {
             exceptionRef.set(cause1);
             latch.countDown();
         } else {
-            handleGetDataObjectSuccess(response1, null, exceptionRef, latch, context); // Tenant ID is not used here
+            handleGetDataObjectSuccess(response1, tenantId, exceptionRef, latch, context);
         }
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
@@ -87,6 +87,7 @@ public class EncryptorImplTest {
     ThreadPool threadPool;
     ThreadContext threadContext;
     final String USER_STRING = "myuser|role1,role2|myTenant";
+    final String TENANT_ID = "myTenant";
 
     private static final TestThreadPool testThreadPool = new TestThreadPool(
         EncryptorImplTest.class.getName(),
@@ -193,10 +194,10 @@ public class EncryptorImplTest {
         when(client.index(any(IndexRequest.class))).thenReturn(indexFuture);
 
         Encryptor encryptor = new EncryptorImpl(clusterService, client, sdkClient, mlIndicesHandler);
-        Assert.assertNull(encryptor.getMasterKey(null));
-        String encrypted = encryptor.encrypt("test", null);
+        Assert.assertNull(encryptor.getMasterKey(TENANT_ID));
+        String encrypted = encryptor.encrypt("test", TENANT_ID);
         Assert.assertNotNull(encrypted);
-        Assert.assertNotEquals(masterKey.get(DEFAULT_TENANT_ID), encryptor.getMasterKey(null));
+        Assert.assertNotEquals(masterKey.get(DEFAULT_TENANT_ID), encryptor.getMasterKey(TENANT_ID));
     }
 
     @Test
@@ -218,8 +219,8 @@ public class EncryptorImplTest {
         when(client.index(any(IndexRequest.class))).thenReturn(indexFuture);
 
         Encryptor encryptor = new EncryptorImpl(clusterService, client, sdkClient, mlIndicesHandler);
-        Assert.assertNull(encryptor.getMasterKey(null));
-        encryptor.encrypt("test", null);
+        Assert.assertNull(encryptor.getMasterKey(TENANT_ID));
+        encryptor.encrypt("test", TENANT_ID);
     }
 
     @Test
@@ -241,8 +242,8 @@ public class EncryptorImplTest {
         when(client.index(any(IndexRequest.class))).thenReturn(indexFuture);
 
         Encryptor encryptor = new EncryptorImpl(clusterService, client, sdkClient, mlIndicesHandler);
-        Assert.assertNull(encryptor.getMasterKey(null));
-        encryptor.encrypt("test", null);
+        Assert.assertNull(encryptor.getMasterKey(TENANT_ID));
+        encryptor.encrypt("test", TENANT_ID);
     }
 
     @Test
@@ -264,8 +265,8 @@ public class EncryptorImplTest {
         when(client.index(any(IndexRequest.class))).thenReturn(indexFuture);
 
         Encryptor encryptor = new EncryptorImpl(clusterService, client, sdkClient, mlIndicesHandler);
-        Assert.assertNull(encryptor.getMasterKey(null));
-        encryptor.encrypt("test", null);
+        Assert.assertNull(encryptor.getMasterKey(TENANT_ID));
+        encryptor.encrypt("test", TENANT_ID);
     }
 
     @Test
@@ -287,8 +288,8 @@ public class EncryptorImplTest {
         when(client.index(any(IndexRequest.class))).thenReturn(indexFuture);
 
         Encryptor encryptor = new EncryptorImpl(clusterService, client, sdkClient, mlIndicesHandler);
-        Assert.assertNull(encryptor.getMasterKey(null));
-        encryptor.encrypt("test", null);
+        Assert.assertNull(encryptor.getMasterKey(TENANT_ID));
+        encryptor.encrypt("test", TENANT_ID);
     }
 
     @Test
@@ -310,8 +311,8 @@ public class EncryptorImplTest {
         when(client.index(any(IndexRequest.class))).thenReturn(indexFuture);
 
         Encryptor encryptor = new EncryptorImpl(clusterService, client, sdkClient, mlIndicesHandler);
-        Assert.assertNull(encryptor.getMasterKey(null));
-        encryptor.encrypt("test", null);
+        Assert.assertNull(encryptor.getMasterKey(TENANT_ID));
+        encryptor.encrypt("test", TENANT_ID);
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -139,6 +139,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .tenantId(TENANT_ID)
             .overwriteIfExists(false)
             .tenantId(TENANT_ID)
             .dataObject(testDataObject)
@@ -241,20 +242,13 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
     }
 
     @Test
-    public void testPutDataObject_NullTenantId_SetsDefaultTenantId() {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).dataObject(testDataObject).build();
-        Mockito.when(dynamoDbClient.putItem(Mockito.any(PutItemRequest.class))).thenReturn(PutItemResponse.builder().build());
-        sdkClient.putDataObjectAsync(putRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
-        Mockito.verify(dynamoDbClient).putItem(putItemRequestArgumentCaptor.capture());
-
-        PutItemRequest putItemRequest = putItemRequestArgumentCaptor.getValue();
-        Assert.assertEquals("DEFAULT_TENANT", putItemRequest.item().get(HASH_KEY).s());
-        Assert.assertNull(putItemRequest.item().get(SOURCE).m().get(CommonValue.TENANT_ID));
-    }
-
-    @Test
     public void testPutDataObject_NullId_SetsDefaultTenantId() {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .tenantId(TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
         Mockito.when(dynamoDbClient.putItem(Mockito.any(PutItemRequest.class))).thenReturn(PutItemResponse.builder().build());
         PutDataObjectResponse response = sdkClient
             .putDataObjectAsync(putRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
@@ -269,7 +263,13 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testPutDataObject_DDBException_ThrowsException() {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
         Mockito.when(dynamoDbClient.putItem(Mockito.any(PutItemRequest.class))).thenThrow(new RuntimeException("Test exception"));
         CompletableFuture<PutDataObjectResponse> future = sdkClient
             .putDataObjectAsync(putRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
@@ -420,15 +420,6 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
     }
 
     @Test
-    public void testDeleteDataObject_NullTenantId_UsesDefaultTenantId() {
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID).index(TEST_INDEX).build();
-        Mockito.when(dynamoDbClient.deleteItem(deleteItemRequestArgumentCaptor.capture())).thenReturn(DeleteItemResponse.builder().build());
-        sdkClient.deleteDataObjectAsync(deleteRequest, testThreadPool.executor(GENERAL_THREAD_POOL)).toCompletableFuture().join();
-        DeleteItemRequest deleteItemRequest = deleteItemRequestArgumentCaptor.getValue();
-        Assert.assertEquals("DEFAULT_TENANT", deleteItemRequest.key().get(HASH_KEY).s());
-    }
-
-    @Test
     public void testUpdateDataObjectAsync_HappyCase() {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
@@ -551,6 +542,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .tenantId(TENANT_ID)
             .dataObject(testDataObject)
             .build();
         Mockito.when(dynamoDbClient.getItem(Mockito.any(GetItemRequest.class))).thenThrow(new RuntimeException("Test exception"));
@@ -568,6 +560,7 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .tenantId(TENANT_ID)
             .dataObject(testDataObject)
             .ifSeqNo(5)
             .ifPrimaryTerm(2)

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
@@ -133,7 +133,12 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testPutDataObject() throws IOException {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .tenantId(TEST_TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
 
         IndexResponse indexResponse = new IndexResponse.Builder()
             .id(TEST_ID)
@@ -170,6 +175,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .overwriteIfExists(false)
             .dataObject(testDataObject)
             .build();
@@ -207,7 +213,12 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testPutDataObject_Exception() throws IOException {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .tenantId(TEST_TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
 
         ArgumentCaptor<IndexRequest<?>> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
         when(mockedOpenSearchClient.index(indexRequestCaptor.capture())).thenThrow(new IOException("test"));
@@ -222,7 +233,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void testGetDataObject() throws IOException {
-        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
 
         GetResponse<?> getResponse = new GetResponse.Builder<>()
             .index(TEST_INDEX)
@@ -257,7 +268,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void testGetDataObject_NotFound() throws IOException {
-        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
 
         GetResponse<?> getResponse = new GetResponse.Builder<>().index(TEST_INDEX).id(TEST_ID).found(false).build();
 
@@ -278,7 +289,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void testGetDataObject_Exception() throws IOException {
-        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
 
         ArgumentCaptor<GetRequest> getRequestCaptor = ArgumentCaptor.forClass(GetRequest.class);
         ArgumentCaptor<Class<Map>> mapClassCaptor = ArgumentCaptor.forClass(Class.class);
@@ -297,6 +308,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .build();
 
@@ -337,6 +349,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .retryOnConflict(3)
             .dataObject(Map.of("foo", "bar"))
             .build();
@@ -368,6 +381,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .build();
 
@@ -407,6 +421,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .build();
 
@@ -426,6 +441,7 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
             .builder()
             .index(TEST_INDEX)
             .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .ifSeqNo(5)
             .ifPrimaryTerm(2)
@@ -451,7 +467,12 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testDeleteDataObject() throws IOException {
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .build();
 
         DeleteResponse deleteResponse = new DeleteResponse.Builder()
             .id(TEST_ID)
@@ -484,7 +505,12 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testDeleteDataObject_NotFound() throws IOException {
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .build();
 
         DeleteResponse deleteResponse = new DeleteResponse.Builder()
             .id(TEST_ID)
@@ -514,7 +540,12 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testDeleteDataObject_Exception() throws IOException {
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .build();
 
         ArgumentCaptor<DeleteRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
         when(mockedOpenSearchClient.delete(deleteRequestCaptor.capture())).thenThrow(new IOException("test"));
@@ -591,27 +622,6 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
         Throwable cause = ce.getCause();
         assertEquals(UnsupportedOperationException.class, cause.getClass());
         assertEquals("test", cause.getMessage());
-    }
-
-    public void testSearchDataObject_NullTenant() throws IOException {
-        // Tests exception if multitenancy enabled
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        SearchDataObjectRequest searchRequest = SearchDataObjectRequest
-            .builder()
-            .indices(TEST_INDEX)
-            // null tenant Id
-            .searchSourceBuilder(searchSourceBuilder)
-            .build();
-
-        when(mockedOpenSearchClient.search(any(SearchRequest.class), any())).thenThrow(new UnsupportedOperationException("test"));
-        CompletableFuture<SearchDataObjectResponse> future = sdkClient
-            .searchDataObjectAsync(searchRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
-            .toCompletableFuture();
-
-        CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
-        Throwable cause = ce.getCause();
-        assertEquals(OpenSearchStatusException.class, cause.getClass());
-        assertEquals("Tenant ID is required when multitenancy is enabled.", cause.getMessage());
     }
 
     public void testSearchDataObject_NullTenantNoMultitenancy() throws IOException {


### PR DESCRIPTION
### Description

Adds a check that all the SDKClient requests have a non-null or empty tenant id when multitenancy is enabled.  

This should not be user-facing, but exists as a check to developers.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
