### PR TITLE
Directly return Response objects from metadata client responses

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/agents/DeleteAgentTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/DeleteAgentTransportAction.java
@@ -109,7 +109,7 @@ public class DeleteAgentTransportAction extends HandledTransportAction<ActionReq
                     }
                 } else {
                     try {
-                        GetResponse gr = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                        GetResponse gr = r.getResponse();
                         assert gr != null;
                         if (gr.isExists()) {
                             try (

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/DeleteAgentTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/DeleteAgentTransportAction.java
@@ -186,7 +186,7 @@ public class DeleteAgentTransportAction extends HandledTransportAction<ActionReq
             actionListener.onFailure(cause);
         } else {
             try {
-                DeleteResponse deleteResponse = DeleteResponse.fromXContent(response.parser());
+                DeleteResponse deleteResponse = response.deleteResponse();
                 log.info("Agent deletion result: {}, agent id: {}", deleteResponse.getResult(), response.id());
                 actionListener.onResponse(deleteResponse);
             } catch (Exception e) {

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/GetAgentTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/GetAgentTransportAction.java
@@ -109,7 +109,7 @@ public class GetAgentTransportAction extends HandledTransportAction<ActionReques
                     }
                 } else {
                     try {
-                        GetResponse gr = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                        GetResponse gr = r.getResponse();
                         if (gr != null && gr.isExists()) {
                             try (
                                 XContentParser parser = jsonXContent

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
@@ -150,7 +150,7 @@ public class TransportRegisterAgentAction extends HandledTransportAction<ActionR
                                 listener.onFailure(cause);
                             } else {
                                 try {
-                                    IndexResponse indexResponse = IndexResponse.fromXContent(r.parser());
+                                    IndexResponse indexResponse = r.indexResponse();
                                     log.info("Agent creation result: {}, Agent id: {}", indexResponse.getResult(), indexResponse.getId());
                                     MLRegisterAgentResponse response = new MLRegisterAgentResponse(r.id());
                                     listener.onResponse(response);

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/TransportSearchAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/TransportSearchAgentAction.java
@@ -7,7 +7,6 @@ package org.opensearch.ml.action.agents;
 
 import static org.opensearch.ml.action.handler.MLSearchHandler.wrapRestActionListener;
 
-import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -15,7 +14,6 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.ml.common.CommonValue;
@@ -96,25 +94,7 @@ public class TransportSearchAgentAction extends HandledTransportAction<MLSearchA
                 .tenantId(tenantId)
                 .build();
 
-            sdkClient.searchDataObjectAsync(searchDataObjectRequest).whenComplete((r, throwable) -> {
-                if (throwable != null) {
-                    Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable, OpenSearchStatusException.class);
-                    log.error("Failed to search agent", cause);
-                    wrappedListener.onFailure(cause);
-                } else {
-                    try {
-                        SearchResponse searchResponse = SearchResponse.fromXContent(r.parser());
-                        log.info("Agent search complete: {}", searchResponse.getHits().getTotalHits());
-                        wrappedListener.onResponse(searchResponse);
-                    } catch (Exception e) {
-                        log.error("Failed to parse model search response", e);
-                        wrappedListener
-                            .onFailure(
-                                new OpenSearchStatusException("Failed to parse model search response", RestStatus.INTERNAL_SERVER_ERROR)
-                            );
-                    }
-                }
-            });
+            sdkClient.searchDataObjectAsync(searchDataObjectRequest).whenComplete(SdkClientUtils.wrapSearchCompletion(wrappedListener));
         } catch (Exception e) {
             log.error("failed to search the agent index", e);
             actionListener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
@@ -8,7 +8,6 @@ package org.opensearch.ml.action.connector;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -221,10 +220,10 @@ public class DeleteConnectorTransportAction extends HandledTransportAction<Actio
             actionListener.onFailure(cause);
         } else {
             try {
-                DeleteResponse deleteResponse = DeleteResponse.fromXContent(response.parser());
+                DeleteResponse deleteResponse = response.deleteResponse();
                 log.info("Connector deletion result: {}, connector id: {}", deleteResponse.getResult(), response.id());
                 actionListener.onResponse(deleteResponse);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 actionListener.onFailure(e);
             }
         }

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/DeleteConnectorTransportAction.java
@@ -154,7 +154,8 @@ public class DeleteConnectorTransportAction extends HandledTransportAction<Actio
         }
 
         try {
-            SearchResponse response = SearchResponse.fromXContent(searchResponse.parser());
+            SearchResponse response = searchResponse.searchResponse();
+            // Parsing failure would produce NPE on next line
             SearchHit[] searchHits = response.getHits().getHits();
 
             if (searchHits.length == 0) {

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
@@ -9,7 +9,6 @@ import static org.opensearch.ml.common.CommonValue.ML_COMMONS_MCP_FEATURE_DISABL
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
@@ -179,7 +178,7 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
                             listener.onFailure(cause);
                         } else {
                             try {
-                                IndexResponse indexResponse = IndexResponse.fromXContent(r.parser());
+                                IndexResponse indexResponse = r.indexResponse();
                                 log
                                     .info(
                                         "Connector creation result: {}, connector id: {}",
@@ -187,7 +186,7 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
                                         indexResponse.getId()
                                     );
                                 listener.onResponse(new MLCreateConnectorResponse(indexResponse.getId()));
-                            } catch (IOException e) {
+                            } catch (Exception e) {
                                 listener.onFailure(e);
                             }
                         }

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
@@ -177,7 +177,8 @@ public class UpdateConnectorTransportAction extends HandledTransportAction<Actio
         sdkClient.searchDataObjectAsync(searchDataObjectRequest).whenComplete((sr, st) -> {
             if (sr != null) {
                 try {
-                    SearchResponse searchResponse = SearchResponse.fromXContent(sr.parser());
+                    SearchResponse searchResponse = sr.searchResponse();
+                    // Parsing failure would cause NPE on next line
                     SearchHit[] searchHits = searchResponse.getHits().getHits();
                     if (searchHits.length == 0) {
                         sdkClient.updateDataObjectAsync(updateDataObjectRequest).whenComplete((r, throwable) -> {

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
@@ -9,7 +9,6 @@ import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -228,9 +227,8 @@ public class UpdateConnectorTransportAction extends HandledTransportAction<Actio
             updateListener.onFailure(cause);
         } else {
             try {
-                UpdateResponse updateResponse = r.parser() == null ? null : UpdateResponse.fromXContent(r.parser());
-                updateListener.onResponse(updateResponse);
-            } catch (IOException e) {
+                updateListener.onResponse(r.updateResponse());
+            } catch (Exception e) {
                 updateListener.onFailure(e);
             }
         }

--- a/plugin/src/main/java/org/opensearch/ml/action/handler/MLSearchHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/handler/MLSearchHandler.java
@@ -140,20 +140,9 @@ public class MLSearchHandler {
                     .searchSourceBuilder(request.source())
                     .tenantId(tenantId)
                     .build();
-                sdkClient.searchDataObjectAsync(searchDataObjectRequest).whenComplete((r, throwable) -> {
-                    if (throwable == null) {
-                        try {
-                            SearchResponse searchResponse = SearchResponse.fromXContent(r.parser());
-                            log.info("Model search complete: {}", searchResponse.getHits().getTotalHits());
-                            doubleWrapperListener.onResponse(searchResponse);
-                        } catch (Exception e) {
-                            doubleWrapperListener.onFailure(e);
-                        }
-                    } else {
-                        Exception e = SdkClientUtils.unwrapAndConvertToException(throwable, OpenSearchStatusException.class);
-                        doubleWrapperListener.onFailure(e);
-                    }
-                });
+                sdkClient
+                    .searchDataObjectAsync(searchDataObjectRequest)
+                    .whenComplete(SdkClientUtils.wrapSearchCompletion(doubleWrapperListener));
             } else {
                 SearchSourceBuilder sourceBuilder = modelAccessControlHelper.createSearchSourceBuilder(user);
                 SearchRequest modelGroupSearchRequest = new SearchRequest();
@@ -182,20 +171,9 @@ public class MLSearchHandler {
                         .searchSourceBuilder(request.source())
                         .tenantId(tenantId)
                         .build();
-                    sdkClient.searchDataObjectAsync(searchDataObjectRequest).whenComplete((sr, throwable) -> {
-                        if (throwable == null) {
-                            try {
-                                SearchResponse searchResponse = SearchResponse.fromXContent(sr.parser());
-                                log.info("Model search complete: {}", searchResponse.getHits().getTotalHits());
-                                doubleWrapperListener.onResponse(searchResponse);
-                            } catch (Exception e) {
-                                doubleWrapperListener.onFailure(e);
-                            }
-                        } else {
-                            Exception e = SdkClientUtils.unwrapAndConvertToException(throwable, OpenSearchStatusException.class);
-                            doubleWrapperListener.onFailure(e);
-                        }
-                    });
+                    sdkClient
+                        .searchDataObjectAsync(searchDataObjectRequest)
+                        .whenComplete(SdkClientUtils.wrapSearchCompletion(doubleWrapperListener));
                 }, e -> {
                     log.error("Fail to search model groups!", e);
                     wrappedListener.onFailure(e);
@@ -206,20 +184,9 @@ public class MLSearchHandler {
                     .searchSourceBuilder(modelGroupSearchRequest.source())
                     .tenantId(tenantId)
                     .build();
-                sdkClient.searchDataObjectAsync(searchDataObjectRequest).whenComplete((r, throwable) -> {
-                    if (throwable == null) {
-                        try {
-                            SearchResponse searchResponse = SearchResponse.fromXContent(r.parser());
-                            log.info("Model search complete: {}", searchResponse.getHits().getTotalHits());
-                            modelGroupSearchActionListener.onResponse(searchResponse);
-                        } catch (Exception e) {
-                            modelGroupSearchActionListener.onFailure(e);
-                        }
-                    } else {
-                        Exception e = SdkClientUtils.unwrapAndConvertToException(throwable, OpenSearchStatusException.class);
-                        modelGroupSearchActionListener.onFailure(e);
-                    }
-                });
+                sdkClient
+                    .searchDataObjectAsync(searchDataObjectRequest)
+                    .whenComplete(SdkClientUtils.wrapSearchCompletion(modelGroupSearchActionListener));
             }
         } catch (Exception e) {
             log.error(e.getMessage(), e);

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
@@ -156,7 +156,8 @@ public class DeleteModelGroupTransportAction extends HandledTransportAction<Acti
         }
 
         try {
-            SearchResponse response = SearchResponse.fromXContent(searchResponse.parser());
+            SearchResponse response = searchResponse.searchResponse();
+            // Parsing failure would cause NPE on next line
             if (response.getHits().getHits().length == 0) {
                 DeleteRequest deleteRequest = new DeleteRequest(ML_MODEL_GROUP_INDEX, modelGroupId);
                 deleteModelGroup(deleteRequest, tenantId, listener);

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
@@ -9,8 +9,6 @@ import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_GROUP_ID;
 
-import java.io.IOException;
-
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
@@ -211,10 +209,10 @@ public class DeleteModelGroupTransportAction extends HandledTransportAction<Acti
             actionListener.onFailure(cause);
         } else {
             try {
-                DeleteResponse deleteResponse = DeleteResponse.fromXContent(response.parser());
+                DeleteResponse deleteResponse = response.deleteResponse();
                 log.debug("Completed Delete Model Group Request, model group id:{} deleted", response.id());
                 actionListener.onResponse(deleteResponse);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 actionListener.onFailure(e);
             }
         }

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/GetModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/GetModelGroupTransportAction.java
@@ -146,7 +146,7 @@ public class GetModelGroupTransportAction extends HandledTransportAction<ActionR
         ActionListener<MLModelGroupGetResponse> wrappedListener
     ) {
         try {
-            GetResponse gr = getDataObjectResponse.parser() == null ? null : GetResponse.fromXContent(getDataObjectResponse.parser());
+            GetResponse gr = getDataObjectResponse.getResponse();
             if (gr != null && gr.isExists()) {
                 try (
                     XContentParser parser = jsonXContent

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupAction.java
@@ -131,7 +131,7 @@ public class TransportUpdateModelGroupAction extends HandledTransportAction<Acti
                     }
                 } else {
                     try {
-                        GetResponse gr = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                        GetResponse gr = r.getResponse();
                         if (gr != null && gr.isExists()) {
                             try (
                                 XContentParser parser = jsonXContent

--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -168,7 +168,7 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
             sdkClient.getDataObjectAsync(getDataObjectRequest).whenComplete((r, throwable) -> {
                 if (throwable == null) {
                     try {
-                        GetResponse gr = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                        GetResponse gr = r.getResponse();
                         if (gr != null && gr.isExists()) {
                             try (
                                 XContentParser parser = jsonXContent

--- a/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/DeleteModelTransportAction.java
@@ -332,7 +332,7 @@ public class DeleteModelTransportAction extends HandledTransportAction<ActionReq
         sdkClient.deleteDataObjectAsync(deleteDataObjectRequest).whenComplete((r, throwable) -> {
             if (throwable == null) {
                 try {
-                    DeleteResponse deleteResponse = DeleteResponse.fromXContent(r.parser());
+                    DeleteResponse deleteResponse = r.deleteResponse();
                     deleteModelChunksAndController(actionListener, modelId, functionName, isHidden, deleteResponse);
                 } catch (Exception e) {
                     actionListener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/action/models/GetModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/GetModelTransportAction.java
@@ -113,7 +113,7 @@ public class GetModelTransportAction extends HandledTransportAction<ActionReques
             sdkClient.getDataObjectAsync(getDataObjectRequest).whenComplete((r, throwable) -> {
                 if (throwable == null) {
                     try {
-                        GetResponse gr = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                        GetResponse gr = r.getResponse();
                         if (gr != null && gr.isExists()) {
                             try (
                                 XContentParser parser = jsonXContent

--- a/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
@@ -450,8 +450,7 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         sdkClient.updateDataObjectAsync(updateDataObjectRequest).whenComplete((ur, ut) -> {
             if (ut == null) {
                 try {
-                    UpdateResponse updateResponse = ur.parser() == null ? null : UpdateResponse.fromXContent(ur.parser());
-                    updateListener.onResponse(updateResponse);
+                    updateListener.onResponse(ur.updateResponse());
                 } catch (Exception e) {
                     updateListener.onFailure(e);
                 }
@@ -503,8 +502,7 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                 sdkClient.updateDataObjectAsync(updateDataObjectRequest).whenComplete((ur, ut) -> {
                     if (ut == null) {
                         try {
-                            UpdateResponse updateResponse = ur.parser() == null ? null : UpdateResponse.fromXContent(ur.parser());
-                            updateListener.onResponse(updateResponse);
+                            updateListener.onResponse(ur.updateResponse());
                         } catch (Exception e) {
                             updateListener.onFailure(e);
                         }

--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/DeleteTaskTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/DeleteTaskTransportAction.java
@@ -9,8 +9,6 @@ import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
 
-import java.io.IOException;
-
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
@@ -192,10 +190,10 @@ public class DeleteTaskTransportAction extends HandledTransportAction<ActionRequ
 
     private void processDeleteResponse(DeleteDataObjectResponse deleteDataObjectResponse, ActionListener<DeleteResponse> actionListener) {
         try {
-            DeleteResponse deleteResponse = DeleteResponse.fromXContent(deleteDataObjectResponse.parser());
+            DeleteResponse deleteResponse = deleteDataObjectResponse.deleteResponse();
             log.info("Task deletion result: {}, task id: {}", deleteResponse.getResult(), deleteResponse.getId());
             actionListener.onResponse(deleteResponse);
-        } catch (IOException e) {
+        } catch (Exception e) {
             actionListener.onFailure(e);
         }
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
@@ -279,7 +279,7 @@ public class GetTaskTransportAction extends HandledTransportAction<ActionRequest
         ActionListener<MLTaskGetResponse> actionListener
     ) {
         try {
-            GetResponse gr = response.parser() == null ? null : GetResponse.fromXContent(response.parser());
+            GetResponse gr = response.getResponse();
 
             if (gr == null || !gr.isExists()) {
                 actionListener.onFailure(new OpenSearchStatusException("Failed to find task", RestStatus.NOT_FOUND));

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelAction.java
@@ -213,7 +213,7 @@ public class TransportUndeployModelAction extends
                         wrappedListener.onFailure(cause);
                     } else {
                         try {
-                            BulkResponse bulkResponse = BulkResponse.fromXContent(r.parser());
+                            BulkResponse bulkResponse = r.bulkResponse();
                             log
                                 .info(
                                     "Executed {} bulk operations with {} failures, Took: {}",

--- a/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/undeploy/TransportUndeployModelsAction.java
@@ -354,7 +354,8 @@ public class TransportUndeployModelsAction extends HandledTransportAction<Action
                     }
                 } else {
                     try {
-                        SearchResponse searchResponse = SearchResponse.fromXContent(r.parser());
+                        SearchResponse searchResponse = r.searchResponse();
+                        // Parsing failure would cause NPE on next line
                         log.info("Model Index search complete: {}", searchResponse.getHits().getTotalHits());
                         listener.onResponse(searchResponse);
                     } catch (Exception e) {

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLSyncUpCron.java
@@ -324,7 +324,8 @@ public class MLSyncUpCron implements Runnable {
             sdkClient.searchDataObjectAsync(searchRequest).whenComplete((r, throwable) -> {
                 if (throwable == null) {
                     try {
-                        SearchResponse res = SearchResponse.fromXContent(r.parser());
+                        SearchResponse res = r.searchResponse();
+                        // Parsing failure would cause NPE on next line
                         SearchHit[] hits = res.getHits().getHits();
                         Map<String, String> tenantIds = new HashMap<>();
                         Map<String, MLModelState> newModelStates = new HashMap<>();

--- a/plugin/src/main/java/org/opensearch/ml/helper/ConnectorAccessControlHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/ConnectorAccessControlHelper.java
@@ -194,7 +194,7 @@ public class ConnectorAccessControlHelper {
                 }
             } else {
                 try {
-                    GetResponse gr = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                    GetResponse gr = r.getResponse();
                     if (gr != null && gr.isExists()) {
                         try (
                             XContentParser parser = jsonXContent

--- a/plugin/src/main/java/org/opensearch/ml/helper/ModelAccessControlHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/ModelAccessControlHelper.java
@@ -151,7 +151,7 @@ public class ModelAccessControlHelper {
             sdkClient.getDataObjectAsync(getModelGroupRequest).whenComplete((r, throwable) -> {
                 if (throwable == null) {
                     try {
-                        GetResponse gr = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                        GetResponse gr = r.getResponse();
                         if (gr != null && gr.isExists()) {
                             try (
                                 XContentParser parser = jsonXContent

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -246,10 +246,11 @@ public class MLModelGroupManager {
                     }
                 } else {
                     try {
-                        SearchResponse searchResponse = SearchResponse.fromXContent(r.parser());
+                        SearchResponse searchResponse = r.searchResponse();
+                        // Parsing failure would cause NPE on next line
                         log.info("Model group search complete: {}", searchResponse.getHits().getTotalHits());
                         listener.onResponse(searchResponse);
-                    } catch (IOException e) {
+                    } catch (Exception e) {
                         log.error("Failed to parse search response", e);
                         listener
                             .onFailure(new OpenSearchStatusException("Failed to parse search response", RestStatus.INTERNAL_SERVER_ERROR));

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -145,7 +145,7 @@ public class MLModelGroupManager {
                                         wrappedListener.onFailure(cause);
                                     } else {
                                         try {
-                                            IndexResponse indexResponse = IndexResponse.fromXContent(r.parser());
+                                            IndexResponse indexResponse = r.indexResponse();
                                             log
                                                 .info(
                                                     "Model group creation result: {}, model group id: {}",

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelGroupManager.java
@@ -8,7 +8,6 @@ package org.opensearch.ml.model;
 import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.HashSet;
 
@@ -294,7 +293,7 @@ public class MLModelGroupManager {
 
     private void processModelGroupResponse(GetDataObjectResponse response, String modelGroupId, ActionListener<GetResponse> listener) {
         try {
-            GetResponse getResponse = parseGetResponse(response);
+            GetResponse getResponse = response.getResponse();
             if (getResponse == null || !getResponse.isExists()) {
                 listener.onFailure(new MLResourceNotFoundException("Failed to find model group with ID: " + modelGroupId));
                 return;
@@ -304,10 +303,6 @@ public class MLModelGroupManager {
         } catch (Exception e) {
             listener.onFailure(e);
         }
-    }
-
-    private GetResponse parseGetResponse(GetDataObjectResponse response) throws IOException {
-        return response.parser() == null ? null : GetResponse.fromXContent(response.parser());
     }
 
     private void parseAndRespond(GetResponse getResponse, ActionListener<GetResponse> listener) {

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -661,19 +661,7 @@ public class MLModelManager {
                 });
 
                 ThreadedActionListener<IndexResponse> putListener = threadedActionListener(REGISTER_THREAD_POOL, indexListener);
-                sdkClient.putDataObjectAsync(putModelMetaRequest).whenComplete((r, throwable) -> {
-                    if (throwable == null) {
-                        try {
-                            IndexResponse ir = IndexResponse.fromXContent(r.parser());
-                            putListener.onResponse(ir);
-                        } catch (Exception e) {
-                            putListener.onFailure(e);
-                        }
-                    } else {
-                        Exception e = SdkClientUtils.unwrapAndConvertToException(throwable);
-                        putListener.onFailure(e);
-                    }
-                });
+                sdkClient.putDataObjectAsync(putModelMetaRequest).whenComplete(SdkClientUtils.wrapPutCompletion(putListener));
             }, error -> {
                 // failed to initialize the model index
                 log.error("Failed to init model index", error);
@@ -764,19 +752,7 @@ public class MLModelManager {
                 });
 
                 ThreadedActionListener<IndexResponse> putListener = threadedActionListener(REGISTER_THREAD_POOL, indexListener);
-                sdkClient.putDataObjectAsync(putModelMetaRequest).whenComplete((r, throwable) -> {
-                    if (throwable == null) {
-                        try {
-                            IndexResponse ir = IndexResponse.fromXContent(r.parser());
-                            putListener.onResponse(ir);
-                        } catch (Exception e) {
-                            putListener.onFailure(e);
-                        }
-                    } else {
-                        Exception e = SdkClientUtils.unwrapAndConvertToException(throwable);
-                        putListener.onFailure(e);
-                    }
-                });
+                sdkClient.putDataObjectAsync(putModelMetaRequest).whenComplete(SdkClientUtils.wrapPutCompletion(putListener));
 
             }, e -> {
                 log.error("Failed to init model index", e);

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -55,7 +55,6 @@ import static org.opensearch.ml.utils.MLNodeUtils.checkOpenCircuitBreaker;
 import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.security.PrivilegedActionException;
 import java.time.Instant;
@@ -2271,9 +2270,8 @@ public class MLModelManager {
             updateListener.onFailure(cause);
         } else {
             try {
-                UpdateResponse updateResponse = r.parser() == null ? null : UpdateResponse.fromXContent(r.parser());
-                updateListener.onResponse(updateResponse);
-            } catch (IOException e) {
+                updateListener.onResponse(r.updateResponse());
+            } catch (Exception e) {
                 updateListener.onFailure(e);
             }
         }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -408,7 +408,7 @@ public class MLModelManager {
             sdkClient.getDataObjectAsync(getModelGroupRequest).whenComplete((r, throwable) -> {
                 if (throwable == null) {
                     try {
-                        GetResponse getModelGroupResponse = GetResponse.fromXContent(r.parser());
+                        GetResponse getModelGroupResponse = r.getResponse();
                         if (getModelGroupResponse.isExists()) {
                             Map<String, Object> modelGroupSourceMap = getModelGroupResponse.getSourceAsMap();
                             int updatedVersion = incrementLatestVersion(modelGroupSourceMap);
@@ -1938,7 +1938,7 @@ public class MLModelManager {
         sdkClient.getDataObjectAsync(getRequest).whenComplete((r, throwable) -> {
             if (throwable == null) {
                 try {
-                    GetResponse gr = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                    GetResponse gr = r.getResponse();
                     if (gr != null && gr.isExists()) {
                         try (
                             XContentParser parser = jsonXContent
@@ -2006,7 +2006,7 @@ public class MLModelManager {
 
     private void processGetResponse(GetDataObjectResponse response, String modelId, ActionListener<MLModel> listener) {
         try {
-            GetResponse getResponse = parseGetResponse(response);
+            GetResponse getResponse = response.getResponse();
             if (getResponse == null || !getResponse.isExists()) {
                 listener.onFailure(new OpenSearchStatusException("Failed to find model", RestStatus.NOT_FOUND));
                 return;
@@ -2016,10 +2016,6 @@ public class MLModelManager {
         } catch (Exception e) {
             listener.onFailure(e);
         }
-    }
-
-    private GetResponse parseGetResponse(GetDataObjectResponse response) throws IOException {
-        return response.parser() == null ? null : GetResponse.fromXContent(response.parser());
     }
 
     private void parseAndReturnModel(GetResponse getResponse, String algorithmName, String modelId, ActionListener<MLModel> listener) {
@@ -2092,7 +2088,7 @@ public class MLModelManager {
                     }
                 } else {
                     try {
-                        GetResponse gr = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                        GetResponse gr = r.getResponse();
                         if (gr != null && gr.isExists()) {
                             try (
                                 XContentParser parser = MLNodeUtils

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -304,7 +304,7 @@ public class MLTaskManager {
                             listener.onFailure(cause);
                         } else {
                             try {
-                                IndexResponse indexResponse = IndexResponse.fromXContent(r.parser());
+                                IndexResponse indexResponse = r.indexResponse();
                                 log.info("Task creation result: {}, Task id: {}", indexResponse.getResult(), indexResponse.getId());
                                 listener.onResponse(indexResponse);
                             } catch (Exception e) {

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -505,9 +505,8 @@ public class MLTaskManager {
             updateListener.onFailure(cause);
         } else {
             try {
-                UpdateResponse updateResponse = r.parser() == null ? null : UpdateResponse.fromXContent(r.parser());
-                updateListener.onResponse(updateResponse);
-            } catch (IOException e) {
+                updateListener.onResponse(r.updateResponse());
+            } catch (Exception e) {
                 updateListener.onFailure(e);
             }
         }


### PR DESCRIPTION
### Description

Updates ML Commons SdkClient usage to take advantage of https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/141 which will directly pass response objects from NodeClient and avoid serialization and parsing.

In the case of Search, this fixes the aggregation bug reported:
 - https://github.com/opensearch-project/ml-commons-dashboards/issues/410
 - https://github.com/opensearch-project/ml-commons/issues/3713
 - https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/132

### Related Issues
Resolves the bugs listed above.

### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
