### PR TITLE
Revert Text Block changes from "Enhance validation for create connector API" #3260

### DIFF
--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorActionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorActionTest.java
@@ -100,11 +100,11 @@ public class ConnectorActionTest {
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         action.toXContent(builder, ToXContent.EMPTY_PARAMS);
         String content = TestHelper.xContentBuilderToString(builder);
-        String expctedContent = """
-            {"action_type":"PREDICT","method":"http","url":"https://test.com",\
-            "request_body":"{\\"input\\": \\"${parameters.input}\\"}"}\
-            """;
-        assertEquals(expctedContent, content);
+        assertEquals(
+            "{\"action_type\":\"PREDICT\",\"method\":\"http\",\"url\":\"https://test.com\","
+                + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\"}",
+            content
+        );
     }
 
     @Test
@@ -127,23 +127,21 @@ public class ConnectorActionTest {
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         action.toXContent(builder, ToXContent.EMPTY_PARAMS);
         String content = TestHelper.xContentBuilderToString(builder);
-        String expctedContent = """
-            {"action_type":"PREDICT","method":"http","url":"https://test.com","headers":{"key1":"value1"},\
-            "request_body":"{\\"input\\": \\"${parameters.input}\\"}",\
-            "pre_process_function":"connector.pre_process.openai.embedding",\
-            "post_process_function":"connector.post_process.openai.embedding"}\
-            """;
-        assertEquals(expctedContent, content);
+        assertEquals(
+            "{\"action_type\":\"PREDICT\",\"method\":\"http\",\"url\":\"https://test.com\","
+                + "\"headers\":{\"key1\":\"value1\"},\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
+                + "\"pre_process_function\":\"connector.pre_process.openai.embedding\","
+                + "\"post_process_function\":\"connector.post_process.openai.embedding\"}",
+            content
+        );
     }
 
     @Test
     public void parse() throws IOException {
-        String jsonStr = """
-            {"action_type":"PREDICT","method":"http","url":"https://test.com","headers":{"key1":"value1"},\
-            "request_body":"{\\"input\\": \\"${parameters.input}\\"}",\
-            "pre_process_function":"connector.pre_process.openai.embedding",\
-            "post_process_function":"connector.post_process.openai.embedding"}"\
-            """;
+        String jsonStr = "{\"action_type\":\"PREDICT\",\"method\":\"http\",\"url\":\"https://test.com\","
+            + "\"headers\":{\"key1\":\"value1\"},\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
+            + "\"pre_process_function\":\"connector.pre_process.openai.embedding\","
+            + "\"post_process_function\":\"connector.post_process.openai.embedding\"}";
         XContentParser parser = XContentType.JSON
             .xContent()
             .createParser(

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -55,19 +55,18 @@ public class MLCreateConnectorInputTests {
     private static final String TEST_CREDENTIAL_VALUE = "test_key_value";
     private static final String TEST_ROLE1 = "role1";
     private static final String TEST_ROLE2 = "role2";
-    private final String expectedInputStr = """
-        {"name":"test_connector_name","description":"this is a test connector","version":"1","protocol":"http",\
-        "parameters":{"input":"test input value"},"credential":{"key":"test_key_value"},\
-        "actions":[{"action_type":"PREDICT","method":"POST","url":"https://test.com",\
-        "headers":{"api_key":"${credential.key}"},\
-        "request_body":"{\\"input\\": \\"${parameters.input}\\"}",\
-        "pre_process_function":"connector.pre_process.openai.embedding",\
-        "post_process_function":"connector.post_process.openai.embedding"}],\
-        "backend_roles":["role1","role2"],"add_all_backend_roles":false,\
-        "access_mode":"PUBLIC","client_config":{"max_connection":20,\
-        "connection_timeout":10000,"read_timeout":10000,\
-        "retry_backoff_millis":10,"retry_timeout_seconds":10,"max_retry_times":-1,"retry_backoff_policy":"constant"}}\
-        """;
+    private final String expectedInputStr = "{\"name\":\"test_connector_name\","
+        + "\"description\":\"this is a test connector\",\"version\":\"1\",\"protocol\":\"http\","
+        + "\"parameters\":{\"input\":\"test input value\"},\"credential\":{\"key\":\"test_key_value\"},"
+        + "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\","
+        + "\"headers\":{\"api_key\":\"${credential.key}\"},"
+        + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
+        + "\"pre_process_function\":\"connector.pre_process.openai.embedding\","
+        + "\"post_process_function\":\"connector.post_process.openai.embedding\"}],"
+        + "\"backend_roles\":[\"role1\",\"role2\"],\"add_all_backend_roles\":false,"
+        + "\"access_mode\":\"PUBLIC\",\"client_config\":{\"max_connection\":20,"
+        + "\"connection_timeout\":10000,\"read_timeout\":10000,"
+        + "\"retry_backoff_millis\":10,\"retry_timeout_seconds\":10,\"max_retry_times\":-1,\"retry_backoff_policy\":\"constant\"}}";
 
     @Before
     public void setUp() {
@@ -238,15 +237,16 @@ public class MLCreateConnectorInputTests {
 
     @Test
     public void testParse_ArrayParameter() throws Exception {
-        String expectedInputStr = """
-            {"name":"test_connector_name","description":"this is a test connector","version":"1",\
-            "protocol":"http","parameters":{"input":["test input value"]},"credential":{"key":"test_key_value"},\
-            "actions":[{"action_type":"PREDICT","method":"POST","url":"https://test.com",\
-            "headers":{"api_key":"${credential.key}"},"request_body":"{\\"input\\": \\"${parameters.input}\\"}",\
-            "pre_process_function":"connector.pre_process.openai.embedding",\
-            "post_process_function":"connector.post_process.openai.embedding"}],\
-            "backend_roles":["role1","role2"],"add_all_backend_roles":false,"access_mode":"PUBLIC"};\
-            """;
+        String expectedInputStr = "{\"name\":\"test_connector_name\","
+            + "\"description\":\"this is a test connector\",\"version\":\"1\",\"protocol\":\"http\","
+            + "\"parameters\":{\"input\":[\"test input value\"]},\"credential\":{\"key\":\"test_key_value\"},"
+            + "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\","
+            + "\"headers\":{\"api_key\":\"${credential.key}\"},"
+            + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
+            + "\"pre_process_function\":\"connector.pre_process.openai.embedding\","
+            + "\"post_process_function\":\"connector.post_process.openai.embedding\"}],"
+            + "\"backend_roles\":[\"role1\",\"role2\"],\"add_all_backend_roles\":false,"
+            + "\"access_mode\":\"PUBLIC\"}";
         testParseFromJsonString(expectedInputStr, parsedInput -> {
             assertEquals(TEST_CONNECTOR_NAME, parsedInput.getName());
             assertEquals(1, parsedInput.getParameters().size());


### PR DESCRIPTION
### Description

Text Block changes introduced in JDK15. Even though our main release is based on JDK21, 2.x is still based on JDK11. So to support auto bot backport of these test files in the future, reverting Text Block related changes from test cases.

### Related Issues
Revert Text Block changes from #3260

### Check List
- [ ] ~New functionality includes testing.~
- [ ] ~New functionality has been documented.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
