### PR TITLE
Bump guava version to 32.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ subprojects {
 
     configurations.all {
         // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
-        resolutionStrategy.force "com.google.guava:guava:32.1.2-jre"
+        resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
         resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
     }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compileOnly group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     compileOnly group: 'org.json', name: 'json', version: '20231013'
     testImplementation group: 'org.json', name: 'json', version: '20231013'
-    implementation('com.google.guava:guava:32.1.2-jre') {
+    implementation('com.google.guava:guava:32.1.3-jre') {
         exclude group: 'com.google.guava', module: 'failureaccess'
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
         exclude group: 'org.checkerframework', module: 'checker-qual'

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: "${versions.httpcore5}"
     implementation "org.opensearch:common-utils:${common_utils_version}"
-    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     testImplementation (group: 'junit', name: 'junit', version: '4.13.2') {
         exclude module : 'hamcrest'
         exclude module : 'hamcrest-core'

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation group: 'io.protostuff', name: 'protostuff-collectionschema', version: '1.8.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     implementation platform("ai.djl:bom:0.28.0")
     implementation group: 'ai.djl.pytorch', name: 'pytorch-model-zoo'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     implementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
-    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'

--- a/search-processors/build.gradle
+++ b/search-processors/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation group: 'org.opensearch', name: 'common-utils', version: "${common_utils_version}"
     // https://mvnrepository.com/artifact/org.apache.httpcomponents.core5/httpcore5
     implementation group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: "${versions.httpcore5}"
-    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     implementation group: 'org.json', name: 'json', version: '20231013'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     testImplementation "org.opensearch.test:framework:${opensearch_version}"


### PR DESCRIPTION
### Description
Bump guava version to 32.1.3 to resolve version conflicts in neural search plugin to compile ml-commons plugin.
```
| Caused by: java.lang.IllegalStateException: jar hell!
| class: com.google.common.annotations.Beta
| jar1: /local/home/junqiu/dev/neural-search/build/testclusters/integTest-0/distro/3.0.0-ARCHIVE/plugins/opensearch-ml/guava-32.1.2-jre.jar
| jar2: /local/home/junqiu/dev/neural-search/build/testclusters/integTest-0/distro/3.0.0-ARCHIVE/plugins/opensearch-knn/guava-32.1.3-jre.jar
|       at org.opensearch.bootstrap.JarHell.checkClass(JarHell.java:316)
|       at org.opensearch.bootstrap.JarHell.checkJarHell(JarHell.java:215)
|       at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:675)
|       ... 11 more
``` 

### Related Issues
https://github.com/opensearch-project/neural-search/issues/480

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
