### PR TITLE
Add textract and comprehend url to trusted enpoints

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -162,7 +162,9 @@ public final class MLCommonsSettings {
                     "^https://api\\.cohere\\.ai/.*$",
                     "^https://bedrock-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
                     "^https://bedrock-agent-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
-                    "^https://bedrock\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"
+                    "^https://bedrock\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                    "^https://textract\\..*[a-z0-9-]\\.amazonaws\\.com$",
+                    "^https://comprehend\\..*[a-z0-9-]\\.amazonaws\\.com$"
                 ),
             Function.identity(),
             Setting.Property.NodeScope,


### PR DESCRIPTION
### Description
This PR add textract and comprehend url to trusted enpoints, which already supported in our blueprints

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
