### PR TITLE
Replace null GetResponse with valid response and not exists

### DIFF
--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.opensearch.ml.common.CommonValue.CREATE_TIME_FIELD;
 import static org.opensearch.ml.common.CommonValue.MASTER_KEY;
 import static org.opensearch.ml.common.CommonValue.ML_CONFIG_INDEX;
@@ -160,9 +162,10 @@ public class EncryptorImplTest {
         }).when(mlIndicesHandler).initMLConfigIndex(any());
         IndexResponse indexResponse = prepareIndexResponse();
 
+        GetResponse getResponse = prepareNotExistsGetResponse();
         doAnswer(invocation -> {
             ActionListener<GetResponse> actionListener = (ActionListener) invocation.getArgument(1);
-            actionListener.onResponse(null);
+            actionListener.onResponse(getResponse);
             return null;
         }).when(client).get(any(), any());
 
@@ -191,7 +194,8 @@ public class EncryptorImplTest {
         }).when(mlIndicesHandler).initMLConfigIndex(any());
         doAnswer(invocation -> {
             ActionListener<GetResponse> actionListener = (ActionListener) invocation.getArgument(1);
-            actionListener.onResponse(null);
+            GetResponse getResponse = prepareNotExistsGetResponse();
+            actionListener.onResponse(getResponse);
             return null;
         }).when(client).get(any(), any());
         doAnswer(invocation -> {
@@ -216,7 +220,8 @@ public class EncryptorImplTest {
         }).when(mlIndicesHandler).initMLConfigIndex(any());
         doAnswer(invocation -> {
             ActionListener<GetResponse> actionListener = (ActionListener) invocation.getArgument(1);
-            actionListener.onResponse(null);
+            GetResponse getResponse = prepareNotExistsGetResponse();
+            actionListener.onResponse(getResponse);
             return null;
         }).when(client).get(any(), any());
         doAnswer(invocation -> {
@@ -245,7 +250,8 @@ public class EncryptorImplTest {
         }).when(mlIndicesHandler).initMLConfigIndex(any());
         doAnswer(invocation -> {
             ActionListener<GetResponse> actionListener = (ActionListener) invocation.getArgument(1);
-            actionListener.onResponse(null);
+            GetResponse getResponse = prepareNotExistsGetResponse();
+            actionListener.onResponse(getResponse);
             return null;
         }).doAnswer(invocation -> {
             ActionListener<GetResponse> actionListener = (ActionListener) invocation.getArgument(1);
@@ -500,7 +506,8 @@ public class EncryptorImplTest {
 
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onResponse(null);
+            GetResponse getResponse = prepareNotExistsGetResponse();
+            listener.onResponse(getResponse);
             return null;
         }).when(client).get(any(), any());
 
@@ -776,5 +783,21 @@ public class EncryptorImplTest {
     private IndexResponse prepareIndexResponse() {
         ShardId shardId = new ShardId(ML_CONFIG_INDEX, "index_uuid", 0);
         return new IndexResponse(shardId, MASTER_KEY, 1L, 1L, 1L, true);
+    }
+
+    // Helper method to prepare a valid GetResponse
+    private GetResponse prepareNotExistsGetResponse() {
+        GetResult getResult = new GetResult(
+            ML_CONFIG_INDEX,
+            "fake_id",
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            -1L,
+            false,
+            null,
+            null,
+            null
+        );
+        return new GetResponse(getResult);
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/DeleteTaskTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/DeleteTaskTransportAction.java
@@ -125,11 +125,9 @@ public class DeleteTaskTransportAction extends HandledTransportAction<ActionRequ
         ActionListener<DeleteResponse> actionListener
     ) {
         try {
-            GetResponse getResponse = getDataObjectResponse.parser() == null
-                ? null
-                : GetResponse.fromXContent(getDataObjectResponse.parser());
+            GetResponse getResponse = getDataObjectResponse.getResponse();
 
-            if (getResponse == null || !getResponse.isExists()) {
+            if (!getResponse.isExists()) {
                 actionListener.onFailure(new OpenSearchStatusException("Failed to find task", RestStatus.NOT_FOUND));
                 return;
             }

--- a/plugin/src/test/java/org/opensearch/ml/action/agents/GetAgentTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agents/GetAgentTransportActionTests.java
@@ -7,6 +7,9 @@ package org.opensearch.ml.action.agents;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.verify;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -205,14 +208,25 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
     }
 
     @Test
-    public void testGetTask_NullResponse() {
+    public void testGetTask_NotFoundResponse() {
         String agentId = "test-agent-id-NullResponse";
         Task task = mock(Task.class);
         ActionListener<MLAgentGetResponse> actionListener = mock(ActionListener.class);
         MLAgentGetRequest getRequest = new MLAgentGetRequest(agentId, true, null);
+        GetResult getResult = new GetResult(
+            ML_AGENT_INDEX,
+            "fake_id",
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            -1L,
+            false,
+            null,
+            null,
+            null
+        );
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onResponse(null);
+            listener.onResponse(new GetResponse(getResult));
             return null;
         }).when(client).get(any(), any());
         getAgentTransportAction.doExecute(task, getRequest, actionListener);

--- a/plugin/src/test/java/org/opensearch/ml/action/model_group/GetModelGroupTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/model_group/GetModelGroupTransportActionTests.java
@@ -10,6 +10,9 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -167,10 +170,21 @@ public class GetModelGroupTransportActionTests extends OpenSearchTestCase {
         assertEquals("Failed to validate access", argumentCaptor.getValue().getMessage());
     }
 
-    public void testGetModel_NullResponse() {
+    public void testGetModel_NotExistsResponse() {
+        GetResult getResult = new GetResult(
+            ML_MODEL_GROUP_INDEX,
+            "fake_id",
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            -1L,
+            false,
+            null,
+            null,
+            null
+        );
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onResponse(null);
+            listener.onResponse(new GetResponse(getResult));
             return null;
         }).when(client).get(any(), any());
         getModelGroupTransportAction.doExecute(null, mlModelGroupGetRequest, actionListener);

--- a/plugin/src/test/java/org/opensearch/ml/action/models/GetModelTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/GetModelTransportActionTests.java
@@ -11,6 +11,9 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -212,10 +215,21 @@ public class GetModelTransportActionTests extends OpenSearchTestCase {
         assertEquals("Failed to validate access", argumentCaptor.getValue().getMessage());
     }
 
-    public void testGetModel_NullResponse() {
+    public void testGetModel_NotExistsResponse() {
+        GetResult getResult = new GetResult(
+            ML_MODEL_INDEX,
+            "fake_id",
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            -1L,
+            false,
+            null,
+            null,
+            null
+        );
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onResponse(null);
+            listener.onResponse(new GetResponse(getResult));
             return null;
         }).when(client).get(any(), any());
 

--- a/plugin/src/test/java/org/opensearch/ml/action/tasks/DeleteTaskTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/tasks/DeleteTaskTransportActionTests.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.action.DocWriteResponse.Result.DELETED;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
 
 import java.io.IOException;
@@ -144,10 +146,21 @@ public class DeleteTaskTransportActionTests extends OpenSearchTestCase {
         assertEquals("Failed to get data object from index .plugins-ml-task", argumentCaptor.getValue().getMessage());
     }
 
-    public void testDeleteTask_GetResponseNullException() {
+    public void testDeleteTask_GetResponseNotExistsException() {
+        GetResult getResult = new GetResult(
+            ML_TASK_INDEX,
+            "fake_id",
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            -1L,
+            false,
+            null,
+            null,
+            null
+        );
         doAnswer(invocation -> {
             ActionListener<GetResponse> actionListener = invocation.getArgument(1);
-            actionListener.onResponse(null);
+            actionListener.onResponse(new GetResponse(getResult));
             return null;
         }).when(client).get(any(), any());
 

--- a/plugin/src/test/java/org/opensearch/ml/action/tasks/GetTaskTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/tasks/GetTaskTransportActionTests.java
@@ -15,6 +15,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
 import static org.opensearch.ml.common.connector.AbstractConnector.*;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_REMOTE_JOB_STATUS_CANCELLED_REGEX;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_REMOTE_JOB_STATUS_CANCELLING_REGEX;
@@ -255,9 +258,20 @@ public class GetTaskTransportActionTests extends OpenSearchTestCase {
     }
 
     public void testGetTask_NullResponse() {
+        GetResult getResult = new GetResult(
+            ML_TASK_INDEX,
+            "fake_id",
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            -1L,
+            false,
+            null,
+            null,
+            null
+        );
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onResponse(null);
+            listener.onResponse(new GetResponse(getResult));
             return null;
         }).when(client).get(any(), any());
         getTaskTransportAction.doExecute(null, mlTaskGetRequest, actionListener);

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelGroupManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelGroupManagerTests.java
@@ -10,6 +10,8 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 
 import java.io.IOException;
@@ -398,9 +400,20 @@ public class MLModelGroupManagerTests extends OpenSearchTestCase {
     }
 
     public void test_NotFoundGetModelGroup() throws IOException {
+        GetResult getResult = new GetResult(
+            ML_MODEL_GROUP_INDEX,
+            "fake_id",
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            -1L,
+            false,
+            null,
+            null,
+            null
+        );
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onResponse(null);
+            listener.onResponse(new GetResponse(getResult));
             return null;
         }).when(client).get(any(GetRequest.class), isA(ActionListener.class));
 

--- a/plugin/src/test/java/org/opensearch/ml/utils/MockHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/MockHelper.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 
@@ -34,19 +35,20 @@ import org.opensearch.transport.client.Client;
 public class MockHelper {
 
     public static void mock_client_get_NotExist(Client client) {
+        GetResult getResult = new GetResult(
+            "fake_index",
+            "fake_id",
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            -1L,
+            false,
+            null,
+            null,
+            null
+        );
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = invocation.getArgument(1);
-            GetResponse response = mock(GetResponse.class);
-            when(response.isExists()).thenReturn(false);
-            listener.onResponse(null);
-            return null;
-        }).when(client).get(any(), any());
-    }
-
-    public static void mock_client_get_NullResponse(Client client) {
-        doAnswer(invocation -> {
-            ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onResponse(null);
+            listener.onResponse(new GetResponse(getResult));
             return null;
         }).when(client).get(any(), any());
     }


### PR DESCRIPTION
### Description

Several unit tests assume that it is possible for `client.get(request, actionListener)` to complete the listener's `onResponse()` method with `null`.  This is impossible.  See [here](https://github.com/opensearch-project/OpenSearch/blob/caf5d71ff02c5250a820f3ec1b346eff37b1d230/server/src/main/java/org/opensearch/action/get/TransportGetAction.java#L146-L165) for the ultimate return value of get requests.

What was done:
 - many tests that used `actionListener.onResponse(null)` were replaced with a non-null `GetResponse` object with a `false` value for the document existing.
   - for ease of review, these really are largely copy/paste with the only change being the index name
 - in the case of `MLModelManagerTests` there were two nearly identical tests, one for not exists (which was fixed as above) and one for null (which is impossible, and was removed, along with the mock helper producing the impossible result)

### Related Issues
Resolves test failures resulting from https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/145 which assumes that an `ActionListener.onResponse()` on a `client.get()` call will never be null.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
