### PR TITLE
Add Feature Flag for MCP connectors Feature

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common;
 import java.util.Set;
 
 import org.opensearch.Version;
+import org.opensearch.common.settings.Setting;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -94,6 +95,13 @@ public class CommonValue {
     public static final String MCP_SYNC_CLIENT = "mcp_sync_client";
     public static final String MCP_EXECUTOR_SERVICE = "mcp_executor_service";
     public static final String MCP_TOOLS_FIELD = "tools";
+    public static final String MCP_CONNECTORS_FIELD = "mcp_connectors";
+    public static final String MCP_CONNECTOR_ID_FIELD = "mcp_connector_id";
+
+    public static final Setting<Boolean> ML_COMMONS_MCP_FEATURE_ENABLED = Setting
+        .boolSetting("plugins.ml_commons.mcp_feature_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
+    public static final String ML_COMMONS_MCP_FEATURE_DISABLED_MESSAGE =
+        "The MCP feature is not enabled. To enable, please update the setting " + ML_COMMONS_MCP_FEATURE_ENABLED.getKey();
 
     // TOOL Constants
     public static final String TOOL_INPUT_SCHEMA_FIELD = "input_schema";

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -6,6 +6,8 @@
 package org.opensearch.ml.engine.algorithms.agent;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.MCP_CONNECTORS_FIELD;
+import static org.opensearch.ml.common.CommonValue.MCP_CONNECTOR_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.utils.StringUtils.getParameterMap;
@@ -125,8 +127,6 @@ public class AgentUtils {
     public static final String LLM_FINAL_RESPONSE_POST_FILTER = "llm_final_response_post_filter";
     public static final String LLM_FINISH_REASON_PATH = "llm_finish_reason_path";
     public static final String LLM_FINISH_REASON_TOOL_USE = "llm_finish_reason_tool_use";
-    public static final String MCP_CONNECTORS_FIELD = "mcp_connectors";
-    public static final String MCP_CONNECTOR_ID_FIELD = "mcp_connector_id";
     public static final String TOOL_FILTERS_FIELD = "tool_filters";
 
     public static String addExamplesToPrompt(Map<String, String> parameters, String prompt) {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutorTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.naming.Context;
 
@@ -43,6 +44,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -55,6 +57,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.get.GetResult;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.agent.LLMSpec;
@@ -167,6 +170,9 @@ public class MLAgentExecutorTest {
         Mockito.when(memory.getMemoryManager()).thenReturn(memoryManager);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(this.clusterService.getSettings()).thenReturn(settings);
+        when(this.clusterService.getClusterSettings())
+            .thenReturn(new ClusterSettings(settings, Set.of(CommonValue.ML_COMMONS_MCP_FEATURE_ENABLED)));
 
         settings = Settings.builder().build();
         mlAgentExecutor = Mockito

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1054,7 +1054,8 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.REMOTE_METADATA_TYPE,
                 MLCommonsSettings.REMOTE_METADATA_ENDPOINT,
                 MLCommonsSettings.REMOTE_METADATA_REGION,
-                MLCommonsSettings.REMOTE_METADATA_SERVICE_NAME
+                MLCommonsSettings.REMOTE_METADATA_SERVICE_NAME,
+                MLCommonsSettings.ML_COMMONS_MCP_FEATURE_ENABLED
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
+++ b/plugin/src/main/java/org/opensearch/ml/settings/MLCommonsSettings.java
@@ -16,6 +16,7 @@ import java.util.function.Function;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.conversation.ConversationalIndexConstants;
 import org.opensearch.searchpipelines.questionanswering.generative.GenerativeQAProcessorConstants;
 
@@ -215,6 +216,8 @@ public final class MLCommonsSettings {
         );
 
     public static final Setting<Boolean> ML_COMMONS_MEMORY_FEATURE_ENABLED = ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_ENABLED;
+
+    public static final Setting<Boolean> ML_COMMONS_MCP_FEATURE_ENABLED = CommonValue.ML_COMMONS_MCP_FEATURE_ENABLED;
 
     // Feature flag for enabling search processors for Retrieval Augmented Generation using OpenSearch and Remote Inference.
     public static final Setting<Boolean> ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED =

--- a/plugin/src/test/java/org/opensearch/ml/action/agents/RegisterAgentTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agents/RegisterAgentTransportActionTests.java
@@ -15,6 +15,7 @@ import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -25,12 +26,14 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.agent.LLMSpec;
 import org.opensearch.ml.common.agent.MLAgent;
@@ -95,6 +98,8 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
         when(clusterService.getSettings()).thenReturn(settings);
+        when(this.clusterService.getClusterSettings())
+            .thenReturn(new ClusterSettings(settings, Set.of(CommonValue.ML_COMMONS_MCP_FEATURE_ENABLED)));
         transportRegisterAgentAction = new TransportRegisterAgentAction(
             transportService,
             actionFilters,

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
@@ -41,6 +41,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.AccessMode;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.ConnectorProtocols;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
@@ -141,11 +142,13 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
         ClusterSettings clusterSettings = clusterSetting(
             settings,
             ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX,
-            ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED
+            ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED,
+            CommonValue.ML_COMMONS_MCP_FEATURE_ENABLED
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+        when(this.clusterService.getSettings()).thenReturn(settings);
 
         action = new TransportCreateConnectorAction(
             transportService,


### PR DESCRIPTION
### Description
The MCP feature enables customer to provide connection details about an MCP server via an MCP connector. This feature is being released as an experimental feature and hence we will expose it behind a feature flag.

To use MCP feature, one has to set the feature flag `plugins.ml_commons.mcp_feature_enabled` to `true`

This feature flag blocks the following when disabled:

- Creation of an MCP connector
- Creation of an Agent with MCP tools
- Executing an Agent created with MCP

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
