### PR TITLE
TypoFix in amazon_comprehend_connector_blueprint.md

### DIFF
--- a/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
+++ b/docs/remote_inference_blueprints/amazon_comprehend_connector_blueprint.md
@@ -4,7 +4,7 @@ Amazon Comprehend uses natural language processing (NLP) to extract insights abo
 
 ## Language detection with DetectDominantLanguage API
 
-This tutorial shows how to create an OpenSearch connector for an Amazon Comprehend model. The model examines the input text, detects the language using the Amazon Comrehend [DetectDominantLanguage API](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectDominantLanguage.html), and sets a corresponding language code.
+This tutorial shows how to create an OpenSearch connector for an Amazon Comprehend model. The model examines the input text, detects the language using the Amazon Comprehend [DetectDominantLanguage API](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectDominantLanguage.html), and sets a corresponding language code.
 
 Note: This functionality is available in OpenSearch 2.14.0 or later.
 


### PR DESCRIPTION
There was a typo in the doc. 'Comrehend'-> 'Comprehend'

### Description
Typo is fixed

### Related Issues
None

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
