### PR TITLE
Add Unit Tests for MCP feature

### DIFF
--- a/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
@@ -1,0 +1,267 @@
+package org.opensearch.ml.common.connector;
+
+import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
+import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_SSE;
+import static org.opensearch.ml.common.connector.RetryBackoffPolicy.CONSTANT;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.AccessMode;
+import org.opensearch.ml.common.TestHelper;
+import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
+import org.opensearch.search.SearchModule;
+
+public class McpConnectorTest {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    BiFunction<String, String, String> encryptFunction;
+    BiFunction<String, String, String> decryptFunction;
+
+    String TEST_CONNECTOR_JSON_STRING =
+        "{\"name\":\"test_mcp_connector_name\",\"version\":\"1\",\"description\":\"this is a test mcp connector\",\"protocol\":\"mcp_sse\",\"credential\":{\"key\":\"test_key_value\"},\"backend_roles\":[\"role1\",\"role2\"],\"access\":\"public\",\"client_config\":{\"max_connection\":30,\"connection_timeout\":30000,\"read_timeout\":30000,\"retry_backoff_millis\":10,\"retry_timeout_seconds\":10,\"max_retry_times\":-1,\"retry_backoff_policy\":\"constant\"},\"url\":\"https://test.com\",\"headers\":{\"api_key\":\"${credential.key}\"}}";
+
+    @Before
+    public void setUp() {
+        encryptFunction = (s, v) -> "encrypted: " + s.toLowerCase(Locale.ROOT);
+        decryptFunction = (s, v) -> "decrypted: " + s.toUpperCase(Locale.ROOT);
+    }
+
+    @Test
+    public void constructor_InvalidProtocol() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse]");
+
+        McpConnector.builder().protocol("wrong protocol").build();
+    }
+
+    @Test
+    public void writeTo() throws IOException {
+        McpConnector connector = createMcpConnector();
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        connector.writeTo(output);
+
+        McpConnector connector2 = new McpConnector(output.bytes().streamInput());
+        Assert.assertEquals(connector, connector2);
+    }
+
+    @Test
+    public void toXContent() throws IOException {
+        McpConnector connector = createMcpConnector();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        connector.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+
+        Assert.assertEquals(TEST_CONNECTOR_JSON_STRING, content);
+    }
+
+    @Test
+    public void constructor_Parser() throws IOException {
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                TEST_CONNECTOR_JSON_STRING
+            );
+        parser.nextToken();
+
+        McpConnector connector = new McpConnector("mcp_sse", parser);
+        Assert.assertEquals("test_mcp_connector_name", connector.getName());
+        Assert.assertEquals("1", connector.getVersion());
+        Assert.assertEquals("this is a test mcp connector", connector.getDescription());
+        Assert.assertEquals("mcp_sse", connector.getProtocol());
+        Assert.assertEquals(AccessMode.PUBLIC, connector.getAccess());
+        Assert.assertEquals("https://test.com", connector.getUrl());
+        connector.decrypt(PREDICT.name(), decryptFunction, null);
+        Map<String, String> decryptedCredential = connector.getDecryptedCredential();
+        Assert.assertEquals(1, decryptedCredential.size());
+        Assert.assertEquals("decrypted: TEST_KEY_VALUE", decryptedCredential.get("key"));
+        Assert.assertNotNull(connector.getDecryptedHeaders());
+        Assert.assertEquals(1, connector.getDecryptedHeaders().size());
+        Assert.assertEquals("decrypted: TEST_KEY_VALUE", connector.getDecryptedHeaders().get("api_key"));
+    }
+
+    @Test
+    public void cloneConnector() {
+        McpConnector connector = createMcpConnector();
+        Connector connector2 = connector.cloneConnector();
+        Assert.assertEquals(connector, connector2);
+    }
+
+    @Test
+    public void decrypt() {
+        McpConnector connector = createMcpConnector();
+        connector.decrypt("", decryptFunction, null);
+        Map<String, String> decryptedCredential = connector.getDecryptedCredential();
+        Assert.assertEquals(1, decryptedCredential.size());
+        Assert.assertEquals("decrypted: TEST_KEY_VALUE", decryptedCredential.get("key"));
+        Assert.assertNotNull(connector.getDecryptedHeaders());
+        Assert.assertEquals(1, connector.getDecryptedHeaders().size());
+        Assert.assertEquals("decrypted: TEST_KEY_VALUE", connector.getDecryptedHeaders().get("api_key"));
+
+        connector.removeCredential();
+        Assert.assertNull(connector.getCredential());
+        Assert.assertNull(connector.getDecryptedCredential());
+        Assert.assertNull(connector.getDecryptedHeaders());
+    }
+
+    @Test
+    public void encrypt() {
+        McpConnector connector = createMcpConnector();
+        connector.encrypt(encryptFunction, null);
+        Map<String, String> credential = connector.getCredential();
+        Assert.assertEquals(1, credential.size());
+        Assert.assertEquals("encrypted: test_key_value", credential.get("key"));
+
+        connector.removeCredential();
+        Assert.assertNull(connector.getCredential());
+        Assert.assertNull(connector.getDecryptedCredential());
+        Assert.assertNull(connector.getDecryptedHeaders());
+    }
+
+    @Test
+    public void validateConnectorURL_Invalid() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Connector URL is not matching the trusted connector endpoint regex");
+        McpConnector connector = createMcpConnector();
+        connector
+            .validateConnectorURL(
+                Arrays
+                    .asList(
+                        "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                        "^https://api\\.openai\\.com/.*$",
+                        "^https://api\\.cohere\\.ai/.*$",
+                        "^https://bedrock-agent-runtime\\\\..*[a-z0-9-]\\\\.amazonaws\\\\.com/.*$"
+                    )
+            );
+    }
+
+    @Test
+    public void validateConnectorURL() {
+        McpConnector connector = createMcpConnector();
+        connector
+            .validateConnectorURL(
+                Arrays
+                    .asList(
+                        "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                        "^https://api\\.openai\\.com/.*$",
+                        "^https://bedrock-agent-runtime\\\\..*[a-z0-9-]\\\\.amazonaws\\\\.com/.*$",
+                        "^" + connector.getUrl()
+                    )
+            );
+    }
+
+    @Test
+    public void testUpdate() {
+        McpConnector connector = createMcpConnector();
+        Map<String, String> initialCredential = new HashMap<>(connector.getCredential());
+
+        // Create update content
+        String updatedName = "updated_name";
+        String updatedDescription = "updated description";
+        String updatedVersion = "2";
+        Map<String, String> updatedCredential = new HashMap<>();
+        updatedCredential.put("new_key", "new_value");
+        List<String> updatedBackendRoles = List.of("role3", "role4");
+        AccessMode updatedAccessMode = AccessMode.PRIVATE;
+        ConnectorClientConfig updatedClientConfig = new ConnectorClientConfig(40, 40000, 40000, 20, 20, 5, CONSTANT);
+        String updatedUrl = "https://updated.test.com";
+        Map<String, String> updatedHeaders = new HashMap<>();
+        updatedHeaders.put("new_header", "new_header_value");
+        updatedHeaders.put("updated_api_key", "${credential.new_key}"); // Referencing new credential key
+
+        MLCreateConnectorInput updateInput = MLCreateConnectorInput.builder()
+                .name(updatedName)
+                .description(updatedDescription)
+                .version(updatedVersion)
+                .credential(updatedCredential)
+                .backendRoles(updatedBackendRoles)
+                .access(updatedAccessMode)
+                .connectorClientConfig(updatedClientConfig)
+                .url(updatedUrl)
+                .headers(updatedHeaders)
+                .protocol(MCP_SSE)
+                .build();
+
+        // Call the update method
+        connector.update(updateInput, encryptFunction);
+
+        // Assertions
+        Assert.assertEquals(updatedName, connector.getName());
+        Assert.assertEquals(updatedDescription, connector.getDescription());
+        Assert.assertEquals(updatedVersion, connector.getVersion());
+        Assert.assertEquals(MCP_SSE, connector.getProtocol()); // Should not change if not provided
+        Assert.assertEquals(updatedBackendRoles, connector.getBackendRoles());
+        Assert.assertEquals(updatedAccessMode, connector.getAccess());
+        Assert.assertEquals(updatedClientConfig, connector.getConnectorClientConfig());
+        Assert.assertEquals(updatedUrl, connector.getUrl());
+        Assert.assertEquals(updatedHeaders, connector.getHeaders());
+
+        // Check encrypted credentials
+        Map<String, String> currentCredential = connector.getCredential();
+        Assert.assertNotNull(currentCredential);
+        Assert.assertEquals(1, currentCredential.size()); // Should replace old credentials
+        Assert.assertEquals("encrypted: new_value", currentCredential.get("new_key"));
+        Assert.assertNotEquals(initialCredential, currentCredential);
+
+        // Check decrypted credentials and headers (need to explicitly decrypt after update)
+        connector.decrypt("", decryptFunction, null); // Use decrypt function from setUp
+        Map<String, String> decryptedCredential = connector.getDecryptedCredential();
+        Assert.assertNotNull(decryptedCredential);
+        Assert.assertEquals(1, decryptedCredential.size());
+        Assert.assertEquals("decrypted: ENCRYPTED: NEW_VALUE", decryptedCredential.get("new_key")); // Uses the decrypt function logic
+
+        Map<String, String> decryptedHeaders = connector.getDecryptedHeaders();
+        Assert.assertNotNull(decryptedHeaders);
+        Assert.assertEquals(2, decryptedHeaders.size());
+        Assert.assertEquals("new_header_value", decryptedHeaders.get("new_header"));
+        Assert.assertEquals("decrypted: ENCRYPTED: NEW_VALUE", decryptedHeaders.get("updated_api_key")); // Check header substitution
+    }
+
+    public static McpConnector createMcpConnector() {
+        Map<String, String> credential = new HashMap<>();
+        credential.put("key", "test_key_value");
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("api_key", "${credential.key}");
+
+        ConnectorClientConfig clientConfig = new ConnectorClientConfig(30, 30000, 30000, 10, 10, -1, RetryBackoffPolicy.CONSTANT);
+
+        return McpConnector
+            .builder()
+            .name("test_mcp_connector_name")
+            .version("1")
+            .description("this is a test mcp connector")
+            .protocol(MCP_SSE)
+            .credential(credential)
+            .backendRoles(List.of("role1", "role2"))
+            .accessMode(AccessMode.PUBLIC)
+            .connectorClientConfig(clientConfig)
+            .url("https://test.com")
+            .headers(headers)
+            .build();
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.connector;
 
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;

--- a/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
@@ -193,18 +193,19 @@ public class McpConnectorTest {
         updatedHeaders.put("new_header", "new_header_value");
         updatedHeaders.put("updated_api_key", "${credential.new_key}"); // Referencing new credential key
 
-        MLCreateConnectorInput updateInput = MLCreateConnectorInput.builder()
-                .name(updatedName)
-                .description(updatedDescription)
-                .version(updatedVersion)
-                .credential(updatedCredential)
-                .backendRoles(updatedBackendRoles)
-                .access(updatedAccessMode)
-                .connectorClientConfig(updatedClientConfig)
-                .url(updatedUrl)
-                .headers(updatedHeaders)
-                .protocol(MCP_SSE)
-                .build();
+        MLCreateConnectorInput updateInput = MLCreateConnectorInput
+            .builder()
+            .name(updatedName)
+            .description(updatedDescription)
+            .version(updatedVersion)
+            .credential(updatedCredential)
+            .backendRoles(updatedBackendRoles)
+            .access(updatedAccessMode)
+            .connectorClientConfig(updatedClientConfig)
+            .url(updatedUrl)
+            .headers(updatedHeaders)
+            .protocol(MCP_SSE)
+            .build();
 
         // Call the update method
         connector.update(updateInput, encryptFunction);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -95,10 +95,10 @@ public class AgentUtilsTest extends MLStaticMockBase {
     @Mock
     private Encryptor encryptor;
 
-    ThreadContext threadContext;
+    private ThreadContext threadContext;
 
     @Mock
-    ThreadPool threadPool;
+    private ThreadPool threadPool;
 
     private Map<String, Map<String, String>> llmResponseExpectedParseResults;
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -1197,7 +1197,7 @@ public class AgentUtilsTest extends MLStaticMockBase {
         Assert.assertTrue(output3.get(FINAL_ANSWER).contains("This is a test response"));
     }
 
-    private static MLToolSpec tool(String name) {
+    private static MLToolSpec buildTool(String name) {
         return MLToolSpec.builder().type(McpSseTool.TYPE).name(name).description("mock").build();
     }
 
@@ -1253,7 +1253,7 @@ public class AgentUtilsTest extends MLStaticMockBase {
     @Test
     public void testGetMcpToolSpecs_SingleConnectorSuccess() throws Exception {
         stubGetConnector();
-        List<MLToolSpec> expected = List.of(tool("Demo"));
+        List<MLToolSpec> expected = List.of(buildTool("Demo"));
 
         try (
             MockedStatic<Connector> connStatic = mockStatic(Connector.class);
@@ -1277,8 +1277,8 @@ public class AgentUtilsTest extends MLStaticMockBase {
     @Test
     public void testGetMcpToolSpecs_ToolFilterApplied() throws Exception {
         stubGetConnector();
-        List<MLToolSpec> repo = List.of(tool("FilterTool"), tool("TempTool"));
-        List<MLToolSpec> expected = List.of(tool("FilterTool"));
+        List<MLToolSpec> repo = List.of(buildTool("FilterTool"), buildTool("TempTool"));
+        List<MLToolSpec> expected = List.of(buildTool("FilterTool"));
 
         try (
             MockedStatic<Connector> connStatic = mockStatic(Connector.class);
@@ -1310,8 +1310,8 @@ public class AgentUtilsTest extends MLStaticMockBase {
     public void testGetMcpToolSpecs_MultipleConnectorsMerged() throws Exception {
         stubGetConnector();                                  // now safe
 
-        List<MLToolSpec> aTools = List.of(tool("A1"));
-        List<MLToolSpec> bTools = List.of(tool("B1"), tool("B2"));
+        List<MLToolSpec> aTools = List.of(buildTool("A1"));
+        List<MLToolSpec> bTools = List.of(buildTool("B1"), buildTool("B2"));
         List<MLToolSpec> expected = new ArrayList<>();
         expected.addAll(aTools);
         expected.addAll(bTools);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
@@ -51,7 +51,7 @@ public class McpConnectorExecutorTest extends MLStaticMockBase {
     public void getMcpToolSpecs_returnsExpectedSpecs() {
 
         String inputSchemaJSON =
-                "{\"type\":\"object\",\"properties\":{\"state\":{\"title\":\"State\",\"type\":\"string\"}},\"required\":[\"state\"],\"additionalProperties\":false}";
+            "{\"type\":\"object\",\"properties\":{\"state\":{\"title\":\"State\",\"type\":\"string\"}},\"required\":[\"state\"],\"additionalProperties\":false}";
 
         McpSchema.Tool tool = new McpSchema.Tool("tool1", "desc1", inputSchemaJSON);
         McpSchema.ListToolsResult mockTools = new McpSchema.ListToolsResult(List.of(tool), null);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
@@ -1,0 +1,92 @@
+package org.opensearch.ml.engine.algorithms.remote;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.connector.McpConnector;
+import org.opensearch.ml.engine.MLStaticMockBase;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+
+public class McpConnectorExecutorTest extends MLStaticMockBase {
+
+    @Mock
+    private McpConnector mockConnector;
+    @Mock
+    private McpSyncClient mcpClient;
+    @Mock
+    private McpClient.SyncSpec builder;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        Map<String, String> decryptedHeaders = Map.of("Authorization", "Bearer secret-token");
+
+        when(mockConnector.getUrl()).thenReturn("http://random-url");
+        when(mockConnector.getDecryptedHeaders()).thenReturn(decryptedHeaders);
+
+        /* ---------- stub the fluent builder chain ------------------------ */
+        when(builder.requestTimeout(any())).thenReturn(builder);
+        when(builder.capabilities(any())).thenReturn(builder);
+        when(builder.build()).thenReturn(mcpClient);
+    }
+
+    @Test
+    public void getMcpToolSpecs_returnsExpectedSpecs() {
+
+        String inputSchemaJSON =
+                "{\"type\":\"object\",\"properties\":{\"state\":{\"title\":\"State\",\"type\":\"string\"}},\"required\":[\"state\"],\"additionalProperties\":false}";
+
+        McpSchema.Tool tool = new McpSchema.Tool("tool1", "desc1", inputSchemaJSON);
+        McpSchema.ListToolsResult mockTools = new McpSchema.ListToolsResult(List.of(tool), null);
+
+        when(mcpClient.listTools()).thenReturn(mockTools);
+        when(mcpClient.initialize()).thenReturn(null);
+
+        try (MockedStatic<McpClient> mocked = mockStatic(McpClient.class)) {
+            mocked.when(() -> McpClient.sync(any(McpClientTransport.class))).thenReturn(builder);
+            McpConnectorExecutor exec = new McpConnectorExecutor(mockConnector);
+            List<MLToolSpec> specs = exec.getMcpToolSpecs();
+
+            Assert.assertEquals(1, specs.size());
+            MLToolSpec spec = specs.get(0);
+            Assert.assertEquals("tool1", spec.getName());
+            Assert.assertEquals("desc1", spec.getDescription());
+            Assert.assertEquals(inputSchemaJSON, spec.getAttributes().get("input_schema"));
+            Assert.assertSame(mcpClient, spec.getRuntimeResources().get("mcp_sync_client"));
+            mocked.verify(() -> McpClient.sync(any(McpClientTransport.class)));
+            verify(builder, times(1)).build();
+            verify(mcpClient, times(1)).initialize();
+            verify(mcpClient, times(1)).listTools();
+        }
+    }
+
+    @Test
+    public void getMcpToolSpecs_throwsOnInitError() {
+
+        when(mcpClient.initialize()).thenThrow(new RuntimeException("Error initializing"));
+        try (MockedStatic<McpClient> mocked = mockStatic(McpClient.class)) {
+            mocked.when(() -> McpClient.sync(any(McpClientTransport.class))).thenReturn(builder);
+            McpConnectorExecutor exec = new McpConnectorExecutor(mockConnector);
+
+            assertThrows(RuntimeException.class, () -> exec.getMcpToolSpecs());
+        }
+    }
+
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.junit.Assert.assertThrows;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.tools;
 
 import static org.junit.Assert.assertEquals;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
@@ -1,9 +1,9 @@
 package org.opensearch.ml.engine.tools;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -38,9 +38,7 @@ public class McpSseToolTests {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         // Initialize the tool with the mocked client
-        tool = McpSseTool.Factory.getInstance().create(
-                Map.of(MCP_SYNC_CLIENT, mcpSyncClient)
-        );
+        tool = McpSseTool.Factory.getInstance().create(Map.of(MCP_SYNC_CLIENT, mcpSyncClient));
         validParams = Map.of("input", "{\"foo\":\"bar\"}");
     }
 
@@ -48,16 +46,13 @@ public class McpSseToolTests {
     public void testRunSuccess() {
         // Arrange: create a CallToolResult wrapping a JSON string
         McpSchema.CallToolResult result = new McpSchema.CallToolResult("{\"foo\":\"bar\"}", false);
-        when(mcpSyncClient.callTool(any(McpSchema.CallToolRequest.class)))
-                .thenReturn(result);
+        when(mcpSyncClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(result);
 
         // Act
         tool.run(validParams, listener);
 
         // Assert: ensure onResponse is called with the JSON string
-        verify(listener).onResponse(
-                "[{\"text\":\"{\\\"foo\\\":\\\"bar\\\"}\"}]"
-        );
+        verify(listener).onResponse("[{\"text\":\"{\\\"foo\\\":\\\"bar\\\"}\"}]");
         verify(listener, never()).onFailure(any());
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
@@ -1,0 +1,114 @@
+package org.opensearch.ml.engine.tools;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.CommonValue.MCP_SYNC_CLIENT;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.spi.tools.Tool;
+
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+
+public class McpSseToolTests {
+
+    @Mock
+    private McpSyncClient mcpSyncClient;
+
+    @Mock
+    private ActionListener<String> listener;
+
+    private Tool tool;
+    private Map<String, String> validParams;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        // Initialize the tool with the mocked client
+        tool = McpSseTool.Factory.getInstance().create(
+                Map.of(MCP_SYNC_CLIENT, mcpSyncClient)
+        );
+        validParams = Map.of("input", "{\"foo\":\"bar\"}");
+    }
+
+    @Test
+    public void testRunSuccess() {
+        // Arrange: create a CallToolResult wrapping a JSON string
+        McpSchema.CallToolResult result = new McpSchema.CallToolResult("{\"foo\":\"bar\"}", false);
+        when(mcpSyncClient.callTool(any(McpSchema.CallToolRequest.class)))
+                .thenReturn(result);
+
+        // Act
+        tool.run(validParams, listener);
+
+        // Assert: ensure onResponse is called with the JSON string
+        verify(listener).onResponse(
+                "[{\"text\":\"{\\\"foo\\\":\\\"bar\\\"}\"}]"
+        );
+        verify(listener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testRunInvalidJsonInput() {
+        // Passing a non-JSON string should trigger failure in parsing
+        Map<String, String> badParams = Map.of("input", "not-json");
+        tool.run(badParams, listener);
+
+        verify(listener).onFailure(any(Exception.class));
+        verify(listener, never()).onResponse(any());
+    }
+
+    @Test
+    public void testRunClientThrows() {
+        // Simulate the MCP client throwing an exception
+        when(mcpSyncClient.callTool(any())).thenThrow(new RuntimeException("client error"));
+
+        tool.run(validParams, listener);
+
+        verify(listener).onFailure(any(RuntimeException.class));
+        verify(listener, never()).onResponse(any());
+    }
+
+    @Test
+    public void testRunMissingInputParam() {
+        // No "input" key in parameters should also be caught
+        tool.run(Collections.emptyMap(), listener);
+
+        verify(listener).onFailure(any(Exception.class));
+        verify(listener, never()).onResponse(any());
+    }
+
+    @Test
+    public void testValidateAndMetadata() {
+        // validate
+        assertTrue(tool.validate(validParams));
+        assertFalse(tool.validate(Collections.emptyMap()));
+        // metadata
+        assertEquals(McpSseTool.TYPE, tool.getName());
+        assertEquals(McpSseTool.TYPE, tool.getType());
+        assertNull(tool.getVersion());
+        assertEquals(McpSseTool.DEFAULT_DESCRIPTION, tool.getDescription());
+    }
+
+    @Test
+    public void testFactoryDefaults() {
+        McpSseTool.Factory factory = McpSseTool.Factory.getInstance();
+        assertEquals(McpSseTool.DEFAULT_DESCRIPTION, factory.getDefaultDescription());
+        assertEquals(McpSseTool.TYPE, factory.getDefaultType());
+        assertNull(factory.getDefaultVersion());
+        assertTrue(factory.getAllModelKeys().isEmpty());
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
@@ -37,21 +37,20 @@ public class McpSseToolTests {
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        // Initialize the tool with the mocked client
+        // Initialize the tool with the mocked mcp client
         tool = McpSseTool.Factory.getInstance().create(Map.of(MCP_SYNC_CLIENT, mcpSyncClient));
         validParams = Map.of("input", "{\"foo\":\"bar\"}");
     }
 
     @Test
     public void testRunSuccess() {
-        // Arrange: create a CallToolResult wrapping a JSON string
+        // create a CallToolResult wrapping a JSON string
         McpSchema.CallToolResult result = new McpSchema.CallToolResult("{\"foo\":\"bar\"}", false);
         when(mcpSyncClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(result);
 
-        // Act
         tool.run(validParams, listener);
 
-        // Assert: ensure onResponse is called with the JSON string
+        // Assert
         verify(listener).onResponse("[{\"text\":\"{\\\"foo\\\":\\\"bar\\\"}\"}]");
         verify(listener, never()).onFailure(any());
     }
@@ -79,7 +78,7 @@ public class McpSseToolTests {
 
     @Test
     public void testRunMissingInputParam() {
-        // No "input" key in parameters should also be caught
+        // No "input" key in parameters should be caught
         tool.run(Collections.emptyMap(), listener);
 
         verify(listener).onFailure(any(Exception.class));


### PR DESCRIPTION
### Description
Adds Unit tests for MCP feature

this tests the files:
- [McpConnector.java](https://github.com/opensearch-project/ml-commons/blob/main/common/src/main/java/org/opensearch/ml/common/connector/McpConnector.java)
- [McpConnectorExecutor.java](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java)
- [getMcpToolSpecs function in Agent Utils](https://github.com/opensearch-project/ml-commons/blob/6187de8d991a64d9eefeef789fa5ee0d1e3e2390/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java#L654C24-L654C39)

We use the getConnector function in agent utils. To test the `getMcpToolSpecs`, we need to mock the internals of the get connector function using stubGetConnector() function in `AgentUtilsTest.java`. We extend the `AgentUtilsTest` class with MLStaticMockBase to mock the static methods inside `getConenctor()` function of AgentUtils


### Related Issues
Resolves #3743

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
