### PR TITLE
fix error message when input map and output map length not match

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
@@ -707,7 +707,7 @@ public class MLInferenceSearchRequestProcessor extends AbstractProcessor impleme
                     "when output_maps/optional_output_maps and input_maps/optional_input_maps are provided, their length needs to match. The input is in length of "
                         + combinedInputMaps.size()
                         + ", while output_maps is in the length of "
-                        + combinedInputMaps.size()
+                        + combinedOutputMaps.size()
                         + ". Please adjust mappings."
                 );
             }

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -641,11 +641,19 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                                             }
                                         } else {
                                             Object modelOutputValuePerDoc;
-                                            if (modelOutputValue instanceof List
-                                                && ((List) modelOutputValue).size() == hitCountInPredictions.get(mappingIndex)) {
-                                                Object valuePerDoc = ((List) modelOutputValue)
-                                                    .get(MapUtils.getCounter(writeOutputMapDocCounter, mappingIndex, modelOutputFieldName));
-                                                modelOutputValuePerDoc = valuePerDoc;
+                                            if (hitCountInPredictions.containsKey(mappingIndex)) {
+                                                if (modelOutputValue instanceof List
+                                                    && ((List) modelOutputValue).size() == hitCountInPredictions.get(mappingIndex)
+                                                    && !oneToOne) {
+                                                    Object valuePerDoc = ((List) modelOutputValue)
+                                                        .get(
+                                                            MapUtils
+                                                                .getCounter(writeOutputMapDocCounter, mappingIndex, modelOutputFieldName)
+                                                        );
+                                                    modelOutputValuePerDoc = valuePerDoc;
+                                                } else {
+                                                    modelOutputValuePerDoc = modelOutputValue;
+                                                }
                                             } else {
                                                 modelOutputValuePerDoc = modelOutputValue;
                                             }

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -907,7 +907,7 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                     "when output_maps/optional_output_maps and input_maps/optional_input_maps are provided, their length needs to match. The input is in length of "
                         + combinedInputMaps.size()
                         + ", while output_maps is in the length of "
-                        + combinedInputMaps.size()
+                        + combinedOutputMaps.size()
                         + ". Please adjust mappings."
                 );
             }

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessor.java
@@ -626,29 +626,29 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                                             ignoreMissing,
                                             fullResponsePath
                                         );
-                                        Object modelOutputValuePerDoc;
-                                        if (modelOutputValue instanceof List
-                                            && ((List) modelOutputValue).size() == hitCountInPredictions.get(mappingIndex)) {
-                                            Object valuePerDoc = ((List) modelOutputValue)
-                                                .get(MapUtils.getCounter(writeOutputMapDocCounter, mappingIndex, modelOutputFieldName));
-                                            modelOutputValuePerDoc = valuePerDoc;
-                                        } else {
-                                            modelOutputValuePerDoc = modelOutputValue;
-                                        }
                                         // writing to search response extension
                                         if (newDocumentFieldName.startsWith(EXTENSION_PREFIX)) {
                                             Map<String, Object> params = ((MLInferenceSearchResponse) response).getParams();
                                             String paramsName = newDocumentFieldName.replaceFirst(EXTENSION_PREFIX + ".", "");
 
                                             if (params != null) {
-                                                params.put(paramsName, modelOutputValuePerDoc);
+                                                params.put(paramsName, modelOutputValue);
                                                 ((MLInferenceSearchResponse) response).setParams(params);
                                             } else {
                                                 Map<String, Object> newParams = new HashMap<>();
-                                                newParams.put(paramsName, modelOutputValuePerDoc);
+                                                newParams.put(paramsName, modelOutputValue);
                                                 ((MLInferenceSearchResponse) response).setParams(newParams);
                                             }
                                         } else {
+                                            Object modelOutputValuePerDoc;
+                                            if (modelOutputValue instanceof List
+                                                && ((List) modelOutputValue).size() == hitCountInPredictions.get(mappingIndex)) {
+                                                Object valuePerDoc = ((List) modelOutputValue)
+                                                    .get(MapUtils.getCounter(writeOutputMapDocCounter, mappingIndex, modelOutputFieldName));
+                                                modelOutputValuePerDoc = valuePerDoc;
+                                            } else {
+                                                modelOutputValuePerDoc = modelOutputValue;
+                                            }
                                             // writing to search response hits
                                             if (sourceAsMap.containsKey(newDocumentFieldName)) {
                                                 if (override) {
@@ -902,7 +902,10 @@ public class MLInferenceSearchResponseProcessor extends AbstractProcessor implem
                         + ". Please reduce the size of input_map or optional_input_map or increase max_prediction_tasks."
                 );
             }
-            if (combinedOutputMaps != null && combinedInputMaps != null && combinedOutputMaps.size() != combinedInputMaps.size()) {
+
+            if (!CollectionUtils.isEmpty(combinedOutputMaps)
+                && !CollectionUtils.isEmpty(combinedInputMaps)
+                && combinedOutputMaps.size() != combinedInputMaps.size()) {
                 throw new IllegalArgumentException(
                     "when output_maps/optional_output_maps and input_maps/optional_input_maps are provided, their length needs to match. The input is in length of "
                         + combinedInputMaps.size()

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
@@ -2250,7 +2250,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
         } catch (IllegalArgumentException e) {
             assertEquals(
                 e.getMessage(),
-                ("when output_maps/optional_output_maps and input_maps/optional_input_maps are provided, their length needs to match. The input is in length of 2, while output_maps is in the length of 2. Please adjust mappings.")
+                ("when output_maps/optional_output_maps and input_maps/optional_input_maps are provided, their length needs to match. The input is in length of 2, while output_maps is in the length of 3. Please adjust mappings.")
             );
         }
     }

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchResponseProcessorTests.java
@@ -5166,7 +5166,7 @@ public class MLInferenceSearchResponseProcessorTests extends AbstractBuilderTest
         } catch (IllegalArgumentException e) {
             assertEquals(
                 e.getMessage(),
-                "when output_maps/optional_output_maps and input_maps/optional_input_maps are provided, their length needs to match. The input is in length of 2, while output_maps is in the length of 2. Please adjust mappings."
+                "when output_maps/optional_output_maps and input_maps/optional_input_maps are provided, their length needs to match. The input is in length of 2, while output_maps is in the length of 3. Please adjust mappings."
             );
 
         }


### PR DESCRIPTION
### Description
fix typo in error message when input map and output map length not match.

also fix when writing to ml_inference search extension, it's only supported when one_to_one is false, so when it's an array to write into ml_inference search extension, don't split up the array and store as a whole in the search extension. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
