### PR TITLE
Mockito upgrade to support JDK 23

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(path: ":${rootProject.name}-common", configuration: 'shadow')
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.15.2'
 
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     compileOnly "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     compileOnly "org.opensearch:common-utils:${common_utils_version}"
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.15.2'
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 
     compileOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -35,7 +35,7 @@ dependencies {
         exclude module : 'hamcrest'
         exclude module : 'hamcrest-core'
     }
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.15.2'
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     testImplementation group: 'com.google.code.gson', name: 'gson', version: '2.11.0'

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation group: 'io.protostuff', name: 'protostuff-api', version: '1.8.0'
     implementation group: 'io.protostuff', name: 'protostuff-collectionschema', version: '1.8.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.15.2'
     implementation (group: 'com.google.guava', name: 'guava', version: '32.1.3-jre') {
 	exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }


### PR DESCRIPTION
### Description
Upgraded mockito in all the packages and made sure the failing test testcases in #3546 are passing.
Did not run all the test cases in local to save time(takes 30 mins).
MERGE ONLY AFTER JDK 23 BUILD PASSES

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
