### PR TITLE
Allow unix domain socket for loopback calls on windows

### DIFF
--- a/plugin/src/main/plugin-metadata/plugin-security.policy
+++ b/plugin/src/main/plugin-metadata/plugin-security.policy
@@ -33,4 +33,7 @@ grant {
 
     // AWS credentials needed for clients
     permission java.io.FilePermission "${user.home}/.aws/-", "read";
+
+    // for accessing Unix domain socket on windows
+    permission java.net.NetPermission "accessUnixDomainSocket";
 };


### PR DESCRIPTION
### Description
With Java agent as a replacement to security manager, we start enforcing access to UnixDomainSockets. On windows since UnixDomainSockets are used for loopback address windows builds are now starting to fail for https://github.com/opensearch-project/skills/pull/551 and https://github.com/opensearch-project/flow-framework/pull/1105.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
