### PR TITLE
Fixes spotless on Java 11

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -423,7 +423,7 @@ spotless {
         removeUnusedImports()
         importOrder 'java', 'javax', 'org', 'com'
 
-        eclipse().configFile rootProject.file('.eclipseformat.xml')
+        eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('.eclipseformat.xml')
     }
 }
 


### PR DESCRIPTION
### Description
Java 11 builds will fail with current spotless implementation e.g.

```
 % sdk use java 11.0.25-amzn 

Using java version 11.0.25-amzn in this shell.

%  ./gradlew spotlessApply                     
Starting a Gradle Daemon, 2 incompatible Daemons could not be reused, use --status for details
[Incubating] Problems report is available at: file:///Users/iflorbri/IdeaProjects/ml-commons/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':opensearch-ml-plugin'.
> java.io.IOException: Failed to load eclipse jdt formatter: java.lang.RuntimeException: org.tukaani.xz.XZFormatException: Input is not in the XZ format

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.
BUILD FAILED in 5s
```
This was fixed in the NS repo https://github.com/opensearch-project/neural-search/pull/1079/files (Thanks Varun!)

This also works with Java 21 and 17
### Related Issues

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
