### PR TITLE
revert CI workflow changes

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -84,18 +84,23 @@ jobs:
                                echo "::add-mask::$COHERE_KEY" &&
                                echo "build and run tests" && ./gradlew build -x spotlessJava &&
                                echo "Publish to Maven Local" && ./gradlew publishToMavenLocal -x spotlessJava &&
-                               echo "Multi Nodes Integration Testing" && ./gradlew integTest -PnumNodes=3 -x spotlessJava &&
-                               echo "Run Jacoco test coverage" && ./gradlew jacocoTestReport && cp -v plugin/build/reports/jacoco/test/jacocoTestReport.xml ./jacocoTestReport.xml'
+                               echo "Multi Nodes Integration Testing" && ./gradlew integTest -PnumNodes=3 -x spotlessJava'
           plugin=`basename $(ls plugin/build/distributions/*.zip)`
           echo $plugin
           mv -v plugin/build/distributions/$plugin ./
           echo "build-test-linux=$plugin" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
-        if: ${{ matrix.os }} == "ubuntu-latest"
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v3
         with:
-          name: coverage-report-${{ matrix.os }}-${{ matrix.java }}
-          path: ./jacocoTestReport.xml
+          flags: ml-commons
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ml-plugin-linux-${{ matrix.java }}
+          path: ${{ steps.step-build-test-linux.outputs.build-test-linux }}
+          if-no-files-found: error
 
 
   Test-ml-linux-docker:
@@ -164,8 +169,8 @@ jobs:
       - name: Generate Password For Admin
         id: genpass
         run: |
-            PASSWORD=$(openssl rand -base64 20 | tr -dc 'A-Za-z0-9!@#$%^&*()_+=-')
-            echo "password={$PASSWORD}" >> $GITHUB_OUTPUT
+          PASSWORD=$(openssl rand -base64 20 | tr -dc 'A-Za-z0-9!@#$%^&*()_+=-')
+          echo "password={$PASSWORD}" >> $GITHUB_OUTPUT
       - name: Run Docker Image
         if: env.imagePresent == 'true'
         run: |
@@ -194,24 +199,6 @@ jobs:
         with:
           flags: ml-commons
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  Precommit-codecov:
-    needs: Build-ml-linux
-    strategy:
-      matrix:
-        java: [21, 23]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: coverage-report-${{ matrix.os }}-${{ matrix.java }}
-          path: ./
-      - name: Upload Coverage Report
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./jacocoTestReport.xml
 
   Build-ml-windows:
     strategy:


### PR DESCRIPTION
### Description
In this PR: https://github.com/opensearch-project/ml-commons/pull/3243, CI workflow was modified to fix the jacoco not update it's latest result issue, but after that all the PRs failed with below error, e.g. https://github.com/opensearch-project/ml-commons/actions/runs/13911015452/job/38928296296, after further investigation the jacoco not updated is caused by integTest not passing(no actual issue with CI workflow configuration), so reverting the change now.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
