### PR TITLE
Fix jar hell issue for neural search plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,10 +91,34 @@ subprojects {
         testImplementation.extendsFrom compileOnly
     }
 
+    dependencies {
+        compileOnly 'org.ow2.asm:asm:9.7'
+        compileOnly 'org.json:json:20231013'
+        compileOnly 'org.javassist:javassist:3.29.2-GA'
+        compileOnly 'org.apache.commons:commons-text:1.10.0'
+        compileOnly 'org.apache.commons:commons-lang3:3.14.0'
+        compileOnly 'com.google.code.gson:gson:2.10.1'
+        compileOnly 'org.reflections:reflections:0.9.12'
+        compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
+        compileOnly 'com.fasterxml.jackson.core:jackson-core:2.18.2'
+        compileOnly 'com.fasterxml.jackson.core:jackson-annotations:2.18.2'
+        compileOnly 'com.google.guava:guava:32.1.3-jre'
+    }
+
     configurations.all {
         // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
         resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
         resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
+        resolutionStrategy.force 'org.javassist:javassist:3.29.2-GA'
+        resolutionStrategy.force 'org.apache.commons:commons-text:1.10.0'
+        resolutionStrategy.force 'org.apache.commons:commons-lang3:3.14.0'
+        resolutionStrategy.force 'com.google.code.gson:gson:2.10.1'
+        resolutionStrategy.force 'org.reflections:reflections:0.9.12'
+        resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
+        resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.18.2'
+        resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-annotations:2.18.2'
+        exclude group: 'org.ow2.asm', module: 'asm'
+        exclude group: 'com.google.guava', module: 'failureaccess'
     }
 }
 


### PR DESCRIPTION
### Description
Fix jar hell issue when install neural search plugin after adding ml-commons as extended plugin.

### Related Issues
https://github.com/opensearch-project/neural-search/issues/480

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
