### PR TITLE
[FEATURE]Improve test coverage for RemoteModel.java

### DIFF
--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
@@ -149,17 +149,21 @@ public class RemoteModelTest extends MLStaticMockBase {
 
     @Test
     public void initModel_Failure_With_RuntimeException() {
-        initModel_Failure_With_Throwable(new IllegalArgumentException("Tag mismatch!"), IllegalArgumentException.class);
+        initModel_Failure_With_Throwable(new IllegalArgumentException("Tag mismatch!"), IllegalArgumentException.class, "Tag mismatch!");
     }
 
     @Test
     public void initModel_Failure_With_Throwable() {
-        initModel_Failure_With_Throwable(new Error("Decryption Error!"), MLException.class);
+        initModel_Failure_With_Throwable(new Error("Decryption Error!"), MLException.class, "Decryption Error!");
     }
 
-    private void initModel_Failure_With_Throwable(Throwable actualException, Class<? extends Throwable> expExcepClass) {
+    private void initModel_Failure_With_Throwable(
+        Throwable actualException,
+        Class<? extends Throwable> expExcepClass,
+        String expExceptionMessage
+    ) {
         exceptionRule.expect(expExcepClass);
-        exceptionRule.expectMessage(actualException.getMessage());
+        exceptionRule.expectMessage(expExceptionMessage);
         Connector connector = createConnector(null);
         when(mlModel.getConnector()).thenReturn(connector);
         doThrow(actualException).when(encryptor).decrypt(any());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.MLModel;
@@ -30,20 +31,26 @@ import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.ConnectorProtocols;
 import org.opensearch.ml.common.connector.HttpConnector;
+import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.transport.MLTaskResponse;
+import org.opensearch.ml.engine.MLEngineClassLoader;
+import org.opensearch.ml.engine.MLStaticMockBase;
 import org.opensearch.ml.engine.encryptor.Encryptor;
 import org.opensearch.ml.engine.encryptor.EncryptorImpl;
 
 import com.google.common.collect.ImmutableMap;
 
-public class RemoteModelTest {
+public class RemoteModelTest extends MLStaticMockBase {
 
     @Mock
     MLInput mlInput;
 
     @Mock
     MLModel mlModel;
+
+    @Mock
+    RemoteConnectorExecutor remoteConnectorExecutor;
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
@@ -73,7 +80,7 @@ public class RemoteModelTest {
     }
 
     @Test
-    public void predict_NullConnectorExecutor() {
+    public void asyncPredict_NullConnectorExecutor() {
         ActionListener<MLTaskResponse> actionListener = mock(ActionListener.class);
         remoteModel.asyncPredict(mlInput, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -86,7 +93,7 @@ public class RemoteModelTest {
     }
 
     @Test
-    public void predict_ModelDeployed_WrongInput() {
+    public void asyncPredict_ModelDeployed_WrongInput() {
         Connector connector = createConnector(ImmutableMap.of("Authorization", "Bearer ${credential.key}"));
         when(mlModel.getConnector()).thenReturn(connector);
         remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
@@ -99,12 +106,63 @@ public class RemoteModelTest {
     }
 
     @Test
-    public void initModel_RuntimeException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Tag mismatch!");
+    public void asyncPredict_Failure_With_RuntimeException() {
+        asyncPredict_Failure_With_Throwable(
+            new RuntimeException("Remote Connection Exception!"),
+            RuntimeException.class,
+            "Remote Connection Exception!"
+        );
+    }
+
+    @Test
+    public void asyncPredict_Failure_With_Throwable() {
+        asyncPredict_Failure_With_Throwable(
+            new Error("Remote Connection Error!"),
+            MLException.class,
+            "java.lang.Error: Remote Connection Error!"
+        );
+    }
+
+    private void asyncPredict_Failure_With_Throwable(
+        Throwable actualException,
+        Class<? extends Throwable> expExceptionClass,
+        String expExceptionMessage
+    ) {
+        ActionListener<MLTaskResponse> actionListener = mock(ActionListener.class);
+        doThrow(actualException)
+            .when(remoteConnectorExecutor)
+            .executeAction(ConnectorAction.ActionType.PREDICT.toString(), mlInput, actionListener);
+        try (MockedStatic<MLEngineClassLoader> loader = mockStatic(MLEngineClassLoader.class)) {
+            Connector connector = createConnector(ImmutableMap.of("Authorization", "Bearer ${credential.key}"));
+            when(mlModel.getConnector()).thenReturn(connector);
+            loader
+                .when(() -> MLEngineClassLoader.initInstance(connector.getProtocol(), connector, Connector.class))
+                .thenReturn(remoteConnectorExecutor);
+            remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+            remoteModel.asyncPredict(mlInput, actionListener);
+            ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+            verify(actionListener).onFailure(argumentCaptor.capture());
+            assert expExceptionClass.isInstance(argumentCaptor.getValue());
+            assertEquals(expExceptionMessage, argumentCaptor.getValue().getMessage());
+        }
+    }
+
+    @Test
+    public void initModel_Failure_With_RuntimeException() {
+        initModel_Failure_With_Throwable(new IllegalArgumentException("Tag mismatch!"), IllegalArgumentException.class);
+    }
+
+    @Test
+    public void initModel_Failure_With_Throwable() {
+        initModel_Failure_With_Throwable(new Error("Decryption Error!"), MLException.class);
+    }
+
+    private void initModel_Failure_With_Throwable(Throwable actualException, Class<? extends Throwable> expExcepClass) {
+        exceptionRule.expect(expExcepClass);
+        exceptionRule.expectMessage(actualException.getMessage());
         Connector connector = createConnector(null);
         when(mlModel.getConnector()).thenReturn(connector);
-        doThrow(new IllegalArgumentException("Tag mismatch!")).when(encryptor).decrypt(any());
+        doThrow(actualException).when(encryptor).decrypt(any());
         remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
     }
 
@@ -129,7 +187,6 @@ public class RemoteModelTest {
         Assert.assertNotNull(executor.getConnector().getDecryptedHeaders());
         assertEquals(1, executor.getConnector().getDecryptedHeaders().size());
         assertEquals("Bearer test_api_key", executor.getConnector().getDecryptedHeaders().get("Authorization"));
-
         remoteModel.close();
         Assert.assertNull(remoteModel.getConnectorExecutor());
     }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
@@ -14,8 +14,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Collections;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
### Description
Added new tests for missing coverage. Mainly coverage was missing for catching exceptions in the methods initModel() and asyncPredict(). Also renamed some tests to match with testing methods.

### Related Issues
Resolves #1382

### Check List
- [ X] New functionality includes testing.
- [ ] ~New functionality has been documented.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [X ] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
