### PR TITLE
Use stream optional enum set from core in MLStatsInput

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/stats/MLStatsInput.java
+++ b/plugin/src/main/java/org/opensearch/ml/stats/MLStatsInput.java
@@ -117,35 +117,26 @@ public class MLStatsInput implements ToXContentObject, Writeable {
     }
 
     public MLStatsInput(StreamInput input) throws IOException {
-        targetStatLevels = input.readBoolean() ? input.readEnumSet(MLStatLevel.class) : EnumSet.noneOf(MLStatLevel.class);
-        clusterLevelStats = input.readBoolean() ? input.readEnumSet(MLClusterLevelStat.class) : EnumSet.noneOf(MLClusterLevelStat.class);
-        nodeLevelStats = input.readBoolean() ? input.readEnumSet(MLNodeLevelStat.class) : EnumSet.noneOf(MLNodeLevelStat.class);
-        actionLevelStats = input.readBoolean() ? input.readEnumSet(MLActionLevelStat.class) : EnumSet.noneOf(MLActionLevelStat.class);
+        targetStatLevels = input.readOptionalEnumSet(MLStatLevel.class);
+        clusterLevelStats = input.readOptionalEnumSet(MLClusterLevelStat.class);
+        nodeLevelStats = input.readOptionalEnumSet(MLNodeLevelStat.class);
+        actionLevelStats = input.readOptionalEnumSet(MLActionLevelStat.class);
         nodeIds = input.readBoolean() ? new HashSet<>(input.readStringList()) : new HashSet<>();
         models = input.readBoolean() ? new HashSet<>(input.readStringList()) : new HashSet<>();
-        algorithms = input.readBoolean() ? input.readEnumSet(FunctionName.class) : EnumSet.noneOf(FunctionName.class);
-        actions = input.readBoolean() ? input.readEnumSet(ActionName.class) : EnumSet.noneOf(ActionName.class);
+        algorithms = input.readOptionalEnumSet(FunctionName.class);
+        actions = input.readOptionalEnumSet(ActionName.class);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        writeEnumSet(out, targetStatLevels);
-        writeEnumSet(out, clusterLevelStats);
-        writeEnumSet(out, nodeLevelStats);
-        writeEnumSet(out, actionLevelStats);
+        out.writeOptionalEnumSet(targetStatLevels);
+        out.writeOptionalEnumSet(clusterLevelStats);
+        out.writeOptionalEnumSet(nodeLevelStats);
+        out.writeOptionalEnumSet(actionLevelStats);
         out.writeOptionalStringCollection(nodeIds);
         out.writeOptionalStringCollection(models);
-        writeEnumSet(out, algorithms);
-        writeEnumSet(out, actions);
-    }
-
-    private void writeEnumSet(StreamOutput out, EnumSet<?> set) throws IOException {
-        if (set != null && set.size() > 0) {
-            out.writeBoolean(true);
-            out.writeEnumSet(set);
-        } else {
-            out.writeBoolean(false);
-        }
+        out.writeOptionalEnumSet(algorithms);
+        out.writeOptionalEnumSet(actions);
     }
 
     public static MLStatsInput parse(XContentParser parser) throws IOException {


### PR DESCRIPTION
### Description
Refactors MLStatsInput to use `StreamInput::readOptionalEnumSet` and `StreamOutput::writeOptionalEnumSet` from OpenSearch core, added in this recent PR: https://github.com/opensearch-project/OpenSearch/pull/17556

The currently this is implemented in ml-commons using a private helper. I added this functionality to core using ml-commons as a reference so it could be reused in neural search, so the implementation is identical. While I made this change so other plugins could use the same function, I figure it might make sense to use it in ml-commons as well.

Compare
[ml-commons implmentation](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/stats/MLStatsInput.java#L142-L149)
```
private void writeEnumSet(StreamOutput out, EnumSet<?> set) throws IOException {
    if (set != null && set.size() > 0) {
        out.writeBoolean(true);
        out.writeEnumSet(set);
    } else {
        out.writeBoolean(false);
    }
}
```

[Core implementation](https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamOutput.java#L1262-L1269)
```
public <E extends Enum<E>> void writeOptionalEnumSet(@Nullable EnumSet<E> enumSet) throws IOException {
    if (enumSet != null && enumSet.size() > 0) {
        writeBoolean(true);
        writeEnumSet(enumSet);
    } else {
        writeBoolean(false);
    }
}
```
### Related Issues
n/a

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
