### PR TITLE
Add runs-on field to Spotless Check step in CI

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -23,6 +23,8 @@ jobs:
       product: opensearch
 
   spotless:
+    if: github.repository == 'opensearch-project/ml-commons'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       # Spotless requires JDK 17+


### PR DESCRIPTION
### Description
Without the runs-on field, the spotless check step fails

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
