### PR TITLE
fix typo in input/output map within ml-inference processor

### DIFF
--- a/docs/tutorials/ml_inference/rerank/ml_Inference_with_Cohere_Rerank_model.md
+++ b/docs/tutorials/ml_inference/rerank/ml_Inference_with_Cohere_Rerank_model.md
@@ -357,15 +357,19 @@ PUT /_search/pipeline/cohere_pipeline
     {
       "ml_inference": {
         "model_id": "your_model_id",
-        "input_map": {
+        "input_map": [
+         {
           "documents": "fact_description",
           "query": "_request.ext.query_context.query_text",
           "top_n": "_request.ext.query_context.top_n"
-        },
-        "output_map": {
+         }
+        ],
+        "output_map": [
+         {
           "relevance_score": "results[*].relevance_score",
           "description": "results[*].document.text"
-        },
+         }
+        ],
         "full_response_path": false,
         "ignore_missing": false,
         "ignore_failure": false,


### PR DESCRIPTION
### Description
There is a typo in a tutorial that used pure maps instead of a list of maps. Please see related issue for more context.

### Related Issues
Resolves: https://github.com/opensearch-project/ml-commons/issues/3545

<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
