### PR TITLE
getFirst is not allowed in java 17

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/functions/preprocess/CohereMultiModalEmbeddingPreProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/functions/preprocess/CohereMultiModalEmbeddingPreProcessFunction.java
@@ -25,9 +25,10 @@ public class CohereMultiModalEmbeddingPreProcessFunction extends ConnectorPrePro
     public void validate(MLInput mlInput) {
         validateTextDocsInput(mlInput);
         List<String> docs = ((TextDocsInputDataSet) mlInput.getInputDataset()).getDocs();
-        if (docs.isEmpty() || (docs.size() == 1 && docs.getFirst() == null)) {
+        if (docs == null || docs.isEmpty() || (docs.size() == 1 && docs.get(0) == null)) {
             throw new IllegalArgumentException("No image provided");
         }
+
     }
 
     @Override
@@ -41,7 +42,7 @@ public class CohereMultiModalEmbeddingPreProcessFunction extends ConnectorPrePro
          * connector.pre_process.cohere.embedding
          * Cohere expects An array of image data URIs for the model to embed. Maximum number of images per call is 1.
          */
-        parametersMap.put("images", inputData.getDocs().getFirst());
+        parametersMap.put("images", inputData.getDocs().get(0));
         return RemoteInferenceInputDataSet
             .builder()
             .parameters(convertScriptStringToJsonString(Map.of("parameters", parametersMap)))


### PR DESCRIPTION
### Description
[getFirst is not allowed in java 17]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
