### PR TITLE
Fixes Two Flaky IT classes RestMLGuardrailsIT & ToolIntegrationWithLLMTest

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -977,7 +977,7 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
             }
             return taskDone.get();
         }, CUSTOM_MODEL_TIMEOUT, TimeUnit.SECONDS);
-        assertTrue(taskDone.get());
+        assertTrue(String.format(Locale.ROOT, "Task Id %s could not get to %s state", taskId, targetState.name()), taskDone.get());
     }
 
     public String registerConnector(String createConnectorInput) throws IOException, InterruptedException {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGuardrailsIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGuardrailsIT.java
@@ -124,17 +124,16 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
         Response response = createConnector(completionModelConnectorEntity);
         Map responseMap = parseResponseToMap(response);
         String connectorId = (String) responseMap.get("connector_id");
+
         response = registerRemoteModelWithLocalRegexGuardrails("openAI-GPT-3.5 completions", connectorId);
+        responseMap = parseResponseToMap(response);
+        String modelId = (String) responseMap.get("model_id");
+
+        response = deployRemoteModel(modelId);
         responseMap = parseResponseToMap(response);
         String taskId = (String) responseMap.get("task_id");
         waitForTask(taskId, MLTaskState.COMPLETED);
-        response = getTask(taskId);
-        responseMap = parseResponseToMap(response);
-        String modelId = (String) responseMap.get("model_id");
-        response = deployRemoteModel(modelId);
-        responseMap = parseResponseToMap(response);
-        taskId = (String) responseMap.get("task_id");
-        waitForTask(taskId, MLTaskState.COMPLETED);
+
         String predictInput = "{\n" + "  \"parameters\": {\n" + "      \"prompt\": \"Say this is a test\"\n" + "  }\n" + "}";
         response = predictRemoteModel(modelId, predictInput);
         responseMap = parseResponseToMap(response);
@@ -144,6 +143,7 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
         responseMap = (Map) responseList.get(0);
         responseMap = (Map) responseMap.get("dataAsMap");
         responseList = (List) responseMap.get("choices");
+
         if (responseList == null) {
             assertTrue(checkThrottlingOpenAI(responseMap));
             return;
@@ -160,18 +160,18 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
         exceptionRule.expect(ResponseException.class);
         exceptionRule.expectMessage("guardrails triggered for user input");
         Response response = createConnector(completionModelConnectorEntity);
+
         Map responseMap = parseResponseToMap(response);
         String connectorId = (String) responseMap.get("connector_id");
+
         response = registerRemoteModelWithLocalRegexGuardrails("openAI-GPT-3.5 completions", connectorId);
         responseMap = parseResponseToMap(response);
-        String taskId = (String) responseMap.get("task_id");
-        waitForTask(taskId, MLTaskState.COMPLETED);
-        response = getTask(taskId);
-        responseMap = parseResponseToMap(response);
         String modelId = (String) responseMap.get("model_id");
+
         response = deployRemoteModel(modelId);
         responseMap = parseResponseToMap(response);
-        taskId = (String) responseMap.get("task_id");
+        String taskId = (String) responseMap.get("task_id");
+
         waitForTask(taskId, MLTaskState.COMPLETED);
         String predictInput = "{\n" + "  \"parameters\": {\n" + "      \"prompt\": \"Say this is a test of stop word.\"\n" + "  }\n" + "}";
         predictRemoteModel(modelId, predictInput);
@@ -187,17 +187,16 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
         Response response = createConnector(completionModelConnectorEntity);
         Map responseMap = parseResponseToMap(response);
         String connectorId = (String) responseMap.get("connector_id");
+
         response = registerRemoteModelNonTypeGuardrails("openAI-GPT-3.5 completions", connectorId);
+        responseMap = parseResponseToMap(response);
+        String modelId = (String) responseMap.get("model_id");
+
+        response = deployRemoteModel(modelId);
         responseMap = parseResponseToMap(response);
         String taskId = (String) responseMap.get("task_id");
         waitForTask(taskId, MLTaskState.COMPLETED);
-        response = getTask(taskId);
-        responseMap = parseResponseToMap(response);
-        String modelId = (String) responseMap.get("model_id");
-        response = deployRemoteModel(modelId);
-        responseMap = parseResponseToMap(response);
-        taskId = (String) responseMap.get("task_id");
-        waitForTask(taskId, MLTaskState.COMPLETED);
+
         String predictInput = "{\n" + "  \"parameters\": {\n" + "      \"prompt\": \"Say this is a test of stop word.\"\n" + "  }\n" + "}";
         predictRemoteModel(modelId, predictInput);
     }
@@ -211,17 +210,16 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
         Response response = createConnector(completionModelConnectorEntityWithGuardrail);
         Map responseMap = parseResponseToMap(response);
         String guardrailConnectorId = (String) responseMap.get("connector_id");
+
         response = registerRemoteModel("guardrail model group", "openAI-GPT-3.5 completions", guardrailConnectorId);
+        responseMap = parseResponseToMap(response);
+        String guardrailModelId = (String) responseMap.get("model_id");
+
+        response = deployRemoteModel(guardrailModelId);
         responseMap = parseResponseToMap(response);
         String taskId = (String) responseMap.get("task_id");
         waitForTask(taskId, MLTaskState.COMPLETED);
-        response = getTask(taskId);
-        responseMap = parseResponseToMap(response);
-        String guardrailModelId = (String) responseMap.get("model_id");
-        response = deployRemoteModel(guardrailModelId);
-        responseMap = parseResponseToMap(response);
-        taskId = (String) responseMap.get("task_id");
-        waitForTask(taskId, MLTaskState.COMPLETED);
+
         // Check the response from guardrails model that should be "accept".
         String predictInput = "{\n" + "  \"parameters\": {\n" + "    \"question\": \"hello\"\n" + "  }\n" + "}";
         response = predictRemoteModel(guardrailModelId, predictInput);
@@ -233,21 +231,21 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
         responseMap = (Map) responseMap.get("dataAsMap");
         String validationResult = (String) responseMap.get("response");
         Assert.assertTrue(validateRegex(validationResult, acceptRegex));
+
         // Create predict model.
         response = createConnector(completionModelConnectorEntity);
         responseMap = parseResponseToMap(response);
         String connectorId = (String) responseMap.get("connector_id");
+
         response = registerRemoteModelWithModelGuardrails("openAI with guardrails", connectorId, guardrailModelId);
         responseMap = parseResponseToMap(response);
-        taskId = (String) responseMap.get("task_id");
-        waitForTask(taskId, MLTaskState.COMPLETED);
-        response = getTask(taskId);
-        responseMap = parseResponseToMap(response);
         String modelId = (String) responseMap.get("model_id");
+
         response = deployRemoteModel(modelId);
         responseMap = parseResponseToMap(response);
         taskId = (String) responseMap.get("task_id");
         waitForTask(taskId, MLTaskState.COMPLETED);
+
         // Predict.
         predictInput = "{\n"
             + "  \"parameters\": {\n"
@@ -282,17 +280,17 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
         Response response = createConnector(completionModelConnectorEntityWithGuardrail);
         Map responseMap = parseResponseToMap(response);
         String guardrailConnectorId = (String) responseMap.get("connector_id");
+
+        //Create the model ID
         response = registerRemoteModel("guardrail model group", "openAI-GPT-3.5 completions", guardrailConnectorId);
+        responseMap = parseResponseToMap(response);
+        String guardrailModelId = (String) responseMap.get("model_id");
+
+        response = deployRemoteModel(guardrailModelId);
         responseMap = parseResponseToMap(response);
         String taskId = (String) responseMap.get("task_id");
         waitForTask(taskId, MLTaskState.COMPLETED);
-        response = getTask(taskId);
-        responseMap = parseResponseToMap(response);
-        String guardrailModelId = (String) responseMap.get("model_id");
-        response = deployRemoteModel(guardrailModelId);
-        responseMap = parseResponseToMap(response);
-        taskId = (String) responseMap.get("task_id");
-        waitForTask(taskId, MLTaskState.COMPLETED);
+
         // Check the response from guardrails model that should be "reject".
         String predictInput = "{\n" + "  \"parameters\": {\n" + "    \"question\": \"I will be executed or tortured.\"\n" + "  }\n" + "}";
         response = predictRemoteModel(guardrailModelId, predictInput);
@@ -304,17 +302,16 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
         responseMap = (Map) responseMap.get("dataAsMap");
         String validationResult = (String) responseMap.get("response");
         Assert.assertTrue(validateRegex(validationResult, rejectRegex));
+
         // Create predict model.
         response = createConnector(completionModelConnectorEntity);
         responseMap = parseResponseToMap(response);
         String connectorId = (String) responseMap.get("connector_id");
+
         response = registerRemoteModelWithModelGuardrails("openAI with guardrails", connectorId, guardrailModelId);
         responseMap = parseResponseToMap(response);
-        taskId = (String) responseMap.get("task_id");
-        waitForTask(taskId, MLTaskState.COMPLETED);
-        response = getTask(taskId);
-        responseMap = parseResponseToMap(response);
         String modelId = (String) responseMap.get("model_id");
+
         response = deployRemoteModel(modelId);
         responseMap = parseResponseToMap(response);
         taskId = (String) responseMap.get("task_id");

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGuardrailsIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGuardrailsIT.java
@@ -281,7 +281,7 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
         Map responseMap = parseResponseToMap(response);
         String guardrailConnectorId = (String) responseMap.get("connector_id");
 
-        //Create the model ID
+        // Create the model ID
         response = registerRemoteModel("guardrail model group", "openAI-GPT-3.5 completions", guardrailConnectorId);
         responseMap = parseResponseToMap(response);
         String guardrailModelId = (String) responseMap.get("model_id");


### PR DESCRIPTION
### Description
This PR attempts to remedy two Flaky classes 
- [RestMLGuardrailsIT.java](https://github.com/opensearch-project/ml-commons/compare/main...brianf-aws:ml-commons:flaky-it-involving-model-fix?expand=1#diff-b973f1adfdde1699a1f4f9a8b7d048b27c01c88c86a836c7c4cc3d6fbae970fb) Borrows code cleanup from https://github.com/opensearch-project/ml-commons/pull/3244 Which removes an extra call to the Task API to get the model id.
- [ToolIntegrationWithLLMTest.java](https://github.com/opensearch-project/ml-commons/compare/main...brianf-aws:ml-commons:flaky-it-involving-model-fix?expand=1#diff-072749d2af860644b27fbe28a9b486d52580d5845e9c82a537f28ed9dcd3cfd8) updates the class to specifically check for the status of the model by calling `GET /_plugins/_ml/models/ modelId` and actively blocking after 5 tries to make sure the model successfully undeployed before deleting which was the crux of the issue (`Model cannot be deleted in deploying or deployed state`). 

This PR also does some code improvement by more descriptive logging, variable naming, spacing. 

### Related Issues
Resolves #3237

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
