### PR TITLE
Fix remote model with embedding input issue

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/utils/ModelInterfaceUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/ModelInterfaceUtils.java
@@ -52,10 +52,7 @@ public class ModelInterfaceUtils {
         + "                \"texts\"\n"
         + "            ]\n"
         + "        }\n"
-        + "    },\n"
-        + "    \"required\": [\n"
-        + "        \"parameters\"\n"
-        + "    ]\n"
+        + "    }\n"
         + "}";
 
     private static final String TITAN_TEXT_EMBEDDING_MODEL_INTERFACE_INPUT = "{\n"
@@ -72,10 +69,7 @@ public class ModelInterfaceUtils {
         + "                \"inputText\"\n"
         + "            ]\n"
         + "        }\n"
-        + "    },\n"
-        + "    \"required\": [\n"
-        + "        \"parameters\"\n"
-        + "    ]\n"
+        + "    }\n"
         + "}";
 
     private static final String TITAN_MULTI_MODAL_EMBEDDING_MODEL_INTERFACE_INPUT = "{\n"
@@ -92,10 +86,7 @@ public class ModelInterfaceUtils {
         + "                }\n"
         + "            }\n"
         + "        }\n"
-        + "    },\n"
-        + "    \"required\": [\n"
-        + "        \"parameters\"\n"
-        + "    ]\n"
+        + "    }\n"
         + "}";
 
     private static final String AMAZON_COMPREHEND_DETECTDOMAINANTLANGUAGE_API_INTERFACE_INPUT = "{\n"

--- a/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
@@ -6,6 +6,9 @@
 package org.opensearch.ml.utils;
 
 import static java.util.Collections.emptyMap;
+import static org.opensearch.ml.common.utils.ModelInterfaceUtils.BEDROCK_COHERE_EMBED_ENGLISH_V3_MODEL_INTERFACE;
+import static org.opensearch.ml.common.utils.ModelInterfaceUtils.BEDROCK_TITAN_EMBED_MULTI_MODAL_V1_MODEL_INTERFACE;
+import static org.opensearch.ml.common.utils.ModelInterfaceUtils.BEDROCK_TITAN_EMBED_TEXT_V1_MODEL_INTERFACE;
 import static org.opensearch.ml.utils.TestHelper.ML_ROLE;
 
 import java.io.IOException;
@@ -68,139 +71,43 @@ public class MLNodeUtilsTests extends OpenSearchTestCase {
 
     @Test
     public void testValidateEmbeddingInputWithGeneralEmbeddingRemoteSchema() throws IOException {
-        String schema = "{\n"
-            + "    \"type\": \"object\",\n"
-            + "    \"properties\": {\n"
-            + "        \"parameters\": {\n"
-            + "            \"type\": \"object\",\n"
-            + "            \"properties\": {\n"
-            + "                \"texts\": {\n"
-            + "                    \"type\": \"array\",\n"
-            + "                    \"items\": {\n"
-            + "                        \"type\": \"string\"\n"
-            + "                    }\n"
-            + "                }\n"
-            + "            },\n"
-            + "            \"required\": [\n"
-            + "                \"texts\"\n"
-            + "            ]\n"
-            + "        }\n"
-            + "    }\n"
-            + "}";
+        String schema = BEDROCK_COHERE_EMBED_ENGLISH_V3_MODEL_INTERFACE.get("input");
         String json = "{\"text_docs\":[ \"today is sunny\", \"today is sunny\"]}";
         MLNodeUtils.validateSchema(schema, json);
     }
 
     @Test
     public void testValidateRemoteInputWithGeneralEmbeddingRemoteSchema() throws IOException {
-        String schema = "{\n"
-            + "    \"type\": \"object\",\n"
-            + "    \"properties\": {\n"
-            + "        \"parameters\": {\n"
-            + "            \"type\": \"object\",\n"
-            + "            \"properties\": {\n"
-            + "                \"texts\": {\n"
-            + "                    \"type\": \"array\",\n"
-            + "                    \"items\": {\n"
-            + "                        \"type\": \"string\"\n"
-            + "                    }\n"
-            + "                }\n"
-            + "            },\n"
-            + "            \"required\": [\n"
-            + "                \"texts\"\n"
-            + "            ]\n"
-            + "        }\n"
-            + "    }\n"
-            + "}";
+        String schema = BEDROCK_COHERE_EMBED_ENGLISH_V3_MODEL_INTERFACE.get("input");
         String json = "{\"parameters\": {\"texts\": [\"Hello\",\"world\"]}}";
         MLNodeUtils.validateSchema(schema, json);
     }
 
     @Test
     public void testValidateEmbeddingInputWithTitanTextRemoteSchema() throws IOException {
-        String schema = "{\n"
-            + "    \"type\": \"object\",\n"
-            + "    \"properties\": {\n"
-            + "        \"parameters\": {\n"
-            + "            \"type\": \"object\",\n"
-            + "            \"properties\": {\n"
-            + "                \"inputText\": {\n"
-            + "                    \"type\": \"string\"\n"
-            + "                }\n"
-            + "            },\n"
-            + "            \"required\": [\n"
-            + "                \"inputText\"\n"
-            + "            ]\n"
-            + "        }\n"
-            + "    }\n"
-            + "}";
+        String schema = BEDROCK_TITAN_EMBED_TEXT_V1_MODEL_INTERFACE.get("input");
         String json = "{\"text_docs\":[ \"today is sunny\", \"today is sunny\"]}";
         MLNodeUtils.validateSchema(schema, json);
     }
 
     @Test
     public void testValidateRemoteInputWithTitanTextRemoteSchema() throws IOException {
-        String schema = "{\n"
-            + "    \"type\": \"object\",\n"
-            + "    \"properties\": {\n"
-            + "        \"parameters\": {\n"
-            + "            \"type\": \"object\",\n"
-            + "            \"properties\": {\n"
-            + "                \"inputText\": {\n"
-            + "                    \"type\": \"string\"\n"
-            + "                }\n"
-            + "            },\n"
-            + "            \"required\": [\n"
-            + "                \"inputText\"\n"
-            + "            ]\n"
-            + "        }\n"
-            + "    }\n"
-            + "}";
+        String schema = BEDROCK_TITAN_EMBED_TEXT_V1_MODEL_INTERFACE.get("input");
         String json = "{\"parameters\": {\"inputText\": \"Say this is a test\"}}";
         MLNodeUtils.validateSchema(schema, json);
     }
 
     @Test
-    public void testValidateEmbeddingInputWithTitanImageRemoteSchema() throws IOException {
-        String schema = "{\n"
-            + "    \"type\": \"object\",\n"
-            + "    \"properties\": {\n"
-            + "        \"parameters\": {\n"
-            + "            \"type\": \"object\",\n"
-            + "            \"properties\": {\n"
-            + "                \"inputText\": {\n"
-            + "                    \"type\": \"string\"\n"
-            + "                },\n"
-            + "                \"inputImage\": {\n"
-            + "                    \"type\": \"string\"\n"
-            + "                }\n"
-            + "            }\n"
-            + "        }\n"
-            + "    }\n"
-            + "}";
+    public void testValidateEmbeddingInputWithTitanMultiModalRemoteSchema() throws IOException {
+        String schema = BEDROCK_TITAN_EMBED_MULTI_MODAL_V1_MODEL_INTERFACE.get("input");
         String json = "{\"text_docs\":[ \"today is sunny\", \"today is sunny\"]}";
         MLNodeUtils.validateSchema(schema, json);
     }
 
     @Test
-    public void testValidateRemoteInputWithTitanImageRemoteSchema() throws IOException {
-        String schema = "{\n"
-            + "    \"type\": \"object\",\n"
-            + "    \"properties\": {\n"
-            + "        \"parameters\": {\n"
-            + "            \"type\": \"object\",\n"
-            + "            \"properties\": {\n"
-            + "                \"inputText\": {\n"
-            + "                    \"type\": \"string\"\n"
-            + "                },\n"
-            + "                \"inputImage\": {\n"
-            + "                    \"type\": \"string\"\n"
-            + "                }\n"
-            + "            }\n"
-            + "        }\n"
-            + "    }\n"
-            + "}";
-        String json = "{{\n"
+    public void testValidateRemoteInputWithTitanMultiModalRemoteSchema() throws IOException {
+        String schema = BEDROCK_TITAN_EMBED_MULTI_MODAL_V1_MODEL_INTERFACE.get("input");
+        String json = "{\n"
             + "  \"parameters\": {\n"
             + "    \"inputText\": \"Say this is a test\",\n"
             + "    \"inputImage\": \"/9jk=\"\n"

--- a/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
@@ -67,7 +67,7 @@ public class MLNodeUtilsTests extends OpenSearchTestCase {
     }
 
     @Test
-    public void testValidateEmbeddingInputWithRemoteSchema() throws IOException {
+    public void testValidateEmbeddingInputWithGeneralEmbeddingRemoteSchema() throws IOException {
         String schema = "{\n"
             + "    \"type\": \"object\",\n"
             + "    \"properties\": {\n"
@@ -88,6 +88,124 @@ public class MLNodeUtilsTests extends OpenSearchTestCase {
             + "    }\n"
             + "}";
         String json = "{\"text_docs\":[ \"today is sunny\", \"today is sunny\"]}";
+        MLNodeUtils.validateSchema(schema, json);
+    }
+
+    @Test
+    public void testValidateRemoteInputWithGeneralEmbeddingRemoteSchema() throws IOException {
+        String schema = "{\n"
+            + "    \"type\": \"object\",\n"
+            + "    \"properties\": {\n"
+            + "        \"parameters\": {\n"
+            + "            \"type\": \"object\",\n"
+            + "            \"properties\": {\n"
+            + "                \"texts\": {\n"
+            + "                    \"type\": \"array\",\n"
+            + "                    \"items\": {\n"
+            + "                        \"type\": \"string\"\n"
+            + "                    }\n"
+            + "                }\n"
+            + "            },\n"
+            + "            \"required\": [\n"
+            + "                \"texts\"\n"
+            + "            ]\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+        String json = "{\"parameters\": {\"texts\": [\"Hello\",\"world\"]}}";
+        MLNodeUtils.validateSchema(schema, json);
+    }
+
+    @Test
+    public void testValidateEmbeddingInputWithTitanTextRemoteSchema() throws IOException {
+        String schema = "{\n"
+            + "    \"type\": \"object\",\n"
+            + "    \"properties\": {\n"
+            + "        \"parameters\": {\n"
+            + "            \"type\": \"object\",\n"
+            + "            \"properties\": {\n"
+            + "                \"inputText\": {\n"
+            + "                    \"type\": \"string\"\n"
+            + "                }\n"
+            + "            },\n"
+            + "            \"required\": [\n"
+            + "                \"inputText\"\n"
+            + "            ]\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+        String json = "{\"text_docs\":[ \"today is sunny\", \"today is sunny\"]}";
+        MLNodeUtils.validateSchema(schema, json);
+    }
+
+    @Test
+    public void testValidateRemoteInputWithTitanTextRemoteSchema() throws IOException {
+        String schema = "{\n"
+            + "    \"type\": \"object\",\n"
+            + "    \"properties\": {\n"
+            + "        \"parameters\": {\n"
+            + "            \"type\": \"object\",\n"
+            + "            \"properties\": {\n"
+            + "                \"inputText\": {\n"
+            + "                    \"type\": \"string\"\n"
+            + "                }\n"
+            + "            },\n"
+            + "            \"required\": [\n"
+            + "                \"inputText\"\n"
+            + "            ]\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+        String json = "{\"parameters\": {\"inputText\": \"Say this is a test\"}}";
+        MLNodeUtils.validateSchema(schema, json);
+    }
+
+    @Test
+    public void testValidateEmbeddingInputWithTitanImageRemoteSchema() throws IOException {
+        String schema = "{\n"
+            + "    \"type\": \"object\",\n"
+            + "    \"properties\": {\n"
+            + "        \"parameters\": {\n"
+            + "            \"type\": \"object\",\n"
+            + "            \"properties\": {\n"
+            + "                \"inputText\": {\n"
+            + "                    \"type\": \"string\"\n"
+            + "                },\n"
+            + "                \"inputImage\": {\n"
+            + "                    \"type\": \"string\"\n"
+            + "                }\n"
+            + "            }\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+        String json = "{\"text_docs\":[ \"today is sunny\", \"today is sunny\"]}";
+        MLNodeUtils.validateSchema(schema, json);
+    }
+
+    @Test
+    public void testValidateRemoteInputWithTitanImageRemoteSchema() throws IOException {
+        String schema = "{\n"
+            + "    \"type\": \"object\",\n"
+            + "    \"properties\": {\n"
+            + "        \"parameters\": {\n"
+            + "            \"type\": \"object\",\n"
+            + "            \"properties\": {\n"
+            + "                \"inputText\": {\n"
+            + "                    \"type\": \"string\"\n"
+            + "                },\n"
+            + "                \"inputImage\": {\n"
+            + "                    \"type\": \"string\"\n"
+            + "                }\n"
+            + "            }\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+        String json = "{{\n"
+            + "  \"parameters\": {\n"
+            + "    \"inputText\": \"Say this is a test\",\n"
+            + "    \"inputImage\": \"/9jk=\"\n"
+            + "  }\n"
+            + "}";
         MLNodeUtils.validateSchema(schema, json);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
@@ -69,24 +69,24 @@ public class MLNodeUtilsTests extends OpenSearchTestCase {
     @Test
     public void testValidateEmbeddingInputWithRemoteSchema() throws IOException {
         String schema = "{\n"
-                + "    \"type\": \"object\",\n"
-                + "    \"properties\": {\n"
-                + "        \"parameters\": {\n"
-                + "            \"type\": \"object\",\n"
-                + "            \"properties\": {\n"
-                + "                \"texts\": {\n"
-                + "                    \"type\": \"array\",\n"
-                + "                    \"items\": {\n"
-                + "                        \"type\": \"string\"\n"
-                + "                    }\n"
-                + "                }\n"
-                + "            },\n"
-                + "            \"required\": [\n"
-                + "                \"texts\"\n"
-                + "            ]\n"
-                + "        }\n"
-                + "    }\n"
-                + "}";
+            + "    \"type\": \"object\",\n"
+            + "    \"properties\": {\n"
+            + "        \"parameters\": {\n"
+            + "            \"type\": \"object\",\n"
+            + "            \"properties\": {\n"
+            + "                \"texts\": {\n"
+            + "                    \"type\": \"array\",\n"
+            + "                    \"items\": {\n"
+            + "                        \"type\": \"string\"\n"
+            + "                    }\n"
+            + "                }\n"
+            + "            },\n"
+            + "            \"required\": [\n"
+            + "                \"texts\"\n"
+            + "            ]\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
         String json = "{\"text_docs\":[ \"today is sunny\", \"today is sunny\"]}";
         MLNodeUtils.validateSchema(schema, json);
     }

--- a/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
@@ -67,6 +67,31 @@ public class MLNodeUtilsTests extends OpenSearchTestCase {
     }
 
     @Test
+    public void testValidateEmbeddingInputWithRemoteSchema() throws IOException {
+        String schema = "{\n"
+                + "    \"type\": \"object\",\n"
+                + "    \"properties\": {\n"
+                + "        \"parameters\": {\n"
+                + "            \"type\": \"object\",\n"
+                + "            \"properties\": {\n"
+                + "                \"texts\": {\n"
+                + "                    \"type\": \"array\",\n"
+                + "                    \"items\": {\n"
+                + "                        \"type\": \"string\"\n"
+                + "                    }\n"
+                + "                }\n"
+                + "            },\n"
+                + "            \"required\": [\n"
+                + "                \"texts\"\n"
+                + "            ]\n"
+                + "        }\n"
+                + "    }\n"
+                + "}";
+        String json = "{\"text_docs\":[ \"today is sunny\", \"today is sunny\"]}";
+        MLNodeUtils.validateSchema(schema, json);
+    }
+
+    @Test
     public void testProcessRemoteInferenceInputDataSetParametersValueNoParameters() throws IOException {
         String json = "{\"key1\":\"foo\",\"key2\":123,\"key3\":true}";
         String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json);


### PR DESCRIPTION
### Description
All remote embedding model will throw exception when use embedding input instead of remote input. However Neural Search uses a hardcoded value `FunctionName.TEXT_EMBEDDING` when instantiating the `MLInput`:
https://github.com/opensearch-project/neural-search/blob/7feacd67b3c7694ff4a1c1c2b430f2447a1ed4ab/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java#L293

Therefore, we removed the required string `parameter` in input interface to enable the dual usage of remote model. In the future, we plan to use different interface on different usage in same connector as a long term fix.

### Related Issues
Resolves #3261

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
