### PR TITLE
model predict: move getModel from rest to transport

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
@@ -7,6 +7,9 @@ package org.opensearch.ml.action.prediction;
 
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE;
 import static org.opensearch.ml.utils.MLExceptionUtils.LOCAL_MODEL_DISABLED_ERR_MSG;
+import static org.opensearch.ml.utils.MLExceptionUtils.REMOTE_INFERENCE_DISABLED_ERR_MSG;
+
+import java.util.Locale;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
@@ -126,9 +129,8 @@ public class TransportPredictionTaskAction extends HandledTransportAction<Action
                     context.restore();
                     modelCacheHelper.setModelInfo(modelId, mlModel);
                     FunctionName functionName = mlModel.getAlgorithm();
-                    if (FunctionName.isDLModel(functionName) && !mlFeatureEnabledSetting.isLocalModelEnabled()) {
-                        throw new IllegalStateException(LOCAL_MODEL_DISABLED_ERR_MSG);
-                    }
+                    String modelType = functionName.name();
+                    validateModelType(modelType);
                     mlPredictionTaskRequest.getMlInput().setAlgorithm(functionName);
                     modelAccessControlHelper
                         .validateModelGroupAccess(
@@ -271,6 +273,15 @@ public class TransportPredictionTaskAction extends HandledTransportAction<Action
                     RestStatus.BAD_REQUEST
                 );
             }
+        }
+    }
+
+    private void validateModelType(String modelType) {
+        if (FunctionName.REMOTE.name().equals(modelType) && !mlFeatureEnabledSetting.isRemoteInferenceEnabled()) {
+            throw new IllegalStateException(REMOTE_INFERENCE_DISABLED_ERR_MSG);
+        } else if (FunctionName.isDLModel(FunctionName.from(modelType.toUpperCase(Locale.ROOT)))
+            && !mlFeatureEnabledSetting.isLocalModelEnabled()) {
+            throw new IllegalStateException(LOCAL_MODEL_DISABLED_ERR_MSG);
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionAction.java
@@ -8,8 +8,6 @@ package org.opensearch.ml.rest;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
 import static org.opensearch.ml.utils.MLExceptionUtils.BATCH_INFERENCE_DISABLED_ERR_MSG;
-import static org.opensearch.ml.utils.MLExceptionUtils.LOCAL_MODEL_DISABLED_ERR_MSG;
-import static org.opensearch.ml.utils.MLExceptionUtils.REMOTE_INFERENCE_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_ALGORITHM;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
 import static org.opensearch.ml.utils.RestActionUtils.getActionTypeFromRestRequest;
@@ -22,12 +20,8 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.FunctionName;
-import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.connector.ConnectorAction.ActionType;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
@@ -35,7 +29,6 @@ import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.ml.settings.MLFeatureEnabledSetting;
 import org.opensearch.rest.BaseRestHandler;
-import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestToXContentListener;
 import org.opensearch.transport.client.node.NodeClient;
@@ -88,45 +81,12 @@ public class RestMLPredictionAction extends BaseRestHandler {
         String modelId = getParameterId(request, PARAMETER_MODEL_ID);
         Optional<FunctionName> functionName = modelManager.getOptionalModelFunctionName(modelId);
 
-        // check if the model is in cache
-        if (functionName.isPresent()) {
-            MLPredictionTaskRequest predictionRequest = getRequest(
-                modelId,
-                functionName.get().name(),
-                Objects.requireNonNullElse(userAlgorithm, functionName.get().name()),
-                request
-            );
-            return channel -> client.execute(MLPredictionTaskAction.INSTANCE, predictionRequest, new RestToXContentListener<>(channel));
-        }
-
-        // If the model isn't in cache
-        return channel -> {
-            ActionListener<MLModel> listener = ActionListener.wrap(mlModel -> {
-                String modelType = mlModel.getAlgorithm().name();
-                String modelAlgorithm = Objects.requireNonNullElse(userAlgorithm, mlModel.getAlgorithm().name());
-                client
-                    .execute(
-                        MLPredictionTaskAction.INSTANCE,
-                        getRequest(modelId, modelType, modelAlgorithm, request),
-                        new RestToXContentListener<>(channel)
-                    );
-            }, e -> {
-                log.error("Failed to get ML model", e);
-                try {
-                    channel.sendResponse(new BytesRestResponse(channel, RestStatus.NOT_FOUND, e));
-                } catch (IOException ex) {
-                    log.error("Failed to send error response", ex);
-                }
-            });
-            try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-                modelManager
-                    .getModel(
-                        modelId,
-                        getTenantID(mlFeatureEnabledSetting.isMultiTenancyEnabled(), request),
-                        ActionListener.runBefore(listener, context::restore)
-                    );
-            }
-        };
+        MLPredictionTaskRequest predictionRequest = getRequest(
+            modelId,
+            Objects.requireNonNullElse(userAlgorithm, functionName.get().name()),
+            request
+        );
+        return channel -> client.execute(MLPredictionTaskAction.INSTANCE, predictionRequest, new RestToXContentListener<>(channel));
     }
 
     /**
@@ -134,21 +94,15 @@ public class RestMLPredictionAction extends BaseRestHandler {
      * enabled features and model types, and parses the input data for prediction.
      *
      * @param modelId The ID of the ML model to use for prediction
-     * @param modelType The type of the ML model, extracted from model cache to specify if its a remote model or a local model
      * @param userAlgorithm The algorithm specified by the user for prediction, this is used todetermine the interface of the model
      * @param request The REST request containing prediction input data
      * @return MLPredictionTaskRequest configured with the model and input parameters
      */
     @VisibleForTesting
-    MLPredictionTaskRequest getRequest(String modelId, String modelType, String userAlgorithm, RestRequest request) throws IOException {
+    MLPredictionTaskRequest getRequest(String modelId, String userAlgorithm, RestRequest request) throws IOException {
         String tenantId = getTenantID(mlFeatureEnabledSetting.isMultiTenancyEnabled(), request);
         ActionType actionType = ActionType.from(getActionTypeFromRestRequest(request));
-        if (FunctionName.REMOTE.name().equals(modelType) && !mlFeatureEnabledSetting.isRemoteInferenceEnabled()) {
-            throw new IllegalStateException(REMOTE_INFERENCE_DISABLED_ERR_MSG);
-        } else if (FunctionName.isDLModel(FunctionName.from(modelType.toUpperCase(Locale.ROOT)))
-            && !mlFeatureEnabledSetting.isLocalModelEnabled()) {
-            throw new IllegalStateException(LOCAL_MODEL_DISABLED_ERR_MSG);
-        } else if (ActionType.BATCH_PREDICT == actionType && !mlFeatureEnabledSetting.isOfflineBatchInferenceEnabled()) {
+        if (ActionType.BATCH_PREDICT == actionType && !mlFeatureEnabledSetting.isOfflineBatchInferenceEnabled()) {
             throw new IllegalStateException(BATCH_INFERENCE_DISABLED_ERR_MSG);
         } else if (!ActionType.isValidActionInModelPrediction(actionType)) {
             throw new IllegalArgumentException("Wrong action type in the rest request path!");

--- a/plugin/src/test/java/org/opensearch/ml/action/prediction/TransportPredictionTaskActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prediction/TransportPredictionTaskActionTests.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE;
 import static org.opensearch.ml.utils.MLExceptionUtils.LOCAL_MODEL_DISABLED_ERR_MSG;
+import static org.opensearch.ml.utils.MLExceptionUtils.REMOTE_INFERENCE_DISABLED_ERR_MSG;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -197,6 +198,22 @@ public class TransportPredictionTaskActionTests extends OpenSearchTestCase {
         assertEquals(
                 e.getMessage(),
                 LOCAL_MODEL_DISABLED_ERR_MSG
+        );
+    }
+
+    @Test
+    public void testPrediction_remote_inference_not_exception() {
+        when(modelCacheHelper.getModelInfo(anyString())).thenReturn(model);
+        when(model.getAlgorithm()).thenReturn(FunctionName.REMOTE);
+        when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(false);
+
+        IllegalStateException e = assertThrows(
+                IllegalStateException.class,
+                () -> transportPredictionTaskAction.doExecute(null, mlPredictionTaskRequest, actionListener)
+        );
+        assertEquals(
+                e.getMessage(),
+                REMOTE_INFERENCE_DISABLED_ERR_MSG
         );
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLPredictionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLPredictionActionTests.java
@@ -8,8 +8,6 @@ package org.opensearch.ml.rest;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import static org.opensearch.ml.utils.MLExceptionUtils.LOCAL_MODEL_DISABLED_ERR_MSG;
-import static org.opensearch.ml.utils.MLExceptionUtils.REMOTE_INFERENCE_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
 import static org.opensearch.ml.utils.TestHelper.getBatchRestRequest;
 import static org.opensearch.ml.utils.TestHelper.getBatchRestRequest_WrongActionType;
@@ -127,33 +125,10 @@ public class RestMLPredictionActionTests extends OpenSearchTestCase {
     @Test
     public void testGetRequest() throws IOException {
         RestRequest request = getRestRequest_PredictModel();
-        MLPredictionTaskRequest mlPredictionTaskRequest = restMLPredictionAction
-            .getRequest("modelId", FunctionName.KMEANS.name(), FunctionName.KMEANS.name(), request);
+        MLPredictionTaskRequest mlPredictionTaskRequest = restMLPredictionAction.getRequest("modelId", FunctionName.KMEANS.name(), request);
 
         MLInput mlInput = mlPredictionTaskRequest.getMlInput();
         verifyParsedKMeansMLInput(mlInput);
-    }
-
-    @Test
-    public void testGetRequest_RemoteInferenceDisabled() throws IOException {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage(REMOTE_INFERENCE_DISABLED_ERR_MSG);
-
-        when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(false);
-        RestRequest request = getRestRequest_PredictModel();
-        MLPredictionTaskRequest mlPredictionTaskRequest = restMLPredictionAction
-            .getRequest("modelId", FunctionName.REMOTE.name(), "text_embedding", request);
-    }
-
-    @Test
-    public void testGetRequest_LocalModelInferenceDisabled() throws IOException {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage(LOCAL_MODEL_DISABLED_ERR_MSG);
-
-        when(mlFeatureEnabledSetting.isLocalModelEnabled()).thenReturn(false);
-        RestRequest request = getRestRequest_PredictModel();
-        MLPredictionTaskRequest mlPredictionTaskRequest = restMLPredictionAction
-            .getRequest("modelId", FunctionName.TEXT_EMBEDDING.name(), "text_embedding", request);
     }
 
     @Test
@@ -196,7 +171,7 @@ public class RestMLPredictionActionTests extends OpenSearchTestCase {
         thrown.expectMessage("Wrong Action Type");
 
         RestRequest request = getBatchRestRequest_WrongActionType();
-        restMLPredictionAction.getRequest("model id", "remote", "text_embedding", request);
+        restMLPredictionAction.getRequest("model id", "text_embedding", request);
     }
 
     @Ignore
@@ -234,17 +209,7 @@ public class RestMLPredictionActionTests extends OpenSearchTestCase {
         thrown.expectMessage("Wrong Action Type of models");
 
         RestRequest request = getBatchRestRequest_WrongActionType();
-        restMLPredictionAction.getRequest("model_id", FunctionName.REMOTE.name(), "text_embedding", request);
-    }
-
-    @Test
-    public void testGetRequest_UnsupportedAlgorithm() throws IOException {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Wrong function name");
-
-        // Create a RestRequest with an unsupported algorithm
-        RestRequest request = getRestRequest_PredictModel();
-        restMLPredictionAction.getRequest("model_id", "INVALID_ALGO", "text_embedding", request);
+        restMLPredictionAction.getRequest("model_id", "text_embedding", request);
     }
 
     private RestRequest getRestRequest_PredictModel() {

--- a/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/SecureMLRestIT.java
@@ -408,7 +408,7 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
         train(mlReadOnlyClient, FunctionName.KMEANS, irisIndex, kMeansParams, searchSourceBuilder, null, false);
     }
 
-    public void testPredictWithReadOnlyMLAccess() throws IOException {
+    public void testPredictWithReadOnlyMLAccessModelExisting() throws IOException {
         KMeansParams kMeansParams = KMeansParams.builder().build();
         train(mlFullAccessClient, FunctionName.KMEANS, irisIndex, kMeansParams, searchSourceBuilder, trainResult -> {
             String modelId = (String) trainResult.get("model_id");
@@ -434,6 +434,13 @@ public class SecureMLRestIT extends MLCommonsRestTestCase {
                 fail("Unexpected IOException: " + e.getMessage());
             }
         }, false);
+    }
+
+    public void testPredictWithReadOnlyMLAccessModelNonExisting() throws IOException {
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("no permissions for [cluster:admin/opensearch/ml/predict]");
+        KMeansParams kMeansParams = KMeansParams.builder().build();
+        predict(mlReadOnlyClient, FunctionName.KMEANS, "modelId", irisIndex, kMeansParams, searchSourceBuilder, null);
     }
 
     public void testTrainAndPredictWithFullAccess() throws IOException {


### PR DESCRIPTION
### Description
To prevent security issue, put index read behind transport call.

### Related Issues
https://github.com/opensearch-project/ml-commons/issues/3651

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
