### PR TITLE
applying multi-tenancy for forward request which is important for deploy request

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/deploy/MLDeployModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/deploy/MLDeployModelInput.java
@@ -16,6 +16,7 @@ import org.opensearch.ml.common.MLTask;
 @Data
 public class MLDeployModelInput implements Writeable {
     private String modelId;
+    private String tenantId;
     private String taskId;
     private String modelContentHash;
     private Integer nodeCount;
@@ -26,6 +27,8 @@ public class MLDeployModelInput implements Writeable {
     public MLDeployModelInput(StreamInput in) throws IOException {
         this.modelId = in.readString();
         this.taskId = in.readString();
+        // todo: need to check BWC test
+        this.tenantId = in.readOptionalString();
         this.modelContentHash = in.readOptionalString();
         this.nodeCount = in.readInt();
         this.coordinatingNodeId = in.readString();
@@ -34,9 +37,10 @@ public class MLDeployModelInput implements Writeable {
     }
 
     @Builder
-    public MLDeployModelInput(String modelId, String taskId, String modelContentHash, Integer nodeCount, String coordinatingNodeId, Boolean isDeployToAllNodes, MLTask mlTask) {
+    public MLDeployModelInput(String modelId, String taskId, String tenantId, String modelContentHash, Integer nodeCount, String coordinatingNodeId, Boolean isDeployToAllNodes, MLTask mlTask) {
         this.modelId = modelId;
         this.taskId = taskId;
+        this.tenantId = tenantId;
         this.modelContentHash = modelContentHash;
         this.nodeCount = nodeCount;
         this.coordinatingNodeId = coordinatingNodeId;
@@ -51,6 +55,7 @@ public class MLDeployModelInput implements Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(modelId);
         out.writeString(taskId);
+        out.writeOptionalString(tenantId);
         out.writeOptionalString(modelContentHash);
         out.writeInt(nodeCount);
         out.writeString(coordinatingNodeId);

--- a/common/src/main/java/org/opensearch/ml/common/transport/forward/MLForwardInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/forward/MLForwardInput.java
@@ -23,6 +23,7 @@ public class MLForwardInput implements Writeable {
 
     private String taskId;
     private String modelId;
+    private String tenantId;
     private String workerNodeId;
     private MLForwardRequestType requestType;
     private MLTask mlTask;
@@ -32,11 +33,12 @@ public class MLForwardInput implements Writeable {
     private MLRegisterModelInput registerModelInput;
 
     @Builder(toBuilder = true)
-    public MLForwardInput(String taskId, String modelId, String workerNodeId, MLForwardRequestType requestType,
+    public MLForwardInput(String taskId, String modelId, String tenantId, String workerNodeId, MLForwardRequestType requestType,
                           MLTask mlTask, MLInput modelInput,
                           String error, String[] workerNodes, MLRegisterModelInput registerModelInput) {
         this.taskId = taskId;
         this.modelId = modelId;
+        this.tenantId = tenantId;
         this.workerNodeId = workerNodeId;
         this.requestType = requestType;
         this.mlTask = mlTask;
@@ -49,6 +51,8 @@ public class MLForwardInput implements Writeable {
     public MLForwardInput(StreamInput in) throws IOException {
         this.taskId = in.readOptionalString();
         this.modelId = in.readOptionalString();
+        // todo: need to do BWC check
+        this.tenantId = in.readOptionalString();
         this.workerNodeId = in.readOptionalString();
         this.requestType = in.readEnum(MLForwardRequestType.class);
         if (in.readBoolean()) {
@@ -68,6 +72,8 @@ public class MLForwardInput implements Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalString(taskId);
         out.writeOptionalString(modelId);
+        // TODO: need to do BWC check
+        out.writeOptionalString(tenantId);
         out.writeOptionalString(workerNodeId);
         out.writeEnum(requestType);
         if (this.mlTask != null) {

--- a/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelNodesRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelNodesRequestTest.java
@@ -84,7 +84,7 @@ public class MLDeployModelNodesRequestTest {
     @Test
     public void testConstructorSerialization1() throws IOException {
         String [] nodeIds = {"id1", "id2", "id3"};
-        MLDeployModelInput deployModelInput = new MLDeployModelInput("modelId", "taskId", "modelContentHash", 3, "coordinatingNodeId", true, mlTask);
+        MLDeployModelInput deployModelInput = new MLDeployModelInput("modelId", "taskId", null, "modelContentHash", 3, "coordinatingNodeId", true, mlTask);
         MLDeployModelNodeRequest MLDeployModelNodeRequest = new MLDeployModelNodeRequest(
                 new MLDeployModelNodesRequest(nodeIds, deployModelInput)
         );
@@ -104,7 +104,7 @@ public class MLDeployModelNodesRequestTest {
     @Test
     public void testConstructorSerialization2() throws IOException {
         DiscoveryNode [] nodeIds = {localNode1, localNode2, localNode3};
-        MLDeployModelInput deployModelInput = new MLDeployModelInput("modelId", "taskId", "modelContentHash", 3, "coordinatingNodeId", true, mlTask);
+        MLDeployModelInput deployModelInput = new MLDeployModelInput("modelId", "taskId", null, "modelContentHash", 3, "coordinatingNodeId", true, mlTask);
         MLDeployModelNodeRequest MLDeployModelNodeRequest = new MLDeployModelNodeRequest(
                 new MLDeployModelNodesRequest(nodeIds, deployModelInput)
         );
@@ -140,7 +140,7 @@ public class MLDeployModelNodesRequestTest {
     @Test
     public void testConstructorFromInputStream() throws IOException {
         String [] nodeIds = {"id1", "id2", "id3"};
-        MLDeployModelInput deployModelInput = new MLDeployModelInput("modelId", "taskId", "modelContentHash", 3, "coordinatingNodeId", true, mlTask);
+        MLDeployModelInput deployModelInput = new MLDeployModelInput("modelId", "taskId", null, "modelContentHash", 3, "coordinatingNodeId", true, mlTask);
         MLDeployModelNodeRequest MLDeployModelNodeRequest = new MLDeployModelNodeRequest(
                 new MLDeployModelNodesRequest(nodeIds, deployModelInput)
         );

--- a/plugin/src/main/java/org/opensearch/ml/action/controller/CreateControllerTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/controller/CreateControllerTransportAction.java
@@ -187,8 +187,7 @@ public class CreateControllerTransportAction extends HandledTransportAction<Acti
                     log.info(errorMessage, indexResponse.getResult());
                     if (indexResponse.getResult() == DocWriteResponse.Result.CREATED) {
                         // we aren't enabling controller feature for multi-tenancy. So tenant id is null by default.
-                        mlModelManager
-                            .updateModel(modelId, null, isHidden, Map.of(MLModel.IS_CONTROLLER_ENABLED_FIELD, true));
+                        mlModelManager.updateModel(modelId, null, isHidden, Map.of(MLModel.IS_CONTROLLER_ENABLED_FIELD, true));
                     }
                     if (!ArrayUtils.isEmpty(mlModelCacheHelper.getWorkerNodes(modelId))) {
                         log

--- a/plugin/src/main/java/org/opensearch/ml/action/controller/CreateControllerTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/controller/CreateControllerTransportAction.java
@@ -186,8 +186,9 @@ public class CreateControllerTransportAction extends HandledTransportAction<Acti
                     String errorMessage = getErrorMessage("Model controller saved into index, result:{}", modelId, isHidden);
                     log.info(errorMessage, indexResponse.getResult());
                     if (indexResponse.getResult() == DocWriteResponse.Result.CREATED) {
+                        // we aren't enabling controller feature for multi-tenancy. So tenant id is null by default.
                         mlModelManager
-                            .updateModel(modelId, mlModel.getTenantId(), isHidden, Map.of(MLModel.IS_CONTROLLER_ENABLED_FIELD, true));
+                            .updateModel(modelId, null, isHidden, Map.of(MLModel.IS_CONTROLLER_ENABLED_FIELD, true));
                     }
                     if (!ArrayUtils.isEmpty(mlModelCacheHelper.getWorkerNodes(modelId))) {
                         log

--- a/plugin/src/main/java/org/opensearch/ml/action/controller/CreateControllerTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/controller/CreateControllerTransportAction.java
@@ -186,7 +186,8 @@ public class CreateControllerTransportAction extends HandledTransportAction<Acti
                     String errorMessage = getErrorMessage("Model controller saved into index, result:{}", modelId, isHidden);
                     log.info(errorMessage, indexResponse.getResult());
                     if (indexResponse.getResult() == DocWriteResponse.Result.CREATED) {
-                        mlModelManager.updateModel(modelId, isHidden, Map.of(MLModel.IS_CONTROLLER_ENABLED_FIELD, true));
+                        mlModelManager
+                            .updateModel(modelId, mlModel.getTenantId(), isHidden, Map.of(MLModel.IS_CONTROLLER_ENABLED_FIELD, true));
                     }
                     if (!ArrayUtils.isEmpty(mlModelCacheHelper.getWorkerNodes(modelId))) {
                         log

--- a/plugin/src/main/java/org/opensearch/ml/action/controller/DeleteControllerTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/controller/DeleteControllerTransportAction.java
@@ -234,7 +234,7 @@ public class DeleteControllerTransportAction extends HandledTransportAction<Acti
                         getErrorMessage("Model controller for the provided successfully deleted from index, result: {}", modelId, isHidden),
                         deleteResponse.getResult()
                     );
-                mlModelManager.updateModel(modelId, isHidden, Map.of(MLModel.IS_CONTROLLER_ENABLED_FIELD, false));
+                mlModelManager.updateModel(modelId, null, isHidden, Map.of(MLModel.IS_CONTROLLER_ENABLED_FIELD, false));
                 actionListener.onResponse(deleteResponse);
             }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
@@ -285,10 +285,10 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
             String taskId = response.getId();
             mlTask.setTaskId(taskId);
             if (algorithm == FunctionName.REMOTE) {
-                if (mlFeatureEnabledSetting.isMultiTenancyEnabled()) {
-                    listener.onResponse(new MLDeployModelResponse(taskId, MLTaskType.DEPLOY_MODEL, MLTaskState.CREATED.name()));
-                    return;
-                }
+                // if (mlFeatureEnabledSetting.isMultiTenancyEnabled()) {
+                // listener.onResponse(new MLDeployModelResponse(taskId, MLTaskType.DEPLOY_MODEL, MLTaskState.CREATED.name()));
+                // return;
+                // }
                 mlTaskManager.add(mlTask, eligibleNodeIds);
                 deployRemoteModel(mlModel, mlTask, localNodeId, eligibleNodes, deployToAllNodes, listener);
                 return;
@@ -302,6 +302,7 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
                         () -> updateModelDeployStatusAndTriggerOnNodesAction(
                             modelId,
                             taskId,
+                            tenantId,
                             mlModel,
                             localNodeId,
                             mlTask,
@@ -344,6 +345,7 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
         MLDeployModelInput deployModelInput = new MLDeployModelInput(
             mlModel.getModelId(),
             mlTask.getTaskId(),
+            mlModel.getTenantId(),
             mlModel.getModelContentHash(),
             eligibleNodes.size(),
             localNodeId,
@@ -367,6 +369,7 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
         mlModelManager
             .updateModel(
                 mlModel.getModelId(),
+                mlModel.getTenantId(),
                 Map
                     .of(
                         MLModel.MODEL_STATE_FIELD,
@@ -408,7 +411,7 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
                     TASK_SEMAPHORE_TIMEOUT,
                     true
                 );
-            mlModelManager.updateModel(modelId, isHidden, Map.of(MLModel.MODEL_STATE_FIELD, MLModelState.DEPLOY_FAILED));
+            mlModelManager.updateModel(modelId, tenantId, isHidden, Map.of(MLModel.MODEL_STATE_FIELD, MLModelState.DEPLOY_FAILED));
             listener.onFailure(e);
         });
     }
@@ -417,6 +420,7 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
     void updateModelDeployStatusAndTriggerOnNodesAction(
         String modelId,
         String taskId,
+        String tenantId,
         MLModel mlModel,
         String localNodeId,
         MLTask mlTask,
@@ -426,6 +430,7 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
         MLDeployModelInput deployModelInput = new MLDeployModelInput(
             modelId,
             taskId,
+            tenantId,
             mlModel.getModelContentHash(),
             eligibleNodes.size(),
             localNodeId,
@@ -451,13 +456,20 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
                     TASK_SEMAPHORE_TIMEOUT,
                     true
                 );
-            mlModelManager.updateModel(modelId, mlModel.getIsHidden(), Map.of(MLModel.MODEL_STATE_FIELD, MLModelState.DEPLOY_FAILED));
+            mlModelManager
+                .updateModel(
+                    modelId,
+                    mlModel.getTenantId(),
+                    mlModel.getIsHidden(),
+                    Map.of(MLModel.MODEL_STATE_FIELD, MLModelState.DEPLOY_FAILED)
+                );
         });
 
         List<String> workerNodes = eligibleNodes.stream().map(DiscoveryNode::getId).collect(Collectors.toList());
         mlModelManager
             .updateModel(
                 modelId,
+                mlModel.getTenantId(),
                 Map
                     .of(
                         MLModel.MODEL_STATE_FIELD,

--- a/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java
@@ -285,10 +285,6 @@ public class TransportDeployModelAction extends HandledTransportAction<ActionReq
             String taskId = response.getId();
             mlTask.setTaskId(taskId);
             if (algorithm == FunctionName.REMOTE) {
-                // if (mlFeatureEnabledSetting.isMultiTenancyEnabled()) {
-                // listener.onResponse(new MLDeployModelResponse(taskId, MLTaskType.DEPLOY_MODEL, MLTaskState.CREATED.name()));
-                // return;
-                // }
                 mlTaskManager.add(mlTask, eligibleNodeIds);
                 deployRemoteModel(mlModel, mlTask, localNodeId, eligibleNodes, deployToAllNodes, listener);
                 return;

--- a/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelOnNodeAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelOnNodeAction.java
@@ -129,6 +129,7 @@ public class TransportDeployModelOnNodeAction extends
         MLDeployModelInput deployModelInput = MLDeployModelNodesRequest.getMlDeployModelInput();
         String modelId = deployModelInput.getModelId();
         String taskId = deployModelInput.getTaskId();
+        String tenantId = deployModelInput.getTenantId();
         String coordinatingNodeId = deployModelInput.getCoordinatingNodeId();
         MLTask mlTask = deployModelInput.getMlTask();
         String modelContentHash = deployModelInput.getModelContentHash();
@@ -140,12 +141,13 @@ public class TransportDeployModelOnNodeAction extends
         String localNodeId = clusterService.localNode().getId();
 
         ActionListener<MLForwardResponse> taskDoneListener = ActionListener
-            .wrap(res -> { log.info("deploy model task done " + taskId); }, ex -> {
+            .wrap(res -> { log.info("deploy model task done {}", taskId); }, ex -> {
                 logException("Deploy model task failed: " + taskId, ex, log);
             });
 
         deployModel(
             modelId,
+            tenantId,
             modelContentHash,
             mlTask.getFunctionName(),
             localNodeId,
@@ -158,6 +160,7 @@ public class TransportDeployModelOnNodeAction extends
                     .requestType(MLForwardRequestType.DEPLOY_MODEL_DONE)
                     .taskId(taskId)
                     .modelId(modelId)
+                    .tenantId(tenantId)
                     .workerNodeId(clusterService.localNode().getId())
                     .build();
                 MLForwardRequest deployModelDoneMessage = new MLForwardRequest(mlForwardInput);
@@ -177,6 +180,7 @@ public class TransportDeployModelOnNodeAction extends
                     .requestType(MLForwardRequestType.DEPLOY_MODEL_DONE)
                     .taskId(taskId)
                     .modelId(modelId)
+                    .tenantId(tenantId)
                     .workerNodeId(clusterService.localNode().getId())
                     .error(MLExceptionUtils.getRootCauseMessage(e))
                     .build();
@@ -211,6 +215,7 @@ public class TransportDeployModelOnNodeAction extends
 
     private void deployModel(
         String modelId,
+        String tenantId,
         String modelContentHash,
         FunctionName functionName,
         String localNodeId,
@@ -224,7 +229,7 @@ public class TransportDeployModelOnNodeAction extends
             mlModelManager
                 .deployModel(
                     modelId,
-                    null,
+                    tenantId,
                     modelContentHash,
                     functionName,
                     deployToAllNodes,

--- a/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java
@@ -16,7 +16,6 @@ import static org.opensearch.ml.utils.MLExceptionUtils.LOCAL_MODEL_DISABLED_ERR_
 import static org.opensearch.ml.utils.MLExceptionUtils.logException;
 
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -402,7 +401,7 @@ public class TransportRegisterModelAction extends HandledTransportAction<ActionR
                         );
                 });
                 try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-                    mlTaskManager.add(mlTask, Arrays.asList(nodeId));
+                    mlTaskManager.add(mlTask, List.of(nodeId));
                     MLForwardInput forwardInput = MLForwardInput
                         .builder()
                         .requestType(MLForwardRequestType.REGISTER_MODEL)

--- a/plugin/src/main/java/org/opensearch/ml/autoredeploy/MLModelAutoReDeployer.java
+++ b/plugin/src/main/java/org/opensearch/ml/autoredeploy/MLModelAutoReDeployer.java
@@ -115,7 +115,7 @@ public class MLModelAutoReDeployer {
     private void undeployModelsOnDataNodes() {
         List<String> dataNodeIds = new ArrayList<>();
         clusterService.state().nodes().getDataNodes().values().iterator().forEachRemaining(x -> { dataNodeIds.add(x.getId()); });
-        if (dataNodeIds.size() > 0)
+        if (!dataNodeIds.isEmpty())
             triggerUndeployModelsOnDataNodes(dataNodeIds);
     }
 
@@ -152,7 +152,7 @@ public class MLModelAutoReDeployer {
             startCronjobAndClearListener();
             return;
         }
-        if (modelAutoRedeployArrangements.size() == 0) {
+        if (modelAutoRedeployArrangements.isEmpty()) {
             log.info("No models needs to be auto redeployed!");
             startCronjobAndClearListener();
             return;
@@ -204,7 +204,7 @@ public class MLModelAutoReDeployer {
         ActionListener<SearchResponse> listener = ActionListener.wrap(res -> {
             if (res != null && res.getHits() != null && res.getHits().getTotalHits() != null && res.getHits().getTotalHits().value > 0) {
                 Arrays.stream(res.getHits().getHits()).forEach(x -> modelIds.add(x.getId()));
-                if (modelIds.size() > 0) {
+                if (!modelIds.isEmpty()) {
                     ActionListener<MLUndeployModelNodesResponse> undeployModelListener = ActionListener.wrap(r -> {
                         log.info("Undeploy models on data nodes successfully!");
                     }, e -> { log.error("Failed to undeploy models on data nodes, error is: {}", e.getMessage(), e); });
@@ -272,13 +272,13 @@ public class MLModelAutoReDeployer {
         String[] nodeIds = null;
         if (deployToAllNodes || !allowCustomDeploymentPlan) {
             nodeIds = new String[0];
-        } else if (planningWorkerNodes != null && planningWorkerNodes.size() > 0) {
+        } else if (planningWorkerNodes != null && !planningWorkerNodes.isEmpty()) {
             // allow custom deploy plan and not deploy to all case, we need to check if the added nodes in planning worker nodes.
             List<String> needRedeployPlanningWorkerNodes = Arrays
                 .stream(planningWorkerNodes.toArray(new String[0]))
                 .filter(addedNodes::contains)
                 .collect(Collectors.toList());
-            nodeIds = needRedeployPlanningWorkerNodes.size() > 0 ? planningWorkerNodes.toArray(new String[0]) : null;
+            nodeIds = !needRedeployPlanningWorkerNodes.isEmpty() ? planningWorkerNodes.toArray(new String[0]) : null;
         }
 
         if (nodeIds == null) {
@@ -302,9 +302,12 @@ public class MLModelAutoReDeployer {
             redeployAModel();
         });
 
+        // TODO: currently just provided tenantId null as auto re-deployer should work only in single tenant service. Will revisit this
+        // later.
         mlModelManager
             .updateModel(
                 modelId,
+                null,
                 false,
                 ImmutableMap.of(MLModel.AUTO_REDEPLOY_RETRY_TIMES_FIELD, Optional.ofNullable(autoRedeployRetryTimes).orElse(0) + 1)
             );

--- a/plugin/src/test/java/org/opensearch/ml/action/deploy/TransportDeployModelOnNodeActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/deploy/TransportDeployModelOnNodeActionTests.java
@@ -377,6 +377,7 @@ public class TransportDeployModelOnNodeActionTests extends OpenSearchTestCase {
         MLDeployModelInput deployModelInput = new MLDeployModelInput(
             "modelId",
             "taskId",
+            null,
             "modelContentHash",
             3,
             coordinatingNodeId,

--- a/plugin/src/test/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/syncup/TransportSyncUpOnNodeActionTests.java
@@ -287,7 +287,7 @@ public class TransportSyncUpOnNodeActionTests extends OpenSearchTestCase {
         when(mlTaskManager.getMLTaskCache(taskId)).thenReturn(taskCache);
         action.cleanUpLocalCache(runningDeployModelTasks);
         verify(mlTaskManager, times(1)).updateMLTask(anyString(), any(), any(), anyLong(), anyBoolean());
-        verify(mlModelManager, never()).updateModel(anyString(), (Boolean) any(), any());
+        verify(mlModelManager, never()).updateModel(anyString(), anyString(), (Boolean) any(), any());
     }
 
     public void testCleanUpLocalCache_ExpiredMLTask_Deploy_NullWorkerNode() {
@@ -326,7 +326,7 @@ public class TransportSyncUpOnNodeActionTests extends OpenSearchTestCase {
         action.cleanUpLocalCache(runningDeployModelTasks);
         verify(mlTaskManager, times(1)).updateMLTask(anyString(), any(), any(), anyLong(), anyBoolean());
         ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(mlModelManager, never()).updateModel(eq(modelId), eq(false), argumentCaptor.capture());
+        verify(mlModelManager, never()).updateModel(eq(modelId), eq(null), eq(false), argumentCaptor.capture());
     }
 
     private MLSyncUpInput prepareRequest() {

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -923,7 +923,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
 
     public void testUpdateModel_NullUpdatedFields() {
         ActionListener<UpdateResponse> listener = mock(ActionListener.class);
-        modelManager.updateModel(modelId, null, listener);
+        modelManager.updateModel(modelId, null, null, listener);
         ArgumentCaptor<Exception> failure = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(failure.capture());
         assertEquals("Updated fields is null or empty", failure.getValue().getMessage());
@@ -931,7 +931,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
 
     public void testUpdateModel_EmptyUpdatedFields() {
         ActionListener<UpdateResponse> listener = mock(ActionListener.class);
-        modelManager.updateModel(modelId, ImmutableMap.of(), listener);
+        modelManager.updateModel(modelId, null, ImmutableMap.of(), listener);
         ArgumentCaptor<Exception> failure = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(failure.capture());
         assertEquals("Updated fields is null or empty", failure.getValue().getMessage());
@@ -940,7 +940,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
     public void testUpdateModel_ThreadPoolException() {
         mock_client_ThreadContext_Exception(client, threadPool, threadContext);
         ActionListener<UpdateResponse> listener = mock(ActionListener.class);
-        modelManager.updateModel(modelId, ImmutableMap.of(MLModel.MODEL_STATE_FIELD, MLModelState.DEPLOYED), listener);
+        modelManager.updateModel(modelId, null, ImmutableMap.of(MLModel.MODEL_STATE_FIELD, MLModelState.DEPLOYED), listener);
         ArgumentCaptor<Exception> failure = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(failure.capture());
         assertEquals("failed to stashContext", failure.getValue().getMessage());


### PR DESCRIPTION
…loy request

### Description
[applying multi-tenancy for forward request which is important for deploy request

purpose of TransportForwardAction.java is to forward the request to other nodes in a multi-node cluster
Also at the same time, currently in multi-tenancy, if a model is deployed, the status is not being updated in the index. Because that update wasn't happening through sdkclient.
]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
