### PR TITLE
Enhance Message and Memory API Validation and storage

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/conversation/Interaction.java
+++ b/common/src/main/java/org/opensearch/ml/common/conversation/Interaction.java
@@ -184,10 +184,18 @@ public class Interaction implements Writeable, ToXContentObject {
         builder.field(ActionConstants.CONVERSATION_ID_FIELD, conversationId);
         builder.field(ActionConstants.RESPONSE_INTERACTION_ID_FIELD, id);
         builder.field(ConversationalIndexConstants.INTERACTIONS_CREATE_TIME_FIELD, createTime);
-        builder.field(ConversationalIndexConstants.INTERACTIONS_INPUT_FIELD, input);
-        builder.field(ConversationalIndexConstants.INTERACTIONS_PROMPT_TEMPLATE_FIELD, promptTemplate);
-        builder.field(ConversationalIndexConstants.INTERACTIONS_RESPONSE_FIELD, response);
-        builder.field(ConversationalIndexConstants.INTERACTIONS_ORIGIN_FIELD, origin);
+        if (input != null && !input.trim().isEmpty()) {
+            builder.field(ConversationalIndexConstants.INTERACTIONS_INPUT_FIELD, input);
+        }
+        if (promptTemplate != null && !promptTemplate.trim().isEmpty()) {
+            builder.field(ConversationalIndexConstants.INTERACTIONS_PROMPT_TEMPLATE_FIELD, promptTemplate);
+        }
+        if (response != null && !response.trim().isEmpty()) {
+            builder.field(ConversationalIndexConstants.INTERACTIONS_RESPONSE_FIELD, response);
+        }
+        if (origin != null && !origin.trim().isEmpty()) {
+            builder.field(ConversationalIndexConstants.INTERACTIONS_ORIGIN_FIELD, origin);
+        }
         if (additionalInfo != null) {
             builder.field(ConversationalIndexConstants.INTERACTIONS_ADDITIONAL_INFO_FIELD, additionalInfo);
         }

--- a/common/src/test/java/org/opensearch/ml/common/conversation/InteractionTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/conversation/InteractionTests.java
@@ -124,13 +124,14 @@ public class InteractionTests {
             .origin("amazon bedrock")
             .parentInteractionId("parant id")
             .additionalInfo(Collections.singletonMap("suggestion", "new suggestion"))
+            .response("sample response")
             .traceNum(1)
             .build();
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         interaction.toXContent(builder, EMPTY_PARAMS);
         String interactionContent = TestHelper.xContentBuilderToString(builder);
         assertEquals(
-            "{\"memory_id\":\"conversation id\",\"message_id\":null,\"create_time\":null,\"input\":null,\"prompt_template\":null,\"response\":null,\"origin\":\"amazon bedrock\",\"additional_info\":{\"suggestion\":\"new suggestion\"},\"parent_message_id\":\"parant id\",\"trace_number\":1}",
+            "{\"memory_id\":\"conversation id\",\"message_id\":null,\"create_time\":null,\"response\":\"sample response\",\"origin\":\"amazon bedrock\",\"additional_info\":{\"suggestion\":\"new suggestion\"},\"parent_message_id\":\"parant id\",\"trace_number\":1}",
             interactionContent
         );
     }

--- a/common/src/test/java/org/opensearch/ml/common/conversation/InteractionTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/conversation/InteractionTests.java
@@ -122,6 +122,7 @@ public class InteractionTests {
             .builder()
             .conversationId("conversation id")
             .origin("amazon bedrock")
+            .promptTemplate(" ")
             .parentInteractionId("parant id")
             .additionalInfo(Collections.singletonMap("suggestion", "new suggestion"))
             .response("sample response")

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequest.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequest.java
@@ -137,12 +137,27 @@ public class CreateConversationRequest extends ActionRequest {
         }
         try (XContentParser parser = restRequest.contentParser()) {
             Map<String, Object> body = parser.map();
+            String name = null;
+            String applicationType = null;
+            Map<String, String> additionalInfo = null;
+
+            for (String key : body.keySet()) {
+                switch (key) {
+                    case ActionConstants.REQUEST_CONVERSATION_NAME_FIELD:
+                        name = (String) body.get(ActionConstants.REQUEST_CONVERSATION_NAME_FIELD);
+                        break;
+                    case APPLICATION_TYPE_FIELD:
+                        applicationType = (String) body.get(APPLICATION_TYPE_FIELD);
+                        break;
+                    case META_ADDITIONAL_INFO_FIELD:
+                        additionalInfo = (Map<String, String>) body.get(META_ADDITIONAL_INFO_FIELD);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Invalid field [" + key + "] found in request body");
+                }
+            }
             if (body.get(ActionConstants.REQUEST_CONVERSATION_NAME_FIELD) != null) {
-                return new CreateConversationRequest(
-                    (String) body.get(ActionConstants.REQUEST_CONVERSATION_NAME_FIELD),
-                    body.get(APPLICATION_TYPE_FIELD) == null ? null : (String) body.get(APPLICATION_TYPE_FIELD),
-                    body.get(META_ADDITIONAL_INFO_FIELD) == null ? null : (Map<String, String>) body.get(META_ADDITIONAL_INFO_FIELD)
-                );
+                return new CreateConversationRequest(name, applicationType, additionalInfo);
             } else {
                 return new CreateConversationRequest();
             }

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequest.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequest.java
@@ -153,7 +153,8 @@ public class CreateConversationRequest extends ActionRequest {
                         additionalInfo = (Map<String, String>) body.get(META_ADDITIONAL_INFO_FIELD);
                         break;
                     default:
-                        throw new IllegalArgumentException("Invalid field [" + key + "] found in request body");
+                        parser.skipChildren();
+                        break;
                 }
             }
             if (body.get(ActionConstants.REQUEST_CONVERSATION_NAME_FIELD) != null) {

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/CreateInteractionRequest.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/CreateInteractionRequest.java
@@ -166,7 +166,8 @@ public class CreateInteractionRequest extends ActionRequest {
                     tracenum = parser.intValue(false);
                     break;
                 default:
-                    throw new IllegalArgumentException("Invalid field [" + fieldName + "] found in request body");
+                    parser.skipChildren();
+                    break;
             }
         }
 

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/CreateInteractionRequest.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/CreateInteractionRequest.java
@@ -166,11 +166,20 @@ public class CreateInteractionRequest extends ActionRequest {
                     tracenum = parser.intValue(false);
                     break;
                 default:
-                    parser.skipChildren();
-                    break;
+                    throw new IllegalArgumentException("Invalid field [" + fieldName + "] found in request body");
             }
         }
 
+        boolean allFieldsEmpty = (input == null || input.trim().isEmpty())
+            && (prompt == null || prompt.trim().isEmpty())
+            && (response == null || response.trim().isEmpty())
+            && (origin == null || origin.trim().isEmpty())
+            && (addinf == null || addinf.isEmpty());
+        if (allFieldsEmpty) {
+            throw new IllegalArgumentException(
+                "At least one of the following parameters must be non-empty: " + "input, prompt_template, response, origin, additional_info"
+            );
+        }
         return new CreateInteractionRequest(cid, input, prompt, response, origin, addinf, parintid, tracenum);
     }
 

--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -22,6 +22,7 @@ import static org.opensearch.ml.common.utils.IndexUtils.DEFAULT_INDEX_SETTINGS;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -161,28 +162,28 @@ public class InteractionsIndex {
             if (indexExists) {
                 this.conversationMetaIndex.checkAccess(conversationId, ActionListener.wrap(access -> {
                     if (access) {
-                        IndexRequest request = Requests
-                            .indexRequest(INTERACTIONS_INDEX_NAME)
-                            .source(
-                                ConversationalIndexConstants.INTERACTIONS_ORIGIN_FIELD,
-                                origin,
-                                ConversationalIndexConstants.INTERACTIONS_CONVERSATION_ID_FIELD,
-                                conversationId,
-                                ConversationalIndexConstants.INTERACTIONS_INPUT_FIELD,
-                                input,
-                                ConversationalIndexConstants.INTERACTIONS_PROMPT_TEMPLATE_FIELD,
-                                promptTemplate,
-                                ConversationalIndexConstants.INTERACTIONS_RESPONSE_FIELD,
-                                response,
-                                ConversationalIndexConstants.INTERACTIONS_ADDITIONAL_INFO_FIELD,
-                                additionalInfo,
-                                ConversationalIndexConstants.INTERACTIONS_CREATE_TIME_FIELD,
-                                timestamp,
-                                ConversationalIndexConstants.PARENT_INTERACTIONS_ID_FIELD,
-                                parintid,
-                                ConversationalIndexConstants.INTERACTIONS_TRACE_NUMBER_FIELD,
-                                traceNumber
-                            );
+                        Map<String, Object> sourceMap = new HashMap<>();
+                        sourceMap.put(ConversationalIndexConstants.INTERACTIONS_CONVERSATION_ID_FIELD, conversationId);
+                        sourceMap.put(ConversationalIndexConstants.INTERACTIONS_CREATE_TIME_FIELD, timestamp);
+                        sourceMap.put(ConversationalIndexConstants.PARENT_INTERACTIONS_ID_FIELD, parintid);
+                        sourceMap.put(ConversationalIndexConstants.INTERACTIONS_TRACE_NUMBER_FIELD, traceNumber);
+
+                        if (input != null && !input.trim().isEmpty()) {
+                            sourceMap.put(ConversationalIndexConstants.INTERACTIONS_INPUT_FIELD, input);
+                        }
+                        if (promptTemplate != null && !promptTemplate.trim().isEmpty()) {
+                            sourceMap.put(ConversationalIndexConstants.INTERACTIONS_PROMPT_TEMPLATE_FIELD, promptTemplate);
+                        }
+                        if (response != null && !response.trim().isEmpty()) {
+                            sourceMap.put(ConversationalIndexConstants.INTERACTIONS_RESPONSE_FIELD, response);
+                        }
+                        if (origin != null && !origin.trim().isEmpty()) {
+                            sourceMap.put(ConversationalIndexConstants.INTERACTIONS_ORIGIN_FIELD, origin);
+                        }
+                        if (additionalInfo != null && !additionalInfo.isEmpty()) {
+                            sourceMap.put(ConversationalIndexConstants.INTERACTIONS_ADDITIONAL_INFO_FIELD, additionalInfo);
+                        }
+                        IndexRequest request = Requests.indexRequest(INTERACTIONS_INDEX_NAME).source(sourceMap);
                         try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
                             ActionListener<String> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());
                             ActionListener<IndexResponse> al = ActionListener.wrap(resp -> {

--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -154,11 +154,11 @@ public class InteractionsIndex {
         Integer traceNumber
     ) {
         initInteractionsIndexIfAbsent(ActionListener.wrap(indexExists -> {
-            String userstr = client
+            String userStr = client
                 .threadPool()
                 .getThreadContext()
                 .getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
-            String user = User.parse(userstr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userstr).getName();
+            String user = User.parse(userStr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userStr).getName();
             if (indexExists) {
                 this.conversationMetaIndex.checkAccess(conversationId, ActionListener.wrap(access -> {
                     if (access) {
@@ -273,11 +273,11 @@ public class InteractionsIndex {
             if (access) {
                 innerGetInteractions(conversationId, from, maxResults, listener);
             } else {
-                String userstr = client
+                String userStr = client
                     .threadPool()
                     .getThreadContext()
                     .getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
-                String user = User.parse(userstr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userstr).getName();
+                String user = User.parse(userStr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userStr).getName();
                 throw new OpenSearchStatusException(
                     "User [" + user + "] does not have access to memory " + conversationId,
                     RestStatus.UNAUTHORIZED
@@ -362,13 +362,13 @@ public class InteractionsIndex {
                     if (access) {
                         innerGetTraces(interactionId, from, maxResults, listener);
                     } else {
-                        String userstr = client
+                        String userStr = client
                             .threadPool()
                             .getThreadContext()
                             .getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
-                        String user = User.parse(userstr) == null
+                        String user = User.parse(userStr) == null
                             ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS
-                            : User.parse(userstr).getName();
+                            : User.parse(userStr).getName();
                         throw new OpenSearchStatusException(
                             "User [" + user + "] does not have access to message " + interactionId,
                             RestStatus.UNAUTHORIZED
@@ -483,8 +483,8 @@ public class InteractionsIndex {
             listener.onResponse(true);
             return;
         }
-        String userstr = client.threadPool().getThreadContext().getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
-        String user = User.parse(userstr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userstr).getName();
+        String userStr = client.threadPool().getThreadContext().getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
+        String user = User.parse(userStr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userStr).getName();
         try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<Boolean> internalListener = ActionListener.runBefore(listener, () -> threadContext.restore());
             ActionListener<List<Interaction>> searchListener = ActionListener.wrap(interactions -> {
@@ -550,11 +550,11 @@ public class InteractionsIndex {
                     listener.onFailure(e);
                 }
             } else {
-                String userstr = client
+                String userStr = client
                     .threadPool()
                     .getThreadContext()
                     .getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
-                String user = User.parse(userstr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userstr).getName();
+                String user = User.parse(userStr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userStr).getName();
                 throw new OpenSearchStatusException(
                     "User [" + user + "] does not have access to memory " + conversationId,
                     RestStatus.UNAUTHORIZED
@@ -629,13 +629,13 @@ public class InteractionsIndex {
                     if (access) {
                         innerUpdateInteraction(updateRequest, internalListener);
                     } else {
-                        String userstr = client
+                        String userStr = client
                             .threadPool()
                             .getThreadContext()
                             .getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
-                        String user = User.parse(userstr) == null
+                        String user = User.parse(userStr) == null
                             ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS
-                            : User.parse(userstr).getName();
+                            : User.parse(userStr).getName();
                         throw new OpenSearchStatusException(
                             "User [" + user + "] does not have access to message " + interactionId,
                             RestStatus.UNAUTHORIZED
@@ -672,11 +672,11 @@ public class InteractionsIndex {
                 internalListener.onResponse(interaction);
                 log.info("Successfully get the message : {}", interactionId);
             } else {
-                String userstr = client
+                String userStr = client
                     .threadPool()
                     .getThreadContext()
                     .getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
-                String user = User.parse(userstr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userstr).getName();
+                String user = User.parse(userStr) == null ? ActionConstants.DEFAULT_USERNAME_FOR_ERRORS : User.parse(userStr).getName();
                 throw new OpenSearchStatusException(
                     "User [" + user + "] does not have access to message " + interactionId,
                     RestStatus.UNAUTHORIZED

--- a/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/index/InteractionsIndex.java
@@ -137,7 +137,7 @@ public class InteractionsIndex {
      * @param origin the origin of the response for this interaction
      * @param additionalInfo additional information used for constructing the LLM prompt
      * @param timestamp when this interaction happened
-     * @param parintid the parent interactionId of this interaction
+     * @param parentId the parent interactionId of this interaction
      * @param traceNumber the trace number for a parent interaction
      * @param listener gets the id of the newly created interaction record
      */
@@ -150,7 +150,7 @@ public class InteractionsIndex {
         Map<String, String> additionalInfo,
         Instant timestamp,
         ActionListener<String> listener,
-        String parintid,
+        String parentId,
         Integer traceNumber
     ) {
         initInteractionsIndexIfAbsent(ActionListener.wrap(indexExists -> {
@@ -165,7 +165,7 @@ public class InteractionsIndex {
                         Map<String, Object> sourceMap = new HashMap<>();
                         sourceMap.put(ConversationalIndexConstants.INTERACTIONS_CONVERSATION_ID_FIELD, conversationId);
                         sourceMap.put(ConversationalIndexConstants.INTERACTIONS_CREATE_TIME_FIELD, timestamp);
-                        sourceMap.put(ConversationalIndexConstants.PARENT_INTERACTIONS_ID_FIELD, parintid);
+                        sourceMap.put(ConversationalIndexConstants.PARENT_INTERACTIONS_ID_FIELD, parentId);
                         sourceMap.put(ConversationalIndexConstants.INTERACTIONS_TRACE_NUMBER_FIELD, traceNumber);
 
                         if (input != null && !input.trim().isEmpty()) {

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequestTests.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
@@ -131,5 +132,25 @@ public class CreateConversationRequestTests extends OpenSearchTestCase {
         Assert.assertNull(request.getApplicationType());
         Assert.assertEquals("value1", request.getAdditionalInfos().get("key1"));
         Assert.assertEquals(123, request.getAdditionalInfos().get("key2"));
+    }
+
+    public void testRestRequest_WithUnknownFields_Fails() throws IOException {
+        String name = "test-name";
+        RestRequest req = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withContent(
+                new BytesArray(gson.toJson(Map.of(ActionConstants.REQUEST_CONVERSATION_NAME_FIELD, name, "unknown_field", "some value"))),
+                MediaTypeRegistry.JSON
+            )
+            .build();
+
+        try {
+            CreateConversationRequest request = CreateConversationRequest.fromRestRequest(req);
+            fail("Expected IllegalArgumentException due to unknown field");
+        } catch (OpenSearchParseException e) {
+            assertEquals(e.getMessage(), "Invalid field [unknown_field] found in request body");
+        } catch (Exception e) {
+            fail("Expected OpenSearchParseException due to unknown field, got " + e.getClass().getName());
+        }
+
     }
 }

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequestTests.java
@@ -27,7 +27,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
-import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
@@ -134,21 +133,4 @@ public class CreateConversationRequestTests extends OpenSearchTestCase {
         Assert.assertEquals(123, request.getAdditionalInfos().get("key2"));
     }
 
-    public void testRestRequest_WithUnknownFields_Fails() throws IOException {
-        String name = "test-name";
-        RestRequest req = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
-            .withContent(
-                new BytesArray(gson.toJson(Map.of(ActionConstants.REQUEST_CONVERSATION_NAME_FIELD, name, "unknown_field", "some value"))),
-                MediaTypeRegistry.JSON
-            )
-            .build();
-
-        OpenSearchParseException exception = assertThrows(
-            "Expected OpenSearchParseException due to unknown field",
-            OpenSearchParseException.class,
-            () -> CreateConversationRequest.fromRestRequest(req)
-        );
-
-        assertEquals(exception.getMessage(), "Invalid field [unknown_field] found in request body");
-    }
 }

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequestTests.java
@@ -143,14 +143,12 @@ public class CreateConversationRequestTests extends OpenSearchTestCase {
             )
             .build();
 
-        try {
-            CreateConversationRequest request = CreateConversationRequest.fromRestRequest(req);
-            fail("Expected IllegalArgumentException due to unknown field");
-        } catch (OpenSearchParseException e) {
-            assertEquals(e.getMessage(), "Invalid field [unknown_field] found in request body");
-        } catch (Exception e) {
-            fail("Expected OpenSearchParseException due to unknown field, got " + e.getClass().getName());
-        }
+        OpenSearchParseException exception = assertThrows(
+            "Expected OpenSearchParseException due to unknown field",
+            OpenSearchParseException.class,
+            () -> CreateConversationRequest.fromRestRequest(req)
+        );
 
+        assertEquals(exception.getMessage(), "Invalid field [unknown_field] found in request body");
     }
 }

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateInteractionRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateInteractionRequestTests.java
@@ -177,14 +177,13 @@ public class CreateInteractionRequestTests extends OpenSearchTestCase {
             .withContent(new BytesArray(gson.toJson(params)), MediaTypeRegistry.JSON)
             .build();
 
-        try {
-            CreateInteractionRequest request = CreateInteractionRequest.fromRestRequest(rrequest);
-            fail("Expected IllegalArgumentException due to unknown field");
-        } catch (IllegalArgumentException e) {
-            assertEquals(e.getMessage(), "Invalid field [unknown_field] found in request body");
-        } catch (Exception e) {
-            fail("Expected IllegalArgumentException due to unknown field, got " + e.getClass().getName());
-        }
+        IllegalArgumentException exception = assertThrows(
+            "Expected IllegalArgumentException due to unknown field",
+            IllegalArgumentException.class,
+            () -> CreateInteractionRequest.fromRestRequest(rrequest)
+        );
+
+        assertEquals(exception.getMessage(), "Invalid field [unknown_field] found in request body");
     }
 
     public void testFromRestRequest_WithAllFieldsEmpty_Fails() throws IOException {
@@ -201,16 +200,16 @@ public class CreateInteractionRequestTests extends OpenSearchTestCase {
             .withContent(new BytesArray(gson.toJson(params)), MediaTypeRegistry.JSON)
             .build();
 
-        try {
-            CreateInteractionRequest request = CreateInteractionRequest.fromRestRequest(rrequest);
-            fail("Expected IllegalArgumentException due to all fields empty");
-        } catch (IllegalArgumentException e) {
-            assertEquals(
-                e.getMessage(),
-                "At least one of the following parameters must be non-empty: input, prompt_template, response, origin, additional_info"
-            );
-        } catch (Exception e) {
-            fail("Expected IllegalArgumentException due to all fields empty, got " + e.getClass().getName());
-        }
+        IllegalArgumentException exception = assertThrows(
+            "Expected IllegalArgumentException due to all fields empty",
+            IllegalArgumentException.class,
+            () -> CreateInteractionRequest.fromRestRequest(rrequest)
+        );
+
+        assertEquals(
+            exception.getMessage(),
+            "At least one of the following parameters must be non-empty: input, prompt_template, response, origin, additional_info"
+        );
+
     }
 }

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateInteractionRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateInteractionRequestTests.java
@@ -155,37 +155,6 @@ public class CreateInteractionRequestTests extends OpenSearchTestCase {
         assert (request.getTraceNumber().equals(1));
     }
 
-    public void testRestRequest_WithUnknownFields_Fails() throws IOException {
-        Map<String, Object> params = Map
-            .of(
-                ActionConstants.INPUT_FIELD,
-                "input",
-                ActionConstants.PROMPT_TEMPLATE_FIELD,
-                "pt",
-                ActionConstants.AI_RESPONSE_FIELD,
-                "response",
-                ActionConstants.RESPONSE_ORIGIN_FIELD,
-                "origin",
-                ActionConstants.ADDITIONAL_INFO_FIELD,
-                Collections.singletonMap("metadata", "some meta"),
-                "unknown_field",
-                "some value"
-            );
-
-        RestRequest rrequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
-            .withParams(Map.of(ActionConstants.MEMORY_ID, "cid"))
-            .withContent(new BytesArray(gson.toJson(params)), MediaTypeRegistry.JSON)
-            .build();
-
-        IllegalArgumentException exception = assertThrows(
-            "Expected IllegalArgumentException due to unknown field",
-            IllegalArgumentException.class,
-            () -> CreateInteractionRequest.fromRestRequest(rrequest)
-        );
-
-        assertEquals(exception.getMessage(), "Invalid field [unknown_field] found in request body");
-    }
-
     public void testFromRestRequest_WithAllFieldsEmpty_Fails() throws IOException {
         Map<String, Object> params = new HashMap<>();
 

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateInteractionRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateInteractionRequestTests.java
@@ -19,6 +19,7 @@ package org.opensearch.ml.memory.action.conversation;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
@@ -152,5 +153,64 @@ public class CreateInteractionRequestTests extends OpenSearchTestCase {
         assert (request.getAdditionalInfo().equals(Collections.singletonMap("metadata", "some meta")));
         assert (request.getParentIid().equals("parentId"));
         assert (request.getTraceNumber().equals(1));
+    }
+
+    public void testRestRequest_WithUnknownFields_Fails() throws IOException {
+        Map<String, Object> params = Map
+            .of(
+                ActionConstants.INPUT_FIELD,
+                "input",
+                ActionConstants.PROMPT_TEMPLATE_FIELD,
+                "pt",
+                ActionConstants.AI_RESPONSE_FIELD,
+                "response",
+                ActionConstants.RESPONSE_ORIGIN_FIELD,
+                "origin",
+                ActionConstants.ADDITIONAL_INFO_FIELD,
+                Collections.singletonMap("metadata", "some meta"),
+                "unknown_field",
+                "some value"
+            );
+
+        RestRequest rrequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withParams(Map.of(ActionConstants.MEMORY_ID, "cid"))
+            .withContent(new BytesArray(gson.toJson(params)), MediaTypeRegistry.JSON)
+            .build();
+
+        try {
+            CreateInteractionRequest request = CreateInteractionRequest.fromRestRequest(rrequest);
+            fail("Expected IllegalArgumentException due to unknown field");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid field [unknown_field] found in request body");
+        } catch (Exception e) {
+            fail("Expected IllegalArgumentException due to unknown field, got " + e.getClass().getName());
+        }
+    }
+
+    public void testFromRestRequest_WithAllFieldsEmpty_Fails() throws IOException {
+        Map<String, Object> params = new HashMap<>();
+
+        params.put(ActionConstants.INPUT_FIELD, "");
+        params.put(ActionConstants.PROMPT_TEMPLATE_FIELD, null);
+        params.put(ActionConstants.AI_RESPONSE_FIELD, " ");
+        params.put(ActionConstants.RESPONSE_ORIGIN_FIELD, null);
+        params.put(ActionConstants.ADDITIONAL_INFO_FIELD, Collections.emptyMap());
+
+        RestRequest rrequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withParams(Map.of(ActionConstants.MEMORY_ID, "cid"))
+            .withContent(new BytesArray(gson.toJson(params)), MediaTypeRegistry.JSON)
+            .build();
+
+        try {
+            CreateInteractionRequest request = CreateInteractionRequest.fromRestRequest(rrequest);
+            fail("Expected IllegalArgumentException due to all fields empty");
+        } catch (IllegalArgumentException e) {
+            assertEquals(
+                e.getMessage(),
+                "At least one of the following parameters must be non-empty: input, prompt_template, response, origin, additional_info"
+            );
+        } catch (Exception e) {
+            fail("Expected IllegalArgumentException due to all fields empty, got " + e.getClass().getName());
+        }
     }
 }

--- a/memory/src/test/java/org/opensearch/ml/memory/index/ConversationMetaIndexITTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/index/ConversationMetaIndexITTests.java
@@ -564,8 +564,8 @@ public class ConversationMetaIndexITTests extends OpenSearchIntegTestCase {
             assert (cid2.result().equals(get2.result().getId()));
             assert (get1.result().getName().equals("convo1"));
             assert (get2.result().getName().equals("convo2"));
-            Assert.assertTrue(convo2.getAdditionalInfos().isEmpty());
-            Assert.assertTrue(get1.result().getAdditionalInfos().isEmpty());
+            Assert.assertTrue(convo2.getAdditionalInfos() == null);
+            Assert.assertTrue(get1.result().getAdditionalInfos() == null);
             cdl.countDown();
         }, e -> {
             cdl.countDown();

--- a/memory/src/test/java/org/opensearch/ml/memory/index/ConversationMetaIndexTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/index/ConversationMetaIndexTests.java
@@ -134,10 +134,10 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
     }
 
     private void setupUser(String user) {
-        String userstr = user == null ? "" : user + "||";
+        String userStr = user == null ? "" : user + "||";
         doAnswer(invocation -> {
             ThreadContext tc = new ThreadContext(Settings.EMPTY);
-            tc.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userstr);
+            tc.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userStr);
             return tc;
         }).when(threadPool).getThreadContext();
     }

--- a/memory/src/test/java/org/opensearch/ml/memory/index/InteractionsIndexTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/index/InteractionsIndexTests.java
@@ -156,7 +156,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
     }
 
     private void setupDenyAccess(String user) {
-        String userstr = user == null ? "" : user + "||";
+        String userStr = user == null ? "" : user + "||";
         doAnswer(invocation -> {
             ActionListener<Boolean> al = invocation.getArgument(1);
             al.onResponse(false);
@@ -164,7 +164,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         }).when(conversationMetaIndex).checkAccess(anyString(), any());
         doAnswer(invocation -> {
             ThreadContext tc = new ThreadContext(Settings.EMPTY);
-            tc.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userstr);
+            tc.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userStr);
             return tc;
         }).when(threadPool).getThreadContext();
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/MLMemoryManager.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/MLMemoryManager.java
@@ -150,11 +150,11 @@ public class MLMemoryManager {
                 if (access) {
                     innerGetFinalInteractions(conversationId, lastNInteraction, actionListener);
                 } else {
-                    String userstr = client
+                    String userStr = client
                         .threadPool()
                         .getThreadContext()
                         .getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
-                    String user = User.parse(userstr) == null ? "" : User.parse(userstr).getName();
+                    String user = User.parse(userStr) == null ? "" : User.parse(userStr).getName();
                     throw new OpenSearchSecurityException("User [" + user + "] does not have access to conversation " + conversationId);
                 }
             }, e -> { actionListener.onFailure(e); });

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/MLMemoryManagerTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/MLMemoryManagerTests.java
@@ -249,7 +249,7 @@ public class MLMemoryManagerTests {
     @Test
     public void testGetInteractions_NoAccessNoUser_ThenFail() {
         doReturn(true).when(metadata).hasIndex(anyString());
-        String userstr = "";
+        String userStr = "";
         doAnswer(invocation -> {
             ActionListener<Boolean> al = invocation.getArgument(1);
             al.onResponse(false);
@@ -258,7 +258,7 @@ public class MLMemoryManagerTests {
 
         doAnswer(invocation -> {
             ThreadContext tc = new ThreadContext(Settings.EMPTY);
-            tc.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userstr);
+            tc.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userStr);
             return tc;
         }).when(threadPool).getThreadContext();
         mlMemoryManager.getFinalInteractions("cid", 10, interactionListActionListener);


### PR DESCRIPTION
Skip saving empty fields in interactions and conversations to optimize storage usage. 
Modify GET requests for interactions and conversations to return only non-null fields. 
Throw an exception if all fields in a create interaction call are empty or null. 
Add unit tests to cover the above cases.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #3250
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
