### PR TITLE
[Backport 2.14] fix model stuck in deploying state during node crash/cluster restart (#3137)

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskCache.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskCache.java
@@ -62,4 +62,9 @@ public class MLTaskCache {
     public boolean allNodeFailed() {
         return workerNodeSize != null && errors.size() == workerNodeSize;
     }
+
+    public void updateWorkerNode(Set<String> nodesRemovedFromCluster) {
+        this.workerNodes.removeAll(nodesRemovedFromCluster);
+        this.workerNodeSize = this.workerNodeSize - nodesRemovedFromCluster.size();
+    }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/forward/TransportForwardActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/forward/TransportForwardActionTests.java
@@ -29,6 +29,7 @@ import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MODEL_AUTO
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_ONLY_RUN_ON_ML_NODE;
 import static org.opensearch.ml.utils.TestHelper.ML_ROLE;
 import static org.opensearch.ml.utils.TestHelper.clusterSetting;
+import static org.opensearch.ml.utils.TestHelper.setupTestClusterState;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -43,6 +44,7 @@ import org.mockito.MockitoAnnotations;
 import org.opensearch.Version;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
@@ -94,6 +96,8 @@ public class TransportForwardActionTests extends OpenSearchTestCase {
 
     private TransportForwardAction forwardAction;
 
+    private ClusterState testState;
+
     Settings settings = Settings
         .builder()
         .put(ML_COMMONS_MODEL_AUTO_REDEPLOY_ENABLE.getKey(), true)
@@ -136,6 +140,9 @@ public class TransportForwardActionTests extends OpenSearchTestCase {
                 mlModelAutoReDeployer
             )
         );
+
+        testState = setupTestClusterState("test_node_id2");
+        when(clusterService.state()).thenReturn(testState);
 
         node1 = new DiscoveryNode(nodeId1, buildNewFakeTransportAddress(), emptyMap(), ImmutableSet.of(ML_ROLE), Version.CURRENT);
         node2 = new DiscoveryNode(nodeId2, buildNewFakeTransportAddress(), emptyMap(), ImmutableSet.of(ML_ROLE), Version.CURRENT);

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLSyncUpCronTests.java
@@ -118,7 +118,7 @@ public class MLSyncUpCronTests extends OpenSearchTestCase {
         encryptor = spy(new EncryptorImpl(null));
         syncUpCron = new MLSyncUpCron(client, clusterService, nodeHelper, mlIndicesHandler, encryptor);
 
-        testState = setupTestClusterState();
+        testState = setupTestClusterState("node");
         when(clusterService.state()).thenReturn(testState);
 
         doAnswer(invocation -> {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLProfileActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLProfileActionTests.java
@@ -151,7 +151,7 @@ public class RestMLProfileActionTests extends OpenSearchTestCase {
             .build();
 
         clusterName = new ClusterName("test cluster");
-        testState = setupTestClusterState();
+        testState = setupTestClusterState("node");
         when(clusterService.state()).thenReturn(testState);
 
         doAnswer(invocation -> {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLStatsActionTests.java
@@ -147,7 +147,7 @@ public class RestMLStatsActionTests extends OpenSearchTestCase {
             roleSet,
             Version.CURRENT
         );
-        testState = setupTestClusterState();
+        testState = setupTestClusterState("node");
         when(clusterService.state()).thenReturn(testState);
 
         clusterName = new ClusterName(clusterNameStr);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLUndeployModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLUndeployModelActionTests.java
@@ -67,7 +67,7 @@ public class RestMLUndeployModelActionTests extends OpenSearchTestCase {
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        testState = setupTestClusterState();
+        testState = setupTestClusterState("node");
         when(clusterService.state()).thenReturn(testState);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         restMLUndeployModelAction = new RestMLUndeployModelAction(clusterService, settings);

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -424,11 +424,11 @@ public class TestHelper {
         return state(new ClusterName("test"), indexName, mapping, clusterManagerNode, clusterManagerNode, allNodes);
     }
 
-    public static ClusterState setupTestClusterState() {
+    public static ClusterState setupTestClusterState(String nodeId) {
         Set<DiscoveryNodeRole> roleSet = new HashSet<>();
         roleSet.add(DiscoveryNodeRole.DATA_ROLE);
         DiscoveryNode node = new DiscoveryNode(
-            "node",
+            nodeId,
             new TransportAddress(TransportAddress.META_ADDRESS, new AtomicInteger().incrementAndGet()),
             new HashMap<>(),
             roleSet,


### PR DESCRIPTION
Signed-off-by: Bhavana Ramaram <rbhavna@amazon.com>
(cherry picked from commit bb6339ff6f4a04adb259c24cb4b3bc80625278fb)

### Description
Backport PR https://github.com/opensearch-project/ml-commons/pull/3137 to 2.14

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
