### PR TITLE
Introduce Ml Inference Search Request Extension

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -362,7 +362,6 @@ public class StringUtils {
      *             JsonPath expression (e.g., "$.store.book[0].title").
      * @return true if the path exists in the JSON object, false otherwise.
      * @throws IllegalArgumentException if the json object is null or if the path is null or empty.
-     * @throws PathNotFoundException if there's an error in parsing the JSON or the path.
      */
     public static boolean pathExists(Object json, String path) {
         if (json == null) {

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -34,7 +34,11 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
@@ -345,6 +349,94 @@ public class StringUtils {
         }
 
         return JsonParser.parseString(jsonString).getAsJsonObject();
+    }
+
+    /**
+     * Checks if a specified JSON path exists within a given JSON object.
+     *
+     * This method attempts to read the value at the specified path in the JSON object.
+     * If the path exists, it returns true. If a PathNotFoundException is thrown,
+     * indicating that the path does not exist, it returns false.
+     *
+     * @param json The JSON object to check. This can be a Map, List, or any object
+     *             that JsonPath can parse.
+     * @param path The JSON path to check for existence. This should be a valid
+     *             JsonPath expression (e.g., "$.store.book[0].title").
+     * @return true if the path exists in the JSON object, false otherwise.
+     * @throws IllegalArgumentException if the json object is null or if the path is null or empty.
+     * @throws PathNotFoundException if there's an error in parsing the JSON or the path.
+     */
+    public static boolean pathExists(Object json, String path) {
+        if (json == null) {
+            throw new IllegalArgumentException("JSON object cannot be null");
+        }
+        if (path == null || path.isEmpty()) {
+            throw new IllegalArgumentException("Path cannot be null or empty");
+        }
+        if (!isValidJSONPath(path)) {
+            throw new IllegalArgumentException("the field path is not a valid json path: " + path);
+        }
+        try {
+            JsonPath.read(json, path);
+            return true;
+        } catch (PathNotFoundException e) {
+            return false;
+        } catch (InvalidJsonException e) {
+            throw new IllegalArgumentException("Invalid JSON input", e);
+        }
+    }
+
+    /**
+     * Prepares nested structures in a JSON object based on the given field path.
+     *
+     * This method ensures that all intermediate nested objects exist in the JSON object
+     * for a given field path. If any part of the path doesn't exist, it creates new empty objects
+     * (HashMaps) for those parts.
+     *
+     * @param jsonObject The JSON object to be updated.
+     * @param fieldPath The full path of the field, potentially including nested structures.
+     * @return The updated JSON object with necessary nested structures in place.
+     *
+     * @throws IllegalArgumentException If there's an issue with JSON parsing or path manipulation.
+     *
+     * @implNote This method uses JsonPath for JSON manipulation and StringUtils for path existence checks.
+     *           It handles paths both with and without a leading "$." notation.
+     *           Each non-existent intermediate object in the path is created as an empty HashMap.
+     *
+     * @see JsonPath
+     * @see StringUtils
+     */
+    public static Object prepareNestedStructures(Object jsonObject, String fieldPath) {
+
+        if (fieldPath == null) {
+            throw new IllegalArgumentException("the field path is null");
+        }
+        if (!isValidJSONPath(fieldPath)) {
+            throw new IllegalArgumentException("the field path is not a valid json path: " + fieldPath);
+        }
+        String path = fieldPath.startsWith("$.") ? fieldPath.substring(2) : fieldPath;
+        String[] pathParts = path.split("\\.");
+        Configuration suppressExceptionConfiguration = Configuration
+            .builder()
+            .options(Option.SUPPRESS_EXCEPTIONS, Option.DEFAULT_PATH_LEAF_TO_NULL)
+            .build();
+        StringBuilder currentPath = new StringBuilder("$");
+
+        for (int i = 0; i < pathParts.length - 1; i++) {
+            currentPath.append(".").append(pathParts[i]);
+            if (!StringUtils.pathExists(jsonObject, currentPath.toString())) {
+                try {
+                    jsonObject = JsonPath
+                        .using(suppressExceptionConfiguration)
+                        .parse(jsonObject)
+                        .set(currentPath.toString(), new java.util.HashMap<>())
+                        .json();
+                } catch (Exception e) {
+                    throw new IllegalArgumentException("Error creating nested structure for path: " + currentPath, e);
+                }
+            }
+        }
+        return jsonObject;
     }
 
     public static void validateSchema(String schemaString, String instanceString) {

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -34,7 +34,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
-import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.networknt.schema.JsonSchema;
@@ -378,8 +377,6 @@ public class StringUtils {
             return true;
         } catch (PathNotFoundException e) {
             return false;
-        } catch (InvalidJsonException e) {
-            throw new IllegalArgumentException("Invalid JSON input", e);
         }
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
@@ -6,7 +6,10 @@
 package org.opensearch.ml.common.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.opensearch.ml.common.utils.StringUtils.TO_STRING_FUNCTION_NAME;
 import static org.opensearch.ml.common.utils.StringUtils.collectToStringPrefixes;
 import static org.opensearch.ml.common.utils.StringUtils.getJsonPath;
@@ -22,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.text.StringSubstitutor;
@@ -29,40 +33,42 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.OpenSearchParseException;
 
+import com.jayway.jsonpath.JsonPath;
+
 public class StringUtilsTest {
 
     @Test
     public void isJson_True() {
-        Assert.assertTrue(StringUtils.isJson("{}"));
-        Assert.assertTrue(StringUtils.isJson("[]"));
-        Assert.assertTrue(StringUtils.isJson("{\"key\": \"value\"}"));
-        Assert.assertTrue(StringUtils.isJson("{\"key\": 123}"));
-        Assert.assertTrue(StringUtils.isJson("[1, 2, 3]"));
-        Assert.assertTrue(StringUtils.isJson("[\"a\", \"b\"]"));
-        Assert.assertTrue(StringUtils.isJson("[1, \"a\"]"));
-        Assert.assertTrue(StringUtils.isJson("{\"key1\": \"value\", \"key2\": 123}"));
-        Assert.assertTrue(StringUtils.isJson("{}"));
-        Assert.assertTrue(StringUtils.isJson("[]"));
-        Assert.assertTrue(StringUtils.isJson("[ ]"));
-        Assert.assertTrue(StringUtils.isJson("[,]"));
-        Assert.assertTrue(StringUtils.isJson("[abc]"));
-        Assert.assertTrue(StringUtils.isJson("[\"abc\", 123]"));
+        assertTrue(StringUtils.isJson("{}"));
+        assertTrue(StringUtils.isJson("[]"));
+        assertTrue(StringUtils.isJson("{\"key\": \"value\"}"));
+        assertTrue(StringUtils.isJson("{\"key\": 123}"));
+        assertTrue(StringUtils.isJson("[1, 2, 3]"));
+        assertTrue(StringUtils.isJson("[\"a\", \"b\"]"));
+        assertTrue(StringUtils.isJson("[1, \"a\"]"));
+        assertTrue(StringUtils.isJson("{\"key1\": \"value\", \"key2\": 123}"));
+        assertTrue(StringUtils.isJson("{}"));
+        assertTrue(StringUtils.isJson("[]"));
+        assertTrue(StringUtils.isJson("[ ]"));
+        assertTrue(StringUtils.isJson("[,]"));
+        assertTrue(StringUtils.isJson("[abc]"));
+        assertTrue(StringUtils.isJson("[\"abc\", 123]"));
     }
 
     @Test
     public void isJson_False() {
-        Assert.assertFalse(StringUtils.isJson("{"));
-        Assert.assertFalse(StringUtils.isJson("["));
-        Assert.assertFalse(StringUtils.isJson("{\"key\": \"value}"));
-        Assert.assertFalse(StringUtils.isJson("{\"key\": \"value\", \"key\": 123}"));
-        Assert.assertFalse(StringUtils.isJson("[1, \"a]"));
-        Assert.assertFalse(StringUtils.isJson("[]\""));
-        Assert.assertFalse(StringUtils.isJson("[ ]\""));
-        Assert.assertFalse(StringUtils.isJson("[,]\""));
-        Assert.assertFalse(StringUtils.isJson("[,\"]"));
-        Assert.assertFalse(StringUtils.isJson("[]\"123\""));
-        Assert.assertFalse(StringUtils.isJson("[abc\"]"));
-        Assert.assertFalse(StringUtils.isJson("[abc\n123]"));
+        assertFalse(StringUtils.isJson("{"));
+        assertFalse(StringUtils.isJson("["));
+        assertFalse(StringUtils.isJson("{\"key\": \"value}"));
+        assertFalse(StringUtils.isJson("{\"key\": \"value\", \"key\": 123}"));
+        assertFalse(StringUtils.isJson("[1, \"a]"));
+        assertFalse(StringUtils.isJson("[]\""));
+        assertFalse(StringUtils.isJson("[ ]\""));
+        assertFalse(StringUtils.isJson("[,]\""));
+        assertFalse(StringUtils.isJson("[,\"]"));
+        assertFalse(StringUtils.isJson("[]\"123\""));
+        assertFalse(StringUtils.isJson("[abc\"]"));
+        assertFalse(StringUtils.isJson("[abc\n123]"));
     }
 
     @Test
@@ -84,7 +90,7 @@ public class StringUtilsTest {
         Map<String, Object> response = StringUtils
             .fromJson("{\"key\": {\"nested_key\": \"nested_value\", \"nested_array\": [1, \"a\"]}}", "response");
         assertEquals(1, response.size());
-        Assert.assertTrue(response.get("key") instanceof Map);
+        assertTrue(response.get("key") instanceof Map);
         Map nestedMap = (Map) response.get("key");
         assertEquals("nested_value", nestedMap.get("nested_key"));
         List list = (List) nestedMap.get("nested_array");
@@ -97,7 +103,7 @@ public class StringUtilsTest {
     public void fromJson_SimpleList() {
         Map<String, Object> response = StringUtils.fromJson("[1, \"a\"]", "response");
         assertEquals(1, response.size());
-        Assert.assertTrue(response.get("response") instanceof List);
+        assertTrue(response.get("response") instanceof List);
         List list = (List) response.get("response");
         assertEquals(1.0, list.get(0));
         assertEquals("a", list.get(1));
@@ -107,12 +113,12 @@ public class StringUtilsTest {
     public void fromJson_NestedList() {
         Map<String, Object> response = StringUtils.fromJson("[1, \"a\", [2, 3], {\"key\": \"value\"}]", "response");
         assertEquals(1, response.size());
-        Assert.assertTrue(response.get("response") instanceof List);
+        assertTrue(response.get("response") instanceof List);
         List list = (List) response.get("response");
         assertEquals(1.0, list.get(0));
         assertEquals("a", list.get(1));
-        Assert.assertTrue(list.get(2) instanceof List);
-        Assert.assertTrue(list.get(3) instanceof Map);
+        assertTrue(list.get(2) instanceof List);
+        assertTrue(list.get(3) instanceof Map);
     }
 
     @Test
@@ -152,23 +158,23 @@ public class StringUtilsTest {
         List<String> processedDocs = StringUtils.processTextDocs(Arrays.asList("abc \n\n123\"4", null, "[1.01,\"abc\"]"));
         assertEquals(3, processedDocs.size());
         assertEquals("abc \\n\\n123\\\"4", processedDocs.get(0));
-        Assert.assertNull(processedDocs.get(1));
+        assertNull(processedDocs.get(1));
         assertEquals("[1.01,\\\"abc\\\"]", processedDocs.get(2));
     }
 
     @Test
     public void isEscapeUsed() {
-        Assert.assertFalse(StringUtils.isEscapeUsed("String escape"));
-        Assert.assertTrue(StringUtils.isEscapeUsed(" escape(\"abc\n123\")"));
+        assertFalse(StringUtils.isEscapeUsed("String escape"));
+        assertTrue(StringUtils.isEscapeUsed(" escape(\"abc\n123\")"));
     }
 
     @Test
     public void containsEscapeMethod() {
-        Assert.assertFalse(StringUtils.containsEscapeMethod("String escape"));
-        Assert.assertFalse(StringUtils.containsEscapeMethod("String escape()"));
-        Assert.assertFalse(StringUtils.containsEscapeMethod(" escape(\"abc\n123\")"));
-        Assert.assertTrue(StringUtils.containsEscapeMethod("String escape(def abc)"));
-        Assert.assertTrue(StringUtils.containsEscapeMethod("String escape(String input)"));
+        assertFalse(StringUtils.containsEscapeMethod("String escape"));
+        assertFalse(StringUtils.containsEscapeMethod("String escape()"));
+        assertFalse(StringUtils.containsEscapeMethod(" escape(\"abc\n123\")"));
+        assertTrue(StringUtils.containsEscapeMethod("String escape(def abc)"));
+        assertTrue(StringUtils.containsEscapeMethod("String escape(String input)"));
     }
 
     @Test
@@ -183,7 +189,7 @@ public class StringUtilsTest {
         String input = "return escape(\"abc\n123\");";
         String result = StringUtils.addDefaultMethod(input);
         Assert.assertNotEquals(input, result);
-        Assert.assertTrue(result.startsWith(StringUtils.DEFAULT_ESCAPE_FUNCTION));
+        assertTrue(result.startsWith(StringUtils.DEFAULT_ESCAPE_FUNCTION));
     }
 
     @Test
@@ -464,51 +470,174 @@ public class StringUtilsTest {
 
     @Test
     public void testisValidJSONPath_InvalidInputs() {
-        Assert.assertFalse(isValidJSONPath("..bar"));
-        Assert.assertFalse(isValidJSONPath("."));
-        Assert.assertFalse(isValidJSONPath(".."));
-        Assert.assertFalse(isValidJSONPath("foo.bar."));
-        Assert.assertFalse(isValidJSONPath(".foo.bar."));
+        assertFalse(isValidJSONPath("..bar"));
+        assertFalse(isValidJSONPath("."));
+        assertFalse(isValidJSONPath(".."));
+        assertFalse(isValidJSONPath("foo.bar."));
+        assertFalse(isValidJSONPath(".foo.bar."));
     }
 
     @Test
     public void testisValidJSONPath_NullInput() {
-        Assert.assertFalse(isValidJSONPath(null));
+        assertFalse(isValidJSONPath(null));
     }
 
     @Test
     public void testisValidJSONPath_EmptyInput() {
-        Assert.assertFalse(isValidJSONPath(""));
+        assertFalse(isValidJSONPath(""));
     }
 
     @Test
     public void testisValidJSONPath_ValidInputs() {
-        Assert.assertTrue(isValidJSONPath("foo"));
-        Assert.assertTrue(isValidJSONPath("foo.bar"));
-        Assert.assertTrue(isValidJSONPath("foo.bar.baz"));
-        Assert.assertTrue(isValidJSONPath("foo.bar.baz.qux"));
-        Assert.assertTrue(isValidJSONPath(".foo"));
-        Assert.assertTrue(isValidJSONPath("$.foo"));
-        Assert.assertTrue(isValidJSONPath(".foo.bar"));
-        Assert.assertTrue(isValidJSONPath("$.foo.bar"));
+        assertTrue(isValidJSONPath("foo"));
+        assertTrue(isValidJSONPath("foo.bar"));
+        assertTrue(isValidJSONPath("foo.bar.baz"));
+        assertTrue(isValidJSONPath("foo.bar.baz.qux"));
+        assertTrue(isValidJSONPath(".foo"));
+        assertTrue(isValidJSONPath("$.foo"));
+        assertTrue(isValidJSONPath(".foo.bar"));
+        assertTrue(isValidJSONPath("$.foo.bar"));
     }
 
     @Test
     public void testisValidJSONPath_WithFilter() {
-        Assert.assertTrue(isValidJSONPath("$.store['book']"));
-        Assert.assertTrue(isValidJSONPath("$['store']['book'][0]['title']"));
-        Assert.assertTrue(isValidJSONPath("$.store.book[0]"));
-        Assert.assertTrue(isValidJSONPath("$.store.book[1,2]"));
-        Assert.assertTrue(isValidJSONPath("$.store.book[-1:] "));
-        Assert.assertTrue(isValidJSONPath("$.store.book[0:2]"));
-        Assert.assertTrue(isValidJSONPath("$.store.book[*]"));
-        Assert.assertTrue(isValidJSONPath("$.store.book[?(@.price < 10)]"));
-        Assert.assertTrue(isValidJSONPath("$.store.book[?(@.author == 'J.K. Rowling')]"));
-        Assert.assertTrue(isValidJSONPath("$..author"));
-        Assert.assertTrue(isValidJSONPath("$..book[?(@.price > 15)]"));
-        Assert.assertTrue(isValidJSONPath("$.store.book[0,1]"));
-        Assert.assertTrue(isValidJSONPath("$['store','warehouse']"));
-        Assert.assertTrue(isValidJSONPath("$..book[?(@.price > 20)].title"));
+        assertTrue(isValidJSONPath("$.store['book']"));
+        assertTrue(isValidJSONPath("$['store']['book'][0]['title']"));
+        assertTrue(isValidJSONPath("$.store.book[0]"));
+        assertTrue(isValidJSONPath("$.store.book[1,2]"));
+        assertTrue(isValidJSONPath("$.store.book[-1:] "));
+        assertTrue(isValidJSONPath("$.store.book[0:2]"));
+        assertTrue(isValidJSONPath("$.store.book[*]"));
+        assertTrue(isValidJSONPath("$.store.book[?(@.price < 10)]"));
+        assertTrue(isValidJSONPath("$.store.book[?(@.author == 'J.K. Rowling')]"));
+        assertTrue(isValidJSONPath("$..author"));
+        assertTrue(isValidJSONPath("$..book[?(@.price > 15)]"));
+        assertTrue(isValidJSONPath("$.store.book[0,1]"));
+        assertTrue(isValidJSONPath("$['store','warehouse']"));
+        assertTrue(isValidJSONPath("$..book[?(@.price > 20)].title"));
+    }
+
+    @Test
+    public void testPathExists_ExistingPath() {
+        Object json = JsonPath.parse("{\"a\":{\"b\":42}}").json();
+        assertTrue(StringUtils.pathExists(json, "$.a.b"));
+    }
+
+    @Test
+    public void testPathExists_NonExistingPath() {
+        Object json = JsonPath.parse("{\"a\":{\"b\":42}}").json();
+        assertFalse(StringUtils.pathExists(json, "$.a.c"));
+    }
+
+    @Test
+    public void testPathExists_EmptyObject() {
+        Object json = JsonPath.parse("{}").json();
+        assertFalse(StringUtils.pathExists(json, "$.a"));
+    }
+
+    @Test
+    public void testPathExists_NullJson() {
+        assertThrows(IllegalArgumentException.class, () -> StringUtils.pathExists(null, "$.a"));
+    }
+
+    @Test
+    public void testPathExists_NullPath() {
+        Object json = JsonPath.parse("{\"a\":42}").json();
+        assertThrows(IllegalArgumentException.class, () -> StringUtils.pathExists(json, null));
+    }
+
+    @Test
+    public void testPathExists_EmptyPath() {
+        Object json = JsonPath.parse("{\"a\":42}").json();
+        assertThrows(IllegalArgumentException.class, () -> StringUtils.pathExists(json, ""));
+    }
+
+    @Test
+    public void testPathExists_InvalidPath() {
+        Object json = JsonPath.parse("{\"a\":42}").json();
+        assertThrows(IllegalArgumentException.class, () -> StringUtils.pathExists(json, "This is not a valid path"));
+    }
+
+    @Test
+    public void testPathExists_ArrayElement() {
+        Object json = JsonPath.parse("{\"a\":[1,2,3]}").json();
+        assertTrue(StringUtils.pathExists(json, "$.a[1]"));
+        assertFalse(StringUtils.pathExists(json, "$.a[3]"));
+    }
+
+    @Test
+    public void testPathExists_NestedStructure() {
+        Object json = JsonPath.parse("{\"a\":{\"b\":{\"c\":{\"d\":42}}}}").json();
+        assertTrue(StringUtils.pathExists(json, "$.a.b.c.d"));
+        assertFalse(StringUtils.pathExists(json, "$.a.b.c.e"));
+    }
+
+    @Test
+    public void testPrepareNestedStructures_EmptyObject() {
+        Object jsonObject = new HashMap<>();
+        Object result = StringUtils.prepareNestedStructures(jsonObject, "a.b.c");
+        assertTrue(JsonPath.read(result, "$.a.b") instanceof Map);
+    }
+
+    @Test
+    public void testPrepareNestedStructures_ExistingStructure() {
+        Object jsonObject = JsonPath.parse("{\"a\":{\"b\":{}}}").json();
+        Object result = StringUtils.prepareNestedStructures(jsonObject, "a.b.c");
+        assertTrue(JsonPath.read(result, "$.a.b") instanceof Map);
+    }
+
+    @Test
+    public void testPrepareNestedStructures_PartiallyExistingStructure() {
+        Object jsonObject = JsonPath.parse("{\"a\":{}}").json();
+        Object result = StringUtils.prepareNestedStructures(jsonObject, "a.b.c.d");
+        assertTrue(JsonPath.read(result, "$.a.b.c") instanceof Map);
+    }
+
+    @Test
+    public void testPrepareNestedStructures_WithDollarSign() {
+        Object jsonObject = new HashMap<>();
+        Object result = StringUtils.prepareNestedStructures(jsonObject, "$.a.b.c");
+        assertTrue(JsonPath.read(result, "$.a.b") instanceof Map);
+    }
+
+    @Test
+    public void testPrepareNestedStructures_SingleLevel() {
+        Object jsonObject = new HashMap<>();
+        Object result = StringUtils.prepareNestedStructures(jsonObject, "a");
+        assertEquals(jsonObject, result);
+    }
+
+    @Test
+    public void testPrepareNestedStructures_ExistingValue() {
+        Object jsonObject = JsonPath.parse("{\"a\":{\"b\":42}}").json();
+        Object result = StringUtils.prepareNestedStructures(jsonObject, "a.b.c");
+        assertEquals(Optional.ofNullable(42), Optional.ofNullable(JsonPath.read(result, "$.a.b")));
+    }
+
+    @Test
+    public void testPrepareNestedStructures_NullInput() {
+        assertThrows(IllegalArgumentException.class, () -> StringUtils.prepareNestedStructures(null, "a.b.c"));
+    }
+
+    @Test
+    public void testPrepareNestedStructures_NullPath() {
+        Object jsonObject = new HashMap<>();
+        assertThrows(IllegalArgumentException.class, () -> StringUtils.prepareNestedStructures(jsonObject, null));
+    }
+
+    @Test
+    public void testPrepareNestedStructures_ComplexPath() {
+        Object jsonObject = new HashMap<>();
+        Object result = StringUtils.prepareNestedStructures(jsonObject, "a.b.c.d.e.f");
+        assertTrue(JsonPath.read(result, "$.a.b.c.d.e") instanceof Map);
+    }
+
+    @Test
+    public void testPrepareNestedStructures_MixedExistingAndNew() {
+        Object jsonObject = JsonPath.parse("{\"a\":{\"b\":42,\"c\":{}}}").json();
+        Object result = StringUtils.prepareNestedStructures(jsonObject, "a.c.d.e");
+        assertEquals(Optional.of(42), Optional.of(JsonPath.read(result, "$.a.b")));
+        assertTrue(JsonPath.read(result, "$.a.c.d") instanceof Map);
     }
 
     @Test

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
+    testImplementation 'com.jayway.jsonpath:json-path:2.9.0'
 }
 
 test {

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -285,6 +285,7 @@ import org.opensearch.ml.rest.RestMemorySearchConversationsAction;
 import org.opensearch.ml.rest.RestMemorySearchInteractionsAction;
 import org.opensearch.ml.rest.RestMemoryUpdateConversationAction;
 import org.opensearch.ml.rest.RestMemoryUpdateInteractionAction;
+import org.opensearch.ml.searchext.MLInferenceRequestParametersExtBuilder;
 import org.opensearch.ml.settings.MLCommonsSettings;
 import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.stats.MLClusterLevelStat;
@@ -1052,6 +1053,15 @@ public class MachineLearningPlugin extends Plugin
                     GenerativeQAParamExtBuilder.PARAMETER_NAME,
                     input -> new GenerativeQAParamExtBuilder(input),
                     parser -> GenerativeQAParamExtBuilder.parse(parser)
+                )
+            );
+
+        searchExts
+            .add(
+                new SearchPlugin.SearchExtSpec<>(
+                    MLInferenceRequestParametersExtBuilder.NAME,
+                    input -> new MLInferenceRequestParametersExtBuilder(input),
+                    parser -> MLInferenceRequestParametersExtBuilder.parse(parser)
                 )
             );
 

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
@@ -226,7 +226,7 @@ public class MLInferenceSearchRequestProcessor extends AbstractProcessor impleme
      * @param queryString      the original query string
      * @param requestListener  the {@link ActionListener} to be notified when the query string or query template is updated
      * @param processOutputMap the list of output mappings
-     * @param requestContext
+     * @param requestContext   the requestContext can be carried over search processors into the search pipeline
      * @return an {@link ActionListener} that handles the response from the ML model inference
      */
     private ActionListener<Map<Integer, MLOutput>> createRewriteRequestListener(
@@ -316,6 +316,9 @@ public class MLInferenceSearchRequestProcessor extends AbstractProcessor impleme
                         Object modelOutputValue = getModelOutputValue(mlOutput, modelOutputFieldName, ignoreMissing, fullResponsePath);
                         requestContext.setAttribute(newQueryField, modelOutputValue);
 
+                        // if output mapping is using jsonpath starts with $. or use dot path starts with ext.
+                        // to allow writing to search extension, try to prepare the path in the query,
+                        // for example {"ext":{"ml_inference":{}}}
                         if (newQueryField.startsWith("$.ext.") || newQueryField.startsWith("ext.")) {
                             incomeQueryObject = StringUtils.prepareNestedStructures(incomeQueryObject, newQueryField);
                         }

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
@@ -149,7 +149,7 @@ public class MLInferenceSearchRequestProcessor extends AbstractProcessor impleme
             if (request.source() == null) {
                 throw new IllegalArgumentException("query body is empty, cannot processor inference on empty query request.");
             }
-
+            setRequestContextFromExt(request, requestContext);
             String queryString = request.source().toString();
             rewriteQueryString(request, queryString, requestListener, requestContext);
 
@@ -504,9 +504,8 @@ public class MLInferenceSearchRequestProcessor extends AbstractProcessor impleme
      */
     private static SearchSourceBuilder getSearchSourceBuilder(NamedXContentRegistry xContentRegistry, String queryString)
         throws IOException {
-        // MLInferenceRequestParametersExtBuilder mlInferenceExtBuilder = new MLInferenceRequestParametersExtBuilder();
+
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        // SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().ext(List.of(mlInferenceExtBuilder));
 
         XContentParser queryParser = XContentType.JSON
             .xContent()

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -162,6 +162,8 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                 return;
             }
 
+            setRequestContextFromExt(request, responseContext);
+
             // if many to one, run rewriteResponseDocuments
             if (!oneToOne) {
                 // use MLInferenceSearchResponseProcessor to allow writing to extension

--- a/plugin/src/main/java/org/opensearch/ml/processor/ModelExecutor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/ModelExecutor.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -352,13 +353,16 @@ public interface ModelExecutor {
                 mlParams
                     .forEach(
                         (key, value) -> requestContext
-                            .setAttribute(String.format("ext.%s.%s", MLInferenceRequestParametersExtBuilder.NAME, key), value)
+                            .setAttribute(String.format(Locale.ROOT, "ext.%s.%s", MLInferenceRequestParametersExtBuilder.NAME, key), value)
                     );
             }
             if (ext instanceof GenerativeQAParamExtBuilder) {
                 GenerativeQAParamExtBuilder qaParamExtBuilder = (GenerativeQAParamExtBuilder) ext;
                 Map<String, Object> mlParams = (Map<String, Object>) qaParamExtBuilder.getParams();
-                mlParams.forEach((key, value) -> requestContext.setAttribute(String.format("ext.%s.%s", PARAMETER_NAME, key), value));
+                mlParams
+                    .forEach(
+                        (key, value) -> requestContext.setAttribute(String.format(Locale.ROOT, "ext.%s.%s", PARAMETER_NAME, key), value)
+                    );
             }
         }
 

--- a/plugin/src/main/java/org/opensearch/ml/processor/ModelExecutor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/ModelExecutor.java
@@ -343,6 +343,24 @@ public interface ModelExecutor {
         return path.replaceAll("\\[(\\d+)\\]", "$1\\.").replaceAll("\\['(.*?)']", "$1\\.").replaceAll("^\\$", "").replaceAll("\\.$", "");
     }
 
+    /**
+     * Sets the request context from the extensions in the SearchRequest.
+     *
+     * This method processes the extensions in the provided SearchRequest and sets
+     * corresponding attributes in the PipelineProcessingContext. It specifically
+     * handles two types of extensions:
+     * 1. MLInferenceRequestParametersExtBuilder
+     * 2. GenerativeQAParamExtBuilder
+     *
+     * For each recognized extension, it extracts parameters and sets them as
+     * attributes in the requestContext with appropriate prefixes.
+     *
+     * @param request The SearchRequest containing the extensions to process.
+     *                This should be a valid SearchRequest that may contain
+     *                ML Inference or Generative QA extensions.
+     * @param requestContext The PipelineProcessingContext where attributes will be set.
+     *                       This context will be updated with parameters from the extensions.
+     * */
     default void setRequestContextFromExt(SearchRequest request, PipelineProcessingContext requestContext) {
 
         List<SearchExtBuilder> extBuilderList = request.source().ext();

--- a/plugin/src/main/java/org/opensearch/ml/processor/ModelExecutor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/ModelExecutor.java
@@ -105,11 +105,11 @@ public interface ModelExecutor {
      * Retrieves the model output value from the given ModelTensorOutput for the specified modelOutputFieldName.
      * It handles cases where the output contains a single tensor or multiple tensors.
      *
-     * @param modelTensorOutput          the ModelTensorOutput containing the model output
-     * @param modelOutputFieldName       the name of the field in the model output to retrieve the value for
-     * @param ignoreMissing              a flag indicating whether to ignore missing fields or throw an exception
+     * @param modelTensorOutput    the ModelTensorOutput containing the model output
+     * @param modelOutputFieldName the name of the field in the model output to retrieve the value for
+     * @param ignoreMissing        a flag indicating whether to ignore missing fields or throw an exception
      * @return the model output value as an Object
-     * @throws RuntimeException          if there is an error retrieving the model output value
+     * @throws RuntimeException if there is an error retrieving the model output value
      */
     default Object getModelOutputValue(ModelTensorOutput modelTensorOutput, String modelOutputFieldName, boolean ignoreMissing) {
         Object modelOutputValue;
@@ -298,6 +298,7 @@ public interface ModelExecutor {
      * Writes a new dot path for a nested object within the given JSON object.
      * This method is useful when dealing with arrays or nested objects in the JSON structure.
      * for example foo.*.bar.*.quk to be [foo.0.bar.0.quk, foo.0.bar.1.quk..]
+     *
      * @param json    the JSON object containing the nested object
      * @param dotPath the dot path representing the location of the nested object
      * @return a list of dot paths representing the new locations of the nested object

--- a/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParameters.java
+++ b/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParameters.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.ml.searchext;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+public class MLInferenceRequestParameters implements Writeable, ToXContentObject {
+    static final String ML_INFERENCE_FIELD = "ml_inference";
+
+    @Setter
+    @Getter
+    private Map<String, Object> params;
+
+    public MLInferenceRequestParameters(Map<String, Object> params) {
+        this.params = params;
+
+    }
+
+    public MLInferenceRequestParameters(StreamInput input) throws IOException {
+        this.params = input.readMap();
+    }
+
+    /**
+     * Write this into the {@linkplain StreamOutput}.
+     *
+     * @param out
+     */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeMap(this.params);
+    }
+
+    public static MLInferenceRequestParameters parse(XContentParser parser) throws IOException {
+        return new MLInferenceRequestParameters(parser.map());
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(ML_INFERENCE_FIELD);
+        return builder.map(this.params);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        MLInferenceRequestParameters config = (MLInferenceRequestParameters) o;
+
+        return params.equals(config.getParams());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(params);
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParameters.java
+++ b/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParameters.java
@@ -19,16 +19,21 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
+/**
+ * Represents the parameters for an ML inference request.
+ *
+ * The parameters are stored as a Map of String keys to Object values, allowing
+ * for flexible parameter structures.
+ *
+ */
+@Data
 @NoArgsConstructor
 public class MLInferenceRequestParameters implements Writeable, ToXContentObject {
     static final String ML_INFERENCE_FIELD = "ml_inference";
 
-    @Setter
-    @Getter
     private Map<String, Object> params;
 
     public MLInferenceRequestParameters(Map<String, Object> params) {

--- a/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersExtBuilder.java
+++ b/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersExtBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.ml.searchext;
+
+import static org.opensearch.ml.searchext.MLInferenceRequestParameters.ML_INFERENCE_FIELD;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.search.SearchExtBuilder;
+
+public class MLInferenceRequestParametersExtBuilder extends SearchExtBuilder {
+    private static final Logger logger = LogManager.getLogger(MLInferenceRequestParametersExtBuilder.class);
+    public static final String NAME = ML_INFERENCE_FIELD;
+    private MLInferenceRequestParameters requestParameters;
+
+    public MLInferenceRequestParametersExtBuilder() {}
+
+    public MLInferenceRequestParametersExtBuilder(StreamInput input) throws IOException {
+        this.requestParameters = new MLInferenceRequestParameters(input);
+    }
+
+    public MLInferenceRequestParameters getRequestParameters() {
+        return requestParameters;
+    }
+
+    public void setRequestParameters(MLInferenceRequestParameters requestParameters) {
+        this.requestParameters = requestParameters;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getClass(), this.requestParameters);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof MLInferenceRequestParametersExtBuilder)) {
+            return false;
+        }
+        MLInferenceRequestParametersExtBuilder o = (MLInferenceRequestParametersExtBuilder) obj;
+        return this.requestParameters.equals(o.requestParameters);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+
+        requestParameters.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.value(requestParameters);
+    }
+
+    public static MLInferenceRequestParametersExtBuilder parse(XContentParser parser) throws IOException {
+
+        MLInferenceRequestParametersExtBuilder extBuilder = new MLInferenceRequestParametersExtBuilder();
+        MLInferenceRequestParameters requestParameters = MLInferenceRequestParameters.parse(parser);
+        extBuilder.setRequestParameters(requestParameters);
+        return extBuilder;
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersExtBuilder.java
+++ b/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersExtBuilder.java
@@ -20,6 +20,10 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.SearchExtBuilder;
 
+/**
+ * This class extends SearchExtBuilder to handle ML inference request parameters.
+ * Ml inference request parameters contain an object of params
+ */
 public class MLInferenceRequestParametersExtBuilder extends SearchExtBuilder {
     private static final Logger logger = LogManager.getLogger(MLInferenceRequestParametersExtBuilder.class);
     public static final String NAME = ML_INFERENCE_FIELD;

--- a/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtil.java
+++ b/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtil.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.ml.searchext;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.search.SearchExtBuilder;
+
+public class MLInferenceRequestParametersUtil {
+
+    public static MLInferenceRequestParameters getMLInferenceRequestParameters(SearchRequest searchRequest) {
+        MLInferenceRequestParametersExtBuilder mLInferenceRequestParametersExtBuilder = null;
+        if (searchRequest.source() != null && searchRequest.source().ext() != null && !searchRequest.source().ext().isEmpty()) {
+            List<SearchExtBuilder> extBuilders = searchRequest
+                .source()
+                .ext()
+                .stream()
+                .filter(extBuilder -> MLInferenceRequestParametersExtBuilder.NAME.equals(extBuilder.getWriteableName()))
+                .collect(Collectors.toList());
+
+            if (!extBuilders.isEmpty()) {
+                mLInferenceRequestParametersExtBuilder = (MLInferenceRequestParametersExtBuilder) extBuilders.get(0);
+            }
+        }
+        MLInferenceRequestParameters mlInferenceRequestParameters = null;
+        if (mLInferenceRequestParametersExtBuilder != null) {
+            mlInferenceRequestParameters = mLInferenceRequestParametersExtBuilder.getRequestParameters();
+        }
+        return mlInferenceRequestParameters;
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtil.java
+++ b/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtil.java
@@ -23,7 +23,14 @@ import org.opensearch.search.SearchExtBuilder;
  *
  */
 public class MLInferenceRequestParametersUtil {
-
+    /**
+     * Extracts ML Inference Request Parameters from a SearchRequest.
+     *
+     * This method examines the provided SearchRequest for ML-inference parameters
+     * that are embedded within the request's extensions. It specifically looks for
+     * the MLInferenceRequestParametersExtBuilder and extracts the ML Inference
+     * Request Parameters if present.
+     * */
     public static MLInferenceRequestParameters getMLInferenceRequestParameters(SearchRequest searchRequest) {
         MLInferenceRequestParametersExtBuilder mLInferenceRequestParametersExtBuilder = null;
         if (searchRequest.source() != null && searchRequest.source().ext() != null && !searchRequest.source().ext().isEmpty()) {

--- a/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtil.java
+++ b/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtil.java
@@ -13,6 +13,15 @@ import java.util.stream.Collectors;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.search.SearchExtBuilder;
 
+/**
+ * Utility class for handling ML Inference Request Parameters.
+ *
+ * This class provides utility methods to extract ML Inference Request Parameters
+ * from a SearchRequest. It is designed to work with the OpenSearch ML plugin
+ * and facilitates the retrieval of ML-specific parameters that are embedded
+ * within search requests.
+ *
+ */
 public class MLInferenceRequestParametersUtil {
 
     public static MLInferenceRequestParameters getMLInferenceRequestParameters(SearchRequest searchRequest) {
@@ -27,12 +36,14 @@ public class MLInferenceRequestParametersUtil {
 
             if (!extBuilders.isEmpty()) {
                 mLInferenceRequestParametersExtBuilder = (MLInferenceRequestParametersExtBuilder) extBuilders.get(0);
+                MLInferenceRequestParameters mlInferenceRequestParameters = null;
+                if (mLInferenceRequestParametersExtBuilder != null) {
+                    mlInferenceRequestParameters = mLInferenceRequestParametersExtBuilder.getRequestParameters();
+                }
+                return mlInferenceRequestParameters;
             }
+
         }
-        MLInferenceRequestParameters mlInferenceRequestParameters = null;
-        if (mLInferenceRequestParametersExtBuilder != null) {
-            mlInferenceRequestParameters = mLInferenceRequestParametersExtBuilder.getRequestParameters();
-        }
-        return mlInferenceRequestParameters;
+        return null;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/plugin/MachineLearningPluginTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/plugin/MachineLearningPluginTests.java
@@ -40,6 +40,7 @@ import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.engine.tools.MLModelTool;
 import org.opensearch.ml.processor.MLInferenceSearchRequestProcessor;
 import org.opensearch.ml.processor.MLInferenceSearchResponseProcessor;
+import org.opensearch.ml.searchext.MLInferenceRequestParametersExtBuilder;
 import org.opensearch.plugins.ExtensiblePlugin;
 import org.opensearch.plugins.SearchPipelinePlugin;
 import org.opensearch.plugins.SearchPlugin;
@@ -66,9 +67,11 @@ public class MachineLearningPluginTests {
     @Test
     public void testGetSearchExts() {
         List<SearchPlugin.SearchExtSpec<?>> searchExts = plugin.getSearchExts();
-        assertEquals(1, searchExts.size());
-        SearchPlugin.SearchExtSpec<?> spec = searchExts.get(0);
-        assertEquals(GenerativeQAParamExtBuilder.PARAMETER_NAME, spec.getName().getPreferredName());
+        assertEquals(2, searchExts.size());
+        SearchPlugin.SearchExtSpec<?> spec1 = searchExts.get(0);
+        assertEquals(GenerativeQAParamExtBuilder.PARAMETER_NAME, spec1.getName().getPreferredName());
+        SearchPlugin.SearchExtSpec<?> spec2 = searchExts.get(1);
+        assertEquals(MLInferenceRequestParametersExtBuilder.NAME, spec2.getName().getPreferredName());
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
@@ -35,6 +35,9 @@ import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.repackage.com.google.common.collect.ImmutableMap;
+import org.opensearch.ml.searchext.MLInferenceRequestParameters;
+import org.opensearch.ml.searchext.MLInferenceRequestParametersExtBuilder;
+import org.opensearch.plugins.SearchPlugin;
 import org.opensearch.search.SearchModule;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.pipeline.PipelineProcessingContext;
@@ -48,15 +51,27 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
     @Mock
     private PipelineProcessingContext requestContext;
 
-    static public final NamedXContentRegistry TEST_XCONTENT_REGISTRY_FOR_QUERY = new NamedXContentRegistry(
-        new SearchModule(Settings.EMPTY, List.of()).getNamedXContents()
-    );
+    static public NamedXContentRegistry TEST_XCONTENT_REGISTRY_FOR_QUERY;
     private static final String PROCESSOR_TAG = "inference";
     private static final String DESCRIPTION = "inference_test";
 
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
+
+        TEST_XCONTENT_REGISTRY_FOR_QUERY = new NamedXContentRegistry(new SearchModule(Settings.EMPTY, List.of(new SearchPlugin() {
+            @Override
+            public List<SearchExtSpec<?>> getSearchExts() {
+                return List
+                    .of(
+                        new SearchExtSpec<>(
+                            MLInferenceRequestParametersExtBuilder.NAME,
+                            MLInferenceRequestParametersExtBuilder::new,
+                            parser -> MLInferenceRequestParametersExtBuilder.parse(parser)
+                        )
+                    );
+            }
+        })).getNamedXContents());
     }
 
     /**
@@ -183,7 +198,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
 
             @Override
             public void onFailure(Exception e) {
-                throw new RuntimeException("Failed in executing processRequestAsync.");
+                throw new RuntimeException("Failed in executing processRequestAsync." + e.getMessage());
             }
         };
 
@@ -240,7 +255,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
 
             @Override
             public void onFailure(Exception e) {
-                throw new RuntimeException("Failed in executing processRequestAsync.");
+                throw new RuntimeException("Failed in executing processRequestAsync." + e.getMessage());
             }
         };
 
@@ -1017,6 +1032,139 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
                 throw new RuntimeException("error handling not properly");
             }
         };
+        requestProcessor.processRequestAsync(request, requestContext, Listener);
+
+    }
+
+    /**
+     * Tests the successful rewriting of a single string in a term query based on the model output.
+     *
+     * @throws Exception if an error occurs during the test
+     */
+    public void testExecute_rewriteTermQueryWriteToExtensionSuccess() throws Exception {
+
+        /**
+         * example term query: {"query":{"term":{"text":{"value":"foo","boost":1.0}}}}
+         */
+        String modelInputField = "inputs";
+        String originalQueryField = "query.term.text.value";
+        String newQueryField = "$.ext.ml_inference.llm_response";
+        String modelOutputField = "response";
+        MLInferenceSearchRequestProcessor requestProcessor = getMlInferenceSearchRequestProcessor(
+            null,
+            modelInputField,
+            originalQueryField,
+            newQueryField,
+            modelOutputField,
+            false,
+            false
+        );
+        ModelTensor modelTensor = ModelTensor.builder().dataAsMap(ImmutableMap.of("response", "eng")).build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        QueryBuilder incomingQuery = new TermQueryBuilder("text", "foo");
+        SearchSourceBuilder source = new SearchSourceBuilder().query(incomingQuery);
+        SearchRequest request = new SearchRequest().source(source);
+
+        Map<String, Object> llmResponse = new HashMap<>();
+        llmResponse.put("llm_response", "eng");
+        MLInferenceRequestParameters requestParameters = new MLInferenceRequestParameters(llmResponse);
+        MLInferenceRequestParametersExtBuilder mlInferenceExtBuilder = new MLInferenceRequestParametersExtBuilder();
+        mlInferenceExtBuilder.setRequestParameters(requestParameters);
+        SearchSourceBuilder expectedSource = new SearchSourceBuilder().query(incomingQuery).ext(List.of(mlInferenceExtBuilder));
+        SearchRequest expectRequest = new SearchRequest().source(expectedSource);
+
+        ActionListener<SearchRequest> Listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchRequest newSearchRequest) {
+                assertEquals(incomingQuery, newSearchRequest.source().query());
+                assertEquals(expectRequest.source().toString(), newSearchRequest.source().toString());
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException("Failed in executing processRequestAsync." + e.getMessage());
+            }
+        };
+
+        requestProcessor.processRequestAsync(request, requestContext, Listener);
+
+    }
+
+    /**
+     * Tests the successful rewriting of a single string in a term query based on the model output.
+     *
+     * @throws Exception if an error occurs during the test
+     */
+    public void testExecute_rewriteTermQueryReadAndWriteToExtensionSuccess() throws Exception {
+
+        /**
+         * example term query: {"query":{"term":{"text":{"value":"foo","boost":1.0}}}}
+         */
+        String modelInputField = "inputs";
+        String originalQueryField = "ext.ml_inference.question";
+        String newQueryField = "ext.ml_inference.llm_response";
+        String modelOutputField = "response";
+        MLInferenceSearchRequestProcessor requestProcessor = getMlInferenceSearchRequestProcessor(
+            null,
+            modelInputField,
+            originalQueryField,
+            newQueryField,
+            modelOutputField,
+            false,
+            false
+        );
+        ModelTensor modelTensor = ModelTensor.builder().dataAsMap(ImmutableMap.of("response", "eng")).build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        QueryBuilder incomingQuery = new TermQueryBuilder("text", "foo");
+
+        Map<String, Object> llmQuestion = new HashMap<>();
+        llmQuestion.put("question", "what language is this text in?");
+        MLInferenceRequestParameters requestParameters = new MLInferenceRequestParameters(llmQuestion);
+        MLInferenceRequestParametersExtBuilder mlInferenceExtBuilder = new MLInferenceRequestParametersExtBuilder();
+        mlInferenceExtBuilder.setRequestParameters(requestParameters);
+        SearchSourceBuilder source = new SearchSourceBuilder().query(incomingQuery).ext(List.of(mlInferenceExtBuilder));
+
+        SearchRequest request = new SearchRequest().source(source);
+
+        // expecting new request with ml inference search extensions
+        Map<String, Object> params = new HashMap<>();
+        params.put("question", "what language is this text in?");
+        params.put("llm_response", "eng");
+        MLInferenceRequestParameters expectedRequestParameters = new MLInferenceRequestParameters(params);
+        MLInferenceRequestParametersExtBuilder expectedMlInferenceExtBuilder = new MLInferenceRequestParametersExtBuilder();
+        expectedMlInferenceExtBuilder.setRequestParameters(expectedRequestParameters);
+        SearchSourceBuilder expectedSource = new SearchSourceBuilder().query(incomingQuery).ext(List.of(expectedMlInferenceExtBuilder));
+        SearchRequest expectRequest = new SearchRequest().source(expectedSource);
+
+        ActionListener<SearchRequest> Listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchRequest newSearchRequest) {
+                assertEquals(incomingQuery, newSearchRequest.source().query());
+                assertEquals(expectRequest.toString(), newSearchRequest.toString());
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException("Failed in executing processRequestAsync." + e.getMessage());
+            }
+        };
+
         requestProcessor.processRequestAsync(request, requestContext, Listener);
 
     }

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
@@ -66,6 +66,8 @@ import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 import org.opensearch.ml.repackage.com.google.common.collect.ImmutableMap;
+import org.opensearch.ml.searchext.MLInferenceRequestParameters;
+import org.opensearch.ml.searchext.MLInferenceRequestParametersExtBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.SearchModule;
@@ -518,7 +520,84 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             toJson(inputDataSet.getParameters()),
             "{\"text_docs\":\"[\\\"value 0\\\",\\\"value 1\\\",\\\"value 2\\\",\\\"value 3\\\",\\\"value 4\\\"]\"}"
         );
+    }
 
+    /**
+     * Tests the successful processing of a response with a single pair of input and output mappings.
+     * read the query text into model config
+     * with query extensions
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void testProcessResponseSuccessReadQueryTextFromExt() throws Exception {
+        String modelInputField = "text_docs";
+        String originalDocumentField = "text";
+        String newDocumentField = "similarity_score";
+        String modelOutputField = "response";
+        List<Map<String, String>> inputMap = new ArrayList<>();
+        Map<String, String> input = new HashMap<>();
+        input.put(modelInputField, originalDocumentField);
+        input.put("query_text", "_request.ext.ml_inference.query_text");
+        inputMap.add(input);
+        List<Map<String, String>> outputMap = new ArrayList<>();
+        Map<String, String> output = new HashMap<>();
+        output.put(newDocumentField, modelOutputField);
+        outputMap.add(output);
+        Map<String, String> modelConfig = new HashMap<>();
+        MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
+            "model1",
+            inputMap,
+            outputMap,
+            modelConfig,
+            DEFAULT_MAX_PREDICTION_TASKS,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            false,
+            "text_similarity",
+            false,
+            false,
+            false,
+            "{ \"query_text\": \"${input_map.query_text}\", \"text_docs\":${input_map.text_docs}}",
+            client,
+            TEST_XCONTENT_REGISTRY_FOR_QUERY,
+            false
+        );
+        assertEquals(responseProcessor.getType(), TYPE);
+        SearchRequest request = getSearchRequestWithExtension("query_text", "query.term.text.value");
+        String fieldName = "text";
+        SearchResponse response = getSearchResponse(5, true, fieldName);
+
+        ModelTensor modelTensor = ModelTensor
+            .builder()
+            .dataAsMap(ImmutableMap.of("response", Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)))
+            .build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        ActionListener<SearchResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse newSearchResponse) {
+                assertEquals(newSearchResponse.getHits().getHits().length, 5);
+                assertEquals(newSearchResponse.getHits().getHits()[0].getSourceAsMap().get(newDocumentField), 0.0);
+                assertEquals(newSearchResponse.getHits().getHits()[1].getSourceAsMap().get(newDocumentField), 1.0);
+                assertEquals(newSearchResponse.getHits().getHits()[2].getSourceAsMap().get(newDocumentField), 2.0);
+                assertEquals(newSearchResponse.getHits().getHits()[3].getSourceAsMap().get(newDocumentField), 3.0);
+                assertEquals(newSearchResponse.getHits().getHits()[4].getSourceAsMap().get(newDocumentField), 4.0);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        responseProcessor.processResponseAsync(request, response, responseContext, listener);
     }
 
     /**
@@ -3928,6 +4007,22 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         QueryBuilder incomingQuery = new TermQueryBuilder("text", "foo");
         SearchSourceBuilder source = new SearchSourceBuilder().query(incomingQuery).size(5).sort("text");
         SearchRequest request = new SearchRequest().source(source);
+        return request;
+    }
+
+    private static SearchRequest getSearchRequestWithExtension(String queryText, String queryPath) {
+        QueryBuilder incomingQuery = new TermQueryBuilder("text", "foo");
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(queryText, queryPath);
+        MLInferenceRequestParameters requestParameters = new MLInferenceRequestParameters(params);
+
+        MLInferenceRequestParametersExtBuilder extBuilder = new MLInferenceRequestParametersExtBuilder();
+        extBuilder.setRequestParameters(requestParameters);
+        SearchSourceBuilder source = new SearchSourceBuilder().query(incomingQuery).ext(List.of(extBuilder));
+        ;
+        SearchRequest request = new SearchRequest().source(source);
+
         return request;
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLInferenceSearchResponseProcessorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLInferenceSearchResponseProcessorIT.java
@@ -17,6 +17,7 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.ml.common.FunctionName;
@@ -256,6 +257,7 @@ public class RestMLInferenceSearchResponseProcessorIT extends MLCommonsRestTestC
      *
      * @throws Exception if any error occurs during the test
      */
+    @Test
     public void testMLInferenceProcessorRemoteModelStringField() throws Exception {
         // Skip test if key is null
         if (AWS_ACCESS_KEY_ID == null) {

--- a/plugin/src/test/java/org/opensearch/ml/searchext/MLInferenceRequestParametersExtBuilderTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/searchext/MLInferenceRequestParametersExtBuilderTests.java
@@ -1,0 +1,306 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.ml.searchext;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.searchext.MLInferenceRequestParameters.ML_INFERENCE_FIELD;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentHelper;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.plugins.SearchPlugin;
+import org.opensearch.search.SearchModule;
+import org.opensearch.searchpipelines.questionanswering.generative.ext.GenerativeQAParamExtBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class MLInferenceRequestParametersExtBuilderTests extends OpenSearchTestCase {
+
+    public NamedXContentRegistry xContentRegistry = new NamedXContentRegistry(new SearchModule(Settings.EMPTY, List.of(new SearchPlugin() {
+        @Override
+        public List<SearchPlugin.SearchExtSpec<?>> getSearchExts() {
+            return List
+                .of(
+                    new SearchPlugin.SearchExtSpec<>(
+                        MLInferenceRequestParametersExtBuilder.NAME,
+                        MLInferenceRequestParametersExtBuilder::new,
+                        parser -> MLInferenceRequestParametersExtBuilder.parse(parser)
+                    )
+                );
+        }
+    })).getNamedXContents());
+
+    public void testParse() throws IOException {
+        String requiredJsonStr = "{\"llm_question\":\"this is test llm question\"}";
+
+        XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry, null, requiredJsonStr);
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        MLInferenceRequestParametersExtBuilder builder = MLInferenceRequestParametersExtBuilder.parse(parser);
+        assertNotNull(builder);
+        assertNotNull(builder.getRequestParameters());
+        MLInferenceRequestParameters params = builder.getRequestParameters();
+        Assert.assertEquals("this is test llm question", params.getParams().get("llm_question"));
+    }
+
+    @Test
+    public void testMultipleParameters() throws IOException {
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_text", "foo");
+        params.put("model_id", "model1");
+        params.put("max_tokens", 100);
+        MLInferenceRequestParameters requestParameters = new MLInferenceRequestParameters(params);
+        MLInferenceRequestParametersExtBuilder builder = new MLInferenceRequestParametersExtBuilder();
+        builder.setRequestParameters(requestParameters);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        builder.writeTo(out);
+
+        MLInferenceRequestParametersExtBuilder deserialized = new MLInferenceRequestParametersExtBuilder(out.bytes().streamInput());
+        assertEquals(builder, deserialized);
+        assertEquals(params, deserialized.getRequestParameters().getParams());
+    }
+
+    @Test
+    public void testParseWithEmptyObject() throws IOException {
+        String emptyJsonStr = "{}";
+        XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry, null, emptyJsonStr);
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        MLInferenceRequestParametersExtBuilder builder = MLInferenceRequestParametersExtBuilder.parse(parser);
+        assertNotNull(builder);
+        assertNotNull(builder.getRequestParameters());
+        assertTrue(builder.getRequestParameters().getParams().isEmpty());
+    }
+
+    @Test
+    public void testWriteableName() throws IOException {
+        MLInferenceRequestParametersExtBuilder builder = new MLInferenceRequestParametersExtBuilder();
+        assertEquals(builder.getWriteableName(), ML_INFERENCE_FIELD);
+    }
+
+    @Test
+    public void testEquals() throws IOException {
+        MLInferenceRequestParametersExtBuilder MlInferenceParamBuilder = new MLInferenceRequestParametersExtBuilder();
+        GenerativeQAParamExtBuilder qaParamExtBuilder = new GenerativeQAParamExtBuilder();
+        assertEquals(MlInferenceParamBuilder.equals(qaParamExtBuilder), false);
+        assertEquals(MlInferenceParamBuilder.equals(null), false);
+    }
+
+    @Test
+    public void testMLInferenceRequestParametersEqualsWithNull() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_text", "foo");
+        MLInferenceRequestParameters parameters = new MLInferenceRequestParameters(params);
+        assertFalse(parameters.equals(null));
+    }
+
+    @Test
+    public void testMLInferenceRequestParametersEqualsWithDifferentClass() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_text", "foo");
+        MLInferenceRequestParameters parameters = new MLInferenceRequestParameters(params);
+        assertFalse(parameters.equals("not a MLInferenceRequestParameters object"));
+    }
+
+    @Test
+    public void testMLInferenceRequestParametersToXContentWithEmptyParams() throws IOException {
+        MLInferenceRequestParameters parameters = new MLInferenceRequestParameters(new HashMap<>());
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        parameters.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        assertEquals("{\"ml_inference\":{}}", builder.toString());
+    }
+
+    @Test
+    public void testMLInferenceRequestParametersExtBuilderToXContentWithEmptyParams() throws IOException {
+        MLInferenceRequestParameters parameters = new MLInferenceRequestParameters(new HashMap<>());
+        MLInferenceRequestParametersExtBuilder builder = new MLInferenceRequestParametersExtBuilder();
+        builder.setRequestParameters(parameters);
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        builder.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+        assertEquals("{\"ml_inference\":{}}", xContentBuilder.toString());
+    }
+
+    @Test
+    public void testMLInferenceRequestParametersStreamRoundTripWithNullParams() throws IOException {
+        MLInferenceRequestParameters original = new MLInferenceRequestParameters();
+        original.setParams(null);
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        MLInferenceRequestParameters deserialized = new MLInferenceRequestParameters(out.bytes().streamInput());
+        assertNull(deserialized.getParams());
+    }
+
+    @Test
+    public void testMLInferenceRequestParametersExtBuilderStreamRoundTripWithNullParams() throws IOException {
+        MLInferenceRequestParametersExtBuilder original = new MLInferenceRequestParametersExtBuilder();
+        original.setRequestParameters(null);
+        BytesStreamOutput out = new BytesStreamOutput();
+        assertThrows(NullPointerException.class, () -> original.writeTo(out));
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        Map<String, Object> params1 = new HashMap<>();
+        params1.put("query_text", "foo");
+        MLInferenceRequestParameters requestParameters1 = new MLInferenceRequestParameters(params1);
+        MLInferenceRequestParametersExtBuilder builder1 = new MLInferenceRequestParametersExtBuilder();
+        builder1.setRequestParameters(requestParameters1);
+
+        Map<String, Object> params2 = new HashMap<>();
+        params2.put("query_text", "foo");
+        MLInferenceRequestParameters requestParameters2 = new MLInferenceRequestParameters(params2);
+        MLInferenceRequestParametersExtBuilder builder2 = new MLInferenceRequestParametersExtBuilder();
+        builder2.setRequestParameters(requestParameters2);
+
+        assertEquals(builder1, builder2);
+        assertEquals(builder1.hashCode(), builder2.hashCode());
+
+        Map<String, Object> params3 = new HashMap<>();
+        params3.put("query_text", "bar");
+        MLInferenceRequestParameters requestParameters3 = new MLInferenceRequestParameters(params3);
+        MLInferenceRequestParametersExtBuilder builder3 = new MLInferenceRequestParametersExtBuilder();
+        builder3.setRequestParameters(requestParameters3);
+
+        assertNotEquals(builder1, builder3);
+        assertNotEquals(builder1.hashCode(), builder3.hashCode());
+    }
+
+    @Test
+    public void testXContentRoundTrip() throws IOException {
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_text", "foo");
+        MLInferenceRequestParameters requestParameters = new MLInferenceRequestParameters(params);
+        MLInferenceRequestParametersExtBuilder mlInferenceExtBuilder = new MLInferenceRequestParametersExtBuilder();
+        mlInferenceExtBuilder.setRequestParameters(requestParameters);
+
+        XContentType xContentType = randomFrom(XContentType.values());
+        BytesReference serialized = XContentHelper.toXContent(mlInferenceExtBuilder, xContentType, true);
+
+        XContentParser parser = createParser(xContentType.xContent(), serialized);
+
+        MLInferenceRequestParametersExtBuilder deserialized = MLInferenceRequestParametersExtBuilder.parse(parser);
+
+        assertEquals(deserialized.getRequestParameters().getParams().get(ML_INFERENCE_FIELD), params);
+
+    }
+
+    @Test
+    public void testStreamRoundTrip() throws IOException {
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_text", "foo");
+        MLInferenceRequestParameters requestParameters = new MLInferenceRequestParameters();
+        requestParameters.setParams(params);
+        MLInferenceRequestParametersExtBuilder mlInferenceExtBuilder = new MLInferenceRequestParametersExtBuilder();
+        mlInferenceExtBuilder.setRequestParameters(requestParameters);
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        mlInferenceExtBuilder.writeTo(bytesStreamOutput);
+
+        MLInferenceRequestParametersExtBuilder deserialized = new MLInferenceRequestParametersExtBuilder(
+            bytesStreamOutput.bytes().streamInput()
+        );
+        assertEquals(mlInferenceExtBuilder, deserialized);
+    }
+
+    @Test
+    public void testNullRequestParameters() throws IOException {
+        MLInferenceRequestParametersExtBuilder builder = new MLInferenceRequestParametersExtBuilder();
+        assertNull(builder.getRequestParameters());
+
+        BytesStreamOutput out = new BytesStreamOutput();
+
+        // Expect NullPointerException when writing null requestParameters
+        assertThrows(NullPointerException.class, () -> builder.writeTo(out));
+
+        // Test that we can still create a new builder with null requestParameters
+        MLInferenceRequestParametersExtBuilder newBuilder = new MLInferenceRequestParametersExtBuilder();
+        assertNull(newBuilder.getRequestParameters());
+    }
+
+    @Test
+    public void testEmptyRequestParameters() throws IOException {
+        MLInferenceRequestParameters emptyParams = new MLInferenceRequestParameters(new HashMap<>());
+        MLInferenceRequestParametersExtBuilder builder = new MLInferenceRequestParametersExtBuilder();
+        builder.setRequestParameters(emptyParams);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        builder.writeTo(out);
+
+        MLInferenceRequestParametersExtBuilder deserialized = new MLInferenceRequestParametersExtBuilder(out.bytes().streamInput());
+        assertNotNull(deserialized.getRequestParameters());
+        assertTrue(deserialized.getRequestParameters().getParams().isEmpty());
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_text", "foo");
+        MLInferenceRequestParameters requestParameters = new MLInferenceRequestParameters(params);
+        MLInferenceRequestParametersExtBuilder builder = new MLInferenceRequestParametersExtBuilder();
+        builder.setRequestParameters(requestParameters);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        builder.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+
+        String expected = "{\"ml_inference\":{\"query_text\":\"foo\"}}";
+        assertEquals(expected, xContentBuilder.toString());
+    }
+
+    @Test
+    public void testMLInferenceRequestParametersEqualsAndHashCode() {
+        Map<String, Object> params1 = new HashMap<>();
+        params1.put("query_text", "foo");
+        MLInferenceRequestParameters requestParameters1 = new MLInferenceRequestParameters(params1);
+
+        Map<String, Object> params2 = new HashMap<>();
+        params2.put("query_text", "foo");
+        MLInferenceRequestParameters requestParameters2 = new MLInferenceRequestParameters(params2);
+
+        Map<String, Object> params3 = new HashMap<>();
+        params3.put("query_text", "bar");
+        MLInferenceRequestParameters requestParameters3 = new MLInferenceRequestParameters(params3);
+
+        assertEquals(requestParameters1, requestParameters2);
+        assertEquals(requestParameters1.hashCode(), requestParameters2.hashCode());
+        assertNotEquals(requestParameters1, requestParameters3);
+        assertNotEquals(requestParameters1.hashCode(), requestParameters3.hashCode());
+    }
+
+    @Test
+    public void testMLInferenceRequestParametersToXContent() throws IOException {
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_text", "foo");
+        MLInferenceRequestParameters requestParameters = new MLInferenceRequestParameters(params);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        requestParameters.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+
+        String expected = "{\"ml_inference\":{\"query_text\":\"foo\"}}";
+        assertEquals(expected, xContentBuilder.toString());
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtilTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtilTests.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ *
+ */
+package org.opensearch.ml.searchext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+public class MLInferenceRequestParametersUtilTests {
+    @Test
+    public void testExtractParameters() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_text", "foo");
+        MLInferenceRequestParameters expected = new MLInferenceRequestParameters(params);
+        MLInferenceRequestParametersExtBuilder extBuilder = new MLInferenceRequestParametersExtBuilder();
+        extBuilder.setRequestParameters(expected);
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource().ext(List.of(extBuilder));
+        SearchRequest request = new SearchRequest("my_index").source(sourceBuilder);
+        MLInferenceRequestParameters actual = MLInferenceRequestParametersUtil.getMLInferenceRequestParameters(request);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testExtractParametersWithNullSource() {
+        SearchRequest request = new SearchRequest();
+        MLInferenceRequestParameters result = MLInferenceRequestParametersUtil.getMLInferenceRequestParameters(request);
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractParametersWithEmptyExt() {
+        SearchRequest request = new SearchRequest();
+        request.source(new SearchSourceBuilder());
+        MLInferenceRequestParameters result = MLInferenceRequestParametersUtil.getMLInferenceRequestParameters(request);
+        assertNull(result);
+    }
+
+}


### PR DESCRIPTION
### Description
Introduce Ml Inference Search Request Extension, this is adding ml_inference search extension during search request/query phase,

For the search response side, I already introduced a  `ml_inference` search response extension in earlier PR released in 2.18.  [Support ML Inference Search Processor Writing to Search Extension](https://github.com/opensearch-project/ml-commons/commit/09aa6ea0b108c29ff074292278370c2f5e772688)

### Related Issues
 https://github.com/opensearch-project/ml-commons/issues/3286
https://github.com/opensearch-project/ml-commons/issues/3054

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
