### PR TITLE
Update highlighting model translator to adapt new model

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QAConstants.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QAConstants.java
@@ -49,4 +49,5 @@ public final class QAConstants {
     public static final String TOKENIZER_FILE_NAME = "tokenizer.json";
     // Special token value used to ignore tokens in sentence ID mapping
     public static final int IGNORE_TOKEN_ID = -100;
+    public static final int CONTEXT_START_DEFAULT_INDEX = 0;
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QAConstants.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QAConstants.java
@@ -27,6 +27,7 @@ public final class QAConstants {
     public static final String INPUT_IDS = "input_ids";
     public static final String ATTENTION_MASK = "attention_mask";
     public static final String TOKEN_TYPE_IDS = "token_type_ids";
+    public static final String SENTENCE_IDS = "sentence_ids";
 
     // Default values for warm-up
     public static final String DEFAULT_WARMUP_QUESTION = "How is the weather?";

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QAConstants.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QAConstants.java
@@ -23,6 +23,10 @@ public final class QAConstants {
     // Context keys
     public static final String KEY_SENTENCES = "sentences";
 
+    // Sentence highlighting model predict chunk input key
+    public static final String HIGHLIGHTING_MODEL_CHUNK_NUMBER_KEY = "chunk";
+    public static final String HIGHLIGHTING_MODEL_INITIAL_CHUNK_NUMBER_STRING = "0";
+
     // Model input names
     public static final String INPUT_IDS = "input_ids";
     public static final String ATTENTION_MASK = "attention_mask";
@@ -32,4 +36,17 @@ public final class QAConstants {
     // Default values for warm-up
     public static final String DEFAULT_WARMUP_QUESTION = "How is the weather?";
     public static final String DEFAULT_WARMUP_CONTEXT = "The weather is nice, it is beautiful day. The sun is shining. The sky is blue.";
+
+    // Default model configuration
+    public static final String TOKEN_MAX_LENGTH_KEY = "token_max_length";
+    public static final Integer DEFAULT_TOKEN_MAX_LENGTH = 512;
+    public static final String TOKEN_OVERLAP_STRIDE_LENGTH_KEY = "token_overlap_stride";
+    public static final Integer DEFAULT_TOKEN_OVERLAP_STRIDE_LENGTH = 128;
+    public static final String WITH_OVERFLOWING_TOKENS_KEY = "with_overflowing_tokens";
+    public static final Boolean DEFAULT_WITH_OVERFLOWING_TOKENS = true;
+    public static final String PADDING_KEY = "padding";
+    public static final Boolean DEFAULT_PADDING = false;
+    public static final String TOKENIZER_FILE_NAME = "tokenizer.json";
+    // Special token value used to ignore tokens in sentence ID mapping
+    public static final int IGNORE_TOKEN_ID = -100;
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModel.java
@@ -5,29 +5,38 @@
 
 package org.opensearch.ml.engine.algorithms.question_answering;
 
+import static org.opensearch.ml.engine.ModelHelper.PYTORCH_ENGINE;
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.DEFAULT_WARMUP_CONTEXT;
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.DEFAULT_WARMUP_QUESTION;
+import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.FIELD_HIGHLIGHTS;
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.SENTENCE_HIGHLIGHTING_TYPE;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.QuestionAnsweringInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.model.MLModelConfig;
+import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.engine.algorithms.DLModel;
 import org.opensearch.ml.engine.annotation.Function;
 
+import ai.djl.huggingface.tokenizers.Encoding;
 import ai.djl.inference.Predictor;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.translate.TranslateException;
 import ai.djl.translate.Translator;
 import ai.djl.translate.TranslatorFactory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
 /**
@@ -36,7 +45,12 @@ import lombok.extern.log4j.Log4j2;
  */
 @Log4j2
 @Function(FunctionName.QUESTION_ANSWERING)
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
 public class QuestionAnsweringModel extends DLModel {
+    private MLModelConfig modelConfig;
+    private Translator<Input, Output> translator;
 
     @Override
     public void warmUp(Predictor predictor, String modelId, MLModelConfig modelConfig) throws TranslateException {
@@ -47,50 +61,220 @@ public class QuestionAnsweringModel extends DLModel {
             throw new IllegalArgumentException("model id is null");
         }
 
+        // Initialize model type from config if not set
+        if (modelConfig != null) {
+            this.modelConfig = modelConfig;
+        }
+
         // Create input for the predictor
         Input input = new Input();
         input.add(DEFAULT_WARMUP_QUESTION);
         input.add(DEFAULT_WARMUP_CONTEXT);
+        input.add("0");
 
         // Run prediction to warm up the model
         predictor.predict(input);
     }
 
-    /**
-     * Checks if the model is configured for sentence highlighting.
-     *
-     * @param modelConfig The model configuration
-     * @return true if the model is configured for sentence highlighting, false otherwise
-     */
-    private boolean isSentenceHighlightingType(MLModelConfig modelConfig) {
-        if (modelConfig != null) {
-            return SENTENCE_HIGHLIGHTING_TYPE.equalsIgnoreCase(modelConfig.getModelType());
-        }
-        return false;
-    }
-
     @Override
     public ModelTensorOutput predict(String modelId, MLInput mlInput) throws TranslateException {
         MLInputDataset inputDataSet = mlInput.getInputDataset();
-        List<ModelTensors> tensorOutputs = new ArrayList<>();
-        Output output;
         QuestionAnsweringInputDataSet qaInputDataSet = (QuestionAnsweringInputDataSet) inputDataSet;
         String question = qaInputDataSet.getQuestion();
         String context = qaInputDataSet.getContext();
+
+        if (isStandardQAModel()) {
+            return predictStandardQA(question, context);
+        }
+
+        return predictSentenceHighlightingQA(question, context);
+    }
+
+    private boolean isStandardQAModel() {
+        return modelConfig == null
+            || modelConfig.getModelType() == null
+            || !SENTENCE_HIGHLIGHTING_TYPE.equalsIgnoreCase(modelConfig.getModelType());
+    }
+
+    private ModelTensorOutput predictStandardQA(String question, String context) throws TranslateException {
         Input input = new Input();
         input.add(question);
         input.add(context);
-        output = getPredictor().predict(input);
-        tensorOutputs.add(parseModelTensorOutput(output, null));
-        return new ModelTensorOutput(tensorOutputs);
+
+        try {
+            Output output = getPredictor().predict(input);
+            ModelTensors tensors = parseModelTensorOutput(output, null);
+            return new ModelTensorOutput(List.of(tensors));
+        } catch (Exception e) {
+            log.error("Error processing standard QA model prediction", e);
+            throw new TranslateException("Failed to process standard QA model prediction", e);
+        }
+    }
+
+    private ModelTensorOutput predictSentenceHighlightingQA(String question, String context) throws TranslateException {
+        SentenceHighlightingQATranslator translator = (SentenceHighlightingQATranslator) getTranslator(PYTORCH_ENGINE, this.modelConfig);
+
+        try {
+            List<Map<String, Object>> allHighlights = new ArrayList<>();
+
+            // Process initial chunk
+            processInitialChunk(question, context, allHighlights);
+
+            // Process overflow chunks if any
+            processOverflowChunks(question, context, translator, allHighlights);
+
+            return createHighlightOutput(allHighlights);
+        } catch (Exception e) {
+            log.error("Error processing sentence highlighting model prediction", e);
+            throw new TranslateException("Failed to process chunks for sentence highlighting", e);
+        }
+    }
+
+    private void processInitialChunk(String question, String context, List<Map<String, Object>> allHighlights) throws TranslateException {
+        Input initialInput = new Input();
+        initialInput.add(question);
+        initialInput.add(context);
+        initialInput.add("0");
+
+        List<Output> initialOutputs = getPredictor().batchPredict(List.of(initialInput));
+        for (Output output : initialOutputs) {
+            ModelTensors tensors = parseModelTensorOutput(output, null);
+            allHighlights.addAll(extractHighlights(tensors));
+        }
+    }
+
+    private void processOverflowChunks(
+        String question,
+        String context,
+        SentenceHighlightingQATranslator translator,
+        List<Map<String, Object>> allHighlights
+    ) throws TranslateException {
+        Encoding encodings = translator.getTokenizer().encode(question, context);
+        Encoding[] overflowEncodings = encodings.getOverflowing();
+
+        if (overflowEncodings == null || overflowEncodings.length == 0) {
+            return;
+        }
+
+        List<Input> overflowInputs = createOverflowInputs(question, context, overflowEncodings.length);
+        processOverflowInputs(overflowInputs, allHighlights);
+    }
+
+    private List<Input> createOverflowInputs(String question, String context, int numOverflowChunks) {
+        List<Input> overflowInputs = new ArrayList<>();
+        for (int i = 0; i < numOverflowChunks; i++) {
+            Input chunkInput = new Input();
+            chunkInput.add(question);
+            chunkInput.add(context);
+            chunkInput.add(String.valueOf(i + 1));
+            overflowInputs.add(chunkInput);
+        }
+        return overflowInputs;
+    }
+
+    private void processOverflowInputs(List<Input> overflowInputs, List<Map<String, Object>> allHighlights) throws TranslateException {
+        try {
+            processOverflowInputsBatch(overflowInputs, allHighlights);
+        } catch (IllegalArgumentException e) {
+            log.info("Batch processing of chunks failed. Processing chunks individually: {}", e.getMessage());
+            processOverflowInputsIndividually(overflowInputs, allHighlights);
+        }
+    }
+
+    private void processOverflowInputsBatch(List<Input> overflowInputs, List<Map<String, Object>> allHighlights) throws TranslateException {
+        List<Output> overflowOutputs = getPredictor().batchPredict(overflowInputs);
+        for (Output output : overflowOutputs) {
+            try {
+                ModelTensors tensors = parseModelTensorOutput(output, null);
+                allHighlights.addAll(extractHighlights(tensors));
+            } catch (Exception e) {
+                log.warn("Error processing output from chunk", e);
+            }
+        }
+    }
+
+    private void processOverflowInputsIndividually(List<Input> overflowInputs, List<Map<String, Object>> allHighlights) {
+        for (int i = 0; i < overflowInputs.size(); i++) {
+            processOverflowChunkWithBatch(i + 1, overflowInputs.get(i), allHighlights);
+        }
+    }
+
+    /**
+     * Process a single overflow chunk using batchPredict and add any extracted highlights
+     * 
+     * @param chunkIndex The index of the overflow chunk (1-based)
+     * @param chunkInput The prepared input for this chunk
+     * @param highlights Collection to add extracted highlights to
+     */
+    private void processOverflowChunkWithBatch(int chunkIndex, Input chunkInput, List<Map<String, Object>> highlights) {
+        try {
+            // Use batchPredict instead of predict to avoid the bug
+            List<Output> outputs = getPredictor().batchPredict(List.of(chunkInput));
+            if (outputs.isEmpty()) {
+                log.warn("No output returned for chunk {}", chunkIndex);
+                return;
+            }
+
+            // Process all outputs from this chunk
+            for (Output output : outputs) {
+                ModelTensors tensors = parseModelTensorOutput(output, null);
+                List<Map<String, Object>> chunkHighlights = extractHighlights(tensors);
+                highlights.addAll(chunkHighlights);
+            }
+        } catch (Exception e) {
+            log.warn("Error processing overflow chunk {}", chunkIndex, e);
+            // Continue with next chunk even if one fails
+        }
+    }
+
+    /**
+     * Extract highlights from model tensors output
+     * 
+     * @param tensors The model tensors to extract highlights from
+     * @return List of highlight data maps
+     */
+    private List<Map<String, Object>> extractHighlights(ModelTensors tensors) {
+        List<Map<String, Object>> highlights = new ArrayList<>();
+
+        for (ModelTensor tensor : tensors.getMlModelTensors()) {
+            Map<String, ?> dataAsMap = tensor.getDataAsMap();
+            if (dataAsMap != null && dataAsMap.containsKey(FIELD_HIGHLIGHTS)) {
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> tensorHighlights = (List<Map<String, Object>>) dataAsMap.get(FIELD_HIGHLIGHTS);
+                highlights.addAll(tensorHighlights);
+            }
+        }
+
+        return highlights;
+    }
+
+    /**
+     * Create a model tensor output for highlights
+     * 
+     * @param highlights The list of highlights to include
+     * @return ModelTensorOutput containing highlights
+     */
+    private ModelTensorOutput createHighlightOutput(List<Map<String, Object>> highlights) {
+        Map<String, Object> combinedData = new HashMap<>();
+        combinedData.put(FIELD_HIGHLIGHTS, highlights);
+
+        ModelTensor combinedTensor = ModelTensor.builder().name(FIELD_HIGHLIGHTS).dataAsMap(combinedData).build();
+
+        return new ModelTensorOutput(List.of(new ModelTensors(List.of(combinedTensor))));
     }
 
     @Override
     public Translator<Input, Output> getTranslator(String engine, MLModelConfig modelConfig) throws IllegalArgumentException {
-        if (isSentenceHighlightingType(modelConfig)) {
-            return SentenceHighlightingQATranslator.createDefault();
+        if (translator == null) {
+            if (modelConfig != null
+                && modelConfig.getModelType() != null
+                && SENTENCE_HIGHLIGHTING_TYPE.equalsIgnoreCase(modelConfig.getModelType())) {
+                translator = SentenceHighlightingQATranslator.createDefault();
+            } else {
+                translator = new QuestionAnsweringTranslator();
+            }
         }
-        return new QuestionAnsweringTranslator();
+        return translator;
     }
 
     @Override

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModel.java
@@ -9,6 +9,8 @@ import static org.opensearch.ml.engine.ModelHelper.PYTORCH_ENGINE;
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.DEFAULT_WARMUP_CONTEXT;
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.DEFAULT_WARMUP_QUESTION;
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.FIELD_HIGHLIGHTS;
+import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.HIGHLIGHTING_MODEL_CHUNK_NUMBER_KEY;
+import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.HIGHLIGHTING_MODEL_INITIAL_CHUNK_NUMBER_STRING;
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.SENTENCE_HIGHLIGHTING_TYPE;
 
 import java.util.ArrayList;
@@ -68,9 +70,16 @@ public class QuestionAnsweringModel extends DLModel {
 
         // Create input for the predictor
         Input input = new Input();
-        input.add(DEFAULT_WARMUP_QUESTION);
-        input.add(DEFAULT_WARMUP_CONTEXT);
-        input.add("0");
+
+        if (isSentenceHighlightingModel()) {
+            input.add(MLInput.QUESTION_FIELD, DEFAULT_WARMUP_QUESTION);
+            input.add(MLInput.CONTEXT_FIELD, DEFAULT_WARMUP_CONTEXT);
+            // Add initial chunk number key value pair which is needed for sentence highlighting model
+            input.add(HIGHLIGHTING_MODEL_CHUNK_NUMBER_KEY, HIGHLIGHTING_MODEL_INITIAL_CHUNK_NUMBER_STRING);
+        } else {
+            input.add(DEFAULT_WARMUP_QUESTION);
+            input.add(DEFAULT_WARMUP_CONTEXT);
+        }
 
         // Run prediction to warm up the model
         predictor.predict(input);
@@ -83,17 +92,15 @@ public class QuestionAnsweringModel extends DLModel {
         String question = qaInputDataSet.getQuestion();
         String context = qaInputDataSet.getContext();
 
-        if (isStandardQAModel()) {
-            return predictStandardQA(question, context);
+        if (isSentenceHighlightingModel()) {
+            return predictSentenceHighlightingQA(question, context);
         }
 
-        return predictSentenceHighlightingQA(question, context);
+        return predictStandardQA(question, context);
     }
 
-    private boolean isStandardQAModel() {
-        return modelConfig == null
-            || modelConfig.getModelType() == null
-            || !SENTENCE_HIGHLIGHTING_TYPE.equalsIgnoreCase(modelConfig.getModelType());
+    private boolean isSentenceHighlightingModel() {
+        return modelConfig != null && SENTENCE_HIGHLIGHTING_TYPE.equalsIgnoreCase(modelConfig.getModelType());
     }
 
     private ModelTensorOutput predictStandardQA(String question, String context) throws TranslateException {
@@ -132,9 +139,9 @@ public class QuestionAnsweringModel extends DLModel {
 
     private void processInitialChunk(String question, String context, List<Map<String, Object>> allHighlights) throws TranslateException {
         Input initialInput = new Input();
-        initialInput.add(question);
-        initialInput.add(context);
-        initialInput.add("0");
+        initialInput.add(MLInput.QUESTION_FIELD, question);
+        initialInput.add(MLInput.CONTEXT_FIELD, context);
+        initialInput.add(HIGHLIGHTING_MODEL_CHUNK_NUMBER_KEY, HIGHLIGHTING_MODEL_INITIAL_CHUNK_NUMBER_STRING);
 
         List<Output> initialOutputs = getPredictor().batchPredict(List.of(initialInput));
         for (Output output : initialOutputs) {
@@ -164,9 +171,10 @@ public class QuestionAnsweringModel extends DLModel {
         List<Input> overflowInputs = new ArrayList<>();
         for (int i = 0; i < numOverflowChunks; i++) {
             Input chunkInput = new Input();
-            chunkInput.add(question);
-            chunkInput.add(context);
-            chunkInput.add(String.valueOf(i + 1));
+            chunkInput.add(MLInput.QUESTION_FIELD, question);
+            chunkInput.add(MLInput.CONTEXT_FIELD, context);
+            chunkInput.add(HIGHLIGHTING_MODEL_CHUNK_NUMBER_KEY, String.valueOf(i + 1));
+
             overflowInputs.add(chunkInput);
         }
         return overflowInputs;
@@ -193,7 +201,8 @@ public class QuestionAnsweringModel extends DLModel {
         }
     }
 
-    private void processOverflowInputsIndividually(List<Input> overflowInputs, List<Map<String, Object>> allHighlights) {
+    private void processOverflowInputsIndividually(List<Input> overflowInputs, List<Map<String, Object>> allHighlights)
+        throws TranslateException {
         for (int i = 0; i < overflowInputs.size(); i++) {
             processOverflowChunkWithBatch(i + 1, overflowInputs.get(i), allHighlights);
         }
@@ -206,7 +215,8 @@ public class QuestionAnsweringModel extends DLModel {
      * @param chunkInput The prepared input for this chunk
      * @param highlights Collection to add extracted highlights to
      */
-    private void processOverflowChunkWithBatch(int chunkIndex, Input chunkInput, List<Map<String, Object>> highlights) {
+    private void processOverflowChunkWithBatch(int chunkIndex, Input chunkInput, List<Map<String, Object>> highlights)
+        throws TranslateException {
         try {
             // Use batchPredict instead of predict to avoid the bug
             List<Output> outputs = getPredictor().batchPredict(List.of(chunkInput));
@@ -222,8 +232,8 @@ public class QuestionAnsweringModel extends DLModel {
                 highlights.addAll(chunkHighlights);
             }
         } catch (Exception e) {
-            log.warn("Error processing overflow chunk {}", chunkIndex, e);
-            // Continue with next chunk even if one fails
+            log.error("Error processing overflow chunk {}", chunkIndex, e);
+            throw new TranslateException("Failed to process overflow chunk " + chunkIndex, e);
         }
     }
 
@@ -233,15 +243,19 @@ public class QuestionAnsweringModel extends DLModel {
      * @param tensors The model tensors to extract highlights from
      * @return List of highlight data maps
      */
-    private List<Map<String, Object>> extractHighlights(ModelTensors tensors) {
+    private List<Map<String, Object>> extractHighlights(ModelTensors tensors) throws TranslateException {
         List<Map<String, Object>> highlights = new ArrayList<>();
 
         for (ModelTensor tensor : tensors.getMlModelTensors()) {
             Map<String, ?> dataAsMap = tensor.getDataAsMap();
             if (dataAsMap != null && dataAsMap.containsKey(FIELD_HIGHLIGHTS)) {
-                @SuppressWarnings("unchecked")
-                List<Map<String, Object>> tensorHighlights = (List<Map<String, Object>>) dataAsMap.get(FIELD_HIGHLIGHTS);
-                highlights.addAll(tensorHighlights);
+                try {
+                    List<Map<String, Object>> tensorHighlights = (List<Map<String, Object>>) dataAsMap.get(FIELD_HIGHLIGHTS);
+                    highlights.addAll(tensorHighlights);
+                } catch (ClassCastException e) {
+                    log.error("Failed to cast highlights data to expected format", e);
+                    throw new TranslateException("Failed to cast highlights data to expected format", e);
+                }
             }
         }
 
@@ -266,10 +280,8 @@ public class QuestionAnsweringModel extends DLModel {
     @Override
     public Translator<Input, Output> getTranslator(String engine, MLModelConfig modelConfig) throws IllegalArgumentException {
         if (translator == null) {
-            if (modelConfig != null
-                && modelConfig.getModelType() != null
-                && SENTENCE_HIGHLIGHTING_TYPE.equalsIgnoreCase(modelConfig.getModelType())) {
-                translator = SentenceHighlightingQATranslator.createDefault();
+            if (modelConfig != null && SENTENCE_HIGHLIGHTING_TYPE.equalsIgnoreCase(modelConfig.getModelType())) {
+                translator = SentenceHighlightingQATranslator.create(modelConfig);
             } else {
                 translator = new QuestionAnsweringTranslator();
             }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModel.java
@@ -64,7 +64,7 @@ public class QuestionAnsweringModel extends DLModel {
             throw new IllegalArgumentException("model id is null");
         }
 
-        // Initialize model type from config if not set
+        // Initialize model config from model if it exists, the model config field is required for sentence highlighting model.
         if (modelConfig != null) {
             this.modelConfig = modelConfig;
         }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQATranslator.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQATranslator.java
@@ -14,15 +14,19 @@ import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.FIELD_TEXT;
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.INPUT_IDS;
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.KEY_SENTENCES;
+import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.SENTENCE_IDS;
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.TOKEN_TYPE_IDS;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import org.jetbrains.annotations.NotNull;
 import org.opensearch.ml.common.input.MLInput;
@@ -48,33 +52,15 @@ import lombok.extern.log4j.Log4j2;
 /**
  * Translator for sentence highlighting question answering model.
  *
- * <p>Expected model output format:
- * The model should output binary predictions for each sentence, where:
- * - 1 indicates a relevant sentence (that answers the question)
- * - 0 indicates a non-relevant sentence
- * 
- * This format can be customized by overriding the isRelevantPrediction method.
  */
 @Log4j2
 @Getter
 @Builder
 public class SentenceHighlightingQATranslator implements ServingTranslator {
     /**
-     * Default relevance value that indicates a sentence is relevant.
-     * By default, 1 means relevant and 0 means not relevant.
-     * The method specifically checks for equality with RELEVANT_VALUE (1) to determine relevance.
+     * This translator works with the semantic sentence highlighting model, which returns
+     * sentence indices directly rather than binary relevance scores.
      */
-    private static final long RELEVANT_VALUE = 1L;
-
-    /**
-     * Determines if a prediction value indicates a relevant sentence.
-     * 
-     * @param predictionValue The prediction value from the model
-     * @return true if the prediction indicates a relevant sentence, false otherwise
-     */
-    protected boolean isRelevantPrediction(long predictionValue) {
-        return predictionValue == RELEVANT_VALUE;
-    }
 
     @Builder.Default
     private final SentenceSegmenter segmenter = new DefaultSentenceSegmenter();
@@ -93,7 +79,16 @@ public class SentenceHighlightingQATranslator implements ServingTranslator {
     @Override
     public void prepare(TranslatorContext ctx) throws IOException {
         Path path = ctx.getModel().getModelPath();
-        tokenizer = HuggingFaceTokenizer.builder().optPadding(true).optTokenizerPath(path.resolve("tokenizer.json")).build();
+        tokenizer = HuggingFaceTokenizer
+            .builder()
+            .optTokenizerPath(path.resolve("tokenizer.json"))
+            .optMaxLength(512)
+            .optStride(128)
+            .optWithOverflowingTokens(true)
+            .optTruncateSecondOnly()
+            .optPadding(false)
+            .optAddSpecialTokens(true)
+            .build();
     }
 
     @Override
@@ -107,89 +102,188 @@ public class SentenceHighlightingQATranslator implements ServingTranslator {
             NDManager manager = ctx.getNDManager();
             String question = input.getAsString(0);
             String context = input.getAsString(1);
+            int chunkNumber = Integer.parseInt(input.getAsString(2));
 
+            // Store the full context and question for reference
+            ctx.setAttachment("question", question);
+            ctx.setAttachment(MLInput.CONTEXT_FIELD, context);
+
+            // Step 1: Split context into sentences (using full context)
             List<Sentence> sentences = segmenter.segment(context);
             ctx.setAttachment(KEY_SENTENCES, sentences);
-            ctx.setAttachment(MLInput.QUESTION_FIELD, question);
 
-            Encoding encodings = tokenizer.encode(question, context);
+            // Step 2: Create word-level sentence IDs from full context
+            int[] wordLevelSentenceIds = createWordLevelSentenceIds(sentences, context);
 
-            NDArray indicesArray = manager.create(encodings.getIds());
-            indicesArray.setName(INPUT_IDS);
+            // Step 3: Get the target chunk's encoding
+            Encoding targetEncoding = getChunkEncoding(question, context, chunkNumber);
 
-            NDArray attentionMaskArray = manager.create(encodings.getAttentionMask());
-            if (attentionMaskArray.isEmpty()) {
-                throw new IllegalArgumentException("Attention mask is empty in sentence highlighting QA model input");
-            }
-            attentionMaskArray.setName(ATTENTION_MASK);
+            // Step 4: Create sentence IDs array for this chunk
+            int[] sentenceIdsArray = createSentenceIdsArray(targetEncoding, wordLevelSentenceIds, chunkNumber);
 
-            NDArray tokenTypeIdsArray = manager.create(encodings.getTypeIds());
-            tokenTypeIdsArray.setName(TOKEN_TYPE_IDS);
+            // Step 5: Create NDArrays for model input
+            return createModelInputs(manager, targetEncoding, sentenceIdsArray);
 
-            return new NDList(indicesArray, attentionMaskArray, tokenTypeIdsArray);
         } catch (Exception e) {
+            log.error("Error processing input", e);
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Error processing input: %s", e.getMessage()), e);
         }
+    }
+
+    /**
+     * Get the encoding for a specific chunk
+     */
+    private Encoding getChunkEncoding(String question, String context, int chunkNumber) {
+        Encoding fullEncoding = tokenizer.encode(question, context);
+
+        if (chunkNumber == 0) {
+            return fullEncoding;
+        } else {
+            Encoding[] overflowEncodings = fullEncoding.getOverflowing();
+            if (overflowEncodings != null && chunkNumber <= overflowEncodings.length) {
+                return overflowEncodings[chunkNumber - 1];
+            } else {
+                throw new IllegalArgumentException("Invalid chunk number: " + chunkNumber);
+            }
+        }
+    }
+
+    /**
+     * Create sentence IDs array for the given chunk
+     */
+    private int[] createSentenceIdsArray(Encoding encoding, int[] wordLevelSentenceIds, int chunkNumber) {
+        long[] wordIds = encoding.getWordIds();
+        int[] sentenceIdsArray = new int[wordIds.length];
+        Arrays.fill(sentenceIdsArray, -100); // Initialize with -100 (ignore token)
+
+        // Find where the context starts in this chunk
+        long[] typeIds = encoding.getTypeIds();
+        int contextStartIndex = findContextStartIndex(typeIds);
+
+        // Map word IDs to sentence IDs
+        for (int i = contextStartIndex; i < wordIds.length; i++) {
+            long wordId = wordIds[i];
+            if (wordId != -1 && wordId < wordLevelSentenceIds.length) {
+                sentenceIdsArray[i] = wordLevelSentenceIds[(int) wordId];
+            }
+        }
+
+        return sentenceIdsArray;
+    }
+
+    /**
+     * Find where the context starts in the token sequence
+     */
+    private int findContextStartIndex(long[] typeIds) {
+        for (int i = 0; i < typeIds.length; i++) {
+            if (typeIds[i] == 1) {
+                return i;
+            }
+        }
+        return 0;  // Default to 0 if not found
+    }
+
+    /**
+     * Create model inputs from encodings and sentence IDs
+     */
+    private NDList createModelInputs(NDManager manager, Encoding encoding, int[] sentenceIdsArray) {
+        NDArray sentenceIdsNDArray = manager.create(sentenceIdsArray);
+        NDArray inputIds = manager.create(encoding.getIds());
+        NDArray attentionMask = manager.create(encoding.getAttentionMask());
+        NDArray tokenTypeIds = manager.create(encoding.getTypeIds());
+
+        sentenceIdsNDArray.setName(SENTENCE_IDS);
+        inputIds.setName(INPUT_IDS);
+        attentionMask.setName(ATTENTION_MASK);
+        tokenTypeIds.setName(TOKEN_TYPE_IDS);
+
+        return new NDList(inputIds, attentionMask, tokenTypeIds, sentenceIdsNDArray);
+    }
+
+    /**
+     * Creates an array mapping each word in the context to its sentence ID
+     */
+    private int[] createWordLevelSentenceIds(List<Sentence> sentences, String context) {
+        String[] contextWords = context.split("\\s+");
+        int[] wordSentenceIds = new int[contextWords.length];
+
+        // For each sentence
+        for (int sentIdx = 0; sentIdx < sentences.size(); sentIdx++) {
+            Sentence sentence = sentences.get(sentIdx);
+            int startIndex = sentence.getStartIndex();
+            int endIndex = sentence.getEndIndex();
+
+            // Find all words within the sentence's start and end indices
+            for (int wordIdx = 0; wordIdx < contextWords.length; wordIdx++) {
+                int wordStart = 0;
+                for (int i = 0; i < wordIdx; i++) {
+                    wordStart += contextWords[i].length() + 1; // +1 for space
+                }
+                int wordEnd = wordStart + contextWords[wordIdx].length();
+
+                // If word is within sentence boundaries, assign it this sentence ID
+                if (wordStart >= startIndex && wordEnd <= endIndex) {
+                    wordSentenceIds[wordIdx] = sentIdx;
+                }
+            }
+        }
+
+        return wordSentenceIds;
     }
 
     @Override
     public Output processOutput(TranslatorContext ctx, NDList list) {
         try {
-            Output output = new Output(200, "OK");
-
+            // Get the sentences we stored during input processing
             @SuppressWarnings("unchecked")
             List<Sentence> sentences = (List<Sentence>) ctx.getAttachment(KEY_SENTENCES);
-            boolean[] isRelevant = new boolean[sentences.size()];
-
-            // Check if we have valid output from the model
-            if (list == null || list.isEmpty()) {
-                return createErrorOutput("Model returned empty or null output");
+            if (sentences == null || sentences.isEmpty()) {
+                return createErrorOutput("No sentences found in context");
             }
 
-            // The model returns a tensor where 1 means relevant, 0 means not relevant
-            NDArray binaryPreds = list.getFirst();
-
-            // Validate prediction shape
-            if (binaryPreds.getShape().dimension() == 0 || binaryPreds.getShape().get(0) == 0) {
-                return createErrorOutput(String.format("Invalid prediction shape: %s", binaryPreds.getShape()));
-            }
-
-            // Convert to boolean array
-            for (int i = 0; i < Math.min(sentences.size(), binaryPreds.getShape().get(0)); i++) {
-                try {
-                    long predValue = binaryPreds.getLong(i);
-                    isRelevant[i] = isRelevantPrediction(predValue);
-                } catch (Exception e) {
-                    log.warn(String.format("Error processing prediction for sentence %d: %s", i, e.getMessage()));
-                    isRelevant[i] = false;
+            // Process model output to get highlighted sentence indices
+            Set<Integer> highlightedIndices = new HashSet<>();
+            for (NDArray array : list) {
+                long[] indices = array.toLongArray();
+                for (long idx : indices) {
+                    if (idx >= 0 && idx < sentences.size()) {
+                        highlightedIndices.add((int) idx);
+                    }
                 }
             }
 
-            // Create sentence data objects
+            if (highlightedIndices.isEmpty()) {
+                log.warn("No relevant sentences found in model output");
+                return createErrorOutput("No relevant sentences found");
+            }
+
+            // Convert indices to SentenceData objects
             List<SentenceData> sentenceDataList = new ArrayList<>();
             for (int i = 0; i < sentences.size(); i++) {
                 Sentence sentence = sentences.get(i);
-                boolean relevant = isRelevant[i];
-                sentenceDataList.add(new SentenceData(sentence.getText(), relevant, sentence.getPosition()));
+                boolean isRelevant = highlightedIndices.contains(i);
+                sentenceDataList.add(new SentenceData(sentence.getText(), isRelevant, i));
             }
 
-            // Prepare output list for relevant sentences
-            List<Map<String, Object>> relevantSentenceDetails = getRelevantSentenceDetails(sentenceDataList, sentences);
-            log.info("Relevant sentence details: {}", relevantSentenceDetails);
+            // Get the relevant sentence details
+            List<Map<String, Object>> highlights = getRelevantSentenceDetails(sentenceDataList, sentences);
 
-            // Create a map to hold our data
-            Map<String, Object> dataMap = new HashMap<>();
-            dataMap.put(FIELD_HIGHLIGHTS, relevantSentenceDetails);
+            // Create output map
+            Map<String, Object> outputMap = new HashMap<>();
+            outputMap.put(FIELD_HIGHLIGHTS, highlights);
 
-            // Create the ModelTensor using the builder pattern
-            ModelTensor tensor = ModelTensor.builder().name(FIELD_HIGHLIGHTS).dataAsMap(dataMap).build();
+            // Create output tensor
+            ModelTensor tensor = ModelTensor.builder().name(FIELD_HIGHLIGHTS).dataAsMap(outputMap).build();
 
-            // Wrap in ModelTensors and convert to bytes
-            ModelTensors modelTensorOutput = new ModelTensors(List.of(tensor));
-            output.add(modelTensorOutput.toBytes());
+            // Create final output
+            Output output = new Output();
+            output.add(new ModelTensors(List.of(tensor)).toBytes());
+
             return output;
+
         } catch (Exception e) {
-            return createErrorOutput(String.format("Error processing output: %s", e.getMessage()));
+            log.error("Error processing model output", e);
+            return createErrorOutput("Error processing model output: " + e.getMessage());
         }
     }
 
@@ -199,22 +293,23 @@ public class SentenceHighlightingQATranslator implements ServingTranslator {
     ) {
         List<Map<String, Object>> relevantSentenceDetails = new ArrayList<>();
 
-        for (SentenceData data : sentenceDataList) {
+        // Process each sentence - use array index for position
+        for (int i = 0; i < sentenceDataList.size(); i++) {
+            SentenceData data = sentenceDataList.get(i);
             if (data.isRelevant) {
-                // Find the corresponding sentence to get start and end indices
-                for (Sentence sentence : sentences) {
-                    if (sentence.getPosition() == data.position) {
-                        Map<String, Object> sentenceDetail = new HashMap<>();
-                        sentenceDetail.put(FIELD_TEXT, data.text);
-                        sentenceDetail.put(FIELD_POSITION, data.position);
-                        sentenceDetail.put(FIELD_START, sentence.getStartIndex());
-                        sentenceDetail.put(FIELD_END, sentence.getEndIndex());
-                        relevantSentenceDetails.add(sentenceDetail);
-                        break;
-                    }
-                }
+                // Get the corresponding sentence object
+                Sentence sentence = sentences.get(i);
+
+                // Create details map for this sentence
+                Map<String, Object> sentenceDetail = new HashMap<>();
+                sentenceDetail.put(FIELD_TEXT, data.text);
+                sentenceDetail.put(FIELD_POSITION, i);
+                sentenceDetail.put(FIELD_START, sentence.getStartIndex());
+                sentenceDetail.put(FIELD_END, sentence.getEndIndex());
+                relevantSentenceDetails.add(sentenceDetail);
             }
         }
+
         return relevantSentenceDetails;
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQATranslator.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQATranslator.java
@@ -65,7 +65,20 @@ import lombok.extern.log4j.Log4j2;
 
 /**
  * Translator for sentence highlighting question answering model.
- *
+ * 
+ * This translator processes input for semantic sentence highlighting models that identify
+ * relevant sentences within a context document based on a user query or question.
+ * 
+ * The translator performs the following key functions:
+ * 1. Tokenizes the question and context using Hugging Face tokenizer
+ * 2. Segments the context into sentences 
+ * 3. Maps tokens to their corresponding sentence IDs
+ * 4. Handles chunking for long contexts that exceed the model's maximum token length
+ * 5. Processes model outputs to identify and highlight sentences that answer the question
+ * 
+ * The highlighted sentences are returned with their text and position information within
+ * the original context, which allows for easy visualization and extraction of relevant
+ * information from the document.
  */
 @Log4j2
 @Getter
@@ -166,6 +179,17 @@ public class SentenceHighlightingQATranslator implements ServingTranslator {
         // No arguments needed for this translator
     }
 
+    /**
+     * Prepares the translator by initializing the tokenizer with the appropriate configuration.
+     *
+     * The tokenizer is configured to handle chunking for long contexts that exceed the model's
+     * maximum token length. Even when processing individual chunks, the full context is always 
+     * passed to the model in the input stage, ensuring that sentence segmentation and token-to-sentence
+     * mapping is consistent across all chunks.
+     *
+     * @param ctx The translator context which provides access to the model path
+     * @throws IOException If there is an error loading the tokenizer
+     */
     @Override
     public NDList processInput(TranslatorContext ctx, Input input) {
         try {
@@ -301,6 +325,13 @@ public class SentenceHighlightingQATranslator implements ServingTranslator {
         return wordSentenceIds;
     }
 
+    /**
+     * Processes the model's output to extract highlighted sentences. 
+     *
+     * @param ctx The translator context containing sentence information
+     * @param list The model's output predictions
+     * @return Formatted output with highlighted sentence details or error information
+     */
     @Override
     public Output processOutput(TranslatorContext ctx, NDList list) {
         try {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModelTest.java
@@ -89,6 +89,7 @@ public class QuestionAnsweringModelTest {
         mlCachePath = Path.of("/tmp/ml_cache" + UUID.randomUUID());
         encryptor = new EncryptorImpl(null, "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
         mlEngine = new MLEngine(mlCachePath, encryptor);
+        // Standard QA model
         mlModel = MLModel
             .builder()
             .algorithm(FunctionName.QUESTION_ANSWERING)

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/QuestionAnsweringModelTest.java
@@ -4,13 +4,16 @@
  */
 package org.opensearch.ml.engine.algorithms.question_answering;
 
+import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.engine.ModelHelper.PYTORCH_ENGINE;
 import static org.opensearch.ml.engine.algorithms.DLModel.*;
 import static org.opensearch.ml.engine.algorithms.question_answering.QAConstants.*;
 
@@ -33,6 +36,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.dataset.MLInputDataType;
+import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.QuestionAnsweringInputDataSet;
 import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
@@ -46,6 +51,7 @@ import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.engine.MLEngine;
 import org.opensearch.ml.engine.ModelHelper;
+import org.opensearch.ml.engine.algorithms.DLModel;
 import org.opensearch.ml.engine.encryptor.Encryptor;
 import org.opensearch.ml.engine.encryptor.EncryptorImpl;
 import org.opensearch.ml.engine.utils.FileUtils;
@@ -57,8 +63,10 @@ import ai.djl.modality.Output;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
+import ai.djl.translate.TranslateException;
 import ai.djl.translate.Translator;
 import ai.djl.translate.TranslatorContext;
+import ai.djl.translate.TranslatorFactory;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
@@ -66,7 +74,7 @@ public class QuestionAnsweringModelTest {
 
     private File modelZipFile;
     private File sentenceHighlightingModelZipFile;
-    private MLModel model;
+    private MLModel mlModel;
     private ModelHelper modelHelper;
     private Map<String, Object> params;
     private QuestionAnsweringModel questionAnsweringModel;
@@ -80,15 +88,16 @@ public class QuestionAnsweringModelTest {
         mlCachePath = Path.of("/tmp/ml_cache" + UUID.randomUUID());
         encryptor = new EncryptorImpl(null, "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
         mlEngine = new MLEngine(mlCachePath, encryptor);
-        model = MLModel
+        mlModel = MLModel
             .builder()
+            .algorithm(FunctionName.QUESTION_ANSWERING)
             .modelFormat(MLModelFormat.TORCH_SCRIPT)
             .name("test_model_name")
             .modelId("test_model_id")
-            .algorithm(FunctionName.QUESTION_ANSWERING)
             .version("1.0.0")
             .modelState(MLModelState.TRAINED)
             .build();
+
         modelHelper = new ModelHelper(mlEngine);
         params = new HashMap<>();
         modelZipFile = new File(getClass().getResource("question_answering_pt.zip").toURI());
@@ -96,9 +105,9 @@ public class QuestionAnsweringModelTest {
         params.put(MODEL_ZIP_FILE, modelZipFile);
         params.put(MODEL_HELPER, modelHelper);
         params.put(ML_ENGINE, mlEngine);
-        questionAnsweringModel = new QuestionAnsweringModel();
 
-        inputDataSet = QuestionAnsweringInputDataSet.builder().question("What color is apple").context("Apples are red").build();
+        questionAnsweringModel = new QuestionAnsweringModel();
+        inputDataSet = new QuestionAnsweringInputDataSet("What is the capital of France?", "Paris is the capital of France.");
     }
 
     @Test
@@ -152,7 +161,7 @@ public class QuestionAnsweringModelTest {
 
     @Test
     public void initModel_predict_TorchScript_QuestionAnswering() throws URISyntaxException {
-        questionAnsweringModel.initModel(model, params, encryptor);
+        questionAnsweringModel.initModel(mlModel, params, encryptor);
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.QUESTION_ANSWERING).inputDataset(inputDataSet).build();
         ModelTensorOutput output = (ModelTensorOutput) questionAnsweringModel.predict(mlInput);
         List<ModelTensors> mlModelOutputs = output.getMlModelOutputs();
@@ -168,7 +177,7 @@ public class QuestionAnsweringModelTest {
     // ONNX is working fine but the model is too big to upload to git. Trying to find small models @Test
     @Test
     public void initModel_predict_ONNX_QuestionAnswering() throws URISyntaxException {
-        model = MLModel
+        mlModel = MLModel
             .builder()
             .modelFormat(MLModelFormat.ONNX)
             .name("test_model_name")
@@ -180,7 +189,7 @@ public class QuestionAnsweringModelTest {
         modelZipFile = new File(getClass().getResource("question_answering_onnx.zip").toURI());
         params.put(MODEL_ZIP_FILE, modelZipFile);
 
-        questionAnsweringModel.initModel(model, params, encryptor);
+        questionAnsweringModel.initModel(mlModel, params, encryptor);
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.QUESTION_ANSWERING).inputDataset(inputDataSet).build();
         ModelTensorOutput output = (ModelTensorOutput) questionAnsweringModel.predict(mlInput);
         List<ModelTensors> mlModelOutputs = output.getMlModelOutputs();
@@ -199,7 +208,7 @@ public class QuestionAnsweringModelTest {
         params.put(MODEL_ZIP_FILE, new File(getClass().getResource("question_answering_pt.zip").toURI()));
         IllegalArgumentException e = assertThrows(
             IllegalArgumentException.class,
-            () -> questionAnsweringModel.initModel(model, params, encryptor)
+            () -> questionAnsweringModel.initModel(mlModel, params, encryptor)
         );
         assert (e.getMessage().equals("model helper is null"));
     }
@@ -211,17 +220,17 @@ public class QuestionAnsweringModelTest {
         params.put(MODEL_HELPER, modelHelper);
         IllegalArgumentException e = assertThrows(
             IllegalArgumentException.class,
-            () -> questionAnsweringModel.initModel(model, params, encryptor)
+            () -> questionAnsweringModel.initModel(mlModel, params, encryptor)
         );
         assert (e.getMessage().equals("ML engine is null"));
     }
 
     @Test
     public void initModel_NullModelId() {
-        model.setModelId(null);
+        mlModel.setModelId(null);
         IllegalArgumentException e = assertThrows(
             IllegalArgumentException.class,
-            () -> questionAnsweringModel.initModel(model, params, encryptor)
+            () -> questionAnsweringModel.initModel(mlModel, params, encryptor)
         );
         assert (e.getMessage().equals("model id is null"));
     }
@@ -232,7 +241,7 @@ public class QuestionAnsweringModelTest {
         params.put(MODEL_HELPER, modelHelper);
         params.put(MODEL_ZIP_FILE, new File(getClass().getResource("../text_embedding/wrong_zip_with_2_pt_file.zip").toURI()));
         params.put(ML_ENGINE, mlEngine);
-        MLException e = assertThrows(MLException.class, () -> questionAnsweringModel.initModel(model, params, encryptor));
+        MLException e = assertThrows(MLException.class, () -> questionAnsweringModel.initModel(mlModel, params, encryptor));
         Throwable rootCause = e.getCause();
         assert (rootCause instanceof IllegalArgumentException);
         assert (rootCause.getMessage().equals("found multiple models"));
@@ -240,10 +249,10 @@ public class QuestionAnsweringModelTest {
 
     @Test
     public void initModel_WrongFunctionName() {
-        MLModel mlModel = model.toBuilder().algorithm(FunctionName.KMEANS).build();
+        MLModel wrongModel = mlModel.toBuilder().algorithm(FunctionName.KMEANS).build();
         IllegalArgumentException e = assertThrows(
             IllegalArgumentException.class,
-            () -> questionAnsweringModel.initModel(mlModel, params, encryptor)
+            () -> questionAnsweringModel.initModel(wrongModel, params, encryptor)
         );
         assert (e.getMessage().equals("wrong function name"));
     }
@@ -260,10 +269,10 @@ public class QuestionAnsweringModelTest {
 
     @Test
     public void predict_NullModelId() {
-        model.setModelId(null);
+        mlModel.setModelId(null);
         IllegalArgumentException e = assertThrows(
             IllegalArgumentException.class,
-            () -> questionAnsweringModel.initModel(model, params, encryptor)
+            () -> questionAnsweringModel.initModel(mlModel, params, encryptor)
         );
         assert (e.getMessage().equals("model id is null"));
         IllegalArgumentException e2 = assertThrows(
@@ -276,7 +285,7 @@ public class QuestionAnsweringModelTest {
 
     @Test
     public void predict_AfterModelClosed() {
-        questionAnsweringModel.initModel(model, params, encryptor);
+        questionAnsweringModel.initModel(mlModel, params, encryptor);
         questionAnsweringModel.close();
         MLException e = assertThrows(
             MLException.class,
@@ -299,7 +308,7 @@ public class QuestionAnsweringModelTest {
             .build();
 
         // Set the model config
-        model = model.toBuilder().modelConfig(modelConfig).build();
+        mlModel = mlModel.toBuilder().modelConfig(modelConfig).build();
 
         // Use the sentence highlighting model file
         Map<String, Object> sentenceParams = new HashMap<>(params);
@@ -323,7 +332,7 @@ public class QuestionAnsweringModelTest {
             .build();
 
         // Set the model config
-        model = model.toBuilder().modelConfig(modelConfig).build();
+        mlModel = mlModel.toBuilder().modelConfig(modelConfig).build();
 
         // Initialize the model
         questionAnsweringModel = new QuestionAnsweringModel();
@@ -336,7 +345,7 @@ public class QuestionAnsweringModelTest {
     @Test
     public void testCheckHighlightingType_WithNullModelConfig() {
         // Set null model config
-        model = model.toBuilder().modelConfig(null).build();
+        mlModel = mlModel.toBuilder().modelConfig(null).build();
 
         // Initialize the model
         questionAnsweringModel = new QuestionAnsweringModel();
@@ -356,7 +365,7 @@ public class QuestionAnsweringModelTest {
             .build();
 
         // Set the model config
-        model = model.toBuilder().modelConfig(modelConfig).build();
+        mlModel = mlModel.toBuilder().modelConfig(modelConfig).build();
 
         // Use the sentence highlighting model file
         Map<String, Object> sentenceParams = new HashMap<>(params);
@@ -413,7 +422,7 @@ public class QuestionAnsweringModelTest {
             .build();
 
         // Set the model config
-        model = model.toBuilder().modelConfig(modelConfig).build();
+        mlModel = mlModel.toBuilder().modelConfig(modelConfig).build();
 
         // Mock predictor for warmup
         @SuppressWarnings("unchecked")
@@ -426,6 +435,463 @@ public class QuestionAnsweringModelTest {
 
         // Verify that predict was called with the correct input
         // We can only verify indirectly by checking that no exception was thrown
+    }
+
+    @Test
+    public void testWarmUp_WithNullPredictor() {
+        QuestionAnsweringModel model = new QuestionAnsweringModel();
+        assertThrows(IllegalArgumentException.class, () -> model.warmUp(null, "test_model_id", null));
+    }
+
+    @Test
+    public void testWarmUp_WithNullModelId() {
+        QuestionAnsweringModel model = new QuestionAnsweringModel();
+        Predictor predictor = mock(Predictor.class);
+        assertThrows(IllegalArgumentException.class, () -> model.warmUp(predictor, null, null));
+    }
+
+    @Test
+    public void testWarmUp_WithValidInputs() throws TranslateException {
+        QuestionAnsweringModel model = new QuestionAnsweringModel();
+        Predictor<Input, Output> predictor = mock(Predictor.class);
+        Input input = new Input();
+        input.add(DEFAULT_WARMUP_QUESTION);
+        input.add(DEFAULT_WARMUP_CONTEXT);
+        input.add("0");
+
+        when(predictor.predict(any(Input.class))).thenReturn(new Output());
+
+        model.warmUp(predictor, "test_model_id", null);
+        verify(predictor).predict(any(Input.class));
+    }
+
+    @Test
+    public void testGetTranslatorFactory() {
+        QuestionAnsweringModel model = new QuestionAnsweringModel();
+        TranslatorFactory factory = model.getTranslatorFactory("pytorch", null);
+        assertNull(factory);
+    }
+
+    @Test
+    public void testPredict_WithInvalidInputType() throws Exception {
+        QuestionAnsweringModel model = new QuestionAnsweringModel();
+        model.initModel(mlModel, params, encryptor);
+
+        MLInput mlInput = MLInput
+            .builder()
+            .algorithm(FunctionName.QUESTION_ANSWERING)
+            .inputDataset(new TestInputDataSet()) // Invalid input type
+            .build();
+
+        try {
+            model.predict(mlInput);
+            fail("Expected MLException");
+        } catch (MLException e) {
+            // Expected exception
+            assertTrue(e.getCause() instanceof ClassCastException);
+        }
+    }
+
+    @Test
+    public void testPredict_WithNullModelConfig() throws Exception {
+        QuestionAnsweringModel model = new QuestionAnsweringModel();
+        model.initModel(mlModel, params, encryptor);
+
+        // Mock predictor
+        Predictor<Input, Output> predictor = mock(Predictor.class);
+        Output mockOutput = new Output();
+        byte[] mockBytes = ModelTensors.builder().mlModelTensors(List.of(new ModelTensor("test", "test"))).build().toBytes();
+        mockOutput.add(mockBytes);
+        when(predictor.predict(any(Input.class))).thenReturn(mockOutput);
+
+        // Set predictor using reflection
+        java.lang.reflect.Field predictorsField = DLModel.class.getDeclaredField("predictors");
+        predictorsField.setAccessible(true);
+        predictorsField.set(model, new Predictor[] { predictor });
+
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.QUESTION_ANSWERING).inputDataset(inputDataSet).build();
+
+        ModelTensorOutput output = (ModelTensorOutput) model.predict(mlInput);
+        assertNotNull(output);
+        assertEquals(1, output.getMlModelOutputs().size());
+    }
+
+    @Test
+    public void testPredict_WithStandardQAModel() throws Exception {
+        QuestionAnsweringModel model = new QuestionAnsweringModel();
+
+        // Create model config for standard QA
+        MLModelConfig modelConfig = QuestionAnsweringModelConfig
+            .builder()
+            .modelType("standard")
+            .frameworkType(QuestionAnsweringModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .build();
+
+        mlModel = mlModel.toBuilder().modelConfig(modelConfig).build();
+        model.initModel(mlModel, params, encryptor);
+
+        // Mock predictor
+        Predictor<Input, Output> predictor = mock(Predictor.class);
+        Output mockOutput = new Output();
+        byte[] mockBytes = ModelTensors.builder().mlModelTensors(List.of(new ModelTensor("test", "test"))).build().toBytes();
+        mockOutput.add(mockBytes);
+        when(predictor.predict(any(Input.class))).thenReturn(mockOutput);
+
+        // Set predictor using reflection
+        java.lang.reflect.Field predictorsField = DLModel.class.getDeclaredField("predictors");
+        predictorsField.setAccessible(true);
+        predictorsField.set(model, new Predictor[] { predictor });
+
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.QUESTION_ANSWERING).inputDataset(inputDataSet).build();
+
+        ModelTensorOutput output = (ModelTensorOutput) model.predict(mlInput);
+        assertNotNull(output);
+        assertEquals(1, output.getMlModelOutputs().size());
+    }
+
+    // Helper class for testing invalid input type
+    private static class TestInputDataSet extends MLInputDataset {
+        public TestInputDataSet() {
+            super(MLInputDataType.TEXT_DOCS);
+        }
+    }
+
+    @Test
+    public void testCreateHighlightOutput() {
+        QuestionAnsweringModel model = new QuestionAnsweringModel();
+
+        // Create sample highlights
+        List<Map<String, Object>> highlights = new ArrayList<>();
+
+        // Create first highlight
+        Map<String, Object> highlight1 = new HashMap<>();
+        highlight1.put(FIELD_TEXT, "This is the first highlighted sentence.");
+        highlight1.put(FIELD_POSITION, 0);
+        highlight1.put(FIELD_START, 0);
+        highlight1.put(FIELD_END, 38);
+        highlights.add(highlight1);
+
+        // Create second highlight
+        Map<String, Object> highlight2 = new HashMap<>();
+        highlight2.put(FIELD_TEXT, "This is the second highlighted sentence.");
+        highlight2.put(FIELD_POSITION, 2);
+        highlight2.put(FIELD_START, 80);
+        highlight2.put(FIELD_END, 119);
+        highlights.add(highlight2);
+
+        // Call the method under test using reflection
+        try {
+            java.lang.reflect.Method method = QuestionAnsweringModel.class.getDeclaredMethod("createHighlightOutput", List.class);
+            method.setAccessible(true);
+            ModelTensorOutput output = (ModelTensorOutput) method.invoke(model, highlights);
+
+            // Verify the output
+            assertNotNull(output);
+            assertEquals(1, output.getMlModelOutputs().size());
+
+            ModelTensors tensors = output.getMlModelOutputs().get(0);
+            assertEquals(1, tensors.getMlModelTensors().size());
+
+            ModelTensor tensor = tensors.getMlModelTensors().get(0);
+            assertEquals(FIELD_HIGHLIGHTS, tensor.getName());
+
+            Map<String, ?> dataMap = tensor.getDataAsMap();
+            assertNotNull(dataMap);
+
+            Object highlightsObj = dataMap.get(FIELD_HIGHLIGHTS);
+            assertNotNull(highlightsObj);
+            assertTrue(highlightsObj instanceof List);
+
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> resultHighlights = (List<Map<String, Object>>) highlightsObj;
+            assertEquals(2, resultHighlights.size());
+
+            // Verify the first highlight
+            Map<String, Object> resultHighlight1 = resultHighlights.get(0);
+            assertEquals("This is the first highlighted sentence.", resultHighlight1.get(FIELD_TEXT));
+            assertEquals(0, resultHighlight1.get(FIELD_POSITION));
+            assertEquals(0, resultHighlight1.get(FIELD_START));
+            assertEquals(38, resultHighlight1.get(FIELD_END));
+
+            // Verify the second highlight
+            Map<String, Object> resultHighlight2 = resultHighlights.get(1);
+            assertEquals("This is the second highlighted sentence.", resultHighlight2.get(FIELD_TEXT));
+            assertEquals(2, resultHighlight2.get(FIELD_POSITION));
+            assertEquals(80, resultHighlight2.get(FIELD_START));
+            assertEquals(119, resultHighlight2.get(FIELD_END));
+
+        } catch (Exception e) {
+            fail("Exception thrown: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testExtractHighlights() {
+        QuestionAnsweringModel model = new QuestionAnsweringModel();
+
+        // Create a ModelTensors object with highlights
+        List<Map<String, Object>> inputHighlights = new ArrayList<>();
+
+        // Add a highlight
+        Map<String, Object> highlight = new HashMap<>();
+        highlight.put(FIELD_TEXT, "Sample highlighted text");
+        highlight.put(FIELD_POSITION, 1);
+        inputHighlights.add(highlight);
+
+        // Create data map
+        Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(FIELD_HIGHLIGHTS, inputHighlights);
+
+        // Create model tensor with the data
+        ModelTensor tensor = ModelTensor.builder().name(FIELD_HIGHLIGHTS).dataAsMap(dataMap).build();
+
+        // Create model tensors
+        ModelTensors tensors = new ModelTensors(List.of(tensor));
+
+        // Call the method under test using reflection
+        try {
+            java.lang.reflect.Method method = QuestionAnsweringModel.class.getDeclaredMethod("extractHighlights", ModelTensors.class);
+            method.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> extractedHighlights = (List<Map<String, Object>>) method.invoke(model, tensors);
+
+            // Verify the extracted highlights
+            assertNotNull(extractedHighlights);
+            assertEquals(1, extractedHighlights.size());
+
+            Map<String, Object> extractedHighlight = extractedHighlights.get(0);
+            assertEquals("Sample highlighted text", extractedHighlight.get(FIELD_TEXT));
+            assertEquals(1, extractedHighlight.get(FIELD_POSITION));
+
+        } catch (Exception e) {
+            fail("Exception thrown: " + e.getMessage());
+        }
+
+        // Test with multiple tensors
+        try {
+            // Create another tensor with highlights
+            List<Map<String, Object>> moreHighlights = new ArrayList<>();
+            Map<String, Object> highlight2 = new HashMap<>();
+            highlight2.put(FIELD_TEXT, "Another highlight");
+            highlight2.put(FIELD_POSITION, 2);
+            moreHighlights.add(highlight2);
+
+            Map<String, Object> dataMap2 = new HashMap<>();
+            dataMap2.put(FIELD_HIGHLIGHTS, moreHighlights);
+
+            ModelTensor tensor2 = ModelTensor.builder().name(FIELD_HIGHLIGHTS).dataAsMap(dataMap2).build();
+
+            // Create a tensor without highlights
+            ModelTensor tensor3 = ModelTensor.builder().name("other_data").dataAsMap(new HashMap<>()).build();
+
+            // Create model tensors with multiple tensors
+            ModelTensors multipleTensors = new ModelTensors(List.of(tensor, tensor2, tensor3));
+
+            // Call the method
+            java.lang.reflect.Method method = QuestionAnsweringModel.class.getDeclaredMethod("extractHighlights", ModelTensors.class);
+            method.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> extractedHighlights = (List<Map<String, Object>>) method.invoke(model, multipleTensors);
+
+            // Verify the extracted highlights
+            assertNotNull(extractedHighlights);
+            assertEquals(2, extractedHighlights.size());
+
+            Map<String, Object> extractedHighlight1 = extractedHighlights.get(0);
+            assertEquals("Sample highlighted text", extractedHighlight1.get(FIELD_TEXT));
+            assertEquals(1, extractedHighlight1.get(FIELD_POSITION));
+
+            Map<String, Object> extractedHighlight2 = extractedHighlights.get(1);
+            assertEquals("Another highlight", extractedHighlight2.get(FIELD_TEXT));
+            assertEquals(2, extractedHighlight2.get(FIELD_POSITION));
+
+        } catch (Exception e) {
+            fail("Exception thrown: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Test for sentence highlighting model configuration
+     */
+    @Test
+    public void testSentenceHighlightingQAModelConfiguration() {
+        // Create model config with sentence highlighting
+        MLModelConfig modelConfig = QuestionAnsweringModelConfig
+            .builder()
+            .modelType(SENTENCE_HIGHLIGHTING_TYPE)
+            .frameworkType(QuestionAnsweringModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .build();
+
+        // Set up the model with config
+        QuestionAnsweringModel model = new QuestionAnsweringModel();
+
+        try {
+            // Set model config
+            java.lang.reflect.Field modelConfigField = QuestionAnsweringModel.class.getDeclaredField("modelConfig");
+            modelConfigField.setAccessible(true);
+            modelConfigField.set(model, modelConfig);
+
+            // Verify that the model is configured for sentence highlighting
+            Translator<Input, Output> translator = model.getTranslator(PYTORCH_ENGINE, modelConfig);
+            assertEquals(SentenceHighlightingQATranslator.class, translator.getClass());
+
+            // Check isStandardQAModel returns false for sentence highlighting
+            java.lang.reflect.Method isStandardMethod = QuestionAnsweringModel.class.getDeclaredMethod("isStandardQAModel");
+            isStandardMethod.setAccessible(true);
+            boolean isStandard = (Boolean) isStandardMethod.invoke(model);
+            assertFalse("Model should not be identified as standard QA model", isStandard);
+        } catch (Exception e) {
+            fail("Exception thrown: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Test for predictSentenceHighlightingQA method using a subclass implementation
+     */
+    @Test
+    public void testPredictSentenceHighlightingQA() throws Exception {
+        // Create model config with sentence highlighting
+        MLModelConfig modelConfig = QuestionAnsweringModelConfig
+            .builder()
+            .modelType(SENTENCE_HIGHLIGHTING_TYPE)
+            .frameworkType(QuestionAnsweringModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .build();
+
+        // Create test question and context
+        String question = "What is climate change?";
+        String context = "Climate change is a long-term shift in temperatures and weather patterns.";
+
+        // Create a sample highlight for the output
+        Map<String, Object> highlight = new HashMap<>();
+        highlight.put(FIELD_TEXT, "Climate change is a long-term shift in temperatures and weather patterns.");
+        highlight.put(FIELD_POSITION, 0);
+
+        List<Map<String, Object>> highlights = new ArrayList<>();
+        highlights.add(highlight);
+
+        Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(FIELD_HIGHLIGHTS, highlights);
+
+        ModelTensor tensor = ModelTensor.builder().name(FIELD_HIGHLIGHTS).dataAsMap(dataMap).build();
+
+        ModelTensors tensors = new ModelTensors(List.of(tensor));
+        ModelTensorOutput expectedOutput = new ModelTensorOutput(List.of(tensors));
+
+        // Create a new implementation that returns the expected output
+        QuestionAnsweringModel testModel = new QuestionAnsweringModel() {
+            @Override
+            public ModelTensorOutput predict(MLInput mlInput) {
+                QuestionAnsweringInputDataSet qaInputDataSet = (QuestionAnsweringInputDataSet) mlInput.getInputDataset();
+                String q = qaInputDataSet.getQuestion();
+                String c = qaInputDataSet.getContext();
+
+                // Assert input values are correct
+                assertEquals(question, q);
+                assertEquals(context, c);
+
+                // Return expected output
+                return expectedOutput;
+            }
+        };
+
+        // Set model config using reflection
+        java.lang.reflect.Field modelConfigField = QuestionAnsweringModel.class.getDeclaredField("modelConfig");
+        modelConfigField.setAccessible(true);
+        modelConfigField.set(testModel, modelConfig);
+
+        // Create input for prediction
+        QuestionAnsweringInputDataSet inputDataSet = new QuestionAnsweringInputDataSet(question, context);
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.QUESTION_ANSWERING).inputDataset(inputDataSet).build();
+
+        // Call predict
+        ModelTensorOutput output = (ModelTensorOutput) testModel.predict(mlInput);
+
+        // Verify the output
+        assertNotNull(output);
+        assertEquals(1, output.getMlModelOutputs().size());
+
+        ModelTensors resultTensors = output.getMlModelOutputs().get(0);
+        assertEquals(1, resultTensors.getMlModelTensors().size());
+
+        ModelTensor resultTensor = resultTensors.getMlModelTensors().get(0);
+        assertEquals(FIELD_HIGHLIGHTS, resultTensor.getName());
+
+        Map<String, ?> resultDataMap = resultTensor.getDataAsMap();
+        assertNotNull(resultDataMap);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> resultHighlights = (List<Map<String, Object>>) resultDataMap.get(FIELD_HIGHLIGHTS);
+        assertNotNull(resultHighlights);
+        assertEquals(1, resultHighlights.size());
+
+        Map<String, Object> resultHighlight = resultHighlights.get(0);
+        assertEquals("Climate change is a long-term shift in temperatures and weather patterns.", resultHighlight.get(FIELD_TEXT));
+        assertEquals(0, resultHighlight.get(FIELD_POSITION));
+    }
+
+    /**
+     * Test for directly checking the result structure without mocking problematic classes
+     */
+    @Test
+    public void testProcessOverflowChunks() throws Exception {
+        // This test directly verifies the structure of a highlights result similar to what
+        // would be produced by processOverflowChunks and other internal methods, without
+        // trying to mock difficult classes
+
+        // Create sample highlight data
+        Map<String, Object> highlight1 = new HashMap<>();
+        highlight1.put(FIELD_TEXT, "This is the first highlighted sentence.");
+        highlight1.put(FIELD_POSITION, 0);
+        highlight1.put(FIELD_START, 0);
+        highlight1.put(FIELD_END, 38);
+
+        Map<String, Object> highlight2 = new HashMap<>();
+        highlight2.put(FIELD_TEXT, "This is from overflow chunk processing.");
+        highlight2.put(FIELD_POSITION, 1);
+        highlight2.put(FIELD_START, 40);
+        highlight2.put(FIELD_END, 78);
+
+        // Create a collection of highlights similar to what would be produced
+        List<Map<String, Object>> highlights = new ArrayList<>();
+        highlights.add(highlight1);
+        highlights.add(highlight2);
+
+        // Now use the createHighlightOutput method to produce the final output
+        QuestionAnsweringModel model = new QuestionAnsweringModel();
+
+        // Call the createHighlightOutput method using reflection
+        java.lang.reflect.Method createHighlightOutputMethod = QuestionAnsweringModel.class
+            .getDeclaredMethod("createHighlightOutput", List.class);
+        createHighlightOutputMethod.setAccessible(true);
+        ModelTensorOutput output = (ModelTensorOutput) createHighlightOutputMethod.invoke(model, highlights);
+
+        // Verify the output structure matches what we expect
+        assertNotNull(output);
+        assertEquals(1, output.getMlModelOutputs().size());
+
+        ModelTensors tensors = output.getMlModelOutputs().get(0);
+        assertEquals(1, tensors.getMlModelTensors().size());
+
+        ModelTensor tensor = tensors.getMlModelTensors().get(0);
+        assertEquals(FIELD_HIGHLIGHTS, tensor.getName());
+
+        Map<String, ?> dataMap = tensor.getDataAsMap();
+        assertNotNull(dataMap);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> resultHighlights = (List<Map<String, Object>>) dataMap.get(FIELD_HIGHLIGHTS);
+        assertNotNull(resultHighlights);
+        assertEquals(2, resultHighlights.size());
+
+        // Verify the first highlight remains unchanged
+        Map<String, Object> resultHighlight1 = resultHighlights.get(0);
+        assertEquals("This is the first highlighted sentence.", resultHighlight1.get(FIELD_TEXT));
+        assertEquals(0, resultHighlight1.get(FIELD_POSITION));
+
+        // Verify the "overflow chunk" highlight is present
+        Map<String, Object> resultHighlight2 = resultHighlights.get(1);
+        assertEquals("This is from overflow chunk processing.", resultHighlight2.get(FIELD_TEXT));
+        assertEquals(1, resultHighlight2.get(FIELD_POSITION));
     }
 
     @After

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQAModelIT.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQAModelIT.java
@@ -160,6 +160,16 @@ public class SentenceHighlightingQAModelIT {
             assertNotNull(firstHighlight.get(FIELD_POSITION));
             assertNotNull(firstHighlight.get(FIELD_START));
             assertNotNull(firstHighlight.get(FIELD_END));
+
+            // Verify the values are within expected ranges
+            int position = ((Number) firstHighlight.get(FIELD_POSITION)).intValue();
+            int start = ((Number) firstHighlight.get(FIELD_START)).intValue();
+            int end = ((Number) firstHighlight.get(FIELD_END)).intValue();
+
+            assertTrue("Position should be non-negative", position >= 0);
+            assertTrue("Start index should be non-negative", start >= 0);
+            assertTrue("End index should be greater than start", end > start);
+            assertTrue("End index should not exceed context length", end <= inputDataSet.getContext().length());
         }
     }
 
@@ -207,17 +217,28 @@ public class SentenceHighlightingQAModelIT {
         assertTrue("Should have at least one highlighted sentence", highlights.size() > 0);
 
         // Log the highlighted sentences for inspection
-        log.info("Highlighted sentences for agriculture question:");
+        log.info("Highlighted sentences for question '{}':", differentQuestion);
         for (Map<String, Object> highlight : highlights) {
             log.info("  - {}", highlight.get(FIELD_TEXT));
+        }
 
-            // For this question, we expect the sentence about farmers to be highlighted
-            if (highlight.get(FIELD_TEXT).equals("Farmers are experiencing unpredictable growing seasons and crop failures.")) {
-                assertEquals(
-                    "Farmers are experiencing unpredictable growing seasons and crop failures.",
-                    highlight.get(FIELD_TEXT).toString()
-                );
-            }
+        // Verify structure of first highlight
+        if (!highlights.isEmpty()) {
+            Map<String, Object> firstHighlight = highlights.get(0);
+            assertNotNull(firstHighlight.get(FIELD_TEXT));
+            assertNotNull(firstHighlight.get(FIELD_POSITION));
+            assertNotNull(firstHighlight.get(FIELD_START));
+            assertNotNull(firstHighlight.get(FIELD_END));
+
+            // Verify the values are within expected ranges
+            int position = ((Number) firstHighlight.get(FIELD_POSITION)).intValue();
+            int start = ((Number) firstHighlight.get(FIELD_START)).intValue();
+            int end = ((Number) firstHighlight.get(FIELD_END)).intValue();
+
+            assertTrue("Position should be non-negative", position >= 0);
+            assertTrue("Start index should be non-negative", start >= 0);
+            assertTrue("End index should be greater than start", end > start);
+            assertTrue("End index should not exceed context length", end <= differentInputDataSet.getContext().length());
         }
     }
 
@@ -278,6 +299,25 @@ public class SentenceHighlightingQAModelIT {
         log.info("Highlighted sentences for longer context:");
         for (Map<String, Object> highlight : highlights) {
             log.info("  - {}", highlight.get(FIELD_TEXT));
+        }
+
+        // Verify structure of first highlight
+        if (!highlights.isEmpty()) {
+            Map<String, Object> firstHighlight = highlights.get(0);
+            assertNotNull(firstHighlight.get(FIELD_TEXT));
+            assertNotNull(firstHighlight.get(FIELD_POSITION));
+            assertNotNull(firstHighlight.get(FIELD_START));
+            assertNotNull(firstHighlight.get(FIELD_END));
+
+            // Verify the values are within expected ranges
+            int position = ((Number) firstHighlight.get(FIELD_POSITION)).intValue();
+            int start = ((Number) firstHighlight.get(FIELD_START)).intValue();
+            int end = ((Number) firstHighlight.get(FIELD_END)).intValue();
+
+            assertTrue("Position should be non-negative", position >= 0);
+            assertTrue("Start index should be non-negative", start >= 0);
+            assertTrue("End index should be greater than start", end > start);
+            assertTrue("End index should not exceed context length", end <= longerContext.length());
         }
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQAModelIT.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQAModelIT.java
@@ -5,6 +5,7 @@
 package org.opensearch.ml.engine.algorithms.question_answering;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.opensearch.ml.engine.algorithms.DLModel.*;
@@ -214,32 +215,24 @@ public class SentenceHighlightingQAModelIT {
         assertNotNull(highlights);
 
         // We expect at least one highlighted sentence
-        assertTrue("Should have at least one highlighted sentence", highlights.size() > 0);
-
-        // Log the highlighted sentences for inspection
-        log.info("Highlighted sentences for question '{}':", differentQuestion);
-        for (Map<String, Object> highlight : highlights) {
-            log.info("  - {}", highlight.get(FIELD_TEXT));
-        }
+        assertFalse("Should have at least one highlighted sentence", highlights.isEmpty());
 
         // Verify structure of first highlight
-        if (!highlights.isEmpty()) {
-            Map<String, Object> firstHighlight = highlights.get(0);
-            assertNotNull(firstHighlight.get(FIELD_TEXT));
-            assertNotNull(firstHighlight.get(FIELD_POSITION));
-            assertNotNull(firstHighlight.get(FIELD_START));
-            assertNotNull(firstHighlight.get(FIELD_END));
+        Map<String, Object> firstHighlight = highlights.getFirst();
+        assertNotNull(firstHighlight.get(FIELD_TEXT));
+        assertNotNull(firstHighlight.get(FIELD_POSITION));
+        assertNotNull(firstHighlight.get(FIELD_START));
+        assertNotNull(firstHighlight.get(FIELD_END));
 
-            // Verify the values are within expected ranges
-            int position = ((Number) firstHighlight.get(FIELD_POSITION)).intValue();
-            int start = ((Number) firstHighlight.get(FIELD_START)).intValue();
-            int end = ((Number) firstHighlight.get(FIELD_END)).intValue();
+        // Verify the values are within expected ranges
+        int position = ((Number) firstHighlight.get(FIELD_POSITION)).intValue();
+        int start = ((Number) firstHighlight.get(FIELD_START)).intValue();
+        int end = ((Number) firstHighlight.get(FIELD_END)).intValue();
 
-            assertTrue("Position should be non-negative", position >= 0);
-            assertTrue("Start index should be non-negative", start >= 0);
-            assertTrue("End index should be greater than start", end > start);
-            assertTrue("End index should not exceed context length", end <= differentInputDataSet.getContext().length());
-        }
+        assertTrue("Position should be non-negative", position >= 0);
+        assertTrue("Start index should be non-negative", start >= 0);
+        assertTrue("End index should be greater than start", end > start);
+        assertTrue("End index should not exceed context length", end <= differentInputDataSet.getContext().length());
     }
 
     @Test

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQAModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQAModelTest.java
@@ -210,22 +210,22 @@ public class SentenceHighlightingQAModelTest {
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> highlights = (List<Map<String, Object>>) dataMap.get(FIELD_HIGHLIGHTS);
         assertNotNull("Highlights should not be null", highlights);
-        // expect 4 highlights since chunk
-        assertEquals("Should have four highlights", 4, highlights.size());
+        // After deduplication, we expect only unique highlights based on position
+        assertEquals("Should have unique highlights after deduplication", 2, highlights.size());
 
         // Verify first highlight
         Map<String, Object> firstHighlight = highlights.get(0);
-        assertEquals(3.0, firstHighlight.get(FIELD_POSITION));
-        assertEquals("Global temperatures have risen significantly over the past century.", firstHighlight.get(FIELD_TEXT));
-        assertEquals(208.0, firstHighlight.get(FIELD_START));
-        assertEquals(275.0, firstHighlight.get(FIELD_END));
+        assertEquals(0.0, firstHighlight.get(FIELD_POSITION));
+        assertEquals("Many coastal cities face increased flooding during storms.", firstHighlight.get(FIELD_TEXT));
+        assertEquals(0.0, firstHighlight.get(FIELD_START));
+        assertEquals(58.0, firstHighlight.get(FIELD_END));
 
         // Verify second highlight
         Map<String, Object> secondHighlight = highlights.get(1);
-        assertEquals(0.0, secondHighlight.get(FIELD_POSITION));
-        assertEquals("Many coastal cities face increased flooding during storms.", secondHighlight.get(FIELD_TEXT));
-        assertEquals(0.0, secondHighlight.get(FIELD_START));
-        assertEquals(58.0, secondHighlight.get(FIELD_END));
+        assertEquals(3.0, secondHighlight.get(FIELD_POSITION));
+        assertEquals("Global temperatures have risen significantly over the past century.", secondHighlight.get(FIELD_TEXT));
+        assertEquals(208.0, secondHighlight.get(FIELD_START));
+        assertEquals(275.0, secondHighlight.get(FIELD_END));
 
         // Clean up
         questionAnsweringModel.close();

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQAModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQAModelTest.java
@@ -76,6 +76,7 @@ public class SentenceHighlightingQAModelTest {
             .builder()
             .modelType(SENTENCE_HIGHLIGHTING_TYPE)
             .frameworkType(QuestionAnsweringModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .allConfig("{\"token_max_length\":64,\"token_overlap_stride\":16,\"with_overflowing_tokens\":true,\"padding\":false}")
             .build();
 
         // Create model with config
@@ -101,10 +102,15 @@ public class SentenceHighlightingQAModelTest {
         // Create test input data
         String question = "What are the impacts of climate change?";
         String context = "Many coastal cities face increased flooding during storms. "
+            + "Rising sea levels threaten coastal infrastructure and communities. "
             + "Farmers are experiencing unpredictable growing seasons and crop failures. "
+            + "Droughts are becoming more frequent and severe in many regions. "
             + "Scientists predict these environmental shifts will continue to accelerate. "
             + "Global temperatures have risen significantly over the past century. "
-            + "Polar ice caps are melting at an alarming rate.";
+            + "Polar ice caps are melting at an alarming rate. "
+            + "Extreme weather events are becoming more frequent and intense. "
+            + "Biodiversity is declining as ecosystems struggle to adapt. "
+            + "Mountain glaciers are retreating worldwide at unprecedented rates. ";
 
         inputDataSet = QuestionAnsweringInputDataSet.builder().question(question).context(context).build();
 
@@ -204,7 +210,8 @@ public class SentenceHighlightingQAModelTest {
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> highlights = (List<Map<String, Object>>) dataMap.get(FIELD_HIGHLIGHTS);
         assertNotNull("Highlights should not be null", highlights);
-        assertEquals("Should have two highlights", 2, highlights.size());
+        // expect 4 highlights since chunk
+        assertEquals("Should have four highlights", 4, highlights.size());
 
         // Verify first highlight
         Map<String, Object> firstHighlight = highlights.get(0);
@@ -247,9 +254,6 @@ public class SentenceHighlightingQAModelTest {
 
         // Initialize the model
         questionAnsweringModel.initModel(model, params, encryptor);
-
-        // Create MLInput for prediction
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.QUESTION_ANSWERING).inputDataset(inputDataSet).build();
 
         // Verify that the model is set up for sentence highlighting
         assertEquals(SENTENCE_HIGHLIGHTING_TYPE, modelConfig.getModelType());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQATranslatorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQATranslatorTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.ml.common.model.MLModelConfig;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.engine.algorithms.question_answering.sentence.DefaultSentenceSegmenter;
@@ -245,7 +246,8 @@ public class SentenceHighlightingQATranslatorTest {
 
     @Test
     public void testCreateDefault() {
-        SentenceHighlightingQATranslator translator = SentenceHighlightingQATranslator.createDefault();
+        MLModelConfig modelConfig = mock(MLModelConfig.class);
+        SentenceHighlightingQATranslator translator = SentenceHighlightingQATranslator.create(modelConfig);
         assertNotNull(translator);
         assertNotNull(translator.getSegmenter());
         assertEquals(DefaultSentenceSegmenter.class, translator.getSegmenter().getClass());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQATranslatorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/question_answering/SentenceHighlightingQATranslatorTest.java
@@ -24,11 +24,9 @@ import org.opensearch.ml.engine.algorithms.question_answering.sentence.DefaultSe
 import org.opensearch.ml.engine.algorithms.question_answering.sentence.Sentence;
 import org.opensearch.ml.engine.algorithms.question_answering.sentence.SentenceSegmenter;
 
-import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
-import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.translate.TranslatorContext;
 import lombok.extern.log4j.Log4j2;
@@ -39,12 +37,11 @@ public class SentenceHighlightingQATranslatorTest {
     private SentenceHighlightingQATranslator translator;
     private TranslatorContext translatorContext;
     private List<Sentence> sentences;
-    private String question;
 
     @Before
     public void setUp() {
         // Create test data
-        question = "What are the impacts of climate change?";
+        String question = "What are the impacts of climate change?";
         String textContext = "Many coastal cities face increased flooding during storms. "
             + "Farmers are experiencing unpredictable growing seasons and crop failures. "
             + "Scientists predict these environmental shifts will continue to accelerate. "
@@ -58,8 +55,6 @@ public class SentenceHighlightingQATranslatorTest {
         // Create mocks
         translator = SentenceHighlightingQATranslator.builder().build();
         translatorContext = mock(TranslatorContext.class);
-        NDManager manager = mock(NDManager.class);
-        Input input = mock(Input.class);
     }
 
     @Test


### PR DESCRIPTION
### Description
Update highlighting QA model to adapt new highlighter model:
* Add chunk strategy due to model max length limitation to 512 by default
* Introduced `sentence_ids` which is required by new model

### Related Issues
https://github.com/opensearch-project/neural-search/issues/1182

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
