### PR TITLE
Fix template query link on documentation

### DIFF
--- a/docs/tutorials/ml_inference/semantic_search/optimize_vector_search_with_cohere_compressed_embedding.md
+++ b/docs/tutorials/ml_inference/semantic_search/optimize_vector_search_with_cohere_compressed_embedding.md
@@ -9,7 +9,7 @@ Bedrock supports compressed embeddings from Cohere Embed now ([blog](https://aws
 We'll use the following OpenSearch features:
 - [ML inference ingest processor](https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/) to generate embedding when ingest data; 
 - [ML inference search request processor](https://opensearch.org/docs/latest/search-plugins/search-pipelines/ml-inference-search-request/)
-- [Search template query](https://opensearch.org/docs/latest/api-reference/search-template/) for searching.
+- [Template query](https://opensearch.org/docs/latest/query-dsl/specialized/template/) for searching.
 - [k-NN index](https://opensearch.org/docs/latest/search-plugins/knn/index/) and [k-NN byte vector](https://opensearch.org/docs/latest/field-types/supported-field-types/knn-vector/#byte-vectors)
 
 Note: Replace the placeholders that start with `your_` with your own values.


### PR DESCRIPTION
### Description
Fix template query link on documentation
 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
