### PR TITLE
Don't convert schema-defined strings to other types during validation

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionTaskAction.java
@@ -262,7 +262,7 @@ public class TransportPredictionTaskAction extends HandledTransportAction<Action
             try {
                 String InputString = mlInput.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS).toString();
                 // Process the parameters field in the input dataset to convert it back to its original datatype, instead of a string
-                String processedInputString = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(InputString);
+                String processedInputString = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(InputString, inputSchemaString);
                 MLNodeUtils.validateSchema(inputSchemaString, processedInputString);
             } catch (Exception e) {
                 throw new OpenSearchStatusException(

--- a/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
@@ -118,61 +118,94 @@ public class MLNodeUtilsTests extends OpenSearchTestCase {
 
     @Test
     public void testProcessRemoteInferenceInputDataSetParametersValueNoParameters() throws IOException {
+        String schema = "{\"type\": \"object\",\"properties\": {}}";
         String json = "{\"key1\":\"foo\",\"key2\":123,\"key3\":true}";
-        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json);
+        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json, schema);
         assertEquals(json, processedJson);
     }
 
     @Test
     public void testProcessRemoteInferenceInputDataSetInvalidJson() {
+        String schema = "{\"type\": \"object\",\"properties\": {}}";
         String json = "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":{\"a\"}}";
-        assertThrows(JsonParseException.class, () -> MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json));
+        assertThrows(JsonParseException.class, () -> MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json, schema));
     }
 
     @Test
     public void testProcessRemoteInferenceInputDataSetEmptyParameters() throws IOException {
+        String schema = "{\"type\": \"object\",\"properties\": {\"parameters\": {\"type\": \"object\"}}}";
         String json = "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":{}}";
-        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json);
+        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json, schema);
         assertEquals(json, processedJson);
     }
 
     @Test
     public void testProcessRemoteInferenceInputDataSetParametersValueParametersWrongType() throws IOException {
+        String schema = "{\"type\": \"object\",\"properties\": {\"parameters\": {\"type\": \"array\"}}}";
         String json = "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":[\"Hello\",\"world\"]}";
-        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json);
+        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json, schema);
         assertEquals(json, processedJson);
     }
 
     @Test
     public void testProcessRemoteInferenceInputDataSetParametersValueWithParametersProcessArray() throws IOException {
+        String schema = "{\"type\": \"object\",\"properties\": {\"parameters\": {\"type\": \"object\",\"properties\": {"
+            + "\"texts\": {\"type\": \"array\",\"items\": {\"type\": \"string\"}}"
+            + "}}}}";
         String json = "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":{\"texts\":\"[\\\"Hello\\\",\\\"world\\\"]\"}}";
         String expectedJson = "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":{\"texts\":[\"Hello\",\"world\"]}}";
-        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json);
+        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json, schema);
         assertEquals(expectedJson, processedJson);
     }
 
     @Test
     public void testProcessRemoteInferenceInputDataSetParametersValueWithParametersProcessObject() throws IOException {
+        String schema = "{\"type\": \"object\",\"properties\": {\"parameters\": {\"type\": \"object\",\"properties\": {"
+            + "\"messages\": {\"type\": \"object\"}"
+            + "}}}}";
         String json =
-            "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":{\"messages\":\"{\\\"role\\\":\\\"system\\\",\\\"foo\\\":\\\"{\\\\\\\"a\\\\\\\": \\\\\\\"b\\\\\\\"}\\\",\\\"content\\\":{\\\"a\\\":\\\"b\\\"}}\"}}}";
+            "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":{\"messages\":\"{\\\"role\\\":\\\"system\\\",\\\"foo\\\":\\\"{\\\\\\\"a\\\\\\\": \\\\\\\"b\\\\\\\"}\\\",\\\"content\\\":{\\\"a\\\":\\\"b\\\"}}\"}}";
         String expectedJson =
             "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":{\"messages\":{\"role\":\"system\",\"foo\":\"{\\\"a\\\": \\\"b\\\"}\",\"content\":{\"a\":\"b\"}}}}";
-        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json);
+        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json, schema);
         assertEquals(expectedJson, processedJson);
     }
 
     @Test
+    public void testProcessRemoteInferenceInputDataSetParametersValueWithParametersQuotedNumber() throws IOException {
+        String schema = "{\"type\": \"object\",\"properties\": {\"parameters\": {\"type\": \"object\",\"properties\": {"
+            + "\"key1\": {\"type\": \"string\"},"
+            + "\"key2\": {\"type\": \"integer\"},"
+            + "\"key3\": {\"type\": \"boolean\"}"
+            + "}}}}";
+        String json = "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":{\"key1\":\"123\",\"key2\":123,\"key3\":true}}";
+        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json, schema);
+        assertEquals(json, processedJson);
+    }
+
+    @Test
     public void testProcessRemoteInferenceInputDataSetParametersValueWithParametersNoProcess() throws IOException {
+        String schema = "{\"type\": \"object\",\"properties\": {\"parameters\": {\"type\": \"object\",\"properties\": {"
+            + "\"key1\": {\"type\": \"string\"},"
+            + "\"key2\": {\"type\": \"integer\"},"
+            + "\"key3\": {\"type\": \"boolean\"}"
+            + "}}}}";
         String json = "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":{\"key1\":\"foo\",\"key2\":123,\"key3\":true}}";
-        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json);
+        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json, schema);
         assertEquals(json, processedJson);
     }
 
     @Test
     public void testProcessRemoteInferenceInputDataSetParametersValueWithParametersInvalidJson() throws IOException {
+        String schema = "{\"type\": \"object\",\"properties\": {\"parameters\": {\"type\": \"object\",\"properties\": {"
+            + "\"key1\": {\"type\": \"string\"},"
+            + "\"key2\": {\"type\": \"integer\"},"
+            + "\"key3\": {\"type\": \"boolean\"},"
+            + "\"texts\": {\"type\": \"array\"}"
+            + "}}}}";
         String json =
             "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"texts\":\"[\\\"Hello\\\",\\\"world\\\"\"}}";
-        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json);
+        String processedJson = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json, schema);
         assertEquals(json, processedJson);
     }
 }


### PR DESCRIPTION
### Description

Prevents converting strings to numbers or any other validation-failing conversion, by limiting the conversion specifically to objects or arrays.

Wrote a test which failed similar to existing code by converting a string to a number, then updated the util so the test passes.

### Related Issues
Resolves #3758

### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
