### PR TITLE
[Backport 2.x] Upgraded software.amazon.awssdk from 2.25.40 to 2.29.12 to address CVE…

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -62,19 +62,19 @@ dependencies {
         }
     }
 
-    implementation platform('software.amazon.awssdk:bom:2.25.40')
-    api 'software.amazon.awssdk:auth:2.25.40'
+    implementation platform('software.amazon.awssdk:bom:2.29.12')
+    api 'software.amazon.awssdk:auth:2.29.12'
     implementation 'software.amazon.awssdk:apache-client'
     implementation ('com.amazonaws:aws-encryption-sdk-java:2.4.1') {
         exclude group: 'org.bouncycastle', module: 'bcprov-ext-jdk18on'
     }
     implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
-    implementation group: 'software.amazon.awssdk', name: 'aws-core', version: '2.25.40'
-    implementation group: 'software.amazon.awssdk', name: 's3', version: '2.25.40'
-    implementation group: 'software.amazon.awssdk', name: 'regions', version: '2.25.40'
+    implementation group: 'software.amazon.awssdk', name: 'aws-core', version: '2.29.12'
+    implementation group: 'software.amazon.awssdk', name: 's3', version: '2.29.12'
+    implementation group: 'software.amazon.awssdk', name: 'regions', version: '2.29.12'
     implementation 'com.jayway.jsonpath:json-path:2.9.0'
     implementation group: 'org.json', name: 'json', version: '20231013'
-    implementation group: 'software.amazon.awssdk', name: 'netty-nio-client', version: '2.25.40'
+    implementation group: 'software.amazon.awssdk', name: 'netty-nio-client', version: '2.29.12'
 }
 
 lombok {


### PR DESCRIPTION
…… (#3320)

* Upgraded software.amazon.awssdk from 2.25.40 to 2.29.0 to address CVE-2024-47535

* Upgrading to 2.29.12 to upgrade netty-common library to 4.1.115

Backport for #3320 
---------

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
