### PR TITLE
typo: MLTaskDispatcher _cluster/settings api

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskDispatcher.java
@@ -171,7 +171,7 @@ public class MLTaskDispatcher {
                 "No eligible node found to execute this request. It's best practice to"
                     + " provision ML nodes to serve your models. You can disable this setting to serve the model on your data"
                     + " node for development purposes by disabling the \"plugins.ml_commons.only_run_on_ml_node\" "
-                    + "configuration using the _cluster/setting api"
+                    + "configuration using the _cluster/settings api"
             );
         }
         dispatchTaskWithRoundRobin(eligibleNodes, listener);


### PR DESCRIPTION
### Description
in `dispatchTaskWithRoundRobin` method, MLTaskDispatcher
modify typo of `_cluster/setting` to `_cluster/settings`

### Related Issues
Resolves #3693 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
