### PR TITLE
[Backport 2.12] Use model type to check local or remote model

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -44,13 +44,13 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.ML_ROLE }}
           aws-region: us-west-2
 
       - name: Checkout MLCommons
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -72,12 +72,12 @@ jobs:
           echo "build-test-linux=$plugin" >> $GITHUB_OUTPUT
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           flags: ml-commons
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ml-plugin-linux-${{ matrix.java }}
           path: ${{ steps.step-build-test-linux.outputs.build-test-linux }}
@@ -96,17 +96,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.ML_ROLE }}
           aws-region: us-west-2
 
       - name: Checkout MLCommons
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ml-plugin-linux-${{ matrix.java }}
 
@@ -171,7 +171,7 @@ jobs:
           fi
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           flags: ml-commons
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -191,14 +191,14 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.ML_ROLE }}
           aws-region: us-west-2
 
       # ml-commons
       - name: Checkout MLCommons
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactoryTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/httpclient/MLHttpClientFactoryTests.java
@@ -34,7 +34,7 @@ public class MLHttpClientFactoryTests {
     @Test
     public void test_validateIp_invalidIp_throwException() throws UnknownHostException {
         expectedException.expect(UnknownHostException.class);
-        MLHttpClientFactory.validateIp("www.zaniu.com");
+        MLHttpClientFactory.validateIp("www.makesureitisaunknownhostxyz.com");
     }
 
     @Test

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
@@ -15,6 +15,7 @@ import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.opensearch.client.node.NodeClient;
@@ -74,27 +75,30 @@ public class RestMLPredictionAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        String algorithm = request.param(PARAMETER_ALGORITHM);
+        String userAlgorithm = request.param(PARAMETER_ALGORITHM);
         String modelId = getParameterId(request, PARAMETER_MODEL_ID);
         Optional<FunctionName> functionName = modelManager.getOptionalModelFunctionName(modelId);
 
-        if (algorithm == null && functionName.isPresent()) {
-            algorithm = functionName.get().name();
+        // check if the model is in cache
+        if (functionName.isPresent()) {
+            MLPredictionTaskRequest predictionRequest = getRequest(
+                modelId,
+                functionName.get().name(),
+                Objects.requireNonNullElse(userAlgorithm, functionName.get().name()),
+                request
+            );
+            return channel -> client.execute(MLPredictionTaskAction.INSTANCE, predictionRequest, new RestToXContentListener<>(channel));
         }
 
-        if (algorithm != null) {
-            MLPredictionTaskRequest mlPredictionTaskRequest = getRequest(modelId, algorithm, request);
-            return channel -> client
-                .execute(MLPredictionTaskAction.INSTANCE, mlPredictionTaskRequest, new RestToXContentListener<>(channel));
-        }
-
+        // If the model isn't in cache
         return channel -> {
             ActionListener<MLModel> listener = ActionListener.wrap(mlModel -> {
-                String algoName = mlModel.getAlgorithm().name();
+                String modelType = mlModel.getAlgorithm().name();
+                String modelAlgorithm = Objects.requireNonNullElse(userAlgorithm, mlModel.getAlgorithm().name());
                 client
                     .execute(
                         MLPredictionTaskAction.INSTANCE,
-                        getRequest(modelId, algoName, request),
+                        getRequest(modelId, modelType, modelAlgorithm, request),
                         new RestToXContentListener<>(channel)
                     );
             }, e -> {
@@ -112,19 +116,23 @@ public class RestMLPredictionAction extends BaseRestHandler {
     }
 
     /**
-     * Creates a MLPredictionTaskRequest from a RestRequest
+     * Creates a MLPredictionTaskRequest from a RestRequest. This method validates the request based on
+     * enabled features and model types, and parses the input data for prediction.
      *
-     * @param request RestRequest
-     * @return MLPredictionTaskRequest
+     * @param modelId The ID of the ML model to use for prediction
+     * @param modelType The type of the ML model, extracted from model cache to specify if its a remote model or a local model
+     * @param userAlgorithm The algorithm specified by the user for prediction, this is used todetermine the interface of the model
+     * @param request The REST request containing prediction input data
+     * @return MLPredictionTaskRequest configured with the model and input parameters
      */
     @VisibleForTesting
-    MLPredictionTaskRequest getRequest(String modelId, String algorithm, RestRequest request) throws IOException {
-        if (FunctionName.REMOTE.name().equals(algorithm) && !mlFeatureEnabledSetting.isRemoteInferenceEnabled()) {
+    MLPredictionTaskRequest getRequest(String modelId, String modelType, String userAlgorithm, RestRequest request) throws IOException {
+        if (FunctionName.REMOTE.name().equals(modelType) && !mlFeatureEnabledSetting.isRemoteInferenceEnabled()) {
             throw new IllegalStateException(REMOTE_INFERENCE_DISABLED_ERR_MSG);
         }
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-        MLInput mlInput = MLInput.parse(parser, algorithm);
+        MLInput mlInput = MLInput.parse(parser, userAlgorithm);
         return new MLPredictionTaskRequest(modelId, mlInput, null);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLPredictionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLPredictionActionTests.java
@@ -45,6 +45,7 @@ import org.opensearch.rest.action.RestToXContentListener;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.node.NodeClient;
 
 public class RestMLPredictionActionTests extends OpenSearchTestCase {
     @Rule
@@ -65,7 +66,7 @@ public class RestMLPredictionActionTests extends OpenSearchTestCase {
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        when(modelManager.getOptionalModelFunctionName(anyString())).thenReturn(Optional.empty());
+        when(modelManager.getOptionalModelFunctionName(anyString())).thenReturn(Optional.of(FunctionName.REMOTE));
         when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(true);
         restMLPredictionAction = new RestMLPredictionAction(modelManager, mlFeatureEnabledSetting);
 
@@ -107,7 +108,8 @@ public class RestMLPredictionActionTests extends OpenSearchTestCase {
 
     public void testGetRequest() throws IOException {
         RestRequest request = getRestRequest_PredictModel();
-        MLPredictionTaskRequest mlPredictionTaskRequest = restMLPredictionAction.getRequest("modelId", FunctionName.KMEANS.name(), request);
+        MLPredictionTaskRequest mlPredictionTaskRequest = restMLPredictionAction
+            .getRequest("modelId", FunctionName.KMEANS.name(), FunctionName.KMEANS.name(), request);
 
         MLInput mlInput = mlPredictionTaskRequest.getMlInput();
         verifyParsedKMeansMLInput(mlInput);
@@ -119,7 +121,8 @@ public class RestMLPredictionActionTests extends OpenSearchTestCase {
 
         when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(false);
         RestRequest request = getRestRequest_PredictModel();
-        MLPredictionTaskRequest mlPredictionTaskRequest = restMLPredictionAction.getRequest("modelId", FunctionName.REMOTE.name(), request);
+        MLPredictionTaskRequest mlPredictionTaskRequest = restMLPredictionAction
+            .getRequest("modelId", FunctionName.REMOTE.name(), "text_embedding", request);
     }
 
     public void testPrepareRequest() throws Exception {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLPredictionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLPredictionActionTests.java
@@ -45,7 +45,6 @@ import org.opensearch.rest.action.RestToXContentListener;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.transport.client.node.NodeClient;
 
 public class RestMLPredictionActionTests extends OpenSearchTestCase {
     @Rule

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
@@ -453,14 +453,6 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         }, null);
     }
 
-    public void testOpenAITextEmbeddingModel_ISO8859_1() throws IOException, InterruptedException {
-        testOpenAITextEmbeddingModel("ISO-8859-1", null, (exception) -> {
-            assertTrue(exception instanceof org.opensearch.client.ResponseException);
-            String stackTrace = ExceptionUtils.getStackTrace(exception);
-            assertTrue(stackTrace.contains("'utf-8' codec can't decode byte 0xeb"));
-        });
-    }
-
     private void testOpenAITextEmbeddingModel(String charset, Consumer<Map> verifyResponse, Consumer<Exception> verifyException)
         throws IOException,
         InterruptedException {
@@ -589,115 +581,6 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
         responseList = (List) responseMap.get("generations");
         responseMap = (Map) responseList.get(0);
         assertFalse(((String) responseMap.get("text")).isEmpty());
-    }
-
-    public void testCohereClassifyModel() throws IOException, InterruptedException {
-        // Skip test if key is null
-        if (COHERE_KEY == null) {
-            return;
-        }
-        String entity = "{\n"
-            + "  \"name\": \"Cohere classify model Connector\",\n"
-            + "  \"description\": \"The connector to public Cohere classify model service\",\n"
-            + "  \"version\": 1,\n"
-            + "  \"protocol\": \"http\",\n"
-            + "  \"parameters\": {\n"
-            + "      \"endpoint\": \"api.cohere.ai\",\n"
-            + "      \"auth\": \"API_Key\",\n"
-            + "      \"content_type\": \"application/json\",\n"
-            + "      \"max_tokens\": \"20\"\n"
-            + "  },\n"
-            + "  \"credential\": {\n"
-            + "      \"cohere_key\": \""
-            + COHERE_KEY
-            + "\"\n"
-            + "  },\n"
-            + "  \"actions\": [\n"
-            + "      {\n"
-            + "      \"action_type\": \"predict\",\n"
-            + "          \"method\": \"POST\",\n"
-            + "          \"url\": \"https://${parameters.endpoint}/v1/classify\",\n"
-            + "          \"headers\": { \n"
-            + "          \"Authorization\": \"Bearer ${credential.cohere_key}\"\n"
-            + "          },\n"
-            + "          \"request_body\": \"{ \\\"inputs\\\": ${parameters.inputs}, \\\"examples\\\": ${parameters.examples}, \\\"truncate\\\": \\\"END\\\" }\"\n"
-            + "      }\n"
-            + "  ]\n"
-            + "}";
-        Response response = createConnector(entity);
-        Map responseMap = parseResponseToMap(response);
-        String connectorId = (String) responseMap.get("connector_id");
-        response = registerRemoteModel("cohere classify model", connectorId);
-        responseMap = parseResponseToMap(response);
-        String taskId = (String) responseMap.get("task_id");
-        waitForTask(taskId, MLTaskState.COMPLETED);
-        response = getTask(taskId);
-        responseMap = parseResponseToMap(response);
-        String modelId = (String) responseMap.get("model_id");
-        response = deployRemoteModel(modelId);
-        responseMap = parseResponseToMap(response);
-        taskId = (String) responseMap.get("task_id");
-        waitForTask(taskId, MLTaskState.COMPLETED);
-        String predictInput = "{\n"
-            + "  \"parameters\": {\n"
-            + "      \"inputs\": [\n"
-            + "            \"Confirm your email address\",\n"
-            + "            \"hey i need u to send some $\"\n"
-            + "        ],\n"
-            + "        \"examples\": [\n"
-            + "            {\n"
-            + "                \"text\": \"Dermatologists don't like her!\",\n"
-            + "                \"label\": \"Spam\"\n"
-            + "            },\n"
-            + "            {\n"
-            + "                \"text\": \"Hello, open to this?\",\n"
-            + "                \"label\": \"Spam\"\n"
-            + "            },\n"
-            + "            {\n"
-            + "                \"text\": \"I need help please wire me $1000 right now\",\n"
-            + "                \"label\": \"Spam\"\n"
-            + "            },\n"
-            + "            {\n"
-            + "                \"text\": \"Nice to know you ;)\",\n"
-            + "                \"label\": \"Spam\"\n"
-            + "            },\n"
-            + "            {\n"
-            + "                \"text\": \"Please help me?\",\n"
-            + "                \"label\": \"Spam\"\n"
-            + "            },\n"
-            + "            {\n"
-            + "                \"text\": \"Your parcel will be delivered today\",\n"
-            + "                \"label\": \"Not spam\"\n"
-            + "            },\n"
-            + "            {\n"
-            + "                \"text\": \"Review changes to our Terms and Conditions\",\n"
-            + "                \"label\": \"Not spam\"\n"
-            + "            },\n"
-            + "            {\n"
-            + "                \"text\": \"Weekly sync notes\",\n"
-            + "                \"label\": \"Not spam\"\n"
-            + "            },\n"
-            + "            {\n"
-            + "                \"text\": \"Re: Follow up from todays meeting\",\n"
-            + "                \"label\": \"Not spam\"\n"
-            + "            },\n"
-            + "            {\n"
-            + "                \"text\": \"Pre-read for tomorrow\",\n"
-            + "                \"label\": \"Not spam\"\n"
-            + "            }\n"
-            + "        ]\n"
-            + "  }\n"
-            + "}";
-
-        response = predictRemoteModel(modelId, predictInput);
-        responseMap = parseResponseToMap(response);
-        List responseList = (List) responseMap.get("inference_results");
-        responseMap = (Map) responseList.get(0);
-        responseList = (List) responseMap.get("output");
-        responseMap = (Map) responseList.get(0);
-        responseMap = (Map) responseMap.get("dataAsMap");
-        responseList = (List) responseMap.get("classifications");
-        assertFalse(responseList.isEmpty());
     }
 
     private Response createConnector(String input) throws IOException {


### PR DESCRIPTION
### Description
In stead of using user input algorithm we use model type extracting from model cache to check local or remote model, this will fix disable local model will cause remote neural search failure issue

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
