### PR TITLE
Undeploy models with no WorkerNodes

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
@@ -228,22 +228,22 @@ public class TransportUndeployModelsAction extends HandledTransportAction<Action
         }
 
         bulkUpdateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        log.info("No nodes service: {}", Arrays.toString(modelIds));
+        log.info("No nodes running these models: {}", Arrays.toString(modelIds));
 
         try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<MLUndeployModelsResponse> listenerWithContextRestoration = ActionListener
                 .runBefore(listener, () -> threadContext.restore());
             ActionListener<BulkResponse> bulkResponseListener = ActionListener.wrap(br -> {
-                log.debug("Successfully set modelIds to UNDEPLOY in index");
+                log.debug("Successfully set the following modelId(s) to UNDEPLOY in index: {}", Arrays.toString(modelIds));
                 listenerWithContextRestoration.onResponse(new MLUndeployModelsResponse(response));
             }, e -> {
-                log.error("Failed to set modelIds to UNDEPLOY in index", e);
+                log.error("Failed to set the following modelId(s) to UNDEPLOY in index: {}", Arrays.toString(modelIds), e);
                 listenerWithContextRestoration.onFailure(e);
             });
 
             client.bulk(bulkUpdateRequest, bulkResponseListener);
         } catch (Exception e) {
-            log.error("Unexpected error while setting modelIds to UNDEPLOY status to index", e);
+            log.error("Unexpected error while setting the following modelId(s) to UNDEPLOY in index: {}", Arrays.toString(modelIds), e);
             listener.onFailure(e);
         }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.action.undeploy;
 
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,10 +15,13 @@ import java.util.stream.Collectors;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
+import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -33,6 +37,7 @@ import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
 import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.model.MLModelState;
 import org.opensearch.ml.common.transport.deploy.MLDeployModelRequest;
 import org.opensearch.ml.common.transport.undeploy.MLUndeployModelAction;
 import org.opensearch.ml.common.transport.undeploy.MLUndeployModelNodesRequest;
@@ -57,6 +62,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -180,8 +186,34 @@ public class TransportUndeployModelsAction extends HandledTransportAction<Action
         mlUndeployModelNodesRequest.setTenantId(tenantId);
 
         client.execute(MLUndeployModelAction.INSTANCE, mlUndeployModelNodesRequest, ActionListener.wrap(r -> {
+            if (r.getNodes().isEmpty()) {
+                bulkSetModelIndexToUndeploy(modelIds);
+            }
             listener.onResponse(new MLUndeployModelsResponse(r));
         }, listener::onFailure));
+    }
+
+    private void bulkSetModelIndexToUndeploy(String[] modelIds) {
+        BulkRequest bulkUpdateRequest = new BulkRequest();
+        for (String modelId : modelIds) {
+            UpdateRequest updateRequest = new UpdateRequest();
+            Instant now = Instant.now();
+            ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+            builder.put(MLModel.MODEL_STATE_FIELD, MLModelState.UNDEPLOYED.name());
+
+            builder.put(MLModel.PLANNING_WORKER_NODES_FIELD, List.of());
+            builder.put(MLModel.PLANNING_WORKER_NODE_COUNT_FIELD, 0);
+
+            builder.put(MLModel.LAST_UPDATED_TIME_FIELD, now.toEpochMilli());
+            builder.put(MLModel.CURRENT_WORKER_NODE_COUNT_FIELD, 0);
+            updateRequest.index(ML_MODEL_INDEX).id(modelId).doc(builder.build());
+            bulkUpdateRequest.add(updateRequest);
+        }
+        bulkUpdateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        log.info("No models service: {}", modelIds.toString());
+        client.bulk(bulkUpdateRequest, ActionListener.wrap(br -> { log.debug("Successfully set modelIds to UNDEPLOY in index"); }, e -> {
+            log.error("Failed to set modelIds to UNDEPLOY in index", e);
+        }));
     }
 
     private void validateAccess(String modelId, String tenantId, ActionListener<Boolean> listener) {

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
@@ -217,7 +217,7 @@ public class TransportUndeployModelsAction extends HandledTransportAction<Action
         }
 
         bulkUpdateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        log.info("No nodes service: {}", modelIds.toString());
+        log.info("No nodes service: {}", Arrays.toString(modelIds));
 
         client.bulk(bulkUpdateRequest, ActionListener.wrap(br -> {
             log.debug("Successfully set modelIds to UNDEPLOY in index");

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
@@ -237,8 +237,15 @@ public class TransportUndeployModelsAction extends HandledTransportAction<Action
                 log.debug("Successfully set the following modelId(s) to UNDEPLOY in index: {}", Arrays.toString(modelIds));
                 listenerWithContextRestoration.onResponse(new MLUndeployModelsResponse(response));
             }, e -> {
-                log.error("Failed to set the following modelId(s) to UNDEPLOY in index: {}", Arrays.toString(modelIds), e);
-                listenerWithContextRestoration.onFailure(e);
+                String modelsNotFoundMessage = String
+                    .format("Failed to set the following modelId(s) to UNDEPLOY in index: %s", Arrays.toString(modelIds));
+                log.error(modelsNotFoundMessage, e);
+
+                OpenSearchStatusException exception = new OpenSearchStatusException(
+                    modelsNotFoundMessage + e.getMessage(),
+                    RestStatus.INTERNAL_SERVER_ERROR
+                );
+                listenerWithContextRestoration.onFailure(exception);
             });
 
             client.bulk(bulkUpdateRequest, bulkResponseListener);

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
@@ -231,7 +231,8 @@ public class TransportUndeployModelsAction extends HandledTransportAction<Action
         log.info("No nodes service: {}", Arrays.toString(modelIds));
 
         try (ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
-            ActionListener<MLUndeployModelsResponse> listenerWithContextRestoration = ActionListener.runBefore(listener, () -> threadContext.restore());
+            ActionListener<MLUndeployModelsResponse> listenerWithContextRestoration = ActionListener
+                .runBefore(listener, () -> threadContext.restore());
             ActionListener<BulkResponse> bulkResponseListener = ActionListener.wrap(br -> {
                 log.debug("Successfully set modelIds to UNDEPLOY in index");
                 listenerWithContextRestoration.onResponse(new MLUndeployModelsResponse(response));

--- a/plugin/src/test/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsActionTests.java
@@ -271,7 +271,7 @@ public class TransportUndeployModelsActionTests extends OpenSearchTestCase {
             ActionListener<MLModel> listener = invocation.getArgument(4);
             listener.onResponse(mlModel);
             return null;
-        }).when(mlModelManager).getModel(any(), any(), any(),any(), isA(ActionListener.class));
+        }).when(mlModelManager).getModel(any(), any(), any(), any(), isA(ActionListener.class));
 
         doReturn(true).when(transportUndeployModelsAction).isSuperAdminUserWrapper(clusterService, client);
 

--- a/plugin/src/test/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsActionTests.java
@@ -195,10 +195,10 @@ public class TransportUndeployModelsActionTests extends OpenSearchTestCase {
             .build();
 
         doAnswer(invocation -> {
-            ActionListener<MLModel> listener = invocation.getArgument(3);
+            ActionListener<MLModel> listener = invocation.getArgument(4);
             listener.onResponse(mlModel);
             return null;
-        }).when(mlModelManager).getModel(any(), any(), any(), isA(ActionListener.class));
+        }).when(mlModelManager).getModel(any(), any(), any(), any(), isA(ActionListener.class));
 
         doReturn(true).when(transportUndeployModelsAction).isSuperAdminUserWrapper(clusterService, client);
 
@@ -226,7 +226,7 @@ public class TransportUndeployModelsActionTests extends OpenSearchTestCase {
 
         String[] modelIds = new String[] { modelId };
         String[] nodeIds = new String[] { "test_node_id1", "test_node_id2" };
-        MLUndeployModelsRequest request = new MLUndeployModelsRequest(modelIds, nodeIds);
+        MLUndeployModelsRequest request = new MLUndeployModelsRequest(modelIds, nodeIds, null);
 
         transportUndeployModelsAction.doExecute(task, request, actionListener);
 
@@ -268,10 +268,10 @@ public class TransportUndeployModelsActionTests extends OpenSearchTestCase {
             .build();
 
         doAnswer(invocation -> {
-            ActionListener<MLModel> listener = invocation.getArgument(3);
+            ActionListener<MLModel> listener = invocation.getArgument(4);
             listener.onResponse(mlModel);
             return null;
-        }).when(mlModelManager).getModel(any(), any(), any(), isA(ActionListener.class));
+        }).when(mlModelManager).getModel(any(), any(), any(),any(), isA(ActionListener.class));
 
         doReturn(true).when(transportUndeployModelsAction).isSuperAdminUserWrapper(clusterService, client);
 
@@ -293,7 +293,7 @@ public class TransportUndeployModelsActionTests extends OpenSearchTestCase {
 
         String[] modelIds = new String[] { modelId };
         String[] nodeIds = new String[] { "test_node_id1", "test_node_id2" };
-        MLUndeployModelsRequest request = new MLUndeployModelsRequest(modelIds, nodeIds);
+        MLUndeployModelsRequest request = new MLUndeployModelsRequest(modelIds, nodeIds, null);
 
         transportUndeployModelsAction.doExecute(task, request, actionListener);
 


### PR DESCRIPTION
This PR  aims to undeploy modelIds that have no nodes associated to them so as to keep the intention of undeploy truthful.

### Description
When performing undeploy if the model has no nodes associated to it then it will reset the index to UNDEPLOY status

Here is an example of why this code change is needed

This secnario is for the `PARTIALLY_DEPLOYED` issue.
1. Have nodes a,b,c,d in cluster associated with `modelID:@` i.e. peform deploy on it
2. Bring a,b down while having the syncup job running
3. By Now sync up will make this PARTIALLY_UNDEPLOYED
4. stop sync up
5. Bring other 2 c,d down and bring 2 nodes (these now have new ids 1,2)
6. bring the other two nodes back which have different ids so now the cluster has (1,2,3,4)
But the model index says `PARTIALLY_DEPLOYED` and no nodes are servicing

This code fix says. If no nodes are servicing this model then I need to set the index to UNDEPLOYED no matter if its already UNDEPLOYED or not.

### Related Issues
Resolves https://github.com/opensearch-project/ml-commons/issues/3285
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
