### PR TITLE
Downgrade MCP version to 0.9

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -85,8 +85,7 @@ dependencies {
     implementation('net.minidev:json-smart:2.5.2')
     implementation group: 'org.json', name: 'json', version: '20231013'
     implementation group: 'software.amazon.awssdk', name: 'netty-nio-client', version: "2.30.18"
-    // TODO: Replace the custom jar with dependency implementation 'io.modelcontextprotocol.sdk:mcp:0.10.0' after its release
-    api files('libs/mcp-0.10.0-SNAPSHOT.jar')
+    api('io.modelcontextprotocol.sdk:mcp:0.9.0')
     testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
@@ -82,8 +82,6 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
             Duration readTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getReadTimeout());
 
             Consumer<HttpRequest.Builder> headerConfig = builder -> {
-                builder.header("Content-Type", "application/json");
-
                 for (Map.Entry<String, String> entry : connector.getDecryptedHeaders().entrySet()) {
                     builder.header(entry.getKey(), entry.getValue());
                 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -436,6 +436,7 @@ configurations.all {
     resolutionStrategy.force "jakarta.json:jakarta.json-api:2.1.3"
     resolutionStrategy.force "org.opensearch:opensearch:${opensearch_version}"
     resolutionStrategy.force "org.bouncycastle:bcprov-jdk18on:1.78.1"
+    resolutionStrategy.force 'io.projectreactor:reactor-core:3.7.0'
 }
 
 apply plugin: 'com.netflix.nebula.ospackage'


### PR DESCRIPTION
### Description
We are using the 0.9 version of MCP to make it compatible with MCP server and also, the MCP have back ported the custom headers change to 0.9 (initially anticipated for 0.10)

Removed the extra content type header since it is being added by MCP client by default.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
