### PR TITLE
fix optional mappings in ml inference search processors

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -38,6 +38,7 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -93,7 +94,9 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
     // allow to write to the extension of the search response, the path to point to search extension
     // is prefix with ext.ml_inference
     public static final String EXTENSION_PREFIX = "ext.ml_inference";
+    @Getter
     private final List<Map<String, String>> optionalInputMaps;
+    @Getter
     private final List<Map<String, String>> optionalOutputMaps;
 
     protected MLInferenceSearchResponseProcessor(
@@ -391,7 +394,7 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
         Map<String, Object> modelInputParameters = new HashMap<>();
 
         Map<String, String> inputMapping;
-        if (processInputMap != null && !processInputMap.isEmpty()) {
+        if (!CollectionUtils.isEmpty(processInputMap)) {
             inputMapping = processInputMap.get(inputMapIndex);
             boolean isRequestInputMissing = checkIsRequestInputMissing(queryString, inputMapping);
             if (isRequestInputMissing) {
@@ -605,7 +608,7 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                                 }
 
                                 boolean isDocumentFieldMissing = false;
-                                if (processInputMap != null && !processInputMap.isEmpty()) {
+                                if (!CollectionUtils.isEmpty(processInputMap)) {
                                     isDocumentFieldMissing = checkIsDocumentFieldMissing(document, requiredInputMapping);
                                 }
                                 if (!isDocumentFieldMissing) {
@@ -788,7 +791,7 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
     ) {
         Map<String, String> inputMapping;
 
-        if (processInputMap == null || processInputMap.size() == 0) {
+        if (!CollectionUtils.isEmpty(processInputMap)) {
             inputMapping = new HashMap<>();
             inputMapping.putAll(StringUtils.getParameterMap(sourceAsMap));
         } else {

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -13,6 +13,8 @@ import static org.opensearch.ml.processor.InferenceProcessorAttributes.MODEL_CON
 import static org.opensearch.ml.processor.InferenceProcessorAttributes.MODEL_ID;
 import static org.opensearch.ml.processor.InferenceProcessorAttributes.OUTPUT_MAP;
 import static org.opensearch.ml.processor.MLInferenceIngestProcessor.OVERRIDE;
+import static org.opensearch.ml.processor.MLInferenceSearchRequestProcessor.OPTIONAL_INPUT_MAP;
+import static org.opensearch.ml.processor.MLInferenceSearchRequestProcessor.OPTIONAL_OUTPUT_MAP;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -58,11 +60,14 @@ import org.opensearch.transport.client.Client;
 
 import com.jayway.jsonpath.JsonPath;
 
+import lombok.Getter;
+
 public class MLInferenceSearchResponseProcessor extends AbstractProcessor implements SearchResponseProcessor, ModelExecutor {
 
     public static final String REQUEST_PREFIX = "_request.";
     private final NamedXContentRegistry xContentRegistry;
     private static final Logger logger = LogManager.getLogger(MLInferenceSearchResponseProcessor.class);
+    @Getter
     private final InferenceProcessorAttributes inferenceProcessorAttributes;
     private final boolean ignoreMissing;
     private final String functionName;
@@ -88,11 +93,15 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
     // allow to write to the extension of the search response, the path to point to search extension
     // is prefix with ext.ml_inference
     public static final String EXTENSION_PREFIX = "ext.ml_inference";
+    private final List<Map<String, String>> optionalInputMaps;
+    private final List<Map<String, String>> optionalOutputMaps;
 
     protected MLInferenceSearchResponseProcessor(
         String modelId,
         List<Map<String, String>> inputMaps,
         List<Map<String, String>> outputMaps,
+        List<Map<String, String>> optionalInputMaps,
+        List<Map<String, String>> optionalOutputMaps,
         Map<String, String> modelConfigMaps,
         int maxPredictionTask,
         String tag,
@@ -116,6 +125,8 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
             modelConfigMaps,
             maxPredictionTask
         );
+        this.optionalInputMaps = optionalInputMaps;
+        this.optionalOutputMaps = optionalOutputMaps;
         this.ignoreMissing = ignoreMissing;
         this.functionName = functionName;
         this.fullResponsePath = fullResponsePath;
@@ -316,8 +327,13 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
         throws IOException {
         List<Map<String, String>> processInputMap = inferenceProcessorAttributes.getInputMaps();
         List<Map<String, String>> processOutputMap = inferenceProcessorAttributes.getOutputMaps();
-        int inputMapSize = (processInputMap == null) ? 0 : processInputMap.size();
 
+        // Combine processInputMap and optionalInputMaps
+        List<Map<String, String>> combinedInputMaps = ModelExecutor.combineMaps(processInputMap, optionalInputMaps);
+        // Combine processOutputMap and optionalOutputMaps
+        List<Map<String, String>> combinedOutputMaps = ModelExecutor.combineMaps(processOutputMap, optionalOutputMaps);
+
+        int inputMapSize = (combinedInputMaps == null) ? 0 : combinedInputMaps.size();
         // hitCountInPredictions keeps track of the count of hit that have the required input fields for each round of prediction
         Map<Integer, Integer> hitCountInPredictions = new HashMap<>();
 
@@ -325,7 +341,8 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
             response,
             responseListener,
             processInputMap,
-            processOutputMap,
+            combinedInputMaps,
+            combinedOutputMaps,
             hitCountInPredictions
         );
 
@@ -334,8 +351,9 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
             inputMapSize
         );
         SearchHit[] hits = response.getHits().getHits();
+
         for (int inputMapIndex = 0; inputMapIndex < max(inputMapSize, 1); inputMapIndex++) {
-            processPredictions(hits, processInputMap, inputMapIndex, batchPredictionListener, hitCountInPredictions, queryString);
+            processPredictions(hits, combinedInputMaps, inputMapIndex, batchPredictionListener, hitCountInPredictions, queryString);
         }
     }
 
@@ -384,9 +402,17 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                 }
             }
 
+            List<Map<String, String>> requiredInputFields = this.getInferenceProcessorAttributes().getInputMaps();
+            Map<String, String> requiredInputMapping;
+            if (requiredInputFields != null && requiredInputFields.size() > inputMapIndex) {
+                requiredInputMapping = requiredInputFields.get(inputMapIndex);
+            } else {
+                requiredInputMapping = new HashMap<>();
+            }
+
             for (SearchHit hit : hits) {
                 Map<String, Object> document = hit.getSourceAsMap();
-                boolean isDocumentFieldMissing = checkIsDocumentFieldMissing(document, inputMapping);
+                boolean isDocumentFieldMissing = checkIsDocumentFieldMissing(document, requiredInputMapping);
                 if (!isDocumentFieldMissing) {
                     MapUtils.incrementCounter(hitCountInPredictions, inputMapIndex);
                     for (Map.Entry<String, String> entry : inputMapping.entrySet()) {
@@ -536,6 +562,7 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
      *
      * @param response              the search response
      * @param responseListener      the listener to be notified when the response is processed
+     * @param requiredInputFields   the list of required input fields
      * @param processInputMap       the list of input mappings
      * @param processOutputMap      the list of output mappings
      * @param hitCountInPredictions a map to keep track of the count of hits that have the required input fields for each round of prediction
@@ -544,6 +571,7 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
     private ActionListener<Map<Integer, MLOutput>> createRewriteResponseListener(
         SearchResponse response,
         ActionListener<SearchResponse> responseListener,
+        List<Map<String, String>> requiredInputFields,
         List<Map<String, String>> processInputMap,
         List<Map<String, String>> processOutputMap,
         Map<Integer, Integer> hitCountInPredictions
@@ -568,13 +596,17 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                             for (Map.Entry<Integer, MLOutput> entry : multipleMLOutputs.entrySet()) {
                                 Integer mappingIndex = entry.getKey();
                                 MLOutput mlOutput = entry.getValue();
-
-                                Map<String, String> inputMapping = getDefaultInputMapping(sourceAsMap, mappingIndex, processInputMap);
                                 Map<String, String> outputMapping = getDefaultOutputMapping(mappingIndex, processOutputMap);
+                                Map<String, String> requiredInputMapping;
+                                if (requiredInputFields != null && requiredInputFields.size() > mappingIndex) {
+                                    requiredInputMapping = requiredInputFields.get(mappingIndex);
+                                } else {
+                                    requiredInputMapping = new HashMap<>();
+                                }
 
                                 boolean isDocumentFieldMissing = false;
                                 if (processInputMap != null && !processInputMap.isEmpty()) {
-                                    isDocumentFieldMissing = checkIsDocumentFieldMissing(document, inputMapping);
+                                    isDocumentFieldMissing = checkIsDocumentFieldMissing(document, requiredInputMapping);
                                 }
                                 if (!isDocumentFieldMissing) {
                                     // Iterate over outputMapping
@@ -819,6 +851,12 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
 
             List<Map<String, String>> inputMaps = ConfigurationUtils.readOptionalList(TYPE, processorTag, config, INPUT_MAP);
             List<Map<String, String>> outputMaps = ConfigurationUtils.readOptionalList(TYPE, processorTag, config, OUTPUT_MAP);
+
+            List<Map<String, String>> optionalInputMaps = ConfigurationUtils
+                .readOptionalList(TYPE, processorTag, config, OPTIONAL_INPUT_MAP);
+            List<Map<String, String>> optionalOutputMaps = ConfigurationUtils
+                .readOptionalList(TYPE, processorTag, config, OPTIONAL_OUTPUT_MAP);
+
             int maxPredictionTask = ConfigurationUtils
                 .readIntProperty(TYPE, processorTag, config, MAX_PREDICTION_TASKS, DEFAULT_MAX_PREDICTION_TASKS);
             boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, IGNORE_MISSING, false);
@@ -845,25 +883,32 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
             if (modelConfigInput != null) {
                 modelConfigMaps = StringUtils.getParameterMap(modelConfigInput);
             }
+
+            // Combine processInputMap and optionalInputMaps
+            List<Map<String, String>> combinedInputMaps = ModelExecutor.combineMaps(inputMaps, optionalInputMaps);
+            // Combine processOutputMap and optionalOutputMaps
+            List<Map<String, String>> combinedOutputMaps = ModelExecutor.combineMaps(outputMaps, optionalOutputMaps);
+
             // check if the number of prediction tasks exceeds max prediction tasks
-            if (inputMaps != null && inputMaps.size() > maxPredictionTask) {
+            if (combinedInputMaps != null && combinedInputMaps.size() > maxPredictionTask) {
                 throw new IllegalArgumentException(
                     "The number of prediction task setting in this process is "
-                        + inputMaps.size()
+                        + combinedInputMaps.size()
                         + ". It exceeds the max_prediction_tasks of "
                         + maxPredictionTask
-                        + ". Please reduce the size of input_map or increase max_prediction_tasks."
+                        + ". Please reduce the size of input_map or optional_input_map or increase max_prediction_tasks."
                 );
             }
-            if (outputMaps != null && inputMaps != null && outputMaps.size() != inputMaps.size()) {
+            if (combinedOutputMaps != null && combinedInputMaps != null && combinedOutputMaps.size() != combinedInputMaps.size()) {
                 throw new IllegalArgumentException(
-                    "when output_maps and input_maps are provided, their length needs to match. The input_maps is in length of "
-                        + inputMaps.size()
+                    "when output_maps/optional_output_maps and input_maps/optional_input_maps are provided, their length needs to match. The input is in length of "
+                        + combinedInputMaps.size()
                         + ", while output_maps is in the length of "
-                        + outputMaps.size()
+                        + combinedInputMaps.size()
                         + ". Please adjust mappings."
                 );
             }
+
             boolean writeToSearchExtension = false;
 
             if (outputMaps != null) {
@@ -882,6 +927,8 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                 modelId,
                 inputMaps,
                 outputMaps,
+                optionalInputMaps,
+                optionalOutputMaps,
                 modelConfigMaps,
                 maxPredictionTask,
                 processorTag,

--- a/plugin/src/main/java/org/opensearch/ml/processor/ModelExecutor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/ModelExecutor.java
@@ -381,4 +381,37 @@ public interface ModelExecutor {
         }
 
     }
+
+    /**
+     * Combines two lists of maps into a single list of maps.
+     *
+     * This method takes two lists of maps and combines them into a single list.
+     * For each index, it merges the maps from both lists (if available) into a new map.
+     * If one list is longer than the other, the remaining maps are added without merging.
+     * If either input list is null, it is treated as an empty list.
+     *
+     * @param mapList1 The first list of maps to be combined, can be null
+     * @param mapList2 The second list of maps to be combined, can be null
+     * @return A new list containing the combined maps
+     */
+    static List<Map<String, String>> combineMaps(List<Map<String, String>> mapList1, List<Map<String, String>> mapList2) {
+        List<Map<String, String>> combinedMaps = new ArrayList<>();
+
+        // Handle null inputs by treating them as empty lists
+        mapList1 = (mapList1 != null) ? mapList1 : new ArrayList<>();
+        mapList2 = (mapList2 != null) ? mapList2 : new ArrayList<>();
+
+        int maxSize = Math.max(mapList1.size(), mapList2.size());
+        for (int i = 0; i < maxSize; i++) {
+            Map<String, String> combinedMap = new HashMap<>();
+            if (i < mapList1.size()) {
+                combinedMap.putAll(mapList1.get(i));
+            }
+            if (i < mapList2.size()) {
+                combinedMap.putAll(mapList2.get(i));
+            }
+            combinedMaps.add(combinedMap);
+        }
+        return combinedMaps;
+    }
 }

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
@@ -18,6 +18,8 @@ import static org.opensearch.ml.processor.InferenceProcessorAttributes.MAX_PREDI
 import static org.opensearch.ml.processor.InferenceProcessorAttributes.MODEL_CONFIG;
 import static org.opensearch.ml.processor.InferenceProcessorAttributes.MODEL_ID;
 import static org.opensearch.ml.processor.InferenceProcessorAttributes.OUTPUT_MAP;
+import static org.opensearch.ml.processor.MLInferenceSearchRequestProcessor.OPTIONAL_INPUT_MAP;
+import static org.opensearch.ml.processor.MLInferenceSearchRequestProcessor.OPTIONAL_OUTPUT_MAP;
 import static org.opensearch.ml.processor.MLInferenceSearchResponseProcessor.DEFAULT_MAX_PREDICTION_TASKS;
 import static org.opensearch.ml.processor.MLInferenceSearchResponseProcessor.DEFAULT_OUTPUT_FIELD_NAME;
 import static org.opensearch.ml.processor.MLInferenceSearchResponseProcessor.FULL_RESPONSE_PATH;
@@ -86,6 +88,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
     );
     private static final String PROCESSOR_TAG = "inference";
     private static final String DESCRIPTION = "inference_test";
+    private List<Map<String, String>> optionalOutputMaps = null;
+    private List<Map<String, String>> optionalInputMaps = null;
 
     @Before
     public void setup() {
@@ -207,6 +211,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -294,6 +300,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -382,6 +390,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -460,6 +470,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -548,6 +560,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -632,6 +646,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -729,6 +745,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -821,6 +839,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             null,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -898,6 +918,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             null,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -979,6 +1001,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1037,6 +1061,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             null,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1119,6 +1145,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1207,6 +1235,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1297,6 +1327,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1359,6 +1391,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1416,6 +1450,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1474,6 +1510,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1566,6 +1604,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1653,6 +1693,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1737,6 +1779,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1823,6 +1867,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1885,6 +1931,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -1949,6 +1997,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -2006,6 +2056,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -2069,6 +2121,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -2152,6 +2206,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -2283,6 +2339,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -2384,6 +2442,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -2495,6 +2555,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -2560,6 +2622,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             null,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -2641,6 +2705,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             null,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -3182,6 +3248,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -3269,6 +3337,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -3336,6 +3406,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             null,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -3382,6 +3454,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             null,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -3433,6 +3507,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             null,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -3485,6 +3561,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             null,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -3530,6 +3608,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             null,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -3584,6 +3664,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -3652,6 +3734,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -3720,6 +3804,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             null,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             null,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -3949,6 +4035,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -4035,6 +4123,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             modelConfig,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -4107,6 +4197,603 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
 
         responseProcessor.processResponseAsync(request, mLInferenceSearchResponse, responseContext, listener);
 
+    }
+
+    /**
+     * Tests the successful processing of a response with a single pair of optional input and required output mappings.
+     * Send one prediction based on one hit.
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void testProcessResponseOptionalInputMapOneToOneSuccess() throws Exception {
+        String modelInputFieldText = "inputText";
+        String modelInputFieldImage = "inputImage";
+        String originalDocumentFieldText = "text";
+        String originalDocumentFieldImage = "image";
+        String newDocumentField = "multi_modal_embedding";
+        String modelOutputField = "response";
+        List<Map<String, String>> optionalInputMapsMultiModal = new ArrayList<>();
+        Map<String, String> input = new HashMap<>();
+        input.put(modelInputFieldText, originalDocumentFieldText);
+        input.put(modelInputFieldImage, originalDocumentFieldImage);
+        optionalInputMapsMultiModal.add(input);
+
+        List<Map<String, String>> outputMap = new ArrayList<>();
+        Map<String, String> output = new HashMap<>();
+        output.put(newDocumentField, modelOutputField);
+        outputMap.add(output);
+        Map<String, String> model_config = new HashMap<>();
+        model_config.put("truncate_result", "false");
+        MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
+            "model1",
+            null,
+            outputMap,
+            optionalInputMapsMultiModal,
+            null,
+            model_config,
+            DEFAULT_MAX_PREDICTION_TASKS,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            false,
+            "remote",
+            false,
+            false,
+            false,
+            "{ \"parameters\": ${ml_inference.parameters} }",
+            client,
+            TEST_XCONTENT_REGISTRY_FOR_QUERY,
+            true
+        );
+
+        assertEquals(responseProcessor.getType(), TYPE);
+        SearchRequest request = getSearchRequest();
+        String fieldName = "text";
+        SearchResponse response = getSearchResponse(5, true, fieldName);
+
+        ModelTensor modelTensor = ModelTensor
+            .builder()
+            .dataAsMap(ImmutableMap.of("response", Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)))
+            .build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        ActionListener<SearchResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse newSearchResponse) {
+                assertEquals(newSearchResponse.getHits().getHits().length, 5);
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[0].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[1].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[2].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[3].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[4].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        responseProcessor.processResponseAsync(request, response, responseContext, listener);
+        verify(client, times(5)).execute(any(), any(), any());
+    }
+
+    /**
+     * Tests the successful processing of a response with a single pair of optional input and required output mappings.
+     * Send one prediction based on all hits.
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void testProcessResponseOptionalInputMapManyToOneSuccess() throws Exception {
+        String modelInputFieldText = "inputText";
+        String modelInputFieldImage = "inputImage";
+        String originalDocumentFieldText = "text";
+        String originalDocumentFieldImage = "image";
+        String newDocumentField = "multi_modal_embedding";
+        String modelOutputField = "response";
+        List<Map<String, String>> optionalInputMapsMultiModal = new ArrayList<>();
+        Map<String, String> input = new HashMap<>();
+        input.put(modelInputFieldText, originalDocumentFieldText);
+        input.put(modelInputFieldImage, originalDocumentFieldImage);
+        optionalInputMapsMultiModal.add(input);
+
+        List<Map<String, String>> outputMap = new ArrayList<>();
+        Map<String, String> output = new HashMap<>();
+        output.put(newDocumentField, modelOutputField);
+        outputMap.add(output);
+        Map<String, String> model_config = new HashMap<>();
+        model_config.put("truncate_result", "false");
+        MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
+            "model1",
+            null,
+            outputMap,
+            optionalInputMapsMultiModal,
+            null,
+            model_config,
+            DEFAULT_MAX_PREDICTION_TASKS,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            false,
+            "remote",
+            false,
+            false,
+            false,
+            "{ \"parameters\": ${ml_inference.parameters} }",
+            client,
+            TEST_XCONTENT_REGISTRY_FOR_QUERY,
+            false
+        );
+
+        assertEquals(responseProcessor.getType(), TYPE);
+        SearchRequest request = getSearchRequest();
+        String fieldName = "image";
+        SearchResponse response = getSearchResponse(5, true, fieldName);
+
+        ModelTensor modelTensor = ModelTensor
+            .builder()
+            .dataAsMap(ImmutableMap.of("response", Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)))
+            .build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        ActionListener<SearchResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse newSearchResponse) {
+                assertEquals(newSearchResponse.getHits().getHits().length, 5);
+                assertEquals(newSearchResponse.getHits().getHits()[0].getSourceAsMap().get(newDocumentField), 0.0);
+                assertEquals(newSearchResponse.getHits().getHits()[1].getSourceAsMap().get(newDocumentField), 1.0);
+                assertEquals(newSearchResponse.getHits().getHits()[2].getSourceAsMap().get(newDocumentField), 2.0);
+                assertEquals(newSearchResponse.getHits().getHits()[3].getSourceAsMap().get(newDocumentField), 3.0);
+                assertEquals(newSearchResponse.getHits().getHits()[4].getSourceAsMap().get(newDocumentField), 4.0);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        responseProcessor.processResponseAsync(request, response, responseContext, listener);
+        verify(client, times(1)).execute(any(), any(), any());
+    }
+
+    /**
+     * Tests the successful processing of a response with an optional input, a required output and an optional output.
+     * Send one prediction based on one hit.
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void testProcessResponseOptionalOutputMapOneToOneSuccess() throws Exception {
+        String modelInputFieldText = "inputText";
+        String modelInputFieldImage = "inputImage";
+        String originalDocumentFieldText = "text";
+        String originalDocumentFieldImage = "image";
+        String newDocumentField = "multi_modal_embedding";
+        String modelOutputField = "response";
+        String newOptionalDocumentField = "multi_modal_embedding_size";
+        String optionalModelOutputField = "embedding_size";
+        List<Map<String, String>> optionalInputMapsMultiModal = new ArrayList<>();
+        Map<String, String> input = new HashMap<>();
+        input.put(modelInputFieldText, originalDocumentFieldText);
+        input.put(modelInputFieldImage, originalDocumentFieldImage);
+        optionalInputMapsMultiModal.add(input);
+
+        List<Map<String, String>> outputMap = new ArrayList<>();
+        Map<String, String> output = new HashMap<>();
+        output.put(newDocumentField, modelOutputField);
+        outputMap.add(output);
+
+        List<Map<String, String>> optionalOutputMap = new ArrayList<>();
+        Map<String, String> optionalOutput = new HashMap<>();
+        optionalOutput.put(newOptionalDocumentField, optionalModelOutputField);
+        optionalOutputMap.add(output);
+
+        Map<String, String> model_config = new HashMap<>();
+        model_config.put("truncate_result", "false");
+        MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
+            "model1",
+            null,
+            outputMap,
+            optionalInputMapsMultiModal,
+            optionalOutputMap,
+            model_config,
+            DEFAULT_MAX_PREDICTION_TASKS,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            false,
+            "remote",
+            false,
+            false,
+            false,
+            "{ \"parameters\": ${ml_inference.parameters} }",
+            client,
+            TEST_XCONTENT_REGISTRY_FOR_QUERY,
+            true
+        );
+
+        assertEquals(responseProcessor.getType(), TYPE);
+        SearchRequest request = getSearchRequest();
+        String fieldName = "text";
+        SearchResponse response = getSearchResponse(5, true, fieldName);
+
+        ModelTensor modelTensor = ModelTensor
+            .builder()
+            .dataAsMap(ImmutableMap.of("response", Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)))
+            .build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        ActionListener<SearchResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse newSearchResponse) {
+                assertEquals(newSearchResponse.getHits().getHits().length, 5);
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[0].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[1].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[2].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[3].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[4].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        responseProcessor.processResponseAsync(request, response, responseContext, listener);
+        verify(client, times(5)).execute(any(), any(), any());
+    }
+
+    /**
+     * Tests the successful processing of a response with an optional input, a required output and an optional output.
+     * Send one prediction based on one hit.
+     * When there is the third hit missed all input fields. When ignoreFailure is true, the thrid hit will be skipped.
+     * But the rest of the hits should have the newDocumentField.
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void testProcessResponseOptionalOutputMapOneToOneMissAllInput() throws Exception {
+        String modelInputFieldText = "inputText";
+        String modelInputFieldImage = "inputImage";
+        String originalDocumentFieldText = "text";
+        String originalDocumentFieldImage = "image";
+        String newDocumentField = "multi_modal_embedding";
+        String modelOutputField = "response";
+        String newOptionalDocumentField = "multi_modal_embedding_size";
+        String optionalModelOutputField = "embedding_size";
+        List<Map<String, String>> optionalInputMapsMultiModal = new ArrayList<>();
+        Map<String, String> input = new HashMap<>();
+        input.put(modelInputFieldText, originalDocumentFieldText);
+        input.put(modelInputFieldImage, originalDocumentFieldImage);
+        optionalInputMapsMultiModal.add(input);
+
+        List<Map<String, String>> outputMap = new ArrayList<>();
+        Map<String, String> output = new HashMap<>();
+        output.put(newDocumentField, modelOutputField);
+        outputMap.add(output);
+
+        List<Map<String, String>> optionalOutputMap = new ArrayList<>();
+        Map<String, String> optionalOutput = new HashMap<>();
+        optionalOutput.put(newOptionalDocumentField, optionalModelOutputField);
+        optionalOutputMap.add(output);
+
+        Map<String, String> model_config = new HashMap<>();
+        model_config.put("truncate_result", "false");
+        MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
+            "model1",
+            null,
+            outputMap,
+            optionalInputMapsMultiModal,
+            optionalOutputMap,
+            model_config,
+            DEFAULT_MAX_PREDICTION_TASKS,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            false,
+            "remote",
+            false,
+            true,
+            false,
+            "{ \"parameters\": ${ml_inference.parameters} }",
+            client,
+            TEST_XCONTENT_REGISTRY_FOR_QUERY,
+            true
+        );
+
+        assertEquals(responseProcessor.getType(), TYPE);
+        SearchRequest request = getSearchRequest();
+        String fieldName = "text";
+        SearchResponse response = getSearchResponseMissingField(5, true, fieldName);
+
+        ModelTensor modelTensor = ModelTensor
+            .builder()
+            .dataAsMap(ImmutableMap.of("response", Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)))
+            .build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        AtomicInteger executionCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            int count = executionCount.incrementAndGet();
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+
+            if (count == 3) {
+                actionListener.onFailure(new RuntimeException("Simulated model failure"));
+            } else if (count <= 5) {
+                actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            } else {
+                actionListener.onFailure(new RuntimeException("Unexpected execution count: " + count));
+            }
+
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        ActionListener<SearchResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse newSearchResponse) {
+                assertEquals(newSearchResponse.getHits().getHits().length, 5);
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[0].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[1].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(newSearchResponse.getHits().getHits()[2].getSourceAsMap().get(newDocumentField), null);
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[3].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[4].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        responseProcessor.processResponseAsync(request, response, responseContext, listener);
+        verify(client, times(5)).execute(any(), any(), any());
+    }
+
+    /**
+     * Tests the successful processing of a response with an optional input, a required output and an optional output.
+     * Send one prediction based on all hits.
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void testProcessResponseOptionalOutputMapManyToOneSuccess() throws Exception {
+        String modelInputFieldText = "inputText";
+        String modelInputFieldImage = "inputImage";
+        String originalDocumentFieldText = "text";
+        String originalDocumentFieldImage = "image";
+        String newDocumentField = "multi_modal_embedding";
+        String modelOutputField = "response";
+        String newOptionalDocumentField = "multi_modal_embedding_size";
+        String optionalModelOutputField = "embedding_size";
+        List<Map<String, String>> optionalInputMapsMultiModal = new ArrayList<>();
+        Map<String, String> input = new HashMap<>();
+        input.put(modelInputFieldText, originalDocumentFieldText);
+        input.put(modelInputFieldImage, originalDocumentFieldImage);
+        optionalInputMapsMultiModal.add(input);
+
+        List<Map<String, String>> outputMap = new ArrayList<>();
+        Map<String, String> output = new HashMap<>();
+        output.put(newDocumentField, modelOutputField);
+        outputMap.add(output);
+        Map<String, String> model_config = new HashMap<>();
+
+        List<Map<String, String>> optionalOutputMap = new ArrayList<>();
+        Map<String, String> optionalOutput = new HashMap<>();
+        optionalOutput.put(newOptionalDocumentField, optionalModelOutputField);
+        optionalOutputMap.add(output);
+
+        model_config.put("truncate_result", "false");
+        MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
+            "model1",
+            null,
+            outputMap,
+            optionalInputMapsMultiModal,
+            null,
+            model_config,
+            DEFAULT_MAX_PREDICTION_TASKS,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            false,
+            "remote",
+            false,
+            false,
+            false,
+            "{ \"parameters\": ${ml_inference.parameters} }",
+            client,
+            TEST_XCONTENT_REGISTRY_FOR_QUERY,
+            false
+        );
+
+        assertEquals(responseProcessor.getType(), TYPE);
+        SearchRequest request = getSearchRequest();
+        String fieldName = "image";
+        SearchResponse response = getSearchResponse(5, true, fieldName);
+
+        ModelTensor modelTensor = ModelTensor
+            .builder()
+            .dataAsMap(ImmutableMap.of("response", Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)))
+            .build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        ActionListener<SearchResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse newSearchResponse) {
+                assertEquals(newSearchResponse.getHits().getHits().length, 5);
+                assertEquals(newSearchResponse.getHits().getHits()[0].getSourceAsMap().get(newDocumentField), 0.0);
+                assertEquals(newSearchResponse.getHits().getHits()[1].getSourceAsMap().get(newDocumentField), 1.0);
+                assertEquals(newSearchResponse.getHits().getHits()[2].getSourceAsMap().get(newDocumentField), 2.0);
+                assertEquals(newSearchResponse.getHits().getHits()[3].getSourceAsMap().get(newDocumentField), 3.0);
+                assertEquals(newSearchResponse.getHits().getHits()[4].getSourceAsMap().get(newDocumentField), 4.0);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        responseProcessor.processResponseAsync(request, response, responseContext, listener);
+        verify(client, times(1)).execute(any(), any(), any());
+    }
+
+    /**
+     * Tests the successful processing of a response with no input mapping or optional input mapping .
+     * then all document fields are passed to the model directly as input.
+     * when one to one is true, send one prediction based on all hits.
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void testProcessResponseNoInputMappings() throws Exception {
+        String newDocumentField = "multi_modal_embedding";
+        String modelOutputField = "response";
+
+        List<Map<String, String>> outputMap = new ArrayList<>();
+        Map<String, String> output = new HashMap<>();
+        output.put(newDocumentField, modelOutputField);
+        outputMap.add(output);
+        Map<String, String> model_config = new HashMap<>();
+
+        model_config.put("truncate_result", "false");
+        MLInferenceSearchResponseProcessor responseProcessor = new MLInferenceSearchResponseProcessor(
+            "model1",
+            null,
+            outputMap,
+            null,
+            null,
+            model_config,
+            DEFAULT_MAX_PREDICTION_TASKS,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            false,
+            "remote",
+            false,
+            false,
+            false,
+            "{ \"parameters\": ${ml_inference.parameters} }",
+            client,
+            TEST_XCONTENT_REGISTRY_FOR_QUERY,
+            true
+        );
+
+        assertEquals(responseProcessor.getType(), TYPE);
+        SearchRequest request = getSearchRequest();
+        String fieldName = "image";
+        SearchResponse response = getSearchResponse(5, true, fieldName);
+
+        ModelTensor modelTensor = ModelTensor
+            .builder()
+            .dataAsMap(ImmutableMap.of("response", Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)))
+            .build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        ActionListener<SearchResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse newSearchResponse) {
+                assertEquals(newSearchResponse.getHits().getHits().length, 5);
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[0].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[1].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[2].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[3].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+                assertEquals(
+                    newSearchResponse.getHits().getHits()[4].getSourceAsMap().get(newDocumentField),
+                    Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0)
+                );
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        responseProcessor.processResponseAsync(request, response, responseContext, listener);
+        verify(client, times(5)).execute(any(), any(), any());
     }
 
     private static SearchRequest getSearchRequest() {
@@ -4189,6 +4876,8 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
             "model1",
             inputMap,
             outputMap,
+            optionalInputMaps,
+            optionalOutputMaps,
             model_config,
             DEFAULT_MAX_PREDICTION_TASKS,
             PROCESSOR_TAG,
@@ -4436,7 +5125,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         } catch (IllegalArgumentException e) {
             assertEquals(
                 e.getMessage(),
-                ("The number of prediction task setting in this process is 3. It exceeds the max_prediction_tasks of 2. Please reduce the size of input_map or increase max_prediction_tasks.")
+                ("The number of prediction task setting in this process is 3. It exceeds the max_prediction_tasks of 2. Please reduce the size of input_map or optional_input_map or increase max_prediction_tasks.")
             );
         }
     }
@@ -4477,7 +5166,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         } catch (IllegalArgumentException e) {
             assertEquals(
                 e.getMessage(),
-                "when output_maps and input_maps are provided, their length needs to match. The input_maps is in length of 2, while output_maps is in the length of 3. Please adjust mappings."
+                "when output_maps/optional_output_maps and input_maps/optional_input_maps are provided, their length needs to match. The input is in length of 2, while output_maps is in the length of 2. Please adjust mappings."
             );
 
         }
@@ -4504,9 +5193,19 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         Map<String, String> output = new HashMap<>();
         output.put("text_embedding", "response");
         outputMap.add(output);
+        List<Map<String, String>> optionalInputMap = new ArrayList<>();
+        Map<String, String> optionalInput = new HashMap<>();
+        optionalInput.put("optionalInputs", "text_size");
+        optionalInputMap.add(optionalInput);
+        List<Map<String, String>> optionalOutputMap = new ArrayList<>();
+        Map<String, String> optionalOutput = new HashMap<>();
+        optionalOutput.put("metadata", "response_details");
+        optionalOutputMap.add(optionalOutput);
         config.put(INPUT_MAP, inputMap);
         config.put(OUTPUT_MAP, outputMap);
         config.put(MAX_PREDICTION_TASKS, 5);
+        config.put(OPTIONAL_INPUT_MAP, optionalInputMap);
+        config.put(OPTIONAL_OUTPUT_MAP, optionalOutputMap);
         String processorTag = randomAlphaOfLength(10);
 
         MLInferenceSearchResponseProcessor MLInferenceSearchResponseProcessor = factory

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
@@ -5215,6 +5215,25 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         assertEquals(MLInferenceSearchResponseProcessor.getType(), MLInferenceSearchResponseProcessor.TYPE);
         assertEquals(MLInferenceSearchResponseProcessor.isIgnoreFailure(), true);
         assertEquals(MLInferenceSearchResponseProcessor.getDescription(), "test");
+        assertEquals(MLInferenceSearchResponseProcessor.getInferenceProcessorAttributes().getModelId(), "model2");
+        assertEquals(MLInferenceSearchResponseProcessor.getInferenceProcessorAttributes().getModelConfigMaps().get("hidden_size"), "768");
+        assertEquals(
+            MLInferenceSearchResponseProcessor.getInferenceProcessorAttributes().getModelConfigMaps().get("gradient_checkpointing"),
+            "false"
+        );
+        assertEquals(
+            MLInferenceSearchResponseProcessor.getInferenceProcessorAttributes().getModelConfigMaps().get("position_embedding_type"),
+            "absolute"
+        );
+        assertEquals(MLInferenceSearchResponseProcessor.getInferenceProcessorAttributes().getInputMaps().get(0).get("inputs"), "text");
+        assertEquals(
+            MLInferenceSearchResponseProcessor.getInferenceProcessorAttributes().getOutputMaps().get(0).get("text_embedding"),
+            "response"
+        );
+        assertEquals(MLInferenceSearchResponseProcessor.getInferenceProcessorAttributes().getMaxPredictionTask(), 5);
+        assertEquals(MLInferenceSearchResponseProcessor.getOptionalInputMaps().get(0).get("optionalInputs"), "text_size");
+        assertEquals(MLInferenceSearchResponseProcessor.getOptionalOutputMaps().get(0).get("metadata"), "response_details");
+
     }
 
     /**

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLInferenceSearchResponseProcessorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLInferenceSearchResponseProcessorIT.java
@@ -38,6 +38,7 @@ public class RestMLInferenceSearchResponseProcessorIT extends MLCommonsRestTestC
     private String bedrockEmbeddingModelId;
     private String localModelId;
     private String bedrockClaudeModelId;
+    private String bedrockMultiModalEmbeddingModelId;
     private final String completionModelConnectorEntity = "{\n"
         + "  \"name\": \"OpenAI text embedding model Connector\",\n"
         + "  \"description\": \"The connector to public OpenAI text embedding model service\",\n"
@@ -149,6 +150,43 @@ public class RestMLInferenceSearchResponseProcessorIT extends MLCommonsRestTestC
         + "  ]\n"
         + "}";
 
+    private final String bedrockMultiModalEmbeddingModelConnectorEntity = "{\n"
+        + "  \"name\": \"Amazon Bedrock Connector: bedrock Titan multi-modal embedding model\",\n"
+        + "  \"description\": \"Test connector for Amazon Bedrock Titan multi-modal embedding model\",\n"
+        + "  \"version\": 1,\n"
+        + "  \"protocol\": \"aws_sigv4\",\n"
+        + "  \"parameters\": {\n"
+        + "    \"region\": \""
+        + GITHUB_CI_AWS_REGION
+        + "\",\n"
+        + "    \"service_name\": \"bedrock\",\n"
+        + "    \"model\": \"amazon.titan-embed-image-v1\",\n"
+        + "    \"input_docs_processed_step_size\": 2\n"
+        + "  },\n"
+        + "  \"credential\": {\n"
+        + "    \"access_key\": \""
+        + AWS_ACCESS_KEY_ID
+        + "\",\n"
+        + "    \"secret_key\": \""
+        + AWS_SECRET_ACCESS_KEY
+        + "\",\n"
+        + "    \"session_token\": \""
+        + AWS_SESSION_TOKEN
+        + "\"\n"
+        + "  },\n"
+        + "  \"actions\": [\n"
+        + "    {\n"
+        + "      \"action_type\": \"predict\",\n"
+        + "      \"method\": \"POST\",\n"
+        + "      \"url\": \"https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke\",\n"
+        + "      \"headers\": {\n"
+        + "        \"content-type\": \"application/json\"\n"
+        + "      },\n"
+        + "      \"request_body\": \"{\\\"inputText\\\": \\\"${parameters.inputText:-null}\\\", \\\"inputImage\\\": \\\"${parameters.inputImage:-null}\\\"}\"\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
     /**
      * Registers two remote models and creates an index and documents before running the tests.
      *
@@ -164,6 +202,13 @@ public class RestMLInferenceSearchResponseProcessorIT extends MLCommonsRestTestC
         this.bedrockEmbeddingModelId = registerRemoteModel(bedrockEmbeddingModelConnectorEntity, bedrockEmbeddingModelName, true);
         String bedrockClaudeModelName = "bedrock claude model " + randomAlphaOfLength(5);
         this.bedrockClaudeModelId = registerRemoteModel(bedrockClaudeModelConnectorEntity, bedrockClaudeModelName, true);
+        String bedrockMultiModalEmbeddingModelName = "bedrock multi modal embedding model " + randomAlphaOfLength(5);
+        this.bedrockMultiModalEmbeddingModelId = registerRemoteModel(
+            bedrockMultiModalEmbeddingModelConnectorEntity,
+            bedrockMultiModalEmbeddingModelName,
+            true
+        );
+
         String index_name = "daily_index";
         String createIndexRequestBody = "{\n"
             + "  \"mappings\": {\n"
@@ -377,6 +422,59 @@ public class RestMLInferenceSearchResponseProcessorIT extends MLCommonsRestTestC
         Assert.assertEquals(embeddingList.size(), 1536);
         Assert.assertEquals((Double) embeddingList.get(0), 0.734375, 0.005);
         Assert.assertEquals((Double) embeddingList.get(1), 0.87109375, 0.005);
+    }
+
+    /**
+     * Tests the MLInferenceSearchResponseProcessor with a remote model and
+     * read the optional model input from string field from search hits
+     * It creates a search pipeline with the processor configured to use the remote model,
+     * runs one to one prediction by sending one document to one prediction
+     * performs a search using the pipeline, and verifies the inference results.
+     *
+     * @throws Exception if any error occurs during the test
+     */
+    public void testMLInferenceProcessorRemoteModelOptionalInputs() throws Exception {
+        // Skip test if key is null
+        if (AWS_ACCESS_KEY_ID == null || AWS_SECRET_ACCESS_KEY == null || AWS_SESSION_TOKEN == null) {
+            return;
+        }
+        String createPipelineRequestBody = "{\n"
+            + "  \"response\": [\n"
+            + "    {\n"
+            + "      \"ml_inference\": {\n"
+            + "        \"tag\": \"ml_inference\",\n"
+            + "        \"description\": \"This processor is to run knn query when query on both text and image\",\n"
+            + "        \"model_id\": \""
+            + this.bedrockMultiModalEmbeddingModelId
+            + "\",\n"
+            + "        \"optional_input_map\": [\n"
+            + "          {\n"
+            + "            \"inputText\": \"diary\",\n"
+            + "            \"inputImage\": \"diary_image\"\n"
+            + "          }\n"
+            + "        ],\n"
+            + "        \"output_map\": [\n"
+            + "          {\n"
+            + "            \"multi_modal_embedding\": \"embedding\"\n"
+            + "          }\n"
+            + "        ],\n"
+            + "        \"model_config\": {},\n"
+            + "        \"one_to_one\": true,\n"
+            + "        \"ignore_failure\": false\n"
+            + "      }\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+        String index_name = "daily_index";
+
+        String pipelineName = "diary_multimodal_embedding_pipeline";
+        String query = "{\"query\":{\"term\":{\"diary\":{\"value\":\"happy\"}}}}";
+        createSearchPipelineProcessor(createPipelineRequestBody, pipelineName);
+
+        Map response = searchWithPipeline(client(), index_name, pipelineName, query);
+
+        assertEquals((int) JsonPath.parse(response).read("$.hits.hits.length()"), 1);
+        Assert.assertEquals(JsonPath.parse(response).read("$.hits.hits[0]._source.multi_modal_embedding.length()"), "1024");
     }
 
     /**


### PR DESCRIPTION
### Description
fix optional mappings in ml inference search processors by adding new parameters `optional_input_map` and  `optional_output_map`. Please refer to the REST IT test to see the sample settings.

### Related Issues
[[Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->](https://github.com/opensearch-project/ml-commons/issues/3563)](https://github.com/opensearch-project/ml-commons/issues/3563)

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
