### PR TITLE
Bump aws sdk to version 2.30.18 to mitigate CVE-2025-24970

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -67,8 +67,8 @@ dependencies {
         }
     }
 
-    implementation platform('software.amazon.awssdk:bom:2.29.12')
-    api 'software.amazon.awssdk:auth:2.29.12'
+    implementation platform('software.amazon.awssdk:bom:2.30.18')
+    api 'software.amazon.awssdk:auth:2.30.18'
     implementation 'software.amazon.awssdk:apache-client'
     implementation ('com.amazonaws:aws-encryption-sdk-java:2.4.1') {
         exclude group: 'org.bouncycastle', module: 'bcprov-ext-jdk18on'
@@ -76,12 +76,12 @@ dependencies {
     implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
 
     compileOnly group: 'software.amazon.awssdk', name: 'aws-core', version: '2.30.18'
-    compileOnly group: 'software.amazon.awssdk', name: 's3', version: '2.29.12'
-    compileOnly group: 'software.amazon.awssdk', name: 'regions', version: '2.29.12'
+    compileOnly group: 'software.amazon.awssdk', name: 's3', version: '2.30.18'
+    compileOnly group: 'software.amazon.awssdk', name: 'regions', version: '2.30.18'
 
     implementation 'com.jayway.jsonpath:json-path:2.9.0'
     implementation group: 'org.json', name: 'json', version: '20231013'
-    implementation group: 'software.amazon.awssdk', name: 'netty-nio-client', version: '2.29.12'
+    implementation group: 'software.amazon.awssdk', name: 'netty-nio-client', version: '2.30.18'
     testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
@@ -94,7 +94,7 @@ lombok {
 configurations.all {
     resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.25.5'
     resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
-    resolutionStrategy.force 'software.amazon.awssdk:bom:2.29.12'
+    resolutionStrategy.force 'software.amazon.awssdk:bom:2.30.18'
 }
 
 

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     }
     implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
 
-    compileOnly group: 'software.amazon.awssdk', name: 'aws-core', version: '2.29.12'
+    compileOnly group: 'software.amazon.awssdk', name: 'aws-core', version: '2.30.18'
     compileOnly group: 'software.amazon.awssdk', name: 's3', version: '2.29.12'
     compileOnly group: 'software.amazon.awssdk', name: 'regions', version: '2.29.12'
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation project(':opensearch-ml-memory')
     compileOnly "com.google.guava:guava:32.1.3-jre"
 
-    implementation group: 'software.amazon.awssdk', name: 'aws-core', version: '2.29.12'
+    implementation group: 'software.amazon.awssdk', name: 'aws-core', version: '2.30.18'
     implementation group: 'software.amazon.awssdk', name: 's3', version: '2.29.12'
     implementation group: 'software.amazon.awssdk', name: 'regions', version: '2.29.12'
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -60,14 +60,14 @@ dependencies {
     compileOnly "com.google.guava:guava:32.1.3-jre"
 
     implementation group: 'software.amazon.awssdk', name: 'aws-core', version: '2.30.18'
-    implementation group: 'software.amazon.awssdk', name: 's3', version: '2.29.12'
-    implementation group: 'software.amazon.awssdk', name: 'regions', version: '2.29.12'
+    implementation group: 'software.amazon.awssdk', name: 's3', version: '2.30.18'
+    implementation group: 'software.amazon.awssdk', name: 'regions', version: '2.30.18'
 
-    implementation group: 'software.amazon.awssdk', name: 'aws-xml-protocol', version: '2.29.12'
+    implementation group: 'software.amazon.awssdk', name: 'aws-xml-protocol', version: '2.30.18'
 
-    implementation group: 'software.amazon.awssdk', name: 'aws-query-protocol', version: '2.29.12'
+    implementation group: 'software.amazon.awssdk', name: 'aws-query-protocol', version: '2.30.18'
 
-    implementation group: 'software.amazon.awssdk', name: 'protocol-core', version: '2.29.12'
+    implementation group: 'software.amazon.awssdk', name: 'protocol-core', version: '2.30.18'
 
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"


### PR DESCRIPTION
### Description
Bump aws sdk to version 2.30.18 to mitigate CVE-2025-24970

### Related Issues
https://github.com/opensearch-project/opensearch-build/issues/5323

### Check List
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [x] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
