### PR TITLE
fix compilation error

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -12,7 +12,7 @@ import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE
 import static org.opensearch.cluster.node.DiscoveryNodeRole.DATA_ROLE;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.INGEST_ROLE;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE;
-import static org.opensearch.cluster.node.DiscoveryNodeRole.SEARCH_ROLE;
+import static org.opensearch.cluster.node.DiscoveryNodeRole.WARM_ROLE;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_AGENT_ID;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_ALGORITHM;
@@ -105,7 +105,7 @@ public class TestHelper {
 
     public static SortedSet<DiscoveryNodeRole> ALL_ROLES = Collections
         .unmodifiableSortedSet(
-            new TreeSet<>(Arrays.asList(DATA_ROLE, INGEST_ROLE, CLUSTER_MANAGER_ROLE, REMOTE_CLUSTER_CLIENT_ROLE, SEARCH_ROLE, ML_ROLE))
+            new TreeSet<>(Arrays.asList(DATA_ROLE, INGEST_ROLE, CLUSTER_MANAGER_ROLE, REMOTE_CLUSTER_CLIENT_ROLE, WARM_ROLE, ML_ROLE))
         );
 
     public static XContentParser parser(String xc) throws IOException {


### PR DESCRIPTION
### Description
OpenSearch core is renaming the search node role to warm node role: https://github.com/opensearch-project/OpenSearch/pull/17573 which breaks the compilation in ml-commons.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
