### PR TITLE
adding multi-modal pre-processor for cohere

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/MLPreProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/MLPreProcessFunction.java
@@ -11,6 +11,7 @@ import java.util.function.Function;
 
 import org.opensearch.ml.common.connector.functions.preprocess.BedrockEmbeddingPreProcessFunction;
 import org.opensearch.ml.common.connector.functions.preprocess.CohereEmbeddingPreProcessFunction;
+import org.opensearch.ml.common.connector.functions.preprocess.CohereMultiModalEmbeddingPreProcessFunction;
 import org.opensearch.ml.common.connector.functions.preprocess.CohereRerankPreProcessFunction;
 import org.opensearch.ml.common.connector.functions.preprocess.MultiModalConnectorPreProcessFunction;
 import org.opensearch.ml.common.connector.functions.preprocess.OpenAIEmbeddingPreProcessFunction;
@@ -21,6 +22,7 @@ public class MLPreProcessFunction {
 
     private static final Map<String, Function<MLInput, RemoteInferenceInputDataSet>> PRE_PROCESS_FUNCTIONS = new HashMap<>();
     public static final String TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT = "connector.pre_process.cohere.embedding";
+    public static final String IMAGE_TO_COHERE_MULTI_MODAL_EMBEDDING_INPUT = "connector.pre_process.cohere.multimodal_embedding";
     public static final String TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT = "connector.pre_process.openai.embedding";
     public static final String TEXT_DOCS_TO_BEDROCK_EMBEDDING_INPUT = "connector.pre_process.bedrock.embedding";
     public static final String TEXT_IMAGE_TO_BEDROCK_EMBEDDING_INPUT = "connector.pre_process.bedrock.multimodal_embedding";
@@ -37,7 +39,10 @@ public class MLPreProcessFunction {
         BedrockEmbeddingPreProcessFunction bedrockEmbeddingPreProcessFunction = new BedrockEmbeddingPreProcessFunction();
         CohereRerankPreProcessFunction cohereRerankPreProcessFunction = new CohereRerankPreProcessFunction();
         MultiModalConnectorPreProcessFunction multiModalEmbeddingPreProcessFunction = new MultiModalConnectorPreProcessFunction();
+        CohereMultiModalEmbeddingPreProcessFunction cohereMultiModalEmbeddingPreProcessFunction =
+            new CohereMultiModalEmbeddingPreProcessFunction();
         PRE_PROCESS_FUNCTIONS.put(TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT, cohereEmbeddingPreProcessFunction);
+        PRE_PROCESS_FUNCTIONS.put(IMAGE_TO_COHERE_MULTI_MODAL_EMBEDDING_INPUT, cohereMultiModalEmbeddingPreProcessFunction);
         PRE_PROCESS_FUNCTIONS.put(TEXT_IMAGE_TO_BEDROCK_EMBEDDING_INPUT, multiModalEmbeddingPreProcessFunction);
         PRE_PROCESS_FUNCTIONS.put(TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT, openAIEmbeddingPreProcessFunction);
         PRE_PROCESS_FUNCTIONS.put(TEXT_DOCS_TO_DEFAULT_EMBEDDING_INPUT, openAIEmbeddingPreProcessFunction);

--- a/common/src/main/java/org/opensearch/ml/common/connector/functions/preprocess/CohereMultiModalEmbeddingPreProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/functions/preprocess/CohereMultiModalEmbeddingPreProcessFunction.java
@@ -34,6 +34,13 @@ public class CohereMultiModalEmbeddingPreProcessFunction extends ConnectorPrePro
     public RemoteInferenceInputDataSet process(MLInput mlInput) {
         TextDocsInputDataSet inputData = (TextDocsInputDataSet) mlInput.getInputDataset();
         Map<String, String> parametersMap = new HashMap<>();
+
+        /**
+         * Cohere multi-modal model expects either image or texts, not both.
+         * For image, customer can use this pre-process function. For texts, customer can use
+         * connector.pre_process.cohere.embedding
+         * Cohere expects An array of image data URIs for the model to embed. Maximum number of images per call is 1.
+         */
         parametersMap.put("images", inputData.getDocs().getFirst());
         return RemoteInferenceInputDataSet
             .builder()

--- a/common/src/main/java/org/opensearch/ml/common/connector/functions/preprocess/CohereMultiModalEmbeddingPreProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/functions/preprocess/CohereMultiModalEmbeddingPreProcessFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.connector.functions.preprocess;
+
+import static org.opensearch.ml.common.utils.StringUtils.convertScriptStringToJsonString;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
+import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.input.MLInput;
+
+public class CohereMultiModalEmbeddingPreProcessFunction extends ConnectorPreProcessFunction {
+
+    public CohereMultiModalEmbeddingPreProcessFunction() {
+        this.returnDirectlyForRemoteInferenceInput = true;
+    }
+
+    @Override
+    public void validate(MLInput mlInput) {
+        validateTextDocsInput(mlInput);
+        List<String> docs = ((TextDocsInputDataSet) mlInput.getInputDataset()).getDocs();
+        if (docs.isEmpty() || (docs.size() == 1 && docs.getFirst() == null)) {
+            throw new IllegalArgumentException("No image provided");
+        }
+    }
+
+    @Override
+    public RemoteInferenceInputDataSet process(MLInput mlInput) {
+        TextDocsInputDataSet inputData = (TextDocsInputDataSet) mlInput.getInputDataset();
+        Map<String, String> parametersMap = new HashMap<>();
+        parametersMap.put("images", inputData.getDocs().getFirst());
+        return RemoteInferenceInputDataSet
+            .builder()
+            .parameters(convertScriptStringToJsonString(Map.of("parameters", parametersMap)))
+            .build();
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/CohereMultiModalEmbeddingPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/CohereMultiModalEmbeddingPreProcessFunctionTest.java
@@ -8,7 +8,6 @@ package org.opensearch.ml.common.connector.functions.preprocess;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -22,11 +21,11 @@ import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
-public class MultiModalConnectorPreProcessFunctionTest {
+public class CohereMultiModalEmbeddingPreProcessFunctionTest {
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
 
-    MultiModalConnectorPreProcessFunction function;
+    CohereMultiModalEmbeddingPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
     TextDocsInputDataSet textDocsInputDataSet;
@@ -38,13 +37,10 @@ public class MultiModalConnectorPreProcessFunctionTest {
 
     @Before
     public void setUp() {
-        function = new MultiModalConnectorPreProcessFunction();
+        function = new CohereMultiModalEmbeddingPreProcessFunction();
         textSimilarityInputDataSet = TextSimilarityInputDataSet.builder().queryText("test").textDocs(List.of("hello")).build();
-        textDocsInputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("hello", "world")).build();
-        remoteInferenceInputDataSet = RemoteInferenceInputDataSet
-            .builder()
-            .parameters(Map.of("inputText", "value1", "inputImage", "value2"))
-            .build();
+        textDocsInputDataSet = TextDocsInputDataSet.builder().docs(List.of("imageString")).build();
+        remoteInferenceInputDataSet = RemoteInferenceInputDataSet.builder().parameters(Map.of("images", "value2")).build();
 
         textEmbeddingInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
         textSimilarityInput = MLInput.builder().algorithm(FunctionName.TEXT_SIMILARITY).inputDataset(textSimilarityInputDataSet).build();
@@ -69,24 +65,15 @@ public class MultiModalConnectorPreProcessFunctionTest {
     public void testProcess_whenCorrectInput_expectCorrectOutput() {
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
         RemoteInferenceInputDataSet dataSet = function.apply(mlInput);
-        assertEquals(2, dataSet.getParameters().size());
-        assertEquals("hello", dataSet.getParameters().get("inputText"));
-        assertEquals("world", dataSet.getParameters().get("inputImage"));
-    }
-
-    @Test
-    public void testProcess_whenInputTextOnly_expectInputTextShowUp() {
-        TextDocsInputDataSet textDocsInputDataSet1 = TextDocsInputDataSet.builder().docs(Arrays.asList("hello")).build();
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet1).build();
-        RemoteInferenceInputDataSet dataSet = function.apply(mlInput);
         assertEquals(1, dataSet.getParameters().size());
-        assertEquals("hello", dataSet.getParameters().get("inputText"));
+        assertEquals("imageString", dataSet.getParameters().get("images"));
+
     }
 
     @Test
     public void testProcess_whenInputTextIsnull_expectIllegalArgumentException() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("No input text or image provided");
+        exceptionRule.expectMessage("No image provided");
         List<String> docs = new ArrayList<>();
         docs.add(null);
         TextDocsInputDataSet textDocsInputDataSet1 = TextDocsInputDataSet.builder().docs(docs).build();


### PR DESCRIPTION
### Description
[adding multi-modal pre-processor for cohere

Cohere multi-modal model either accepts array of texts or array of base64 images (but only 1 item in the array). So if customer wants to use images then then they can use this pre-processor. 
]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
