### PR TITLE
Support phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,16 @@ allprojects {
     }
 
     project.getExtensions().getExtraProperties().set("versions", VersionProperties.getVersions());
+}
 
+configurations {
+    agent
+}
+
+dependencies {
+    agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+    agent "org.opensearch:opensearch-agent:${opensearch_version}"
+    agent "net.bytebuddy:byte-buddy:1.17.5"
 }
 
 subprojects {
@@ -114,4 +123,14 @@ task updateVersion {
         // Include the required files that needs to be updated with new Version
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
+}
+
+task prepareAgent(type: Copy) {
+    from(configurations.agent)
+    into "$buildDir/agent"
+}
+
+tasks.withType(Test) {
+    dependsOn prepareAgent
+    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -14,6 +14,10 @@ plugins {
     id 'signing'
 }
 
+configurations {
+    agent
+}
+
 dependencies {
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     compileOnly group: 'org.reflections', name: 'reflections', version: '0.9.12'
@@ -44,6 +48,10 @@ dependencies {
     compileOnly group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
     // Multi-tenant SDK Client
     compileOnly "org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}"
+
+    agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+    agent "org.opensearch:opensearch-agent:${opensearch_version}"
+    agent "net.bytebuddy:byte-buddy:1.17.5"
 }
 
 lombok {
@@ -157,3 +165,13 @@ publishing {
     }
 }
 publishShadowPublicationToMavenLocal.mustRunAfter shadowJar
+
+task prepareAgent(type: Copy) {
+    from(configurations.agent)
+    into "$buildDir/agent"
+}
+
+tasks.withType(Test) {
+    dependsOn prepareAgent
+    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
+}

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -23,6 +23,10 @@ plugins {
     id 'com.diffplug.spotless' version '6.25.0'
 }
 
+configurations {
+    agent
+}
+
 dependencies {
     implementation project(path: ":${rootProject.name}-common", configuration: 'shadow')
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
@@ -47,6 +51,10 @@ dependencies {
         exclude group: 'net.minidev', module: 'json-smart'
     }
     testImplementation('net.minidev:json-smart:2.5.2')
+
+    agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+    agent "org.opensearch:opensearch-agent:${opensearch_version}"
+    agent "net.bytebuddy:byte-buddy:1.17.5"
 }
 
 test {
@@ -89,4 +97,14 @@ spotless {
 
         eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('.eclipseformat.xml')
     }
+}
+
+task prepareAgent(type: Copy) {
+    from(configurations.agent)
+    into "$buildDir/agent"
+}
+
+tasks.withType(Test) {
+    dependsOn prepareAgent
+    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -17,6 +17,10 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    agent
+}
+
 dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
     implementation project(path: ":${rootProject.name}-common", configuration: 'shadow')
@@ -88,6 +92,10 @@ dependencies {
     testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
+
+    agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+    agent "org.opensearch:opensearch-agent:${opensearch_version}"
+    agent "net.bytebuddy:byte-buddy:1.17.5"
 }
 
 lombok {
@@ -143,4 +151,14 @@ spotless {
 
         eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('.eclipseformat.xml')
     }
+}
+
+task prepareAgent(type: Copy) {
+    from(configurations.agent)
+    into "$buildDir/agent"
+}
+
+tasks.withType(Test) {
+    dependsOn prepareAgent
+    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -49,6 +49,7 @@ opensearchplugin {
 
 configurations {
     zipArchive
+    agent
 }
 
 dependencies {
@@ -94,6 +95,10 @@ dependencies {
         exclude group: 'net.minidev', module: 'json-smart'
     }
     implementation('net.minidev:json-smart:2.5.2')
+
+    agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+    agent "org.opensearch:opensearch-agent:${opensearch_version}"
+    agent "net.bytebuddy:byte-buddy:1.17.5"
 }
 
 publishing {
@@ -650,4 +655,14 @@ task bwcTestSuite(type: StandaloneRestIntegTestTask) {
 forbiddenPatterns {
     exclude '**/*.pdf'
     exclude '**/*.jpg'
+}
+
+task prepareAgent(type: Copy) {
+    from(configurations.agent)
+    into "$buildDir/agent"
+}
+
+tasks.withType(Test) {
+    dependsOn prepareAgent
+    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }

--- a/plugin/src/main/plugin-metadata/plugin-security.policy
+++ b/plugin/src/main/plugin-metadata/plugin-security.policy
@@ -12,6 +12,9 @@ grant {
     // Register model
     permission java.net.SocketPermission "*", "connect,resolve";
 
+    // for accessing Unix domain socket on windows
+    permission java.net.NetPermission "accessUnixDomainSocket";
+
     // Deploy model
     permission java.lang.RuntimePermission "createClassLoader";
     permission java.lang.RuntimePermission "loadLibrary.*";

--- a/search-processors/build.gradle
+++ b/search-processors/build.gradle
@@ -27,6 +27,10 @@ repositories {
     mavenLocal()
 }
 
+configurations {
+    agent
+}
+
 dependencies {
     implementation project(path: ":${rootProject.name}-common", configuration: 'shadow')
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
@@ -42,6 +46,10 @@ dependencies {
     implementation group: 'org.json', name: 'json', version: '20231013'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
+
+    agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+    agent "org.opensearch:opensearch-agent:${opensearch_version}"
+    agent "net.bytebuddy:byte-buddy:1.17.5"
 }
 
 test {
@@ -82,4 +90,14 @@ spotless {
 
         eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('.eclipseformat.xml')
     }
+}
+
+task prepareAgent(type: Copy) {
+    from(configurations.agent)
+    into "$buildDir/agent"
+}
+
+tasks.withType(Test) {
+    dependsOn prepareAgent
+    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }


### PR DESCRIPTION
### Description
With Java agent as a replacement to security manager, we start enforcing access to UnixDomainSockets. On windows since UnixDomainSockets are used for loopback address windows builds are now starting to fail for [skills](https://github.com/opensearch-project/skills/pull/551) and [flow-framework](https://github.com/opensearch-project/flow-framework/pull/1105). 

Additionally for this plugin's integ test to work, it will need a new jvm args to be passed. this change also includes the JVM args included in build.gradle. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
