### PR TITLE
Adds preset contentRegistry for IngestProcessors

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1062,10 +1062,12 @@ public class MachineLearningPlugin extends Plugin
     @Override
     public Map<String, org.opensearch.ingest.Processor.Factory> getProcessors(org.opensearch.ingest.Processor.Parameters parameters) {
         Map<String, org.opensearch.ingest.Processor.Factory> processors = new HashMap<>();
+        NamedXContentRegistry contentRegistry = new NamedXContentRegistry(getNamedXContent());
+
         processors
             .put(
                 MLInferenceIngestProcessor.TYPE,
-                new MLInferenceIngestProcessor.Factory(parameters.scriptService, parameters.client, xContentRegistry)
+                new MLInferenceIngestProcessor.Factory(parameters.scriptService, parameters.client, contentRegistry)
             );
         return Collections.unmodifiableMap(processors);
     }

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceIngestProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceIngestProcessorTests.java
@@ -182,7 +182,10 @@ public class MLInferenceIngestProcessorTests extends OpenSearchTestCase {
 
             processor.execute(ingestDocument, handler);
             verify(handler)
-                .accept(isNull(), argThat(exception -> exception instanceof NullPointerException && exception.getMessage().equals(npeMessage)));
+                .accept(
+                    isNull(),
+                    argThat(exception -> exception instanceof NullPointerException && exception.getMessage().equals(npeMessage))
+                );
         } catch (Exception e) {
             assertEquals("this catch block should not get executed.", e.getMessage());
         }

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceIngestProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceIngestProcessorTests.java
@@ -31,6 +31,7 @@ import org.opensearch.client.Client;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ingest.IngestDocument;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.model.MLResultDataType;
@@ -136,6 +137,57 @@ public class MLInferenceIngestProcessorTests extends OpenSearchTestCase {
             assertEquals("this method should not get executed.", e.getMessage());
         }
 
+    }
+
+    /**
+     * Models that use the parameters field need to have a valid NamedXContentRegistry object to create valid MLInputs. For example
+     * <pre>
+     * PUT   /_plugins/_ml/_predict/text_embedding/model_id
+     *  {
+     *     "parameters": {
+     *         "content_type" : "query"
+     *     },
+     *     "text_docs" : ["what day is it today?"],
+     *     "target_response" : ["sentence_embedding"]
+     *   }
+     * </pre>
+     * These types of models like Local Asymmetric embedding models use the parameters field.
+     * And as such we need to test that having the contentRegistry throws an exception as it can not
+     * properly create a valid MLInput to perform prediction
+     *
+     * @implNote If you check the stack trace of the test you will see it tells you that it's a direct consequence of xContentRegistry being null
+     */
+    public void testExecute_xContentRegistryNullWithLocalModel_throwsException() throws Exception {
+        // Set the registry to null and reset after exiting the test
+        xContentRegistry = null;
+
+        String localModelInput =
+            "{ \"text_docs\": [\"What day is it today?\"],\"target_response\": [\"sentence_embedding\"], \"parameters\": { \"contentType\" : \"query\"} }";
+
+        MLInferenceIngestProcessor processor = createMLInferenceProcessor(
+            "local_model_id",
+            null,
+            null,
+            null,
+            false,
+            FunctionName.TEXT_EMBEDDING.toString(),
+            false,
+            false,
+            false,
+            localModelInput
+        );
+        try {
+            String npeMessage =
+                "Cannot invoke \"org.opensearch.ml.common.input.MLInput.setAlgorithm(org.opensearch.ml.common.FunctionName)\" because \"mlInput\" is null";
+
+            processor.execute(ingestDocument, handler);
+            verify(handler)
+                .accept(isNull(), argThat(exception -> exception instanceof NullPointerException && exception.getMessage().equals(npeMessage)));
+        } catch (Exception e) {
+            assertEquals("this catch block should not get executed.", e.getMessage());
+        }
+        // reset to mocked object
+        xContentRegistry = mock(NamedXContentRegistry.class);
     }
 
     /**

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestData.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestData.java
@@ -30,6 +30,7 @@ public class TestData {
         "https://github.com/opensearch-project/ml-commons/blob/2.x/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/text_embedding/all-MiniLM-L6-v2_torchscript_huggingface.zip?raw=true";
     public static final String SENTENCE_TRANSFORMER_MODEL_URL =
         "https://github.com/opensearch-project/ml-commons/blob/2.x/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/text_embedding/traced_small_model.zip?raw=true";
+    public static final String SENTENCE_TRANSFORMER_MODEL_HASH_VALUE = "e13b74006290a9d0f58c1376f9629d4ebc05a0f9385f40db837452b167ae9021";
     public static final String TIME_FIELD = "timestamp";
     public static final String HUGGINGFACE_TRANSFORMER_MODEL_HASH_VALUE =
         "e13b74006290a9d0f58c1376f9629d4ebc05a0f9385f40db837452b167ae9021";


### PR DESCRIPTION
### Background

Currently local models that use the parameters map within the payload to create a request can not create objects to be used for local model prediction, when using the MLInferenceIngestProcessor. 
e.g.
```json
## This is a cutom Asymmetric model prediction this passes
POST {{ _.domain }}/_plugins/_ml/_predict/text_embedding/{{ _.model_id }}
{
  "parameters": {
    "content_type": "query"
  },
  "text_docs": ["What day is it today?"],
  "target_response": ["sentence_embedding"]
}

## Ingest Pipeline configuration (Using the MLInferenceIngest Processor) that fails to create the MLInput needed for model prediciton

PUT {{ _.domain }}/_ingest/pipeline/asymmetric_embedding_ingest_pipeline
{
	"description": "ingest passage text and generate a embedding using an asymmetric model",
	"processors": [
		{
			"ml_inference": {

				"model_input": "{\"text_docs\":[\"${input_map.text_docs}\"],\"target_response\":[\"sentence_embedding\"],\"parameters\":{\"content_type\":\"query\"}}",
				"function_name": "text_embedding",
				"model_id": "{{ _.model_id }}",
				"input_map": [
					{
						"text_docs": "description"
					}
				],
				"output_map": [
					{
						"fact_embedding": "$.inference_results.*.output.*.data",
						"embedding_size": "$.inference_results.*.output.*.shape[0]"
					}
				]
			}
		}
	]
}
```

This requires a opensearch core change because it needs the contentRegistry,however given there is not much dependency on the registry (currently) we can give it the preset registry given in the MachineLearningPlugin class via the getNamedXContent() class to temporarily unblock this use case while a OpenSearch Core fix gives a proper change. 

### Context
Please see this issue https://github.com/opensearch-project/ml-commons/issues/3276. 

### Related Issues
Temporarily resolves https://github.com/opensearch-project/ml-commons/issues/3276 while waiting for a OpenSearch core fix.

<!-- List any other related issues here -->

### Check List
- [X] New functionality includes manual testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
