### PR TITLE
apply multi-tenancy and sdk client in Connector (Create + Get + Delete)

### DIFF
--- a/client/src/main/java/org/opensearch/ml/client/MachineLearningClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MachineLearningClient.java
@@ -323,7 +323,20 @@ public interface MachineLearningClient {
         return actionFuture;
     }
 
+    /**
+     * Delete connector for remote model
+     * @param connectorId The id of the connector to delete
+     * @return the result future
+     */
+    default ActionFuture<DeleteResponse> deleteConnector(String connectorId, String tenantId) {
+        PlainActionFuture<DeleteResponse> actionFuture = PlainActionFuture.newFuture();
+        deleteConnector(connectorId, tenantId, actionFuture);
+        return actionFuture;
+    }
+
     void deleteConnector(String connectorId, ActionListener<DeleteResponse> listener);
+
+    void deleteConnector(String connectorId, String tenantId, ActionListener<DeleteResponse> listener);
 
     /**
      * Register model group

--- a/client/src/main/java/org/opensearch/ml/client/MachineLearningNodeClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MachineLearningNodeClient.java
@@ -146,7 +146,7 @@ public class MachineLearningNodeClient implements MachineLearningClient {
         mlInput.setParameters(mlAlgoParams);
         switch (action) {
             case TRAIN:
-                boolean asyncTask = args.containsKey(ASYNC) ? (boolean) args.get(ASYNC) : false;
+                boolean asyncTask = args.containsKey(ASYNC) && (boolean) args.get(ASYNC);
                 train(mlInput, asyncTask, listener);
                 break;
             case PREDICT:
@@ -174,30 +174,19 @@ public class MachineLearningNodeClient implements MachineLearningClient {
         ActionListener<MLModelGetResponse> internalListener = ActionListener.wrap(predictionResponse -> {
             listener.onResponse(predictionResponse.getMlModel());
         }, listener::onFailure);
-        ActionListener<MLModelGetResponse> actionListener = wrapActionListener(internalListener, res -> {
-            MLModelGetResponse getResponse = MLModelGetResponse.fromActionResponse(res);
-            return getResponse;
-        });
-        return actionListener;
+        return wrapActionListener(internalListener, MLModelGetResponse::fromActionResponse);
     }
 
     @Override
     public void deleteModel(String modelId, ActionListener<DeleteResponse> listener) {
         MLModelDeleteRequest mlModelDeleteRequest = MLModelDeleteRequest.builder().modelId(modelId).build();
 
-        client.execute(MLModelDeleteAction.INSTANCE, mlModelDeleteRequest, ActionListener.wrap(deleteResponse -> {
-            listener.onResponse(deleteResponse);
-        }, listener::onFailure));
+        client.execute(MLModelDeleteAction.INSTANCE, mlModelDeleteRequest, ActionListener.wrap(listener::onResponse, listener::onFailure));
     }
 
     @Override
     public void searchModel(SearchRequest searchRequest, ActionListener<SearchResponse> listener) {
-        client
-            .execute(
-                MLModelSearchAction.INSTANCE,
-                searchRequest,
-                ActionListener.wrap(searchResponse -> { listener.onResponse(searchResponse); }, listener::onFailure)
-            );
+        client.execute(MLModelSearchAction.INSTANCE, searchRequest, ActionListener.wrap(listener::onResponse, listener::onFailure));
     }
 
     @Override
@@ -238,19 +227,12 @@ public class MachineLearningNodeClient implements MachineLearningClient {
     public void deleteTask(String taskId, ActionListener<DeleteResponse> listener) {
         MLTaskDeleteRequest mlTaskDeleteRequest = MLTaskDeleteRequest.builder().taskId(taskId).build();
 
-        client.execute(MLTaskDeleteAction.INSTANCE, mlTaskDeleteRequest, ActionListener.wrap(deleteResponse -> {
-            listener.onResponse(deleteResponse);
-        }, listener::onFailure));
+        client.execute(MLTaskDeleteAction.INSTANCE, mlTaskDeleteRequest, ActionListener.wrap(listener::onResponse, listener::onFailure));
     }
 
     @Override
     public void searchTask(SearchRequest searchRequest, ActionListener<SearchResponse> listener) {
-        client
-            .execute(
-                MLTaskSearchAction.INSTANCE,
-                searchRequest,
-                ActionListener.wrap(searchResponse -> { listener.onResponse(searchResponse); }, listener::onFailure)
-            );
+        client.execute(MLTaskSearchAction.INSTANCE, searchRequest, ActionListener.wrap(listener::onResponse, listener::onFailure));
     }
 
     @Override
@@ -280,9 +262,23 @@ public class MachineLearningNodeClient implements MachineLearningClient {
     @Override
     public void deleteConnector(String connectorId, ActionListener<DeleteResponse> listener) {
         MLConnectorDeleteRequest connectorDeleteRequest = new MLConnectorDeleteRequest(connectorId);
-        client.execute(MLConnectorDeleteAction.INSTANCE, connectorDeleteRequest, ActionListener.wrap(deleteResponse -> {
-            listener.onResponse(deleteResponse);
-        }, listener::onFailure));
+        client
+            .execute(
+                MLConnectorDeleteAction.INSTANCE,
+                connectorDeleteRequest,
+                ActionListener.wrap(listener::onResponse, listener::onFailure)
+            );
+    }
+
+    @Override
+    public void deleteConnector(String connectorId, String tenantId, ActionListener<DeleteResponse> listener) {
+        MLConnectorDeleteRequest connectorDeleteRequest = new MLConnectorDeleteRequest(connectorId, tenantId);
+        client
+            .execute(
+                MLConnectorDeleteAction.INSTANCE,
+                connectorDeleteRequest,
+                ActionListener.wrap(listener::onResponse, listener::onFailure)
+            );
     }
 
     @Override
@@ -294,9 +290,7 @@ public class MachineLearningNodeClient implements MachineLearningClient {
     @Override
     public void deleteAgent(String agentId, ActionListener<DeleteResponse> listener) {
         MLAgentDeleteRequest agentDeleteRequest = new MLAgentDeleteRequest(agentId);
-        client.execute(MLAgentDeleteAction.INSTANCE, agentDeleteRequest, ActionListener.wrap(deleteResponse -> {
-            listener.onResponse(deleteResponse);
-        }, listener::onFailure));
+        client.execute(MLAgentDeleteAction.INSTANCE, agentDeleteRequest, ActionListener.wrap(listener::onResponse, listener::onFailure));
     }
 
     @Override
@@ -324,123 +318,78 @@ public class MachineLearningNodeClient implements MachineLearningClient {
         ActionListener<MLToolsListResponse> internalListener = ActionListener.wrap(mlModelListResponse -> {
             listener.onResponse(mlModelListResponse.getToolMetadataList());
         }, listener::onFailure);
-        ActionListener<MLToolsListResponse> actionListener = wrapActionListener(internalListener, res -> {
-            MLToolsListResponse getResponse = MLToolsListResponse.fromActionResponse(res);
-            return getResponse;
-        });
-        return actionListener;
+        return wrapActionListener(internalListener, MLToolsListResponse::fromActionResponse);
     }
 
     private ActionListener<MLToolGetResponse> getMlGetToolResponseActionListener(ActionListener<ToolMetadata> listener) {
         ActionListener<MLToolGetResponse> internalListener = ActionListener.wrap(mlModelGetResponse -> {
             listener.onResponse(mlModelGetResponse.getToolMetadata());
         }, listener::onFailure);
-        ActionListener<MLToolGetResponse> actionListener = wrapActionListener(internalListener, res -> {
-            MLToolGetResponse getResponse = MLToolGetResponse.fromActionResponse(res);
-            return getResponse;
-        });
-        return actionListener;
+        return wrapActionListener(internalListener, MLToolGetResponse::fromActionResponse);
     }
 
     private ActionListener<MLConfigGetResponse> getMlGetConfigResponseActionListener(ActionListener<MLConfig> listener) {
         ActionListener<MLConfigGetResponse> internalListener = ActionListener.wrap(mlConfigGetResponse -> {
             listener.onResponse(mlConfigGetResponse.getMlConfig());
         }, listener::onFailure);
-        ActionListener<MLConfigGetResponse> actionListener = wrapActionListener(internalListener, res -> {
-            MLConfigGetResponse getResponse = MLConfigGetResponse.fromActionResponse(res);
-            return getResponse;
-        });
-        return actionListener;
+        return wrapActionListener(internalListener, MLConfigGetResponse::fromActionResponse);
     }
 
     private ActionListener<MLRegisterAgentResponse> getMLRegisterAgentResponseActionListener(
         ActionListener<MLRegisterAgentResponse> listener
     ) {
-        ActionListener<MLRegisterAgentResponse> actionListener = wrapActionListener(listener, res -> {
-            MLRegisterAgentResponse mlRegisterAgentResponse = MLRegisterAgentResponse.fromActionResponse(res);
-            return mlRegisterAgentResponse;
-        });
-        return actionListener;
+        return wrapActionListener(listener, MLRegisterAgentResponse::fromActionResponse);
     }
 
     private ActionListener<MLTaskGetResponse> getMLTaskResponseActionListener(ActionListener<MLTask> listener) {
         ActionListener<MLTaskGetResponse> internalListener = ActionListener
             .wrap(getResponse -> { listener.onResponse(getResponse.getMlTask()); }, listener::onFailure);
-        ActionListener<MLTaskGetResponse> actionListener = wrapActionListener(internalListener, response -> {
-            MLTaskGetResponse getResponse = MLTaskGetResponse.fromActionResponse(response);
-            return getResponse;
-        });
-        return actionListener;
+        return wrapActionListener(internalListener, MLTaskGetResponse::fromActionResponse);
     }
 
     private ActionListener<MLDeployModelResponse> getMlDeployModelResponseActionListener(ActionListener<MLDeployModelResponse> listener) {
-        ActionListener<MLDeployModelResponse> actionListener = wrapActionListener(listener, response -> {
-            MLDeployModelResponse deployModelResponse = MLDeployModelResponse.fromActionResponse(response);
-            return deployModelResponse;
-        });
-        return actionListener;
+        return wrapActionListener(listener, MLDeployModelResponse::fromActionResponse);
     }
 
     private ActionListener<MLUndeployModelsResponse> getMlUndeployModelsResponseActionListener(
         ActionListener<MLUndeployModelsResponse> listener
     ) {
-        ActionListener<MLUndeployModelsResponse> actionListener = wrapActionListener(listener, response -> {
-            MLUndeployModelsResponse deployModelResponse = MLUndeployModelsResponse.fromActionResponse(response);
-            return deployModelResponse;
-        });
-        return actionListener;
+        return wrapActionListener(listener, MLUndeployModelsResponse::fromActionResponse);
     }
 
     private ActionListener<MLCreateConnectorResponse> getMlCreateConnectorResponseActionListener(
         ActionListener<MLCreateConnectorResponse> listener
     ) {
-        ActionListener<MLCreateConnectorResponse> actionListener = wrapActionListener(listener, response -> {
-            MLCreateConnectorResponse createConnectorResponse = MLCreateConnectorResponse.fromActionResponse(response);
-            return createConnectorResponse;
-        });
-        return actionListener;
+        return wrapActionListener(listener, MLCreateConnectorResponse::fromActionResponse);
     }
 
     private ActionListener<MLRegisterModelGroupResponse> getMlRegisterModelGroupResponseActionListener(
         ActionListener<MLRegisterModelGroupResponse> listener
     ) {
-        ActionListener<MLRegisterModelGroupResponse> actionListener = wrapActionListener(listener, response -> {
-            MLRegisterModelGroupResponse registerModelGroupResponse = MLRegisterModelGroupResponse.fromActionResponse(response);
-            return registerModelGroupResponse;
-        });
-        return actionListener;
+        return wrapActionListener(listener, MLRegisterModelGroupResponse::fromActionResponse);
     }
 
     private ActionListener<MLTaskResponse> getMlPredictionTaskResponseActionListener(ActionListener<MLOutput> listener) {
         ActionListener<MLTaskResponse> internalListener = ActionListener.wrap(predictionResponse -> {
             listener.onResponse(predictionResponse.getOutput());
         }, listener::onFailure);
-        ActionListener<MLTaskResponse> actionListener = wrapActionListener(internalListener, res -> {
-            MLTaskResponse predictionResponse = MLTaskResponse.fromActionResponse(res);
-            return predictionResponse;
-        });
-        return actionListener;
+        return wrapActionListener(internalListener, MLTaskResponse::fromActionResponse);
     }
 
     private ActionListener<MLRegisterModelResponse> getMLRegisterModelResponseActionListener(
         ActionListener<MLRegisterModelResponse> listener
     ) {
-        ActionListener<MLRegisterModelResponse> actionListener = wrapActionListener(listener, res -> {
-            MLRegisterModelResponse registerModelResponse = MLRegisterModelResponse.fromActionResponse(res);
-            return registerModelResponse;
-        });
-        return actionListener;
+        return wrapActionListener(listener, MLRegisterModelResponse::fromActionResponse);
     }
 
     private <T extends ActionResponse> ActionListener<T> wrapActionListener(
         final ActionListener<T> listener,
         final Function<ActionResponse, T> recreate
     ) {
-        ActionListener<T> actionListener = ActionListener.wrap(r -> {
+        return ActionListener.wrap(r -> {
             listener.onResponse(recreate.apply(r));
             ;
-        }, e -> { listener.onFailure(e); });
-        return actionListener;
+        }, listener::onFailure);
     }
 
     private void validateMLInput(MLInput mlInput, boolean requireInput) {

--- a/client/src/test/java/org/opensearch/ml/client/MachineLearningClientTest.java
+++ b/client/src/test/java/org/opensearch/ml/client/MachineLearningClientTest.java
@@ -217,6 +217,11 @@ public class MachineLearningClientTest {
             }
 
             @Override
+            public void deleteConnector(String connectorId, String tenantId, ActionListener<DeleteResponse> listener) {
+                listener.onResponse(deleteResponse);
+            }
+
+            @Override
             public void deleteConnector(String connectorId, ActionListener<DeleteResponse> listener) {
                 listener.onResponse(deleteResponse);
             }

--- a/common/src/main/java/org/opensearch/ml/common/connector/AwsConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/AwsConnector.java
@@ -41,7 +41,8 @@ public class AwsConnector extends HttpConnector {
         List<String> backendRoles,
         AccessMode accessMode,
         User owner,
-        ConnectorClientConfig connectorClientConfig
+        ConnectorClientConfig connectorClientConfig,
+        String tenantId
     ) {
         super(
             name,
@@ -54,7 +55,8 @@ public class AwsConnector extends HttpConnector {
             backendRoles,
             accessMode,
             owner,
-            connectorClientConfig
+            connectorClientConfig,
+            tenantId
         );
         validate();
     }

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLConnectorDeleteRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLConnectorDeleteRequest.java
@@ -6,12 +6,14 @@
 package org.opensearch.ml.common.transport.connector;
 
 import static org.opensearch.action.ValidateActions.addValidationError;
+import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.core.common.io.stream.InputStreamStreamInput;
@@ -22,24 +24,41 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import lombok.Builder;
 import lombok.Getter;
 
+@Getter
 public class MLConnectorDeleteRequest extends ActionRequest {
-    @Getter
-    String connectorId;
+    private final String connectorId;
+    private final String tenantId;
 
     @Builder
+    public MLConnectorDeleteRequest(String connectorId, String tenantId) {
+        this.connectorId = connectorId;
+        this.tenantId = tenantId;
+    }
+
     public MLConnectorDeleteRequest(String connectorId) {
         this.connectorId = connectorId;
+        this.tenantId = null;
     }
 
     public MLConnectorDeleteRequest(StreamInput input) throws IOException {
         super(input);
+        Version streamInputVersion = input.getVersion();
         this.connectorId = input.readString();
+        if (streamInputVersion.onOrAfter(VERSION_2_19_0)) {
+            this.tenantId = input.readOptionalString();
+        } else {
+            this.tenantId = null;
+        }
     }
 
     @Override
     public void writeTo(StreamOutput output) throws IOException {
+        Version streamOutputVersion = output.getVersion();
         super.writeTo(output);
         output.writeString(connectorId);
+        if (streamOutputVersion.onOrAfter(VERSION_2_19_0)) {
+            output.writeOptionalString(tenantId);
+        }
     }
 
     @Override

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLConnectorGetResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLConnectorGetResponse.java
@@ -35,6 +35,10 @@ public class MLConnectorGetResponse extends ActionResponse implements ToXContent
         mlConnector = Connector.fromStream(in);
     }
 
+    public Connector getMlConnector() {
+        return mlConnector;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         mlConnector.writeTo(out);

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -6,6 +6,8 @@
 package org.opensearch.ml.common.transport.connector;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
 import static org.opensearch.ml.common.utils.StringUtils.getParameterMap;
 
 import java.io.IOException;
@@ -30,6 +32,7 @@ import org.opensearch.ml.common.connector.ConnectorClientConfig;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.Setter;
 
 @Data
 public class MLCreateConnectorInput implements ToXContentObject, Writeable {
@@ -56,6 +59,8 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
     private String description;
     private String version;
     private String protocol;
+    @Setter
+    private String tenantId;
     private Map<String, String> parameters;
     private Map<String, String> credential;
     private List<ConnectorAction> actions;
@@ -80,7 +85,8 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
         AccessMode access,
         boolean dryRun,
         boolean updateConnector,
-        ConnectorClientConfig connectorClientConfig
+        ConnectorClientConfig connectorClientConfig,
+        String tenantId
 
     ) {
         if (!dryRun && !updateConnector) {
@@ -110,6 +116,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
         this.dryRun = dryRun;
         this.updateConnector = updateConnector;
         this.connectorClientConfig = connectorClientConfig;
+        this.tenantId = tenantId;
 
     }
 
@@ -130,6 +137,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
         AccessMode access = null;
         boolean dryRun = false;
         ConnectorClientConfig connectorClientConfig = null;
+        String tenantId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -181,6 +189,9 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
                 case AbstractConnector.CLIENT_CONFIG_FIELD:
                     connectorClientConfig = ConnectorClientConfig.parse(parser);
                     break;
+                case TENANT_ID_FIELD:
+                    tenantId = parser.text();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -199,7 +210,8 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
             access,
             dryRun,
             updateConnector,
-            connectorClientConfig
+            connectorClientConfig,
+            tenantId
         );
     }
 
@@ -238,6 +250,9 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
         }
         if (connectorClientConfig != null) {
             builder.field(AbstractConnector.CLIENT_CONFIG_FIELD, connectorClientConfig);
+        }
+        if (tenantId != null) {
+            builder.field(TENANT_ID_FIELD, tenantId);
         }
         builder.endObject();
         return builder;
@@ -294,6 +309,9 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
                 output.writeBoolean(false);
             }
         }
+        if (streamOutputVersion.onOrAfter(VERSION_2_19_0)) {
+            output.writeOptionalString(tenantId);
+        }
     }
 
     public MLCreateConnectorInput(StreamInput input) throws IOException {
@@ -328,6 +346,9 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
             if (input.readBoolean()) {
                 this.connectorClientConfig = new ConnectorClientConfig(input);
             }
+        }
+        if (streamInputVersion.onOrAfter(VERSION_2_19_0)) {
+            this.tenantId = input.readOptionalString();
         }
 
     }

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLConnectorDeleteRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLConnectorDeleteRequestTests.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
 public class MLConnectorDeleteRequestTests {
@@ -93,5 +94,28 @@ public class MLConnectorDeleteRequestTests {
             .fromActionRequest(mlConnectorDeleteRequest);
         assertSame(mlConnectorDeleteRequest, mlConnectorDeleteRequestFromActionRequest);
         assertEquals(mlConnectorDeleteRequest.getConnectorId(), mlConnectorDeleteRequestFromActionRequest.getConnectorId());
+    }
+
+    @Test
+    public void testConstructorWithTenantId() {
+        String tenantId = "test_tenant";
+        MLConnectorDeleteRequest request = MLConnectorDeleteRequest.builder().connectorId(connectorId).tenantId(tenantId).build();
+
+        assertEquals(connectorId, request.getConnectorId());
+        assertEquals(tenantId, request.getTenantId());
+    }
+
+    @Test
+    public void testWriteToWithTenantId() throws IOException {
+        String tenantId = "test_tenant";
+        MLConnectorDeleteRequest request = MLConnectorDeleteRequest.builder().connectorId(connectorId).tenantId(tenantId).build();
+        BytesStreamOutput output = new BytesStreamOutput();
+        request.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        MLConnectorDeleteRequest parsedRequest = new MLConnectorDeleteRequest(input);
+
+        assertEquals(connectorId, parsedRequest.getConnectorId());
+        assertEquals(tenantId, parsedRequest.getTenantId());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLConnectorGetResponseTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLConnectorGetResponseTests.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import java.io.IOException;
@@ -107,5 +108,11 @@ public class MLConnectorGetResponseTests {
             }
         };
         MLConnectorGetResponse.fromActionResponse(actionResponse);
+    }
+
+    @Test
+    public void testNullConnector() {
+        MLConnectorGetResponse response = MLConnectorGetResponse.builder().build();
+        assertNull(response.getMlConnector());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -314,6 +314,36 @@ public class MLCreateConnectorInputTests {
     }
 
     @Test
+    public void testParseWithTenantId() throws Exception {
+        String inputWithTenantId =
+            "{\"name\":\"test_connector_name\",\"credential\":{\"key\":\"test_key_value\"},\"version\":\"1\",\"protocol\":\"http\",\"tenant_id\":\"test_tenant\"}";
+        testParseFromJsonString(inputWithTenantId, parsedInput -> {
+            assertEquals("test_connector_name", parsedInput.getName());
+            assertEquals("test_tenant", parsedInput.getTenantId());
+        });
+    }
+
+    @Test
+    public void testParseWithUnknownFields() throws Exception {
+        String inputWithUnknownFields =
+            "{\"name\":\"test_connector_name\",\"credential\":{\"key\":\"test_key_value\"},\"version\":\"1\",\"protocol\":\"http\",\"unknown_field\":\"unknown_value\"}";
+        testParseFromJsonString(inputWithUnknownFields, parsedInput -> {
+            assertEquals("test_connector_name", parsedInput.getName());
+            assertNull(parsedInput.getTenantId());
+        });
+    }
+
+    @Test
+    public void testParseWithEmptyActions() throws Exception {
+        String inputWithEmptyActions =
+            "{\"name\":\"test_connector_name\",\"credential\":{\"key\":\"test_key_value\"},\"version\":\"1\",\"protocol\":\"http\",\"actions\":[]}";
+        testParseFromJsonString(inputWithEmptyActions, parsedInput -> {
+            assertEquals("test_connector_name", parsedInput.getName());
+            assertTrue(parsedInput.getActions().isEmpty());
+        });
+    }
+
+    @Test
     public void testWriteToVersionCompatibility() throws IOException {
         MLCreateConnectorInput input = mlCreateConnectorInput; // Assuming mlCreateConnectorInput is already initialized
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/MultiTenantPredictable.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/MultiTenantPredictable.java
@@ -1,0 +1,18 @@
+package org.opensearch.ml.engine;
+
+import java.util.Map;
+
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.engine.encryptor.Encryptor;
+
+public interface MultiTenantPredictable extends Predictable {
+
+    /**
+     * Init model (load model into memory) with ML model content and params.
+     * @param model ML model
+     * @param params other parameters
+     * @param encryptor encryptor
+     * @param tenantId tenantId
+     */
+    void initModel(MLModel model, Map<String, Object> params, Encryptor encryptor, String tenantId);
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/GetConnectorTransportAction.java
@@ -5,16 +5,11 @@
 
 package org.opensearch.ml.action.connector;
 
-import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
-import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
 import static org.opensearch.ml.utils.RestActionUtils.getFetchSourceContext;
-
-import java.util.Objects;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
-import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.client.Client;
@@ -23,15 +18,16 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetAction;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetRequest;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetResponse;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.utils.RestActionUtils;
+import org.opensearch.ml.utils.TenantAwareHelper;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -45,22 +41,26 @@ import lombok.extern.log4j.Log4j2;
 public class GetConnectorTransportAction extends HandledTransportAction<ActionRequest, MLConnectorGetResponse> {
 
     Client client;
-    NamedXContentRegistry xContentRegistry;
+    SdkClient sdkClient;
 
     ConnectorAccessControlHelper connectorAccessControlHelper;
+
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     @Inject
     public GetConnectorTransportAction(
         TransportService transportService,
         ActionFilters actionFilters,
         Client client,
-        NamedXContentRegistry xContentRegistry,
-        ConnectorAccessControlHelper connectorAccessControlHelper
+        SdkClient sdkClient,
+        ConnectorAccessControlHelper connectorAccessControlHelper,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting
     ) {
         super(MLConnectorGetAction.NAME, transportService, actionFilters, MLConnectorGetRequest::new);
         this.client = client;
-        this.xContentRegistry = xContentRegistry;
+        this.sdkClient = sdkClient;
         this.connectorAccessControlHelper = connectorAccessControlHelper;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
     }
 
     @Override
@@ -68,64 +68,60 @@ public class GetConnectorTransportAction extends HandledTransportAction<ActionRe
         MLConnectorGetRequest mlConnectorGetRequest = MLConnectorGetRequest.fromActionRequest(request);
         String connectorId = mlConnectorGetRequest.getConnectorId();
         String tenantId = mlConnectorGetRequest.getTenantId();
+        if (!TenantAwareHelper.validateTenantId(mlFeatureEnabledSetting, tenantId, actionListener)) {
+            return;
+        }
         FetchSourceContext fetchSourceContext = getFetchSourceContext(mlConnectorGetRequest.isReturnContent());
-        GetRequest getRequest = new GetRequest(ML_CONNECTOR_INDEX).id(connectorId).fetchSourceContext(fetchSourceContext);
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
+            .index(ML_CONNECTOR_INDEX)
+            .id(connectorId)
+            .tenantId(tenantId)
+            .fetchSourceContext(fetchSourceContext)
+            .build();
         User user = RestActionUtils.getUserContext(client);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            client.get(getRequest, ActionListener.runBefore(ActionListener.wrap(r -> {
-                log.debug("Completed Get Connector Request, id:{}", connectorId);
-
-                if (r != null && r.isExists()) {
-                    try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, r.getSourceAsBytesRef())) {
-                        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-                        Connector mlConnector = Connector.createConnector(parser);
-                        mlConnector.removeCredential();
-                        if (!Objects.equals(tenantId, mlConnector.getTenantId())) {
-                            actionListener
-                                .onFailure(
-                                    new OpenSearchStatusException(
-                                        "You don't have permission to access this connector",
-                                        RestStatus.FORBIDDEN
-                                    )
-                                );
-                        }
-                        if (connectorAccessControlHelper.hasPermission(user, mlConnector)) {
-                            actionListener.onResponse(MLConnectorGetResponse.builder().mlConnector(mlConnector).build());
-                        } else {
-                            actionListener
-                                .onFailure(
-                                    new OpenSearchStatusException(
-                                        "You don't have permission to access this connector",
-                                        RestStatus.FORBIDDEN
-                                    )
-                                );
-                        }
-                    } catch (Exception e) {
-                        log.error("Failed to parse ml connector" + r.getId(), e);
-                        actionListener.onFailure(e);
-                    }
-                } else {
-                    actionListener
-                        .onFailure(
-                            new OpenSearchStatusException(
-                                "Failed to find connector with the provided connector id: " + connectorId,
-                                RestStatus.NOT_FOUND
-                            )
-                        );
-                }
-            }, e -> {
-                if (e instanceof IndexNotFoundException) {
-                    log.error("Failed to get connector index", e);
-                    actionListener.onFailure(new OpenSearchStatusException("Failed to find connector", RestStatus.NOT_FOUND));
-                } else {
-                    log.error("Failed to get ML connector " + connectorId, e);
-                    actionListener.onFailure(e);
-                }
-            }), context::restore));
+            connectorAccessControlHelper
+                .getConnector(
+                    sdkClient,
+                    client,
+                    context,
+                    getDataObjectRequest,
+                    connectorId,
+                    ActionListener
+                        .wrap(
+                            connector -> handleConnectorAccessValidation(user, tenantId, connector, actionListener),
+                            e -> handleConnectorAccessValidationFailure(connectorId, e, actionListener)
+                        )
+                );
         } catch (Exception e) {
-            log.error("Failed to get ML connector " + connectorId, e);
+            log.error("Failed to get ML connector {}", connectorId, e);
             actionListener.onFailure(e);
         }
+    }
 
+    private void handleConnectorAccessValidation(
+        User user,
+        String tenantId,
+        Connector mlConnector,
+        ActionListener<MLConnectorGetResponse> actionListener
+    ) {
+        if (TenantAwareHelper.validateTenantResource(mlFeatureEnabledSetting, tenantId, mlConnector.getTenantId(), actionListener)) {
+            if (connectorAccessControlHelper.hasPermission(user, mlConnector)) {
+                actionListener.onResponse(MLConnectorGetResponse.builder().mlConnector(mlConnector).build());
+            } else {
+                actionListener
+                    .onFailure(new OpenSearchStatusException("You don't have permission to access this connector", RestStatus.FORBIDDEN));
+            }
+        }
+    }
+
+    private void handleConnectorAccessValidationFailure(
+        String connectorId,
+        Exception e,
+        ActionListener<MLConnectorGetResponse> actionListener
+    ) {
+        log.error("Failed to get ML connector: {}", connectorId, e);
+        actionListener.onFailure(e);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
@@ -6,25 +6,24 @@
 package org.opensearch.ml.action.connector;
 
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 
 import org.opensearch.action.ActionRequest;
-import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
-import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.util.CollectionUtils;
@@ -41,7 +40,12 @@ import org.opensearch.ml.engine.exceptions.MetaDataException;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.utils.RestActionUtils;
+import org.opensearch.ml.utils.TenantAwareHelper;
+import org.opensearch.remote.metadata.client.PutDataObjectRequest;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.common.SdkClientUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -51,8 +55,11 @@ import lombok.extern.log4j.Log4j2;
 public class TransportCreateConnectorAction extends HandledTransportAction<ActionRequest, MLCreateConnectorResponse> {
     private final MLIndicesHandler mlIndicesHandler;
     private final Client client;
+    private final SdkClient sdkClient;
     private final MLEngine mlEngine;
     private final MLModelManager mlModelManager;
+
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
     private final ConnectorAccessControlHelper connectorAccessControlHelper;
 
     private volatile List<String> trustedConnectorEndpointsRegex;
@@ -63,18 +70,22 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
         ActionFilters actionFilters,
         MLIndicesHandler mlIndicesHandler,
         Client client,
+        SdkClient sdkClient,
         MLEngine mlEngine,
         ConnectorAccessControlHelper connectorAccessControlHelper,
         Settings settings,
         ClusterService clusterService,
-        MLModelManager mlModelManager
+        MLModelManager mlModelManager,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting
     ) {
         super(MLCreateConnectorAction.NAME, transportService, actionFilters, MLCreateConnectorRequest::new);
         this.mlIndicesHandler = mlIndicesHandler;
         this.client = client;
+        this.sdkClient = sdkClient;
         this.mlEngine = mlEngine;
         this.connectorAccessControlHelper = connectorAccessControlHelper;
         this.mlModelManager = mlModelManager;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
         trustedConnectorEndpointsRegex = ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX.get(settings);
         clusterService
             .getClusterSettings()
@@ -85,6 +96,9 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
     protected void doExecute(Task task, ActionRequest request, ActionListener<MLCreateConnectorResponse> listener) {
         MLCreateConnectorRequest mlCreateConnectorRequest = MLCreateConnectorRequest.fromActionRequest(request);
         MLCreateConnectorInput mlCreateConnectorInput = mlCreateConnectorRequest.getMlCreateConnectorInput();
+        if (!TenantAwareHelper.validateTenantId(mlFeatureEnabledSetting, mlCreateConnectorInput.getTenantId(), listener)) {
+            return;
+        }
         if (mlCreateConnectorInput.isDryRun()) {
             MLCreateConnectorResponse response = new MLCreateConnectorResponse(MLCreateConnectorInput.DRY_RUN_CONNECTOR_NAME);
             listener.onResponse(response);
@@ -115,7 +129,7 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
             log.error("The masterKey for credential encryption is missing in connector creation");
             listener.onFailure(e);
         } catch (Exception e) {
-            log.error("Failed to create connector " + connectorName, e);
+            log.error("Failed to create connector {}", connectorName, e);
             listener.onFailure(e);
         }
     }
@@ -129,20 +143,40 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
                 return;
             }
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-                ActionListener<IndexResponse> indexResponseListener = ActionListener.wrap(r -> {
-                    log.info("Connector saved into index, result:{}, connector id: {}", r.getResult(), r.getId());
-                    MLCreateConnectorResponse response = new MLCreateConnectorResponse(r.getId());
-                    listener.onResponse(response);
-                }, listener::onFailure);
-
                 Instant currentTime = Instant.now();
                 connector.setCreatedTime(currentTime);
                 connector.setLastUpdateTime(currentTime);
-
-                IndexRequest indexRequest = new IndexRequest(ML_CONNECTOR_INDEX);
-                indexRequest.source(connector.toXContent(XContentBuilder.builder(XContentType.JSON.xContent()), ToXContent.EMPTY_PARAMS));
-                indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-                client.index(indexRequest, ActionListener.runBefore(indexResponseListener, context::restore));
+                sdkClient
+                    .putDataObjectAsync(
+                        PutDataObjectRequest
+                            .builder()
+                            .tenantId(connector.getTenantId())
+                            .index(ML_CONNECTOR_INDEX)
+                            .dataObject(connector)
+                            .build(),
+                        client.threadPool().executor(GENERAL_THREAD_POOL)
+                    )
+                    .whenComplete((r, throwable) -> {
+                        context.restore();
+                        if (throwable != null) {
+                            Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable);
+                            log.error("Failed to create ML connector", cause);
+                            listener.onFailure(cause);
+                        } else {
+                            try {
+                                IndexResponse indexResponse = IndexResponse.fromXContent(r.parser());
+                                log
+                                    .info(
+                                        "Connector creation result: {}, connector id: {}",
+                                        indexResponse.getResult(),
+                                        indexResponse.getId()
+                                    );
+                                listener.onResponse(new MLCreateConnectorResponse(indexResponse.getId()));
+                            } catch (IOException e) {
+                                listener.onFailure(e);
+                            }
+                        }
+                    });
             } catch (Exception e) {
                 log.error("Failed to save ML connector", e);
                 listener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -732,7 +732,8 @@ public class MachineLearningPlugin extends Plugin
                 clusterManagerEventListener,
                 mlCircuitBreakerService,
                 mlModelAutoRedeployer,
-                cmHandler
+                cmHandler,
+                sdkClient
             );
     }
 
@@ -776,7 +777,7 @@ public class MachineLearningPlugin extends Plugin
         RestMLDeleteModelGroupAction restMLDeleteModelGroupAction = new RestMLDeleteModelGroupAction();
         RestMLCreateConnectorAction restMLCreateConnectorAction = new RestMLCreateConnectorAction(mlFeatureEnabledSetting);
         RestMLGetConnectorAction restMLGetConnectorAction = new RestMLGetConnectorAction(clusterService, settings, mlFeatureEnabledSetting);
-        RestMLDeleteConnectorAction restMLDeleteConnectorAction = new RestMLDeleteConnectorAction();
+        RestMLDeleteConnectorAction restMLDeleteConnectorAction = new RestMLDeleteConnectorAction(mlFeatureEnabledSetting);
         RestMLSearchConnectorAction restMLSearchConnectorAction = new RestMLSearchConnectorAction();
         RestMemoryCreateConversationAction restCreateConversationAction = new RestMemoryCreateConversationAction();
         RestMemoryGetConversationsAction restListConversationsAction = new RestMemoryGetConversationsAction();

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLCreateConnectorAction.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.rest;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
 import static org.opensearch.ml.utils.MLExceptionUtils.REMOTE_INFERENCE_DISABLED_ERR_MSG;
+import static org.opensearch.ml.utils.TenantAwareHelper.getTenantID;
 
 import java.io.IOException;
 import java.util.List;
@@ -71,6 +72,8 @@ public class RestMLCreateConnectorAction extends BaseRestHandler {
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         MLCreateConnectorInput mlCreateConnectorInput = MLCreateConnectorInput.parse(parser);
+        String tenantId = getTenantID(mlFeatureEnabledSetting.isMultiTenancyEnabled(), request);
+        mlCreateConnectorInput.setTenantId(tenantId);
         return new MLCreateConnectorRequest(mlCreateConnectorInput);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLDeleteConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLDeleteConnectorAction.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.rest;
 
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_CONNECTOR_ID;
+import static org.opensearch.ml.utils.TenantAwareHelper.getTenantID;
 
 import java.io.IOException;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.Locale;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.ml.common.transport.connector.MLConnectorDeleteAction;
 import org.opensearch.ml.common.transport.connector.MLConnectorDeleteRequest;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestToXContentListener;
@@ -27,7 +29,11 @@ import com.google.common.collect.ImmutableList;
 public class RestMLDeleteConnectorAction extends BaseRestHandler {
     private static final String ML_DELETE_CONNECTOR_ACTION = "ml_delete_connector_action";
 
-    public void RestMLDeleteConnectorAction() {}
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    public RestMLDeleteConnectorAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
 
     @Override
     public String getName() {
@@ -45,8 +51,8 @@ public class RestMLDeleteConnectorAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String connectorId = request.param(PARAMETER_CONNECTOR_ID);
-
-        MLConnectorDeleteRequest mlConnectorDeleteRequest = new MLConnectorDeleteRequest(connectorId);
+        String tenantId = getTenantID(mlFeatureEnabledSetting.isMultiTenancyEnabled(), request);
+        MLConnectorDeleteRequest mlConnectorDeleteRequest = new MLConnectorDeleteRequest(connectorId, tenantId);
         return channel -> client.execute(MLConnectorDeleteAction.INSTANCE, mlConnectorDeleteRequest, new RestToXContentListener<>(channel));
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -308,13 +308,13 @@ public final class MLCommonsSettings {
 
     /** This setting sets the remote metadata endpoint */
     public static final Setting<String> REMOTE_METADATA_ENDPOINT = Setting
-        .simpleString("plugins.flow_framework." + REMOTE_METADATA_ENDPOINT_KEY, Setting.Property.NodeScope, Setting.Property.Final);
+        .simpleString("plugins.ml_commons." + REMOTE_METADATA_ENDPOINT_KEY, Setting.Property.NodeScope, Setting.Property.Final);
 
     /** This setting sets the remote metadata region */
     public static final Setting<String> REMOTE_METADATA_REGION = Setting
-        .simpleString("plugins.flow_framework." + REMOTE_METADATA_REGION_KEY, Setting.Property.NodeScope, Setting.Property.Final);
+        .simpleString("plugins.ml_commons." + REMOTE_METADATA_REGION_KEY, Setting.Property.NodeScope, Setting.Property.Final);
 
     /** This setting sets the remote metadata service name */
     public static final Setting<String> REMOTE_METADATA_SERVICE_NAME = Setting
-        .simpleString("plugins.flow_framework." + REMOTE_METADATA_SERVICE_NAME_KEY, Setting.Property.NodeScope, Setting.Property.Final);
+        .simpleString("plugins.ml_commons." + REMOTE_METADATA_SERVICE_NAME_KEY, Setting.Property.NodeScope, Setting.Property.Final);
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/DeleteConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/DeleteConnectorTransportActionTests.java
@@ -6,14 +6,24 @@
 package org.opensearch.ml.action.connector;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.action.DocWriteResponse.Result.DELETED;
+import static org.opensearch.action.DocWriteResponse.Result.NOT_FOUND;
+import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.lucene.search.TotalHits;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -22,19 +32,25 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceNotFoundException;
-import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.LatchedActionListener;
+import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -44,20 +60,41 @@ import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.transport.connector.MLConnectorDeleteRequest;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.utils.TestHelper;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
+import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
+
+    private static final String CONNECTOR_ID = "connector_id";
+
+    private static TestThreadPool testThreadPool = new TestThreadPool(
+        TransportCreateConnectorActionTests.class.getName(),
+        new ScalingExecutorBuilder(
+            GENERAL_THREAD_POOL,
+            1,
+            Math.max(1, OpenSearchExecutors.allocatedProcessors(Settings.EMPTY) - 1),
+            TimeValue.timeValueMinutes(1),
+            ML_THREAD_POOL_PREFIX + GENERAL_THREAD_POOL
+        )
+    );
+
     @Mock
     ThreadPool threadPool;
 
     @Mock
     Client client;
+
+    SdkClient sdkClient;
 
     @Mock
     TransportService transportService;
@@ -85,99 +122,146 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
     @Mock
     private ConnectorAccessControlHelper connectorAccessControlHelper;
 
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
     @Before
     public void setup() throws IOException {
         MockitoAnnotations.openMocks(this);
 
-        mlConnectorDeleteRequest = MLConnectorDeleteRequest.builder().connectorId("connector_id").build();
-
+        sdkClient = SdkClientFactory.createSdkClient(client, NamedXContentRegistry.EMPTY, Collections.emptyMap());
+        mlConnectorDeleteRequest = MLConnectorDeleteRequest.builder().connectorId(CONNECTOR_ID).build();
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
         Settings settings = Settings.builder().build();
         deleteConnectorTransportAction = spy(
-            new DeleteConnectorTransportAction(transportService, actionFilters, client, xContentRegistry, connectorAccessControlHelper)
+            new DeleteConnectorTransportAction(
+                transportService,
+                actionFilters,
+                client,
+                sdkClient,
+                xContentRegistry,
+                connectorAccessControlHelper,
+                mlFeatureEnabledSetting
+            )
         );
 
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(2);
+            ActionListener<Boolean> listener = invocation.getArgument(5);
             listener.onResponse(true);
             return null;
-        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any());
+        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), isA(ActionListener.class));
 
         threadContext = new ThreadContext(settings);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(threadPool.executor(any())).thenReturn(testThreadPool.executor(GENERAL_THREAD_POOL));
     }
 
-    public void testDeleteConnector_Success() throws IOException {
+    @AfterClass
+    public static void cleanup() {
+        ThreadPool.terminate(testThreadPool, 500, TimeUnit.MILLISECONDS);
+    }
+
+    public void testDeleteConnector_Success() throws InterruptedException {
+        DeleteResponse deleteResponse = new DeleteResponse(new ShardId(ML_CONNECTOR_INDEX, "_na_", 0), CONNECTOR_ID, 1, 0, 2, true);
+        PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(deleteResponse);
+        when(client.delete(any(DeleteRequest.class))).thenReturn(future);
+
         doAnswer(invocation -> {
-            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
-            listener.onResponse(deleteResponse);
+            ActionListener<Boolean> listener = invocation.getArgument(5);
+            listener.onResponse(true);
             return null;
-        }).when(client).delete(any(), any());
+        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
         SearchResponse searchResponse = getEmptySearchResponse();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onResponse(searchResponse);
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
 
-        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
-        verify(actionListener).onResponse(deleteResponse);
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
+        ArgumentCaptor<DeleteResponse> captor = ArgumentCaptor.forClass(DeleteResponse.class);
+        verify(actionListener).onResponse(captor.capture());
+        assertEquals(CONNECTOR_ID, captor.getValue().getId());
+        assertEquals(DELETED, captor.getValue().getResult());
     }
 
-    public void testDeleteConnector_ModelIndexNotFoundSuccess() throws IOException {
+    public void testDeleteConnector_ModelIndexNotFoundSuccess() throws InterruptedException {
+        DeleteResponse deleteResponse = new DeleteResponse(new ShardId(ML_CONNECTOR_INDEX, "_na_", 0), CONNECTOR_ID, 1, 0, 2, true);
+        PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(deleteResponse);
+        when(client.delete(any(DeleteRequest.class))).thenReturn(future);
+
         doAnswer(invocation -> {
-            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
-            listener.onResponse(deleteResponse);
+            ActionListener<Boolean> listener = invocation.getArgument(5);
+            listener.onResponse(true);
             return null;
-        }).when(client).delete(any(), any());
+        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
+
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onFailure(new IndexNotFoundException("ml_model index not found!"));
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
+        ArgumentCaptor<DeleteResponse> captor = ArgumentCaptor.forClass(DeleteResponse.class);
+        verify(actionListener).onResponse(captor.capture());
+        assertEquals(CONNECTOR_ID, captor.getValue().getId());
+        assertEquals(DELETED, captor.getValue().getResult());
+    }
+
+    public void testDeleteConnector_ConnectorNotFound() throws InterruptedException {
+        DeleteResponse deleteResponse = new DeleteResponse(new ShardId(ML_CONNECTOR_INDEX, "_na_", 0), CONNECTOR_ID, 1, 0, 2, false);
+        PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(deleteResponse);
+        when(client.delete(any(DeleteRequest.class))).thenReturn(future);
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(5);
+            listener.onResponse(true);
+            return null;
+        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
         SearchResponse searchResponse = getEmptySearchResponse();
-        doAnswer(invocation -> {
-            ActionListener<Exception> actionListener = invocation.getArgument(1);
-            actionListener.onFailure(new IndexNotFoundException("ml_model index not found!"));
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onResponse(searchResponse);
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
 
-        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
-        verify(actionListener).onResponse(deleteResponse);
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
+        ArgumentCaptor<DeleteResponse> captor = ArgumentCaptor.forClass(DeleteResponse.class);
+        verify(actionListener).onResponse(captor.capture());
+        assertEquals(CONNECTOR_ID, captor.getValue().getId());
+        assertEquals(NOT_FOUND, captor.getValue().getResult());
     }
 
-    public void testDeleteConnector_ConnectorNotFound() throws IOException {
-        when(deleteResponse.getResult()).thenReturn(DocWriteResponse.Result.NOT_FOUND);
-
+    public void testDeleteConnector_BlockedByModel() throws IOException, InterruptedException {
         doAnswer(invocation -> {
-            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
-            listener.onResponse(deleteResponse);
+            ActionListener<Boolean> listener = invocation.getArgument(5);
+            listener.onResponse(true);
             return null;
-        }).when(client).delete(any(), any());
-
-        SearchResponse searchResponse = getEmptySearchResponse();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), any());
-
-        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
-        verify(actionListener).onResponse(deleteResponse);
-    }
-
-    public void testDeleteConnector_BlockedByModel() throws IOException {
-        doAnswer(invocation -> {
-            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
-            listener.onResponse(deleteResponse);
-            return null;
-        }).when(client).delete(any(), any());
+        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
         SearchResponse searchResponse = getNonEmptySearchResponse();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onResponse(searchResponse);
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
 
-        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
@@ -188,10 +272,10 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
 
     public void test_UserHasNoAccessException() throws IOException {
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(2);
+            ActionListener<Boolean> listener = invocation.getArgument(5);
             listener.onResponse(false);
             return null;
-        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any());
+        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
         deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -199,27 +283,35 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
         assertEquals("You are not allowed to delete this connector", argumentCaptor.getValue().getMessage());
     }
 
-    public void testDeleteConnector_SearchFailure() throws IOException {
+    public void testDeleteConnector_SearchFailure() throws InterruptedException {
         doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onFailure(new RuntimeException("Search Failed!"));
+            ActionListener<Boolean> listener = invocation.getArgument(5);
+            listener.onResponse(true);
             return null;
-        }).when(client).search(any(), any());
+        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
-        doAnswer(invocation -> {
-            ActionListener<DeleteResponse> actionListener = invocation.getArgument(1);
-            actionListener.onFailure(new ResourceNotFoundException("errorMessage"));
-            return null;
-        }).when(client).delete(any(), any());
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onFailure(new RuntimeException("Search Failed!"));
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
 
-        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Search Failed!", argumentCaptor.getValue().getMessage());
     }
 
-    public void testDeleteConnector_SearchException() throws IOException {
+    public void testDeleteConnector_SearchException() {
         when(client.threadPool()).thenThrow(new RuntimeException("Thread Context Error!"));
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(5);
+            listener.onResponse(true);
+            return null;
+        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
         deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
@@ -227,44 +319,58 @@ public class DeleteConnectorTransportActionTests extends OpenSearchTestCase {
         assertEquals("Thread Context Error!", argumentCaptor.getValue().getMessage());
     }
 
-    public void testDeleteConnector_ResourceNotFoundException() throws IOException {
+    public void testDeleteConnector_ResourceNotFoundException() throws InterruptedException {
+        when(client.delete(any(DeleteRequest.class))).thenThrow(new ResourceNotFoundException("errorMessage"));
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(5);
+            listener.onResponse(true);
+            return null;
+        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
+
         SearchResponse searchResponse = getEmptySearchResponse();
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), any());
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onResponse(searchResponse);
+        when(client.search(any(SearchRequest.class))).thenReturn(searchFuture);
 
-        doAnswer(invocation -> {
-            ActionListener<DeleteResponse> actionListener = invocation.getArgument(1);
-            actionListener.onFailure(new ResourceNotFoundException("errorMessage"));
-            return null;
-        }).when(client).delete(any(), any());
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
 
-        deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("errorMessage", argumentCaptor.getValue().getMessage());
     }
 
-    public void test_ValidationFailedException() throws IOException {
-        GetResponse getResponse = prepareMLConnector();
+    public void test_ValidationFailedException() {
         doAnswer(invocation -> {
-            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(getResponse);
-            return null;
-        }).when(client).search(any(), any());
-
-        doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(2);
+            ActionListener<Boolean> listener = invocation.getArgument(5);
             listener.onFailure(new Exception("Failed to validate access"));
             return null;
-        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any());
+        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any(), any(), any(), any());
 
         deleteConnectorTransportAction.doExecute(null, mlConnectorDeleteRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Failed to validate access", argumentCaptor.getValue().getMessage());
+    }
+
+    public void testDeleteConnector_MultiTenancyEnabled_NoTenantId() throws InterruptedException {
+        // Enable multi-tenancy
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+
+        // Create a request without a tenant ID
+        MLConnectorDeleteRequest requestWithoutTenant = MLConnectorDeleteRequest.builder().connectorId(CONNECTOR_ID).build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<DeleteResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        deleteConnectorTransportAction.doExecute(null, requestWithoutTenant, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("You don't have permission to access this resource", argumentCaptor.getValue().getMessage());
     }
 
     public GetResponse prepareMLConnector() throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/GetConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/GetConnectorTransportActionTests.java
@@ -6,49 +6,84 @@
 package org.opensearch.ml.action.connector;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
+import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.LatchedActionListener;
+import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.get.GetResult;
+import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetRequest;
 import org.opensearch.ml.common.transport.connector.MLConnectorGetResponse;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
+import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 public class GetConnectorTransportActionTests extends OpenSearchTestCase {
+    private static final String CONNECTOR_ID = "connector_id";
+
+    private static final String TENANT_ID = "_tenant_id";
+
+    private static final TestThreadPool testThreadPool = new TestThreadPool(
+        GetConnectorTransportActionTests.class.getName(),
+        new ScalingExecutorBuilder(
+            GENERAL_THREAD_POOL,
+            1,
+            Math.max(1, OpenSearchExecutors.allocatedProcessors(Settings.EMPTY) - 1),
+            TimeValue.timeValueMinutes(1),
+            ML_THREAD_POOL_PREFIX + GENERAL_THREAD_POOL
+        )
+    );
+
     @Mock
     ThreadPool threadPool;
 
     @Mock
     Client client;
 
-    @Mock
-    NamedXContentRegistry xContentRegistry;
+    SdkClient sdkClient;
 
     @Mock
     TransportService transportService;
@@ -60,113 +95,157 @@ public class GetConnectorTransportActionTests extends OpenSearchTestCase {
     ActionListener<MLConnectorGetResponse> actionListener;
 
     @Mock
+    GetResponse getResponse;
+
+    @Mock
     private ConnectorAccessControlHelper connectorAccessControlHelper;
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
     GetConnectorTransportAction getConnectorTransportAction;
     MLConnectorGetRequest mlConnectorGetRequest;
     ThreadContext threadContext;
 
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Captor
+    private ArgumentCaptor<GetDataObjectRequest> getDataObjectRequestArgumentCaptor;
+
     @Before
     public void setup() throws IOException {
         MockitoAnnotations.openMocks(this);
-        mlConnectorGetRequest = MLConnectorGetRequest.builder().connectorId("connector_id").build();
+
         Settings settings = Settings.builder().build();
+        sdkClient = SdkClientFactory.createSdkClient(client, NamedXContentRegistry.EMPTY, Collections.emptyMap());
+        mlConnectorGetRequest = MLConnectorGetRequest.builder().connectorId(CONNECTOR_ID).tenantId(TENANT_ID).build();
+        when(getResponse.getId()).thenReturn(CONNECTOR_ID);
+        when(getResponse.getSourceAsString()).thenReturn("{}");
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
 
         getConnectorTransportAction = spy(
-            new GetConnectorTransportAction(transportService, actionFilters, client, xContentRegistry, connectorAccessControlHelper)
+            new GetConnectorTransportAction(
+                transportService,
+                actionFilters,
+                client,
+                sdkClient,
+                connectorAccessControlHelper,
+                mlFeatureEnabledSetting
+            )
         );
-
-        doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(3);
-            listener.onResponse(true);
-            return null;
-        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any());
 
         threadContext = new ThreadContext(settings);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(threadPool.executor(anyString())).thenReturn(testThreadPool.executor(GENERAL_THREAD_POOL));
     }
 
-    public void testGetConnector_UserHasNodeAccess() throws IOException {
-        doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(3);
-            listener.onResponse(false);
-            return null;
-        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any());
+    @AfterClass
+    public static void cleanup() {
+        ThreadPool.terminate(testThreadPool, 500, TimeUnit.MILLISECONDS);
+    }
 
-        GetResponse getResponse = prepareConnector();
+    @Test
+    public void testGetConnector_UserHasNoAccess() throws IOException, InterruptedException {
+        HttpConnector httpConnector = HttpConnector.builder().name("test_connector").protocol("http").tenantId("tenantId").build();
+        when(connectorAccessControlHelper.hasPermission(any(), any())).thenReturn(false);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onResponse(getResponse);
+            ActionListener<Connector> listener = invocation.getArgument(5);
+            listener.onResponse(httpConnector);
             return null;
-        }).when(client).get(any(), any());
+        }).when(connectorAccessControlHelper).getConnector(any(), any(), any(), any(), any(), any());
 
-        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, actionListener);
+        GetResponse getResponse = prepareConnector(null);
+        PlainActionFuture<GetResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(getResponse);
+        when(client.get(any(GetRequest.class))).thenReturn(future);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("You don't have permission to access this connector", argumentCaptor.getValue().getMessage());
     }
 
-    public void testGetConnector_ValidateAccessFailed() throws IOException {
+    @Test
+    public void testGetConnector_NullResponse() throws InterruptedException {
         doAnswer(invocation -> {
-            ActionListener<Boolean> listener = invocation.getArgument(3);
-            listener.onFailure(new Exception("Failed to validate access"));
+            ActionListener<Connector> listener = invocation.getArgument(5);
+            listener
+                .onFailure(
+                    new OpenSearchStatusException(
+                        "Failed to find connector with the provided connector id: connector_id",
+                        RestStatus.NOT_FOUND
+                    )
+                );
             return null;
-        }).when(connectorAccessControlHelper).validateConnectorAccess(any(), any(), any());
+        }).when(connectorAccessControlHelper).getConnector(any(), any(), any(), any(), any(), any());
 
-        GetResponse getResponse = prepareConnector();
-        doAnswer(invocation -> {
-            ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onResponse(getResponse);
-            return null;
-        }).when(client).get(any(), any());
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
 
-        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, actionListener);
-        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals("You don't have permission to access this connector", argumentCaptor.getValue().getMessage());
-    }
-
-    public void testGetConnector_NullResponse() {
-        doAnswer(invocation -> {
-            ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onResponse(null);
-            return null;
-        }).when(client).get(any(), any());
-        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Failed to find connector with the provided connector id: connector_id", argumentCaptor.getValue().getMessage());
     }
 
-    public void testGetConnector_IndexNotFoundException() {
+    public void testGetConnector_MultiTenancyEnabled_Success() throws IOException, InterruptedException {
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+        when(connectorAccessControlHelper.hasPermission(any(), any())).thenReturn(true);
+        String tenantId = "test_tenant";
+        mlConnectorGetRequest = MLConnectorGetRequest.builder().connectorId(CONNECTOR_ID).tenantId(tenantId).build();
+
+        HttpConnector httpConnector = HttpConnector.builder().name("test_connector").protocol("http").tenantId(tenantId).build();
+        when(connectorAccessControlHelper.hasPermission(any(), any())).thenReturn(true);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new IndexNotFoundException("Fail to find model"));
+            ActionListener<Connector> listener = invocation.getArgument(5);
+            listener.onResponse(httpConnector);
             return null;
-        }).when(client).get(any(), any());
-        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, actionListener);
-        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals("Failed to find connector", argumentCaptor.getValue().getMessage());
+        }).when(connectorAccessControlHelper).getConnector(any(), any(), any(),
+                getDataObjectRequestArgumentCaptor.capture(), any(), any());
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
+        Assert.assertEquals(tenantId, getDataObjectRequestArgumentCaptor.getValue().tenantId());
+        Assert.assertEquals(CONNECTOR_ID, getDataObjectRequestArgumentCaptor.getValue().id());
+        ArgumentCaptor<MLConnectorGetResponse> argumentCaptor = ArgumentCaptor.forClass(MLConnectorGetResponse.class);
+        verify(actionListener).onResponse(argumentCaptor.capture());
+        assertEquals(tenantId, argumentCaptor.getValue().getMlConnector().getTenantId());
     }
 
-    public void testGetConnector_RuntimeException() {
+    @Test
+    public void testGetConnector_MultiTenancyEnabled_ForbiddenAccess() throws IOException, InterruptedException {
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+        when(connectorAccessControlHelper.hasPermission(any(), any())).thenReturn(true);
+        String tenantId = "test_tenant";
+        mlConnectorGetRequest = MLConnectorGetRequest.builder().connectorId(CONNECTOR_ID).tenantId(tenantId).build();
+
+        HttpConnector httpConnector = HttpConnector.builder().name("test_connector").protocol("http").tenantId("tenantId").build();
+        when(connectorAccessControlHelper.hasPermission(any(), any())).thenReturn(true);
         doAnswer(invocation -> {
-            ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new RuntimeException("errorMessage"));
+            ActionListener<Connector> listener = invocation.getArgument(5);
+            listener.onResponse(httpConnector);
             return null;
-        }).when(client).get(any(), any());
-        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, actionListener);
+        }).when(connectorAccessControlHelper).getConnector(any(), any(), any(), any(), any(), any());
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<MLConnectorGetResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        getConnectorTransportAction.doExecute(null, mlConnectorGetRequest, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals("errorMessage", argumentCaptor.getValue().getMessage());
+        assertEquals("You don't have permission to access this resource", argumentCaptor.getValue().getMessage());
     }
 
-    public GetResponse prepareConnector() throws IOException {
-        HttpConnector httpConnector = HttpConnector.builder().name("test_connector").protocol("http").build();
+    public GetResponse prepareConnector(String tenantId) throws IOException {
+        HttpConnector httpConnector = HttpConnector.builder().name("test_connector").protocol("http").tenantId(tenantId).build();
 
         XContentBuilder content = httpConnector.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
         BytesReference bytesReference = BytesReference.bytes(content);

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
@@ -5,35 +5,51 @@
 package org.opensearch.ml.action.connector;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
 import static org.opensearch.ml.task.MLPredictTaskRunnerTests.USER_STRING;
 import static org.opensearch.ml.utils.TestHelper.clusterSetting;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.ConnectorProtocols;
@@ -44,8 +60,14 @@ import org.opensearch.ml.engine.MLEngine;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
+import org.opensearch.remote.metadata.client.PutDataObjectRequest;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
+import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -54,12 +76,27 @@ import com.google.common.collect.ImmutableMap;
 
 public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
 
+    private static final String CONNECTOR_ID = "connector_id";
+    private static final String TENANT_ID = "_tenant_id";
+
+    private static TestThreadPool testThreadPool = new TestThreadPool(
+        TransportCreateConnectorActionTests.class.getName(),
+        new ScalingExecutorBuilder(
+            GENERAL_THREAD_POOL,
+            1,
+            Math.max(1, OpenSearchExecutors.allocatedProcessors(Settings.EMPTY) - 1),
+            TimeValue.timeValueMinutes(1),
+            ML_THREAD_POOL_PREFIX + GENERAL_THREAD_POOL
+        )
+    );
+
     private TransportCreateConnectorAction action;
 
     @Mock
     private MLIndicesHandler mlIndicesHandler;
     @Mock
     private Client client;
+    private SdkClient sdkClient;
     @Mock
     private MLEngine mlEngine;
     @Mock
@@ -82,6 +119,11 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
     @Mock
     ActionListener<MLCreateConnectorResponse> actionListener;
 
+    IndexResponse indexResponse;
+
+    @Mock
+    NamedXContentRegistry xContentRegistry;
+
     @Mock
     private ThreadPool threadPool;
 
@@ -92,32 +134,47 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
 
     private Settings settings;
 
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Captor
+    private ArgumentCaptor<PutDataObjectRequest> putDataObjectRequestArgumentCaptor;
+
     private static final List<String> TRUSTED_CONNECTOR_ENDPOINTS_REGEXES = ImmutableList
         .of("^https://runtime\\.sagemaker\\..*\\.amazonaws\\.com/.*$", "^https://api\\.openai\\.com/.*$", "^https://api\\.cohere\\.ai/.*$");
 
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
+
         settings = Settings
             .builder()
             .putList(ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX.getKey(), TRUSTED_CONNECTOR_ENDPOINTS_REGEXES)
             .build();
+        sdkClient = SdkClientFactory.createSdkClient(client, NamedXContentRegistry.EMPTY, Collections.emptyMap());
+        indexResponse = new IndexResponse(new ShardId(ML_CONNECTOR_INDEX, "_na_", 0), CONNECTOR_ID, 1, 0, 2, true);
+
         ClusterSettings clusterSettings = clusterSetting(
             settings,
             ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX,
             ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+
         action = new TransportCreateConnectorAction(
             transportService,
             actionFilters,
             mlIndicesHandler,
             client,
+            sdkClient,
             mlEngine,
             connectorAccessControlHelper,
             settings,
             clusterService,
-            mlModelManager
+            mlModelManager,
+            mlFeatureEnabledSetting
         );
         Settings settings = Settings.builder().put(ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED.getKey(), true).build();
         threadContext = new ThreadContext(settings);
@@ -125,6 +182,7 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(threadPool.executor(anyString())).thenReturn(testThreadPool.executor(GENERAL_THREAD_POOL));
 
         List<ConnectorAction> actions = new ArrayList<>();
         actions
@@ -151,7 +209,12 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
         when(request.getMlCreateConnectorInput()).thenReturn(input);
     }
 
-    public void test_execute_connectorAccessControl_notEnabled_success() {
+    @AfterClass
+    public static void cleanup() {
+        ThreadPool.terminate(testThreadPool, 500, TimeUnit.MILLISECONDS);
+    }
+
+    public void test_execute_connectorAccessControl_notEnabled_success() throws InterruptedException {
         when(connectorAccessControlHelper.accessControlNotEnabled(any(User.class))).thenReturn(true);
         input.setAddAllBackendRoles(null);
         input.setBackendRoles(null);
@@ -162,16 +225,48 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
-        doAnswer(invocation -> {
-            ActionListener<IndexResponse> listener = invocation.getArgument(1);
-            listener.onResponse(mock(IndexResponse.class));
-            return null;
-        }).when(client).index(any(IndexRequest.class), isA(ActionListener.class));
-        action.doExecute(task, request, actionListener);
+        PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(indexResponse);
+        when(client.index(any(IndexRequest.class))).thenReturn(future);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<MLCreateConnectorResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        action.doExecute(task, request, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
         verify(actionListener).onResponse(any(MLCreateConnectorResponse.class));
     }
 
-    public void test_execute_connectorAccessControl_notEnabled_withPermissionInfo_exception() {
+    public void test_execute_connector_registration_multi_tenancy_fail() throws InterruptedException {
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+        when(connectorAccessControlHelper.accessControlNotEnabled(any(User.class))).thenReturn(true);
+        input.setAddAllBackendRoles(null);
+        input.setBackendRoles(null);
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
+
+        PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(indexResponse);
+        when(client.index(any(IndexRequest.class))).thenReturn(future);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<MLCreateConnectorResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        action.doExecute(task, request, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+                "You don't have permission to access this resource",
+                argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    public void test_execute_connectorAccessControl_notEnabled_withPermissionInfo_exception() throws InterruptedException {
         when(connectorAccessControlHelper.accessControlNotEnabled(any(User.class))).thenReturn(true);
         input.setBackendRoles(null);
         input.setAddAllBackendRoles(true);
@@ -182,21 +277,24 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
-        doAnswer(invocation -> {
-            ActionListener<IndexResponse> listener = invocation.getArgument(1);
-            listener.onResponse(mock(IndexResponse.class));
-            return null;
-        }).when(client).index(any(IndexRequest.class), isA(ActionListener.class));
-        action.doExecute(task, request, actionListener);
+        PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(mock(IndexResponse.class));
+        when(client.index(any(IndexRequest.class))).thenReturn(future);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<MLCreateConnectorResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        action.doExecute(task, request, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
-            "You cannot specify connector access control parameters because the Security plugin or connector access control is disabled on your cluster.",
-            argumentCaptor.getValue().getMessage()
+                "You cannot specify connector access control parameters because the Security plugin or connector access control is disabled on your cluster.",
+                argumentCaptor.getValue().getMessage()
         );
     }
 
-    public void test_execute_connectorAccessControlEnabled_success() {
+    public void test_execute_connectorAccessControlEnabled_success() throws InterruptedException {
         when(connectorAccessControlHelper.accessControlNotEnabled(any(User.class))).thenReturn(false);
         input.setAddAllBackendRoles(false);
         input.setBackendRoles(ImmutableList.of("role1", "role2"));
@@ -207,16 +305,20 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
-        doAnswer(invocation -> {
-            ActionListener<IndexResponse> listener = invocation.getArgument(1);
-            listener.onResponse(mock(IndexResponse.class));
-            return null;
-        }).when(client).index(any(IndexRequest.class), isA(ActionListener.class));
-        action.doExecute(task, request, actionListener);
+        PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(indexResponse);
+        when(client.index(any(IndexRequest.class))).thenReturn(future);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<MLCreateConnectorResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        request.getMlCreateConnectorInput().setTenantId(TENANT_ID);
+        action.doExecute(task, request, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
         verify(actionListener).onResponse(any(MLCreateConnectorResponse.class));
     }
 
-    public void test_execute_connectorAccessControlEnabled_missingPermissionInfo_defaultToPrivate() {
+    public void test_execute_connectorAccessControlEnabled_missingPermissionInfo_defaultToPrivate() throws InterruptedException {
         when(connectorAccessControlHelper.accessControlNotEnabled(any(User.class))).thenReturn(false);
         input.setAddAllBackendRoles(null);
         input.setBackendRoles(null);
@@ -227,12 +329,15 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
-        doAnswer(invocation -> {
-            ActionListener<IndexResponse> listener = invocation.getArgument(1);
-            listener.onResponse(mock(IndexResponse.class));
-            return null;
-        }).when(client).index(any(IndexRequest.class), isA(ActionListener.class));
-        action.doExecute(task, request, actionListener);
+        PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(indexResponse);
+        when(client.index(any(IndexRequest.class))).thenReturn(future);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<MLCreateConnectorResponse> latchedActionListener = new LatchedActionListener<>(actionListener, latch);
+        action.doExecute(task, request, latchedActionListener);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
         verify(actionListener).onResponse(any(MLCreateConnectorResponse.class));
     }
 
@@ -248,16 +353,11 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
-        doAnswer(invocation -> {
-            ActionListener<IndexResponse> listener = invocation.getArgument(1);
-            listener.onResponse(mock(IndexResponse.class));
-            return null;
-        }).when(client).index(any(IndexRequest.class), isA(ActionListener.class));
         action.doExecute(task, request, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
-            "Admin can't add all backend roles", argumentCaptor.getValue().getMessage()
+                "Admin can't add all backend roles", argumentCaptor.getValue().getMessage()
         );
     }
 
@@ -273,17 +373,12 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
-        doAnswer(invocation -> {
-            ActionListener<IndexResponse> listener = invocation.getArgument(1);
-            listener.onResponse(mock(IndexResponse.class));
-            return null;
-        }).when(client).index(any(IndexRequest.class), isA(ActionListener.class));
         action.doExecute(task, request, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
-            "You can specify backend roles only for a connector with the restricted access mode.",
-            argumentCaptor.getValue().getMessage()
+                "You can specify backend roles only for a connector with the restricted access mode.",
+                argumentCaptor.getValue().getMessage()
         );
     }
 
@@ -306,21 +401,18 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
-        doAnswer(invocation -> {
-            ActionListener<IndexResponse> listener = invocation.getArgument(1);
-            listener.onResponse(mock(IndexResponse.class));
-            return null;
-        }).when(client).index(any(IndexRequest.class), isA(ActionListener.class));
         TransportCreateConnectorAction action = new TransportCreateConnectorAction(
             transportService,
             actionFilters,
             mlIndicesHandler,
             client,
+            sdkClient,
             mlEngine,
             connectorAccessControlHelper,
             settings,
             clusterService,
-            mlModelManager
+            mlModelManager,
+            mlFeatureEnabledSetting
         );
         action.doExecute(task, request, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -347,21 +439,18 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
-        doAnswer(invocation -> {
-            ActionListener<IndexResponse> listener = invocation.getArgument(1);
-            listener.onResponse(mock(IndexResponse.class));
-            return null;
-        }).when(client).index(any(IndexRequest.class), isA(ActionListener.class));
         TransportCreateConnectorAction action = new TransportCreateConnectorAction(
             transportService,
             actionFilters,
             mlIndicesHandler,
             client,
+            sdkClient,
             mlEngine,
             connectorAccessControlHelper,
             settings,
             clusterService,
-            mlModelManager
+            mlModelManager,
+            mlFeatureEnabledSetting
         );
         action.doExecute(task, request, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -391,21 +480,18 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
 
-        doAnswer(invocation -> {
-            ActionListener<IndexResponse> listener = invocation.getArgument(1);
-            listener.onResponse(mock(IndexResponse.class));
-            return null;
-        }).when(client).index(any(IndexRequest.class), isA(ActionListener.class));
         TransportCreateConnectorAction action = new TransportCreateConnectorAction(
             transportService,
             actionFilters,
             mlIndicesHandler,
             client,
+            sdkClient,
             mlEngine,
             connectorAccessControlHelper,
             settings,
             clusterService,
-            mlModelManager
+            mlModelManager,
+            mlFeatureEnabledSetting
         );
         action.doExecute(task, request, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -423,12 +509,6 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             listener.onResponse(true);
             return null;
         }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
-
-        doAnswer(invocation -> {
-            ActionListener<IndexResponse> listener = invocation.getArgument(1);
-            listener.onResponse(mock(IndexResponse.class));
-            return null;
-        }).when(client).index(any(IndexRequest.class), isA(ActionListener.class));
 
         MLCreateConnectorInput mlCreateConnectorInput = mock(MLCreateConnectorInput.class);
         when(mlCreateConnectorInput.getName()).thenReturn(MLCreateConnectorInput.DRY_RUN_CONNECTOR_NAME);
@@ -469,11 +549,13 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             actionFilters,
             mlIndicesHandler,
             client,
+            sdkClient,
             mlEngine,
             connectorAccessControlHelper,
             settings,
             clusterService,
-            mlModelManager
+            mlModelManager,
+            mlFeatureEnabledSetting
         );
         action.doExecute(task, request, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);

--- a/plugin/src/test/java/org/opensearch/ml/helper/ConnectorAccessControlHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/ConnectorAccessControlHelperTests.java
@@ -8,43 +8,67 @@ package org.opensearch.ml.helper;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.GENERAL_THREAD_POOL;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_THREAD_POOL_PREFIX;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED;
 import static org.opensearch.ml.task.MLPredictTaskRunnerTests.USER_STRING;
 import static org.opensearch.ml.utils.TestHelper.clusterSetting;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.LatchedActionListener;
+import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.CommonValue;
+import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorProtocols;
 import org.opensearch.ml.common.connector.HttpConnector;
+import org.opensearch.ml.settings.MLFeatureEnabledSetting;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
+import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
 import com.google.common.collect.ImmutableList;
@@ -61,6 +85,9 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
     private ActionListener<Boolean> actionListener;
 
     @Mock
+    private ActionListener<Connector> getConnectorActionListener;
+
+    @Mock
     private ThreadPool threadPool;
 
     ThreadContext threadContext;
@@ -71,14 +98,35 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
 
     private User user;
 
+    SdkClient sdkClient;
+
+    @Mock
+    NamedXContentRegistry xContentRegistry;
+
+    @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    private static TestThreadPool testThreadPool = new TestThreadPool(
+        ConnectorAccessControlHelperTests.class.getName(),
+        new ScalingExecutorBuilder(
+            GENERAL_THREAD_POOL,
+            1,
+            Math.max(1, OpenSearchExecutors.allocatedProcessors(Settings.EMPTY) - 1),
+            TimeValue.timeValueMinutes(1),
+            ML_THREAD_POOL_PREFIX + GENERAL_THREAD_POOL
+        )
+    );
+
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
         Settings settings = Settings.builder().put(ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED.getKey(), true).build();
+        sdkClient = SdkClientFactory.createSdkClient(client, NamedXContentRegistry.EMPTY, Collections.emptyMap());
         threadContext = new ThreadContext(settings);
         ClusterSettings clusterSettings = clusterSetting(settings, ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-        connectorAccessControlHelper = new ConnectorAccessControlHelper(clusterService, settings);
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+        connectorAccessControlHelper = spy(new ConnectorAccessControlHelper(clusterService, settings));
         user = User.parse("mockUser|role-1,role-2|null");
 
         getResponse = createGetResponse(null);
@@ -90,14 +138,22 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
 
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(threadPool.executor(any())).thenReturn(testThreadPool.executor(GENERAL_THREAD_POOL));
     }
 
+    @AfterClass
+    public static void cleanup() {
+        ThreadPool.terminate(testThreadPool, 500, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
     public void test_hasPermission_user_null_return_true() {
         HttpConnector httpConnector = mock(HttpConnector.class);
         boolean hasPermission = connectorAccessControlHelper.hasPermission(null, httpConnector);
         assertTrue(hasPermission);
     }
 
+    @Test
     public void test_hasPermission_connectorAccessControl_not_enabled_return_true() {
         HttpConnector httpConnector = mock(HttpConnector.class);
         Settings settings = Settings.builder().put(ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED.getKey(), false).build();
@@ -108,6 +164,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         assertTrue(hasPermission);
     }
 
+    @Test
     public void test_hasPermission_connectorOwner_is_null_return_true() {
         HttpConnector httpConnector = mock(HttpConnector.class);
         when(httpConnector.getOwner()).thenReturn(null);
@@ -115,12 +172,14 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         assertTrue(hasPermission);
     }
 
+    @Test
     public void test_hasPermission_user_is_admin_return_true() {
         User user = User.parse("admin|role-1|all_access");
         boolean hasPermission = connectorAccessControlHelper.hasPermission(user, mock(HttpConnector.class));
         assertTrue(hasPermission);
     }
 
+    @Test
     public void test_hasPermission_connector_isPublic_return_true() {
         HttpConnector httpConnector = mock(HttpConnector.class);
         when(httpConnector.getAccess()).thenReturn(AccessMode.PUBLIC);
@@ -128,6 +187,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         assertTrue(hasPermission);
     }
 
+    @Test
     public void test_hasPermission_connector_isPrivate_userIsOwner_return_true() {
         HttpConnector httpConnector = mock(HttpConnector.class);
         when(httpConnector.getAccess()).thenReturn(AccessMode.PRIVATE);
@@ -136,6 +196,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         assertTrue(hasPermission);
     }
 
+    @Test
     public void test_hasPermission_connector_isPrivate_userIsNotOwner_return_false() {
         HttpConnector httpConnector = mock(HttpConnector.class);
         when(httpConnector.getAccess()).thenReturn(AccessMode.PRIVATE);
@@ -145,6 +206,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         assertFalse(hasPermission);
     }
 
+    @Test
     public void test_hasPermission_connector_isRestricted_userHasBackendRole_return_true() {
         HttpConnector httpConnector = mock(HttpConnector.class);
         when(httpConnector.getAccess()).thenReturn(AccessMode.RESTRICTED);
@@ -153,6 +215,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         assertTrue(hasPermission);
     }
 
+    @Test
     public void test_hasPermission_connector_isRestricted_userNotHasBackendRole_return_false() {
         HttpConnector httpConnector = mock(HttpConnector.class);
         when(httpConnector.getAccess()).thenReturn(AccessMode.RESTRICTED);
@@ -162,7 +225,8 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         assertFalse(hasPermission);
     }
 
-    public void test_validateConnectorAccess_user_isAdmin_return_true() {
+    // todo: will remove this later
+    public void test_validateConnectorAccess_user_isAdmin_return_true_old() {
         String userString = "admin|role-1|all_access";
         Settings settings = Settings.builder().put(ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED.getKey(), true).build();
         ThreadContext threadContext = new ThreadContext(settings);
@@ -174,7 +238,21 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         verify(actionListener).onResponse(true);
     }
 
-    public void test_validateConnectorAccess_user_isNotAdmin_hasNoBackendRole_return_false() {
+    @Test
+    public void test_validateConnectorAccess_user_isAdmin_return_true() {
+        String userString = "admin|role-1|all_access";
+        Settings settings = Settings.builder().put(ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED.getKey(), true).build();
+        ThreadContext threadContext = new ThreadContext(settings);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, userString);
+
+        connectorAccessControlHelper.validateConnectorAccess(sdkClient, client, "anyId", null, mlFeatureEnabledSetting, actionListener);
+        verify(actionListener).onResponse(true);
+    }
+
+    // todo will remove later.
+    public void test_validateConnectorAccess_user_isNotAdmin_hasNoBackendRole_return_false_old() {
         GetResponse getResponse = createGetResponse(ImmutableList.of("role-3"));
         Client client = mock(Client.class);
         doAnswer(invocation -> {
@@ -190,12 +268,67 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         verify(actionListener).onResponse(false);
     }
 
+    @Test
+    public void test_validateConnectorAccess_user_isNotAdmin_hasNoBackendRole_return_false() throws Exception {
+        // Mock the client thread pool
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        // Set up user context
+        threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, USER_STRING);
+        // Create HttpConnector
+        HttpConnector httpConnector = HttpConnector.builder()
+                .name("testConnector")
+                .protocol(ConnectorProtocols.HTTP)
+                .owner(user)
+                .description("This is test connector")
+                .backendRoles(Collections.singletonList("role-3"))
+                .accessMode(AccessMode.RESTRICTED)
+                .build();
+
+        doAnswer(invocation -> {
+            ActionListener<Connector> listener = invocation.getArgument(5);
+            listener.onResponse(httpConnector);
+            return null;
+        }).when(connectorAccessControlHelper).getConnector(any(), any(), any(), any(), any(), any());
+
+        // Execute the validation
+        connectorAccessControlHelper.validateConnectorAccess(sdkClient, client, "anyId", null, mlFeatureEnabledSetting, actionListener);
+
+        // Verify the action listener was called with false
+        verify(actionListener).onResponse(false);
+    }
+
+    @Test
     public void test_validateConnectorAccess_user_isNotAdmin_hasBackendRole_return_true() {
+        connectorAccessControlHelper.validateConnectorAccess(sdkClient, client, "anyId", null, mlFeatureEnabledSetting, actionListener);
+        verify(actionListener).onResponse(true);
+    }
+
+    // todo will remove later
+    public void test_validateConnectorAccess_user_isNotAdmin_hasBackendRole_return_true_old() {
         connectorAccessControlHelper.validateConnectorAccess(client, "anyId", actionListener);
         verify(actionListener).onResponse(true);
     }
 
+    @Test
     public void test_validateConnectorAccess_connectorNotFound_return_false() {
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(5);
+            listener.onFailure(new OpenSearchStatusException("Failed to find connector", RestStatus.NOT_FOUND));
+            return null;
+        }).when(connectorAccessControlHelper).getConnector(any(), any(), any(), any(), any(), any());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, USER_STRING);
+
+        // connectorAccessControlHelper.validateConnectorAccess(client, "anyId", actionListener);
+        connectorAccessControlHelper.validateConnectorAccess(sdkClient, client, "anyId", null, mlFeatureEnabledSetting, actionListener);
+        verify(actionListener, times(1)).onFailure(any(OpenSearchStatusException.class));
+    }
+
+    // todo will remove later
+    public void test_validateConnectorAccess_connectorNotFound_return_false_old() {
         Client client = mock(Client.class);
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = invocation.getArgument(1);
@@ -210,7 +343,24 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         verify(actionListener, times(1)).onFailure(any(OpenSearchStatusException.class));
     }
 
+    @Test
     public void test_validateConnectorAccess_searchConnectorException_return_false() {
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(5);
+            listener.onFailure(new RuntimeException("Failed to find connector"));
+            return null;
+        }).when(connectorAccessControlHelper).getConnector(any(), any(), any(), any(), any(), any());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, USER_STRING);
+
+        // connectorAccessControlHelper.validateConnectorAccess(client, "anyId", actionListener);
+        connectorAccessControlHelper.validateConnectorAccess(sdkClient, client, "anyId", null, mlFeatureEnabledSetting, actionListener);
+        verify(actionListener, times(1)).onFailure(any(RuntimeException.class));
+    }
+
+    // todo will remove later
+    public void test_validateConnectorAccess_searchConnectorException_return_false_old() {
         Client client = mock(Client.class);
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = invocation.getArgument(1);
@@ -225,11 +375,13 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         verify(actionListener).onFailure(any(OpenSearchStatusException.class));
     }
 
+    @Test
     public void test_skipConnectorAccessControl_userIsNull_return_true() {
         boolean skip = connectorAccessControlHelper.skipConnectorAccessControl(null);
         assertTrue(skip);
     }
 
+    @Test
     public void test_skipConnectorAccessControl_connectorAccessControl_notEnabled_return_true() {
         Settings settings = Settings.builder().put(ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED.getKey(), false).build();
         ClusterSettings clusterSettings = clusterSetting(settings, ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED);
@@ -239,12 +391,14 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         assertTrue(skip);
     }
 
+    @Test
     public void test_skipConnectorAccessControl_userIsAdmin_return_true() {
         User user = User.parse("admin|role-1|all_access");
         boolean skip = connectorAccessControlHelper.skipConnectorAccessControl(user);
         assertTrue(skip);
     }
 
+    @Test
     public void test_accessControlNotEnabled_connectorAccessControl_notEnabled_return_true() {
         Settings settings = Settings.builder().put(ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED.getKey(), false).build();
         ClusterSettings clusterSettings = clusterSetting(settings, ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED);
@@ -254,17 +408,20 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         assertTrue(skip);
     }
 
+    @Test
     public void test_accessControlNotEnabled_userIsNull_return_true() {
         boolean notEnabled = connectorAccessControlHelper.accessControlNotEnabled(null);
         assertTrue(notEnabled);
     }
 
+    @Test
     public void test_addUserBackendRolesFilter_nullQuery() {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         SearchSourceBuilder result = connectorAccessControlHelper.addUserBackendRolesFilter(user, searchSourceBuilder);
         assertNotNull(result);
     }
 
+    @Test
     public void test_addUserBackendRolesFilter_boolQuery() {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.query(new BoolQueryBuilder());
@@ -272,11 +429,92 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         assertEquals("bool", result.query().getName());
     }
 
+    @Test
     public void test_addUserBackendRolesFilter_nonBoolQuery() {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.query(new MatchAllQueryBuilder());
         SearchSourceBuilder result = connectorAccessControlHelper.addUserBackendRolesFilter(user, searchSourceBuilder);
         assertEquals("bool", result.query().getName());
+    }
+
+    @Test
+    public void testGetConnectorHappyCase() throws IOException, InterruptedException {
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(CommonValue.ML_CONNECTOR_INDEX).id("connectorId").build();
+        GetResponse getResponse = prepareConnector();
+
+        PlainActionFuture<GetResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(getResponse);
+        when(client.get(any(GetRequest.class))).thenReturn(future);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<Connector> latchedActionListener = new LatchedActionListener<>(getConnectorActionListener, latch);
+        connectorAccessControlHelper
+            .getConnector(
+                sdkClient,
+                client,
+                client.threadPool().getThreadContext().newStoredContext(true),
+                getRequest,
+                "connectorId",
+                latchedActionListener
+            );
+        latch.await(500, TimeUnit.MILLISECONDS);
+
+        ArgumentCaptor<GetRequest> requestCaptor = ArgumentCaptor.forClass(GetRequest.class);
+        verify(client, times(1)).get(requestCaptor.capture());
+        assertEquals(CommonValue.ML_CONNECTOR_INDEX, requestCaptor.getValue().index());
+    }
+
+    @Test
+    public void testGetConnectorException() throws IOException, InterruptedException {
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(CommonValue.ML_CONNECTOR_INDEX).id("connectorId").build();
+
+        PlainActionFuture<GetResponse> future = PlainActionFuture.newFuture();
+        future.onFailure(new RuntimeException("Failed to get connector"));
+        when(client.get(any(GetRequest.class))).thenReturn(future);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<Connector> latchedActionListener = new LatchedActionListener<>(getConnectorActionListener, latch);
+        connectorAccessControlHelper
+            .getConnector(
+                sdkClient,
+                client,
+                client.threadPool().getThreadContext().newStoredContext(true),
+                getRequest,
+                "connectorId",
+                latchedActionListener
+            );
+        latch.await(500, TimeUnit.MILLISECONDS);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(getConnectorActionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Failed to get connector", argumentCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void testGetConnectorIndexNotFound() throws IOException, InterruptedException {
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(CommonValue.ML_CONNECTOR_INDEX).id("connectorId").build();
+
+        PlainActionFuture<GetResponse> future = PlainActionFuture.newFuture();
+        future.onFailure(new IndexNotFoundException("Index not found"));
+        when(client.get(any(GetRequest.class))).thenReturn(future);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<Connector> latchedActionListener = new LatchedActionListener<>(getConnectorActionListener, latch);
+        connectorAccessControlHelper
+            .getConnector(
+                sdkClient,
+                client,
+                client.threadPool().getThreadContext().newStoredContext(true),
+                getRequest,
+                "connectorId",
+                latchedActionListener
+            );
+        latch.await(500, TimeUnit.MILLISECONDS);
+
+        ArgumentCaptor<OpenSearchStatusException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(getConnectorActionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Failed to find connector", argumentCaptor.getValue().getMessage());
+        assertEquals(RestStatus.NOT_FOUND, argumentCaptor.getValue().status());
     }
 
     private GetResponse createGetResponse(List<String> backendRoles) {
@@ -289,7 +527,7 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
             .backendRoles(Optional.ofNullable(backendRoles).orElse(ImmutableList.of("role-1")))
             .accessMode(AccessMode.RESTRICTED)
             .build();
-        XContentBuilder content = null;
+        XContentBuilder content;
         try {
             content = httpConnector.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
         } catch (IOException e) {
@@ -298,5 +536,14 @@ public class ConnectorAccessControlHelperTests extends OpenSearchTestCase {
         BytesReference bytesReference = BytesReference.bytes(content);
         GetResult getResult = new GetResult(CommonValue.ML_MODEL_GROUP_INDEX, "111", 111l, 111l, 111l, true, bytesReference, null, null);
         return new GetResponse(getResult);
+    }
+
+    public GetResponse prepareConnector() throws IOException {
+        HttpConnector httpConnector = HttpConnector.builder().name("test_connector").protocol("http").build();
+        XContentBuilder content = httpConnector.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
+        BytesReference bytesReference = BytesReference.bytes(content);
+        GetResult getResult = new GetResult("indexName", "111", 111l, 111l, 111l, true, bytesReference, null, null);
+        GetResponse getResponse = new GetResponse(getResult);
+        return getResponse;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLCreateConnectorActionTests.java
@@ -104,7 +104,7 @@ public class RestMLCreateConnectorActionTests extends OpenSearchTestCase {
     }
 
     public void testGetRequest() throws IOException {
-        RestRequest request = getCreateConnectorRestRequest();
+        RestRequest request = getCreateConnectorRestRequest(null);
         MLCreateConnectorRequest mlCreateConnectorRequest = restMLCreateConnectorAction.getRequest(request);
 
         MLCreateConnectorInput mlCreateConnectorInput = mlCreateConnectorRequest.getMlCreateConnectorInput();
@@ -112,7 +112,7 @@ public class RestMLCreateConnectorActionTests extends OpenSearchTestCase {
     }
 
     public void testPrepareRequest() throws Exception {
-        RestRequest request = getCreateConnectorRestRequest();
+        RestRequest request = getCreateConnectorRestRequest(null);
         restMLCreateConnectorAction.handleRequest(request, channel, client);
 
         ArgumentCaptor<MLCreateConnectorRequest> argumentCaptor = ArgumentCaptor.forClass(MLCreateConnectorRequest.class);
@@ -135,7 +135,17 @@ public class RestMLCreateConnectorActionTests extends OpenSearchTestCase {
         thrown.expectMessage(REMOTE_INFERENCE_DISABLED_ERR_MSG);
 
         when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(false);
-        RestRequest request = getCreateConnectorRestRequest();
+        RestRequest request = getCreateConnectorRestRequest(null);
         restMLCreateConnectorAction.handleRequest(request, channel, client);
+    }
+
+    public void testGetRequest_MultiTenancyEnabled() throws IOException {
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+        RestRequest request = getCreateConnectorRestRequest("tenantId");
+        MLCreateConnectorRequest mlCreateConnectorRequest = restMLCreateConnectorAction.getRequest(request);
+
+        MLCreateConnectorInput mlCreateConnectorInput = mlCreateConnectorRequest.getMlCreateConnectorInput();
+        verifyParsedCreateConnectorInput(mlCreateConnectorInput);
+        assertEquals("tenantId", mlCreateConnectorInput.getTenantId());
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -76,6 +76,7 @@ import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.dataset.MLInputDataType;
 import org.opensearch.ml.common.dataset.SearchQueryInputDataset;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.input.Constants;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.input.execute.metricscorrelation.MetricsCorrelationInput;
 import org.opensearch.ml.common.input.execute.samplecalculator.LocalSampleCalculatorInput;
@@ -245,7 +246,12 @@ public class TestHelper {
         return request;
     }
 
-    public static RestRequest getCreateConnectorRestRequest() {
+    public static RestRequest getCreateConnectorRestRequest(String tenantId) {
+        Map<String, List<String>> headers = new HashMap<>();
+        if (tenantId != null) {
+            headers.put(Constants.TENANT_ID_HEADER, Collections.singletonList(tenantId));
+        }
+
         final String requestContent = "{\n"
             + "    \"name\": \"OpenAI Connector\",\n"
             + "    \"description\": \"The connector to public OpenAI model service for GPT 3.5\",\n"
@@ -276,6 +282,7 @@ public class TestHelper {
             + "    \"access_mode\": \"public\"\n"
             + "}";
         RestRequest request = new FakeRestRequest.Builder(getXContentRegistry())
+            .withHeaders(headers)
             .withContent(new BytesArray(requestContent), XContentType.JSON)
             .build();
         return request;


### PR DESCRIPTION
### Description
[apply multi-tenancy and sdk client in Connector (Create + Get + Delete)]

By default, this is single tenant. If we enable [multi-tenancy settings](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java#L302-L303), then the request will expect an header `x-tenant-id`. And one tenant won't be able to access other tenant's resource. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
