### PR TITLE
DELETE Prompt API 

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/prompt/MLPromptDeleteAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/prompt/MLPromptDeleteAction.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.prompt;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.delete.DeleteResponse;
+
+public class MLPromptDeleteAction extends ActionType<DeleteResponse> {
+    public static final MLPromptDeleteAction INSTANCE = new MLPromptDeleteAction();
+    public static final String NAME = "cluster:admin/opensearch/ml/prompts/delete";
+
+    private MLPromptDeleteAction() {
+        super(NAME, DeleteResponse::new);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/prompt/MLPromptDeleteRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/prompt/MLPromptDeleteRequest.java
@@ -101,7 +101,7 @@ public class MLPromptDeleteRequest extends ActionRequest {
                 return new MLPromptDeleteRequest(input);
             }
         } catch (IOException e) {
-            throw new UncheckedIOException("failed to parse ActionRequest into MLPromptDeleteRequest", e);
+            throw new UncheckedIOException("Failed to parse ActionRequest into MLPromptDeleteRequest", e);
         }
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/prompt/MLPromptDeleteRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/prompt/MLPromptDeleteRequest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.prompt;
+
+import static org.opensearch.action.ValidateActions.addValidationError;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * MLPromptDeleteRequest is the request class for MLPromptDeleteAction.
+ * It contains prompt id and tenant id that is required delete a prompt
+ */
+@Getter
+public class MLPromptDeleteRequest extends ActionRequest {
+    private final String promptId;
+    private final String tenantId;
+
+    /**
+     * Construct to pass values to the MLPromptDeleteRequest constructor
+     *
+     * @param promptId a prompt id of a prompt that needs to be retrieved
+     * @param tenantId a tenant id of a prompt that needs to be retrieved
+     */
+    @Builder
+    public MLPromptDeleteRequest(String promptId, String tenantId) {
+        this.promptId = promptId;
+        this.tenantId = tenantId;
+    }
+
+    /**
+     * Constructor to parse StreamInput to MLPromptDeleteRequest
+     *
+     * @param input StreamInput
+     * @throws IOException if an I/O exception occurred while reading from the StreamInput
+     */
+    public MLPromptDeleteRequest(StreamInput input) throws IOException {
+        super(input);
+        this.promptId = input.readString();
+        this.tenantId = input.readOptionalString();
+    }
+
+    /**
+     * Write MLPromptDeleteRequest to StreamOutput
+     *
+     * @param output Stream Output
+     * @throws IOException if an I/O exception occurred while writing to StreamOutput
+     */
+    @Override
+    public void writeTo(StreamOutput output) throws IOException {
+        super.writeTo(output);
+        output.writeString(this.promptId);
+        output.writeOptionalString(this.tenantId);
+    }
+
+    /**
+     * Validate MLPromptDeleteRequest
+     *
+     * @return ActionRequestValidationException if validation fails, null otherwise
+     */
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException exception = null;
+
+        if (this.promptId == null) {
+            exception = addValidationError("ML prompt id can't be null", exception);
+        }
+
+        return exception;
+    }
+
+    /**
+     * Parse ActionRequest into MLPromptDeleteRequest
+     *
+     * @param actionRequest ActionRequest
+     * @return MLPromptDeleteRequest
+     */
+    public static MLPromptDeleteRequest fromActionRequest(ActionRequest actionRequest) {
+        if (actionRequest instanceof MLPromptDeleteRequest) {
+            return (MLPromptDeleteRequest) actionRequest;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionRequest.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLPromptDeleteRequest(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionRequest into MLPromptDeleteRequest", e);
+        }
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/prompt/MLPromptDeleteRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/prompt/MLPromptDeleteRequestTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.prompt;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+public class MLPromptDeleteRequestTest {
+    private String promptId;
+    private MLPromptDeleteRequest mlPromptDeleteRequest;
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        promptId = "test_promptId";
+        mlPromptDeleteRequest = new MLPromptDeleteRequest(promptId, null);
+    }
+
+    @Test
+    public void constructor() {
+        MLPromptDeleteRequest mlPromptDeleteRequest = new MLPromptDeleteRequest(promptId, null);
+        assertNotNull(mlPromptDeleteRequest);
+        assertEquals(promptId, mlPromptDeleteRequest.getPromptId());
+        assertNull(mlPromptDeleteRequest.getTenantId());
+    }
+
+    @Test
+    public void validateSuccess() throws IOException {
+        assertNull(mlPromptDeleteRequest.validate());
+    }
+
+    @Test
+    public void writeToSuccess() throws IOException {
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        mlPromptDeleteRequest.writeTo(streamOutput);
+        MLPromptDeleteRequest parsedRequest = new MLPromptDeleteRequest(streamOutput.bytes().streamInput());
+        assertEquals(mlPromptDeleteRequest.getPromptId(), parsedRequest.getPromptId());
+    }
+
+    @Test
+    public void validateWithNullPromptIdException() {
+        MLPromptDeleteRequest mlPromptDeleteRequest = MLPromptDeleteRequest.builder().build();
+        ActionRequestValidationException exception = mlPromptDeleteRequest.validate();
+        Assert.assertEquals("Validation Failed: 1: ML prompt id can't be null;", exception.getMessage());
+    }
+
+    @Test
+    public void fromActionRequestWithPromptDeleteRequestSuccess() {
+        MLPromptDeleteRequest parsedRequest = MLPromptDeleteRequest.fromActionRequest(mlPromptDeleteRequest);
+        assertSame(mlPromptDeleteRequest, parsedRequest);
+    }
+
+    @Test
+    public void fromActionRequestWithNonMLPromptDeleteRequestSuccess() {
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput output) throws IOException {
+                mlPromptDeleteRequest.writeTo(output);
+            }
+        };
+        MLPromptDeleteRequest parsedRequest = MLPromptDeleteRequest.fromActionRequest(actionRequest);
+        assertNotSame(mlPromptDeleteRequest, parsedRequest);
+        assertEquals(mlPromptDeleteRequest.getPromptId(), parsedRequest.getPromptId());
+    }
+
+    @Test
+    public void fromActionRequestException() {
+        exceptionRule.expect(UncheckedIOException.class);
+        exceptionRule.expectMessage("Failed to parse ActionRequest into MLPromptDeleteRequest");
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException();
+            }
+        };
+        MLPromptDeleteRequest.fromActionRequest(actionRequest);
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/prompt/DeletePromptTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/prompt/DeletePromptTransportAction.java
@@ -30,6 +30,10 @@ import org.opensearch.transport.client.Client;
 
 import lombok.extern.log4j.Log4j2;
 
+/**
+ * Transport Action class that handles received validated ActionRequest from Rest Layer and
+ * executes the actual operation of deleting a prompt from a system index.
+ */
 @Log4j2
 public class DeletePromptTransportAction extends HandledTransportAction<MLPromptDeleteRequest, DeleteResponse> {
     private final Client client;
@@ -53,6 +57,15 @@ public class DeletePromptTransportAction extends HandledTransportAction<MLPrompt
         this.mlPromptManager = mlPromptManager;
     }
 
+    /**
+     * Executes the received request by deleting the prompt from the system index based on the provided prompt id.
+     * Notify the listener with the DeleteResponse if the operation is successful. Otherwise, failure exception
+     * is notified to the listener.
+     *
+     * @param task The task
+     * @param mlPromptDeleteRequest mlPromptDeleteRequest that contains the prompt id of a prompt that needs to be deleted
+     * @param actionListener a listener to be notified of the response
+     */
     @Override
     protected void doExecute(Task task, MLPromptDeleteRequest mlPromptDeleteRequest, ActionListener<DeleteResponse> actionListener) {
         String promptId = mlPromptDeleteRequest.getPromptId();
@@ -80,6 +93,15 @@ public class DeletePromptTransportAction extends HandledTransportAction<MLPrompt
             );
     }
 
+    /**
+     * Delete the prompt based on the requested prompt id and hard delete by removing the corresponding doc from
+     * the provided system index
+     *
+     * @param mlPrompt the MLPrompt that needs to be deleted
+     * @param promptId The prompt ID of a prompt that needs to deleted
+     * @param tenantId The tenant ID
+     * @param listener a listener to be notified of the response
+     */
     private void executeDeletePrompt(MLPrompt mlPrompt, String promptId, String tenantId, ActionListener<DeleteResponse> listener) {
         DeleteDataObjectRequest deleteDataObjectRequest = DeleteDataObjectRequest.builder().index(ML_PROMPT_INDEX).id(promptId).build();
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
@@ -90,6 +112,14 @@ public class DeletePromptTransportAction extends HandledTransportAction<MLPrompt
         }
     }
 
+    /**
+     * Handles the response from the delete prompt request. If the response is successful, notify the listener
+     * with the DeleteResponse. Otherwise, notify the failure exception to the listener.
+     *
+     * @param deleteDataObjectResponse The response from the delete prompt request
+     * @param throwable The exception that occurred during the delete prompt request
+     * @param listener The listener to be notified of the response
+     */
     private void handleDeleteResponse(
         DeleteDataObjectResponse deleteDataObjectResponse,
         Throwable throwable,
@@ -105,6 +135,14 @@ public class DeletePromptTransportAction extends HandledTransportAction<MLPrompt
         listener.onResponse(deleteResponse);
     }
 
+    /**
+     * Notify the listener of the failure exception. while fetching and deleting the prompt object from the system index
+     *
+     * @param exception The failure exception
+     * @param promptId The prompt id
+     * @param listener ActionListener to be notified of the response
+     * @param likelyCause the likely cause message of failure
+     */
     private void handleFailure(Exception exception, String promptId, ActionListener<DeleteResponse> listener, String likelyCause) {
         log.error(likelyCause, promptId, exception);
         listener.onFailure(exception);

--- a/plugin/src/main/java/org/opensearch/ml/action/prompt/DeletePromptTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/prompt/DeletePromptTransportAction.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.prompt;
+
+import static org.opensearch.ml.common.CommonValue.ML_PROMPT_INDEX;
+
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.prompt.MLPrompt;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.prompt.MLPromptDeleteAction;
+import org.opensearch.ml.common.transport.prompt.MLPromptDeleteRequest;
+import org.opensearch.ml.prompt.MLPromptManager;
+import org.opensearch.ml.utils.TenantAwareHelper;
+import org.opensearch.remote.metadata.client.DeleteDataObjectRequest;
+import org.opensearch.remote.metadata.client.DeleteDataObjectResponse;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.common.SdkClientUtils;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class DeletePromptTransportAction extends HandledTransportAction<MLPromptDeleteRequest, DeleteResponse> {
+    private final Client client;
+    private final SdkClient sdkClient;
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
+    private final MLPromptManager mlPromptManager;
+
+    @Inject
+    public DeletePromptTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client,
+        SdkClient sdkClient,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting,
+        MLPromptManager mlPromptManager
+    ) {
+        super(MLPromptDeleteAction.NAME, transportService, actionFilters, MLPromptDeleteRequest::new);
+        this.client = client;
+        this.sdkClient = sdkClient;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+        this.mlPromptManager = mlPromptManager;
+    }
+
+    @Override
+    protected void doExecute(Task task, MLPromptDeleteRequest mlPromptDeleteRequest, ActionListener<DeleteResponse> actionListener) {
+        String promptId = mlPromptDeleteRequest.getPromptId();
+        String tenantId = mlPromptDeleteRequest.getTenantId();
+
+        if (!TenantAwareHelper.validateTenantId(mlFeatureEnabledSetting, tenantId, actionListener)) {
+            return;
+        }
+
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
+            .index(ML_PROMPT_INDEX)
+            .id(promptId)
+            .tenantId(tenantId)
+            .build();
+        mlPromptManager
+            .getPromptAsync(
+                getDataObjectRequest,
+                promptId,
+                ActionListener
+                    .wrap(
+                        mlPrompt -> executeDeletePrompt(mlPrompt, promptId, tenantId, actionListener),
+                        e -> handleFailure(e, promptId, actionListener, "Failed to get ML Prompt {}")
+                    )
+            );
+    }
+
+    private void executeDeletePrompt(MLPrompt mlPrompt, String promptId, String tenantId, ActionListener<DeleteResponse> listener) {
+        DeleteDataObjectRequest deleteDataObjectRequest = DeleteDataObjectRequest.builder().index(ML_PROMPT_INDEX).id(promptId).build();
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            sdkClient.deleteDataObjectAsync(deleteDataObjectRequest).whenComplete((deleteDataObjectResponse, throwable) -> {
+                context.restore();
+                handleDeleteResponse(deleteDataObjectResponse, throwable, promptId, listener);
+            });
+        }
+    }
+
+    private void handleDeleteResponse(
+        DeleteDataObjectResponse deleteDataObjectResponse,
+        Throwable throwable,
+        String promptId,
+        ActionListener<DeleteResponse> listener
+    ) {
+        if (throwable != null) {
+            Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable);
+            handleFailure(cause, promptId, listener, "Failed to delete ML prompt {}");
+            return;
+        }
+        DeleteResponse deleteResponse = deleteDataObjectResponse.deleteResponse();
+        listener.onResponse(deleteResponse);
+    }
+
+    private void handleFailure(Exception exception, String promptId, ActionListener<DeleteResponse> listener, String likelyCause) {
+        log.error(likelyCause, promptId, exception);
+        listener.onFailure(exception);
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -102,6 +102,7 @@ import org.opensearch.ml.action.models.UpdateModelTransportAction;
 import org.opensearch.ml.action.prediction.TransportPredictionTaskAction;
 import org.opensearch.ml.action.profile.MLProfileAction;
 import org.opensearch.ml.action.profile.MLProfileTransportAction;
+import org.opensearch.ml.action.prompt.DeletePromptTransportAction;
 import org.opensearch.ml.action.prompt.GetPromptTransportAction;
 import org.opensearch.ml.action.prompt.TransportCreatePromptAction;
 import org.opensearch.ml.action.prompt.UpdatePromptTransportAction;
@@ -183,6 +184,7 @@ import org.opensearch.ml.common.transport.model_group.MLRegisterModelGroupAction
 import org.opensearch.ml.common.transport.model_group.MLUpdateModelGroupAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prompt.MLCreatePromptAction;
+import org.opensearch.ml.common.transport.prompt.MLPromptDeleteAction;
 import org.opensearch.ml.common.transport.prompt.MLPromptGetAction;
 import org.opensearch.ml.common.transport.prompt.MLUpdatePromptAction;
 import org.opensearch.ml.common.transport.register.MLRegisterModelAction;
@@ -273,6 +275,7 @@ import org.opensearch.ml.rest.RestMLDeleteConnectorAction;
 import org.opensearch.ml.rest.RestMLDeleteControllerAction;
 import org.opensearch.ml.rest.RestMLDeleteModelAction;
 import org.opensearch.ml.rest.RestMLDeleteModelGroupAction;
+import org.opensearch.ml.rest.RestMLDeletePromptAction;
 import org.opensearch.ml.rest.RestMLDeleteTaskAction;
 import org.opensearch.ml.rest.RestMLDeployModelAction;
 import org.opensearch.ml.rest.RestMLExecuteAction;
@@ -481,6 +484,7 @@ public class MachineLearningPlugin extends Plugin
                 new ActionHandler<>(MLConnectorSearchAction.INSTANCE, SearchConnectorTransportAction.class),
                 new ActionHandler<>(MLCreatePromptAction.INSTANCE, TransportCreatePromptAction.class),
                 new ActionHandler<>(MLPromptGetAction.INSTANCE, GetPromptTransportAction.class),
+                new ActionHandler<>(MLPromptDeleteAction.INSTANCE, DeletePromptTransportAction.class),
                 new ActionHandler<>(MLUpdatePromptAction.INSTANCE, UpdatePromptTransportAction.class),
                 new ActionHandler<>(CreateConversationAction.INSTANCE, CreateConversationTransportAction.class),
                 new ActionHandler<>(GetConversationsAction.INSTANCE, GetConversationsTransportAction.class),
@@ -861,6 +865,7 @@ public class MachineLearningPlugin extends Plugin
         RestMLCreatePromptAction restMLCreatePromptAction = new RestMLCreatePromptAction(mlFeatureEnabledSetting);
         RestMLGetPromptAction restMLGetPromptAction = new RestMLGetPromptAction(mlFeatureEnabledSetting);
         RestMLUpdatePromptAction restMLUpdatePromptAction = new RestMLUpdatePromptAction(mlFeatureEnabledSetting);
+        RestMLDeletePromptAction restMLDeletePromptAction = new RestMLDeletePromptAction(mlFeatureEnabledSetting);
         RestMemoryCreateConversationAction restCreateConversationAction = new RestMemoryCreateConversationAction();
         RestMemoryGetConversationsAction restListConversationsAction = new RestMemoryGetConversationsAction();
         RestMemoryCreateInteractionAction restCreateInteractionAction = new RestMemoryCreateInteractionAction();
@@ -924,6 +929,7 @@ public class MachineLearningPlugin extends Plugin
                 restMLSearchConnectorAction,
                 restMLCreatePromptAction,
                 restMLGetPromptAction,
+                restMLDeletePromptAction,
                 restMLUpdatePromptAction,
                 restCreateConversationAction,
                 restListConversationsAction,

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLDeletePromptAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLDeletePromptAction.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_PROMPT_ID;
+import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
+import static org.opensearch.ml.utils.TenantAwareHelper.getTenantID;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.prompt.MLPromptDeleteAction;
+import org.opensearch.ml.common.transport.prompt.MLPromptDeleteRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This class consists of the REST handler to delete ML Prompt.
+ */
+public class RestMLDeletePromptAction extends BaseRestHandler {
+    private static final String ML_DELETE_PROMPT_ACTION = "ml_delete_prompt_action";
+
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    public RestMLDeletePromptAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
+
+    /**
+     * Get the name of rest action
+     *
+     * @return String that is used to register rest action
+     */
+    @Override
+    public String getName() {
+        return ML_DELETE_PROMPT_ACTION;
+    }
+
+    /**
+     * List the routes that this rest action is responsible for handling
+     *
+     * @return List of routes that this action handles
+     */
+    @Override
+    public List<RestHandler.Route> routes() {
+        return ImmutableList
+            .of(
+                new RestHandler.Route(
+                    RestRequest.Method.DELETE,
+                    String.format(Locale.ROOT, "%s/prompts/{%s}", ML_BASE_URI, PARAMETER_PROMPT_ID)
+                )
+            );
+    }
+
+    /**
+     * Prepare the request by creating MLPromptDeleteRequest from RestRequest and
+     * execute the request against a channel
+     *
+     * @param request RestRequest to create MLPromptDeleteRequest
+     * @param client NodeClient to execute the request against
+     * @return RestChannelConsumer
+     * @throws IOException if an I/O exception occurred while reading from the request
+     */
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        MLPromptDeleteRequest mlPromptDeleteRequest = getRequest(request);
+        return channel -> client.execute(MLPromptDeleteAction.INSTANCE, mlPromptDeleteRequest, new RestToXContentListener<>(channel));
+    }
+
+    /**
+     * Creates a MLPromptDeleteRequest from a RestRequest
+     *
+     * @param request RestRequest to create MLPromptDeleteRequest
+     * @return MLPromptDeleteRequest
+     * @throws IllegalStateException if remote inference is disabled
+     * @throws IOException if an I/O exception occurred while reading from the request
+     */
+    @VisibleForTesting
+    MLPromptDeleteRequest getRequest(RestRequest request) throws IOException {
+        String promptId = getParameterId(request, PARAMETER_PROMPT_ID);
+        String tenantId = getTenantID(mlFeatureEnabledSetting.isMultiTenancyEnabled(), request);
+        return new MLPromptDeleteRequest(promptId, tenantId);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/prompt/DeletePromptTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prompt/DeletePromptTransportActionTests.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.prompt;
+
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.CommonValue.ML_PROMPT_INDEX;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.ml.common.prompt.MLPrompt;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.prompt.MLPromptDeleteRequest;
+import org.opensearch.ml.prompt.MLPromptManager;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class DeletePromptTransportActionTests extends OpenSearchTestCase {
+    private static final String PROMPT_ID = "prompt_id";
+    private static final String TENANT_ID = "tenant_id";
+
+    @Mock
+    private TransportService transportService;
+
+    @Mock
+    private Client client;
+
+    private SdkClient sdkClient;
+
+    @Mock
+    ThreadPool threadPool;
+
+    ThreadContext threadContext;
+
+    @Mock
+    private ActionFilters actionFilters;
+
+    @Mock
+    private Task task;
+
+    @Mock
+    private ActionListener<DeleteResponse> actionListener;
+
+    @Mock
+    private DeleteResponse deleteResponse;
+
+    private DeletePromptTransportAction deletePromptTransportAction;
+
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Mock
+    private MLPromptDeleteRequest mlPromptDeleteRequest;
+
+    @Mock
+    private MLPromptManager mlPromptManager;
+
+    @Captor
+    private ArgumentCaptor<GetDataObjectRequest> getDataObjectRequestArgumentCaptor;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.openMocks(this);
+
+        sdkClient = SdkClientFactory.createSdkClient(client, NamedXContentRegistry.EMPTY, Collections.emptyMap());
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+        mlPromptDeleteRequest = MLPromptDeleteRequest.builder().promptId(PROMPT_ID).tenantId(TENANT_ID).build();
+        ShardId shardId = new ShardId(new Index(ML_PROMPT_INDEX, "_na_"), 1);
+        deleteResponse = new DeleteResponse(shardId, "taskId", 1, 1, 1, true);
+
+        deletePromptTransportAction = spy(
+            new DeletePromptTransportAction(transportService, actionFilters, client, sdkClient, mlFeatureEnabledSetting, mlPromptManager)
+        );
+
+        threadContext = new ThreadContext(Settings.EMPTY);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+    }
+
+    @Test
+    public void testConstructor() {
+        DeletePromptTransportAction deletePromptTransportAction = new DeletePromptTransportAction(
+            transportService,
+            actionFilters,
+            client,
+            sdkClient,
+            mlFeatureEnabledSetting,
+            mlPromptManager
+        );
+        assertNotNull(deletePromptTransportAction);
+    }
+
+    @Test
+    public void testDoExecute_success() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<MLPrompt> listener = invocation.getArgument(2);
+            listener.onResponse(MLPrompt.builder().build());
+            return null;
+        }).when(mlPromptManager).getPromptAsync(getDataObjectRequestArgumentCaptor.capture(), any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
+            listener.onResponse(deleteResponse);
+            return null;
+        }).when(client).delete(any(), any());
+
+        deletePromptTransportAction.doExecute(task, mlPromptDeleteRequest, actionListener);
+
+        ArgumentCaptor<DeleteResponse> captor = forClass(DeleteResponse.class);
+        verify(actionListener).onResponse(captor.capture());
+
+        DeleteResponse actualResponse = captor.getValue();
+        assertEquals(deleteResponse.getId(), actualResponse.getId());
+        assertEquals(deleteResponse.getIndex(), actualResponse.getIndex());
+        assertEquals(deleteResponse.getVersion(), actualResponse.getVersion());
+        assertEquals(deleteResponse.getResult(), actualResponse.getResult());
+    }
+
+    @Test
+    public void testDoExecute_getPrompt_fail() throws InterruptedException {
+        doAnswer(invocation -> {
+            ActionListener<MLPrompt> listener = invocation.getArgument(2);
+            listener
+                .onFailure(
+                    new OpenSearchStatusException("Failed to find prompt with the provided prompt id: prompt_id", RestStatus.NOT_FOUND)
+                );
+            return null;
+        }).when(mlPromptManager).getPromptAsync(any(), any(), any());
+
+        deletePromptTransportAction.doExecute(task, mlPromptDeleteRequest, actionListener);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Failed to find prompt with the provided prompt id: prompt_id", argumentCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void testDoExecute_multi_tenancy_fail() throws InterruptedException {
+        MLPromptDeleteRequest mlPromptGetRequest = MLPromptDeleteRequest.builder().promptId(PROMPT_ID).build();
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+
+        deletePromptTransportAction.doExecute(task, mlPromptGetRequest, actionListener);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("You don't have permission to access this resource", argumentCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void testDoExecute_failWithDelete() {
+        doAnswer(invocation -> {
+            ActionListener<MLPrompt> listener = invocation.getArgument(2);
+            listener.onResponse(MLPrompt.builder().build());
+            return null;
+        }).when(mlPromptManager).getPromptAsync(getDataObjectRequestArgumentCaptor.capture(), any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new IndexNotFoundException("Index not found"));
+            return null;
+        }).when(client).delete(any(DeleteRequest.class), isA(ActionListener.class));
+
+        deletePromptTransportAction.doExecute(task, mlPromptDeleteRequest, actionListener);
+
+        ArgumentCaptor<OpenSearchStatusException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Failed to delete data object from index .plugins-ml-prompt", argumentCaptor.getValue().getMessage());
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeletePromptActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeletePromptActionTests.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_PROMPT_ID;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.input.Constants;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.prompt.MLPromptDeleteAction;
+import org.opensearch.ml.common.transport.prompt.MLPromptDeleteRequest;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestMLDeletePromptActionTests extends OpenSearchTestCase {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    private RestMLDeletePromptAction restMLDeletePromptAction;
+
+    NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        restMLDeletePromptAction = new RestMLDeletePromptAction(mlFeatureEnabledSetting);
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLPromptDeleteAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
+    }
+
+    public void testConstructor() {
+        RestMLDeletePromptAction restMLDeletePromptAction = new RestMLDeletePromptAction(mlFeatureEnabledSetting);
+        assertNotNull(restMLDeletePromptAction);
+    }
+
+    public void testGetName() {
+        String actionName = restMLDeletePromptAction.getName();
+        assertFalse(Strings.isNullOrEmpty(actionName));
+        assertEquals("ml_delete_prompt_action", actionName);
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = restMLDeletePromptAction.routes();
+        assertNotNull(routes);
+        assertFalse(routes.isEmpty());
+        RestHandler.Route route = routes.get(0);
+        assertEquals(RestRequest.Method.DELETE, route.getMethod());
+        assertEquals("/_plugins/_ml/prompts/{prompt_id}", route.getPath());
+    }
+
+    public void testGetRequest() throws IOException {
+        RestRequest request = getRestRequest(null);
+        MLPromptDeleteRequest mlPromptDeleteRequest = restMLDeletePromptAction.getRequest(request);
+
+        String promptId = mlPromptDeleteRequest.getPromptId();
+        assertEquals("prompt_id", promptId);
+    }
+
+    public void testGetRequest_MultiTenancyEnabled() throws IOException {
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+        RestRequest request = getRestRequest("tenantId");
+        MLPromptDeleteRequest mlPromptDeleteRequest = restMLDeletePromptAction.getRequest(request);
+
+        String promptId = mlPromptDeleteRequest.getPromptId();
+        String tenantId = mlPromptDeleteRequest.getTenantId();
+        assertEquals("tenantId", tenantId);
+        assertEquals("prompt_id", promptId);
+    }
+
+    public void testPrepareRequest() throws Exception {
+        RestRequest request = getRestRequest(null);
+        restMLDeletePromptAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLPromptDeleteRequest> argumentcaptor = ArgumentCaptor.forClass(MLPromptDeleteRequest.class);
+        verify(client, times(1)).execute(eq(MLPromptDeleteAction.INSTANCE), argumentcaptor.capture(), any());
+        String promptId = argumentcaptor.getValue().getPromptId();
+        assertEquals("prompt_id", promptId);
+    }
+
+    public void testPrepareRequest_EmptyContent() throws Exception {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Request should contain prompt_id");
+        Map<String, String> params = new HashMap<>();
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).build();
+
+        restMLDeletePromptAction.handleRequest(request, channel, client);
+    }
+
+    private RestRequest getRestRequest(String tenantId) {
+        Map<String, String> params = new HashMap<>();
+        Map<String, List<String>> headers = new HashMap<>();
+        params.put(PARAMETER_PROMPT_ID, "prompt_id");
+        if (tenantId != null) {
+            headers.put(Constants.TENANT_ID_HEADER, Collections.singletonList(tenantId));
+        }
+        return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withHeaders(headers).withParams(params).build();
+    }
+}


### PR DESCRIPTION
### Description
Implements an API to delete a prompt 

### Related Issues
Resolves #3711 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
