### PR TITLE
Retrieve remote model id from registration response in IT to avoid flaky

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -1002,15 +1002,11 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
         String connectorId = (String) responseMap.get("connector_id");
         response = RestMLRemoteInferenceIT.registerRemoteModel(modelName, modelName, connectorId);
         responseMap = parseResponseToMap(response);
-        String taskId = (String) responseMap.get("task_id");
-        waitForTask(taskId, MLTaskState.COMPLETED);
-        response = RestMLRemoteInferenceIT.getTask(taskId);
-        responseMap = parseResponseToMap(response);
         String modelId = (String) responseMap.get("model_id");
         if (deploy) {
             response = RestMLRemoteInferenceIT.deployRemoteModel(modelId);
             responseMap = parseResponseToMap(response);
-            taskId = (String) responseMap.get("task_id");
+            String taskId = (String) responseMap.get("task_id");
             waitForTask(taskId, MLTaskState.COMPLETED);
         }
         return modelId;


### PR DESCRIPTION
### Description
Retrieve remote model id from registration response in IT to avoid flaky, an example is: 
```
RestBedRockInferenceIT > test_bedrock_multimodal_model_empty_imageInput_null_textInput FAILED
    org.opensearch.client.ResponseException: method [POST], host [http://127.0.0.1:45675/], URI [/_plugins/_ml/models/null/_deploy], status line [HTTP/1.1 404 Not Found]
    {"error":{"root_cause":[{"type":"status_exception","reason":"Failed to find model"}],"type":"status_exception","reason":"Failed to find model"},"status":404}
        at __randomizedtesting.SeedInfo.seed([7D8B7621F7A9A3F2:CB22567814C8B651]:0)
        at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:501)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:384)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:359)
        at app//org.opensearch.ml.utils.TestHelper.makeRequest(TestHelper.java:182)
        at app//org.opensearch.ml.utils.TestHelper.makeRequest(TestHelper.java:155)
        at app//org.opensearch.ml.utils.TestHelper.makeRequest(TestHelper.java:144)
        at app//org.opensearch.ml.rest.RestMLRemoteInferenceIT.deployRemoteModel(RestMLRemoteInferenceIT.java:1220)
        at app//org.opensearch.ml.rest.MLCommonsRestTestCase.registerRemoteModel(MLCommonsRestTestCase.java:1011)
        at app//org.opensearch.ml.rest.RestBedRockInferenceIT.test_bedrock_multimodal_model_empty_imageInput_null_textInput(RestBedRockInferenceIT.java:216)
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
