### PR TITLE
[Feature/multi_tenancy] Implement client.bulk in SDK Client

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelNodesRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelNodesRequest.java
@@ -6,6 +6,8 @@
 package org.opensearch.ml.common.transport.undeploy;
 
 import lombok.Getter;
+import lombok.Setter;
+
 import org.opensearch.action.support.nodes.BaseNodesRequest;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -17,10 +19,15 @@ public class MLUndeployModelNodesRequest extends BaseNodesRequest<MLUndeployMode
 
     @Getter
     private String[] modelIds;
+    @Getter
+    @Setter
+    private String tenantId;
 
     public MLUndeployModelNodesRequest(StreamInput in) throws IOException {
         super(in);
         this.modelIds = in.readOptionalStringArray();
+        // TODO: will do bwc check later.
+        this.tenantId = in.readOptionalString();
     }
 
     public MLUndeployModelNodesRequest(String[] nodeIds, String[] modelIds) {
@@ -36,6 +43,7 @@ public class MLUndeployModelNodesRequest extends BaseNodesRequest<MLUndeployMode
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeOptionalStringArray(modelIds);
+        out.writeOptionalString(tenantId);
     }
 
 }

--- a/common/src/main/java/org/opensearch/sdk/AbstractSdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/AbstractSdkClient.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+public abstract class AbstractSdkClient implements SdkClientDelegate {
+
+    @SuppressWarnings({ "deprecation", "removal" })
+    protected <T> CompletionStage<T> executePrivilegedAsync(PrivilegedAction<T> action, Executor executor) {
+        return CompletableFuture.supplyAsync(() -> AccessController.doPrivileged(action), executor);
+    }
+}

--- a/common/src/main/java/org/opensearch/sdk/BulkDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/BulkDataObjectRequest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.opensearch.common.Nullable;
+import org.opensearch.core.common.Strings;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class BulkDataObjectRequest {
+
+    private final List<DataObjectRequest> requests = new ArrayList<>();
+    private final Set<String> indices = new HashSet<>();
+    private String globalIndex;
+
+    public BulkDataObjectRequest() {}
+
+    /**
+     * Instantiate this request with a global index.
+     * <p>
+     * For data storage implementations other than OpenSearch, an index may be referred to as a table and the id may be referred to as a primary key.
+     * @param index the index location for all the bulk requests
+     */
+    public BulkDataObjectRequest(@Nullable String globalIndex) {
+        this.globalIndex = globalIndex;
+    }
+
+    /**
+     * Returns the list of requests in this bulk request.
+     * @return the requests list
+     */
+    public List<DataObjectRequest> requests() {
+        return List.copyOf(this.requests);
+    }
+
+    /**
+     * Returns the indices being updated in this bulk request.
+     * @return the indices being updated
+     */
+    public Set<String> getIndices() {
+        return Collections.unmodifiableSet(indices);
+    }
+
+    /**
+     * Add the given request to the {@link BulkDataObjectRequest}
+     * @param request The request to add
+     * @return the updated request object
+     */
+    public BulkDataObjectRequest add(DataObjectRequest request) {
+        if (!request.isWriteRequest()) {
+            throw new IllegalArgumentException("No support for request [" + request.getClass().getName() + "]");
+        }
+        if (Strings.isNullOrEmpty(request.index())) {
+            if (Strings.isNullOrEmpty(globalIndex)) {
+                throw new IllegalArgumentException(
+                    "Either the request [" + request.getClass().getName() + "] or the bulk request must specify an index."
+                );
+            }
+            indices.add(globalIndex);
+            request.index(globalIndex);
+        } else {
+            indices.add(request.index());
+        }
+        requests.add(request);
+        return this;
+    }
+}

--- a/common/src/main/java/org/opensearch/sdk/BulkDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/BulkDataObjectRequest.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 import org.opensearch.common.Nullable;
 import org.opensearch.core.common.Strings;
 
@@ -21,6 +22,7 @@ public class BulkDataObjectRequest {
 
     private final List<DataObjectRequest> requests = new ArrayList<>();
     private final Set<String> indices = new HashSet<>();
+    private RefreshPolicy refreshPolicy = RefreshPolicy.NONE;
     private String globalIndex;
     private String globalTenantId;
 
@@ -87,6 +89,23 @@ public class BulkDataObjectRequest {
         return this;
     }
 
+    /**
+     * Should this request trigger a refresh ({@linkplain RefreshPolicy#IMMEDIATE}), wait for a refresh (
+     * {@linkplain RefreshPolicy#WAIT_UNTIL}), or proceed ignore refreshes entirely ({@linkplain RefreshPolicy#NONE}, the default).
+     */
+    public BulkDataObjectRequest setRefreshPolicy(RefreshPolicy refreshPolicy) {
+        this.refreshPolicy = refreshPolicy;
+        return this;
+    }
+
+    /**
+     * Should this request trigger a refresh ({@linkplain RefreshPolicy#IMMEDIATE}), wait for a refresh (
+     * {@linkplain RefreshPolicy#WAIT_UNTIL}), or proceed ignore refreshes entirely ({@linkplain RefreshPolicy#NONE}, the default).
+     */
+    public RefreshPolicy getRefreshPolicy() {
+        return refreshPolicy;
+    }
+    
     /**
      * Instantiate a builder for this object
      * @return a builder instance

--- a/common/src/main/java/org/opensearch/sdk/BulkDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/BulkDataObjectRequest.java
@@ -24,18 +24,15 @@ public class BulkDataObjectRequest {
     private final Set<String> indices = new HashSet<>();
     private RefreshPolicy refreshPolicy = RefreshPolicy.NONE;
     private String globalIndex;
-    private String globalTenantId;
 
     /**
      * Instantiate this request with a global index.
      * <p>
      * For data storage implementations other than OpenSearch, an index may be referred to as a table and the id may be referred to as a primary key.
      * @param globalIndex the index location for all the bulk requests as a default if not already specified
-     * @param globalTenantId the tenantId for all the bulk requests, overwriting what's specified if not null
      */
-    public BulkDataObjectRequest(@Nullable String globalIndex, @Nullable String globalTenantId) {
+    public BulkDataObjectRequest(@Nullable String globalIndex) {
         this.globalIndex = globalIndex;
-        this.globalTenantId = globalTenantId;
     }
 
     /**
@@ -52,14 +49,6 @@ public class BulkDataObjectRequest {
      */
     public Set<String> getIndices() {
         return Collections.unmodifiableSet(indices);
-    }
-
-    /**
-     * Return the global tenant id to be applied to all requests
-     * @return the globalTenantId
-     */
-    public String globalTenantId() {
-        return this.globalTenantId;
     }
 
     /**
@@ -81,9 +70,6 @@ public class BulkDataObjectRequest {
             request.index(globalIndex);
         } else {
             indices.add(request.index());
-        }
-        if (!Strings.isNullOrEmpty(globalTenantId)) {
-            request.tenantId(globalTenantId);
         }
         requests.add(request);
         return this;
@@ -119,7 +105,6 @@ public class BulkDataObjectRequest {
      */
     public static class Builder {
         private String globalIndex = null;
-        private String globalTenantId = null;
 
         /**
          * Empty constructor to initialize
@@ -137,21 +122,11 @@ public class BulkDataObjectRequest {
         }
 
         /**
-         * Add a tenant id to this builder
-         * @param tenantId the tenant id
-         * @return the updated builder
-         */
-        public Builder globalTenantId(String tenantId) {
-            this.globalTenantId = tenantId;
-            return this;
-        }
-
-        /**
          * Builds the request
          * @return A {@link BulkDataObjectRequest}
          */
         public BulkDataObjectRequest build() {
-            return new BulkDataObjectRequest(this.globalIndex, this.globalTenantId);
+            return new BulkDataObjectRequest(this.globalIndex);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/BulkDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/BulkDataObjectRequest.java
@@ -8,14 +8,14 @@
  */
 package org.opensearch.sdk;
 
-import org.opensearch.common.Nullable;
-import org.opensearch.core.common.Strings;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.opensearch.common.Nullable;
+import org.opensearch.core.common.Strings;
 
 public class BulkDataObjectRequest {
 
@@ -24,16 +24,16 @@ public class BulkDataObjectRequest {
     private String globalIndex;
     private String globalTenantId;
 
-    public BulkDataObjectRequest() {}
-
     /**
      * Instantiate this request with a global index.
      * <p>
      * For data storage implementations other than OpenSearch, an index may be referred to as a table and the id may be referred to as a primary key.
-     * @param index the index location for all the bulk requests
+     * @param globalIndex the index location for all the bulk requests as a default if not already specified
+     * @param globalTenantId the tenantId for all the bulk requests, overwriting what's specified if not null
      */
-    public BulkDataObjectRequest(@Nullable String globalIndex) {
+    public BulkDataObjectRequest(@Nullable String globalIndex, @Nullable String globalTenantId) {
         this.globalIndex = globalIndex;
+        this.globalTenantId = globalTenantId;
     }
 
     /**
@@ -59,7 +59,7 @@ public class BulkDataObjectRequest {
     public String globalTenantId() {
         return this.globalTenantId;
     }
-    
+
     /**
      * Add the given request to the {@link BulkDataObjectRequest}
      * @param request The request to add
@@ -80,8 +80,59 @@ public class BulkDataObjectRequest {
         } else {
             indices.add(request.index());
         }
-        request.tenantId(globalTenantId);
+        if (!Strings.isNullOrEmpty(globalTenantId)) {
+            request.tenantId(globalTenantId);
+        }
         requests.add(request);
         return this;
+    }
+
+    /**
+     * Instantiate a builder for this object
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Class for constructing a Builder for this Request Object
+     */
+    public static class Builder {
+        private String globalIndex = null;
+        private String globalTenantId = null;
+
+        /**
+         * Empty constructor to initialize
+         */
+        protected Builder() {}
+
+        /**
+         * Add an index to this builder
+         * @param index the index to put the object
+         * @return the updated builder
+         */
+        public Builder globalIndex(String index) {
+            this.globalIndex = index;
+            return this;
+        }
+
+        /**
+         * Add a tenant id to this builder
+         * @param tenantId the tenant id
+         * @return the updated builder
+         */
+        public Builder globalTenantId(String tenantId) {
+            this.globalTenantId = tenantId;
+            return this;
+        }
+
+        /**
+         * Builds the request
+         * @return A {@link BulkDataObjectRequest}
+         */
+        public BulkDataObjectRequest build() {
+            return new BulkDataObjectRequest(this.globalIndex, this.globalTenantId);
+        }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/BulkDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/BulkDataObjectRequest.java
@@ -22,6 +22,7 @@ public class BulkDataObjectRequest {
     private final List<DataObjectRequest> requests = new ArrayList<>();
     private final Set<String> indices = new HashSet<>();
     private String globalIndex;
+    private String globalTenantId;
 
     public BulkDataObjectRequest() {}
 
@@ -52,6 +53,14 @@ public class BulkDataObjectRequest {
     }
 
     /**
+     * Return the global tenant id to be applied to all requests
+     * @return the globalTenantId
+     */
+    public String globalTenantId() {
+        return this.globalTenantId;
+    }
+    
+    /**
      * Add the given request to the {@link BulkDataObjectRequest}
      * @param request The request to add
      * @return the updated request object
@@ -71,6 +80,7 @@ public class BulkDataObjectRequest {
         } else {
             indices.add(request.index());
         }
+        request.tenantId(globalTenantId);
         requests.add(request);
         return this;
     }

--- a/common/src/main/java/org/opensearch/sdk/BulkDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/BulkDataObjectResponse.java
@@ -10,22 +10,28 @@ package org.opensearch.sdk;
 
 import java.util.Arrays;
 
+import org.opensearch.core.xcontent.XContentParser;
+
 import static org.opensearch.action.bulk.BulkResponse.NO_INGEST_TOOK;
 
 public class BulkDataObjectResponse {
 
-    private final DataObjectResponse[] responses;
+    private final DataObjectResponse[] responses;    
     private final long tookInMillis;
     private final long ingestTookInMillis;
+    private final boolean failures;
+    private final XContentParser parser;
 
-    public BulkDataObjectResponse(DataObjectResponse[] responses, long tookInMillis) {
-        this(responses, tookInMillis, NO_INGEST_TOOK);
+    public BulkDataObjectResponse(DataObjectResponse[] responses, long tookInMillis, boolean failures, XContentParser parser) {
+        this(responses, tookInMillis, NO_INGEST_TOOK, failures, parser);
     }
 
-    public BulkDataObjectResponse(DataObjectResponse[] responses, long tookInMillis, long ingestTookInMillis) {
+    public BulkDataObjectResponse(DataObjectResponse[] responses, long tookInMillis, long ingestTookInMillis, boolean failures, XContentParser parser) {
         this.responses = responses;
         this.tookInMillis = tookInMillis;
         this.ingestTookInMillis = ingestTookInMillis;
+        this.failures = failures;
+        this.parser = parser;
     }
 
     /**
@@ -57,6 +63,14 @@ public class BulkDataObjectResponse {
      * @return true if any response failed, false otherwise
      */
     public boolean hasFailures() {
-        return Arrays.stream(responses).anyMatch(DataObjectResponse::isFailed);
+        return this.failures;
+    }
+    
+    /**
+     * Returns the parser
+     * @return the parser
+     */
+    public XContentParser parser() {
+        return this.parser;
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/BulkDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/BulkDataObjectResponse.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import java.util.Arrays;
+
+public class BulkDataObjectResponse {
+
+    private final DataObjectResponse[] responses;
+    private final long tookInMillis;
+    private final long ingestTookInMillis;
+
+    public BulkDataObjectResponse(DataObjectResponse[] responses, long tookInMillis, long ingestTookInMillis) {
+        this.responses = responses;
+        this.tookInMillis = tookInMillis;
+        this.ingestTookInMillis = ingestTookInMillis;
+    }
+
+    /**
+     * The items representing each action performed in the bulk operation (in the same order!).
+     * @return the responses in the same order requested
+     */
+    public DataObjectResponse[] getResponses() {
+        return responses;
+    }
+
+    /**
+     * How long the bulk execution took. Excluding ingest preprocessing.
+     * @return the execution time in milliseconds
+     */
+    public long getTookInMillis() {
+        return tookInMillis;
+    }
+
+    /**
+     * If ingest is enabled returns the bulk ingest preprocessing time. in milliseconds, otherwise -1 is returned.
+     * @return the ingest execution time in milliseconds
+     */
+    public long getIngestTookInMillis() {
+        return ingestTookInMillis;
+    }
+
+    /**
+     * Has anything failed with the execution.
+     * @return true if any response failed, false otherwise
+     */
+    public boolean hasFailures() {
+        return Arrays.stream(responses).anyMatch(DataObjectResponse::isFailed);
+    }
+}

--- a/common/src/main/java/org/opensearch/sdk/BulkDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/BulkDataObjectResponse.java
@@ -10,11 +10,17 @@ package org.opensearch.sdk;
 
 import java.util.Arrays;
 
+import static org.opensearch.action.bulk.BulkResponse.NO_INGEST_TOOK;
+
 public class BulkDataObjectResponse {
 
     private final DataObjectResponse[] responses;
     private final long tookInMillis;
     private final long ingestTookInMillis;
+
+    public BulkDataObjectResponse(DataObjectResponse[] responses, long tookInMillis) {
+        this(responses, tookInMillis, NO_INGEST_TOOK);
+    }
 
     public BulkDataObjectResponse(DataObjectResponse[] responses, long tookInMillis, long ingestTookInMillis) {
         this.responses = responses;

--- a/common/src/main/java/org/opensearch/sdk/DataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/DataObjectRequest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+public abstract class DataObjectRequest {
+
+    private String index;
+    private final String id;
+    private final String tenantId;
+    
+    /**
+     * Instantiate this request with an index and id.
+     * <p>
+     * For data storage implementations other than OpenSearch, an index may be referred to as a table and the id may be referred to as a primary key.
+     * @param index the index location to delete the object
+     * @param id the document id
+     * @param tenantId the tenant id
+     */
+    protected DataObjectRequest(String index, String id, String tenantId) {
+        this.index = index;
+        this.id = id;
+        this.tenantId = tenantId;
+    }
+
+    /**
+     * Returns the index
+     * @return the index
+     */
+    public String index() {
+        return this.index;
+    }
+
+    /**
+     * Sets the index
+     * @param index The new index to set
+     */
+    public void index(String index) {
+        this.index = index;
+    }
+    
+    /**
+     * Returns the document id
+     * @return the id
+     */
+    public String id() {
+        return this.id;
+    }
+
+    /**
+     * Returns the tenant id
+     * @return the tenantId
+     */
+    public String tenantId() {
+        return this.tenantId;
+    }
+
+    /**
+     * Returns whether the subclass can be used in a {@link BulkDataObjectRequest}
+     * @return
+     */
+    public abstract boolean isWriteRequest();
+
+    /**
+     * Superclass for common fields in subclass builders
+     */
+    public static class Builder<T extends Builder<T>> {
+        protected String index = null;
+        protected String id = null;
+        protected String tenantId = null;
+
+        /**
+         * Empty constructor to initialize
+         */
+        protected Builder() {}
+
+        /**
+         * Add an index to this builder
+         * @param index the index to put the object
+         * @return the updated builder
+         */
+        public T index(String index) {
+            this.index = index;
+            return self();
+        }
+
+        /**
+         * Add an id to this builder
+         * @param id the document id
+         * @return the updated builder
+         */
+        public T id(String id) {
+            this.id = id;
+            return self();
+        }
+
+        /**
+         * Add a tenant id to this builder
+         * @param tenantId the tenant id
+         * @return the updated builder
+         */
+        public T tenantId(String tenantId) {
+            this.tenantId = tenantId;
+            return self();
+        }
+
+        /**
+         * Returns this builder as the parameterized type.
+         */
+        @SuppressWarnings("unchecked")
+        protected T self() {
+            return (T) this;
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/sdk/DataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/DataObjectRequest.java
@@ -67,7 +67,7 @@ public abstract class DataObjectRequest {
     public void tenantId(String tenantId) {
         this.tenantId = tenantId;
     }
-    
+
     /**
      * Returns whether the subclass can be used in a {@link BulkDataObjectRequest}
      * @return whether the subclass is a write request

--- a/common/src/main/java/org/opensearch/sdk/DataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/DataObjectRequest.java
@@ -12,7 +12,7 @@ public abstract class DataObjectRequest {
 
     private String index;
     private final String id;
-    private final String tenantId;
+    private String tenantId;
 
     /**
      * Instantiate this request with an index and id.
@@ -60,6 +60,14 @@ public abstract class DataObjectRequest {
         return this.tenantId;
     }
 
+    /**
+     * Sets the tenant id
+     * @param tenantId The new tenant id to set
+     */
+    public void tenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+    
     /**
      * Returns whether the subclass can be used in a {@link BulkDataObjectRequest}
      * @return whether the subclass is a write request

--- a/common/src/main/java/org/opensearch/sdk/DataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/DataObjectRequest.java
@@ -13,7 +13,7 @@ public abstract class DataObjectRequest {
     private String index;
     private final String id;
     private final String tenantId;
-    
+
     /**
      * Instantiate this request with an index and id.
      * <p>
@@ -43,7 +43,7 @@ public abstract class DataObjectRequest {
     public void index(String index) {
         this.index = index;
     }
-    
+
     /**
      * Returns the document id
      * @return the id
@@ -62,7 +62,7 @@ public abstract class DataObjectRequest {
 
     /**
      * Returns whether the subclass can be used in a {@link BulkDataObjectRequest}
-     * @return
+     * @return whether the subclass is a write request
      */
     public abstract boolean isWriteRequest();
 

--- a/common/src/main/java/org/opensearch/sdk/DataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/DataObjectResponse.java
@@ -8,25 +8,43 @@
  */
 package org.opensearch.sdk;
 
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 
 public abstract class DataObjectResponse {
+    private final String index;
     private final String id;
     private final XContentParser parser;
     private final boolean failed;
+    private final Exception cause;
+    private final RestStatus status;
 
     /**
-     * Instantiate this request with an id and parser representing a Response
+     * Instantiate this request with an index, id, failure status, and parser representing a Response
      * <p>
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
+     * @param index the index
      * @param id the document id
      * @param parser a parser that can be used to create a Response
      * @param failed whether the request failed
+     * @param cause the Exception causing the failure
+     * @param status the RestStatus
      */
-    protected DataObjectResponse(String id, XContentParser parser, boolean failed) {
+    protected DataObjectResponse(String index, String id, XContentParser parser, boolean failed, Exception cause, RestStatus status) {
+        this.index = index;
         this.id = id;
         this.parser = parser;
         this.failed = failed;
+        this.cause = cause;
+        this.status = status;
+    }
+
+    /**
+     * Returns the index
+     * @return the index
+     */
+    public String index() {
+        return this.index;
     }
 
     /**
@@ -54,17 +72,46 @@ public abstract class DataObjectResponse {
     }
 
     /**
+     * The actual cause of the failure.
+     * @return the Exception causing the failure
+     */
+    public Exception cause() {
+        return this.cause;
+    }
+
+    /**
+     * The rest status.
+     * @return the rest status.
+     */
+    public RestStatus status() {
+        return this.status;
+    }
+
+    /**
      * Superclass for common fields in subclass builders
      */
     public static class Builder<T extends Builder<T>> {
+        protected String index = null;
         protected String id = null;
         protected XContentParser parser;
         protected boolean failed = false;
+        protected Exception cause = null;
+        protected RestStatus status = null;
 
         /**
          * Empty constructor to initialize
          */
         protected Builder() {}
+
+        /**
+         * Add an index to this builder
+         * @param index the index to add
+         * @return the updated builder
+         */
+        public T index(String index) {
+            this.index = index;
+            return self();
+        }
 
         /**
          * Add an id to this builder
@@ -93,6 +140,26 @@ public abstract class DataObjectResponse {
          */
         public T failed(boolean failed) {
             this.failed = failed;
+            return self();
+        }
+
+        /**
+         * Add a cause to this builder
+         * @param cause the Exception
+         * @return the updated builder
+         */
+        public T cause(Exception cause) {
+            this.cause = cause;
+            return self();
+        }
+
+        /**
+         * Add a rest status to this builder
+         * @param status the rest status
+         * @return the updated builder
+         */
+        public T status(RestStatus status) {
+            this.status = status;
             return self();
         }
 

--- a/common/src/main/java/org/opensearch/sdk/DataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/DataObjectResponse.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.opensearch.core.xcontent.XContentParser;
+
+public abstract class DataObjectResponse {
+    private final String id;
+    private final XContentParser parser;
+    private final boolean failed;
+
+    /**
+     * Instantiate this request with an id and parser representing a Response
+     * <p>
+     * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
+     * @param id the document id
+     * @param parser a parser that can be used to create a Response
+     * @param failed whether the request failed
+     */
+    protected DataObjectResponse(String id, XContentParser parser, boolean failed) {
+        this.id = id;
+        this.parser = parser;
+        this.failed = failed;
+    }
+
+    /**
+     * Returns the document id
+     * @return the id
+     */
+    public String id() {
+        return this.id;
+    }
+
+    /**
+     * Returns the parser that can be used to create an IndexResponse
+     * @return the parser
+     */
+    public XContentParser parser() {
+        return this.parser;
+    }
+
+    /**
+     * Has anything failed with the execution.
+     * @return whether the corresponding bulk request failed
+     */
+    public boolean isFailed() {
+        return this.failed;
+    }
+
+    /**
+     * Superclass for common fields in subclass builders
+     */
+    public static class Builder<T extends Builder<T>> {
+        protected String id = null;
+        protected XContentParser parser;
+        protected boolean failed = false;
+
+        /**
+         * Empty constructor to initialize
+         */
+        protected Builder() {}
+
+        /**
+         * Add an id to this builder
+         * @param id the id to add
+         * @return the updated builder
+         */
+        public T id(String id) {
+            this.id = id;
+            return self();
+        }
+
+        /**
+         * Add a parser to this builder
+         * @param parser a parser that can be used to create a Response for the subclass
+         * @return the updated builder
+         */
+        public T parser(XContentParser parser) {
+            this.parser = parser;
+            return self();
+        }
+
+        /**
+         * Add a failed status to this builder
+         * @param failed whether the request failed
+         * @return the updated builder
+         */
+        public T failed(boolean failed) {
+            this.failed = failed;
+            return self();
+        }
+
+        /**
+         * Returns this builder as the parameterized type.
+         */
+        @SuppressWarnings("unchecked")
+        protected T self() {
+            return (T) this;
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/sdk/DeleteDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/DeleteDataObjectRequest.java
@@ -26,7 +26,7 @@ public class DeleteDataObjectRequest extends DataObjectRequest {
     public boolean isWriteRequest() {
         return true;
     }
-    
+
     /**
      * Instantiate a builder for this object
      * @return a builder instance

--- a/common/src/main/java/org/opensearch/sdk/DeleteDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/DeleteDataObjectRequest.java
@@ -8,11 +8,7 @@
  */
 package org.opensearch.sdk;
 
-public class DeleteDataObjectRequest {
-
-    private final String index;
-    private final String id;
-    private final String tenantId;
+public class DeleteDataObjectRequest extends DataObjectRequest {
 
     /**
      * Instantiate this request with an index and id.
@@ -23,33 +19,12 @@ public class DeleteDataObjectRequest {
      * @param tenantId the tenant id
      */
     public DeleteDataObjectRequest(String index, String id, String tenantId) {
-        this.index = index;
-        this.id = id;
-        this.tenantId = tenantId;
+        super(index, id, tenantId);
     }
 
-    /**
-     * Returns the index
-     * @return the index
-     */
-    public String index() {
-        return this.index;
-    }
-
-    /**
-     * Returns the document id
-     * @return the id
-     */
-    public String id() {
-        return this.id;
-    }
-
-    /**
-     * Returns the tenant id
-     * @return the tenantId
-     */
-    public String tenantId() {
-        return this.tenantId;
+    @Override
+    public boolean isWriteRequest() {
+        return true;
     }
     
     /**
@@ -63,45 +38,7 @@ public class DeleteDataObjectRequest {
     /**
      * Class for constructing a Builder for this Request Object
      */
-    public static class Builder {
-        private String index = null;
-        private String id = null;
-        private String tenantId = null;
-
-        /**
-         * Empty Constructor for the Builder object
-         */
-        private Builder() {}
-
-        /**
-         * Add an index to this builder
-         * @param index the index to put the object
-         * @return the updated builder
-         */
-        public Builder index(String index) {
-            this.index = index;
-            return this;
-        }
-
-        /**
-         * Add an id to this builder
-         * @param id the document id
-         * @return the updated builder
-         */
-        public Builder id(String id) {
-            this.id = id;
-            return this;
-        }
-
-        /**
-         * Add a tenant id to this builder
-         * @param tenantId the tenant id
-         * @return the updated builder
-         */
-        public Builder tenantId(String tenantId) {
-            this.tenantId = tenantId;
-            return this;
-        }
+    public static class Builder extends DataObjectRequest.Builder<Builder> {
 
         /**
          * Builds the object

--- a/common/src/main/java/org/opensearch/sdk/DeleteDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/DeleteDataObjectResponse.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.sdk;
 
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 
 public class DeleteDataObjectResponse extends DataObjectResponse {
@@ -16,12 +17,15 @@ public class DeleteDataObjectResponse extends DataObjectResponse {
      * Instantiate this request with an id and parser representing a DeleteResponse
      * <p>
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
+     * @param index the index
      * @param id the document id
      * @param parser a parser that can be used to create a DeleteResponse
      * @param failed whether the request failed
+     * @param cause the Exception causing the failure
+     * @param status the RestStatus
      */
-    public DeleteDataObjectResponse(String id, XContentParser parser, boolean failed) {
-        super(id, parser, failed);
+    public DeleteDataObjectResponse(String index, String id, XContentParser parser, boolean failed, Exception cause, RestStatus status) {
+        super(index, id, parser, failed, cause, status);
     }
 
     /**
@@ -42,7 +46,7 @@ public class DeleteDataObjectResponse extends DataObjectResponse {
          * @return A {@link DeleteDataObjectResponse}
          */
         public DeleteDataObjectResponse build() {
-            return new DeleteDataObjectResponse(this.id, this.parser, this.failed);
+            return new DeleteDataObjectResponse(this.index, this.id, this.parser, this.failed, this.cause, this.status);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/DeleteDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/DeleteDataObjectResponse.java
@@ -10,9 +10,7 @@ package org.opensearch.sdk;
 
 import org.opensearch.core.xcontent.XContentParser;
 
-public class DeleteDataObjectResponse {
-    private final String id;
-    private final XContentParser parser;
+public class DeleteDataObjectResponse extends DataObjectResponse {
 
     /**
      * Instantiate this request with an id and parser representing a DeleteResponse
@@ -20,28 +18,12 @@ public class DeleteDataObjectResponse {
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
      * @param id the document id
      * @param parser a parser that can be used to create a DeleteResponse
+     * @param failed whether the request failed
      */
-    public DeleteDataObjectResponse(String id, XContentParser parser) {
-        this.id = id;
-        this.parser = parser;
+    public DeleteDataObjectResponse(String id, XContentParser parser, boolean failed) {
+        super(id, parser, failed);
     }
 
-    /**
-     * Returns the document id
-     * @return the id
-     */
-    public String id() {
-        return this.id;
-    }
-    
-    /**
-     * Returns the parser that can be used to create a DeleteResponse
-     * @return the parser
-     */
-    public XContentParser parser() {
-        return this.parser;
-    }
-    
     /**
      * Instantiate a builder for this object
      * @return a builder instance
@@ -53,41 +35,14 @@ public class DeleteDataObjectResponse {
     /**
      * Class for constructing a Builder for this Response Object
      */
-    public static class Builder {
-        private String id = null;
-        private XContentParser parser = null;
+    public static class Builder extends DataObjectResponse.Builder<Builder> {
 
-        /**
-         * Empty Constructor for the Builder object
-         */
-        private Builder() {}
-
-        /**
-         * Add an id to this builder
-         * @param id the id to add
-         * @return the updated builder
-         */
-        public Builder id(String id) {
-            this.id = id;
-            return this;
-        }
-        
-        /**
-         * Add a parser to this builder
-         * @param parser a parser that can be used to create a DeleteResponse
-         * @return the updated builder
-         */
-        public Builder parser(XContentParser parser) {
-            this.parser = parser;
-            return this;
-        }
-        
         /**
          * Builds the response
          * @return A {@link DeleteDataObjectResponse}
          */
         public DeleteDataObjectResponse build() {
-            return new DeleteDataObjectResponse(this.id, this.parser);
+            return new DeleteDataObjectResponse(this.id, this.parser, this.failed);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/GetDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/GetDataObjectRequest.java
@@ -10,11 +10,8 @@ package org.opensearch.sdk;
 
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 
-public class GetDataObjectRequest {
+public class GetDataObjectRequest extends DataObjectRequest {
 
-    private final String index;
-    private final String id;
-    private final String tenantId;
     private final FetchSourceContext fetchSourceContext;
 
     /**
@@ -27,34 +24,8 @@ public class GetDataObjectRequest {
      * @param fetchSourceContext the context to use when fetching _source
      */
     public GetDataObjectRequest(String index, String id, String tenantId, FetchSourceContext fetchSourceContext) {
-        this.index = index;
-        this.id = id;
-        this.tenantId = tenantId;
+        super(index, id, tenantId);
         this.fetchSourceContext = fetchSourceContext;
-    }
-
-    /**
-     * Returns the index
-     * @return the index
-     */
-    public String index() {
-        return this.index;
-    }
-
-    /**
-     * Returns the document id
-     * @return the id
-     */
-    public String id() {
-        return this.id;
-    }
-
-    /**
-     * Returns the tenant id
-     * @return the tenantId
-     */
-    public String tenantId() {
-        return this.tenantId;
     }
 
     /**
@@ -63,6 +34,11 @@ public class GetDataObjectRequest {
      */
     public FetchSourceContext fetchSourceContext() {
         return this.fetchSourceContext;
+    }
+
+    @Override
+    public boolean isWriteRequest() {
+        return false;
     }
 
     /**
@@ -76,46 +52,8 @@ public class GetDataObjectRequest {
     /**
      * Class for constructing a Builder for this Request Object
      */
-    public static class Builder {
-        private String index = null;
-        private String id = null;
-        private String tenantId = null;
+    public static class Builder extends DataObjectRequest.Builder<Builder> {
         private FetchSourceContext fetchSourceContext;
-
-        /**
-         * Empty Constructor for the Builder object
-         */
-        private Builder() {}
-
-        /**
-         * Add an index to this builder
-         * @param index the index to put the object
-         * @return the updated builder
-         */
-        public Builder index(String index) {
-            this.index = index;
-            return this;
-        }
-
-        /**
-         * Add an id to this builder
-         * @param id the document id
-         * @return the updated builder
-         */
-        public Builder id(String id) {
-            this.id = id;
-            return this;
-        }
-
-        /**
-         * Add a tenant id to this builder
-         * @param tenantId the tenant id
-         * @return the updated builder
-         */
-        public Builder tenantId(String tenantId) {
-            this.tenantId = tenantId;
-            return this;
-        }
 
         /**
          * Add a fetchSourceContext to this builder

--- a/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
@@ -11,6 +11,7 @@ package org.opensearch.sdk;
 import java.util.Collections;
 import java.util.Map;
 
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 
 public class GetDataObjectResponse extends DataObjectResponse {
@@ -20,13 +21,16 @@ public class GetDataObjectResponse extends DataObjectResponse {
      * Instantiate this request with an id and parser/map used to recreate the data object.
      * <p>
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
+     * @param index the index
      * @param id the document id
      * @param parser a parser that can be used to create a GetResponse
      * @param failed whether the request failed
+     * @param cause the Exception causing the failure
+     * @param status the RestStatus
      * @param source the data object as a map
      */
-    public GetDataObjectResponse(String id, XContentParser parser, boolean failed, Map<String, Object> source) {
-        super(id, parser, failed);
+    public GetDataObjectResponse(String index, String id, XContentParser parser, boolean failed, Exception cause, RestStatus status, Map<String, Object> source) {
+        super(index, id, parser, failed, cause, status);
         this.source = source;
     }
 
@@ -67,7 +71,7 @@ public class GetDataObjectResponse extends DataObjectResponse {
          * @return A {@link GetDataObjectResponse}
          */
         public GetDataObjectResponse build() {
-            return new GetDataObjectResponse(this.id, this.parser, this.failed, this.source);
+            return new GetDataObjectResponse(this.index, this.id, this.parser, this.failed, this.cause, this.status, this.source);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
@@ -8,10 +8,10 @@
  */
 package org.opensearch.sdk;
 
-import org.opensearch.core.xcontent.XContentParser;
-
 import java.util.Collections;
 import java.util.Map;
+
+import org.opensearch.core.xcontent.XContentParser;
 
 public class GetDataObjectResponse extends DataObjectResponse {
     private final Map<String, Object> source;

--- a/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/GetDataObjectResponse.java
@@ -13,9 +13,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import java.util.Collections;
 import java.util.Map;
 
-public class GetDataObjectResponse {
-    private final String id;
-    private final XContentParser parser;
+public class GetDataObjectResponse extends DataObjectResponse {
     private final Map<String, Object> source;
 
     /**
@@ -24,30 +22,14 @@ public class GetDataObjectResponse {
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
      * @param id the document id
      * @param parser a parser that can be used to create a GetResponse
+     * @param failed whether the request failed
      * @param source the data object as a map
      */
-    public GetDataObjectResponse(String id, XContentParser parser, Map<String, Object> source) {
-        this.id = id;
-        this.parser = parser;
+    public GetDataObjectResponse(String id, XContentParser parser, boolean failed, Map<String, Object> source) {
+        super(id, parser, failed);
         this.source = source;
     }
 
-    /**
-     * Returns the document id
-     * @return the id
-     */
-    public String id() {
-        return this.id;
-    }
-    
-    /**
-     * Returns the parser that can be used to create a GetResponse
-     * @return the parser
-     */
-    public XContentParser parser() {
-        return this.parser;
-    }
-    
     /**
      * Returns the source map. This is a logical representation of the data object.
      * @return the source map
@@ -67,35 +49,8 @@ public class GetDataObjectResponse {
     /**
      * Class for constructing a Builder for this Response Object
      */
-    public static class Builder {
-        private String id = null;
-        private XContentParser parser = null;
+    public static class Builder extends DataObjectResponse.Builder<Builder> {
         private Map<String, Object> source = Collections.emptyMap();
-
-        /**
-         * Empty Constructor for the Builder object
-         */
-        private Builder() {}
-
-        /**
-         * Add an id to this builder
-         * @param id the id to add
-         * @return the updated builder
-         */
-        public Builder id(String id) {
-            this.id = id;
-            return this;
-        }
-        
-        /**
-         * Add a parser to this builder
-         * @param parser a parser that can be used to create a GetResponse
-         * @return the updated builder
-         */
-        public Builder parser(XContentParser parser) {
-            this.parser = parser;
-            return this;
-        }
 
         /**
          * Add a source map to this builder
@@ -106,13 +61,13 @@ public class GetDataObjectResponse {
             this.source = source == null ? Collections.emptyMap() : source;
             return this;
         }
-        
+
         /**
          * Builds the response
          * @return A {@link GetDataObjectResponse}
          */
         public GetDataObjectResponse build() {
-            return new GetDataObjectResponse(this.id, this.parser, this.source);
+            return new GetDataObjectResponse(this.id, this.parser, this.failed, this.source);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/PutDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/PutDataObjectRequest.java
@@ -8,9 +8,9 @@
  */
 package org.opensearch.sdk;
 
-import org.opensearch.core.xcontent.ToXContentObject;
-
 import java.util.Map;
+
+import org.opensearch.core.xcontent.ToXContentObject;
 
 public class PutDataObjectRequest extends DataObjectRequest {
 

--- a/common/src/main/java/org/opensearch/sdk/PutDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/PutDataObjectRequest.java
@@ -9,16 +9,11 @@
 package org.opensearch.sdk;
 
 import org.opensearch.core.xcontent.ToXContentObject;
-import org.opensearch.core.xcontent.XContentBuilder;
 
-import java.io.IOException;
 import java.util.Map;
 
-public class PutDataObjectRequest {
+public class PutDataObjectRequest extends DataObjectRequest {
 
-    private final String index;
-    private final String id;
-    private final String tenantId;
     private final boolean overwriteIfExists;
     private final ToXContentObject dataObject;
 
@@ -30,37 +25,11 @@ public class PutDataObjectRequest {
      * @param dataObject the data object
      */
     public PutDataObjectRequest(String index, String id, String tenantId, boolean overwriteIfExists, ToXContentObject dataObject) {
-        this.index = index;
-        this.id = id;
-        this.tenantId = tenantId;
+        super(index, id, tenantId);
         this.overwriteIfExists = overwriteIfExists;
         this.dataObject = dataObject;
     }
 
-    /**
-     * Returns the index
-     * @return the index
-     */
-    public String index() {
-        return this.index;
-    }
-
-    /**
-     * Returns the document id
-     * @return the id
-     */
-    public String id() {
-        return this.id;
-    }
-
-    /**
-     * Returns the tenant id
-     * @return the tenantId
-     */
-    public String tenantId() {
-        return this.tenantId;
-    }
-    
     /**
      * Returns whether to overwrite an existing document (upsert)
      * @return true if this request should overwrite
@@ -77,6 +46,11 @@ public class PutDataObjectRequest {
         return this.dataObject;
     }
 
+    @Override
+    public boolean isWriteRequest() {
+        return true;
+    }
+
     /**
      * Instantiate a builder for this object
      * @return a builder instance
@@ -88,47 +62,9 @@ public class PutDataObjectRequest {
     /**
      * Class for constructing a Builder for this Request Object
      */
-    public static class Builder {
-        private String index = null;
-        private String id = null;
-        private String tenantId = null;
+    public static class Builder extends DataObjectRequest.Builder<Builder> {
         private boolean overwriteIfExists = true;
         private ToXContentObject dataObject = null;
-
-        /**
-         * Empty Constructor for the Builder object
-         */
-        private Builder() {}
-
-        /**
-         * Add an index to this builder
-         * @param index the index to put the object
-         * @return the updated builder
-         */
-        public Builder index(String index) {
-            this.index = index;
-            return this;
-        }
-
-        /**
-         * Add an id to this builder
-         * @param id the documet id
-         * @return the updated builder
-         */
-        public Builder id(String id) {
-            this.id = id;
-            return this;
-        }
-
-        /**
-         * Add a tenant id to this builder
-         * @param tenantId the tenant id
-         * @return the updated builder
-         */
-        public Builder tenantId(String tenantId) {
-            this.tenantId = tenantId;
-            return this;
-        }
 
         /**
          * Specify whether to overwrite an existing document/item (upsert). True by default. 
@@ -139,6 +75,7 @@ public class PutDataObjectRequest {
             this.overwriteIfExists = overwriteIfExists;
             return this;
         }
+
         /**
          * Add a data object to this builder
          * @param dataObject the data object

--- a/common/src/main/java/org/opensearch/sdk/PutDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/PutDataObjectResponse.java
@@ -10,9 +10,7 @@ package org.opensearch.sdk;
 
 import org.opensearch.core.xcontent.XContentParser;
 
-public class PutDataObjectResponse {
-    private final String id;
-    private final XContentParser parser;
+public class PutDataObjectResponse extends DataObjectResponse {
 
     /**
      * Instantiate this request with an id and parser representing an IndexResponse
@@ -20,28 +18,12 @@ public class PutDataObjectResponse {
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
      * @param id the document id
      * @param parser a parser that can be used to create an IndexResponse
+     * @param failed whether the request failed
      */
-    public PutDataObjectResponse(String id, XContentParser parser) {
-        this.id = id;
-        this.parser = parser;
+    public PutDataObjectResponse(String id, XContentParser parser, boolean failed) {
+        super(id, parser, failed);
     }
 
-    /**
-     * Returns the document id
-     * @return the id
-     */
-    public String id() {
-        return this.id;
-    }
-    
-    /**
-     * Returns the parser that can be used to create an IndexResponse
-     * @return the parser
-     */
-    public XContentParser parser() {
-        return this.parser;
-    }
-    
     /**
      * Instantiate a builder for this object
      * @return a builder instance
@@ -53,41 +35,14 @@ public class PutDataObjectResponse {
     /**
      * Class for constructing a Builder for this Response Object
      */
-    public static class Builder {
-        private String id = null;
-        private XContentParser parser = null;
+    public static class Builder extends DataObjectResponse.Builder<Builder> {
 
-        /**
-         * Empty Constructor for the Builder object
-         */
-        private Builder() {}
-
-        /**
-         * Add an id to this builder
-         * @param id the id to add
-         * @return the updated builder
-         */
-        public Builder id(String id) {
-            this.id = id;
-            return this;
-        }
-        
-        /**
-         * Add a parser to this builder
-         * @param parser a parser that can be used to create an IndexResponse
-         * @return the updated builder
-         */
-        public Builder parser(XContentParser parser) {
-            this.parser = parser;
-            return this;
-        }
-        
         /**
          * Builds the response
          * @return A {@link PutDataObjectResponse}
          */
         public PutDataObjectResponse build() {
-            return new PutDataObjectResponse(this.id, this.parser);
+            return new PutDataObjectResponse(this.id, this.parser, this.failed);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/PutDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/PutDataObjectResponse.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.sdk;
 
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 
 public class PutDataObjectResponse extends DataObjectResponse {
@@ -16,12 +17,15 @@ public class PutDataObjectResponse extends DataObjectResponse {
      * Instantiate this request with an id and parser representing an IndexResponse
      * <p>
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
+     * @param index the index
      * @param id the document id
      * @param parser a parser that can be used to create an IndexResponse
      * @param failed whether the request failed
+     * @param cause the Exception causing the failure
+     * @param status the RestStatus
      */
-    public PutDataObjectResponse(String id, XContentParser parser, boolean failed) {
-        super(id, parser, failed);
+    public PutDataObjectResponse(String index, String id, XContentParser parser, boolean failed, Exception cause, RestStatus status) {
+        super(index, id, parser, failed, cause, status);
     }
 
     /**
@@ -42,7 +46,7 @@ public class PutDataObjectResponse extends DataObjectResponse {
          * @return A {@link PutDataObjectResponse}
          */
         public PutDataObjectResponse build() {
-            return new PutDataObjectResponse(this.id, this.parser, this.failed);
+            return new PutDataObjectResponse(this.index, this.id, this.parser, this.failed, this.cause, this.status);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -170,7 +170,7 @@ public class SdkClient {
     /**
      * Perform a bulk request for multiple data objects/documents in potentially multiple tables/indices.
      *
-     * @param request  A request identifying the data object to delete
+     * @param request A request identifying the bulk requests to execute
      * @param executor the executor to use for asynchronous execution
      * @return A completion stage encapsulating the response or exception
      */
@@ -182,7 +182,7 @@ public class SdkClient {
     /**
      * Perform a bulk request for multiple data objects/documents in potentially multiple tables/indices.
      *
-     * @param request A request identifying the data object to delete
+     * @param request A request identifying the bulk requests to execute
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<BulkDataObjectResponse> bulkDataObjectAsync(BulkDataObjectRequest request) {
@@ -192,7 +192,7 @@ public class SdkClient {
     /**
      * Perform a bulk request for multiple data objects/documents in potentially multiple tables/indices.
      *
-     * @param request A request identifying the data object to delete
+     * @param request A request identifying the bulk requests to execute
      * @return A response on success. Throws unchecked exceptions or {@link OpenSearchException} wrapping the cause on checked exception.
      */
     public BulkDataObjectResponse bulkDataObject(BulkDataObjectRequest request) {

--- a/common/src/main/java/org/opensearch/sdk/SdkClient.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClient.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.sdk;
 
+import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -175,7 +176,7 @@ public class SdkClient {
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<BulkDataObjectResponse> bulkDataObjectAsync(BulkDataObjectRequest request, Executor executor) {
-        validateTenantId(request.globalTenantId());
+        validateTenantIds(request.requests());
         return delegate.bulkDataObjectAsync(request, executor, isMultiTenancyEnabled);
     }
 
@@ -255,4 +256,16 @@ public class SdkClient {
             throw new IllegalArgumentException("A tenant ID is required when multitenancy is enabled.");
         }
     }
+    
+    /**
+     * Throw exception if tenantId is null for any bulk request and multitenancy is enabled
+     * @param tenantId The tenantId from the request
+     */
+    private void validateTenantIds(List<DataObjectRequest> requests) {
+        if (Boolean.TRUE.equals(isMultiTenancyEnabled) && requests.stream().map(DataObjectRequest::tenantId).anyMatch(Strings::isNullOrEmpty)) {
+            throw new IllegalArgumentException("A tenant ID is required for every bulk request when multitenancy is enabled.");            
+        }
+    }
+
+
 }

--- a/common/src/main/java/org/opensearch/sdk/SdkClientDelegate.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClientDelegate.java
@@ -20,7 +20,11 @@ public interface SdkClientDelegate {
      * @param isMultiTenancyEnabled whether multitenancy is enabled
      * @return A completion stage encapsulating the response or exception
      */
-    CompletionStage<PutDataObjectResponse> putDataObjectAsync(PutDataObjectRequest request, Executor executor, Boolean isMultiTenancyEnabled);
+    CompletionStage<PutDataObjectResponse> putDataObjectAsync(
+        PutDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    );
 
     /**
      * Read/Get a data object/document from a table/index.
@@ -30,7 +34,11 @@ public interface SdkClientDelegate {
      * @param isMultiTenancyEnabled whether multitenancy is enabled
      * @return A completion stage encapsulating the response or exception
      */
-    CompletionStage<GetDataObjectResponse> getDataObjectAsync(GetDataObjectRequest request, Executor executor, Boolean isMultiTenancyEnabled);
+    CompletionStage<GetDataObjectResponse> getDataObjectAsync(
+        GetDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    );
 
     /**
      * Update a data object/document in a table/index.
@@ -40,7 +48,11 @@ public interface SdkClientDelegate {
      * @param isMultiTenancyEnabled whether multitenancy is enabled
      * @return A completion stage encapsulating the response or exception
      */
-    CompletionStage<UpdateDataObjectResponse> updateDataObjectAsync(UpdateDataObjectRequest request, Executor executor, Boolean isMultiTenancyEnabled);
+    CompletionStage<UpdateDataObjectResponse> updateDataObjectAsync(
+        UpdateDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    );
 
     /**
      * Delete a data object/document from a table/index.
@@ -50,7 +62,25 @@ public interface SdkClientDelegate {
      * @param isMultiTenancyEnabled whether multitenancy is enabled
      * @return A completion stage encapsulating the response or exception
      */
-    CompletionStage<DeleteDataObjectResponse> deleteDataObjectAsync(DeleteDataObjectRequest request, Executor executor, Boolean isMultiTenancyEnabled);
+    CompletionStage<DeleteDataObjectResponse> deleteDataObjectAsync(
+        DeleteDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    );
+
+    /**
+     * Perform a bulk request for multiple data objects/documents in potentially multiple tables/indices.
+     *
+     * @param request  A request identifying the requests to process in bulk
+     * @param executor the executor to use for asynchronous execution
+     * @param isMultiTenancyEnabled whether multitenancy is enabled
+     * @return A completion stage encapsulating the response or exception
+     */
+    CompletionStage<BulkDataObjectResponse> bulkDataObjectAsync(
+        BulkDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    );
 
     /**
      * Search for data objects/documents in a table/index.
@@ -60,5 +90,9 @@ public interface SdkClientDelegate {
      * @param isMultiTenancyEnabled whether multitenancy is enabled
      * @return A completion stage encapsulating the response or exception
      */
-    CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(SearchDataObjectRequest request, Executor executor, Boolean isMultiTenancyEnabled);
+    CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(
+        SearchDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    );
 }

--- a/common/src/main/java/org/opensearch/sdk/SdkClientSettings.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClientSettings.java
@@ -8,10 +8,10 @@
  */
 package org.opensearch.sdk;
 
+import java.util.Set;
+
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
-
-import java.util.Set;
 
 /** Settings applicable to the SdkClient */
 public class SdkClientSettings {

--- a/common/src/main/java/org/opensearch/sdk/SdkClientSettings.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClientSettings.java
@@ -27,19 +27,23 @@ public class SdkClientSettings {
     private static final String AOSS_SERVICE_NAME = "aoss";
     /** Service Names compatible with AWS SDK v2. */
     public static final Set<String> VALID_AWS_OPENSEARCH_SERVICE_NAMES = Set.of(AOS_SERVICE_NAME, AOSS_SERVICE_NAME);
-        
+
     /** The value for remote metadata type for a remote cluster on AWS Dynamo DB and Zero-ETL replication to OpenSearch */
     public static final String AWS_DYNAMO_DB = "AWSDynamoDB";
-    
+
     /** The key for remote metadata endpoint, applicable to remote clusters or Zero-ETL DynamoDB sinks */
     public static final String REMOTE_METADATA_ENDPOINT_KEY = "plugins.ml_commons.remote_metadata_endpoint";
     /** The key for remote metadata region, applicable for AWS SDK v2 connections */
     public static final String REMOTE_METADATA_REGION_KEY = "plugins.ml_commons.remote_metadata_region";
     /** The key for remote metadata service name used by service-specific SDKs */
     public static final String REMOTE_METADATA_SERVICE_NAME_KEY = "plugins.ml_commons.remote_metadata_service_name";
-    
-    public static final Setting<String> REMOTE_METADATA_TYPE = Setting.simpleString(REMOTE_METADATA_TYPE_KEY, Property.NodeScope, Property.Final);
-    public static final Setting<String> REMOTE_METADATA_ENDPOINT = Setting.simpleString(REMOTE_METADATA_ENDPOINT_KEY, Property.NodeScope, Property.Final);
-    public static final Setting<String> REMOTE_METADATA_REGION = Setting.simpleString(REMOTE_METADATA_REGION_KEY, Property.NodeScope, Property.Final);
-    public static final Setting<String> REMOTE_METADATA_SERVICE_NAME = Setting.simpleString(REMOTE_METADATA_SERVICE_NAME_KEY, Property.NodeScope, Property.Final);
+
+    public static final Setting<String> REMOTE_METADATA_TYPE = Setting
+        .simpleString(REMOTE_METADATA_TYPE_KEY, Property.NodeScope, Property.Final);
+    public static final Setting<String> REMOTE_METADATA_ENDPOINT = Setting
+        .simpleString(REMOTE_METADATA_ENDPOINT_KEY, Property.NodeScope, Property.Final);
+    public static final Setting<String> REMOTE_METADATA_REGION = Setting
+        .simpleString(REMOTE_METADATA_REGION_KEY, Property.NodeScope, Property.Final);
+    public static final Setting<String> REMOTE_METADATA_SERVICE_NAME = Setting
+        .simpleString(REMOTE_METADATA_SERVICE_NAME_KEY, Property.NodeScope, Property.Final);
 }

--- a/common/src/main/java/org/opensearch/sdk/SdkClientUtils.java
+++ b/common/src/main/java/org/opensearch/sdk/SdkClientUtils.java
@@ -64,11 +64,11 @@ public class SdkClientUtils {
     public static String lowerCaseEnumValues(String field, String json) {
         // Use a matcher to find and replace the field value in lowercase
         Matcher matcher = Pattern.compile("(\"" + Pattern.quote(field) + "\"):(\"[A-Z_]+\")").matcher(json);
-        StringBuffer sb = new StringBuffer();        
+        StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
             matcher.appendReplacement(sb, matcher.group(1) + ":" + matcher.group(2).toLowerCase(Locale.ROOT));
         }
-        matcher.appendTail(sb);        
+        matcher.appendTail(sb);
         return sb.toString();
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
@@ -8,12 +8,13 @@
  */
 package org.opensearch.sdk;
 
-import org.opensearch.core.xcontent.ToXContentObject;
-import org.opensearch.core.xcontent.XContentBuilder;
-import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
-
 import java.io.IOException;
 import java.util.Map;
+
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 
 public class UpdateDataObjectRequest extends DataObjectRequest {
 

--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectRequest.java
@@ -15,11 +15,8 @@ import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import java.io.IOException;
 import java.util.Map;
 
-public class UpdateDataObjectRequest {
+public class UpdateDataObjectRequest extends DataObjectRequest {
 
-    private final String index;
-    private final String id;
-    private final String tenantId;
     private final Long ifSeqNo;
     private final Long ifPrimaryTerm;
     private final int retryOnConflict;
@@ -46,37 +43,11 @@ public class UpdateDataObjectRequest {
         int retryOnConflict,
         ToXContentObject dataObject
     ) {
-        this.index = index;
-        this.id = id;
-        this.tenantId = tenantId;
+        super(index, id, tenantId);
         this.ifSeqNo = ifSeqNo;
         this.ifPrimaryTerm = ifPrimaryTerm;
         this.retryOnConflict = retryOnConflict;
         this.dataObject = dataObject;
-    }
-
-    /**
-     * Returns the index
-     * @return the index
-     */
-    public String index() {
-        return this.index;
-    }
-
-    /**
-     * Returns the document id
-     * @return the id
-     */
-    public String id() {
-        return this.id;
-    }
-
-    /**
-     * Returns the tenant id
-     * @return the tenantId
-     */
-    public String tenantId() {
-        return this.tenantId;
     }
 
     /**
@@ -102,13 +73,18 @@ public class UpdateDataObjectRequest {
     public int retryOnConflict() {
         return retryOnConflict;
     }
-    
+
     /**
      * Returns the data object
      * @return the data object
      */
     public ToXContentObject dataObject() {
         return this.dataObject;
+    }
+
+    @Override
+    public boolean isWriteRequest() {
+        return true;
     }
 
     /**
@@ -122,49 +98,11 @@ public class UpdateDataObjectRequest {
     /**
      * Class for constructing a Builder for this Request Object
      */
-    public static class Builder {
-        private String index = null;
-        private String id = null;
-        private String tenantId = null;
+    public static class Builder extends DataObjectRequest.Builder<Builder> {
         private Long ifSeqNo = null;
         private Long ifPrimaryTerm = null;
         private int retryOnConflict = 0;
         private ToXContentObject dataObject = null;
-
-        /**
-         * Empty Constructor for the Builder object
-         */
-        private Builder() {}
-
-        /**
-         * Add an index to this builder
-         * @param index the index to put the object
-         * @return the updated builder
-         */
-        public Builder index(String index) {
-            this.index = index;
-            return this;
-        }
-
-        /**
-         * Add an id to this builder
-         * @param id the document id
-         * @return the updated builder
-         */
-        public Builder id(String id) {
-            this.id = id;
-            return this;
-        }
-
-        /**
-         * Add a tenant ID to this builder
-         * @param tenantId the tenant id
-         * @return the updated builder
-         */
-        public Builder tenantId(String tenantId) {
-            this.tenantId = tenantId;
-            return this;
-        }
 
         /**
          * Only perform this update request if the document's modification was assigned the given

--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectResponse.java
@@ -10,9 +10,7 @@ package org.opensearch.sdk;
 
 import org.opensearch.core.xcontent.XContentParser;
 
-public class UpdateDataObjectResponse {
-    private final String id;
-    private final XContentParser parser;
+public class UpdateDataObjectResponse extends DataObjectResponse {
 
     /**
      * Instantiate this request with an id and parser representing an UpdateResponse
@@ -20,28 +18,12 @@ public class UpdateDataObjectResponse {
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
      * @param id the document id
      * @param parser a parser that can be used to create an UpdateResponse
+     * @param failed whether the request failed
      */
-    public UpdateDataObjectResponse(String id, XContentParser parser) {
-        this.id = id;
-        this.parser = parser;
+    public UpdateDataObjectResponse(String id, XContentParser parser, boolean failed) {
+        super(id, parser, failed);
     }
 
-    /**
-     * Returns the document id
-     * @return the id
-     */
-    public String id() {
-        return this.id;
-    }
-    
-    /**
-     * Returns the parser that can be used to create an UpdateResponse
-     * @return the parser
-     */
-    public XContentParser parser() {
-        return this.parser;
-    }
-    
     /**
      * Instantiate a builder for this object
      * @return a builder instance
@@ -53,41 +35,14 @@ public class UpdateDataObjectResponse {
     /**
      * Class for constructing a Builder for this Response Object
      */
-    public static class Builder {
-        private String id = null;
-        private XContentParser parser = null;
+    public static class Builder extends DataObjectResponse.Builder<Builder> {
 
-        /**
-         * Empty Constructor for the Builder object
-         */
-        private Builder() {}
-
-        /**
-         * Add an id to this builder
-         * @param id the id to add
-         * @return the updated builder
-         */
-        public Builder id(String id) {
-            this.id = id;
-            return this;
-        }
-        
-        /**
-         * Add a parser to this builder
-         * @param parser a parser that can be used to create an UpdateResponse
-         * @return the updated builder
-         */
-        public Builder parser(XContentParser parser) {
-            this.parser = parser;
-            return this;
-        }
-        
         /**
          * Builds the response
          * @return A {@link UpdateDataObjectResponse}
          */
         public UpdateDataObjectResponse build() {
-            return new UpdateDataObjectResponse(this.id, this.parser);
+            return new UpdateDataObjectResponse(this.id, this.parser, this.failed);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/UpdateDataObjectResponse.java
+++ b/common/src/main/java/org/opensearch/sdk/UpdateDataObjectResponse.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.sdk;
 
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 
 public class UpdateDataObjectResponse extends DataObjectResponse {
@@ -16,12 +17,15 @@ public class UpdateDataObjectResponse extends DataObjectResponse {
      * Instantiate this request with an id and parser representing an UpdateResponse
      * <p>
      * For data storage implementations other than OpenSearch, the id may be referred to as a primary key.
+     * @param index the index
      * @param id the document id
      * @param parser a parser that can be used to create an UpdateResponse
      * @param failed whether the request failed
+     * @param cause the Exception causing the failure
+     * @param status the RestStatus
      */
-    public UpdateDataObjectResponse(String id, XContentParser parser, boolean failed) {
-        super(id, parser, failed);
+    public UpdateDataObjectResponse(String index, String id, XContentParser parser, boolean failed, Exception cause, RestStatus status) {
+        super(index, id, parser, failed, cause, status);
     }
 
     /**
@@ -42,7 +46,7 @@ public class UpdateDataObjectResponse extends DataObjectResponse {
          * @return A {@link UpdateDataObjectResponse}
          */
         public UpdateDataObjectResponse build() {
-            return new UpdateDataObjectResponse(this.id, this.parser, this.failed);
+            return new UpdateDataObjectResponse(this.index, this.id, this.parser, this.failed, this.cause, this.status);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/sdk/client/LocalClusterIndicesClient.java
+++ b/common/src/main/java/org/opensearch/sdk/client/LocalClusterIndicesClient.java
@@ -305,7 +305,13 @@ public class LocalClusterIndicesClient implements SdkClientDelegate {
                             );
                     }
                 }
-                return new BulkDataObjectResponse(responses, bulkResponse.getTook().millis(), bulkResponse.getIngestTookInMillis());
+                return new BulkDataObjectResponse(
+                    responses,
+                    bulkResponse.getTook().millis(),
+                    bulkResponse.getIngestTookInMillis(),
+                    bulkResponse.hasFailures(),
+                    createParser(bulkResponse)
+                );
             } catch (IOException e) {
                 // Rethrow unchecked exception on XContent parsing error
                 throw new OpenSearchStatusException("Failed to parse data object in a bulk response", RestStatus.INTERNAL_SERVER_ERROR);

--- a/common/src/main/java/org/opensearch/sdk/client/LocalClusterIndicesClient.java
+++ b/common/src/main/java/org/opensearch/sdk/client/LocalClusterIndicesClient.java
@@ -53,6 +53,8 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.ml.common.CommonValue;
+import org.opensearch.sdk.BulkDataObjectRequest;
+import org.opensearch.sdk.BulkDataObjectResponse;
 import org.opensearch.sdk.DeleteDataObjectRequest;
 import org.opensearch.sdk.DeleteDataObjectResponse;
 import org.opensearch.sdk.GetDataObjectRequest;
@@ -201,7 +203,9 @@ public class LocalClusterIndicesClient implements SdkClientDelegate {
         return CompletableFuture.supplyAsync(() -> AccessController.doPrivileged((PrivilegedAction<DeleteDataObjectResponse>) () -> {
             try {
                 log.info("Deleting {} from {}", request.id(), request.index());
-                DeleteResponse deleteResponse = client.delete(new DeleteRequest(request.index(), request.id()).setRefreshPolicy(IMMEDIATE)).actionGet();
+                DeleteResponse deleteResponse = client
+                    .delete(new DeleteRequest(request.index(), request.id()).setRefreshPolicy(IMMEDIATE))
+                    .actionGet();
                 log.info("Deletion status for id {}: {}", deleteResponse.getId(), deleteResponse.getResult());
                 return DeleteDataObjectResponse.builder().id(deleteResponse.getId()).parser(createParser(deleteResponse)).build();
             } catch (IOException e) {
@@ -212,6 +216,16 @@ public class LocalClusterIndicesClient implements SdkClientDelegate {
                 );
             }
         }), executor);
+    }
+
+    @Override
+    public CompletionStage<BulkDataObjectResponse> bulkDataObjectAsync(
+        BulkDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        // TODO Complete this
+        return null;
     }
 
     @Override

--- a/common/src/test/java/org/opensearch/sdk/BulkDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/BulkDataObjectRequestTests.java
@@ -8,31 +8,39 @@
  */
 package org.opensearch.sdk;
 
+import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Set;
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class BulkDataObjectRequestTests {
     private String testIndex;
     private String testGlobalIndex;
+    private String testTenantId;
+    private String testGlobalTenantId;
 
     @Before
     public void setUp() {
         testIndex = "test-index";
         testGlobalIndex = "test-global-index";
+        testTenantId = "test-tenant-id";
+        testGlobalTenantId = "test-global-tenant-id";
     }
 
     @Test
     public void testBulkDataObjectRequest() {
-        BulkDataObjectRequest request = new BulkDataObjectRequest(testGlobalIndex)
+        BulkDataObjectRequest request = BulkDataObjectRequest
+            .builder()
+            .globalIndex(testGlobalIndex)
+            .build()
             .add(PutDataObjectRequest.builder().index(testIndex).build())
             .add(UpdateDataObjectRequest.builder().build())
-            .add(DeleteDataObjectRequest.builder().index(testIndex).build());
+            .add(DeleteDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).build());
 
         assertEquals(Set.of(testIndex, testGlobalIndex), request.getIndices());
         assertEquals(3, request.requests().size());
@@ -40,14 +48,40 @@ public class BulkDataObjectRequestTests {
         DataObjectRequest r0 = request.requests().get(0);
         assertTrue(r0 instanceof PutDataObjectRequest);
         assertEquals(testIndex, r0.index());
+        assertNull(r0.tenantId());
 
         DataObjectRequest r1 = request.requests().get(1);
         assertTrue(r1 instanceof UpdateDataObjectRequest);
         assertEquals(testGlobalIndex, r1.index());
+        assertNull(r1.tenantId());
 
         DataObjectRequest r2 = request.requests().get(2);
         assertTrue(r2 instanceof DeleteDataObjectRequest);
         assertEquals(testIndex, r2.index());
+        assertEquals(testTenantId, r2.tenantId());
+    }
+
+    @Test
+    public void testBulkDataObjectRequest_Tenant() {
+        BulkDataObjectRequest request = BulkDataObjectRequest
+            .builder()
+            .globalTenantId(testGlobalTenantId)
+            .build()
+            .add(PutDataObjectRequest.builder().index(testIndex).build())
+            .add(DeleteDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).build());
+
+        assertEquals(Set.of(testIndex), request.getIndices());
+        assertEquals(2, request.requests().size());
+
+        DataObjectRequest r0 = request.requests().get(0);
+        assertTrue(r0 instanceof PutDataObjectRequest);
+        assertEquals(testIndex, r0.index());
+        assertEquals(testGlobalTenantId, r0.tenantId());
+
+        DataObjectRequest r1 = request.requests().get(1);
+        assertTrue(r1 instanceof DeleteDataObjectRequest);
+        assertEquals(testIndex, r1.index());
+        assertEquals(testGlobalTenantId, r1.tenantId());
     }
 
     @Test
@@ -55,7 +89,7 @@ public class BulkDataObjectRequestTests {
         PutDataObjectRequest nullIndexRequest = PutDataObjectRequest.builder().build();
         GetDataObjectRequest badTypeRequest = GetDataObjectRequest.builder().index(testIndex).build();
 
-        BulkDataObjectRequest bulkRequest = new BulkDataObjectRequest();
+        BulkDataObjectRequest bulkRequest = BulkDataObjectRequest.builder().build();
         assertThrows(IllegalArgumentException.class, () -> bulkRequest.add(nullIndexRequest));
         assertThrows(IllegalArgumentException.class, () -> bulkRequest.add(badTypeRequest));
     }

--- a/common/src/test/java/org/opensearch/sdk/BulkDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/BulkDataObjectRequestTests.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -40,10 +41,12 @@ public class BulkDataObjectRequestTests {
             .build()
             .add(PutDataObjectRequest.builder().index(testIndex).build())
             .add(UpdateDataObjectRequest.builder().build())
-            .add(DeleteDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).build());
+            .add(DeleteDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).build())
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE);
 
         assertEquals(Set.of(testIndex, testGlobalIndex), request.getIndices());
         assertEquals(3, request.requests().size());
+        assertEquals(RefreshPolicy.IMMEDIATE, request.getRefreshPolicy());
 
         DataObjectRequest r0 = request.requests().get(0);
         assertTrue(r0 instanceof PutDataObjectRequest);

--- a/common/src/test/java/org/opensearch/sdk/BulkDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/BulkDataObjectRequestTests.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -23,14 +24,12 @@ public class BulkDataObjectRequestTests {
     private String testIndex;
     private String testGlobalIndex;
     private String testTenantId;
-    private String testGlobalTenantId;
 
     @Before
     public void setUp() {
         testIndex = "test-index";
         testGlobalIndex = "test-global-index";
         testTenantId = "test-tenant-id";
-        testGlobalTenantId = "test-global-tenant-id";
     }
 
     @Test
@@ -68,9 +67,8 @@ public class BulkDataObjectRequestTests {
     public void testBulkDataObjectRequest_Tenant() {
         BulkDataObjectRequest request = BulkDataObjectRequest
             .builder()
-            .globalTenantId(testGlobalTenantId)
             .build()
-            .add(PutDataObjectRequest.builder().index(testIndex).build())
+            .add(PutDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).build())
             .add(DeleteDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).build());
 
         assertEquals(Set.of(testIndex), request.getIndices());
@@ -79,12 +77,12 @@ public class BulkDataObjectRequestTests {
         DataObjectRequest r0 = request.requests().get(0);
         assertTrue(r0 instanceof PutDataObjectRequest);
         assertEquals(testIndex, r0.index());
-        assertEquals(testGlobalTenantId, r0.tenantId());
+        assertEquals(testTenantId, r0.tenantId());
 
         DataObjectRequest r1 = request.requests().get(1);
         assertTrue(r1 instanceof DeleteDataObjectRequest);
         assertEquals(testIndex, r1.index());
-        assertEquals(testGlobalTenantId, r1.tenantId());
+        assertEquals(testTenantId, r1.tenantId());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/sdk/BulkDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/BulkDataObjectRequestTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class BulkDataObjectRequestTests {
+    private String testIndex;
+    private String testGlobalIndex;
+
+    @Before
+    public void setUp() {
+        testIndex = "test-index";
+        testGlobalIndex = "test-global-index";
+    }
+
+    @Test
+    public void testBulkDataObjectRequest() {
+        BulkDataObjectRequest request = new BulkDataObjectRequest(testGlobalIndex)
+            .add(PutDataObjectRequest.builder().index(testIndex).build())
+            .add(UpdateDataObjectRequest.builder().build())
+            .add(DeleteDataObjectRequest.builder().index(testIndex).build());
+
+        assertEquals(Set.of(testIndex, testGlobalIndex), request.getIndices());
+        assertEquals(3, request.requests().size());
+
+        DataObjectRequest r0 = request.requests().get(0);
+        assertTrue(r0 instanceof PutDataObjectRequest);
+        assertEquals(testIndex, r0.index());
+
+        DataObjectRequest r1 = request.requests().get(1);
+        assertTrue(r1 instanceof UpdateDataObjectRequest);
+        assertEquals(testGlobalIndex, r1.index());
+
+        DataObjectRequest r2 = request.requests().get(2);
+        assertTrue(r2 instanceof DeleteDataObjectRequest);
+        assertEquals(testIndex, r2.index());
+    }
+
+    @Test
+    public void testBulkDataObjectRequest_Exceptions() {
+        PutDataObjectRequest nullIndexRequest = PutDataObjectRequest.builder().build();
+        GetDataObjectRequest badTypeRequest = GetDataObjectRequest.builder().index(testIndex).build();
+
+        BulkDataObjectRequest bulkRequest = new BulkDataObjectRequest();
+        assertThrows(IllegalArgumentException.class, () -> bulkRequest.add(nullIndexRequest));
+        assertThrows(IllegalArgumentException.class, () -> bulkRequest.add(badTypeRequest));
+    }
+}

--- a/common/src/test/java/org/opensearch/sdk/BulkDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/BulkDataObjectResponseTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BulkDataObjectResponseTests {
+    @Test
+    public void testBulkDataObjectResponse() {
+        
+        DataObjectResponse[] responses = List.of(
+            PutDataObjectResponse.builder().build(),
+            UpdateDataObjectResponse.builder().build(),
+            DeleteDataObjectResponse.builder().build()
+            ).toArray(new DataObjectResponse[0]);
+        
+        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L, -1L);
+
+        assertEquals(3, response.getResponses().length);
+        assertEquals(1L, response.getTookInMillis());
+        assertEquals(-1L, response.getIngestTookInMillis());
+        assertFalse(response.hasFailures());
+    }
+
+    @Test
+    public void testBulkDataObjectRequest_Failures() {
+        DataObjectResponse[] responses = List.of(
+            PutDataObjectResponse.builder().build(),
+            DeleteDataObjectResponse.builder().failed(true).build()
+            ).toArray(new DataObjectResponse[0]);
+        
+        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L, -1L);
+
+        assertTrue(response.hasFailures());
+    }
+}

--- a/common/src/test/java/org/opensearch/sdk/BulkDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/BulkDataObjectResponseTests.java
@@ -19,14 +19,16 @@ import static org.junit.Assert.assertTrue;
 public class BulkDataObjectResponseTests {
     @Test
     public void testBulkDataObjectResponse() {
-        
-        DataObjectResponse[] responses = List.of(
-            PutDataObjectResponse.builder().build(),
-            UpdateDataObjectResponse.builder().build(),
-            DeleteDataObjectResponse.builder().build()
-            ).toArray(new DataObjectResponse[0]);
-        
-        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L, -1L);
+
+        DataObjectResponse[] responses = List
+            .of(
+                PutDataObjectResponse.builder().build(),
+                UpdateDataObjectResponse.builder().build(),
+                DeleteDataObjectResponse.builder().build()
+            )
+            .toArray(new DataObjectResponse[0]);
+
+        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L);
 
         assertEquals(3, response.getResponses().length);
         assertEquals(1L, response.getTookInMillis());
@@ -36,12 +38,11 @@ public class BulkDataObjectResponseTests {
 
     @Test
     public void testBulkDataObjectRequest_Failures() {
-        DataObjectResponse[] responses = List.of(
-            PutDataObjectResponse.builder().build(),
-            DeleteDataObjectResponse.builder().failed(true).build()
-            ).toArray(new DataObjectResponse[0]);
-        
-        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L, -1L);
+        DataObjectResponse[] responses = List
+            .of(PutDataObjectResponse.builder().build(), DeleteDataObjectResponse.builder().failed(true).build())
+            .toArray(new DataObjectResponse[0]);
+
+        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L);
 
         assertTrue(response.hasFailures());
     }

--- a/common/src/test/java/org/opensearch/sdk/BulkDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/BulkDataObjectResponseTests.java
@@ -8,18 +8,32 @@
  */
 package org.opensearch.sdk;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.core.xcontent.XContentParser;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class BulkDataObjectResponseTests {
+    @Mock
+    XContentParser parser;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.openMocks(this);
+    }
+
     @Test
     public void testBulkDataObjectResponse() {
-
         DataObjectResponse[] responses = List
             .of(
                 PutDataObjectResponse.builder().build(),
@@ -28,12 +42,13 @@ public class BulkDataObjectResponseTests {
             )
             .toArray(new DataObjectResponse[0]);
 
-        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L);
+        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L, false, parser);
 
         assertEquals(3, response.getResponses().length);
         assertEquals(1L, response.getTookInMillis());
         assertEquals(-1L, response.getIngestTookInMillis());
         assertFalse(response.hasFailures());
+        assertSame(parser, response.parser());
     }
 
     @Test
@@ -42,8 +57,12 @@ public class BulkDataObjectResponseTests {
             .of(PutDataObjectResponse.builder().build(), DeleteDataObjectResponse.builder().failed(true).build())
             .toArray(new DataObjectResponse[0]);
 
-        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L);
+        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L, true, parser);
 
+        assertEquals(2, response.getResponses().length);
+        assertEquals(1L, response.getTookInMillis());
+        assertEquals(-1L, response.getIngestTookInMillis());
         assertTrue(response.hasFailures());
+        assertSame(parser, response.parser());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/DeleteDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/DeleteDataObjectResponseTests.java
@@ -10,27 +10,49 @@ package org.opensearch.sdk;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 
 public class DeleteDataObjectResponseTests {
 
+    private String testIndex;
     private String testId;
     private XContentParser testParser;
+    private boolean testFailed;
+    private Exception testCause;
+    private RestStatus testStatus;
 
     @Before
     public void setUp() {
+        testIndex = "test-index";
         testId = "test-id";
         testParser = mock(XContentParser.class);
+        testFailed = true;
+        testCause = mock(RuntimeException.class);
+        testStatus = RestStatus.BAD_REQUEST;
     }
 
     @Test
     public void testDeleteDataObjectResponse() {
-        DeleteDataObjectResponse response = DeleteDataObjectResponse.builder().id(testId).parser(testParser).build();
+        DeleteDataObjectResponse response = DeleteDataObjectResponse
+            .builder()
+            .index(testIndex)
+            .id(testId)
+            .parser(testParser)
+            .failed(testFailed)
+            .cause(testCause)
+            .status(testStatus)
+            .build();
 
+        assertEquals(testIndex, response.index());
         assertEquals(testId, response.id());
-        assertEquals(testParser, response.parser());
+        assertSame(testParser, response.parser());
+        assertEquals(testFailed, response.isFailed());
+        assertSame(testCause, response.cause());
+        assertEquals(testStatus, response.status());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/GetDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/GetDataObjectResponseTests.java
@@ -10,31 +10,54 @@ package org.opensearch.sdk;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 
 import java.util.Map;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 
 public class GetDataObjectResponseTests {
 
+    private String testIndex;
     private String testId;
     private XContentParser testParser;
+    private boolean testFailed;
+    private Exception testCause;
+    private RestStatus testStatus;
     private Map<String, Object> testSource;
 
     @Before
     public void setUp() {
+        testIndex = "test-index";
         testId = "test-id";
         testParser = mock(XContentParser.class);
+        testFailed = true;
+        testCause = mock(RuntimeException.class);
+        testStatus = RestStatus.BAD_REQUEST;
         testSource = Map.of("foo", "bar");
     }
 
     @Test
     public void testGetDataObjectResponse() {
-        GetDataObjectResponse response = GetDataObjectResponse.builder().id(testId).parser(testParser).source(testSource).build();
+        GetDataObjectResponse response = GetDataObjectResponse
+            .builder()
+            .index(testIndex)
+            .id(testId)
+            .parser(testParser)
+            .failed(testFailed)
+            .cause(testCause)
+            .status(testStatus)
+            .source(testSource)
+            .build();
 
+        assertEquals(testIndex, response.index());
         assertEquals(testId, response.id());
-        assertEquals(testParser, response.parser());
+        assertSame(testParser, response.parser());
+        assertEquals(testFailed, response.isFailed());
+        assertSame(testCause, response.cause());
+        assertEquals(testStatus, response.status());
         assertEquals(testSource, response.source());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/PutDataObjectRequestTests.java
+++ b/common/src/test/java/org/opensearch/sdk/PutDataObjectRequestTests.java
@@ -14,6 +14,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -79,7 +80,7 @@ public class PutDataObjectRequestTests {
         contentBuilder.flush();
 
         BytesReference bytes = BytesReference.bytes(contentBuilder);
-        Map<String, Object> resultingMap = XContentHelper.convertToMap(bytes, false, XContentType.JSON).v2();
+        Map<String, Object> resultingMap = XContentHelper.convertToMap(bytes, false, (MediaType) XContentType.JSON).v2();
 
         assertEquals(dataObjectMap, resultingMap);
     }

--- a/common/src/test/java/org/opensearch/sdk/PutDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/PutDataObjectResponseTests.java
@@ -10,27 +10,48 @@ package org.opensearch.sdk;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 
 public class PutDataObjectResponseTests {
 
+    private String testIndex;
     private String testId;
     private XContentParser testParser;
+    private boolean testFailed;
+    private Exception testCause;
+    private RestStatus testStatus;
 
     @Before
     public void setUp() {
+        testId = "test-index";
         testId = "test-id";
         testParser = mock(XContentParser.class);
+        testFailed = true;
+        testCause = mock(RuntimeException.class);
+        testStatus = RestStatus.BAD_REQUEST;
     }
 
     @Test
     public void testPutDataObjectResponse() {
-        PutDataObjectResponse response = PutDataObjectResponse.builder().id(testId).parser(testParser).build();
+        PutDataObjectResponse response = PutDataObjectResponse.builder()
+            .index(testIndex)
+            .id(testId)
+            .parser(testParser)
+            .failed(testFailed)
+            .cause(testCause)
+            .status(testStatus)
+            .build();
 
+        assertEquals(testIndex, response.index());
         assertEquals(testId, response.id());
-        assertEquals(testParser, response.parser());
+        assertSame(testParser, response.parser());
+        assertEquals(testFailed, response.isFailed());
+        assertSame(testCause, response.cause());
+        assertEquals(testStatus, response.status());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
@@ -16,6 +16,7 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.core.rest.RestStatus;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -26,6 +27,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -71,7 +73,6 @@ public class SdkClientTests {
         when(getRequest.tenantId()).thenReturn(TENANT_ID);
         when(updateRequest.tenantId()).thenReturn(TENANT_ID);
         when(deleteRequest.tenantId()).thenReturn(TENANT_ID);
-        when(bulkRequest.globalTenantId()).thenReturn(TENANT_ID);
         when(searchRequest.tenantId()).thenReturn(TENANT_ID);
 
         sdkClientImpl = spy(new SdkClientDelegate() {
@@ -280,7 +281,9 @@ public class SdkClientTests {
 
     @Test
     public void testBulkDataObjectNullTenantId() {
-        when(bulkRequest.globalTenantId()).thenReturn(null);
+        DeleteDataObjectRequest deleteRequest = mock(DeleteDataObjectRequest.class);
+        when(deleteRequest.tenantId()).thenReturn(null);
+        when(bulkRequest.requests()).thenReturn(List.of(deleteRequest));
         assertThrows(IllegalArgumentException.class, () -> sdkClient.bulkDataObject(bulkRequest));
     }
 

--- a/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/SdkClientTests.java
@@ -145,30 +145,26 @@ public class SdkClientTests {
         when(putRequest.tenantId()).thenReturn(null);
         assertThrows(IllegalArgumentException.class, () -> sdkClient.putDataObject(putRequest));
     }
-    
+
     @Test
     public void testPutDataObjectException() {
         when(sdkClientImpl.putDataObjectAsync(any(PutDataObjectRequest.class), any(Executor.class), anyBoolean()))
-                .thenReturn(CompletableFuture.failedFuture(testException));
+            .thenReturn(CompletableFuture.failedFuture(testException));
 
-        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
-            sdkClient.putDataObject(putRequest);
-        });
+        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> { sdkClient.putDataObject(putRequest); });
         assertEquals(testException, exception);
-        assertFalse(Thread.interrupted());        
+        assertFalse(Thread.interrupted());
         verify(sdkClientImpl).putDataObjectAsync(any(PutDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
 
     @Test
     public void testPutDataObjectInterrupted() {
         when(sdkClientImpl.putDataObjectAsync(any(PutDataObjectRequest.class), any(Executor.class), anyBoolean()))
-                .thenReturn(CompletableFuture.failedFuture(interruptedException));
+            .thenReturn(CompletableFuture.failedFuture(interruptedException));
 
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
-            sdkClient.putDataObject(putRequest);
-        });
+        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> { sdkClient.putDataObject(putRequest); });
         assertEquals(interruptedException, exception.getCause());
-        assertTrue(Thread.interrupted());        
+        assertTrue(Thread.interrupted());
         verify(sdkClientImpl).putDataObjectAsync(any(PutDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
 
@@ -183,30 +179,26 @@ public class SdkClientTests {
         when(getRequest.tenantId()).thenReturn(null);
         assertThrows(IllegalArgumentException.class, () -> sdkClient.getDataObject(getRequest));
     }
-    
+
     @Test
     public void testGetDataObjectException() {
         when(sdkClientImpl.getDataObjectAsync(any(GetDataObjectRequest.class), any(Executor.class), anyBoolean()))
-                .thenReturn(CompletableFuture.failedFuture(testException));
+            .thenReturn(CompletableFuture.failedFuture(testException));
 
-        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
-            sdkClient.getDataObject(getRequest);
-        });
+        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> { sdkClient.getDataObject(getRequest); });
         assertEquals(testException, exception);
-        assertFalse(Thread.interrupted());        
+        assertFalse(Thread.interrupted());
         verify(sdkClientImpl).getDataObjectAsync(any(GetDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
 
     @Test
     public void testGetDataObjectInterrupted() {
         when(sdkClientImpl.getDataObjectAsync(any(GetDataObjectRequest.class), any(Executor.class), anyBoolean()))
-        .thenReturn(CompletableFuture.failedFuture(interruptedException));
+            .thenReturn(CompletableFuture.failedFuture(interruptedException));
 
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
-            sdkClient.getDataObject(getRequest);
-        });
+        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> { sdkClient.getDataObject(getRequest); });
         assertEquals(interruptedException, exception.getCause());
-        assertTrue(Thread.interrupted());        
+        assertTrue(Thread.interrupted());
         verify(sdkClientImpl).getDataObjectAsync(any(GetDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
 
@@ -215,6 +207,7 @@ public class SdkClientTests {
         assertEquals(updateResponse, sdkClient.updateDataObject(updateRequest));
         verify(sdkClientImpl).updateDataObjectAsync(any(UpdateDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
+
     @Test
     public void testUpdateDataObjectNullTenantId() {
         when(updateRequest.tenantId()).thenReturn(null);
@@ -224,24 +217,23 @@ public class SdkClientTests {
     @Test
     public void testUpdateDataObjectException() {
         when(sdkClientImpl.updateDataObjectAsync(any(UpdateDataObjectRequest.class), any(Executor.class), anyBoolean()))
-                .thenReturn(CompletableFuture.failedFuture(testException));
-        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
-            sdkClient.updateDataObject(updateRequest);
-        });
+            .thenReturn(CompletableFuture.failedFuture(testException));
+        OpenSearchStatusException exception = assertThrows(
+            OpenSearchStatusException.class,
+            () -> { sdkClient.updateDataObject(updateRequest); }
+        );
         assertEquals(testException, exception);
-        assertFalse(Thread.interrupted());        
+        assertFalse(Thread.interrupted());
         verify(sdkClientImpl).updateDataObjectAsync(any(UpdateDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
 
     @Test
     public void testUpdateDataObjectInterrupted() {
         when(sdkClientImpl.updateDataObjectAsync(any(UpdateDataObjectRequest.class), any(Executor.class), anyBoolean()))
-        .thenReturn(CompletableFuture.failedFuture(interruptedException));
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
-            sdkClient.updateDataObject(updateRequest);
-        });
+            .thenReturn(CompletableFuture.failedFuture(interruptedException));
+        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> { sdkClient.updateDataObject(updateRequest); });
         assertEquals(interruptedException, exception.getCause());
-        assertTrue(Thread.interrupted());        
+        assertTrue(Thread.interrupted());
         verify(sdkClientImpl).updateDataObjectAsync(any(UpdateDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
 
@@ -260,27 +252,25 @@ public class SdkClientTests {
     @Test
     public void testDeleteDataObjectException() {
         when(sdkClientImpl.deleteDataObjectAsync(any(DeleteDataObjectRequest.class), any(Executor.class), anyBoolean()))
-                .thenReturn(CompletableFuture.failedFuture(testException));
-        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
-            sdkClient.deleteDataObject(deleteRequest);
-        });
+            .thenReturn(CompletableFuture.failedFuture(testException));
+        OpenSearchStatusException exception = assertThrows(
+            OpenSearchStatusException.class,
+            () -> { sdkClient.deleteDataObject(deleteRequest); }
+        );
         assertEquals(testException, exception);
-        assertFalse(Thread.interrupted());        
+        assertFalse(Thread.interrupted());
         verify(sdkClientImpl).deleteDataObjectAsync(any(DeleteDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
 
     @Test
     public void testDeleteDataObjectInterrupted() {
         when(sdkClientImpl.deleteDataObjectAsync(any(DeleteDataObjectRequest.class), any(Executor.class), anyBoolean()))
-        .thenReturn(CompletableFuture.failedFuture(interruptedException));
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
-            sdkClient.deleteDataObject(deleteRequest);
-        });
+            .thenReturn(CompletableFuture.failedFuture(interruptedException));
+        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> { sdkClient.deleteDataObject(deleteRequest); });
         assertEquals(interruptedException, exception.getCause());
-        assertTrue(Thread.interrupted());        
+        assertTrue(Thread.interrupted());
         verify(sdkClientImpl).deleteDataObjectAsync(any(DeleteDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
-    
 
     @Test
     public void testBulkDataObjectSuccess() {
@@ -297,24 +287,23 @@ public class SdkClientTests {
     @Test
     public void testBulkDataObjectException() {
         when(sdkClientImpl.bulkDataObjectAsync(any(BulkDataObjectRequest.class), any(Executor.class), anyBoolean()))
-                .thenReturn(CompletableFuture.failedFuture(testException));
-        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
-            sdkClient.bulkDataObject(bulkRequest);
-        });
+            .thenReturn(CompletableFuture.failedFuture(testException));
+        OpenSearchStatusException exception = assertThrows(
+            OpenSearchStatusException.class,
+            () -> { sdkClient.bulkDataObject(bulkRequest); }
+        );
         assertEquals(testException, exception);
-        assertFalse(Thread.interrupted());        
+        assertFalse(Thread.interrupted());
         verify(sdkClientImpl).bulkDataObjectAsync(any(BulkDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
 
     @Test
     public void testBulkDataObjectInterrupted() {
         when(sdkClientImpl.bulkDataObjectAsync(any(BulkDataObjectRequest.class), any(Executor.class), anyBoolean()))
-        .thenReturn(CompletableFuture.failedFuture(interruptedException));
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
-            sdkClient.bulkDataObject(bulkRequest);
-        });
+            .thenReturn(CompletableFuture.failedFuture(interruptedException));
+        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> { sdkClient.bulkDataObject(bulkRequest); });
         assertEquals(interruptedException, exception.getCause());
-        assertTrue(Thread.interrupted());        
+        assertTrue(Thread.interrupted());
         verify(sdkClientImpl).bulkDataObjectAsync(any(BulkDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
 
@@ -323,34 +312,33 @@ public class SdkClientTests {
         assertEquals(searchResponse, sdkClient.searchDataObject(searchRequest));
         verify(sdkClientImpl).searchDataObjectAsync(any(SearchDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
+
     @Test
     public void testSearchDataObjectNullTenantId() {
         when(searchRequest.tenantId()).thenReturn(null);
         assertThrows(IllegalArgumentException.class, () -> sdkClient.searchDataObject(searchRequest));
     }
 
-
     @Test
     public void testSearchDataObjectException() {
         when(sdkClientImpl.searchDataObjectAsync(any(SearchDataObjectRequest.class), any(Executor.class), anyBoolean()))
-                .thenReturn(CompletableFuture.failedFuture(testException));
-        OpenSearchStatusException exception = assertThrows(OpenSearchStatusException.class, () -> {
-            sdkClient.searchDataObject(searchRequest);
-        });
+            .thenReturn(CompletableFuture.failedFuture(testException));
+        OpenSearchStatusException exception = assertThrows(
+            OpenSearchStatusException.class,
+            () -> { sdkClient.searchDataObject(searchRequest); }
+        );
         assertEquals(testException, exception);
-        assertFalse(Thread.interrupted());        
+        assertFalse(Thread.interrupted());
         verify(sdkClientImpl).searchDataObjectAsync(any(SearchDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
 
     @Test
     public void testSearchDataObjectInterrupted() {
         when(sdkClientImpl.searchDataObjectAsync(any(SearchDataObjectRequest.class), any(Executor.class), anyBoolean()))
-        .thenReturn(CompletableFuture.failedFuture(interruptedException));
-        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> {
-            sdkClient.searchDataObject(searchRequest);
-        });
+            .thenReturn(CompletableFuture.failedFuture(interruptedException));
+        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> { sdkClient.searchDataObject(searchRequest); });
         assertEquals(interruptedException, exception.getCause());
-        assertTrue(Thread.interrupted());        
+        assertTrue(Thread.interrupted());
         verify(sdkClientImpl).searchDataObjectAsync(any(SearchDataObjectRequest.class), any(Executor.class), anyBoolean());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/UpdateDataObjectResponseTests.java
+++ b/common/src/test/java/org/opensearch/sdk/UpdateDataObjectResponseTests.java
@@ -10,27 +10,50 @@ package org.opensearch.sdk;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 
 public class UpdateDataObjectResponseTests {
 
+    private String testIndex;
     private String testId;
     private XContentParser testParser;
+    private boolean testFailed;
+    private Exception testCause;
+    private RestStatus testStatus;
 
     @Before
     public void setUp() {
+        testIndex = "test-index";
         testId = "test-id";
         testParser = mock(XContentParser.class);
+        testFailed = true;
+        testCause = mock(RuntimeException.class);
+        testStatus = RestStatus.BAD_REQUEST;
+
     }
 
     @Test
     public void testUpdateDataObjectResponse() {
-        UpdateDataObjectResponse response = UpdateDataObjectResponse.builder().id(testId).parser(testParser).build();
+        UpdateDataObjectResponse response = UpdateDataObjectResponse
+            .builder()
+            .index(testIndex)
+            .id(testId)
+            .parser(testParser)
+            .failed(testFailed)
+            .cause(testCause)
+            .status(testStatus)
+            .build();
 
+        assertEquals(testIndex, response.index());
         assertEquals(testId, response.id());
-        assertEquals(testParser, response.parser());
+        assertSame(testParser, response.parser());
+        assertEquals(testFailed, response.isFailed());
+        assertSame(testCause, response.cause());
+        assertEquals(testStatus, response.status());
     }
 }

--- a/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
@@ -566,14 +566,13 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testBulkDataObject() throws IOException {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().id(TEST_ID + "1").dataObject(testDataObject).build();
-        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder().id(TEST_ID + "2").dataObject(testDataObject).build();
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().id(TEST_ID + "1").tenantId(TEST_TENANT_ID).dataObject(testDataObject).build();
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder().id(TEST_ID + "2").tenantId(TEST_TENANT_ID).dataObject(testDataObject).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").tenantId(TEST_TENANT_ID).build();
 
         BulkDataObjectRequest bulkRequest = BulkDataObjectRequest
             .builder()
             .globalIndex(TEST_INDEX)
-            .globalTenantId(TEST_TENANT_ID)
             .build()
             .add(putRequest)
             .add(updateRequest)
@@ -629,20 +628,19 @@ public class LocalClusterIndicesClientTests {
     public void testBulkDataObject_WithFailures() throws IOException {
         PutDataObjectRequest putRequest = PutDataObjectRequest
             .builder()
-            .id(TEST_ID + "1")
+            .id(TEST_ID + "1").tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .build();
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
-            .id(TEST_ID + "2")
+            .id(TEST_ID + "2").tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .build();
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").tenantId(TEST_TENANT_ID).build();
 
         BulkDataObjectRequest bulkRequest = BulkDataObjectRequest
             .builder()
             .globalIndex(TEST_INDEX)
-            .globalTenantId(TEST_TENANT_ID)
             .build()
             .add(putRequest)
             .add(updateRequest)
@@ -682,9 +680,9 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testBulkDataObject_Exception() {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).dataObject(testDataObject).build();
 
-        BulkDataObjectRequest bulkRequest = BulkDataObjectRequest.builder().globalTenantId(TEST_TENANT_ID).build().add(putRequest);
+        BulkDataObjectRequest bulkRequest = BulkDataObjectRequest.builder().build().add(putRequest);
 
         when(mockedClient.bulk(any(BulkRequest.class)))
             .thenThrow(new OpenSearchStatusException("Failed to parse data object in a bulk response", RestStatus.INTERNAL_SERVER_ERROR));

--- a/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
+++ b/common/src/test/java/org/opensearch/sdk/client/LocalClusterIndicesClientTests.java
@@ -8,18 +8,6 @@
  */
 package org.opensearch.sdk.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Map;
@@ -38,6 +26,9 @@ import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteRequest.OpType;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.DocWriteResponse.Result;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
@@ -69,6 +60,8 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.get.GetResult;
+import org.opensearch.sdk.BulkDataObjectRequest;
+import org.opensearch.sdk.BulkDataObjectResponse;
 import org.opensearch.sdk.DeleteDataObjectRequest;
 import org.opensearch.sdk.DeleteDataObjectResponse;
 import org.opensearch.sdk.GetDataObjectRequest;
@@ -85,6 +78,18 @@ import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 
 public class LocalClusterIndicesClientTests {
 
@@ -135,7 +140,8 @@ public class LocalClusterIndicesClientTests {
         PutDataObjectRequest putRequest = PutDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID).tenantId(TEST_TENANT_ID)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .overwriteIfExists(false)
             .dataObject(testDataObject)
             .build();
@@ -166,7 +172,12 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testPutDataObject_Exception() throws IOException {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).tenantId(TEST_TENANT_ID).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .tenantId(TEST_TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
 
         when(mockedClient.index(any(IndexRequest.class))).thenThrow(new UnsupportedOperationException("test"));
 
@@ -188,7 +199,12 @@ public class LocalClusterIndicesClientTests {
                 throw new IOException("test");
             }
         };
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).tenantId(TEST_TENANT_ID).dataObject(badDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .tenantId(TEST_TENANT_ID)
+            .dataObject(badDataObject)
+            .build();
 
         CompletableFuture<PutDataObjectResponse> future = sdkClient
             .putDataObjectAsync(putRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
@@ -300,7 +316,8 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID).tenantId(TEST_TENANT_ID)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .retryOnConflict(3)
             .dataObject(testDataObject)
             .build();
@@ -344,7 +361,8 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID).tenantId(TEST_TENANT_ID)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .dataObject(Map.of("foo", "bar"))
             .build();
 
@@ -377,7 +395,8 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID).tenantId(TEST_TENANT_ID)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .build();
 
@@ -419,7 +438,8 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID).tenantId(TEST_TENANT_ID)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .build();
 
@@ -445,7 +465,8 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID).tenantId(TEST_TENANT_ID)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .build();
 
@@ -467,7 +488,8 @@ public class LocalClusterIndicesClientTests {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
             .builder()
             .index(TEST_INDEX)
-            .id(TEST_ID).tenantId(TEST_TENANT_ID)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
             .dataObject(testDataObject)
             .ifSeqNo(5)
             .ifPrimaryTerm(2)
@@ -493,7 +515,12 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testDeleteDataObject() throws IOException {
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .build();
 
         DeleteResponse deleteResponse = new DeleteResponse(new ShardId(TEST_INDEX, "_na_", 0), TEST_ID, 1, 0, 2, true);
         PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
@@ -517,7 +544,12 @@ public class LocalClusterIndicesClientTests {
 
     @Test
     public void testDeleteDataObject_Exception() throws IOException {
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .build();
 
         ArgumentCaptor<DeleteRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
         when(mockedClient.delete(deleteRequestCaptor.capture())).thenThrow(new UnsupportedOperationException("test"));
@@ -530,6 +562,135 @@ public class LocalClusterIndicesClientTests {
         Throwable cause = ce.getCause();
         assertEquals(UnsupportedOperationException.class, cause.getClass());
         assertEquals("test", cause.getMessage());
+    }
+
+    @Test
+    public void testBulkDataObject() throws IOException {
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().id(TEST_ID + "1").dataObject(testDataObject).build();
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder().id(TEST_ID + "2").dataObject(testDataObject).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").build();
+
+        BulkDataObjectRequest bulkRequest = BulkDataObjectRequest
+            .builder()
+            .globalIndex(TEST_INDEX)
+            .globalTenantId(TEST_TENANT_ID)
+            .build()
+            .add(putRequest)
+            .add(updateRequest)
+            .add(deleteRequest);
+
+        ShardId shardId = new ShardId(TEST_INDEX, "_na_", 0);
+        ShardInfo shardInfo = new ShardInfo(1, 1);
+
+        IndexResponse indexResponse = new IndexResponse(shardId, TEST_ID + "1", 1, 1, 1, true);
+        indexResponse.setShardInfo(shardInfo);
+
+        UpdateResponse updateResponse = new UpdateResponse(shardId, TEST_ID + "2", 1, 1, 1, DocWriteResponse.Result.UPDATED);
+        updateResponse.setShardInfo(shardInfo);
+
+        DeleteResponse deleteResponse = new DeleteResponse(shardId, TEST_ID + "3", 1, 1, 1, true);
+        deleteResponse.setShardInfo(shardInfo);
+
+        BulkResponse bulkResponse = new BulkResponse(
+            new BulkItemResponse[] {
+                new BulkItemResponse(0, OpType.INDEX, indexResponse),
+                new BulkItemResponse(1, OpType.UPDATE, updateResponse),
+                new BulkItemResponse(2, OpType.DELETE, deleteResponse) },
+            100L
+        );
+
+        @SuppressWarnings("unchecked")
+        ActionFuture<BulkResponse> future = mock(ActionFuture.class);
+        when(mockedClient.bulk(any(BulkRequest.class))).thenReturn(future);
+        when(future.actionGet()).thenReturn(bulkResponse);
+
+        BulkDataObjectResponse response = sdkClient
+            .bulkDataObjectAsync(bulkRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
+            .toCompletableFuture()
+            .join();
+
+        ArgumentCaptor<BulkRequest> requestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        verify(mockedClient, times(1)).bulk(requestCaptor.capture());
+        assertEquals(3, requestCaptor.getValue().numberOfActions());
+
+        assertEquals(3, response.getResponses().length);
+        assertEquals(100L, response.getTookInMillis());
+
+        assertTrue(response.getResponses()[0] instanceof PutDataObjectResponse);
+        assertTrue(response.getResponses()[1] instanceof UpdateDataObjectResponse);
+        assertTrue(response.getResponses()[2] instanceof DeleteDataObjectResponse);
+
+        assertEquals(TEST_ID + "1", response.getResponses()[0].id());
+        assertEquals(TEST_ID + "2", response.getResponses()[1].id());
+        assertEquals(TEST_ID + "3", response.getResponses()[2].id());
+    }
+
+    @Test
+    public void testBulkDataObject_WithFailures() throws IOException {
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID + "1")
+            .dataObject(testDataObject)
+            .build();
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID + "2")
+            .dataObject(testDataObject)
+            .build();
+
+        BulkDataObjectRequest bulkRequest = BulkDataObjectRequest
+            .builder()
+            .globalTenantId(TEST_TENANT_ID)
+            .build()
+            .add(putRequest)
+            .add(updateRequest);
+
+        BulkResponse bulkResponse = new BulkResponse(
+            new BulkItemResponse[] {
+                new BulkItemResponse(0, OpType.INDEX, new IndexResponse(new ShardId(TEST_INDEX, "_na_", 0), TEST_ID + "1", 1, 1, 1, true)),
+                new BulkItemResponse(
+                    1,
+                    OpType.UPDATE,
+                    new BulkItemResponse.Failure(TEST_INDEX, TEST_ID + "2", new Exception("Update failed"))
+                ) },
+            100L
+        );
+
+        @SuppressWarnings("unchecked")
+        ActionFuture<BulkResponse> future = mock(ActionFuture.class);
+        when(mockedClient.bulk(any(BulkRequest.class))).thenReturn(future);
+        when(future.actionGet()).thenReturn(bulkResponse);
+
+        BulkDataObjectResponse response = sdkClient
+            .bulkDataObjectAsync(bulkRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
+            .toCompletableFuture()
+            .join();
+
+        assertEquals(2, response.getResponses().length);
+        assertFalse(response.getResponses()[0].isFailed());
+        assertTrue(response.getResponses()[1].isFailed());
+    }
+
+    @Test
+    public void testBulkDataObject_Exception() {
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).dataObject(testDataObject).build();
+
+        BulkDataObjectRequest bulkRequest = BulkDataObjectRequest.builder().globalTenantId(TEST_TENANT_ID).build().add(putRequest);
+
+        when(mockedClient.bulk(any(BulkRequest.class)))
+            .thenThrow(new OpenSearchStatusException("Failed to parse data object in a bulk response", RestStatus.INTERNAL_SERVER_ERROR));
+
+        CompletableFuture<BulkDataObjectResponse> future = sdkClient
+            .bulkDataObjectAsync(bulkRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
+            .toCompletableFuture();
+
+        CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
+        Throwable cause = ce.getCause();
+        assertEquals(OpenSearchStatusException.class, cause.getClass());
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) cause).status());
+        assertEquals("Failed to parse data object in a bulk response", cause.getMessage());
     }
 
     @Test
@@ -642,7 +803,7 @@ public class LocalClusterIndicesClientTests {
         PlainActionFuture<SearchResponse> exceptionalFuture = PlainActionFuture.newFuture();
         exceptionalFuture.onFailure(new UnsupportedOperationException("test"));
         when(mockedClient.search(any(SearchRequest.class))).thenReturn(exceptionalFuture);
-        
+
         CompletableFuture<SearchDataObjectResponse> future = sdkClient
             .searchDataObjectAsync(searchRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
             .toCompletableFuture();
@@ -652,7 +813,7 @@ public class LocalClusterIndicesClientTests {
         assertEquals(UnsupportedOperationException.class, cause.getClass());
         assertEquals("test", cause.getMessage());
     }
-    
+
     @Test
     public void testSearchDataObject_NullTenantNoMultitenancy() throws IOException {
         // Tests no status exception if multitenancy not enabled

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
@@ -153,11 +153,8 @@ public class TransportUndeployModelAction extends
         MLSyncUpNodesRequest syncUpRequest = new MLSyncUpNodesRequest(nodeFilter.getAllNodes(), syncUpInput);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             if (!actualRemovedNodesMap.isEmpty()) {
-                BulkDataObjectRequest bulkRequest = BulkDataObjectRequest
-                    .builder()
-                    .globalTenantId(undeployModelNodesRequest.getTenantId())
-                    .globalIndex(ML_MODEL_INDEX)
-                    .build();
+                BulkDataObjectRequest bulkRequest = BulkDataObjectRequest.builder().globalIndex(ML_MODEL_INDEX).build();
+                String tenantId = undeployModelNodesRequest.getTenantId();
                 Map<String, Boolean> deployToAllNodes = new HashMap<>();
                 for (String modelId : actualRemovedNodesMap.keySet()) {
                     List<String> removedNodes = actualRemovedNodesMap.get(modelId);
@@ -191,6 +188,7 @@ public class TransportUndeployModelAction extends
                     UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
                         .builder()
                         .id(modelId)
+                        .tenantId(tenantId)
                         .dataObject(updateDocument)
                         .build();
                     bulkRequest.add(updateRequest).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.action.undeploy;
 
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.common.CommonValue.UNDEPLOYED;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -17,12 +18,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.opensearch.action.FailedNodeException;
-import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.support.nodes.TransportNodesAction;
-import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -44,6 +43,10 @@ import org.opensearch.ml.common.transport.undeploy.MLUndeployModelNodesResponse;
 import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.ml.stats.MLNodeLevelStat;
 import org.opensearch.ml.stats.MLStats;
+import org.opensearch.sdk.BulkDataObjectRequest;
+import org.opensearch.sdk.SdkClient;
+import org.opensearch.sdk.SdkClientUtils;
+import org.opensearch.sdk.UpdateDataObjectRequest;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -60,6 +63,7 @@ public class TransportUndeployModelAction extends
     private final Client client;
     private final DiscoveryNodeHelper nodeFilter;
     private final MLStats mlStats;
+    private final SdkClient sdkClient;
 
     @Inject
     public TransportUndeployModelAction(
@@ -69,6 +73,7 @@ public class TransportUndeployModelAction extends
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
+        SdkClient sdkClient,
         DiscoveryNodeHelper nodeFilter,
         MLStats mlStats
     ) {
@@ -87,6 +92,7 @@ public class TransportUndeployModelAction extends
 
         this.clusterService = clusterService;
         this.client = client;
+        this.sdkClient = sdkClient;
         this.nodeFilter = nodeFilter;
         this.mlStats = mlStats;
     }
@@ -145,11 +151,10 @@ public class TransportUndeployModelAction extends
 
         MLSyncUpNodesRequest syncUpRequest = new MLSyncUpNodesRequest(nodeFilter.getAllNodes(), syncUpInput);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            if (actualRemovedNodesMap.size() > 0) {
-                BulkRequest bulkRequest = new BulkRequest();
+            if (!actualRemovedNodesMap.isEmpty()) {
+                BulkDataObjectRequest bulkRequest = BulkDataObjectRequest.builder().build();
                 Map<String, Boolean> deployToAllNodes = new HashMap<>();
                 for (String modelId : actualRemovedNodesMap.keySet()) {
-                    UpdateRequest updateRequest = new UpdateRequest();
                     List<String> removedNodes = actualRemovedNodesMap.get(modelId);
                     int removedNodeCount = removedNodes.size();
                     /**
@@ -178,7 +183,12 @@ public class TransportUndeployModelAction extends
                         updateDocument.put(MLModel.CURRENT_WORKER_NODE_COUNT_FIELD, newPlanningWorkerNodes.size());
                         deployToAllNodes.put(modelId, false);
                     }
-                    updateRequest.index(ML_MODEL_INDEX).id(modelId).doc(updateDocument);
+                    UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+                        .builder()
+                        .index(ML_MODEL_INDEX)
+                        .id(modelId)
+                        .dataObject(updateDocument)
+                        .build();
                     bulkRequest.add(updateRequest).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                 }
                 syncUpInput.setDeployToAllNodes(deployToAllNodes);
@@ -189,10 +199,35 @@ public class TransportUndeployModelAction extends
                             Arrays.toString(actualRemovedNodesMap.keySet().toArray(new String[0]))
                         );
                 }, e -> { log.error("Failed to update model state as undeployed", e); });
-                client.bulk(bulkRequest, ActionListener.runAfter(actionListener, () -> {
+                ActionListener<BulkResponse> wrappedListener = ActionListener.runAfter(actionListener, () -> {
                     syncUpUndeployedModels(syncUpRequest);
                     listener.onResponse(undeployModelNodesResponse);
-                }));
+                });
+                sdkClient
+                    .bulkDataObjectAsync(bulkRequest, client.threadPool().executor(GENERAL_THREAD_POOL))
+                    .whenComplete((r, throwable) -> {
+                        if (throwable != null) {
+                            Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable);
+                            log.error("Failed to execute BulkDataObject request", cause);
+                            wrappedListener.onFailure(cause);
+                        } else {
+                            try {
+                                BulkResponse bulkResponse = BulkResponse.fromXContent(r.parser());
+                                log
+                                    .info(
+                                        "Executed {} bulk operations with {} failures, Took: {}",
+                                        bulkResponse.getItems().length,
+                                        bulkResponse.hasFailures()
+                                            ? Arrays.stream(bulkResponse.getItems()).filter(i -> i.isFailed()).count()
+                                            : 0,
+                                        bulkResponse.getTook()
+                                    );
+                                wrappedListener.onResponse(bulkResponse);
+                            } catch (Exception e) {
+                                wrappedListener.onFailure(e);
+                            }
+                        }
+                    });
             } else {
                 syncUpUndeployedModels(syncUpRequest);
                 listener.onResponse(undeployModelNodesResponse);

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
@@ -131,7 +131,7 @@ public class TransportUndeployModelsAction extends HandledTransportAction<Action
             String modelId = modelIds[0];
             validateAccess(modelId, tenantId, ActionListener.wrap(hasPermissionToUndeploy -> {
                 if (hasPermissionToUndeploy) {
-                    undeployModels(targetNodeIds, modelIds, listener);
+                    undeployModels(targetNodeIds, modelIds, tenantId, listener);
                 } else {
                     listener.onFailure(new IllegalArgumentException("No permission to undeploy model " + modelId));
                 }
@@ -157,9 +157,9 @@ public class TransportUndeployModelsAction extends HandledTransportAction<Action
                             .filter(modelId -> !hiddenModelIds.contains(modelId))
                             .toArray(String[]::new);
 
-                        undeployModels(targetNodeIds, modelsIDsToUndeploy, listener);
+                        undeployModels(targetNodeIds, modelsIDsToUndeploy, tenantId, listener);
                     } else {
-                        undeployModels(targetNodeIds, modelIds, listener);
+                        undeployModels(targetNodeIds, modelIds, tenantId, listener);
                     }
                 }, e -> {
                     log.error("Failed to search model index", e);
@@ -169,8 +169,14 @@ public class TransportUndeployModelsAction extends HandledTransportAction<Action
         }
     }
 
-    private void undeployModels(String[] targetNodeIds, String[] modelIds, ActionListener<MLUndeployModelsResponse> listener) {
+    private void undeployModels(
+        String[] targetNodeIds,
+        String[] modelIds,
+        String tenantId,
+        ActionListener<MLUndeployModelsResponse> listener
+    ) {
         MLUndeployModelNodesRequest mlUndeployModelNodesRequest = new MLUndeployModelNodesRequest(targetNodeIds, modelIds);
+        mlUndeployModelNodesRequest.setTenantId(tenantId);
 
         client.execute(MLUndeployModelAction.INSTANCE, mlUndeployModelNodesRequest, ActionListener.wrap(r -> {
             listener.onResponse(new MLUndeployModelsResponse(r));

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterManagerEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterManagerEventListener.java
@@ -102,7 +102,7 @@ public class MLCommonsClusterManagerEventListener implements LocalNodeClusterMan
             log.info("Starting ML sync up job...");
             syncModelRoutingCron = threadPool
                 .scheduleWithFixedDelay(
-                    new MLSyncUpCron(client, clusterService, nodeHelper, mlIndicesHandler, encryptor, mlFeatureEnabledSetting),
+                    new MLSyncUpCron(client, sdkClient, clusterService, nodeHelper, mlIndicesHandler, encryptor, mlFeatureEnabledSetting),
                     TimeValue.timeValueSeconds(jobInterval),
                     GENERAL_THREAD_POOL
                 );

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -38,6 +38,8 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.sdkclient.util.JsonTransformer;
+import org.opensearch.sdk.BulkDataObjectRequest;
+import org.opensearch.sdk.BulkDataObjectResponse;
 import org.opensearch.sdk.DeleteDataObjectRequest;
 import org.opensearch.sdk.DeleteDataObjectResponse;
 import org.opensearch.sdk.GetDataObjectRequest;
@@ -350,6 +352,16 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
                 throw new OpenSearchStatusException("Failed to parse response", RestStatus.INTERNAL_SERVER_ERROR);
             }
         }), executor);
+    }
+
+    @Override
+    public CompletionStage<BulkDataObjectResponse> bulkDataObjectAsync(
+        BulkDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        // TODO Complete this
+        return null;
     }
 
     /**

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -379,6 +379,7 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
 
             List<DataObjectResponse> responses = new ArrayList<>();
 
+            // TODO: Ideally if we only have put and delete requests we can use DynamoDB BatchWriteRequest.
             long startNanos = System.nanoTime();
             for (DataObjectRequest dataObjectRequest : request.requests()) {
                 try {

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DDBOpenSearchClient.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.ml.sdkclient;
 
-import static org.opensearch.action.bulk.BulkResponse.NO_INGEST_TOOK;
 import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
@@ -412,7 +411,7 @@ public class DDBOpenSearchClient implements SdkClientDelegate {
             long tookMillis = TimeUnit.NANOSECONDS.toMillis(endNanos - startNanos);
 
             log.info("Bulk action complete for {} items, took {} ms", responses.size(), tookMillis);
-            return new BulkDataObjectResponse(responses.toArray(new DataObjectResponse[0]), tookMillis, NO_INGEST_TOOK);
+            return new BulkDataObjectResponse(responses.toArray(new DataObjectResponse[0]), tookMillis);
         }), executor);
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.ml.sdkclient;
 
-import static org.opensearch.action.bulk.BulkResponse.NO_INGEST_TOOK;
 import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 
 import java.io.IOException;
@@ -343,11 +342,9 @@ public class RemoteClusterIndicesClient implements SdkClientDelegate {
                             );
                     }
                 }
-                return new BulkDataObjectResponse(
-                    responses,
-                    bulkResponse.took(),
-                    bulkResponse.ingestTook() == null ? NO_INGEST_TOOK : bulkResponse.ingestTook().longValue()
-                );
+                return bulkResponse.ingestTook() == null
+                    ? new BulkDataObjectResponse(responses, bulkResponse.took())
+                    : new BulkDataObjectResponse(responses, bulkResponse.took(), bulkResponse.ingestTook().longValue());
             } catch (IOException e) {
                 // Rethrow unchecked exception on XContent parsing error
                 throw new OpenSearchStatusException("Failed to parse data object in a bulk response", RestStatus.INTERNAL_SERVER_ERROR);

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
@@ -343,8 +343,14 @@ public class RemoteClusterIndicesClient implements SdkClientDelegate {
                     }
                 }
                 return bulkResponse.ingestTook() == null
-                    ? new BulkDataObjectResponse(responses, bulkResponse.took())
-                    : new BulkDataObjectResponse(responses, bulkResponse.took(), bulkResponse.ingestTook().longValue());
+                    ? new BulkDataObjectResponse(responses, bulkResponse.took(), bulkResponse.errors(), createParser(bulkResponse))
+                    : new BulkDataObjectResponse(
+                        responses,
+                        bulkResponse.took(),
+                        bulkResponse.ingestTook().longValue(),
+                        bulkResponse.errors(),
+                        createParser(bulkResponse)
+                    );
             } catch (IOException e) {
                 // Rethrow unchecked exception on XContent parsing error
                 throw new OpenSearchStatusException("Failed to parse data object in a bulk response", RestStatus.INTERNAL_SERVER_ERROR);

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClient.java
@@ -56,6 +56,8 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.MatchPhraseQueryBuilder;
 import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.sdkclient.util.JsonTransformer;
+import org.opensearch.sdk.BulkDataObjectRequest;
+import org.opensearch.sdk.BulkDataObjectResponse;
 import org.opensearch.sdk.DeleteDataObjectRequest;
 import org.opensearch.sdk.DeleteDataObjectResponse;
 import org.opensearch.sdk.GetDataObjectRequest;
@@ -224,6 +226,16 @@ public class RemoteClusterIndicesClient implements SdkClientDelegate {
                 );
             }
         }), executor);
+    }
+
+    @Override
+    public CompletionStage<BulkDataObjectResponse> bulkDataObjectAsync(
+        BulkDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        // TODO Complete this
+        return null;
     }
 
     @Override

--- a/plugin/src/test/java/org/opensearch/ml/action/undeploy/TransportUndeployModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/undeploy/TransportUndeployModelActionTests.java
@@ -28,6 +28,7 @@ import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.opensearch.Version;
@@ -56,8 +57,10 @@ import org.opensearch.ml.common.transport.undeploy.MLUndeployModelNodeResponse;
 import org.opensearch.ml.common.transport.undeploy.MLUndeployModelNodesRequest;
 import org.opensearch.ml.common.transport.undeploy.MLUndeployModelNodesResponse;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.sdkclient.SdkClientFactory;
 import org.opensearch.ml.stats.MLStat;
 import org.opensearch.ml.stats.MLStats;
+import org.opensearch.sdk.SdkClient;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -82,6 +85,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
 
     @Mock
     private Client client;
+    private SdkClient sdkClient;
 
     @Mock
     ClusterState clusterState;
@@ -132,6 +136,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
     public void setup() throws IOException {
         MockitoAnnotations.openMocks(this);
         Settings settings = Settings.builder().build();
+        sdkClient = Mockito.spy(SdkClientFactory.createSdkClient(client, xContentRegistry, settings));
         threadContext = new ThreadContext(settings);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -150,6 +155,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
                 clusterService,
                 threadPool,
                 client,
+                sdkClient,
                 nodeFilter,
                 mlStats
             )

--- a/plugin/src/test/java/org/opensearch/ml/action/undeploy/TransportUndeployModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/undeploy/TransportUndeployModelActionTests.java
@@ -248,7 +248,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
 
     public void testProcessUndeployModelResponseAndUpdateNullResponse() {
         when(undeployModelNodesResponse.getNodes()).thenReturn(null);
-        action.processUndeployModelResponseAndUpdate(undeployModelNodesResponse, actionListener);
+        action.processUndeployModelResponseAndUpdate(mock(), undeployModelNodesResponse, actionListener);
     }
 
     public void testProcessUndeployModelResponseAndUpdateResponse() {
@@ -282,7 +282,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(MLSyncUpNodesRequest.class), any());
 
-        action.processUndeployModelResponseAndUpdate(response, actionListener);
+        action.processUndeployModelResponseAndUpdate(nodesRequest, response, actionListener);
         verify(actionListener).onResponse(response);
     }
 
@@ -316,7 +316,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(MLSyncUpNodesRequest.class), any());
 
-        action.processUndeployModelResponseAndUpdate(response, actionListener);
+        action.processUndeployModelResponseAndUpdate(nodesRequest, response, actionListener);
         verify(actionListener).onResponse(response);
     }
 
@@ -350,7 +350,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(MLSyncUpNodesRequest.class), any());
 
-        action.processUndeployModelResponseAndUpdate(response, actionListener);
+        action.processUndeployModelResponseAndUpdate(nodesRequest, response, actionListener);
         verify(actionListener).onResponse(response);
     }
 
@@ -385,7 +385,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(MLSyncUpNodesRequest.class), any());
 
-        action.processUndeployModelResponseAndUpdate(response, actionListener);
+        action.processUndeployModelResponseAndUpdate(nodesRequest, response, actionListener);
         verify(actionListener).onResponse(response);
     }
 
@@ -422,7 +422,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(MLSyncUpNodesRequest.class), any());
 
-        action.processUndeployModelResponseAndUpdate(response, actionListener);
+        action.processUndeployModelResponseAndUpdate(nodesRequest, response, actionListener);
         verify(actionListener).onResponse(response);
     }
 
@@ -457,7 +457,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).execute(any(), any(MLSyncUpNodesRequest.class), any());
 
-        action.processUndeployModelResponseAndUpdate(response, actionListener);
+        action.processUndeployModelResponseAndUpdate(nodesRequest, response, actionListener);
         verify(actionListener).onResponse(response);
     }
 
@@ -480,7 +480,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
         final List<FailedNodeException> failures = new ArrayList<>();
         final MLUndeployModelNodesResponse response = action.newResponse(nodesRequest, responses, failures);
 
-        action.processUndeployModelResponseAndUpdate(response, actionListener);
+        action.processUndeployModelResponseAndUpdate(nodesRequest, response, actionListener);
     }
 
     public void testProcessUndeployModelResponseAndUpdateResponseUndeployModelWorkerNodeBeforeRemovalNull() {
@@ -500,7 +500,7 @@ public class TransportUndeployModelActionTests extends OpenSearchTestCase {
         final List<FailedNodeException> failures = new ArrayList<>();
         final MLUndeployModelNodesResponse response = action.newResponse(nodesRequest, responses, failures);
 
-        action.processUndeployModelResponseAndUpdate(response, actionListener);
+        action.processUndeployModelResponseAndUpdate(nodesRequest, response, actionListener);
     }
 
     public void testNewResponseWithNotFoundModelStatus() {

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
@@ -274,7 +274,7 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
     public void testRefreshModelState_NoSemaphore() throws InterruptedException {
         syncUpCron.updateModelStateSemaphore.acquire();
         syncUpCron.refreshModelState(null, null);
-        verify(client, never()).search(any());
+        verify(client, Mockito.after(1000).never()).search(any());
         syncUpCron.updateModelStateSemaphore.release();
     }
 
@@ -283,7 +283,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         future.onFailure(new RuntimeException("test exception"));
         when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(null, null);
-        verify(client, times(1)).search(any());
+        // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).search(any(SearchRequest.class));
         assertBusy(() -> { assertTrue(syncUpCron.updateModelStateSemaphore.tryAcquire()); }, 5, TimeUnit.SECONDS);
         syncUpCron.updateModelStateSemaphore.release();
     }
@@ -293,7 +294,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         future.onFailure(new RuntimeException("search error"));
         when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(null, null);
-        verify(client, times(1)).search(any(SearchRequest.class));
+        // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).search(any(SearchRequest.class));
         assertBusy(() -> { assertTrue(syncUpCron.updateModelStateSemaphore.tryAcquire()); }, 5, TimeUnit.SECONDS);
         syncUpCron.updateModelStateSemaphore.release();
     }
@@ -315,8 +317,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         future.onResponse(searchResponse);
         when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(new HashMap<>(), new HashMap<>());
-        verify(client, times(1)).search(any());
         // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).search(any(SearchRequest.class));
         verify(client, Mockito.after(1000).never()).bulk(any());
         assertTrue(syncUpCron.updateModelStateSemaphore.tryAcquire());
         syncUpCron.updateModelStateSemaphore.release();
@@ -330,9 +332,9 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         when(client.search(any(SearchRequest.class))).thenReturn(future);
 
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any(SearchRequest.class));
-        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).search(any(SearchRequest.class));
+        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         verify(client, timeout(1000).times(1)).bulk(bulkRequestCaptor.capture());
         BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertEquals(1, bulkRequest.numberOfActions());
@@ -352,9 +354,9 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         future.onResponse(createSearchModelResponse("modelId", "tenantId", MLModelState.DEPLOYED, 2, 0, Instant.now().toEpochMilli()));
         when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any());
-        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).search(any(SearchRequest.class));
+        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         verify(client, timeout(1000).times(1)).bulk(bulkRequestCaptor.capture());
         BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertEquals(1, bulkRequest.numberOfActions());
@@ -377,9 +379,9 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
             );
         when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any());
-        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).search(any(SearchRequest.class));
+        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         verify(client, timeout(1000).times(1)).bulk(bulkRequestCaptor.capture());
         BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertEquals(1, bulkRequest.numberOfActions());
@@ -400,9 +402,9 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         future.onResponse(createSearchModelResponse("modelId", "tenantId", MLModelState.DEPLOY_FAILED, 2, 0, Instant.now().toEpochMilli()));
         when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any());
-        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).search(any(SearchRequest.class));
+        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         verify(client, timeout(1000).times(1)).bulk(bulkRequestCaptor.capture());
         BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertEquals(1, bulkRequest.numberOfActions());
@@ -422,8 +424,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         future.onResponse(createSearchModelResponse("modelId", "tenantId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli()));
         when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any());
         // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).search(any(SearchRequest.class));
         verify(client, Mockito.after(1000).never()).bulk(any());
     }
 
@@ -434,8 +436,8 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         future.onResponse(createSearchModelResponse("modelId", "tenantId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli()));
         when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any());
         // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).search(any(SearchRequest.class));
         verify(client, Mockito.after(1000).never()).bulk(any());
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
@@ -7,18 +7,21 @@ package org.opensearch.ml.cluster;
 
 import static java.util.Collections.emptyMap;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.CREATE_TIME_FIELD;
 import static org.opensearch.ml.common.CommonValue.MASTER_KEY;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 import static org.opensearch.ml.utils.TestHelper.ML_ROLE;
 import static org.opensearch.ml.utils.TestHelper.setupTestClusterState;
 
@@ -31,21 +34,26 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.lucene.search.TotalHits;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.Version;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.ClusterName;
@@ -56,12 +64,16 @@ import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.action.connector.TransportCreateConnectorActionTests;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.model.MLModelState;
@@ -71,8 +83,10 @@ import org.opensearch.ml.common.transport.sync.MLSyncUpNodesResponse;
 import org.opensearch.ml.engine.encryptor.Encryptor;
 import org.opensearch.ml.engine.encryptor.EncryptorImpl;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
+import org.opensearch.ml.sdkclient.SdkClientFactory;
 import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.utils.TestHelper;
+import org.opensearch.sdk.SdkClient;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.InternalAggregations;
@@ -80,6 +94,8 @@ import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.profile.SearchProfileShardResults;
 import org.opensearch.search.suggest.Suggest;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
+import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
 import com.google.common.collect.ImmutableMap;
@@ -87,8 +103,22 @@ import com.google.common.collect.ImmutableSet;
 
 public class MLSyncUpCronTests extends OpenSearchTestCase {
 
+    private static TestThreadPool testThreadPool = new TestThreadPool(
+        TransportCreateConnectorActionTests.class.getName(),
+        new ScalingExecutorBuilder(
+            GENERAL_THREAD_POOL,
+            1,
+            Math.max(1, OpenSearchExecutors.allocatedProcessors(Settings.EMPTY) - 1),
+            TimeValue.timeValueMinutes(1),
+            ML_THREAD_POOL_PREFIX + GENERAL_THREAD_POOL
+        )
+    );
+
     @Mock
     private Client client;
+    private SdkClient sdkClient;
+    @Mock
+    NamedXContentRegistry xContentRegistry;
     @Mock
     private ClusterService clusterService;
     @Mock
@@ -120,7 +150,6 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         mlNode1 = new DiscoveryNode(mlNode1Id, buildNewFakeTransportAddress(), emptyMap(), ImmutableSet.of(ML_ROLE), Version.CURRENT);
         mlNode2 = new DiscoveryNode(mlNode2Id, buildNewFakeTransportAddress(), emptyMap(), ImmutableSet.of(ML_ROLE), Version.CURRENT);
         encryptor = spy(new EncryptorImpl(null, "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w="));
-        syncUpCron = new MLSyncUpCron(client, clusterService, nodeHelper, mlIndicesHandler, encryptor, mlFeatureEnabledSetting);
 
         testState = setupTestClusterState();
         when(clusterService.state()).thenReturn(testState);
@@ -132,10 +161,18 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         }).when(mlIndicesHandler).initMLConfigIndex(any());
 
         Settings settings = Settings.builder().build();
+        sdkClient = Mockito.spy(SdkClientFactory.createSdkClient(client, xContentRegistry, settings));
         threadContext = new ThreadContext(settings);
         threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, USER_STRING);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(threadPool.executor(anyString())).thenReturn(testThreadPool.executor(GENERAL_THREAD_POOL));
+        syncUpCron = new MLSyncUpCron(client, sdkClient, clusterService, nodeHelper, mlIndicesHandler, encryptor, mlFeatureEnabledSetting);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        ThreadPool.terminate(testThreadPool, 500, TimeUnit.MILLISECONDS);
     }
 
     public void testInitMlConfig_MasterKeyNotExist() {
@@ -236,75 +273,66 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
     public void testRefreshModelState_NoSemaphore() throws InterruptedException {
         syncUpCron.updateModelStateSemaphore.acquire();
         syncUpCron.refreshModelState(null, null);
-        verify(client, never()).search(any(), any());
+        verify(client, never()).search(any());
         syncUpCron.updateModelStateSemaphore.release();
     }
 
-    public void testRefreshModelState_SearchException() {
-        doThrow(new RuntimeException("test exception")).when(client).search(any(), any());
+    public void testRefreshModelState_SearchException() throws Exception {
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        future.onFailure(new RuntimeException("test exception"));
+        when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(null, null);
-        verify(client, times(1)).search(any(), any());
-        assertTrue(syncUpCron.updateModelStateSemaphore.tryAcquire());
+        verify(client, times(1)).search(any());
+        assertBusy(() -> { assertTrue(syncUpCron.updateModelStateSemaphore.tryAcquire()); }, 5, TimeUnit.SECONDS);
         syncUpCron.updateModelStateSemaphore.release();
     }
 
-    public void testRefreshModelState_SearchFailed() {
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onFailure(new RuntimeException("search error"));
-            return null;
-        }).when(client).search(any(), any());
+    public void testRefreshModelState_SearchFailed() throws Exception {
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        future.onFailure(new RuntimeException("search error"));
+        when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(null, null);
-        verify(client, times(1)).search(any(), any());
-        assertTrue(syncUpCron.updateModelStateSemaphore.tryAcquire());
+        verify(client, times(1)).search(any(SearchRequest.class));
+        assertBusy(() -> { assertTrue(syncUpCron.updateModelStateSemaphore.tryAcquire()); }, 5, TimeUnit.SECONDS);
         syncUpCron.updateModelStateSemaphore.release();
     }
 
     public void testRefreshModelState_EmptySearchResponse() {
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            SearchHits hits = new SearchHits(new SearchHit[0], null, Float.NaN);
-            SearchResponseSections searchSections = new SearchResponseSections(
-                hits,
-                InternalAggregations.EMPTY,
-                null,
-                true,
-                false,
-                null,
-                1
-            );
-            SearchResponse searchResponse = new SearchResponse(
-                searchSections,
-                null,
-                1,
-                1,
-                0,
-                11,
-                ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponse.Clusters.EMPTY
-            );
-            actionListener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), any());
+        SearchHits hits = new SearchHits(new SearchHit[0], null, Float.NaN);
+        SearchResponseSections searchSections = new SearchResponseSections(hits, InternalAggregations.EMPTY, null, true, false, null, 1);
+        SearchResponse searchResponse = new SearchResponse(
+            searchSections,
+            null,
+            1,
+            1,
+            0,
+            11,
+            ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY
+        );
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(searchResponse);
+        when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(new HashMap<>(), new HashMap<>());
-        verify(client, times(1)).search(any(), any());
-        verify(client, never()).bulk(any(), any());
+        verify(client, times(1)).search(any());
+        // Need a small delay due to multithreading
+        verify(client, Mockito.after(1000).never()).bulk(any());
         assertTrue(syncUpCron.updateModelStateSemaphore.tryAcquire());
         syncUpCron.updateModelStateSemaphore.release();
     }
 
-    public void testRefreshModelState_ResetAsDeployFailed() {
+    public void testRefreshModelState_ResetAsDeployFailed() throws IOException {
         Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
         Map<String, Set<String>> deployingModels = new HashMap<>();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYED, 2, null, Instant.now().toEpochMilli()));
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYED, 2, null, Instant.now().toEpochMilli()));
+        when(client.search(any(SearchRequest.class))).thenReturn(future);
+
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any(), any());
+        verify(client, times(1)).search(any(SearchRequest.class));
         ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
-        verify(client, times(1)).bulk(bulkRequestCaptor.capture(), any());
+        // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).bulk(bulkRequestCaptor.capture());
         BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertEquals(1, bulkRequest.numberOfActions());
         assertEquals(1, bulkRequest.requests().size());
@@ -315,19 +343,18 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         assertEquals(ML_MODEL_INDEX, updateRequest.index());
     }
 
-    public void testRefreshModelState_ResetAsPartiallyDeployed() {
+    public void testRefreshModelState_ResetAsPartiallyDeployed() throws IOException {
         Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
         modelWorkerNodes.put("modelId", ImmutableSet.of("node1"));
         Map<String, Set<String>> deployingModels = new HashMap<>();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYED, 2, 0, Instant.now().toEpochMilli()));
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYED, 2, 0, Instant.now().toEpochMilli()));
+        when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any(), any());
+        verify(client, times(1)).search(any());
         ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
-        verify(client, times(1)).bulk(bulkRequestCaptor.capture(), any());
+        // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).bulk(bulkRequestCaptor.capture());
         BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertEquals(1, bulkRequest.numberOfActions());
         assertEquals(1, bulkRequest.requests().size());
@@ -338,20 +365,18 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         assertEquals(ML_MODEL_INDEX, updateRequest.index());
     }
 
-    public void testRefreshModelState_ResetCurrentWorkerNodeCountForPartiallyDeployed() {
+    public void testRefreshModelState_ResetCurrentWorkerNodeCountForPartiallyDeployed() throws IOException {
         Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
         modelWorkerNodes.put("modelId", ImmutableSet.of("node1"));
         Map<String, Set<String>> deployingModels = new HashMap<>();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener
-                .onResponse(createSearchModelResponse("modelId", MLModelState.PARTIALLY_DEPLOYED, 3, 2, Instant.now().toEpochMilli()));
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(createSearchModelResponse("modelId", MLModelState.PARTIALLY_DEPLOYED, 3, 2, Instant.now().toEpochMilli()));
+        when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any(), any());
+        verify(client, times(1)).search(any());
         ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
-        verify(client, times(1)).bulk(bulkRequestCaptor.capture(), any());
+        // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).bulk(bulkRequestCaptor.capture());
         BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertEquals(1, bulkRequest.numberOfActions());
         assertEquals(1, bulkRequest.requests().size());
@@ -362,20 +387,19 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         assertEquals(ML_MODEL_INDEX, updateRequest.index());
     }
 
-    public void testRefreshModelState_ResetAsDeploying() {
+    public void testRefreshModelState_ResetAsDeploying() throws IOException {
         Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
         modelWorkerNodes.put("modelId", ImmutableSet.of("node1"));
         Map<String, Set<String>> deployingModels = new HashMap<>();
         deployingModels.put("modelId", ImmutableSet.of("node2"));
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOY_FAILED, 2, 0, Instant.now().toEpochMilli()));
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOY_FAILED, 2, 0, Instant.now().toEpochMilli()));
+        when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any(), any());
+        verify(client, times(1)).search(any());
         ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
-        verify(client, times(1)).bulk(bulkRequestCaptor.capture(), any());
+        // Need a small delay due to multithreading
+        verify(client, timeout(1000).times(1)).bulk(bulkRequestCaptor.capture());
         BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertEquals(1, bulkRequest.numberOfActions());
         assertEquals(1, bulkRequest.requests().size());
@@ -386,31 +410,29 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         assertEquals(ML_MODEL_INDEX, updateRequest.index());
     }
 
-    public void testRefreshModelState_NotResetState_DeployingModelTaskRunning() {
+    public void testRefreshModelState_NotResetState_DeployingModelTaskRunning() throws IOException {
         Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
         Map<String, Set<String>> deployingModels = new HashMap<>();
         deployingModels.put("modelId", ImmutableSet.of("node2"));
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli()));
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli()));
+        when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any(), any());
-        verify(client, never()).bulk(any(), any());
+        verify(client, times(1)).search(any());
+        // Need a small delay due to multithreading
+        verify(client, Mockito.after(1000).never()).bulk(any());
     }
 
-    public void testRefreshModelState_NotResetState_DeployingInGraceTime() {
+    public void testRefreshModelState_NotResetState_DeployingInGraceTime() throws IOException {
         Map<String, Set<String>> modelWorkerNodes = new HashMap<>();
         Map<String, Set<String>> deployingModels = new HashMap<>();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli()));
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(createSearchModelResponse("modelId", MLModelState.DEPLOYING, 2, null, Instant.now().toEpochMilli()));
+        when(client.search(any(SearchRequest.class))).thenReturn(future);
         syncUpCron.refreshModelState(modelWorkerNodes, deployingModels);
-        verify(client, times(1)).search(any(), any());
-        verify(client, never()).bulk(any(), any());
+        verify(client, times(1)).search(any());
+        // Need a small delay due to multithreading
+        verify(client, Mockito.after(1000).never()).bulk(any());
     }
 
     private void mockSyncUp_GatherRunningTasks() {

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -675,13 +675,22 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testBulkDataObject_HappyCase() {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().id(TEST_ID + "1").dataObject(testDataObject).build();
-        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder().id(TEST_ID + "2").dataObject(testDataObject).build();
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .id(TEST_ID + "1")
+            .tenantId(TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
+            .id(TEST_ID + "2")
+            .tenantId(TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").tenantId(TENANT_ID).build();
         BulkDataObjectRequest bulkRequest = BulkDataObjectRequest
             .builder()
             .globalIndex(TEST_INDEX)
-            .globalTenantId(TENANT_ID)
             .build()
             .add(putRequest)
             .add(updateRequest)
@@ -721,13 +730,22 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
 
     @Test
     public void testBulkDataObject_WithFailures() {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().id(TEST_ID + "1").dataObject(testDataObject).build();
-        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder().id(TEST_ID + "2").dataObject(testDataObject).build();
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .id(TEST_ID + "1")
+            .tenantId(TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
+            .id(TEST_ID + "2")
+            .tenantId(TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").tenantId(TENANT_ID).build();
         BulkDataObjectRequest bulkRequest = BulkDataObjectRequest
             .builder()
             .globalIndex(TEST_INDEX)
-            .globalTenantId(TENANT_ID)
             .build()
             .add(putRequest)
             .add(updateRequest)

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DDBOpenSearchClientTests.java
@@ -9,6 +9,7 @@
 
 package org.opensearch.ml.sdkclient;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
@@ -50,6 +51,8 @@ import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.CommonValue;
+import org.opensearch.sdk.BulkDataObjectRequest;
+import org.opensearch.sdk.BulkDataObjectResponse;
 import org.opensearch.sdk.DeleteDataObjectRequest;
 import org.opensearch.sdk.DeleteDataObjectResponse;
 import org.opensearch.sdk.GetDataObjectRequest;
@@ -671,6 +674,88 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
     }
 
     @Test
+    public void testBulkDataObject_HappyCase() {
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().id(TEST_ID + "1").dataObject(testDataObject).build();
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder().id(TEST_ID + "2").dataObject(testDataObject).build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").build();
+        BulkDataObjectRequest bulkRequest = BulkDataObjectRequest
+            .builder()
+            .globalIndex(TEST_INDEX)
+            .globalTenantId(TENANT_ID)
+            .build()
+            .add(putRequest)
+            .add(updateRequest)
+            .add(deleteRequest);
+
+        when(dynamoDbClient.putItem(any(PutItemRequest.class))).thenReturn(PutItemResponse.builder().build());
+        GetItemResponse getItemResponse = GetItemResponse
+            .builder()
+            .item(
+                Map
+                    .ofEntries(
+                        Map.entry(SOURCE, AttributeValue.builder().m(Map.of("data", AttributeValue.builder().s("foo").build())).build()),
+                        Map.entry(SEQ_NUM, AttributeValue.builder().n("0").build())
+                    )
+            )
+            .build();
+        when(dynamoDbClient.getItem(any(GetItemRequest.class))).thenReturn(getItemResponse);
+        when(dynamoDbClient.updateItem(any(UpdateItemRequest.class))).thenReturn(UpdateItemResponse.builder().build());
+        when(dynamoDbClient.deleteItem(any(DeleteItemRequest.class))).thenReturn(DeleteItemResponse.builder().build());
+
+        BulkDataObjectResponse response = sdkClient
+            .bulkDataObjectAsync(bulkRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
+            .toCompletableFuture()
+            .join();
+
+        assertEquals(3, response.getResponses().length);
+        assertTrue(response.getResponses()[0] instanceof PutDataObjectResponse);
+        assertTrue(response.getResponses()[1] instanceof UpdateDataObjectResponse);
+        assertTrue(response.getResponses()[2] instanceof DeleteDataObjectResponse);
+
+        assertEquals(TEST_ID + "1", response.getResponses()[0].id());
+        assertEquals(TEST_ID + "2", response.getResponses()[1].id());
+        assertEquals(TEST_ID + "3", response.getResponses()[2].id());
+
+        assertTrue(response.getTookInMillis() >= 0);
+    }
+
+    @Test
+    public void testBulkDataObject_WithFailures() {
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().id(TEST_ID + "1").dataObject(testDataObject).build();
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder().id(TEST_ID + "2").dataObject(testDataObject).build();
+        BulkDataObjectRequest bulkRequest = BulkDataObjectRequest
+            .builder()
+            .globalIndex(TEST_INDEX)
+            .globalTenantId(TENANT_ID)
+            .build()
+            .add(putRequest)
+            .add(updateRequest);
+
+        when(dynamoDbClient.putItem(any(PutItemRequest.class))).thenReturn(PutItemResponse.builder().build());
+        GetItemResponse getItemResponse = GetItemResponse
+            .builder()
+            .item(
+                Map
+                    .ofEntries(
+                        Map.entry(SOURCE, AttributeValue.builder().m(Map.of("data", AttributeValue.builder().s("foo").build())).build()),
+                        Map.entry(SEQ_NUM, AttributeValue.builder().n("0").build())
+                    )
+            )
+            .build();
+        when(dynamoDbClient.getItem(any(GetItemRequest.class))).thenReturn(getItemResponse);
+        when(dynamoDbClient.updateItem(any(UpdateItemRequest.class))).thenThrow(new RuntimeException("Update failed"));
+
+        BulkDataObjectResponse response = sdkClient
+            .bulkDataObjectAsync(bulkRequest, testThreadPool.executor(GENERAL_THREAD_POOL))
+            .toCompletableFuture()
+            .join();
+
+        assertEquals(2, response.getResponses().length);
+        assertFalse(response.getResponses()[0].isFailed());
+        assertTrue(response.getResponses()[1].isFailed());
+    }
+
+    @Test
     public void searchDataObjectAsync_HappyCase() {
         SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.searchSource();
         SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
@@ -729,5 +814,4 @@ public class DDBOpenSearchClientTests extends OpenSearchTestCase {
                 Map.entry("testObject", AttributeValue.builder().m(Map.of("data", AttributeValue.builder().s("foo").build())).build())
             );
     }
-
 }

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/RemoteClusterIndicesClientTests.java
@@ -568,14 +568,23 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testBulkDataObject() throws IOException {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().id(TEST_ID + "1").dataObject(testDataObject).build();
-        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder().id(TEST_ID + "2").dataObject(testDataObject).build();
-        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .id(TEST_ID + "1")
+            .tenantId(TEST_TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
+            .id(TEST_ID + "2")
+            .tenantId(TEST_TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").tenantId(TEST_TENANT_ID).build();
 
         BulkDataObjectRequest bulkRequest = BulkDataObjectRequest
             .builder()
             .globalIndex(TEST_INDEX)
-            .globalTenantId(TEST_TENANT_ID)
             .build()
             .add(putRequest)
             .add(updateRequest)
@@ -634,14 +643,23 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testBulkDataObject_WithFailures() throws IOException {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().id(TEST_ID + "1").dataObject(testDataObject).build();
-        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder().id(TEST_ID + "2").dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .id(TEST_ID + "1")
+            .tenantId(TEST_TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest
+            .builder()
+            .id(TEST_ID + "2")
+            .tenantId(TEST_TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
         DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder().id(TEST_ID + "3").build();
 
         BulkDataObjectRequest bulkRequest = BulkDataObjectRequest
             .builder()
             .globalIndex(TEST_INDEX)
-            .globalTenantId(TEST_TENANT_ID)
             .build()
             .add(putRequest)
             .add(updateRequest);
@@ -694,9 +712,15 @@ public class RemoteClusterIndicesClientTests extends OpenSearchTestCase {
     }
 
     public void testBulkDataObject_Exception() throws OpenSearchException, IOException {
-        PutDataObjectRequest putRequest = PutDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).dataObject(testDataObject).build();
+        PutDataObjectRequest putRequest = PutDataObjectRequest
+            .builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
 
-        BulkDataObjectRequest bulkRequest = BulkDataObjectRequest.builder().globalTenantId(TEST_TENANT_ID).build().add(putRequest);
+        BulkDataObjectRequest bulkRequest = BulkDataObjectRequest.builder().build().add(putRequest);
 
         when(mockedOpenSearchClient.bulk(any(BulkRequest.class)))
             .thenThrow(


### PR DESCRIPTION
### Description

Adds an SDKClient equivalent to `client.bulk()`.

Summary of changes (helpful for reviewers):
1. Added a new `DataObjectRequest` parent class. I originally started with a tagging interface just to help method signatures, but realized that four classes duplicated the same code for the index, id, and tenantId fields, so refactored those (and the associated builder code) into the superclass. Existing unit tests cover this change. https://github.com/opensearch-project/ml-commons/pull/3192/commits/caeea219cef12a70d344f2639f17f13ac9a62956 
2. Added a new `DataObjectResponse` parent class similar to above, refactoring the id and parser fields from the subclass. Existing unit tests cover this change. https://github.com/opensearch-project/ml-commons/pull/3192/commits/445936bcfa23410778cc024a485b69b307a44c62 (part 1)
3. Added new `BulkDataObjectRequest` and `BulkDataObjectResponse` classes and unit tests.  Added a `failed` field to the response superclass to track failures/errors. https://github.com/opensearch-project/ml-commons/pull/3192/commits/445936bcfa23410778cc024a485b69b307a44c62 (part 2)
4. Added the interface and stubbed implementations for the SdkClient `.bulk()` method, and unit tests https://github.com/opensearch-project/ml-commons/pull/3192/commits/22dccf4af0c41f07625ffe6857fd17df80b0bf79
5. Implemented the new interface method in all 3 clients.  The local and remote implementations use the OpenSearch bulk request natively.  The DynamoDB implementation simply iterates the bulk request and calls existing code for the individual requests; this is not the most efficient but necessary to preserve ordering.  If all the bulk requests are put and delete, it's possible to optimize this with DDB BulkWrite, which is a good future optimization; however since our primary use case uses update I'm deferring that complexity. https://github.com/opensearch-project/ml-commons/pull/3192/commits/ee30d210818a84b89027860e5c3a0ac7762a950b
6. Additional refactoring in response to code review: move the details of ingest_took to a lower level https://github.com/opensearch-project/ml-commons/pull/3192/commits/7f190785408ccbe60899eb6dc45fa78bcafd1033
7. More parameters in the sdkclient request/response to handle the needed implementation https://github.com/opensearch-project/ml-commons/pull/3192/commits/05a64d1553bc8b60be278d16b59bad488344a972
8. Implementation and tests https://github.com/opensearch-project/ml-commons/pull/3192/commits/e2a5ec638ef83265bc751bd788af77c78d72b746

In addition there are several whitespace / import reordering changes due to spotless not having been run on the common module. 

Will be handled integ tests in #2818 

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
