### PR TITLE
Fix test_cohereInference_withDifferent_postProcessFunction flaky test

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestCohereInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestCohereInferenceIT.java
@@ -78,7 +78,7 @@ public class RestCohereInferenceIT extends MLCommonsRestTestCase {
             List output = (List) inferenceResult.get("inference_results");
             assertEquals(errorMsg, 1, output.size());
             assertTrue(errorMsg, output.get(0) instanceof Map);
-            if (output != null && DATA_TYPE != null) {
+            if (output != null) {
                 validateOutput(errorMsg, (Map) output.get(0), DATA_TYPE.get(postProcessFunction));
             }
         }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestCohereInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestCohereInferenceIT.java
@@ -78,7 +78,9 @@ public class RestCohereInferenceIT extends MLCommonsRestTestCase {
             List output = (List) inferenceResult.get("inference_results");
             assertEquals(errorMsg, 1, output.size());
             assertTrue(errorMsg, output.get(0) instanceof Map);
-            validateOutput(errorMsg, (Map) output.get(0), DATA_TYPE.get(postProcessFunction));
+            if (output != null && DATA_TYPE != null) {
+                validateOutput(errorMsg, (Map) output.get(0), DATA_TYPE.get(postProcessFunction));
+            }
         }
     }
 


### PR DESCRIPTION
### Description
Fix `test_cohereInference_withDifferent_postProcessFunction` flaky test due to 
```
java.lang.NullPointerException: Cannot invoke "Object.getClass()" because the return value of "java.util.Map.get(Object)" is null
```

### Related Issues
Resolves https://github.com/opensearch-project/ml-commons/pull/3628#issuecomment-2726981295

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
