### PR TITLE
[Enhancement] Enhance validation for create connector API

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
@@ -55,13 +55,13 @@ public class ConnectorAction implements ToXContentObject, Writeable {
         String postProcessFunction
     ) {
         if (actionType == null) {
-            throw new IllegalArgumentException("action type can't null");
+            throw new IllegalArgumentException("action type can't be null");
         }
         if (url == null) {
-            throw new IllegalArgumentException("url can't null");
+            throw new IllegalArgumentException("url can't be null");
         }
         if (method == null) {
-            throw new IllegalArgumentException("method can't null");
+            throw new IllegalArgumentException("method can't be null");
         }
         this.actionType = actionType;
         this.method = method;

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -93,6 +93,9 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
             if (protocol == null) {
                 throw new IllegalArgumentException("Connector protocol is null");
             }
+            if (credential == null || credential.isEmpty()) {
+                throw new IllegalArgumentException("Connector credential is null or empty list");
+            }
         }
         this.name = name;
         this.description = description;

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.transport.connector;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -19,9 +20,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
@@ -46,20 +45,29 @@ public class MLCreateConnectorInputTests {
     private MLCreateConnectorInput mlCreateConnectorInput;
     private MLCreateConnectorInput mlCreateDryRunConnectorInput;
 
-    @Rule
-    public final ExpectedException exceptionRule = ExpectedException.none();
-    private final String expectedInputStr = "{\"name\":\"test_connector_name\","
-        + "\"description\":\"this is a test connector\",\"version\":\"1\",\"protocol\":\"http\","
-        + "\"parameters\":{\"input\":\"test input value\"},\"credential\":{\"key\":\"test_key_value\"},"
-        + "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\","
-        + "\"headers\":{\"api_key\":\"${credential.key}\"},"
-        + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
-        + "\"pre_process_function\":\"connector.pre_process.openai.embedding\","
-        + "\"post_process_function\":\"connector.post_process.openai.embedding\"}],"
-        + "\"backend_roles\":[\"role1\",\"role2\"],\"add_all_backend_roles\":false,"
-        + "\"access_mode\":\"PUBLIC\",\"client_config\":{\"max_connection\":20,"
-        + "\"connection_timeout\":10000,\"read_timeout\":10000,"
-        + "\"retry_backoff_millis\":10,\"retry_timeout_seconds\":10,\"max_retry_times\":-1,\"retry_backoff_policy\":\"constant\"}}";
+    private static final String TEST_CONNECTOR_NAME = "test_connector_name";
+    private static final String TEST_CONNECTOR_DESCRIPTION = "this is a test connector";
+    private static final String TEST_CONNECTOR_VERSION = "1";
+    private static final String TEST_CONNECTOR_PROTOCOL = "http";
+    private static final String TEST_PARAM_KEY = "input";
+    private static final String TEST_PARAM_VALUE = "test input value";
+    private static final String TEST_CREDENTIAL_KEY = "key";
+    private static final String TEST_CREDENTIAL_VALUE = "test_key_value";
+    private static final String TEST_ROLE1 = "role1";
+    private static final String TEST_ROLE2 = "role2";
+    private final String expectedInputStr = """
+        {"name":"test_connector_name","description":"this is a test connector","version":"1","protocol":"http",\
+        "parameters":{"input":"test input value"},"credential":{"key":"test_key_value"},\
+        "actions":[{"action_type":"PREDICT","method":"POST","url":"https://test.com",\
+        "headers":{"api_key":"${credential.key}"},\
+        "request_body":"{\\"input\\": \\"${parameters.input}\\"}",\
+        "pre_process_function":"connector.pre_process.openai.embedding",\
+        "post_process_function":"connector.post_process.openai.embedding"}],\
+        "backend_roles":["role1","role2"],"add_all_backend_roles":false,\
+        "access_mode":"PUBLIC","client_config":{"max_connection":20,\
+        "connection_timeout":10000,"read_timeout":10000,\
+        "retry_backoff_millis":10,"retry_timeout_seconds":10,"max_retry_times":-1,"retry_backoff_policy":"constant"}}\
+        """;
 
     @Before
     public void setUp() {
@@ -84,15 +92,15 @@ public class MLCreateConnectorInputTests {
 
         mlCreateConnectorInput = MLCreateConnectorInput
             .builder()
-            .name("test_connector_name")
-            .description("this is a test connector")
-            .version("1")
-            .protocol("http")
-            .parameters(Map.of("input", "test input value"))
-            .credential(Map.of("key", "test_key_value"))
+            .name(TEST_CONNECTOR_NAME)
+            .description(TEST_CONNECTOR_DESCRIPTION)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(TEST_CONNECTOR_PROTOCOL)
+            .parameters(Map.of(TEST_PARAM_KEY, TEST_PARAM_VALUE))
+            .credential(Map.of(TEST_CREDENTIAL_KEY, TEST_CREDENTIAL_VALUE))
             .actions(List.of(action))
             .access(AccessMode.PUBLIC)
-            .backendRoles(Arrays.asList("role1", "role2"))
+            .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
             .addAllBackendRoles(false)
             .connectorClientConfig(connectorClientConfig)
             .build();
@@ -102,59 +110,102 @@ public class MLCreateConnectorInputTests {
 
     @Test
     public void constructorMLCreateConnectorInput_NullName() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Connector name is null");
-        MLCreateConnectorInput
-            .builder()
-            .name(null)
-            .description("this is a test connector")
-            .version("1")
-            .protocol("http")
-            .parameters(Map.of("input", "test input value"))
-            .credential(Map.of("key", "test_key_value"))
-            .actions(List.of())
-            .access(AccessMode.PUBLIC)
-            .backendRoles(Arrays.asList("role1", "role2"))
-            .addAllBackendRoles(false)
-            .build();
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLCreateConnectorInput
+                .builder()
+                .name(null)
+                .description(TEST_CONNECTOR_DESCRIPTION)
+                .version(TEST_CONNECTOR_VERSION)
+                .protocol(TEST_CONNECTOR_PROTOCOL)
+                .parameters(Map.of(TEST_PARAM_KEY, TEST_PARAM_VALUE))
+                .credential(Map.of(TEST_CREDENTIAL_KEY, TEST_CREDENTIAL_VALUE))
+                .actions(List.of())
+                .access(AccessMode.PUBLIC)
+                .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
+                .addAllBackendRoles(false)
+                .build();
+        });
+        assertEquals("Connector name is null", exception.getMessage());
     }
 
     @Test
     public void constructorMLCreateConnectorInput_NullVersion() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Connector version is null");
-        MLCreateConnectorInput
-            .builder()
-            .name("test_connector_name")
-            .description("this is a test connector")
-            .version(null)
-            .protocol("http")
-            .parameters(Map.of("input", "test input value"))
-            .credential(Map.of("key", "test_key_value"))
-            .actions(List.of())
-            .access(AccessMode.PUBLIC)
-            .backendRoles(Arrays.asList("role1", "role2"))
-            .addAllBackendRoles(false)
-            .build();
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLCreateConnectorInput
+                .builder()
+                .name(TEST_CONNECTOR_NAME)
+                .description(TEST_CONNECTOR_DESCRIPTION)
+                .version(null)
+                .protocol(TEST_CONNECTOR_PROTOCOL)
+                .parameters(Map.of(TEST_PARAM_KEY, TEST_PARAM_VALUE))
+                .credential(Map.of(TEST_CREDENTIAL_KEY, TEST_CREDENTIAL_VALUE))
+                .actions(List.of())
+                .access(AccessMode.PUBLIC)
+                .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
+                .addAllBackendRoles(false)
+                .build();
+        });
+        assertEquals("Connector version is null", exception.getMessage());
     }
 
     @Test
     public void constructorMLCreateConnectorInput_NullProtocol() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Connector protocol is null");
-        MLCreateConnectorInput
-            .builder()
-            .name("test_connector_name")
-            .description("this is a test connector")
-            .version("1")
-            .protocol(null)
-            .parameters(Map.of("input", "test input value"))
-            .credential(Map.of("key", "test_key_value"))
-            .actions(List.of())
-            .access(AccessMode.PUBLIC)
-            .backendRoles(Arrays.asList("role1", "role2"))
-            .addAllBackendRoles(false)
-            .build();
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLCreateConnectorInput
+                .builder()
+                .name(TEST_CONNECTOR_NAME)
+                .description(TEST_CONNECTOR_DESCRIPTION)
+                .version(TEST_CONNECTOR_VERSION)
+                .protocol(null)
+                .parameters(Map.of(TEST_PARAM_KEY, TEST_PARAM_VALUE))
+                .credential(Map.of(TEST_CREDENTIAL_KEY, TEST_CREDENTIAL_VALUE))
+                .actions(List.of())
+                .access(AccessMode.PUBLIC)
+                .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
+                .addAllBackendRoles(false)
+                .build();
+        });
+        assertEquals("Connector protocol is null", exception.getMessage());
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_NullCredential() {
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLCreateConnectorInput
+                .builder()
+                .name(TEST_CONNECTOR_NAME)
+                .description(TEST_CONNECTOR_DESCRIPTION)
+                .version(TEST_CONNECTOR_VERSION)
+                .protocol(TEST_CONNECTOR_PROTOCOL)
+                .parameters(Map.of(TEST_PARAM_KEY, TEST_PARAM_VALUE))
+                .credential(null)
+                .actions(List.of())
+                .access(AccessMode.PUBLIC)
+                .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
+                .addAllBackendRoles(false)
+                .build();
+        });
+        assertEquals("Connector credential is null or empty list", exception.getMessage());
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_EmptyCredential() {
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLCreateConnectorInput
+                .builder()
+                .name(TEST_CONNECTOR_NAME)
+                .description(TEST_CONNECTOR_DESCRIPTION)
+                .version(TEST_CONNECTOR_VERSION)
+                .protocol(TEST_CONNECTOR_PROTOCOL)
+                .parameters(Map.of(TEST_PARAM_KEY, TEST_PARAM_VALUE))
+                .credential(Map.of())
+                .actions(List.of())
+                .access(AccessMode.PUBLIC)
+                .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
+                .addAllBackendRoles(false)
+                .build();
+        });
+        assertEquals("Connector credential is null or empty list", exception.getMessage());
     }
 
     @Test
@@ -178,7 +229,7 @@ public class MLCreateConnectorInputTests {
     @Test
     public void testParse() throws Exception {
         testParseFromJsonString(expectedInputStr, parsedInput -> {
-            assertEquals("test_connector_name", parsedInput.getName());
+            assertEquals(TEST_CONNECTOR_NAME, parsedInput.getName());
             assertEquals(20, parsedInput.getConnectorClientConfig().getMaxConnections().intValue());
             assertEquals(10000, parsedInput.getConnectorClientConfig().getReadTimeout().intValue());
             assertEquals(10000, parsedInput.getConnectorClientConfig().getConnectionTimeout().intValue());
@@ -187,18 +238,17 @@ public class MLCreateConnectorInputTests {
 
     @Test
     public void testParse_ArrayParameter() throws Exception {
-        String expectedInputStr = "{\"name\":\"test_connector_name\","
-            + "\"description\":\"this is a test connector\",\"version\":\"1\",\"protocol\":\"http\","
-            + "\"parameters\":{\"input\":[\"test input value\"]},\"credential\":{\"key\":\"test_key_value\"},"
-            + "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\","
-            + "\"headers\":{\"api_key\":\"${credential.key}\"},"
-            + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
-            + "\"pre_process_function\":\"connector.pre_process.openai.embedding\","
-            + "\"post_process_function\":\"connector.post_process.openai.embedding\"}],"
-            + "\"backend_roles\":[\"role1\",\"role2\"],\"add_all_backend_roles\":false,"
-            + "\"access_mode\":\"PUBLIC\"}";
+        String expectedInputStr = """
+            {"name":"test_connector_name","description":"this is a test connector","version":"1",\
+            "protocol":"http","parameters":{"input":["test input value"]},"credential":{"key":"test_key_value"},\
+            "actions":[{"action_type":"PREDICT","method":"POST","url":"https://test.com",\
+            "headers":{"api_key":"${credential.key}"},"request_body":"{\\"input\\": \\"${parameters.input}\\"}",\
+            "pre_process_function":"connector.pre_process.openai.embedding",\
+            "post_process_function":"connector.post_process.openai.embedding"}],\
+            "backend_roles":["role1","role2"],"add_all_backend_roles":false,"access_mode":"PUBLIC"};\
+            """;
         testParseFromJsonString(expectedInputStr, parsedInput -> {
-            assertEquals("test_connector_name", parsedInput.getName());
+            assertEquals(TEST_CONNECTOR_NAME, parsedInput.getName());
             assertEquals(1, parsedInput.getParameters().size());
             assertEquals("[\"test input value\"]", parsedInput.getParameters().get("input"));
         });
@@ -222,9 +272,10 @@ public class MLCreateConnectorInputTests {
     public void readInputStream_SuccessWithNullFields() throws IOException {
         MLCreateConnectorInput mlCreateMinimalConnectorInput = MLCreateConnectorInput
             .builder()
-            .name("test_connector_name")
-            .version("1")
-            .protocol("http")
+            .name(TEST_CONNECTOR_NAME)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(TEST_CONNECTOR_PROTOCOL)
+            .credential(Map.of(TEST_CREDENTIAL_KEY, TEST_CREDENTIAL_VALUE))
             .build();
         readInputStream(mlCreateMinimalConnectorInput, parsedInput -> {
             assertEquals(mlCreateMinimalConnectorInput.getName(), parsedInput.getName());
@@ -238,15 +289,15 @@ public class MLCreateConnectorInputTests {
         // Actions can be null for a connector without any specific actions defined.
         MLCreateConnectorInput input = MLCreateConnectorInput
             .builder()
-            .name("test_connector_name")
-            .description("this is a test connector")
-            .version("1")
-            .protocol("http")
-            .parameters(Map.of("input", "test input value"))
-            .credential(Map.of("key", "test_key_value"))
+            .name(TEST_CONNECTOR_NAME)
+            .description(TEST_CONNECTOR_DESCRIPTION)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(TEST_CONNECTOR_PROTOCOL)
+            .parameters(Map.of(TEST_PARAM_KEY, TEST_PARAM_VALUE))
+            .credential(Map.of(TEST_CREDENTIAL_KEY, TEST_CREDENTIAL_VALUE))
             .actions(null) // Setting actions to null
             .access(AccessMode.PUBLIC)
-            .backendRoles(Arrays.asList("role1", "role2"))
+            .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
             .addAllBackendRoles(false)
             .build();
 
@@ -258,10 +309,8 @@ public class MLCreateConnectorInputTests {
         String jsonMissingName = "{\"description\":\"this is a test connector\",\"version\":\"1\",\"protocol\":\"http\"}";
         XContentParser parser = createParser(jsonMissingName);
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Connector name is null");
-
-        MLCreateConnectorInput.parse(parser);
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> { MLCreateConnectorInput.parse(parser); });
+        assertEquals("Connector name is null", exception.getMessage());
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
@@ -450,12 +450,14 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
                     .build()
             );
 
+        Map<String, String> credential = ImmutableMap.of("access_key", "mockKey", "secret_key", "mockSecret");
         MLCreateConnectorInput mlCreateConnectorInput = MLCreateConnectorInput
             .builder()
             .name(randomAlphaOfLength(5))
             .description(randomAlphaOfLength(10))
             .version("1")
             .protocol(ConnectorProtocols.HTTP)
+            .credential(credential)
             .actions(actions)
             .build();
         MLCreateConnectorRequest request = new MLCreateConnectorRequest(mlCreateConnectorInput);


### PR DESCRIPTION
### Description
This PR addresses the first part of this enhancement "Validate if connector payload has all the required fields. If not provided, throw the illegal argument exception". Validation of field credentials is added in this fix. All other validations already exist. Added new test cases corresponding to this validation, fixed all failing test cases because of this new validation and refactored some of the test case code.

### Related Issues
Partially Resolves #1382

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
