### PR TITLE
Adds Json Parsing to nested object during update Query step in ML Inference Request processor

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
@@ -46,7 +46,6 @@ import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.transport.client.Client;
 
-import com.google.gson.Gson;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -362,7 +361,7 @@ public class MLInferenceSearchRequestProcessor extends AbstractProcessor impleme
                     String modelOutputFieldName = outputMapEntry.getValue();
                     Object modelOutputValue = getModelOutputValue(mlOutput, modelOutputFieldName, ignoreMissing, fullResponsePath);
                     if (modelOutputValue instanceof Map) {
-                        modelOutputValue = new Gson().toJson(modelOutputValue);
+                        modelOutputValue = toJson(modelOutputValue);
                     }
                     valuesMap.put(newQueryField, modelOutputValue);
                 }

--- a/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessor.java
@@ -4,13 +4,23 @@
  */
 package org.opensearch.ml.processor;
 
-import com.google.gson.Gson;
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.PathNotFoundException;
-import com.jayway.jsonpath.ReadContext;
-import lombok.Getter;
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.utils.StringUtils.toJson;
+import static org.opensearch.ml.processor.InferenceProcessorAttributes.INPUT_MAP;
+import static org.opensearch.ml.processor.InferenceProcessorAttributes.MAX_PREDICTION_TASKS;
+import static org.opensearch.ml.processor.InferenceProcessorAttributes.MODEL_CONFIG;
+import static org.opensearch.ml.processor.InferenceProcessorAttributes.MODEL_ID;
+import static org.opensearch.ml.processor.InferenceProcessorAttributes.OUTPUT_MAP;
+import static org.opensearch.ml.processor.ModelExecutor.combineMaps;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -36,22 +46,14 @@ import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.transport.client.Client;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.google.gson.Gson;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.ReadContext;
 
-import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.utils.StringUtils.toJson;
-import static org.opensearch.ml.processor.InferenceProcessorAttributes.INPUT_MAP;
-import static org.opensearch.ml.processor.InferenceProcessorAttributes.MAX_PREDICTION_TASKS;
-import static org.opensearch.ml.processor.InferenceProcessorAttributes.MODEL_CONFIG;
-import static org.opensearch.ml.processor.InferenceProcessorAttributes.MODEL_ID;
-import static org.opensearch.ml.processor.InferenceProcessorAttributes.OUTPUT_MAP;
-import static org.opensearch.ml.processor.ModelExecutor.combineMaps;
+import lombok.Getter;
 
 /**
  * MLInferenceSearchRequestProcessor requires a modelId string to call model inferences

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
@@ -1662,14 +1662,14 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
             TEST_XCONTENT_REGISTRY_FOR_QUERY
         );
 
-        /**
+        /*
          * {
          *   "inference_results" : [ {
          *     "output" : [ {
          *       "name" : "response",
          *       "dataAsMap" : {
-         * 		  "content": [
-         * 			"text": "{\"query\": \"match_all\" : {}}"
+         *        "content": [
+         *           "text": "{\"query\": \"match_all\" : {}}"
          *       }
          *     } ]
          *   } ]

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
@@ -41,6 +41,7 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.RangeQueryBuilder;
@@ -1316,7 +1317,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
 
     /**
      * Tests the successful rewriting of a complex nested array in query extension based on the model output.
-     * verify the pipelineConext is set from the extension
+     * verify the pipelineContext is set from the extension
      * @throws Exception if an error occurs during the test
      */
     public void testExecute_rewriteTermQueryReadAndWriteComplexNestedArrayToExtensionSuccess() throws Exception {
@@ -1610,6 +1611,107 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
         };
 
         requestProcessor.processRequestAsync(request, requestContext, Listener);
+    }
+
+    /**
+     * Tests ML Processor can return a OpenSearch Query correctly when performing a rewrite query.
+     *
+     * This simulates a real world scenario where user has a llm return a OpenSearch Query to help them generate a new
+     * query based on the context given in the prompt.
+     *
+     * @throws Exception when an error occurs on the test
+     */
+    public void testExecute_rewriteTermQueryWithNewQuerySuccess() throws Exception {
+        String modelInputField = "inputs";
+        String originalQueryField = "query.term.text.value";
+        String newQueryField = "llm_query";
+        String modelInferenceJsonPathInput = "$.inference_results[0].output[0].dataAsMap.content[0].text";
+
+        String queryTemplate = "${llm_query}";
+
+        String llmQuery = "{\n" +
+                          "  \"query\": {\n" +
+                          "    \"match_all\": {}\n" +
+                          "  }\n" +
+                          "}";
+        Map content = Map.of("content", List.of(Map.of("text", llmQuery)));
+
+
+        List<Map<String, String>> optionalInputMap = new ArrayList<>();
+        Map<String, String> input = new HashMap<>();
+        input.put(modelInputField, originalQueryField);
+        optionalInputMap.add(input);
+
+        List<Map<String, String>> optionalOutputMap = new ArrayList<>();
+        Map<String, String> output = new HashMap<>();
+        output.put(newQueryField, modelInferenceJsonPathInput);
+        optionalOutputMap.add(output);
+
+        MLInferenceSearchRequestProcessor requestProcessor = new MLInferenceSearchRequestProcessor(
+                "model1",
+                queryTemplate,
+                null,
+                null,
+                optionalInputMap,
+                optionalOutputMap,
+                null,
+                DEFAULT_MAX_PREDICTION_TASKS,
+                PROCESSOR_TAG,
+                DESCRIPTION,
+                false,
+                "remote",
+                true,
+                false,
+                "{ \"parameters\": ${ml_inference.parameters} }",
+                client,
+                TEST_XCONTENT_REGISTRY_FOR_QUERY
+        );
+
+        /**
+         * {
+         *   "inference_results" : [ {
+         *     "output" : [ {
+         *       "name" : "response",
+         *       "dataAsMap" : {
+         * 		  "content": [
+         * 			"text": "{\"query\": \"match_all\" : {}}"
+         *       }
+         *     } ]
+         *   } ]
+         * }
+         */
+        ModelTensor modelTensor = ModelTensor
+                .builder()
+                .name("response")
+                .dataAsMap(content)
+                .build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        QueryBuilder incomingQuery = new TermQueryBuilder("text", "foo");
+        SearchSourceBuilder source = new SearchSourceBuilder().query(incomingQuery);
+        SearchRequest sampleRequest = new SearchRequest().source(source);
+
+        ActionListener<SearchRequest> Listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchRequest newSearchRequest) {
+                MatchAllQueryBuilder expectedQuery = new MatchAllQueryBuilder();
+                assertEquals(expectedQuery, newSearchRequest.source().query());
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException("Failed in executing processRequestAsync.", e);
+            }
+        };
+
+        requestProcessor.processRequestAsync(sampleRequest, requestContext, Listener);
     }
 
     /**

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
@@ -1629,13 +1629,8 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
 
         String queryTemplate = "${llm_query}";
 
-        String llmQuery = "{\n" +
-                          "  \"query\": {\n" +
-                          "    \"match_all\": {}\n" +
-                          "  }\n" +
-                          "}";
+        String llmQuery = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  }\n" + "}";
         Map content = Map.of("content", List.of(Map.of("text", llmQuery)));
-
 
         List<Map<String, String>> optionalInputMap = new ArrayList<>();
         Map<String, String> input = new HashMap<>();
@@ -1648,23 +1643,23 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
         optionalOutputMap.add(output);
 
         MLInferenceSearchRequestProcessor requestProcessor = new MLInferenceSearchRequestProcessor(
-                "model1",
-                queryTemplate,
-                null,
-                null,
-                optionalInputMap,
-                optionalOutputMap,
-                null,
-                DEFAULT_MAX_PREDICTION_TASKS,
-                PROCESSOR_TAG,
-                DESCRIPTION,
-                false,
-                "remote",
-                true,
-                false,
-                "{ \"parameters\": ${ml_inference.parameters} }",
-                client,
-                TEST_XCONTENT_REGISTRY_FOR_QUERY
+            "model1",
+            queryTemplate,
+            null,
+            null,
+            optionalInputMap,
+            optionalOutputMap,
+            null,
+            DEFAULT_MAX_PREDICTION_TASKS,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            false,
+            "remote",
+            true,
+            false,
+            "{ \"parameters\": ${ml_inference.parameters} }",
+            client,
+            TEST_XCONTENT_REGISTRY_FOR_QUERY
         );
 
         /**
@@ -1680,11 +1675,7 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
          *   } ]
          * }
          */
-        ModelTensor modelTensor = ModelTensor
-                .builder()
-                .name("response")
-                .dataAsMap(content)
-                .build();
+        ModelTensor modelTensor = ModelTensor.builder().name("response").dataAsMap(content).build();
         ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
         ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
 

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceSearchRequestProcessorTests.java
@@ -42,9 +42,11 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.index.query.functionscore.ScriptScoreQueryBuilder;
 import org.opensearch.ingest.Processor;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
@@ -58,6 +60,8 @@ import org.opensearch.ml.repackage.com.google.common.collect.ImmutableMap;
 import org.opensearch.ml.searchext.MLInferenceRequestParameters;
 import org.opensearch.ml.searchext.MLInferenceRequestParametersExtBuilder;
 import org.opensearch.plugins.SearchPlugin;
+import org.opensearch.script.Script;
+import org.opensearch.script.ScriptType;
 import org.opensearch.search.SearchModule;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.pipeline.PipelineProcessingContext;
@@ -1497,6 +1501,115 @@ public class MLInferenceSearchRequestProcessorTests extends AbstractBuilderTestC
 
         requestProcessor.processRequestAsync(request, requestContext, Listener);
 
+    }
+
+    /**
+     * Tests ML Processor can return a sparse vector correctly when performing a rewrite query.
+     *
+     * This simulates a real world scenario where user has a neural sparse model and attempts to parse
+     * it by asserting FullResponsePath to true.
+     * @throws Exception when an error occurs on the test
+     */
+    public void testExecute_rewriteTermQueryWithSparseVectorSuccess() throws Exception {
+        String modelInputField = "inputs";
+        String originalQueryField = "query.term.text.value";
+        String newQueryField = "vector";
+        String modelInferenceJsonPathInput = "$.inference_results[0].output[0].dataAsMap.response[0]";
+
+        String queryTemplate = "{\n"
+            + "  \"query\": {\n"
+            + "    \"script_score\": {\n"
+            + "      \"query\": {\n"
+            + "        \"match_all\": {}\n"
+            + "      },\n"
+            + "      \"script\": {\n"
+            + "        \"source\": \"return 1;\",\n"
+            + "        \"params\": {\n"
+            + "          \"query_tokens\": ${vector}\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+
+        Map<String, Double> sparseVector = Map.of("this", 1.3123, "which", 0.2447, "here", 0.6674);
+
+        List<Map<String, String>> optionalInputMap = new ArrayList<>();
+        Map<String, String> input = new HashMap<>();
+        input.put(modelInputField, originalQueryField);
+        optionalInputMap.add(input);
+
+        List<Map<String, String>> optionalOutputMap = new ArrayList<>();
+        Map<String, String> output = new HashMap<>();
+        output.put(newQueryField, modelInferenceJsonPathInput);
+        optionalOutputMap.add(output);
+
+        MLInferenceSearchRequestProcessor requestProcessor = new MLInferenceSearchRequestProcessor(
+            "model1",
+            queryTemplate,
+            null,
+            null,
+            optionalInputMap,
+            optionalOutputMap,
+            null,
+            DEFAULT_MAX_PREDICTION_TASKS,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            false,
+            "remote",
+            true,
+            false,
+            "{ \"parameters\": ${ml_inference.parameters} }",
+            client,
+            TEST_XCONTENT_REGISTRY_FOR_QUERY
+        );
+
+        /**
+         * {
+         *   "inference_results" : [ {
+         *     "output" : [ {
+         *       "name" : "response",
+         *       "dataAsMap" : {
+         *         "response" : [ {
+         *           "this" : 1.3123,
+         *           "which" : 0.2447,
+         *           "here" : 0.6674
+         *         } ]
+         *       }
+         *     } ]
+         *   } ]
+         * }
+         */
+        ModelTensor modelTensor = ModelTensor.builder().name("response").dataAsMap(Map.of("response", List.of(sparseVector))).build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+        ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(MLTaskResponse.builder().output(mlModelTensorOutput).build());
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        QueryBuilder incomingQuery = new TermQueryBuilder("text", "foo");
+        SearchSourceBuilder source = new SearchSourceBuilder().query(incomingQuery);
+        SearchRequest request = new SearchRequest().source(source);
+
+        ActionListener<SearchRequest> Listener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchRequest newSearchRequest) {
+                Script script = new Script(ScriptType.INLINE, "painless", "return 1;", Map.of("query_tokens", sparseVector));
+
+                ScriptScoreQueryBuilder expectedQuery = new ScriptScoreQueryBuilder(QueryBuilders.matchAllQuery(), script);
+                assertEquals(expectedQuery, newSearchRequest.source().query());
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException("Failed in executing processRequestAsync.", e);
+            }
+        };
+
+        requestProcessor.processRequestAsync(request, requestContext, Listener);
     }
 
     /**


### PR DESCRIPTION
### Description
Ensures that Sparse Vectors can be parsed by ML Inference Request processor during rewrite.

Next steps can be to write a tutorial showing how we can run neural sparse search with ML Inference request processor.

### Related Issues
Resolves #3767

### Testing
spotlessApply && `./gradlew test`


### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
