### PR TITLE
Add retries for PredictionITTests

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/action/prediction/PredictionITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prediction/PredictionITTests.java
@@ -37,6 +37,7 @@ import org.opensearch.ml.common.input.parameter.rcf.FitRCFParams;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
+import org.opensearch.ml.utils.RetryRule;
 import org.opensearch.ml.utils.TestData;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -51,6 +52,9 @@ public class PredictionITTests extends MLCommonsIntegTestCase {
     private String linearRegressionModelId;
     private String logisticRegressionModelId;
     private int batchRcfDataSize = 100;
+
+    @Rule
+    public RetryRule retryRule = new RetryRule(3);
 
     /**
      * set ML_COMMONS_SYNC_UP_JOB_INTERVAL_IN_SECONDS to 0 to disable ML_COMMONS_SYNC_UP_JOB

--- a/plugin/src/test/java/org/opensearch/ml/utils/RetryRule.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RetryRule.java
@@ -1,0 +1,37 @@
+package org.opensearch.ml.utils;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class RetryRule implements TestRule {
+    private final int retryCount;
+
+    public RetryRule(int retryCount) {
+        this.retryCount = retryCount;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Throwable caughtThrowable = null;
+                for (int i = 0; i < retryCount; i++) {
+                    try {
+                        base.evaluate();  // This runs the entire test (setup, test, teardown)
+                        return;  // Test passed, exit the loop
+                    } catch (Throwable t) {
+                        caughtThrowable = t;
+                        log.warn("{}: run {} failed", description.getDisplayName(), i + 1);
+                    }
+                }
+                log.error("{}: giving up after {} failures", description.getDisplayName(), retryCount);
+                throw caughtThrowable;
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Description
Created a new junit test rule for retries, the PredictionITTests are flaky and the retry logic resolves the issue

The reason for creating the retry rule is to simulate all the before and after methods related to a test case
### Related Issues
Resolves #3550
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
