### PR TITLE
fix decrypted credential null while getting batch predict job status

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
@@ -460,8 +460,8 @@ public class GetTaskTransportAction extends HandledTransportAction<ActionRequest
 
         final Map<String, String> decryptedCredential = connector.getDecryptedCredential() != null
             && !connector.getDecryptedCredential().isEmpty()
-                ? mlEngine.getConnectorCredential(connector)
-                : connector.getDecryptedCredential();
+                ? connector.getDecryptedCredential()
+                : mlEngine.getConnectorCredential(connector);
         RemoteConnectorExecutor connectorExecutor = MLEngineClassLoader.initInstance(connector.getProtocol(), connector, Connector.class);
         connectorExecutor.setScriptService(scriptService);
         connectorExecutor.setClusterService(clusterService);


### PR DESCRIPTION
### Description
fix decrypted credential null while getting batch predict job status

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
