### PR TITLE
downgrading codecov action

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -88,7 +88,7 @@ jobs:
           echo "build-test-linux=$plugin" >> $GITHUB_OUTPUT
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           flags: ml-commons
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Description

```
==> Running git config --global --add safe.directory /__w/ml-commons/ml-commons
/usr/bin/git config --global --add safe.directory /__w/ml-commons/ml-commons
==> Running command '/__w/_actions/codecov/codecov-action/v4/dist/codecov create-commit'
/__w/_actions/codecov/codecov-action/v4/dist/codecov create-commit --git-service github -C b777894ada4b7252b432703ece8e92261ef094e9 --pr 3399
[PYI-7170:ERROR] Failed to load Python shared library '/tmp/_MEIF9N3ND/libpython3.11.so.1.0': dlopen: /lib64/libm.so.6: version `GLIBC_2.29' not found (required by /tmp/_MEIF9N3ND/libpython3.11.so.1.0)
Warning: Codecov: Failed to properly create commit: The process '/__w/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 255
```

Currently code cove is not generating reporting. As codecov action was written in Python not in Node.

I have another PR in main branch. So raising in 2.x and later I will backport to main.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
