### PR TITLE
Fix model search for deleting connector

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
@@ -7,7 +7,6 @@ package org.opensearch.ml.action.connector;
 
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
-import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -137,9 +136,6 @@ public class DeleteConnectorTransportAction extends HandledTransportAction<Actio
     private SearchDataObjectRequest buildModelSearchRequest(String connectorId, String tenantId) {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
         sourceBuilder.query(QueryBuilders.matchQuery(MLModel.CONNECTOR_ID_FIELD, connectorId));
-        if (mlFeatureEnabledSetting.isMultiTenancyEnabled()) {
-            sourceBuilder.query(QueryBuilders.matchQuery(TENANT_ID_FIELD, tenantId));
-        }
 
         return SearchDataObjectRequest.builder().indices(ML_MODEL_INDEX).tenantId(tenantId).searchSourceBuilder(sourceBuilder).build();
     }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -34,7 +34,6 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.ml.common.AccessMode;
-import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.MLModelGroup;
 import org.opensearch.ml.common.exception.MLResourceNotFoundException;
 import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupInput;
@@ -224,9 +223,6 @@ public class MLModelGroupManager {
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             BoolQueryBuilder query = new BoolQueryBuilder();
             query.filter(new TermQueryBuilder(MLRegisterModelGroupInput.NAME_FIELD + ".keyword", name));
-            if (tenantId != null) {
-                query.filter(new TermQueryBuilder(CommonValue.TENANT_ID_FIELD, tenantId));
-            }
 
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(query);
             SearchRequest searchRequest = new SearchRequest(ML_MODEL_GROUP_INDEX).source(searchSourceBuilder);
@@ -234,7 +230,6 @@ public class MLModelGroupManager {
             SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
                 .builder()
                 .indices(searchRequest.indices())
-                .tenantId(tenantId)
                 .searchSourceBuilder(searchRequest.source())
                 .tenantId(tenantId)
                 .build();


### PR DESCRIPTION
### Description

The model search for delete connector incorrectly overwrote the search for connector ID with one for tenant ID. 

There is no need to handle tenant ID in searching, as it is handled by the sdk client when tenant awarness is set, see [here](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/blob/65802084bd0a496e32204154c73c6698de3647eb/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java#L434-L451) and [here](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/blob/65802084bd0a496e32204154c73c6698de3647eb/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java#L513-L525).

Also removed the (redundant) filtering in the search for models in a model group. This properly appended the filter, but as it is handled by the client, is also unnecessary.

Added [41353eb](https://github.com/opensearch-project/ml-commons/pull/3516/commits/41353eb33d85e7095861ce507a7762ddc7eb544e) to integ test PR #3516 which will fail until this PR is merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
