### PR TITLE
changing MLSearchActionRequest to an instance subclass of SearchActionRequest

### DIFF
--- a/common/src/test/java/org/opensearch/ml/common/transport/search/MLSearchActionRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/search/MLSearchActionRequestTest.java
@@ -1,22 +1,18 @@
 package org.opensearch.ml.common.transport.search;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.Version;
-import org.opensearch.action.ActionRequest;
-import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
-import org.opensearch.core.common.io.stream.StreamOutput;
 
 public class MLSearchActionRequestTest {
 
@@ -28,120 +24,66 @@ public class MLSearchActionRequestTest {
     }
 
     @Test
-    public void testConstructorAndGetters() {
-        MLSearchActionRequest request = MLSearchActionRequest.builder().searchRequest(searchRequest).tenantId("test-tenant").build();
-        assertEquals("test-index", request.getSearchRequest().indices()[0]);
-        assertEquals("test-tenant", request.getTenantId());
-    }
+    public void testSerializationDeserialization_Version_2_19_0() throws IOException {
+        // Set up a valid SearchRequest
+        SearchRequest searchRequest = new SearchRequest("test-index");
 
-    @Test
-    public void testStreamConstructorAndWriteTo() throws IOException {
-        MLSearchActionRequest request = MLSearchActionRequest.builder().searchRequest(searchRequest).tenantId("test-tenant").build();
-        BytesStreamOutput out = new BytesStreamOutput();
-        request.writeTo(out);
-
-        MLSearchActionRequest deserializedRequest = new MLSearchActionRequest(out.bytes().streamInput());
-        assertEquals("test-index", deserializedRequest.getSearchRequest().indices()[0]);
-        assertEquals("test-tenant", deserializedRequest.getTenantId());
-    }
-
-    @Test
-    public void testWriteToWithNullSearchRequest() throws IOException {
-        MLSearchActionRequest request = MLSearchActionRequest.builder().tenantId("test-tenant").build();
-        BytesStreamOutput out = new BytesStreamOutput();
-        request.writeTo(out);
-
-        MLSearchActionRequest deserializedRequest = new MLSearchActionRequest(out.bytes().streamInput());
-        assertNull(deserializedRequest.getSearchRequest());
-        assertEquals("test-tenant", deserializedRequest.getTenantId());
-    }
-
-    @Test
-    public void testFromActionRequestWithMLSearchActionRequest() {
-        MLSearchActionRequest request = MLSearchActionRequest.builder().searchRequest(searchRequest).tenantId("test-tenant").build();
-        MLSearchActionRequest result = MLSearchActionRequest.fromActionRequest(request);
-        assertSame(result, request);
-    }
-
-    @Test
-    public void testFromActionRequestWithNonMLSearchActionRequest() throws IOException {
-        MLSearchActionRequest request = MLSearchActionRequest.builder().searchRequest(searchRequest).tenantId("test-tenant").build();
-        ActionRequest actionRequest = new ActionRequest() {
-            @Override
-            public ActionRequestValidationException validate() {
-                return null;
-            }
-
-            @Override
-            public void writeTo(StreamOutput out) throws IOException {
-                request.writeTo(out);
-            }
-        };
-
-        MLSearchActionRequest result = MLSearchActionRequest.fromActionRequest(actionRequest);
-        assertNotSame(result, request);
-        assertEquals(request.getSearchRequest().indices()[0], result.getSearchRequest().indices()[0]);
-        assertEquals(request.getTenantId(), result.getTenantId());
-    }
-
-    @Test(expected = UncheckedIOException.class)
-    public void testFromActionRequestIOException() {
-        ActionRequest actionRequest = new ActionRequest() {
-            @Override
-            public ActionRequestValidationException validate() {
-                return null;
-            }
-
-            @Override
-            public void writeTo(StreamOutput out) throws IOException {
-                throw new IOException("test");
-            }
-        };
-        MLSearchActionRequest.fromActionRequest(actionRequest);
-    }
-
-    @Test
-    public void testBackwardCompatibility() throws IOException {
-        MLSearchActionRequest request = MLSearchActionRequest.builder().searchRequest(searchRequest).tenantId("test-tenant").build();
-
-        BytesStreamOutput out = new BytesStreamOutput();
-        out.setVersion(Version.V_2_18_0); // Older version
-        request.writeTo(out);
-
-        StreamInput in = out.bytes().streamInput();
-        in.setVersion(Version.V_2_18_0);
-
-        MLSearchActionRequest deserializedRequest = new MLSearchActionRequest(in);
-        assertNull(deserializedRequest.getTenantId()); // Ensure tenantId is ignored
-    }
-
-    @Test
-    public void testFromActionRequestWithValidRequest() {
-        MLSearchActionRequest request = MLSearchActionRequest.builder().searchRequest(searchRequest).tenantId("test-tenant").build();
-
-        MLSearchActionRequest result = MLSearchActionRequest.fromActionRequest(request);
-        assertSame(request, result);
-    }
-
-    @Test
-    public void testMixedVersionCompatibility() throws IOException {
+        // Create the MLSearchActionRequest
         MLSearchActionRequest originalRequest = MLSearchActionRequest
             .builder()
             .searchRequest(searchRequest)
             .tenantId("test-tenant")
             .build();
 
-        // Serialize with a newer version
         BytesStreamOutput out = new BytesStreamOutput();
         out.setVersion(Version.V_2_19_0);
         originalRequest.writeTo(out);
 
-        // Deserialize with an older version
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(Version.V_2_19_0);
+        MLSearchActionRequest deserializedRequest = new MLSearchActionRequest(in);
+
+        assertEquals("test-tenant", deserializedRequest.getTenantId());
+    }
+
+    @Test
+    public void testSerializationDeserialization_Version_2_18_0() throws IOException {
+
+        // Create the MLSearchActionRequest
+        MLSearchActionRequest originalRequest = MLSearchActionRequest
+            .builder()
+            .searchRequest(searchRequest)
+            .tenantId("test-tenant")
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_2_18_0);
+        originalRequest.writeTo(out);
+
         StreamInput in = out.bytes().streamInput();
         in.setVersion(Version.V_2_18_0);
-
         MLSearchActionRequest deserializedRequest = new MLSearchActionRequest(in);
-        assertNull(deserializedRequest.getTenantId()); // tenantId should not exist in older versions
+
+        assertNull(deserializedRequest.getTenantId());
+    }
+
+    @Test
+    public void testFromActionRequest_WithMLSearchActionRequest() {
+        MLSearchActionRequest request = MLSearchActionRequest.builder().searchRequest(searchRequest).tenantId("test-tenant").build();
+
+        MLSearchActionRequest result = MLSearchActionRequest.fromActionRequest(request);
+
+        assertSame(request, result);
+    }
+
+    @Test
+    public void testFromActionRequest_WithSearchRequest() throws IOException {
+        SearchRequest simpleRequest = new SearchRequest("test-index");
+
+        MLSearchActionRequest result = MLSearchActionRequest.fromActionRequest(simpleRequest);
+
+        assertNotNull(result);
+        assertNull(result.getTenantId()); // Since tenantId wasn't in original request
     }
 
 }

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/SearchConversationsTransportAction.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/SearchConversationsTransportAction.java
@@ -20,7 +20,6 @@ package org.opensearch.ml.memory.action.conversation;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_DISABLED_MESSAGE;
 
 import org.opensearch.OpenSearchException;
-import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -73,14 +72,13 @@ public class SearchConversationsTransportAction extends HandledTransportAction<M
 
     @Override
     public void doExecute(Task task, MLSearchActionRequest mlSearchActionRequest, ActionListener<SearchResponse> actionListener) {
-        SearchRequest request = mlSearchActionRequest.getSearchRequest();
         if (!featureIsEnabled) {
             actionListener.onFailure(new OpenSearchException(ML_COMMONS_MEMORY_FEATURE_DISABLED_MESSAGE));
             return;
         } else {
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().newStoredContext(true)) {
                 ActionListener<SearchResponse> internalListener = ActionListener.runBefore(actionListener, context::restore);
-                cmHandler.searchConversations(request, internalListener);
+                cmHandler.searchConversations(mlSearchActionRequest, internalListener);
             } catch (Exception e) {
                 log.error("Failed to search memories", e);
                 actionListener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/TransportSearchAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/TransportSearchAgentAction.java
@@ -52,12 +52,12 @@ public class TransportSearchAgentAction extends HandledTransportAction<MLSearchA
 
     @Override
     protected void doExecute(Task task, MLSearchActionRequest request, ActionListener<SearchResponse> actionListener) {
-        request.getSearchRequest().indices(CommonValue.ML_AGENT_INDEX);
+        request.indices(CommonValue.ML_AGENT_INDEX);
         String tenantId = request.getTenantId();
         if (!TenantAwareHelper.validateTenantId(mlFeatureEnabledSetting, tenantId, actionListener)) {
             return;
         }
-        search(request.getSearchRequest(), tenantId, actionListener);
+        search(request, tenantId, actionListener);
     }
 
     private void search(SearchRequest request, String tenantId, ActionListener<SearchResponse> actionListener) {

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/SearchConnectorTransportAction.java
@@ -74,13 +74,13 @@ public class SearchConnectorTransportAction extends HandledTransportAction<MLSea
 
     @Override
     protected void doExecute(Task task, MLSearchActionRequest request, ActionListener<SearchResponse> actionListener) {
-        request.getSearchRequest().indices(CommonValue.ML_CONNECTOR_INDEX);
+        request.indices(CommonValue.ML_CONNECTOR_INDEX);
 
         String tenantId = request.getTenantId();
         if (!TenantAwareHelper.validateTenantId(mlFeatureEnabledSetting, tenantId, actionListener)) {
             return;
         }
-        search(request.getSearchRequest(), tenantId, actionListener);
+        search(request, tenantId, actionListener);
     }
 
     private void search(SearchRequest request, String tenantId, ActionListener<SearchResponse> actionListener) {

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
@@ -21,7 +21,6 @@ import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.transport.model_group.MLModelGroupSearchAction;
 import org.opensearch.ml.common.transport.search.MLSearchActionRequest;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
@@ -65,12 +64,11 @@ public class SearchModelGroupTransportAction extends HandledTransportAction<MLSe
     protected void doExecute(Task task, MLSearchActionRequest request, ActionListener<SearchResponse> actionListener) {
         User user = RestActionUtils.getUserContext(client);
         ActionListener<SearchResponse> listener = wrapRestActionListener(actionListener, "Fail to search");
-        request.getSearchRequest().indices(CommonValue.ML_MODEL_GROUP_INDEX);
         String tenantId = request.getTenantId();
         if (!TenantAwareHelper.validateTenantId(mlFeatureEnabledSetting, tenantId, actionListener)) {
             return;
         }
-        preProcessRoleAndPerformSearch(request.getSearchRequest(), tenantId, user, listener);
+        preProcessRoleAndPerformSearch(request, tenantId, user, listener);
     }
 
     private void preProcessRoleAndPerformSearch(

--- a/plugin/src/main/java/org/opensearch/ml/action/models/SearchModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/SearchModelTransportAction.java
@@ -11,7 +11,6 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.action.handler.MLSearchHandler;
-import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.transport.model.MLModelSearchAction;
 import org.opensearch.ml.common.transport.search.MLSearchActionRequest;
 import org.opensearch.ml.settings.MLFeatureEnabledSetting;
@@ -44,11 +43,11 @@ public class SearchModelTransportAction extends HandledTransportAction<MLSearchA
 
     @Override
     protected void doExecute(Task task, MLSearchActionRequest request, ActionListener<SearchResponse> actionListener) {
-        request.getSearchRequest().indices(CommonValue.ML_MODEL_INDEX);
+
         String tenantId = request.getTenantId();
         if (!TenantAwareHelper.validateTenantId(mlFeatureEnabledSetting, tenantId, actionListener)) {
             return;
         }
-        mlSearchHandler.search(request.getSearchRequest(), tenantId, actionListener);
+        mlSearchHandler.search(request, tenantId, actionListener);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/agents/TransportSearchAgentActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agents/TransportSearchAgentActionTests.java
@@ -106,16 +106,15 @@ public class TransportSearchAgentActionTests extends OpenSearchTestCase {
     public void testDoExecuteWithEmptyQuery() {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
         SearchRequest request = new SearchRequest("my_index").source(sourceBuilder);
-
+        MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(request, null);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onResponse(searchResponse);
             return null;
-        }).when(client).search(eq(request), any());
-        MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(request, null);
+        }).when(client).search(eq(mlSearchActionRequest), any());
 
         transportSearchAgentAction.doExecute(null, mlSearchActionRequest, actionListener);
-        verify(client, times(1)).search(eq(request), any());
+        verify(client, times(1)).search(eq(mlSearchActionRequest), any());
         // Use ArgumentCaptor to capture the SearchResponse
         ArgumentCaptor<SearchResponse> responseCaptor = ArgumentCaptor.forClass(SearchResponse.class);
         // Capture the response passed to actionListener.onResponse
@@ -139,11 +138,11 @@ public class TransportSearchAgentActionTests extends OpenSearchTestCase {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onResponse(searchResponse);
             return null;
-        }).when(client).search(eq(request), any());
+        }).when(client).search(eq(mlSearchActionRequest), any());
 
         transportSearchAgentAction.doExecute(null, mlSearchActionRequest, actionListener);
 
-        verify(client, times(1)).search(eq(request), any());
+        verify(client, times(1)).search(eq(mlSearchActionRequest), any());
         // Use ArgumentCaptor to capture the SearchResponse
         ArgumentCaptor<SearchResponse> responseCaptor = ArgumentCaptor.forClass(SearchResponse.class);
         // Capture the response passed to actionListener.onResponse
@@ -163,11 +162,11 @@ public class TransportSearchAgentActionTests extends OpenSearchTestCase {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onFailure(new Exception("test exception"));
             return null;
-        }).when(client).search(eq(request), any());
+        }).when(client).search(eq(mlSearchActionRequest), any());
 
         transportSearchAgentAction.doExecute(null, mlSearchActionRequest, actionListener);
 
-        verify(client, times(1)).search(eq(request), any());
+        verify(client, times(1)).search(eq(mlSearchActionRequest), any());
         verify(actionListener, times(1)).onFailure(any(Exception.class));
     }
 
@@ -181,11 +180,11 @@ public class TransportSearchAgentActionTests extends OpenSearchTestCase {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onResponse(searchResponse);
             return null;
-        }).when(client).search(eq(request), any());
+        }).when(client).search(eq(mlSearchActionRequest), any());
 
         transportSearchAgentAction.doExecute(null, mlSearchActionRequest, actionListener);
 
-        verify(client, times(1)).search(eq(request), any());
+        verify(client, times(1)).search(eq(mlSearchActionRequest), any());
         // Use ArgumentCaptor to capture the SearchResponse
         ArgumentCaptor<SearchResponse> responseCaptor = ArgumentCaptor.forClass(SearchResponse.class);
         // Capture the response passed to actionListener.onResponse
@@ -207,7 +206,7 @@ public class TransportSearchAgentActionTests extends OpenSearchTestCase {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onFailure(new Exception("failed to search the agent index"));
             return null;
-        }).when(client).search(eq(request), any());
+        }).when(client).search(eq(mlSearchActionRequest), any());
 
         transportSearchAgentAction.doExecute(null, mlSearchActionRequest, actionListener);
 

--- a/plugin/src/test/java/org/opensearch/ml/action/models/SearchModelITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/SearchModelITTests.java
@@ -107,7 +107,7 @@ public class SearchModelITTests extends MLCommonsIntegTestCase {
     }
 
     private void test_empty_body_search() {
-        SearchRequest searchRequest = new SearchRequest();
+        SearchRequest searchRequest = new SearchRequest(".plugins-ml-model");
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(CHUNK_NUMBER)));
@@ -117,7 +117,7 @@ public class SearchModelITTests extends MLCommonsIntegTestCase {
     }
 
     private void test_matchAll_search() {
-        SearchRequest searchRequest = new SearchRequest();
+        SearchRequest searchRequest = new SearchRequest(".plugins-ml-model");
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchRequest.source(searchSourceBuilder);
         searchRequest
@@ -129,7 +129,7 @@ public class SearchModelITTests extends MLCommonsIntegTestCase {
     }
 
     private void test_bool_search() {
-        SearchRequest searchRequest = new SearchRequest();
+        SearchRequest searchRequest = new SearchRequest(".plugins-ml-model");
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchRequest.source(searchSourceBuilder);
         searchRequest
@@ -150,7 +150,7 @@ public class SearchModelITTests extends MLCommonsIntegTestCase {
     }
 
     private void test_term_search() {
-        SearchRequest searchRequest = new SearchRequest();
+        SearchRequest searchRequest = new SearchRequest(".plugins-ml-model");
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchRequest.source(searchSourceBuilder);
         BoolQueryBuilder boolQueryBuilder = QueryBuilders
@@ -164,7 +164,7 @@ public class SearchModelITTests extends MLCommonsIntegTestCase {
     }
 
     private void test_terms_search() {
-        SearchRequest searchRequest = new SearchRequest();
+        SearchRequest searchRequest = new SearchRequest(".plugins-ml-model");
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchRequest.source(searchSourceBuilder);
         BoolQueryBuilder boolQueryBuilder = QueryBuilders
@@ -178,7 +178,7 @@ public class SearchModelITTests extends MLCommonsIntegTestCase {
     }
 
     private void test_range_search() {
-        SearchRequest searchRequest = new SearchRequest();
+        SearchRequest searchRequest = new SearchRequest(".plugins-ml-model");
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchRequest.source(searchSourceBuilder);
         BoolQueryBuilder boolQueryBuilder = QueryBuilders
@@ -192,7 +192,7 @@ public class SearchModelITTests extends MLCommonsIntegTestCase {
     }
 
     private void test_matchPhrase_search() {
-        SearchRequest searchRequest = new SearchRequest();
+        SearchRequest searchRequest = new SearchRequest(".plugins-ml-model");
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchRequest.source(searchSourceBuilder);
         BoolQueryBuilder boolQueryBuilder = QueryBuilders

--- a/plugin/src/test/java/org/opensearch/ml/action/models/SearchModelTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/SearchModelTransportActionTests.java
@@ -173,7 +173,7 @@ public class SearchModelTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(client).search(any(), any());
         searchModelTransportAction.doExecute(null, mlSearchActionRequest, actionListener);
-        verify(mlSearchHandler).search(searchRequest, null,  actionListener);
+        verify(mlSearchHandler).search(mlSearchActionRequest, null,  actionListener);
         verify(client, times(1)).search(any(), any());
     }
 
@@ -186,7 +186,7 @@ public class SearchModelTransportActionTests extends OpenSearchTestCase {
         }).when(client).search(any(), any());
         when(modelAccessControlHelper.createSearchSourceBuilder(any())).thenReturn(searchSourceBuilder);
         searchModelTransportAction.doExecute(null, mlSearchActionRequest, actionListener);
-        verify(mlSearchHandler).search(searchRequest, null, actionListener);
+        verify(mlSearchHandler).search(mlSearchActionRequest, null, actionListener);
         verify(client, times(2)).search(any(), any());
     }
 
@@ -198,7 +198,7 @@ public class SearchModelTransportActionTests extends OpenSearchTestCase {
         }).when(client).search(any(), isA(ActionListener.class));
         when(modelAccessControlHelper.createSearchSourceBuilder(any())).thenReturn(searchSourceBuilder);
         searchModelTransportAction.doExecute(null, mlSearchActionRequest, actionListener);
-        verify(mlSearchHandler).search(searchRequest, null, actionListener);
+        verify(mlSearchHandler).search(mlSearchActionRequest, null, actionListener);
         verify(client, times(2)).search(any(), any());
     }
 
@@ -210,7 +210,7 @@ public class SearchModelTransportActionTests extends OpenSearchTestCase {
         }).when(client).search(any(), isA(ActionListener.class));
         when(modelAccessControlHelper.createSearchSourceBuilder(any())).thenReturn(searchSourceBuilder);
         searchModelTransportAction.doExecute(null, mlSearchActionRequest, actionListener);
-        verify(mlSearchHandler).search(searchRequest, null, actionListener);
+        verify(mlSearchHandler).search(mlSearchActionRequest, null, actionListener);
         verify(client, times(1)).search(any(), any());
     }
 
@@ -222,7 +222,7 @@ public class SearchModelTransportActionTests extends OpenSearchTestCase {
         }).when(client).search(any(), isA(ActionListener.class));
         when(modelAccessControlHelper.skipModelAccessControl(any())).thenReturn(true);
         searchModelTransportAction.doExecute(null, mlSearchActionRequest, actionListener);
-        verify(mlSearchHandler).search(searchRequest, null, actionListener);
+        verify(mlSearchHandler).search(mlSearchActionRequest, null, actionListener);
         verify(client, times(1)).search(any(), any());
         verify(actionListener, times(0)).onFailure(any(IndexNotFoundException.class));
     }
@@ -255,7 +255,7 @@ public class SearchModelTransportActionTests extends OpenSearchTestCase {
         }).when(client).search(any(), isA(ActionListener.class));
         when(modelAccessControlHelper.skipModelAccessControl(any())).thenReturn(true);
         searchModelTransportAction.doExecute(null, mlSearchActionRequest, actionListener);
-        verify(mlSearchHandler).search(searchRequest, null, actionListener);
+        verify(mlSearchHandler).search(mlSearchActionRequest, null, actionListener);
         verify(client, times(1)).search(any(), any());
         verify(actionListener, times(0)).onFailure(any(IndexNotFoundException.class));
         verify(actionListener, times(1)).onResponse(any(SearchResponse.class));
@@ -269,7 +269,7 @@ public class SearchModelTransportActionTests extends OpenSearchTestCase {
         }).when(client).search(any(), isA(ActionListener.class));
         when(modelAccessControlHelper.skipModelAccessControl(any())).thenReturn(true);
         searchModelTransportAction.doExecute(null, mlSearchActionRequest, actionListener);
-        verify(mlSearchHandler).search(searchRequest, null, actionListener);
+        verify(mlSearchHandler).search(mlSearchActionRequest, null, actionListener);
         verify(client, times(1)).search(any(), any());
         verify(actionListener, times(1)).onFailure(any(OpenSearchStatusException.class));
     }
@@ -284,7 +284,7 @@ public class SearchModelTransportActionTests extends OpenSearchTestCase {
         when(modelAccessControlHelper.createSearchSourceBuilder(any())).thenReturn(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.boolQuery().must(QueryBuilders.matchQuery("name", "model_IT")));
         searchModelTransportAction.doExecute(null, mlSearchActionRequest, actionListener);
-        verify(mlSearchHandler).search(searchRequest, null, actionListener);
+        verify(mlSearchHandler).search(mlSearchActionRequest, null, actionListener);
         verify(client, times(2)).search(any(), any());
     }
 
@@ -298,7 +298,7 @@ public class SearchModelTransportActionTests extends OpenSearchTestCase {
         when(modelAccessControlHelper.createSearchSourceBuilder(any())).thenReturn(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.termQuery("name", "model_IT"));
         searchModelTransportAction.doExecute(null, mlSearchActionRequest, actionListener);
-        verify(mlSearchHandler).search(searchRequest, null, actionListener);
+        verify(mlSearchHandler).search(mlSearchActionRequest, null, actionListener);
         verify(client, times(2)).search(any(), any());
     }
 
@@ -336,7 +336,7 @@ public class SearchModelTransportActionTests extends OpenSearchTestCase {
 
         searchModelTransportAction.doExecute(null, mlSearchActionRequest, actionListener);
 
-        verify(mlSearchHandler).search(searchRequest, "123456", actionListener);
+        verify(mlSearchHandler).search(mlSearchActionRequest, "123456", actionListener);
         verify(client, times(2)).search(any(), any());
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/tasks/SearchTaskTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/tasks/SearchTaskTransportActionTests.java
@@ -115,14 +115,15 @@ public class SearchTaskTransportActionTests extends OpenSearchTestCase {
     public void test_DoExecute() {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
         SearchRequest request = new SearchRequest("my_index").source(sourceBuilder);
+        MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(request, null);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onResponse(searchResponse);
             return null;
-        }).when(client).search(eq(request), any());
-        MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(request, null);
+        }).when(client).search(eq(mlSearchActionRequest), any());
+
         searchTaskTransportAction.doExecute(null, mlSearchActionRequest, actionListener);
-        verify(client, times(1)).search(eq(request), any());
+        verify(client, times(1)).search(eq(mlSearchActionRequest), any());
         // Use ArgumentCaptor to capture the SearchResponse
         ArgumentCaptor<SearchResponse> responseCaptor = ArgumentCaptor.forClass(SearchResponse.class);
         // Capture the response passed to actionListener.onResponse

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchAgentActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchAgentActionTests.java
@@ -25,7 +25,6 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
@@ -142,12 +141,11 @@ public class RestMLSearchAgentActionTests extends OpenSearchTestCase {
         verify(client, times(1)).execute(eq(MLSearchAgentAction.INSTANCE), argumentCaptor.capture(), any());
         verify(channel, times(1)).sendResponse(responseCaptor.capture());
         MLSearchActionRequest mlSearchActionRequest = argumentCaptor.getValue();
-        SearchRequest searchRequest = mlSearchActionRequest.getSearchRequest();
-        String[] indices = searchRequest.indices();
+        String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_AGENT_INDEX }, indices);
         assertEquals(
             "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
-            searchRequest.source().toString()
+            mlSearchActionRequest.source().toString()
         );
         RestResponse agentResponse = responseCaptor.getValue();
         assertEquals(RestStatus.OK, agentResponse.status());
@@ -196,12 +194,11 @@ public class RestMLSearchAgentActionTests extends OpenSearchTestCase {
         verify(client, times(1)).execute(eq(MLSearchAgentAction.INSTANCE), argumentCaptor.capture(), any());
         verify(channel, times(1)).sendResponse(responseCaptor.capture());
         MLSearchActionRequest mlSearchActionRequest = argumentCaptor.getValue();
-        SearchRequest searchRequest = mlSearchActionRequest.getSearchRequest();
-        String[] indices = searchRequest.indices();
+        String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_AGENT_INDEX }, indices);
         assertEquals(
             "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
-            searchRequest.source().toString()
+            mlSearchActionRequest.source().toString()
         );
         RestResponse agentResponse = responseCaptor.getValue();
         assertEquals(RestStatus.REQUEST_TIMEOUT, agentResponse.status());

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchConnectorActionTests.java
@@ -26,7 +26,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchWrapperException;
-import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
@@ -144,12 +143,11 @@ public class RestMLSearchConnectorActionTests extends OpenSearchTestCase {
         verify(client, times(1)).execute(eq(MLConnectorSearchAction.INSTANCE), argumentCaptor.capture(), any());
         verify(channel, times(1)).sendResponse(responseCaptor.capture());
         MLSearchActionRequest mlSearchActionRequest = argumentCaptor.getValue();
-        SearchRequest searchRequest = mlSearchActionRequest.getSearchRequest();
-        String[] indices = searchRequest.indices();
+        String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_CONNECTOR_INDEX }, indices);
         assertEquals(
             "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
-            searchRequest.source().toString()
+            mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();
         assertNotEquals(RestStatus.REQUEST_TIMEOUT, restResponse.status());
@@ -191,12 +189,11 @@ public class RestMLSearchConnectorActionTests extends OpenSearchTestCase {
         verify(client, times(1)).execute(eq(MLConnectorSearchAction.INSTANCE), argumentCaptor.capture(), any());
         verify(channel, times(1)).sendResponse(responseCaptor.capture());
         MLSearchActionRequest mlSearchActionRequest = argumentCaptor.getValue();
-        SearchRequest searchRequest = mlSearchActionRequest.getSearchRequest();
-        String[] indices = searchRequest.indices();
+        String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_CONNECTOR_INDEX }, indices);
         assertEquals(
             "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
-            searchRequest.source().toString()
+            mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();
         assertEquals(RestStatus.REQUEST_TIMEOUT, restResponse.status());

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelActionTests.java
@@ -25,7 +25,6 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
@@ -141,12 +140,11 @@ public class RestMLSearchModelActionTests extends OpenSearchTestCase {
         verify(client, times(1)).execute(eq(MLModelSearchAction.INSTANCE), argumentCaptor.capture(), any());
         verify(channel, times(1)).sendResponse(responseCaptor.capture());
         MLSearchActionRequest mlSearchActionRequest = argumentCaptor.getValue();
-        SearchRequest searchRequest = mlSearchActionRequest.getSearchRequest();
-        String[] indices = searchRequest.indices();
+        String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_MODEL_INDEX }, indices);
         assertEquals(
             "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
-            searchRequest.source().toString()
+            mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();
         assertNotEquals(RestStatus.REQUEST_TIMEOUT, restResponse.status());
@@ -162,12 +160,11 @@ public class RestMLSearchModelActionTests extends OpenSearchTestCase {
         verify(client, times(1)).execute(eq(MLModelSearchAction.INSTANCE), argumentCaptor.capture(), any());
         verify(channel, times(1)).sendResponse(responseCaptor.capture());
         MLSearchActionRequest mlSearchActionRequest = argumentCaptor.getValue();
-        SearchRequest searchRequest = mlSearchActionRequest.getSearchRequest();
-        String[] indices = searchRequest.indices();
+        String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_MODEL_INDEX }, indices);
         assertEquals(
                 "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
-                searchRequest.source().toString()
+                mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();
         assertNotEquals(RestStatus.REQUEST_TIMEOUT, restResponse.status());
@@ -209,12 +206,11 @@ public class RestMLSearchModelActionTests extends OpenSearchTestCase {
         verify(client, times(1)).execute(eq(MLModelSearchAction.INSTANCE), argumentCaptor.capture(), any());
         verify(channel, times(1)).sendResponse(responseCaptor.capture());
         MLSearchActionRequest mlSearchActionRequest = argumentCaptor.getValue();
-        SearchRequest searchRequest = mlSearchActionRequest.getSearchRequest();
-        String[] indices = searchRequest.indices();
+        String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_MODEL_INDEX }, indices);
         assertEquals(
             "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
-            searchRequest.source().toString()
+            mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();
         assertEquals(RestStatus.REQUEST_TIMEOUT, restResponse.status());

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelGroupActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelGroupActionTests.java
@@ -24,7 +24,6 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
@@ -140,12 +139,11 @@ public class RestMLSearchModelGroupActionTests extends OpenSearchTestCase {
         verify(client, times(1)).execute(eq(MLModelGroupSearchAction.INSTANCE), argumentCaptor.capture(), any());
         verify(channel, times(1)).sendResponse(responseCaptor.capture());
         MLSearchActionRequest mlSearchActionRequest = argumentCaptor.getValue();
-        SearchRequest searchRequest = mlSearchActionRequest.getSearchRequest();
-        String[] indices = searchRequest.indices();
+        String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_MODEL_GROUP_INDEX }, indices);
         assertEquals(
             "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
-            searchRequest.source().toString()
+            mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();
         assertNotEquals(RestStatus.REQUEST_TIMEOUT, restResponse.status());
@@ -187,12 +185,11 @@ public class RestMLSearchModelGroupActionTests extends OpenSearchTestCase {
         verify(client, times(1)).execute(eq(MLModelGroupSearchAction.INSTANCE), argumentCaptor.capture(), any());
         verify(channel, times(1)).sendResponse(responseCaptor.capture());
         MLSearchActionRequest mlSearchActionRequest = argumentCaptor.getValue();
-        SearchRequest searchRequest = mlSearchActionRequest.getSearchRequest();
-        String[] indices = searchRequest.indices();
+        String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_MODEL_GROUP_INDEX }, indices);
         assertEquals(
             "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
-            searchRequest.source().toString()
+            mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();
         assertEquals(RestStatus.REQUEST_TIMEOUT, restResponse.status());

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemorySearchConversationsActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemorySearchConversationsActionTests.java
@@ -78,6 +78,6 @@ public class RestMemorySearchConversationsActionTests extends OpenSearchTestCase
         ArgumentCaptor<RestResponse> responseCaptor = ArgumentCaptor.forClass(RestResponse.class);
 
         verify(client, times(1)).execute(eq(SearchConversationsAction.INSTANCE), argumentCaptor.capture(), any());
-        assert (argumentCaptor.getValue().getSearchRequest().source().query() instanceof MatchAllQueryBuilder);
+        assert (argumentCaptor.getValue().source().query() instanceof MatchAllQueryBuilder);
     }
 }


### PR DESCRIPTION
In this PR, I'm making MLSearchActionRequest as a subclass of SearchActionRequest to follow the standard. Previously I wasn't quite extending the SearchActionRequest, as I had another SearchActionRequest object in the class and it was being read and written twice. 


### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
