### PR TITLE
run auto deploy remote model in partially deployed status

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
@@ -146,6 +146,11 @@ public class MLModelCache {
         this.workerNodes.addAll(workerNodes);
     }
 
+    public void syncPlanningWorkerNode(Set<String> planningWorkerNodes) {
+        this.targetWorkerNodes.clear();
+        this.targetWorkerNodes.addAll(planningWorkerNodes);
+    }
+
     public boolean isDeployToAllNodes() {
         return this.deployToAllNodes != null && this.deployToAllNodes;
     }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCache.java
@@ -146,7 +146,7 @@ public class MLModelCache {
         this.workerNodes.addAll(workerNodes);
     }
 
-    public void syncPlanningWorkerNode(Set<String> planningWorkerNodes) {
+    public void syncPlanningWorkerNodes(Set<String> planningWorkerNodes) {
         this.targetWorkerNodes.clear();
         this.targetWorkerNodes.addAll(planningWorkerNodes);
     }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
@@ -538,6 +538,21 @@ public class MLModelCacheHelper {
     }
 
     /**
+     * Get target worker nodes of model.
+     *
+     * @param modelId model id
+     * @return array of node id; return null if model not exists in cache
+     */
+    public String[] getTargetWorkerNodes(String modelId) {
+        MLModelCache modelCache = modelCaches.get(modelId);
+        if (modelCache == null) {
+            return null;
+        }
+        return modelCache.getTargetWorkerNodes();
+    }
+
+
+    /**
      * Add worker node of model.
      * 
      * @param modelId model id

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
@@ -632,7 +632,7 @@ public class MLModelCacheHelper {
         log.debug("sync model planning worker nodes");
         modelPlanningWorkerNodes.entrySet().forEach(entry -> {
             MLModelCache modelCache = getOrCreateModelCache(entry.getKey());
-            modelCache.syncPlanningWorkerNode(entry.getValue());
+            modelCache.syncPlanningWorkerNodes(entry.getValue());
         });
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelCacheHelper.java
@@ -551,7 +551,6 @@ public class MLModelCacheHelper {
         return modelCache.getTargetWorkerNodes();
     }
 
-
     /**
      * Add worker node of model.
      * 
@@ -621,6 +620,19 @@ public class MLModelCacheHelper {
         modelWorkerNodes.entrySet().forEach(entry -> {
             MLModelCache modelCache = getOrCreateModelCache(entry.getKey());
             modelCache.syncWorkerNode(entry.getValue());
+        });
+    }
+
+    /**
+     * Sync planning worker nodes for all models.
+     *
+     * @param modelPlanningWorkerNodes planning worker nodes of all models
+     */
+    public void syncPlanningWorkerNodes(Map<String, Set<String>> modelPlanningWorkerNodes) {
+        log.debug("sync model planning worker nodes");
+        modelPlanningWorkerNodes.entrySet().forEach(entry -> {
+            MLModelCache modelCache = getOrCreateModelCache(entry.getKey());
+            modelCache.syncPlanningWorkerNode(entry.getValue());
         });
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -2436,6 +2436,10 @@ public class MLModelManager {
         return getWorkerNodes(modelId, functionName, false).length;
     }
 
+    public String[] getTargetWorkerNodes(String modelId) {
+        return modelCacheHelper.getTargetWorkerNodes(modelId);
+    }
+
     /**
      * Get predictable instance with model id.
      *

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -2480,6 +2480,23 @@ public class MLModelManager {
      */
     public synchronized void syncModelWorkerNodes(Map<String, Set<String>> modelWorkerNodes) {
         modelCacheHelper.syncWorkerNodes(modelWorkerNodes);
+
+        syncModelPlanningWorkerNodes(modelWorkerNodes);
+    }
+
+    public synchronized void syncModelPlanningWorkerNodes(Map<String, Set<String>> modelWorkerNodes) {
+        Map<String, Set<String>> modelPlanningWorkerNodes = new HashMap<>();
+        modelWorkerNodes.keySet().forEach(modelId -> {
+            FunctionName functionName = modelCacheHelper.getFunctionName(modelId);
+            boolean isDeployToAll = modelCacheHelper.getDeployToAllNodes(modelId);
+            if (!isDeployToAll) {
+                return;
+            }
+            DiscoveryNode[] eligibleNodes = nodeHelper.getEligibleNodes(functionName);
+            Set<String> eligibleNodeIds = Arrays.stream(eligibleNodes).map(DiscoveryNode::getId).collect(Collectors.toSet());
+            modelPlanningWorkerNodes.put(modelId, eligibleNodeIds);
+        });
+        modelCacheHelper.syncPlanningWorkerNodes(modelPlanningWorkerNodes);
     }
 
     /**

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -2436,6 +2436,12 @@ public class MLModelManager {
         return getWorkerNodes(modelId, functionName, false).length;
     }
 
+    /**
+     * Get target/planning worker node of a specific model.
+     *
+     * @param modelId      model id
+     * @return list of planning worker node ids
+     */
     public String[] getTargetWorkerNodes(String modelId) {
         return modelCacheHelper.getTargetWorkerNodes(modelId);
     }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -180,7 +180,9 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
                 }
             }, listener::onFailure);
             String[] workerNodes = mlModelManager.getWorkerNodes(modelId, functionName, true);
-            if (workerNodes == null || workerNodes.length == 0) {
+            String[] targetWorkerNodes = mlModelManager.getTargetWorkerNodes(modelId);
+
+            if (requiresAutoDeployment(workerNodes, targetWorkerNodes)) {
                 if (FunctionName.isAutoDeployEnabled(autoDeploymentEnabled, functionName)) {
                     try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
                         mlModelManager.getModel(modelId, request.getTenantId(), ActionListener.runBefore(ActionListener.wrap(model -> {
@@ -650,5 +652,10 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
                 );
             }
         }
+    }
+
+    private boolean requiresAutoDeployment(String[] workerNodes, String[] targetWorkerNodes) {
+        return workerNodes == null || workerNodes.length == 0 ||
+                (targetWorkerNodes != null && workerNodes.length < targetWorkerNodes.length);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -655,7 +655,8 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
     }
 
     private boolean requiresAutoDeployment(String[] workerNodes, String[] targetWorkerNodes) {
-        return workerNodes == null || workerNodes.length == 0 ||
-                (targetWorkerNodes != null && workerNodes.length < targetWorkerNodes.length);
+        return workerNodes == null
+            || workerNodes.length == 0
+            || (targetWorkerNodes != null && workerNodes.length < targetWorkerNodes.length);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelCacheHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelCacheHelperTests.java
@@ -298,6 +298,27 @@ public class MLModelCacheHelperTests extends OpenSearchTestCase {
         assertArrayEquals(new String[] { newNodeId }, cacheHelper.getWorkerNodes(modelId));
     }
 
+    public void testGetTargetWorkerNodes() {
+        String[] workerNodes = cacheHelper.getTargetWorkerNodes(modelId);
+        assertNull(workerNodes);
+        String newNodeId = "new_node_id";
+        Map<String, Set<String>> modelPlannningWorkerNodes = new HashMap<>();
+        modelPlannningWorkerNodes.put(modelId, ImmutableSet.of(newNodeId));
+        cacheHelper.syncPlanningWorkerNodes(modelPlannningWorkerNodes);
+        workerNodes = cacheHelper.getTargetWorkerNodes(modelId);
+        assertArrayEquals(new String[] { "new_node_id" }, workerNodes);
+
+    }
+
+    public void testSyncPlanningWorkerNodes() {
+        String newNodeId = "new_node_id";
+        Map<String, Set<String>> modelPlannningWorkerNodes = new HashMap<>();
+        modelPlannningWorkerNodes.put(modelId, ImmutableSet.of(newNodeId));
+        cacheHelper.syncPlanningWorkerNodes(modelPlannningWorkerNodes);
+        assertArrayEquals(new String[] { modelId }, cacheHelper.getAllModels());
+        assertArrayEquals(new String[] { newNodeId }, cacheHelper.getTargetWorkerNodes(modelId));
+    }
+
     public void testSyncWorkerNodes_ModelState() {
         String modelId2 = "model_id2";
         cacheHelper.initModelState(modelId2, MLModelState.DEPLOYED, FunctionName.TEXT_EMBEDDING, targetWorkerNodes, true);


### PR DESCRIPTION
### Description
Currently the remote model auto-deploy only happens when the model is not deployed at all, by checking the running worker nodes == 0. But in some edge cases, we'd like to auto-deploy the model even it's in PARTIALLY_DEPLOYED status.  
The planning worker nodes are synced in the memory so when there is a partially deployed status, the auto deploy will apply.  

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
