### PR TITLE
Force version 3.29.0 of org.eclipse.core.runtime to address CVE vulnerabilities

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -353,6 +353,7 @@ configurations.all {
     resolutionStrategy.force 'commons-codec:commons-codec:1.15'
     resolutionStrategy.force 'org.slf4j:slf4j-api:1.7.36'
     resolutionStrategy.force 'org.codehaus.plexus:plexus-utils:3.3.0'
+    resolutionStrategy.force 'org.eclipse.platform:org.eclipse.core.runtime:3.29.0'
     exclude group: "org.jetbrains", module: "annotations"
 }
 


### PR DESCRIPTION
### Description
Address CVE vulnerability in plugin/build.gradle: org.eclipse.core.runtime-3.26.100.jar by forcing version 3.29.0

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
