### PR TITLE
Fix connector private IP validation when executing agent without remote model

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutor.java
@@ -5,6 +5,11 @@
 
 package org.opensearch.ml.engine.algorithms.remote;
 
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorClientConfig;
 
@@ -15,6 +20,8 @@ import lombok.Setter;
 @Getter
 public abstract class AbstractConnectorExecutor implements RemoteConnectorExecutor {
     private ConnectorClientConfig connectorClientConfig;
+    protected ClusterService clusterService;
+    protected final AtomicBoolean connectorPrivateIpEnabled = new AtomicBoolean(false);
 
     public void initialize(Connector connector) {
         if (connector.getConnectorClientConfig() != null) {
@@ -22,5 +29,16 @@ public abstract class AbstractConnectorExecutor implements RemoteConnectorExecut
         } else {
             connectorClientConfig = new ConnectorClientConfig();
         }
+    }
+
+    public boolean isConnectorPrivateIpEnabled() {
+        if (clusterService != null) {
+            connectorPrivateIpEnabled.set(clusterService.getClusterSettings().get(ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED));
+            clusterService
+                .getClusterSettings()
+                .addSettingsUpdateConsumer(ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED, it -> connectorPrivateIpEnabled.set(it));
+            return connectorPrivateIpEnabled.get();
+        }
+        return false;
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
@@ -16,7 +16,6 @@ import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.collect.Tuple;
@@ -63,8 +62,6 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
     @Setter
     @Getter
     private MLGuard mlGuard;
-    @Setter
-    private volatile AtomicBoolean connectorPrivateIpEnabled;
 
     private SdkAsyncHttpClient httpClient;
 
@@ -139,6 +136,7 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
         String protocol = url.getProtocol();
         String host = url.getHost();
         int port = url.getPort();
+        connectorPrivateIpEnabled.set(isConnectorPrivateIpEnabled());
         MLHttpClientFactory.validate(protocol, host, port, connectorPrivateIpEnabled);
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
@@ -8,7 +8,6 @@ package org.opensearch.ml.engine.algorithms.remote;
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
 
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.util.TokenBucket;
@@ -115,7 +114,6 @@ public class RemoteModel implements Predictable {
             this.connectorExecutor.setRateLimiter((TokenBucket) params.get(RATE_LIMITER));
             this.connectorExecutor.setUserRateLimiterMap((Map<String, TokenBucket>) params.get(USER_RATE_LIMITER_MAP));
             this.connectorExecutor.setMlGuard((MLGuard) params.get(GUARDRAILS));
-            this.connectorExecutor.setConnectorPrivateIpEnabled((AtomicBoolean) params.get(CONNECTOR_PRIVATE_IP_ENABLED));
         } catch (RuntimeException e) {
             log.error("Failed to init remote model.", e);
             throw e;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
@@ -2,17 +2,28 @@ package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED;
+
+import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.common.connector.AwsConnector;
+import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorClientConfig;
+import org.opensearch.ml.common.connector.HttpConnector;
 
 public class AbstractConnectorExecutorTest {
     @Mock
     private AwsConnector mockConnector;
+
+    @Mock
+    ClusterService clusterService;
 
     private ConnectorClientConfig connectorClientConfig;
 
@@ -41,5 +52,29 @@ public class AbstractConnectorExecutorTest {
         assertEquals(ConnectorClientConfig.MAX_CONNECTION_DEFAULT_VALUE, executor.getConnectorClientConfig().getMaxConnections());
         assertEquals(ConnectorClientConfig.CONNECTION_TIMEOUT_DEFAULT_VALUE, executor.getConnectorClientConfig().getConnectionTimeout());
         assertEquals(ConnectorClientConfig.READ_TIMEOUT_DEFAULT_VALUE, executor.getConnectorClientConfig().getReadTimeout());
+    }
+
+    @Test
+    public void testIsConnectorPrivateIpEnabled() {
+        Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").build();
+        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        assertFalse(executor.isConnectorPrivateIpEnabled());
+        Settings initialSettings = Settings.builder().put(ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED.getKey(), true).build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+            initialSettings,
+            Collections.singleton(ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED)
+        );
+        when(this.clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        executor.setClusterService(this.clusterService);
+        assertTrue(executor.isConnectorPrivateIpEnabled());
+        clusterSettings.applySettings(Settings.builder().put(ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED.getKey(), false).build());
+        assertFalse(executor.isConnectorPrivateIpEnabled());
+    }
+
+    @Test
+    public void testIsConnectorPrivateIpEnabled_NullClusterService() {
+        Connector connector = HttpConnector.builder().name("test connector").version("1").protocol("http").build();
+        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        assertFalse(executor.isConnectorPrivateIpEnabled());
     }
 }


### PR DESCRIPTION
### Description
Fix private IP validation issue that occurs when executing agent with connector directly (without remote model). Initially, RemoteConnectorExecutor has an empty [setConnectorPrivateIpEnabled](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java#L159) setter which is normally set through [RemoteModel](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java#L118) during initialization. However, when agent uses connector directly, this setting remains uninitialized, causing IP [validation](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java#L142) to fail. This change will ensure proper IP validation when connector is used directly by agents or using it through remote model.

### Related Issues
Resolves https://github.com/opensearch-project/ml-commons/issues/3839

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
