### PR TITLE
fix ignoreFailure flag in ml inference search processors

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
@@ -597,9 +597,6 @@ public class MLInferenceSearchRequestProcessor extends AbstractProcessor impleme
             boolean fullResponsePath = ConfigurationUtils
                 .readBooleanProperty(TYPE, processorTag, config, FULL_RESPONSE_PATH, defaultFullResponsePath);
 
-            ignoreFailure = ConfigurationUtils
-                .readBooleanProperty(TYPE, processorTag, config, ConfigurationUtils.IGNORE_FAILURE_KEY, false);
-
             // convert model config user input data structure to Map<String, String>
             Map<String, String> modelConfigMaps = null;
             if (modelConfigInput != null) {

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -840,9 +840,6 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
             boolean fullResponsePath = ConfigurationUtils
                 .readBooleanProperty(TYPE, processorTag, config, FULL_RESPONSE_PATH, defaultFullResponsePath);
 
-            ignoreFailure = ConfigurationUtils
-                .readBooleanProperty(TYPE, processorTag, config, ConfigurationUtils.IGNORE_FAILURE_KEY, false);
-
             // convert model config user input data structure to Map<String, String>
             Map<String, String> modelConfigMaps = null;
             if (modelConfigInput != null) {

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
@@ -706,7 +706,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
         };
 
         requestProcessor.processRequestAsync(request, requestContext, listener);
-
+        assertEquals(requestProcessor.isIgnoreFailure(), true);
     }
 
     /**
@@ -749,7 +749,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
         };
 
         requestProcessor.processRequestAsync(request, requestContext, Listener);
-
+        assertEquals(requestProcessor.isIgnoreFailure(), false);
     }
 
     /**
@@ -788,7 +788,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
         };
 
         requestProcessor.processRequestAsync(request, requestContext, Listener);
-
+        assertEquals(requestProcessor.isIgnoreFailure(), true);
     }
 
     /**
@@ -851,7 +851,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
         };
 
         requestProcessor.processRequestAsync(request, requestContext, Listener);
-
+        assertEquals(requestProcessor.isIgnoreFailure(), false);
     }
 
     /**
@@ -998,7 +998,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
             }
         };
         requestProcessor.processRequestAsync(request, requestContext, Listener);
-
+        assertEquals(requestProcessor.isIgnoreFailure(), true);
     }
 
     /**
@@ -1444,6 +1444,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
         assertNotNull(MLInferenceSearchRequestProcessor);
         assertEquals(MLInferenceSearchRequestProcessor.getTag(), processorTag);
         assertEquals(MLInferenceSearchRequestProcessor.getType(), MLInferenceSearchRequestProcessor.TYPE);
+        assertEquals(MLInferenceSearchRequestProcessor.isIgnoreFailure(), false);
     }
 
     /**
@@ -1478,6 +1479,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
         assertNotNull(MLInferenceSearchRequestProcessor);
         assertEquals(MLInferenceSearchRequestProcessor.getTag(), processorTag);
         assertEquals(MLInferenceSearchRequestProcessor.getType(), MLInferenceSearchRequestProcessor.TYPE);
+        assertEquals(MLInferenceSearchRequestProcessor.isIgnoreFailure(), false);
     }
 
     /**
@@ -1675,9 +1677,11 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
         String processorTag = randomAlphaOfLength(10);
 
         MLInferenceSearchRequestProcessor MLInferenceSearchRequestProcessor = factory
-            .create(Collections.emptyMap(), processorTag, null, false, config, null);
+            .create(Collections.emptyMap(), processorTag, "test", true, config, null);
         assertNotNull(MLInferenceSearchRequestProcessor);
         assertEquals(MLInferenceSearchRequestProcessor.getTag(), processorTag);
         assertEquals(MLInferenceSearchRequestProcessor.getType(), MLInferenceSearchRequestProcessor.TYPE);
+        assertEquals(MLInferenceSearchRequestProcessor.isIgnoreFailure(), true);
+        assertEquals(MLInferenceSearchRequestProcessor.getDescription(), "test");
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
@@ -1449,6 +1449,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         };
         responseProcessor.processResponseAsync(request, response, responseContext, listener);
         verify(client, times(1)).execute(any(), any(), any());
+        assertEquals(responseProcessor.isIgnoreFailure(), true);
     }
 
     /**
@@ -1540,6 +1541,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         };
         responseProcessor.processResponseAsync(request, mockResponse, responseContext, listener);
         verify(client, times(1)).execute(any(), any(), any());
+        assertEquals(responseProcessor.isIgnoreFailure(), true);
     }
 
     /**
@@ -1923,6 +1925,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         };
         responseProcessor.processResponseAsync(request, response, responseContext, listener);
         verify(client, times(1)).execute(any(), any(), any());
+        assertEquals(responseProcessor.isIgnoreFailure(), true);
     }
 
     /**
@@ -2104,6 +2107,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         };
         responseProcessor.processResponseAsync(request, response, responseContext, listener);
         verify(client, times(5)).execute(any(), any(), any());
+        assertEquals(responseProcessor.isIgnoreFailure(), true);
     }
 
     /**
@@ -2542,6 +2546,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         };
         responseProcessor.processResponseAsync(request, response, responseContext, listener);
         verify(client, times(0)).execute(any(), any(), any());
+        assertEquals(responseProcessor.isIgnoreFailure(), true);
     }
 
     /**
@@ -3466,6 +3471,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         };
 
         responseProcessor.processResponseAsync(request, response, responseContext, listener);
+        assertEquals(responseProcessor.isIgnoreFailure(), true);
     }
 
     /**
@@ -3691,6 +3697,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         when(mockResponse.getAggregations()).thenThrow(mockException);
 
         responseProcessor.processResponseAsync(request, mockResponse, responseContext, listener);
+        assertEquals(responseProcessor.isIgnoreFailure(), true);
     }
 
     /**
@@ -4310,6 +4317,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         assertNotNull(MLInferenceSearchResponseProcessor);
         assertEquals(MLInferenceSearchResponseProcessor.getTag(), processorTag);
         assertEquals(MLInferenceSearchResponseProcessor.getType(), MLInferenceSearchResponseProcessor.TYPE);
+        assertEquals(MLInferenceSearchResponseProcessor.isIgnoreFailure(), false);
     }
 
     /**
@@ -4343,6 +4351,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         assertNotNull(MLInferenceSearchResponseProcessor);
         assertEquals(MLInferenceSearchResponseProcessor.getTag(), processorTag);
         assertEquals(MLInferenceSearchResponseProcessor.getType(), MLInferenceSearchResponseProcessor.TYPE);
+        assertEquals(MLInferenceSearchResponseProcessor.isIgnoreFailure(), false);
     }
 
     /**
@@ -4501,10 +4510,12 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         String processorTag = randomAlphaOfLength(10);
 
         MLInferenceSearchResponseProcessor MLInferenceSearchResponseProcessor = factory
-            .create(Collections.emptyMap(), processorTag, null, false, config, null);
+            .create(Collections.emptyMap(), processorTag, "test", true, config, null);
         assertNotNull(MLInferenceSearchResponseProcessor);
         assertEquals(MLInferenceSearchResponseProcessor.getTag(), processorTag);
         assertEquals(MLInferenceSearchResponseProcessor.getType(), MLInferenceSearchResponseProcessor.TYPE);
+        assertEquals(MLInferenceSearchResponseProcessor.isIgnoreFailure(), true);
+        assertEquals(MLInferenceSearchResponseProcessor.getDescription(), "test");
     }
 
     /**


### PR DESCRIPTION
### Description
fix ignoreFailure was not parsing properly in ml inference search processors 

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
