### PR TITLE
support model embedding types in bedrock and cohere post process function

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/MLPostProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/MLPostProcessFunction.java
@@ -6,15 +6,13 @@
 package org.opensearch.ml.common.connector;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import org.opensearch.ml.common.connector.functions.postprocess.BedrockBatchJobArnPostProcessFunction;
 import org.opensearch.ml.common.connector.functions.postprocess.BedrockEmbeddingPostProcessFunction;
 import org.opensearch.ml.common.connector.functions.postprocess.CohereRerankPostProcessFunction;
+import org.opensearch.ml.common.connector.functions.postprocess.ConnectorPostProcessFunction;
 import org.opensearch.ml.common.connector.functions.postprocess.EmbeddingPostProcessFunction;
-import org.opensearch.ml.common.output.model.ModelTensor;
 
 public class MLPostProcessFunction {
 
@@ -28,7 +26,7 @@ public class MLPostProcessFunction {
 
     private static final Map<String, String> JSON_PATH_EXPRESSION = new HashMap<>();
 
-    private static final Map<String, Function<Object, List<ModelTensor>>> POST_PROCESS_FUNCTIONS = new HashMap<>();
+    private static final Map<String, ConnectorPostProcessFunction> POST_PROCESS_FUNCTIONS = new HashMap<>();
 
     static {
         EmbeddingPostProcessFunction embeddingPostProcessFunction = new EmbeddingPostProcessFunction();
@@ -55,7 +53,7 @@ public class MLPostProcessFunction {
         return JSON_PATH_EXPRESSION.get(postProcessFunction);
     }
 
-    public static Function<Object, List<ModelTensor>> get(String postProcessFunction) {
+    public static ConnectorPostProcessFunction get(String postProcessFunction) {
         return POST_PROCESS_FUNCTIONS.get(postProcessFunction);
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/connector/MLPostProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/MLPostProcessFunction.java
@@ -17,6 +17,7 @@ import org.opensearch.ml.common.connector.functions.postprocess.EmbeddingPostPro
 public class MLPostProcessFunction {
 
     public static final String COHERE_EMBEDDING = "connector.post_process.cohere.embedding";
+    public static final String COHERE_V2_EMBEDDING = "connector.post_process.cohere_v2.embedding";
     public static final String OPENAI_EMBEDDING = "connector.post_process.openai.embedding";
     public static final String BEDROCK_EMBEDDING = "connector.post_process.bedrock.embedding";
     public static final String BEDROCK_BATCH_JOB_ARN = "connector.post_process.bedrock.batch_job_arn";
@@ -35,6 +36,7 @@ public class MLPostProcessFunction {
         CohereRerankPostProcessFunction cohereRerankPostProcessFunction = new CohereRerankPostProcessFunction();
         JSON_PATH_EXPRESSION.put(OPENAI_EMBEDDING, "$.data[*].embedding");
         JSON_PATH_EXPRESSION.put(COHERE_EMBEDDING, "$.embeddings");
+        JSON_PATH_EXPRESSION.put(COHERE_V2_EMBEDDING, "$.embeddings.float");
         JSON_PATH_EXPRESSION.put(DEFAULT_EMBEDDING, "$[*]");
         JSON_PATH_EXPRESSION.put(BEDROCK_EMBEDDING, "$.embedding");
         JSON_PATH_EXPRESSION.put(BEDROCK_BATCH_JOB_ARN, "$");
@@ -42,6 +44,7 @@ public class MLPostProcessFunction {
         JSON_PATH_EXPRESSION.put(DEFAULT_RERANK, "$[*]");
         POST_PROCESS_FUNCTIONS.put(OPENAI_EMBEDDING, embeddingPostProcessFunction);
         POST_PROCESS_FUNCTIONS.put(COHERE_EMBEDDING, embeddingPostProcessFunction);
+        POST_PROCESS_FUNCTIONS.put(COHERE_V2_EMBEDDING, embeddingPostProcessFunction);
         POST_PROCESS_FUNCTIONS.put(DEFAULT_EMBEDDING, embeddingPostProcessFunction);
         POST_PROCESS_FUNCTIONS.put(BEDROCK_EMBEDDING, bedrockEmbeddingPostProcessFunction);
         POST_PROCESS_FUNCTIONS.put(BEDROCK_BATCH_JOB_ARN, batchJobArnPostProcessFunction);

--- a/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockBatchJobArnPostProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockBatchJobArnPostProcessFunction.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 import org.opensearch.ml.common.output.model.ModelTensor;
 
-public class BedrockBatchJobArnPostProcessFunction extends ConnectorPostProcessFunction<Map<String, String>> {
+public class BedrockBatchJobArnPostProcessFunction implements ConnectorPostProcessFunction {
     public static final String JOB_ARN = "jobArn";
     public static final String PROCESSED_JOB_ARN = "processedJobArn";
 
@@ -28,7 +28,8 @@ public class BedrockBatchJobArnPostProcessFunction extends ConnectorPostProcessF
     }
 
     @Override
-    public List<ModelTensor> process(Map<String, String> jobInfo) {
+    public List<ModelTensor> process(Object input) {
+        Map<String, String> jobInfo = (Map<String, String>) input;
         List<ModelTensor> modelTensors = new ArrayList<>();
         Map<String, String> processedResult = new HashMap<>();
         processedResult.putAll(jobInfo);

--- a/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockEmbeddingPostProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockEmbeddingPostProcessFunction.java
@@ -7,38 +7,122 @@ package org.opensearch.ml.common.connector.functions.postprocess;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.output.model.MLResultDataType;
 import org.opensearch.ml.common.output.model.ModelTensor;
 
-public class BedrockEmbeddingPostProcessFunction extends ConnectorPostProcessFunction<List<Float>> {
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Bedrock embedding post process function currently is used by bedrock titan models, for v1 model,
+ * the model response is a list of float numbers, for v2 model, the model response combined by two parts:
+ * 1. "embedding" which returns list of float numbers like v1.
+ * 2. "embeddingByType" is a map contains all embedding type results, with embedding type as the key.
+ */
+public class BedrockEmbeddingPostProcessFunction implements ConnectorPostProcessFunction {
 
     @Override
     public void validate(Object input) {
-        if (!(input instanceof List)) {
-            throw new IllegalArgumentException("Post process function input is not a List.");
-        }
-
-        List<?> outerList = (List<?>) input;
-
-        if (!outerList.isEmpty() && !(((List<?>) input).get(0) instanceof Number)) {
-            throw new IllegalArgumentException("The embedding should be a non-empty List containing Float values.");
+        if (input instanceof List<?>) {
+            validateEmbeddingList((List<?>) input);
+        } else if (input instanceof Map) {
+            for (Map.Entry<String, Object> entry : ((Map<String, Object>) input).entrySet()) {
+                if (!(entry.getValue() instanceof List)) {
+                    throw new IllegalArgumentException(
+                        String
+                            .format(
+                                Locale.ROOT,
+                                "Model response embedding type %s result is NOT an list type, please check the model response!",
+                                entry.getKey()
+                            )
+                    );
+                }
+                validateEmbeddingList((List<?>) entry.getValue());
+            }
+        } else {
+            throw new IllegalArgumentException("Model response is neither a list type nor a map type, please check the model response!");
         }
     }
 
+    /**
+     * The response could be list (case1: when specified concrete embedding type or case2: a v1 model specified with $.embedding)
+     * or map (case3: when specified embedding by type), but since the data type is not resolved, so consider this is case2 or case3.
+     * @param input the model's response: v1 model's embedding part or v2 model's embeddingByType part.
+     * @return  List of ModelTensor that represent the embedding result including all different embedding types or single embedding type.
+     */
     @Override
-    public List<ModelTensor> process(List<Float> embedding) {
+    public List<ModelTensor> process(Object input) {
         List<ModelTensor> modelTensors = new ArrayList<>();
-        modelTensors
-            .add(
-                ModelTensor
-                    .builder()
-                    .name("sentence_embedding")
-                    .dataType(MLResultDataType.FLOAT32)
-                    .shape(new long[] { embedding.size() })
-                    .data(embedding.toArray(new Number[0]))
-                    .build()
-            );
+        if (input instanceof Map) {
+            modelTensors
+                .add(
+                    ModelTensor
+                        .builder()
+                        .name(CommonValue.ML_MAP_RESPONSE_KEY)
+                        .dataAsMap(ImmutableMap.of(CommonValue.ML_MAP_RESPONSE_KEY, input))
+                        .build()
+                );
+        } else {
+            List<Float> embedding = (List<Float>) input;
+            modelTensors
+                .add(
+                    ModelTensor
+                        .builder()
+                        .name("sentence_embedding")
+                        .dataType(MLResultDataType.FLOAT32)
+                        .shape(new long[] { embedding.size() })
+                        .data(embedding.toArray(new Number[0]))
+                        .build()
+                );
+        }
         return modelTensors;
+    }
+
+    /**
+     * When the response is map, it means user specifies the response filter to a concrete embedding type, e.g.: $.embeddingByType.float
+     * In this case we need to process the result to ModelTensor's data field as it's same as before. If user specifies the response
+     * filter to embedding, e.g. $.embedding, then we need to convert the result to ModelTensor's dataAsMap field as the result is a map.
+     * @param input Model's response or extracted object from the model response by response filter.
+     * @param mlResultDataType The data type of the model's response.
+     * @return List of ModelTensor that represent the embedding result including all different embedding types or single embedding type.
+     */
+    @Override
+    public List<ModelTensor> process(Object input, MLResultDataType mlResultDataType) {
+        List<ModelTensor> modelTensors = new ArrayList<>();
+        if (input instanceof Map) {
+            modelTensors
+                .add(
+                    ModelTensor
+                        .builder()
+                        .name(CommonValue.ML_MAP_RESPONSE_KEY)
+                        .dataAsMap(ImmutableMap.of(CommonValue.ML_MAP_RESPONSE_KEY, input))
+                        .build()
+                );
+
+        } else if (input instanceof List) {
+            List<Number> embedding = (List<Number>) input;
+            modelTensors
+                .add(
+                    ModelTensor
+                        .builder()
+                        .name("sentence_embedding")
+                        .dataType(mlResultDataType)
+                        .shape(new long[] { embedding.size() })
+                        .data(embedding.toArray(new Number[0]))
+                        .build()
+                );
+        }
+        return modelTensors;
+    }
+
+    private void validateEmbeddingList(List<?> input) {
+        if (input.isEmpty() || !(input.get(0) instanceof Number)) {
+            throw new IllegalArgumentException(
+                "Model result is NOT an non-empty List containing Number values, please check the model response!"
+            );
+        }
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/CohereRerankPostProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/CohereRerankPostProcessFunction.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import org.opensearch.ml.common.output.model.MLResultDataType;
 import org.opensearch.ml.common.output.model.ModelTensor;
 
-public class CohereRerankPostProcessFunction extends ConnectorPostProcessFunction<List<Map<String, Object>>> {
+public class CohereRerankPostProcessFunction implements ConnectorPostProcessFunction {
 
     @Override
     public void validate(Object input) {
@@ -33,7 +33,8 @@ public class CohereRerankPostProcessFunction extends ConnectorPostProcessFunctio
     }
 
     @Override
-    public List<ModelTensor> process(List<Map<String, Object>> rerankResults) {
+    public List<ModelTensor> process(Object input) {
+        List<Map<String, Object>> rerankResults = (List<Map<String, Object>>) input;
         List<ModelTensor> modelTensors = new ArrayList<>();
 
         if (rerankResults.size() > 0) {

--- a/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/ConnectorPostProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/ConnectorPostProcessFunction.java
@@ -6,22 +6,37 @@
 package org.opensearch.ml.common.connector.functions.postprocess;
 
 import java.util.List;
-import java.util.function.Function;
 
+import org.opensearch.ml.common.output.model.MLResultDataType;
 import org.opensearch.ml.common.output.model.ModelTensor;
 
-public abstract class ConnectorPostProcessFunction<T> implements Function<Object, List<ModelTensor>> {
+public interface ConnectorPostProcessFunction {
 
-    @Override
-    public List<ModelTensor> apply(Object input) {
+    default List<ModelTensor> apply(Object input) {
         if (input == null) {
             throw new IllegalArgumentException("Can't run post process function as model output is null");
         }
         validate(input);
-        return process((T) input);
+        return process(input);
     }
 
-    public abstract void validate(Object input);
+    default List<ModelTensor> apply(Object input, MLResultDataType dataType) {
+        if (input == null) {
+            throw new IllegalArgumentException("Can't run post process function as model output is null");
+        }
+        validate(input);
+        return process(input, dataType);
+    }
 
-    public abstract List<ModelTensor> process(T input);
+    void validate(Object input);
+
+    List<ModelTensor> process(Object input);
+
+    default List<ModelTensor> process(Object input, MLResultDataType dataType) {
+        throw new IllegalArgumentException(
+            "The post process function is not expected to run unless your model is a embedding type supported model"
+                + " and the response_filter configuration in connector been set to an embedding type path, please check "
+                + "connector.post_process.default.embedding for more information"
+        );
+    }
 }

--- a/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/EmbeddingPostProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/EmbeddingPostProcessFunction.java
@@ -7,48 +7,166 @@ package org.opensearch.ml.common.connector.functions.postprocess;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.output.model.MLResultDataType;
 import org.opensearch.ml.common.output.model.ModelTensor;
 
-public class EmbeddingPostProcessFunction extends ConnectorPostProcessFunction<List<List<Float>>> {
+import com.google.common.collect.ImmutableMap;
 
+/**
+ * This is the default embedding post process function, the expected result from the model in two cases:
+ * 1. A list of list of float for APIs embedding type is not enabled.
+ * 2. A map of string to list of list of number for APIs that embedding type is enabled.
+ * An example of enabled embedding type is cohere v2, the embedding API requires embedding_types as a mandatory field in the request body:
+ * <a href="https://docs.cohere.com/reference/embed#request.body.embedding_types">...</a>
+ * Currently, OpenAI Cohere and default sagemaker embedding models are using this function.
+ */
+public class EmbeddingPostProcessFunction implements ConnectorPostProcessFunction {
+
+    /**
+     * Validate the model's output is a List of following types:
+     * float
+     * int8: a signed number with eight bit, the value range is [-128, 127].
+     * uint8: an unsigned number with eight bit, the value range is [0, 255].
+     * binary: a binary representation of the embedding, the value range is non-deterministic.
+     * ubinary: a binary representation of the embedding, the value range is non-deterministic.
+     * @param input The input is the output from the model.
+     */
     @Override
     public void validate(Object input) {
-        if (!(input instanceof List)) {
-            throw new IllegalArgumentException("Post process function input is not a List.");
-        }
-
-        List<?> outerList = (List<?>) input;
-
-        if (!outerList.isEmpty()) {
-            if (!(outerList.get(0) instanceof List)) {
-                throw new IllegalArgumentException("The embedding should be a non-empty List containing List of Float values.");
+        if (input instanceof List<?>) {
+            validateEmbeddingList((List<?>) input);
+        } else if (input instanceof Map) {
+            for (Map.Entry<String, Object> entry : ((Map<String, Object>) input).entrySet()) {
+                if (!(entry.getValue() instanceof List)) {
+                    throw new IllegalArgumentException(
+                        String
+                            .format(
+                                Locale.ROOT,
+                                "Model response embedding type %s result is NOT an list type, please check the model response!",
+                                entry.getKey()
+                            )
+                    );
+                }
+                validateEmbeddingList((List<?>) entry.getValue());
             }
-            List<?> innerList = (List<?>) outerList.get(0);
-
-            if (innerList.isEmpty() || !(innerList.get(0) instanceof Number)) {
-                throw new IllegalArgumentException("The embedding should be a non-empty List containing Float values.");
-            }
+        } else {
+            throw new IllegalArgumentException("Model response is neither a list type nor a map type, please check the model response!");
         }
     }
 
+    /**
+     * The response could be list (case1: when specified concrete embedding type or case2: a v1 model specified with $.embeddings)
+     * or map (case3: when specified embeddings in v2 model), but since the data type is not resolved, so consider this is case2 or case3.
+     * v1 model's embeddings part is a list and v2 is a map.
+     * @param input the model's response: v1 model's embeddings part or v2 model's embeddings part.
+     * @return  List of ModelTensor that represent the embedding result including all different embedding types or single embedding type.
+     */
+
     @Override
-    public List<ModelTensor> process(List<List<Float>> embeddings) {
+    public List<ModelTensor> process(Object input) {
         List<ModelTensor> modelTensors = new ArrayList<>();
-        embeddings
-            .forEach(
-                embedding -> modelTensors
+        if (input instanceof Map) {
+            modelTensors
+                .add(
+                    ModelTensor
+                        .builder()
+                        .name(CommonValue.ML_MAP_RESPONSE_KEY)
+                        .dataAsMap(ImmutableMap.of(CommonValue.ML_MAP_RESPONSE_KEY, input))
+                        .build()
+                );
+        } else {
+            List<List<Float>> embeddings = (List<List<Float>>) input;
+            embeddings
+                .forEach(
+                    embedding -> modelTensors
+                        .add(
+                            ModelTensor
+                                .builder()
+                                .name("sentence_embedding")
+                                .dataType(MLResultDataType.FLOAT32)
+                                .shape(new long[] { embedding.size() })
+                                .data(embedding.toArray(new Number[0]))
+                                .build()
+                        )
+                );
+        }
+        return modelTensors;
+    }
+
+    // List<List<Number>> result
+    private void validateEmbeddingList(List<?> outerList) {
+        if (outerList.isEmpty() || !(outerList.get(0) instanceof List)) {
+            throw new IllegalArgumentException(
+                "Model result is NOT an non-empty List containing List values, please check the model response!"
+            );
+        }
+        List<?> innerList = (List<?>) outerList.get(0);
+        if (innerList.isEmpty() || !(innerList.get(0) instanceof Number)) {
+            throw new IllegalArgumentException(
+                "Model result is NOT an non-empty List containing List of Number values, please check the model response!"
+            );
+        }
+    }
+
+    /**
+     * As in connector user can configure response filter to extract the result from raw model response, so we need to support different
+     * cases, take cohere model as an example, the raw result looks like below:
+     * {
+     *     ......
+     *     "embeddings": {
+     *       "float": [
+     *         [
+     *           -0.007247925,
+     *           -0.041229248,
+     *           -0.023223877
+     *           ......
+     *         ]
+     *       ],
+     *       "int8": [
+     *         1,
+     *         2,
+     *         3
+     *       ]
+     *     },
+     *     ......
+     *   }
+     * 1. When response filter is set to: $.embeddings.float, then the result is a list of list<Number>.
+     * 2. When response filter is set to: $.embeddings, then the result is a map of embedding type to list of list<Number>.
+     * 3. When response filter is not set which is the default case, and the result is same with case2.
+     * @param modelOutput the embedding result of embedding type supported models.
+     * @return List of ModelTensor that represent the embedding result including all different embedding types.
+     */
+    @Override
+    public List<ModelTensor> process(Object modelOutput, MLResultDataType mlResultDataType) {
+        List<ModelTensor> modelTensors = new ArrayList<>();
+        if (modelOutput instanceof Map) {
+            modelTensors
+                .add(
+                    ModelTensor
+                        .builder()
+                        .name(CommonValue.ML_MAP_RESPONSE_KEY)
+                        .dataAsMap(ImmutableMap.of(CommonValue.ML_MAP_RESPONSE_KEY, modelOutput))
+                        .build()
+                );
+        } else if (modelOutput instanceof List) {
+            for (Object element : (List<?>) modelOutput) {
+                List<Number> singleEmbedding = (List<Number>) element;
+                modelTensors
                     .add(
                         ModelTensor
                             .builder()
-                            .name("sentence_embedding")
-                            .dataType(MLResultDataType.FLOAT32)
-                            .shape(new long[] { embedding.size() })
-                            .data(embedding.toArray(new Number[0]))
+                            .name("embedding")
+                            .shape(new long[] { singleEmbedding.size() })
+                            .data(singleEmbedding.toArray(new Number[0]))
+                            .dataType(mlResultDataType)
                             .build()
-                    )
-            );
+                    );
+            }
+        }
         return modelTensors;
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/EmbeddingPostProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/functions/postprocess/EmbeddingPostProcessFunction.java
@@ -18,8 +18,8 @@ import com.google.common.collect.ImmutableMap;
 
 /**
  * This is the default embedding post process function, the expected result from the model in two cases:
- * 1. A list of list of float for APIs embedding type is not enabled.
- * 2. A map of string to list of list of number for APIs that embedding type is enabled.
+ * 1. A {@link List} of {@link List} of {@link Float} {@link Float} for APIs embedding type is not enabled.
+ * 2. A map of string to {@link List} of {@link List} of {@link Number} for APIs that embedding type is enabled.
  * An example of enabled embedding type is cohere v2, the embedding API requires embedding_types as a mandatory field in the request body:
  * <a href="https://docs.cohere.com/reference/embed#request.body.embedding_types">...</a>
  * Currently, OpenAI Cohere and default sagemaker embedding models are using this function.
@@ -134,8 +134,8 @@ public class EmbeddingPostProcessFunction implements ConnectorPostProcessFunctio
      *     },
      *     ......
      *   }
-     * 1. When response filter is set to: $.embeddings.float, then the result is a list of list<Number>.
-     * 2. When response filter is set to: $.embeddings, then the result is a map of embedding type to list of list<Number>.
+     * 1. When response filter is set to: $.embeddings.float, then the result is a {@link List} of {@link List} of {@link Number}.
+     * 2. When response filter is set to: $.embeddings, then the result is a map of embedding type to {@link List} of {@link List} of {@link Number}.
      * 3. When response filter is not set which is the default case, and the result is same with case2.
      * @param modelOutput the embedding result of embedding type supported models.
      * @return List of ModelTensor that represent the embedding result including all different embedding types.

--- a/common/src/main/java/org/opensearch/ml/common/output/model/MLResultDataType.java
+++ b/common/src/main/java/org/opensearch/ml/common/output/model/MLResultDataType.java
@@ -15,7 +15,9 @@ public enum MLResultDataType {
     INT64(Format.INT, 8),
     BOOLEAN(Format.BOOLEAN, 1),
     UNKNOWN(Format.UNKNOWN, 0),
-    STRING(Format.STRING, -1);
+    STRING(Format.STRING, -1),
+    BINARY(Format.BINARY, -1),
+    UBINARY(Format.UBINARY, -1);
 
     /** The general data type format categories. */
     public enum Format {
@@ -24,6 +26,8 @@ public enum MLResultDataType {
         INT,
         BOOLEAN,
         STRING,
+        BINARY,
+        UBINARY,
         UNKNOWN
     }
 
@@ -69,5 +73,21 @@ public enum MLResultDataType {
      */
     public boolean isString() {
         return format == Format.STRING;
+    }
+
+    /**
+     * Checks whether it is a binary data type.
+     * @return true if is a binary type, otherwise false
+     */
+    public boolean isBinary() {
+        return format == Format.BINARY;
+    }
+
+    /**
+     * Checks whether it is a ubinary data type.
+     * @return true if is a ubinary type, otherwise false
+     */
+    public boolean isUbinary() {
+        return format == Format.UBINARY;
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockEmbeddingPostProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockEmbeddingPostProcessFunctionTest.java
@@ -30,14 +30,14 @@ public class BedrockEmbeddingPostProcessFunctionTest {
     @Test
     public void process_WrongInput_NotList() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Post process function input is not a List.");
+        exceptionRule.expectMessage("Model response is neither a list type nor a map type, please check the model response!");
         function.apply("abc");
     }
 
     @Test
     public void process_WrongInput_NotNumberList() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The embedding should be a non-empty List containing Float values.");
+        exceptionRule.expectMessage("Model result is NOT an non-empty List containing Number values, please check the model response!");
         function.apply(Arrays.asList("abc"));
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/EmbeddingPostProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/EmbeddingPostProcessFunctionTest.java
@@ -30,21 +30,22 @@ public class EmbeddingPostProcessFunctionTest {
     @Test
     public void process_WrongInput_NotList() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Post process function input is not a List.");
+        exceptionRule.expectMessage("Model response is neither a list type nor a map type, please check the model response!");
         function.apply("abc");
     }
 
     @Test
     public void process_WrongInput_NotListOfList() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The embedding should be a non-empty List containing List of Float values.");
+        exceptionRule.expectMessage("Model result is NOT an non-empty List containing List values, please check the model response!");
         function.apply(Arrays.asList("abc"));
     }
 
     @Test
     public void process_WrongInput_NotListOfNumber() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The embedding should be a non-empty List containing Float values.");
+        exceptionRule
+            .expectMessage("Model result is NOT an non-empty List containing List of Number values, please check the model response!");
         function.apply(List.of(Arrays.asList("abc")));
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestBedRockInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestBedRockInferenceIT.java
@@ -321,7 +321,7 @@ public class RestBedRockInferenceIT extends MLCommonsRestTestCase {
                 if (testCaseName.equals("response_filter_to_embedding_concrete_type")) {
                     assertEquals(errorMsg, 1024, ((List) ((Map<?, ?>) outputList.get(0)).get("data")).size());
                 } else {
-                    assertEquals(errorMsg, 1536, ((List) ((Map<?, ?>) outputList.get(0)).get("data")).size());
+                    assertEquals(errorMsg, 1024, ((List) ((Map<?, ?>) outputList.get(0)).get("data")).size());
                 }
             }
         }

--- a/plugin/src/test/resources/org/opensearch/ml/rest/templates/BedRockEmbeddingTypeSupportedConnectorBodies.json
+++ b/plugin/src/test/resources/org/opensearch/ml/rest/templates/BedRockEmbeddingTypeSupportedConnectorBodies.json
@@ -100,7 +100,7 @@
     "parameters": {
       "region": "%s",
       "service_name": "bedrock",
-      "model_name": "amazon.titan-embed-text-v1"
+      "model_name": "amazon.titan-embed-text-v2:0"
     },
     "credential": {
       "access_key": "%s",

--- a/plugin/src/test/resources/org/opensearch/ml/rest/templates/BedRockEmbeddingTypeSupportedConnectorBodies.json
+++ b/plugin/src/test/resources/org/opensearch/ml/rest/templates/BedRockEmbeddingTypeSupportedConnectorBodies.json
@@ -1,0 +1,125 @@
+{
+  "response_filter_to_embedding": {
+    "name": "Amazon Bedrock Connector with response filter to embedding",
+    "description": "Amazon Bedrock Connector with response filter to embedding",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "parameters": {
+      "region": "%s",
+      "service_name": "bedrock",
+      "model_name": "amazon.titan-embed-text-v2:0",
+      "response_filter": "$.embedding"
+    },
+    "credential": {
+      "access_key": "%s",
+      "secret_key": "%s",
+      "session_token": "%s"
+    },
+    "actions": [
+      {
+        "action_type": "predict",
+        "method": "POST",
+        "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model_name}/invoke",
+        "headers": {
+          "content-type": "application/json",
+          "x-amz-content-sha256": "required"
+        },
+        "request_body": "{ \"inputText\": \"${parameters.inputText}\", \"embeddingTypes\": [\"float\", \"binary\"] }",
+        "pre_process_function": "connector.pre_process.bedrock.embedding",
+        "post_process_function": "connector.post_process.bedrock.embedding"
+      }
+    ]
+  },
+  "response_filter_to_embedding_by_type": {
+    "name": "Amazon Bedrock Connector with response filter to embeddingByType",
+    "description": "Amazon Bedrock Connector with response filter to embeddingByType",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "parameters": {
+      "region": "%s",
+      "service_name": "bedrock",
+      "model_name": "amazon.titan-embed-text-v2:0",
+      "response_filter": "$.embeddingsByType"
+    },
+    "credential": {
+      "access_key": "%s",
+      "secret_key": "%s",
+      "session_token": "%s"
+    },
+    "actions": [
+      {
+        "action_type": "predict",
+        "method": "POST",
+        "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model_name}/invoke",
+        "headers": {
+          "content-type": "application/json",
+          "x-amz-content-sha256": "required"
+        },
+        "request_body": "{ \"inputText\": \"${parameters.inputText}\", \"embeddingTypes\": [\"float\", \"binary\"] }",
+        "pre_process_function": "connector.pre_process.bedrock.embedding",
+        "post_process_function": "connector.post_process.bedrock.embedding"
+      }
+    ]
+  },
+  "response_filter_to_embedding_concrete_type": {
+    "name": "Amazon Bedrock Connector with response filter set to concrete embedding type",
+    "description": "Amazon Bedrock Connector with response filter set to concrete embedding type",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "parameters": {
+      "region": "%s",
+      "service_name": "bedrock",
+      "model_name": "amazon.titan-embed-text-v2:0",
+      "response_filter": "$.embeddingsByType.float"
+    },
+    "credential": {
+      "access_key": "%s",
+      "secret_key": "%s",
+      "session_token": "%s"
+    },
+    "actions": [
+      {
+        "action_type": "predict",
+        "method": "POST",
+        "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model_name}/invoke",
+        "headers": {
+          "content-type": "application/json",
+          "x-amz-content-sha256": "required"
+        },
+        "request_body": "{ \"inputText\": \"${parameters.inputText}\", \"embeddingTypes\": [\"float\", \"binary\"] }",
+        "pre_process_function": "connector.pre_process.bedrock.embedding",
+        "post_process_function": "connector.post_process.bedrock.embedding"
+      }
+    ]
+  },
+  "response_filter_not_set": {
+    "name": "Amazon Bedrock Connector with response filter not set for v1 model",
+    "description": "Amazon Bedrock Connector with response filter not set for v1 model",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "parameters": {
+      "region": "%s",
+      "service_name": "bedrock",
+      "model_name": "amazon.titan-embed-text-v1"
+    },
+    "credential": {
+      "access_key": "%s",
+      "secret_key": "%s",
+      "session_token": "%s"
+    },
+    "actions": [
+      {
+        "action_type": "predict",
+        "method": "POST",
+        "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model_name}/invoke",
+        "headers": {
+          "content-type": "application/json",
+          "x-amz-content-sha256": "required"
+        },
+        "request_body": "{ \"inputText\": \"${parameters.inputText}\"}",
+        "pre_process_function": "connector.pre_process.bedrock.embedding",
+        "post_process_function": "connector.post_process.bedrock.embedding"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Description
BedRock [titan model V2](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html#model-parameters-titan-embed-text-request-response) and Cohere V2 model now supports multiple [embedding types](https://docs.cohere.com/reference/embed#request.body.embedding_types) in their API, which means you can specify different embedding types as a list in the request, and model generates different results based on embedding types in response, e.g.:
```
import cohere
import requests
import base64

co = cohere.ClientV2()

image = requests.get("https://cohere.com/favicon-32x32.png")
stringified_buffer = base64.b64encode(image.content).decode("utf-8")
content_type = image.headers["Content-Type"]
image_base64 = f"data:{content_type};base64,{stringified_buffer}"

response = co.embed(
    model="embed-english-v3.0",
    input_type="image",
    embedding_types=["float", "binary", "int8"],
    images=[image_base64],
)

print(response)
```
Response: 
```
{
  "id": "5807ee2e-0cda-445a-9ec8-864c60a06606",
  "embeddings": {
    "float": [
      [
        -0.007247925,
        -0.041229248,
        -0.023223877,
       ......
      ]
    ],
    "binary": [
        [
            12,
            -13,
            14
        ]
    ],
    "int8": [
        [
            19,
            20,
            21
        ]
    ]
  },
  "texts": [],
  "images": [
    {
      "width": 400,
      "height": 400,
      "format": "jpeg",
      "bit_depth": 24
    }
  ],
  "meta": {
    "api_version": {
      "version": "2"
    },
    "billed_units": {
      "images": 1
    }
  }
}
```

The current bedrock and cohere post process function has default response filter to `$.embedding` and `$.embeddings` respectively and the extracted results are both `List<List<Float>>` type, after they support embedding types, the response structure is different and the default response filter extracts `List<List<Float>>` and `Map<String, List<List<Number>>` type separately. This PR is to add support to user who wants to extract different types of results in model response, and this can be classified into several categories:
#### BedRock (The post process function applies for both v1 and v2 model)
1. The default case(response filter not set) is exactly same as before to maintain BWC.
2. When user specified the response filter to `$.embeddingsByType`, the response will be captured into `dataAsMap` in ModelTensor, and user can get all embedding types result.
3. When user specified the response filter to `$.embeddingsByType.{concrete_embedding_type}`, the response will be captured similar to default case to the `data` field in ModelTensor.

#### Cohere V2 (A new v2 post process function is added to v2 model)
1. The default case(response filter not set) is exactly same between v1 and v2. 
2. When user specified the response filter to `$.embeddings`, the response will be captured into `dataAsMap` in ModelTensor, and user can get all embedding types result.
3. When user specified the response filter to `$.embeddings.{concrete_embedding_type}`, the response will be captured similar to default case to the `data` field in ModelTensor.

### Related Issues
https://github.com/opensearch-project/ml-commons/issues/3093

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
