### PR TITLE
[backport 2.x] Bump guava version to 32.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ subprojects {
 
     configurations.all {
         // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
-        resolutionStrategy.force "com.google.guava:guava:32.1.2-jre"
+        resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
         resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
     }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compileOnly group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     compileOnly group: 'org.json', name: 'json', version: '20231013'
     testImplementation group: 'org.json', name: 'json', version: '20231013'
-    implementation('com.google.guava:guava:32.1.2-jre') {
+    implementation('com.google.guava:guava:32.1.3-jre') {
         exclude group: 'com.google.guava', module: 'failureaccess'
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
         exclude group: 'org.checkerframework', module: 'checker-qual'

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.2.2'
     implementation "org.opensearch:common-utils:${common_utils_version}"
-    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     testImplementation (group: 'junit', name: 'junit', version: '4.13.2') {
         exclude module : 'hamcrest'
         exclude module : 'hamcrest-core'

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation group: 'io.protostuff', name: 'protostuff-collectionschema', version: '1.8.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     implementation platform("ai.djl:bom:0.28.0")
     implementation group: 'ai.djl.pytorch', name: 'pytorch-model-zoo'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     implementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
-    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'


### PR DESCRIPTION

### Description
Backport https://github.com/opensearch-project/ml-commons/pull/3300 into 2.x branch


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
