### PR TITLE
[Enhancement] Enhance validation for create connector API

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
@@ -9,10 +9,14 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -35,6 +39,15 @@ public class ConnectorAction implements ToXContentObject, Writeable {
     public static final String REQUEST_BODY_FIELD = "request_body";
     public static final String ACTION_PRE_PROCESS_FUNCTION = "pre_process_function";
     public static final String ACTION_POST_PROCESS_FUNCTION = "post_process_function";
+    public static final String OPENAI = "openai";
+    public static final String COHERE = "cohere";
+    public static final String BEDROCK = "bedrock";
+    public static final String SAGEMAKER = "sagemaker";
+    public static final String SAGEMAKER_PRE_POST_FUNC_TEXT = "default";
+    public static final List<String> SUPPORTED_REMOTE_SERVERS_FOR_DEFAULT_ACTION_TYPES = List.of(SAGEMAKER, OPENAI, BEDROCK, COHERE);
+
+    private static final String INBUILT_FUNC_PREFIX = "connector.";
+    private static final Logger logger = LogManager.getLogger(ConnectorAction.class);
 
     private ActionType actionType;
     private String method;
@@ -183,6 +196,67 @@ public class ConnectorAction implements ToXContentObject, Writeable {
             .preProcessFunction(preProcessFunction)
             .postProcessFunction(postProcessFunction)
             .build();
+    }
+
+    /**
+     * Validates whether pre and post process functions corresponding to the same llm service or not.
+     * There are specific pre and post process functions defined for each llm services, so if you are
+     * configuring the pre-built functions it has to be from the corresponding list. This method
+     * adds a warning in the log if it is configured wrongly.
+     *
+     * @param parameters - connector parameters
+     */
+    public void validatePrePostProcessFunctions(Map<String, String> parameters) {
+        StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
+        String endPoint = substitutor.replace(url);
+        String remoteServer = getRemoteServerFromURL(endPoint);
+        validateProcessFunctions(remoteServer, preProcessFunction, "PreProcessFunction");
+        validateProcessFunctions(remoteServer, postProcessFunction, "PostProcessFunction");
+    }
+
+    /**
+     * To get the remote server name from url
+     *
+     * @param url - remote server url
+     * @return - returns the corresponding remote server name for url, if server is not in the pre-defined list,
+     * it returns null
+     */
+    public static String getRemoteServerFromURL(String url) {
+        return SUPPORTED_REMOTE_SERVERS_FOR_DEFAULT_ACTION_TYPES.stream().filter(url::contains).findFirst().orElse("");
+    }
+
+    private void validateProcessFunctions(String remoteServer, String processFunction, String funcNameForWarnText) {
+        if (isInBuiltProcessFunction(processFunction)) {
+            switch (remoteServer) {
+                case OPENAI:
+                    if (!processFunction.contains(OPENAI)) {
+                        logWarningForInvalidProcessFunc(OPENAI, funcNameForWarnText);
+                    }
+                    break;
+                case COHERE:
+                    if (!processFunction.contains(COHERE)) {
+                        logWarningForInvalidProcessFunc(COHERE, funcNameForWarnText);
+                    }
+                    break;
+                case BEDROCK:
+                    if (!processFunction.contains(BEDROCK)) {
+                        logWarningForInvalidProcessFunc(BEDROCK, funcNameForWarnText);
+                    }
+                    break;
+                case SAGEMAKER:
+                    if (!processFunction.contains(SAGEMAKER_PRE_POST_FUNC_TEXT)) {
+                        logWarningForInvalidProcessFunc(SAGEMAKER, funcNameForWarnText);
+                    }
+            }
+        }
+    }
+
+    private boolean isInBuiltProcessFunction(String processFunction) {
+        return (processFunction != null && processFunction.startsWith(INBUILT_FUNC_PREFIX));
+    }
+
+    private void logWarningForInvalidProcessFunc(String remoteServer, String funcNameForWarnText) {
+        logger.warn("LLM service is " + remoteServer + ", so " + funcNameForWarnText + " should be corresponding to " + remoteServer);
     }
 
     public enum ActionType {

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -70,6 +70,11 @@ public class HttpConnector extends AbstractConnector {
         String tenantId
     ) {
         validateProtocol(protocol);
+        if (actions != null) {
+            for (ConnectorAction action : actions) {
+                action.validatePrePostProcessFunctions(parameters);
+            }
+        }
         this.name = name;
         this.description = description;
         this.version = version;

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -109,6 +109,11 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
             if (credential == null || credential.isEmpty()) {
                 throw new IllegalArgumentException("Connector credential is null or empty list");
             }
+            if (actions != null) {
+                for (ConnectorAction action : actions) {
+                    action.validatePrePostProcessFunctions(parameters);
+                }
+            }
         }
         this.name = name;
         this.description = description;

--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorActionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorActionTest.java
@@ -6,14 +6,46 @@
 package org.opensearch.ml.common.connector;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.isValidActionInModelPrediction;
+import static org.opensearch.ml.common.connector.MLPostProcessFunction.BEDROCK_BATCH_JOB_ARN;
+import static org.opensearch.ml.common.connector.MLPostProcessFunction.BEDROCK_EMBEDDING;
+import static org.opensearch.ml.common.connector.MLPostProcessFunction.BEDROCK_RERANK;
+import static org.opensearch.ml.common.connector.MLPostProcessFunction.COHERE_EMBEDDING;
+import static org.opensearch.ml.common.connector.MLPostProcessFunction.COHERE_RERANK;
+import static org.opensearch.ml.common.connector.MLPostProcessFunction.DEFAULT_EMBEDDING;
+import static org.opensearch.ml.common.connector.MLPostProcessFunction.DEFAULT_RERANK;
+import static org.opensearch.ml.common.connector.MLPostProcessFunction.OPENAI_EMBEDDING;
+import static org.opensearch.ml.common.connector.MLPreProcessFunction.IMAGE_TO_COHERE_MULTI_MODAL_EMBEDDING_INPUT;
+import static org.opensearch.ml.common.connector.MLPreProcessFunction.TEXT_DOCS_TO_BEDROCK_EMBEDDING_INPUT;
+import static org.opensearch.ml.common.connector.MLPreProcessFunction.TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT;
+import static org.opensearch.ml.common.connector.MLPreProcessFunction.TEXT_DOCS_TO_DEFAULT_EMBEDDING_INPUT;
+import static org.opensearch.ml.common.connector.MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT;
+import static org.opensearch.ml.common.connector.MLPreProcessFunction.TEXT_IMAGE_TO_BEDROCK_EMBEDDING_INPUT;
+import static org.opensearch.ml.common.connector.MLPreProcessFunction.TEXT_SIMILARITY_TO_BEDROCK_RERANK_INPUT;
+import static org.opensearch.ml.common.connector.MLPreProcessFunction.TEXT_SIMILARITY_TO_COHERE_RERANK_INPUT;
+import static org.opensearch.ml.common.connector.MLPreProcessFunction.TEXT_SIMILARITY_TO_DEFAULT_INPUT;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
@@ -33,6 +65,32 @@ public class ConnectorActionTest {
     private static final String TEST_METHOD_HTTP = "http";
     private static final String TEST_REQUEST_BODY = "{\"input\": \"${parameters.input}\"}";
     private static final String URL = "https://test.com";
+    private static final String OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+    private static final String COHERE_URL = "https://api.cohere.ai/v1/embed";
+    private static final String BEDROCK_URL = "https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.titan-embed-text-v1/invoke";
+    private static final String SAGEMAKER_URL =
+        "https://runtime.sagemaker.us-west-2.amazonaws.com/endpoints/lmi-model-2023-06-24-01-35-32-275/invocations";
+    private static final Logger logger = LogManager.getLogger(ConnectorActionTest.class);
+    private static TestLogAppender testAppender;
+
+    @BeforeClass
+    public static void setUpClass() {
+        testAppender = new TestLogAppender("TestAppender");
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        LoggerConfig loggerConfig = context.getConfiguration().getLoggerConfig(logger.getName());
+        loggerConfig.addAppender(testAppender, Level.WARN, null);
+        context.updateLoggers();
+    }
+
+    @After
+    public void tearDown() {
+        testAppender.clear();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        testAppender.stop();
+    }
 
     @Test
     public void constructor_NullActionType() {
@@ -60,6 +118,350 @@ public class ConnectorActionTest {
             () -> new ConnectorAction(TEST_ACTION_TYPE, null, URL, null, TEST_REQUEST_BODY, null, null)
         );
         assertEquals("method can't be null", exception.getMessage());
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithNullPreProcessFunctionSuccess() {
+        ConnectorAction action = new ConnectorAction(TEST_ACTION_TYPE, TEST_METHOD_HTTP, OPENAI_URL, null, TEST_REQUEST_BODY, null, null);
+        action.validatePrePostProcessFunctions(Map.of());
+        assertFalse(testAppender.getLogEvents().stream().anyMatch(event -> event.getLevel() == Level.WARN));
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithCustomPainlessScriptPreProcessFunctionSuccess() {
+        String preProcessFunction =
+            "\"\\n    StringBuilder builder = new StringBuilder();\\n    builder.append(\\\"\\\\\\\"\\\");\\n    String first = params.text_docs[0];\\n    builder.append(first);\\n    builder.append(\\\"\\\\\\\"\\\");\\n    def parameters = \\\"{\\\" +\\\"\\\\\\\"text_inputs\\\\\\\":\\\" + builder + \\\"}\\\";\\n    return  \\\"{\\\" +\\\"\\\\\\\"parameters\\\\\\\":\\\" + parameters + \\\"}\\\";\"";
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            OPENAI_URL,
+            null,
+            TEST_REQUEST_BODY,
+            preProcessFunction,
+            null
+        );
+        action.validatePrePostProcessFunctions(null);
+        assertFalse(testAppender.getLogEvents().stream().anyMatch(event -> event.getLevel() == Level.WARN));
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithOpenAIConnectorCorrectInBuiltPrePostProcessFunctionSuccess() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            "https://${parameters.endpoint}/v1/chat/completions",
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT,
+            OPENAI_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of("endpoint", "api.openai.com"));
+        assertFalse(testAppender.getLogEvents().stream().anyMatch(event -> event.getLevel() == Level.WARN));
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithOpenAIConnectorWrongInBuiltPreProcessFunction() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            OPENAI_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_DOCS_TO_BEDROCK_EMBEDDING_INPUT,
+            OPENAI_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        boolean isWarningLogged = testAppender
+            .getLogEvents()
+            .stream()
+            .anyMatch(
+                event -> event.getLevel() == Level.WARN
+                    && event
+                        .getMessage()
+                        .getFormattedMessage()
+                        .contains("LLM service is openai, so PreProcessFunction should be corresponding to openai")
+            );
+        assertTrue(isWarningLogged);
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithOpenAIConnectorWrongInBuiltPostProcessFunction() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            OPENAI_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT,
+            COHERE_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        boolean isWarningLogged = testAppender
+            .getLogEvents()
+            .stream()
+            .anyMatch(
+                event -> event.getLevel() == Level.WARN
+                    && event
+                        .getMessage()
+                        .getFormattedMessage()
+                        .contains("LLM service is openai, so PostProcessFunction should be corresponding to openai")
+            );
+        assertTrue(isWarningLogged);
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithCohereConnectorCorrectInBuiltPrePostProcessFunctionSuccess() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            COHERE_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT,
+            COHERE_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        assertFalse(testAppender.getLogEvents().stream().anyMatch(event -> event.getLevel() == Level.WARN));
+
+        action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            COHERE_URL,
+            null,
+            TEST_REQUEST_BODY,
+            IMAGE_TO_COHERE_MULTI_MODAL_EMBEDDING_INPUT,
+            COHERE_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        assertFalse(testAppender.getLogEvents().stream().anyMatch(event -> event.getLevel() == Level.WARN));
+
+        action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            COHERE_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_SIMILARITY_TO_COHERE_RERANK_INPUT,
+            COHERE_RERANK
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        assertFalse(testAppender.getLogEvents().stream().anyMatch(event -> event.getLevel() == Level.WARN));
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithCohereConnectorWrongInBuiltPreProcessFunction() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            COHERE_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_DOCS_TO_BEDROCK_EMBEDDING_INPUT,
+            COHERE_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        boolean isWarningLogged = testAppender
+            .getLogEvents()
+            .stream()
+            .anyMatch(
+                event -> event.getLevel() == Level.WARN
+                    && event
+                        .getMessage()
+                        .getFormattedMessage()
+                        .contains("LLM service is cohere, so PreProcessFunction should be corresponding to cohere")
+            );
+        assertTrue(isWarningLogged);
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithCohereConnectorWrongInBuiltPostProcessFunction() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            COHERE_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT,
+            OPENAI_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        boolean isWarningLogged = testAppender
+            .getLogEvents()
+            .stream()
+            .anyMatch(
+                event -> event.getLevel() == Level.WARN
+                    && event
+                        .getMessage()
+                        .getFormattedMessage()
+                        .contains("LLM service is cohere, so PostProcessFunction should be corresponding to cohere")
+            );
+        assertTrue(isWarningLogged);
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithBedrockConnectorCorrectInBuiltPrePostProcessFunctionSuccess() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            BEDROCK_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_DOCS_TO_BEDROCK_EMBEDDING_INPUT,
+            BEDROCK_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        assertFalse(testAppender.getLogEvents().stream().anyMatch(event -> event.getLevel() == Level.WARN));
+
+        action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            BEDROCK_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_IMAGE_TO_BEDROCK_EMBEDDING_INPUT,
+            BEDROCK_BATCH_JOB_ARN
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        assertFalse(testAppender.getLogEvents().stream().anyMatch(event -> event.getLevel() == Level.WARN));
+
+        action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            BEDROCK_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_SIMILARITY_TO_BEDROCK_RERANK_INPUT,
+            BEDROCK_RERANK
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        assertFalse(testAppender.getLogEvents().stream().anyMatch(event -> event.getLevel() == Level.WARN));
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithBedrockConnectorWrongInBuiltPreProcessFunction() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            BEDROCK_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT,
+            BEDROCK_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        boolean isWarningLogged = testAppender
+            .getLogEvents()
+            .stream()
+            .anyMatch(
+                event -> event.getLevel() == Level.WARN
+                    && event
+                        .getMessage()
+                        .getFormattedMessage()
+                        .contains("LLM service is bedrock, so PreProcessFunction should be corresponding to bedrock")
+            );
+        assertTrue(isWarningLogged);
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithBedrockConnectorWrongInBuiltPostProcessFunction() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            BEDROCK_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_IMAGE_TO_BEDROCK_EMBEDDING_INPUT,
+            COHERE_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        boolean isWarningLogged = testAppender
+            .getLogEvents()
+            .stream()
+            .anyMatch(
+                event -> event.getLevel() == Level.WARN
+                    && event
+                        .getMessage()
+                        .getFormattedMessage()
+                        .contains("LLM service is bedrock, so PostProcessFunction should be corresponding to bedrock")
+            );
+        assertTrue(isWarningLogged);
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithSagemakerConnectorWithCorrectInBuiltPrePostProcessFunctionSuccess() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            SAGEMAKER_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_DOCS_TO_DEFAULT_EMBEDDING_INPUT,
+            DEFAULT_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        assertFalse(testAppender.getLogEvents().stream().anyMatch(event -> event.getLevel() == Level.WARN));
+
+        action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            SAGEMAKER_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_SIMILARITY_TO_DEFAULT_INPUT,
+            DEFAULT_RERANK
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        assertFalse(testAppender.getLogEvents().stream().anyMatch(event -> event.getLevel() == Level.WARN));
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithSagemakerConnectorWrongInBuiltPreProcessFunction() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            SAGEMAKER_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_DOCS_TO_COHERE_EMBEDDING_INPUT,
+            DEFAULT_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        boolean isWarningLogged = testAppender
+            .getLogEvents()
+            .stream()
+            .anyMatch(
+                event -> event.getLevel() == Level.WARN
+                    && event
+                        .getMessage()
+                        .getFormattedMessage()
+                        .contains("LLM service is sagemaker, so PreProcessFunction should be corresponding to sagemaker")
+            );
+        assertTrue(isWarningLogged);
+    }
+
+    @Test
+    public void testValidatePrePostProcessFunctionsWithSagemakerConnectorWrongInBuiltPostProcessFunction() {
+        ConnectorAction action = new ConnectorAction(
+            TEST_ACTION_TYPE,
+            TEST_METHOD_HTTP,
+            SAGEMAKER_URL,
+            null,
+            TEST_REQUEST_BODY,
+            TEXT_DOCS_TO_DEFAULT_EMBEDDING_INPUT,
+            BEDROCK_EMBEDDING
+        );
+        action.validatePrePostProcessFunctions(Map.of());
+        boolean isWarningLogged = testAppender
+            .getLogEvents()
+            .stream()
+            .anyMatch(
+                event -> event.getLevel() == Level.WARN
+                    && event
+                        .getMessage()
+                        .getFormattedMessage()
+                        .contains("LLM service is sagemaker, so PostProcessFunction should be corresponding to sagemaker")
+            );
+        assertTrue(isWarningLogged);
     }
 
     @Test
@@ -169,5 +571,31 @@ public class ConnectorActionTest {
     public void test_invalidActionInModelPrediction() {
         ConnectorAction.ActionType actionType = ConnectorAction.ActionType.from("execute");
         assertEquals(isValidActionInModelPrediction(actionType), false);
+    }
+
+    /**
+     * Log appender class to check the logs printed or not
+     */
+    static class TestLogAppender extends AbstractAppender {
+
+        private final List<LogEvent> logEvents = new ArrayList<>();
+
+        public TestLogAppender(String name) {
+            super(name, null, PatternLayout.createDefaultLayout(), false);
+            start();
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            logEvents.add(event.toImmutable());
+        }
+
+        public List<LogEvent> getLogEvents() {
+            return logEvents;
+        }
+
+        public void clear() {
+            logEvents.clear();
+        }
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
@@ -618,7 +618,7 @@ public class AwsConnectorExecutorTest {
             .builder()
             .actionType(PREDICT)
             .method("POST")
-            .url("http://openai.com/mock")
+            .url("http://bedrock.com/mock")
             .requestBody("{\"input\": ${parameters.input}}")
             .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_BEDROCK_EMBEDDING_INPUT)
             .build();


### PR DESCRIPTION
### Description
This change will address the second part of validation "pre and post processing function validation".
Moved the method getRemoteServerFromURL() from ConnectorUtils.java to ConnectorAction.java, to avoid the cyclic dependency

### Related Issues
Partially resolves #2993

### Check List
- [x] New functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
