### PR TITLE
for inline model connector name isn't required

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorRequest.java
@@ -46,7 +46,9 @@ public class MLCreateConnectorRequest extends ActionRequest {
             return addValidationError("ML Connector input can't be null", null);
         }
         Map<String, FieldDescriptor> fieldsToValidate = new HashMap<>();
-        fieldsToValidate.put("Model connector name", new FieldDescriptor(mlCreateConnectorInput.getName(), true));
+
+        fieldsToValidate
+            .put("Model connector name", new FieldDescriptor(mlCreateConnectorInput.getName(), !mlCreateConnectorInput.isDryRun()));
         fieldsToValidate.put("Model connector description", new FieldDescriptor(mlCreateConnectorInput.getDescription(), false));
 
         return validateFields(fieldsToValidate);

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorRequestTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.transport.connector;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -267,4 +268,47 @@ public class MLCreateConnectorRequestTests {
         );
     }
 
+    @Test
+    public void validateWithDryRun() {
+        // Test with dry run set to true
+        MLCreateConnectorInput dryRunInput = MLCreateConnectorInput
+            .builder()
+            .name("")  // Empty name, which would normally fail validation
+            .description("Test description")
+            .version("1")
+            .protocol("http")
+            .parameters(Map.of("input", "test"))
+            .credential(Map.of("key", "value"))
+            .actions(List.of())
+            .access(AccessMode.PUBLIC)
+            .backendRoles(Arrays.asList("role1"))
+            .addAllBackendRoles(false)
+            .dryRun(true)  // Set dry run to true
+            .build();
+
+        MLCreateConnectorRequest dryRunRequest = MLCreateConnectorRequest.builder().mlCreateConnectorInput(dryRunInput).build();
+        ActionRequestValidationException dryRunException = dryRunRequest.validate();
+        assertNull("Validation should pass when dry run is true, even with empty name", dryRunException);
+
+        // Test with dry run set to false (default behavior)
+        MLCreateConnectorInput nonDryRunInput = MLCreateConnectorInput
+            .builder()
+            .name("")  // Empty name, which should fail validation
+            .description("Test description")
+            .version("1")
+            .protocol("http")
+            .parameters(Map.of("input", "test"))
+            .credential(Map.of("key", "value"))
+            .actions(List.of())
+            .access(AccessMode.PUBLIC)
+            .backendRoles(Arrays.asList("role1"))
+            .addAllBackendRoles(false)
+            .dryRun(false)  // Set dry run to false
+            .build();
+
+        MLCreateConnectorRequest nonDryRunRequest = MLCreateConnectorRequest.builder().mlCreateConnectorInput(nonDryRunInput).build();
+        ActionRequestValidationException nonDryRunException = nonDryRunRequest.validate();
+        assertNotNull("Validation should fail when dry run is false and name is empty", nonDryRunException);
+        assertTrue(nonDryRunException.getMessage().contains("Model connector name is required"));
+    }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
@@ -207,7 +207,7 @@ public class ModelHelperTest {
         MLRegisterModelInput registerModelInput = MLRegisterModelInput
             .builder()
             .modelName("huggingface/sentence-transformers/all-mpnet-base-v2")
-            .version("1.0.1")
+            .version("1.0.2")
             .modelGroupId("mockGroupId")
             .modelFormat(modelFormat)
             .deployModel(false)
@@ -223,7 +223,7 @@ public class ModelHelperTest {
         MLRegisterModelInput registerModelInput = MLRegisterModelInput
             .builder()
             .modelName("huggingface/sentence-transformers/all-mpnet-base-v2")
-            .version("1.0.1")
+            .version("1.0.2")
             .modelGroupId("mockGroupId")
             .modelFormat(modelFormat)
             .deployModel(false)


### PR DESCRIPTION
### Description
[for inline model connector name isn't required

We added validation for connector name during connector creation. But when for inline model where connector is the part of the model object, there we don't need connector name. So we are removing this validation for inline model connector. 

]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
