### PR TITLE
fix config index masterkey pull up for multi-tenancy

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
@@ -254,9 +254,15 @@ public class EncryptorImpl implements Encryptor {
         try {
             GetResponse getMasterKeyResponse = response.parser() == null ? null : GetResponse.fromXContent(response.parser());
             if (getMasterKeyResponse != null && getMasterKeyResponse.isExists()) {
-                this.tenantMasterKeys
-                    .put(Objects.requireNonNullElse(tenantId, DEFAULT_TENANT_ID), (String) response.source().get(masterKeyId));
-                log.info("ML encryption master key already initialized, no action needed");
+
+                Object keyValue = response.source().get(MASTER_KEY);
+                if (keyValue instanceof String) {
+                    this.tenantMasterKeys.put(Objects.requireNonNullElse(tenantId, DEFAULT_TENANT_ID), (String) keyValue);
+                    log.info("ML encryption master key already initialized, no action needed");
+                } else {
+                    log.error("Master key not found or not a string for tenantId: {}, masterKeyId: {}", tenantId, masterKeyId);
+                    exceptionRef.set(new ResourceNotFoundException(MASTER_KEY_NOT_READY_ERROR));
+                }
                 latch.countDown();
             } else {
                 initializeNewMasterKey(tenantId, masterKeyId, exceptionRef, latch, context);
@@ -416,9 +422,14 @@ public class EncryptorImpl implements Encryptor {
         } else {
             GetResponse getMasterKeyResponse = response1.parser() == null ? null : GetResponse.fromXContent(response1.parser());
             if (getMasterKeyResponse != null && getMasterKeyResponse.isExists()) {
-                this.tenantMasterKeys
-                    .put(Objects.requireNonNullElse(tenantId, DEFAULT_TENANT_ID), (String) response1.source().get(masterKeyId));
-                log.info("ML encryption master key already initialized, no action needed");
+                Object keyValue = response1.source().get(MASTER_KEY);
+                if (keyValue instanceof String) {
+                    this.tenantMasterKeys.put(Objects.requireNonNullElse(tenantId, DEFAULT_TENANT_ID), (String) keyValue);
+                    log.info("ML encryption master key already initialized, no action needed");
+                } else {
+                    log.error("Master key not found or not a string for tenantId: {}, masterKeyId: {}", tenantId, masterKeyId);
+                    exceptionRef.set(new ResourceNotFoundException(MASTER_KEY_NOT_READY_ERROR));
+                }
                 latch.countDown();
             } else {
                 exceptionRef.set(new ResourceNotFoundException(MASTER_KEY_NOT_READY_ERROR));

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.crypto.spec.SecretKeySpec;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.get.GetResponse;
@@ -364,7 +365,7 @@ public class EncryptorImpl implements Encryptor {
     ) {
         Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable, OpenSearchStatusException.class);
         if (cause instanceof VersionConflictEngineException
-            || (cause instanceof OpenSearchStatusException && ((OpenSearchStatusException) cause).status() == RestStatus.CONFLICT)) {
+            || (cause instanceof OpenSearchException && ((OpenSearchException) cause).status() == RestStatus.CONFLICT)) {
             handleVersionConflict(tenantId, masterKeyId, context, exceptionRef, latch);
         } else {
             log.debug("Failed to index ML encryption master key to config index", cause);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
@@ -76,6 +76,7 @@ public class EncryptorImplTest {
     ThreadContext threadContext;
     final String USER_STRING = "myuser|role1,role2|myTenant";
     final String TENANT_ID = "myTenant";
+    final String GENERATED_MASTER_KEY = "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=";
 
     Encryptor encryptor;
 
@@ -83,7 +84,7 @@ public class EncryptorImplTest {
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         masterKey = new ConcurrentHashMap<>();
-        masterKey.put(DEFAULT_TENANT_ID, "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
+        masterKey.put(DEFAULT_TENANT_ID, GENERATED_MASTER_KEY);
         sdkClient = SdkClientFactory.createSdkClient(client, NamedXContentRegistry.EMPTY, Collections.emptyMap());
 
         doAnswer(invocation -> {
@@ -483,7 +484,7 @@ public class EncryptorImplTest {
         Assert.assertNotNull(tenantMasterKey);
 
         // Ensure that the master key for this tenant matches the expected value
-        Assert.assertEquals("m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=", encryptor.getMasterKey(TENANT_ID));
+        Assert.assertEquals(GENERATED_MASTER_KEY, encryptor.getMasterKey(TENANT_ID));
     }
 
     @Test
@@ -525,7 +526,7 @@ public class EncryptorImplTest {
         Map<String, Object> sourceMap = Map
             .of(
                 MASTER_KEY,
-                "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=", // Valid MASTER_KEY for this tenant
+                GENERATED_MASTER_KEY, // Valid MASTER_KEY for this tenant
                 CREATE_TIME_FIELD,
                 Instant.now().toEpochMilli()
             );
@@ -558,8 +559,7 @@ public class EncryptorImplTest {
         }).when(mlIndicesHandler).initMLConfigIndex(any());
 
         // Prepare a GetResponse where the _source has ONLY "master_key"
-        Map<String, Object> sourceMap = Map
-            .of(MASTER_KEY, "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=", CREATE_TIME_FIELD, Instant.now().toEpochMilli());
+        Map<String, Object> sourceMap = Map.of(MASTER_KEY, GENERATED_MASTER_KEY, CREATE_TIME_FIELD, Instant.now().toEpochMilli());
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
@@ -576,10 +576,8 @@ public class EncryptorImplTest {
         }).when(mlIndicesHandler).initMLConfigIndex(any());
 
         // Prepare a GetResponse where the _source has ONLY "master_key"
-        Map<String, Object> sourceMap = Map.of(
-                MASTER_KEY, "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=",
-                CREATE_TIME_FIELD, Instant.now().toEpochMilli()
-        );
+        Map<String, Object> sourceMap = Map
+            .of(MASTER_KEY, "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=", CREATE_TIME_FIELD, Instant.now().toEpochMilli());
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
@@ -608,7 +606,6 @@ public class EncryptorImplTest {
         Assert.assertNotNull(encrypted);
         Assert.assertEquals("test", encryptor.decrypt(encrypted, TENANT_ID));
     }
-
 
     // Helper method to prepare a valid IndexResponse
     private IndexResponse prepareIndexResponse() {


### PR DESCRIPTION
### Description

In the config index the source can be:

```
{
  "_tenant_id": {
    "S": "058264223758:oasistestm8w8ikom"
  },
  "_id": {
    "S": "master_key_xJWBUnkbw8Gsj7pez-f-g0ccK2-JUSRHcD9uh64Mna0="
  },
  "_seq_no": {
    "N": "0"
  },
  "_source": {
    "M": {
      "create_time": {
        "N": "1743375153989"
      },
      "master_key": {
        "S": "tOVgn8xhoaYWjpgaAWUkvCUiQYcCEDfXv6aA6NJje8Q="
      },
      "tenant_id": {
        "S": "058264223758:oasistestm8w8ikom"
      }
    }
  }
}
```

When we store an ML encryption key, we save it in a config document with:
A unique _id like:  master_key_xJWBUnkbw8Gsj7pez-f-g0ccK2-JUSRHcD9uh64Mna0=
And the actual key value inside the _source field as: "master_key": "<actual AES key>"
The mistake was that when reading the key back, the code incorrectly tried to look it up using the full document ID (like master_key_xJWBUnkbw8...) as the field name — instead of just "master_key".
Since the _source does not contain a field with that name, it returned null. We then attempted to insert that null into the in-memory cache, which caused a NullPointerException when we tried to decode the key later.
What did we fix?
We changed the code to always look up the key from the correct field in _source, using "master_key" as the key — not the document ID.
We also added a check to make sure the retrieved value is a non-null String before using it.
Why this matters:
This fixes a bug that broke connector creation (and possibly other flows that use encryption). Without this fix, a newly created tenant or connector would crash when trying to initialize its master key.


This is only happening for multi-tenancy use case, but not for single tenancy. 


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
