### PR TITLE
increase the wait timeout to fetch the master key

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
@@ -181,7 +181,10 @@ public class EncryptorImpl implements Encryptor {
         }));
 
         try {
-            latch.await(1, SECONDS);
+            boolean completed = latch.await(3, SECONDS);
+            if (!completed) {
+                throw new MLException("Fetching master key timed out.");
+            }
         } catch (InterruptedException e) {
             throw new IllegalStateException(e);
         }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
@@ -462,8 +462,8 @@ public class EncryptorImplTest {
 
     @Test
     public void encrypt_NullMasterKey_NullMasterKey_MasterKeyNotExistInIndex() {
-        exceptionRule.expect(ResourceNotFoundException.class);
-        exceptionRule.expectMessage(MASTER_KEY_NOT_READY_ERROR);
+        exceptionRule.expect(MLException.class);
+        exceptionRule.expectMessage("Fetching master key timed out.");
 
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = invocation.getArgument(1);
@@ -517,8 +517,8 @@ public class EncryptorImplTest {
 
     @Test
     public void decrypt_MLConfigIndexNotFound() {
-        exceptionRule.expect(ResourceNotFoundException.class);
-        exceptionRule.expectMessage(MASTER_KEY_NOT_READY_ERROR);
+        exceptionRule.expect(MLException.class);
+        exceptionRule.expectMessage("Fetching master key timed out.");
 
         Metadata metadata = new Metadata.Builder().indices(ImmutableMap.of()).build();
         when(clusterState.metadata()).thenReturn(metadata);


### PR DESCRIPTION
### Description
There is a race condition during initializing master key when encrypt/decrypt credentials in a connector. The encrypt/decrypt thread could get a null key even if the key is fetched from config index successfully in another thread.

### Related Issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
