### PR TITLE
Remove forcing log4j version to 2.24.2

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -419,8 +419,6 @@ configurations.all {
     resolutionStrategy.force "org.apache.httpcomponents.client5:httpclient5:5.4.1"
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${versions.jackson_databind}"
-    resolutionStrategy.force "org.apache.logging.log4j:log4j-api:2.24.2"
-    resolutionStrategy.force "org.apache.logging.log4j:log4j-core:2.24.2"
     resolutionStrategy.force "jakarta.json:jakarta.json-api:2.1.3"
     resolutionStrategy.force "org.opensearch:opensearch:${opensearch_version}"
     resolutionStrategy.force "org.bouncycastle:bcprov-jdk18on:1.78.1"


### PR DESCRIPTION
### Description
2.24.2 version of log4j introduces an exception: https://github.com/apache/logging-log4j2/issues/3234, causing flakiness in test cases. Removing this will use the version used in openSearch core (currently 2.21.0)

### Related Issues
Resolves #3550

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
