### PR TITLE
Separate Spotless Check to JDK 17 and Exclude from other Build Process

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -100,7 +100,7 @@ jobs:
 
 
   Test-ml-linux-docker:
-    needs: [Get-Require-Approval, Build-ml-linux]
+    needs: [Get-Require-Approval, Build-ml-linux, spotless]
     strategy:
       matrix:
         java: [11, 17, 21]
@@ -197,7 +197,7 @@ jobs:
         java: [11, 17, 21]
     name: Build and Test MLCommons Plugin on Windows
     if: github.repository == 'opensearch-project/ml-commons'
-    needs: [Get-Require-Approval]
+    needs: [Get-Require-Approval, spotless]
     environment: ${{ needs.Get-Require-Approval.outputs.is-require-approval }}
     runs-on: windows-latest
 

--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -22,6 +22,19 @@ jobs:
     with:
       product: opensearch
 
+  spotless:
+    if: github.repository == 'opensearch-project/ml-commons'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Spotless requires JDK 17+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+      - name: Spotless Check
+        run: ./gradlew spotlessCheck
+
   Build-ml-linux:
     needs: [Get-Require-Approval, Get-CI-Image-Tag]
     strategy:
@@ -67,9 +80,9 @@ jobs:
                                export COHERE_KEY=`aws secretsmanager get-secret-value --secret-id github_cohere_key --query SecretString --output text` &&
                                echo "::add-mask::$OPENAI_KEY" &&
                                echo "::add-mask::$COHERE_KEY" &&
-                               echo "build and run tests" && ./gradlew build &&
-                               echo "Publish to Maven Local" && ./gradlew publishToMavenLocal &&
-                               echo "Multi Nodes Integration Testing" && ./gradlew integTest -PnumNodes=3'
+                               echo "build and run tests" && ./gradlew build -x spotlessJava &&
+                               echo "Publish to Maven Local" && ./gradlew publishToMavenLocal -x spotlessJava &&
+                               echo "Multi Nodes Integration Testing" && ./gradlew integTest -PnumNodes=3 -x spotlessJava'
           plugin=`basename $(ls plugin/build/distributions/*.zip)`
           echo $plugin
           mv -v plugin/build/distributions/$plugin ./
@@ -168,10 +181,10 @@ jobs:
           if [ $security -gt 0 ]
           then
             echo "Security plugin is available"
-            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=${{ steps.genpass.outputs.password }}
+            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=${{ steps.genpass.outputs.password }} -x spotlessJava
           else
             echo "Security plugin is NOT available"
-            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster"
+            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -x spotlessJava
           fi
 
       - name: Upload Coverage Report
@@ -214,10 +227,10 @@ jobs:
           export COHERE_KEY=$(aws secretsmanager get-secret-value --secret-id github_cohere_key --query SecretString --output text)
           echo "::add-mask::$OPENAI_KEY"
           echo "::add-mask::$COHERE_KEY"
-          ./gradlew.bat build
+          ./gradlew.bat build -x spotlessJava
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal
+          ./gradlew publishToMavenLocal -x spotlessJava
 #      - name: Multi Nodes Integration Testing
 #        shell: bash
 #        run: |

--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -36,7 +36,7 @@ jobs:
         run: ./gradlew spotlessCheck
 
   Build-ml-linux:
-    needs: [Get-Require-Approval, Get-CI-Image-Tag]
+    needs: [Get-Require-Approval, Get-CI-Image-Tag, spotless]
     strategy:
       matrix:
         java: [11, 17, 21]

--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -23,15 +23,13 @@ jobs:
       product: opensearch
 
   spotless:
-    if: github.repository == 'opensearch-project/ml-commons'
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       # Spotless requires JDK 17+
-      - uses: actions/setup-java@v4
+      - name: Setup Java 21
+        uses: actions/setup-java@v1
         with:
-          java-version: 17
-          distribution: temurin
+          java-version: 21
       - name: Spotless Check
         run: ./gradlew spotlessCheck
 


### PR DESCRIPTION
### Description
This PR modifies the CI pipeline to run the Spotless check on JDK 17 separately from the rest of the build process, which continues to use JDK 11, 17, and 21.

Since we bumped the org.eclipse.core.runtime to 3.29.0 to address the CVE issues in #3313, spotlessJava fails with JDK 11 since 3.29.0 is built with a minimum Required Execution Environment of Java 17.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
