### PR TITLE
change SearchIndexTool arguments parsing logic

### DIFF
--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchIndexToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/SearchIndexToolTests.java
@@ -95,8 +95,21 @@ public class SearchIndexToolTests {
 
     @Test
     @SneakyThrows
-    public void testValidate() {
+    public void testValidateWithInputKey() {
         Map<String, String> parameters = Map.of("input", "{}");
+        assertTrue(mockedSearchIndexTool.validate(parameters));
+    }
+
+    @Test
+    @SneakyThrows
+    public void testValidateWithActualKeys() {
+        Map<String, String> parameters = Map
+            .of(
+                SearchIndexTool.INDEX_FIELD,
+                "test-index",
+                SearchIndexTool.QUERY_FIELD,
+                "{\n" + "    \"query\": {\n" + "        \"match_all\": {}\n" + "    }\n" + "}"
+            );
         assertTrue(mockedSearchIndexTool.validate(parameters));
     }
 
@@ -108,9 +121,23 @@ public class SearchIndexToolTests {
     }
 
     @Test
-    public void testRunWithNormalIndex() {
+    @SneakyThrows
+    public void testValidateWithNullInput() {
+        assertFalse(mockedSearchIndexTool.validate(null));
+    }
+
+    @Test
+    public void testRunWithInputKey() {
         String inputString = "{\"index\": \"test-index\", \"query\": {\"query\": {\"match_all\": {}}}}";
         Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, null);
+        Mockito.verify(client, times(1)).search(any(), any());
+        Mockito.verify(client, Mockito.never()).execute(any(), any(), any());
+    }
+
+    @Test
+    public void testRunWithActualKeys() {
+        Map<String, String> parameters = Map.of("index", "test-index", "query", "{\"query\": {\"match_all\": {}}}");
         mockedSearchIndexTool.run(parameters, null);
         Mockito.verify(client, times(1)).search(any(), any());
         Mockito.verify(client, Mockito.never()).execute(any(), any(), any());


### PR DESCRIPTION
### Description
We want to align the schema of tools in agent and MCP, but now different tools has different ways to parse arguments from parameters map, we need to figure out how they done this and how to align based on the investigation.
**Example**
The registration request body of SearchIndexTool in ReAct agent could be: 
```
{
  "name": "SearchIndexTool",
  "type": "SearchIndexTool",
  "description": "Use this tool to search an index by providing two parameters: 'index' for the index name, and 'query' for the OpenSearch DSL formatted query. Only use this tool when both index name and DSL query is available.",
  "attributes": {
    "input_schema": {
      "type": "object",
      "properties": {
        "index": {
          "type": "string"
        },
        "query": {
          "type": "string"
        }
      },
      "additionalProperties": false
    }
  }
}
```
But in MCP tools, the tool's request body have to be like below, which has an extra layer of `input`:
```
{
  "name": "SearchIndexTool",
  "type": "SearchIndexTool",
  "description": "Use this tool to search an index by providing two parameters: 'index' for the index name, and 'query' for the OpenSearch DSL formatted query. Only use this tool when both index name and DSL query is available.",
  "attributes": {
    "input_schema": {
      "type": "object",
      "properties": {
        "input": {
          "type": "object",
          "properties": {
            "index": {
              "type": "string"
            },
            "query": {
              "type": "string"
            }
          },
          "additionalProperties": false
        }
      }
    }
  }
}

```
The reason is in ReAct agent, the LLM will parse the generated input and put actual arguments in the parameters map, but  the MCP server won't, which causing the difference, more details can found below.

#### How tools parsing arguments from `parameters` map
Based on the tools code, I can see there are three different categories that tools parsing their parameters:

**Parsing from key `input` from parameters map**
Under this category, the `input` key is treated as two different data structure:
1. [AbstractRetrieverTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java#L82-L85) which is super calss of NeuralSparseSearchTool and VectorDBTool. 
2. [RAGTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/RAGTool.java#L103-L105)
3. [McpSseTool](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/McpSseTool.java#L61)
4. [SearchIndexTool](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/SearchIndexTool.java#L121-L124)

**Parsing from concrete keys directly from parameters map**
1. [CreateAlertTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/CreateAlertTool.java#L138-L143)
2. [LogPatternTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/LogPatternTool.java#L111-L112)
3. [SearchAlertsTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/SearchAlertsTool.java#L74-L100)
4. [SearchAnomalyDetectorsTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java#L98-L113)
5. [SearchAnomalyResultsTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java#L88-L103)
6. [SearchMonitorsTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/SearchMonitorsTool.java#L88-L102)
7. [WebSearchTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/WebSearchTool.java#L105-L119)
8. [ConnectorTool](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/ConnectorTool.java#L77)
9. [IndexMappingTool](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/IndexMappingTool.java#L97-L99)
10. [ListIndexTool](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/ListIndexTool.java#L133-L147)
11. [MLModelTool](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/MLModelTool.java#L92)
12. [VisualizationsTool](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/VisualizationsTool.java#L80)

**Hybrid parsing from `input` or from concrete keys from parameters map**
1. [PPLTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/PPLTool.java#L593-L603)
2. [AgentTool](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/AgentTool.java#L150-L162)
3. [CreateAnomalyDetectorTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/CreateAnomalyDetectorTool.java#L318-L332)

Some tools treats `input` as raw string like VisualizationsTool, so our target isn't to get rid of the `input` key itself, we're focusing on get rid of extra `input` if the tool's input is already a json.

For agent, the reason of unnecessary to add `input` key in the schema is because agent framework is not only extracting LLM returned tool input if it's a json, see [here](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java#L903-L906), but also add LLM returned tool input to parameters map with key `input`, see [here](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java#L920).

For MCP tools:
For cases `Parsing from concrete keys directly from parameters map` and case `Hybrid parsing from input or from concrete keys from parameters map`, they're working correctly without top level `input` key. But for case `Parsing from key input from parameters map`: it's not working well without top level `input` key as the tool parsing parameters from `input`, since it's difficult to parse the the MCP message and then transforming it to a different request body, so we can change these tools in this category to let them able to fetch both from `input` or directly from parameters map.

After a deeper look at the first category tools, only the SearchIndexTool has issue. Since [AbstractRetrieverTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java#L82-L85) and [RAGTool](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/RAGTool.java#L103-L105) considers input a string format which means input here is a concrete key instead of a wrapper. [McpSseTool](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/McpSseTool.java#L61) is a generic tool and we don't know the concrete keys so a wrapper key is mandatory.

### Related Issues
https://github.com/opensearch-project/ml-commons/issues/3834

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
