### PR TITLE
Prompt Execution via Predict

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/prompt/MLPromptManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/prompt/MLPromptManager.java
@@ -224,6 +224,9 @@ public class MLPromptManager {
         ActionListener<Map<String, String>> listener
     ) {
         try {
+            Map<String, String> parameters = new HashMap<>();
+            parameters.putAll(inputParameters);
+            parameters.remove(PARAMETERS_PROMPT_PARAMETERS_FIELD);
             String prompt = inputParameters.get(promptType);
             String JsonStrPromptParameters = inputParameters.get(PARAMETERS_PROMPT_PARAMETERS_FIELD);
             PromptParameters promptParam = PromptParameters.buildPromptParameters(JsonStrPromptParameters);
@@ -231,7 +234,7 @@ public class MLPromptManager {
                 case PARAMETERS_PROMPT_FIELD:
                     String promptId = prompt.split("\\(")[1].split("\\)")[0];
                     String key = prompt.split("\\.")[1];
-                    inputParameters.put(PARAMETERS_PROMPT_FIELD, pullPrompt(promptId, key, promptParam, tenantId));
+                    parameters.put(PARAMETERS_PROMPT_FIELD, pullPrompt(promptId, key, promptParam, tenantId));
                     break;
                 case PARAMETERS_MESSAGES_FIELD:
                     Messages messages = Messages.buildMessages(prompt);
@@ -242,7 +245,7 @@ public class MLPromptManager {
                         String content = pullPrompt(message.getPromptId(), message.getKey(), promptParam, tenantId);
                         message.setContent(content);
                     }
-                    inputParameters.put(PARAMETERS_MESSAGES_FIELD, Messages.toJsonString(messages));
+                    parameters.put(PARAMETERS_MESSAGES_FIELD, Messages.toJsonString(messages));
                     break;
                 default:
                     log.error("Wrong prompt type is provided: {}, should provide either prompt or messages", promptType);
@@ -250,7 +253,7 @@ public class MLPromptManager {
                         "Wrong prompt type is provided: " + promptType + ", should provide either prompt or messages"
                     );
             }
-            listener.onResponse(inputParameters);
+            listener.onResponse(parameters);
         } catch (Exception exception) {
             if (exception instanceof ArrayIndexOutOfBoundsException) {
                 exception = new IllegalArgumentException(

--- a/plugin/src/main/java/org/opensearch/ml/prompt/MLPromptManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/prompt/MLPromptManager.java
@@ -275,11 +275,13 @@ public class MLPromptManager {
      * @param tenantId tenant id
      * @return the user-defined content
      * @throws IllegalArgumentException if
-     *      1. fails to replace all the placeholder variables.
-     *      2. the specified key is not defined in the prompt template.
-     *      3. Failed to build a prompt or messages instance
-     *      3. Incorrect pull_prompt(prompt_id).<key> syntax is provided
-     *      4. Provided role does not match specified key during predict
+     * <p>
+     *     1. fails to replace all the placeholder variables.
+     *     2. the specified key is not defined in the prompt template.
+     *     3. Failed to build a prompt or messages instance
+     *     4. Incorrect pull_prompt(prompt_id).key syntax is provided
+     *     5. Provided role does not match specified key during predict
+     * </p>
      * @throws OpenSearchStatusException if the ML Prompt is not found
      */
     public String pullPrompt(String promptId, String key, PromptParameters promptParameters, String tenantId) throws IOException {

--- a/plugin/src/main/java/org/opensearch/ml/prompt/MLPromptManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/prompt/MLPromptManager.java
@@ -224,13 +224,13 @@ public class MLPromptManager {
     /**
      *  Builds a new map containing modified request body after pull_prompt is invoked
      *
-     * @param promptOrMessages type of prompt, either prompt or messages
+     * @param promptType type of prompt, either prompt or messages
      * @param inputParameters a map containing full request body received during predict
      * @param tenantId tenant id
      * @param listener the listener to notified with new map containing modified request body
      */
     public void buildInputParameters(
-        String promptOrMessages,
+        String promptType,
         Map<String, String> inputParameters,
         String tenantId,
         ActionListener<Map<String, String>> listener
@@ -238,13 +238,13 @@ public class MLPromptManager {
         try {
             Map<String, String> parameters = new HashMap<>(inputParameters);
             parameters.remove(PARAMETERS_PROMPT_PARAMETERS_FIELD);
-            String inputContent = inputParameters.get(promptOrMessages);
+            String inputContent = inputParameters.get(promptType);
             if (inputContent == null || inputContent.trim().isEmpty()) {
                 throw new IllegalArgumentException("Missing required input: Either prompt or messages must be provided");
             }
             String JsonStrPromptParameters = inputParameters.get(PARAMETERS_PROMPT_PARAMETERS_FIELD);
             PromptParameters promptParam = PromptParameters.buildPromptParameters(JsonStrPromptParameters);
-            switch (promptOrMessages) {
+            switch (promptType) {
                 case PARAMETERS_PROMPT_FIELD:
                     handlePromptField(parameters, inputContent, promptParam, tenantId);
                     break;
@@ -252,9 +252,9 @@ public class MLPromptManager {
                     handleMessagesField(parameters, inputContent, promptParam, tenantId);
                     break;
                 default:
-                    log.error("Wrong prompt type is provided: {}, should provide either prompt or messages", promptOrMessages);
+                    log.error("Wrong prompt type is provided: {}, should provide either prompt or messages", promptType);
                     throw new IllegalArgumentException(
-                        "Wrong prompt type is provided: " + promptOrMessages + ", should provide either prompt or messages"
+                        "Wrong prompt type is provided: " + promptType + ", should provide either prompt or messages"
                     );
             }
             listener.onResponse(parameters);

--- a/plugin/src/main/java/org/opensearch/ml/prompt/MLPromptManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/prompt/MLPromptManager.java
@@ -15,6 +15,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.text.StringSubstitutor;
 import org.opensearch.ExceptionsHelper;
@@ -35,6 +37,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.prompt.MLPrompt;
 import org.opensearch.ml.common.transport.prompt.MLCreatePromptInput;
 import org.opensearch.ml.common.utils.StringUtils;
@@ -50,6 +53,7 @@ import org.opensearch.transport.client.Client;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 
@@ -197,11 +201,10 @@ public class MLPromptManager {
 
         } catch (Exception e) {
             if (e instanceof IndexNotFoundException || MLExceptionUtils.getRootCause(e) instanceof IndexNotFoundException) {
-                log.debug("ML Prompt index does not exist");
+                log.debug("ML Prompt index does not exist. ML Prompt name: {} will be used to init ML Prompt index", name);
                 return null;
             }
-            log.error("Failed to search ML Prompt index", e);
-            throw new IllegalArgumentException("Failed to search");
+            throw new IllegalArgumentException("Failed to search ML Prompt index due to following cause: " + e);
         }
     }
 
@@ -234,25 +237,18 @@ public class MLPromptManager {
         try {
             Map<String, String> parameters = new HashMap<>(inputParameters);
             parameters.remove(PARAMETERS_PROMPT_PARAMETERS_FIELD);
-            String prompt = inputParameters.get(promptType);
+            String inputContent = inputParameters.get(promptType);
+            if (inputContent == null || inputContent.trim().isEmpty()) {
+                throw new IllegalArgumentException("Missing required input: Either prompt or messages must be provided");
+            }
             String JsonStrPromptParameters = inputParameters.get(PARAMETERS_PROMPT_PARAMETERS_FIELD);
             PromptParameters promptParam = PromptParameters.buildPromptParameters(JsonStrPromptParameters);
             switch (promptType) {
                 case PARAMETERS_PROMPT_FIELD:
-                    String promptId = prompt.split("\\(")[1].split("\\)")[0];
-                    String key = prompt.split("\\.")[1];
-                    parameters.put(PARAMETERS_PROMPT_FIELD, pullPrompt(promptId, key, promptParam, tenantId));
+                    handlePromptField(parameters, inputContent, promptParam, tenantId);
                     break;
                 case PARAMETERS_MESSAGES_FIELD:
-                    Messages messages = Messages.buildMessages(prompt);
-                    for (Message message : messages.messages) {
-                        if (!message.getKey().equals(message.getRole())) {
-                            throw new IllegalArgumentException("Specified key does not match the provided role");
-                        }
-                        String content = pullPrompt(message.getPromptId(), message.getKey(), promptParam, tenantId);
-                        message.setContent(content);
-                    }
-                    parameters.put(PARAMETERS_MESSAGES_FIELD, Messages.toJsonString(messages));
+                    handleMessagesField(parameters, inputContent, promptParam, tenantId);
                     break;
                 default:
                     log.error("Wrong prompt type is provided: {}, should provide either prompt or messages", promptType);
@@ -262,14 +258,76 @@ public class MLPromptManager {
             }
             listener.onResponse(parameters);
         } catch (Exception exception) {
-            if (exception instanceof ArrayIndexOutOfBoundsException) {
-                exception = new IllegalArgumentException(
-                    "Forgot to provide a key. Provide a correct pull_prompt syntax: pull_prompt(prompt_id).<key>"
-                );
-            }
             log.error("Failed to build a new Input Parameters: ", exception);
             listener.onFailure(exception);
         }
+    }
+
+    /**
+     * Convert prompt field content into an actual data fetched from ML Prompt based on provided prompt reference
+     *
+     * @param parameters Parameters field passed in by user in its request body during model execution
+     * @param promptContent content of prompt field
+     * @param promptParam Prompt Parameters field that holds user-defined values to placeholder variables
+     * @param tenantId tenant id
+     */
+    private void handlePromptField(Map<String, String> parameters, String promptContent, PromptParameters promptParam, String tenantId)
+        throws IOException {
+        List<String> IDAndKey = validatePullPromptSyntax(promptContent);
+        String promptId = IDAndKey.getFirst();
+        String key = IDAndKey.getLast();
+        PromptResult promptResult = pullPrompt(promptId, key, promptParam, tenantId);
+        parameters.put(PARAMETERS_PROMPT_FIELD, promptResult.getContent());
+    }
+
+    /**
+     * Convert messages field content into an actual data fetched from ML Prompt based on provided prompt reference
+     *
+     * @param parameters Parameters field passed in by user in its request body during model execution
+     * @param messagesContent content of prompt field
+     * @param promptParam Prompt Parameters field that holds user-defined values to placeholder variables
+     * @param tenantId tenant id
+     */
+    private void handleMessagesField(Map<String, String> parameters, String messagesContent, PromptParameters promptParam, String tenantId)
+        throws IOException {
+        Messages messages = Messages.buildMessages(messagesContent);
+        for (Message message : messages.messages) {
+            if (!message.getKey().equals(message.getRole())) {
+                throw new InvalidPullPromptSyntaxException("Specified key does not match the provided role");
+            }
+            PromptResult promptResult = pullPrompt(message.getPromptId(), message.getKey(), promptParam, tenantId);
+            message.setContent(promptResult.getContent());
+        }
+        parameters.put(PARAMETERS_MESSAGES_FIELD, Messages.toJsonString(messages));
+    }
+
+    /**
+     * Validate pull_prompt syntax and Retrieves prompt reference and key that are needed to retrieve a specific prompt
+     *
+     * @param input input that contains pull_prompt syntax alongside prompt reference and key
+     * @return List that contains prompt reference and key
+     * @throws InvalidPullPromptSyntaxException if invalid syntax is provided
+     */
+    private static List<String> validatePullPromptSyntax(String input) {
+        if (input != null && input.contains("pull_prompt(")) {
+            String pullPromptRegex = "pull_prompt\\(([^)]+)\\)\\.(.+)";
+
+            Pattern pattern = Pattern.compile(pullPromptRegex);
+            Matcher matcher = pattern.matcher(input);
+
+            if (!matcher.matches()) {
+                throw new InvalidPullPromptSyntaxException(
+                    "Invalid pull_prompt syntax is provided: " + input + ". Expected: pull_prompt(prompt_id).key"
+                );
+            }
+            String promptId = matcher.group(1);
+            String key = matcher.group(2);
+
+            return List.of(promptId, key);
+        }
+        throw new InvalidPullPromptSyntaxException(
+            "Invalid pull_prompt syntax is provided: " + input + ". Expected: pull_prompt(prompt_id).key"
+        );
     }
 
     /**
@@ -290,13 +348,9 @@ public class MLPromptManager {
      * </p>
      * @throws OpenSearchStatusException if the ML Prompt is not found
      */
-    public String pullPrompt(String promptRef, String key, PromptParameters promptParameters, String tenantId) throws IOException {
+    public PromptResult pullPrompt(String promptRef, String key, PromptParameters promptParameters, String tenantId) throws IOException {
         try {
-            SearchResponse searchResponse = validateUniquePromptName(promptRef, tenantId);
-            String promptId = promptRef;
-            if (nameAlreadyExists(searchResponse)) {
-                promptId = searchResponse.getHits().getAt(0).getId();
-            }
+            String promptId = resolvePromptID(promptRef, tenantId);
             GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
                 .builder()
                 .index(ML_PROMPT_INDEX)
@@ -305,39 +359,78 @@ public class MLPromptManager {
                 .build();
             // fetch prompt first based on prompt id
             MLPrompt mlPrompt = getPrompt(getDataObjectRequest);
+            // extract a prompt object from retrieved ML Prompt
             Map<String, String> promptField = mlPrompt.getPrompt();
             // check if the specified key is defined in the prompt
             if (!promptField.containsKey(key)) {
-                throw new IllegalArgumentException("Content for specified key is not defined in ML Prompt");
+                throw new InvalidPullPromptSyntaxException("Content for specified key is not defined in ML Prompt");
             }
-            // retrieve the user-defined content during prompt creation
+            // retrieve the user-defined content based on provided key (role)
             String content = promptField.get(key);
             // populate the placeholder variable with user input, if needed
-            if (!promptParameters.isEmpty() && content.contains(PROMPT_PARAMETER_PLACEHOLDER)) {
-                StringSubstitutor substitutor = new StringSubstitutor(
-                    promptParameters.getParameters(promptRef),
-                    PROMPT_PARAMETER_PLACEHOLDER,
-                    "}"
-                );
-                content = substitutor.replace(content);
-            }
-            // this checks if all the required input values are provided by users.
-            if (content.contains(PROMPT_PARAMETER_PLACEHOLDER)) {
-                throw new IllegalArgumentException("Failed to replace all the placeholders");
-            }
-            return content;
-        } catch (Exception e) {
-            if (e instanceof IllegalArgumentException) {
-                throw new OpenSearchStatusException(
-                    "Failed to process prompt: " + promptRef + " for following reason: " + e.getMessage(),
-                    RestStatus.BAD_REQUEST
-                );
-            }
+            content = populatePlaceholders(content, promptParameters, promptRef);
+            return new PromptResult(content, promptId);
+        } catch (InvalidPullPromptSyntaxException e) {
+            throw new OpenSearchStatusException(
+                "Failed to process prompt: " + promptRef + " for following reason: " + e.getMessage(),
+                RestStatus.BAD_REQUEST
+            );
+        } catch (OpenSearchStatusException e) {
             throw new OpenSearchStatusException(
                 "Failed to find prompt with provided prompt reference: " + promptRef + " for following reason: " + e.getMessage(),
                 RestStatus.NOT_FOUND
             );
+        } catch (PromptParsingException e) {
+            throw new OpenSearchStatusException(
+                "Failed to retrieve prompt: " + promptRef + " for following reason: " + e.getMessage(),
+                RestStatus.INTERNAL_SERVER_ERROR
+            );
+        } catch (Exception e) {
+            log.error("Unexpected error processing prompt: {}", promptRef, e);
+            throw new OpenSearchStatusException("Unexpected error processing prompt: " + promptRef, RestStatus.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    /**
+     * Resolve provided prompt reference into prompt ID, if name is provided
+     *
+     * @param promptRef name or prompt id
+     * @param tenantId tenant id
+     * @return prompt id after prompt reference is successfully resolved from name to id
+     */
+    private String resolvePromptID(String promptRef, String tenantId) {
+        SearchResponse searchResponse = validateUniquePromptName(promptRef, tenantId);
+        String promptId = promptRef;
+        // resolves prompt reference to an prompt id from prompt name
+        if (nameAlreadyExists(searchResponse)) {
+            promptId = searchResponse.getHits().getAt(0).getId();
+        }
+        return promptId;
+    }
+
+    /**
+     * Replace all the placeholder variables with user-defined values provided during execution time.
+     *
+     * @param content content that contains placeholder variables
+     * @param promptParameters prompt parameter field that contains all the values to provided placeholder variables
+     * @param promptRef prompt reference provided by user, either name or prompt id
+     * @return
+     */
+    private String populatePlaceholders(String content, PromptParameters promptParameters, String promptRef) {
+        if (!promptParameters.isEmpty() && content.contains(PROMPT_PARAMETER_PLACEHOLDER)) {
+            StringSubstitutor substitutor = new StringSubstitutor(
+                promptParameters.getParameters(promptRef),
+                PROMPT_PARAMETER_PLACEHOLDER,
+                "}"
+            );
+            content = substitutor.replace(content);
+        }
+
+        // this checks if all the required input values are provided by users and all the placeholder variables are replaced.
+        if (content.contains(PROMPT_PARAMETER_PLACEHOLDER)) {
+            throw new InvalidPullPromptSyntaxException("Failed to replace all the placeholders");
+        }
+        return content;
     }
 
     /**
@@ -345,7 +438,7 @@ public class MLPromptManager {
      *
      * @param getDataObjectRequest GetDataObjectRequest that is being sent to retrieve a prompt
      */
-    public MLPrompt getPrompt(GetDataObjectRequest getDataObjectRequest) throws IOException {
+    public MLPrompt getPrompt(GetDataObjectRequest getDataObjectRequest) {
         GetDataObjectResponse getPromptResponse = sdkClient.getDataObject(getDataObjectRequest);
         try (
             XContentParser parser = XContentType.JSON
@@ -358,9 +451,11 @@ public class MLPromptManager {
         ) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
             return MLPrompt.parse(parser);
-        } catch (Exception ex) {
+        } catch (IOException ex) {
             log.error("Failed to parse ML Prompt");
-            throw ex;
+            throw new PromptParsingException(
+                "Failed to parse ML Prompt data in Json format into MLPrompt due to following cause:  + ex.getMessage()"
+            );
         }
     }
 
@@ -377,14 +472,23 @@ public class MLPromptManager {
 
         // convert into json format string
         public static String toJsonString(Messages messages) {
-            List<Map<String, String>> jsonString = new ArrayList<>();
-            for (Message message : messages.messages) {
-                Map<String, String> messageMap = new HashMap<>();
-                messageMap.put(ROLE_PARAMETER, message.getRole());
-                messageMap.put(CONTENT_PARAMETER, message.getContent());
-                jsonString.add(messageMap);
+            Objects.requireNonNull(messages, "Messages content cannot be null when converting to Json");
+            int totalMessages = messages.messages.size();
+            StringBuilder jsonString = new StringBuilder();
+            jsonString.append("[");
+            for (int i = 0; i < totalMessages; i++) {
+                Message message = messages.messages.get(i);
+                jsonString.append("{");
+                jsonString.append("\"" + ROLE_PARAMETER + "\":\"").append(message.getRole()).append("\",");
+                jsonString.append("\"" + CONTENT_PARAMETER + "\":\"").append(message.getContent()).append("\"");
+                if (i == totalMessages - 1) {
+                    jsonString.append("}");
+                } else {
+                    jsonString.append("},");
+                }
             }
-            return StringUtils.toJson(jsonString);
+            jsonString.append("]");
+            return jsonString.toString();
         }
 
         public int size() {
@@ -392,7 +496,7 @@ public class MLPromptManager {
         }
 
         // initialize a Messages instance from json format input string
-        public static Messages buildMessages(String input) throws IOException {
+        public static Messages buildMessages(String input) {
             List<Message> messages = new ArrayList<>();
             XContent xContent = XContentType.JSON.xContent();
             try (
@@ -403,9 +507,10 @@ public class MLPromptManager {
                 while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                     messages.add(Message.buildMessage(parser));
                 }
-            } catch (Exception ex) {
-                log.error("Failed to build Messages");
-                throw ex;
+            } catch (IOException ex) {
+                throw new PromptParsingException(
+                    "Failed to parse Messages Json format into Messages instance due to following cause: " + ex.getMessage()
+                );
             }
             return Messages.builder().messages(messages).build();
         }
@@ -436,11 +541,13 @@ public class MLPromptManager {
         private String promptId;
         private String key;
 
-        public Message(String role, String content) {
-            this.role = role;
-            this.content = content;
-            this.promptId = this.content.split("\\(")[1].split("\\)")[0];
-            this.key = this.content.split("\\.")[1];
+        public Message(@NonNull String role, @NonNull String content) {
+            this.role = Objects.requireNonNull(role, "Missing message role field. Expecting either user or system role");
+            this.content = Objects
+                .requireNonNull(content, "Missing message content field. Expecting message content based on provided role");
+            List<String> IDAndKey = validatePullPromptSyntax(this.content);
+            this.promptId = IDAndKey.getFirst();
+            this.key = IDAndKey.getLast();
         }
 
         public static Message buildMessage(XContentParser parser) throws IOException {
@@ -459,7 +566,7 @@ public class MLPromptManager {
                         content = parser.text();
                         // check if the correct pull_prompt syntax is provided
                         if (!content.contains("pull_prompt")) {
-                            throw new IllegalArgumentException(
+                            throw new InvalidPullPromptSyntaxException(
                                 "You typed "
                                     + content.split("\\(")[0]
                                     + ". Provide Correct pull_prompt syntax: pull_prompt(prompt_id).<key>"
@@ -507,7 +614,7 @@ public class MLPromptManager {
             return this.parameters.isEmpty();
         }
 
-        public static PromptParameters buildPromptParameters(String input) throws IOException {
+        public static PromptParameters buildPromptParameters(String input) {
             Map<String, Map<String, String>> promptParam = new HashMap<>();
             XContent xContent = XContentType.JSON.xContent();
             try (
@@ -521,8 +628,44 @@ public class MLPromptManager {
                     Map<String, String> parameter = StringUtils.getParameterMap(parser.map());
                     promptParam.put(promptId, parameter);
                 }
+                return PromptParameters.builder().parameters(promptParam).build();
+            } catch (IOException e) {
+                throw new PromptParsingException(
+                    "Failed to parse Prompt Parameters Json format into PromptParameters due to following cause: " + e.getMessage()
+                );
             }
-            return PromptParameters.builder().parameters(promptParam).build();
+        }
+    }
+
+    /**
+     * A class that represents Prompt result that contains content after pull prompt op is complete
+     */
+    @Getter
+    static class PromptResult {
+        private final String content;
+        private final String promptId;
+
+        public PromptResult(String content, String promptId) {
+            this.content = content;
+            this.promptId = promptId;
+        }
+    }
+
+    /**
+     * An Exception to be thrown when invalid pull prompt syntax is provided
+     */
+    static class InvalidPullPromptSyntaxException extends IllegalArgumentException {
+        public InvalidPullPromptSyntaxException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * An Exception to be thrown when parsing fails during ML Prompt management
+     */
+    static class PromptParsingException extends MLException {
+        public PromptParsingException(String message) {
+            super(message);
         }
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/prediction/TransportPredictionTaskActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prediction/TransportPredictionTaskActionTests.java
@@ -54,6 +54,7 @@ import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.prompt.MLPromptManager;
 import org.opensearch.ml.task.MLPredictTaskRunner;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
@@ -113,6 +114,9 @@ public class TransportPredictionTaskActionTests extends OpenSearchTestCase {
 
     private MLInput mlInput;
 
+    @Mock
+    private MLPromptManager mlPromptManager;
+
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
@@ -155,6 +159,7 @@ public class TransportPredictionTaskActionTests extends OpenSearchTestCase {
                 xContentRegistry,
                 mlModelManager,
                 modelAccessControlHelper,
+                mlPromptManager,
                 mlFeatureEnabledSetting,
                 settings
             )

--- a/plugin/src/test/java/org/opensearch/ml/action/prediction/TransportPredictionTaskActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prediction/TransportPredictionTaskActionTests.java
@@ -352,8 +352,7 @@ public class TransportPredictionTaskActionTests extends OpenSearchTestCase {
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(remoteInferenceInputDataSet).build();
 
         mlPredictionTaskRequest = MLPredictionTaskRequest.builder().modelId("test_id").mlInput(mlInput).build();
-        transportPredictionTaskAction
-            .checkIfPullPromptExists(mlPredictionTaskRequest, actionListener, mlPredictionTaskRequest.getModelId());
+        transportPredictionTaskAction.checkIfPullPromptExists(mlPredictionTaskRequest, actionListener);
 
         RemoteInferenceInputDataSet inputDataSet = (RemoteInferenceInputDataSet) mlPredictionTaskRequest.getMlInput().getInputDataset();
         assertEquals(inputParametersAfter.get("messages"), inputDataSet.getParameters().get("messages"));
@@ -375,8 +374,7 @@ public class TransportPredictionTaskActionTests extends OpenSearchTestCase {
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(remoteInferenceInputDataSet).build();
 
         mlPredictionTaskRequest = MLPredictionTaskRequest.builder().modelId("test_id").mlInput(mlInput).build();
-        transportPredictionTaskAction
-            .checkIfPullPromptExists(mlPredictionTaskRequest, actionListener, mlPredictionTaskRequest.getModelId());
+        transportPredictionTaskAction.checkIfPullPromptExists(mlPredictionTaskRequest, actionListener);
 
         RemoteInferenceInputDataSet inputDataSet = (RemoteInferenceInputDataSet) mlPredictionTaskRequest.getMlInput().getInputDataset();
         assertEquals(inputParametersAfter.get("prompt"), inputDataSet.getParameters().get("prompt"));

--- a/plugin/src/test/java/org/opensearch/ml/action/prediction/TransportPredictionTaskActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prediction/TransportPredictionTaskActionTests.java
@@ -20,8 +20,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
-import javax.swing.*;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/plugin/src/test/java/org/opensearch/ml/action/prompt/TransportCreatePromptActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prompt/TransportCreatePromptActionTests.java
@@ -91,6 +91,9 @@ public class TransportCreatePromptActionTests extends OpenSearchTestCase {
 
     private MLCreatePromptInput mlCreatePromptInput;
 
+    @Mock
+    private MLPromptManager mlPromptManager;
+
     @Before
     public void setup() throws IOException {
         MockitoAnnotations.openMocks(this);
@@ -99,7 +102,15 @@ public class TransportCreatePromptActionTests extends OpenSearchTestCase {
         when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
         indexResponse = new IndexResponse(new ShardId(ML_PROMPT_INDEX, "_na_", 0), PROMPT_ID, 1, 0, 2, true);
         transportCreatePromptAction = spy(
-            new TransportCreatePromptAction(transportService, actionFilters, mlIndicesHandler, client, sdkClient, mlFeatureEnabledSetting)
+            new TransportCreatePromptAction(
+                transportService,
+                actionFilters,
+                mlIndicesHandler,
+                client,
+                sdkClient,
+                mlPromptManager,
+                mlFeatureEnabledSetting
+            )
         );
         threadContext = new ThreadContext(Settings.EMPTY);
         when(client.threadPool()).thenReturn(threadPool);
@@ -128,6 +139,7 @@ public class TransportCreatePromptActionTests extends OpenSearchTestCase {
             mlIndicesHandler,
             client,
             sdkClient,
+            mlPromptManager,
             mlFeatureEnabledSetting
         );
         assertNotNull(transportCreatePromptAction);

--- a/plugin/src/test/java/org/opensearch/ml/action/prompt/TransportCreatePromptActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prompt/TransportCreatePromptActionTests.java
@@ -138,7 +138,7 @@ public class TransportCreatePromptActionTests extends OpenSearchTestCase {
         mlCreatePromptRequest = MLCreatePromptRequest.builder().mlCreatePromptInput(mlCreatePromptInput).build();
 
         SearchResponse searchResponse = createSearchResponse(0);
-        when(mlPromptManager.validateUniquePromptName(any(), any())).thenReturn(searchResponse);
+        when(mlPromptManager.searchPromptByName(any(), any())).thenReturn(searchResponse);
     }
 
     @Test
@@ -254,21 +254,21 @@ public class TransportCreatePromptActionTests extends OpenSearchTestCase {
 
     public void testDoExecute_fail_withPromptNameAlreadyExists() throws IOException {
         SearchResponse searchResponse = createSearchResponse(1);
-        when(mlPromptManager.validateUniquePromptName(any(), any())).thenReturn(searchResponse);
+        when(mlPromptManager.searchPromptByName(any(), any())).thenReturn(searchResponse);
 
         transportCreatePromptAction.doExecute(task, mlCreatePromptRequest, actionListener);
 
         ArgumentCaptor<IllegalArgumentException> argumentCaptor = ArgumentCaptor.forClass(IllegalArgumentException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
-            "The name you provided is already being used by another Prompt with ID: prompt_id",
+            "The name you provided is already being used by another Prompt with ID: prompt_id . The conflicting name you provided: test_prompt",
             argumentCaptor.getValue().getMessage()
         );
     }
 
     public void testDoExecute_fail_searchResponseParsing() throws IOException {
         SearchResponse searchResponse = createSearchResponse(0);
-        when(mlPromptManager.validateUniquePromptName(any(), any()))
+        when(mlPromptManager.searchPromptByName(any(), any()))
             .thenThrow(new OpenSearchStatusException("Failed to parse search response", RestStatus.INTERNAL_SERVER_ERROR));
 
         transportCreatePromptAction.doExecute(task, mlCreatePromptRequest, actionListener);

--- a/plugin/src/test/java/org/opensearch/ml/action/prompt/UpdatePromptTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prompt/UpdatePromptTransportActionTests.java
@@ -120,11 +120,7 @@ public class UpdatePromptTransportActionTests extends OpenSearchTestCase {
         mlUpdatePromptRequest = MLUpdatePromptRequest.builder().promptId("prompt_id").mlUpdatePromptInput(mlUpdatePromptInput).build();
 
         SearchResponse searchResponse = createSearchResponse(0);
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(2);
-            listener.onResponse(searchResponse);
-            return null;
-        }).when(mlPromptManager).validateUniquePromptName(any(), any(), any());
+        when(mlPromptManager.validateUniquePromptName(any(), any())).thenReturn(searchResponse);
     }
 
     @Test
@@ -246,29 +242,22 @@ public class UpdatePromptTransportActionTests extends OpenSearchTestCase {
 
     public void testDoExecute_fail_withPromptNameAlreadyExists() throws IOException {
         SearchResponse searchResponse = createSearchResponse(1);
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(2);
-            listener.onResponse(searchResponse);
-            return null;
-        }).when(mlPromptManager).validateUniquePromptName(any(), any(), any());
+        when(mlPromptManager.validateUniquePromptName(any(), any())).thenReturn(searchResponse);
 
         updatePromptTransportAction.doExecute(task, mlUpdatePromptRequest, actionListener);
 
         ArgumentCaptor<IllegalArgumentException> argumentCaptor = ArgumentCaptor.forClass(IllegalArgumentException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
-            "The name you provided is already being used by another ML Prompt with ID: prompt_id.",
+            "The name you provided is already being used by another Prompt with ID: prompt_id",
             argumentCaptor.getValue().getMessage()
         );
     }
 
     public void testDoExecute_fail_searchResponseParsing() throws IOException {
         SearchResponse searchResponse = createSearchResponse(0);
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(2);
-            listener.onFailure(new OpenSearchStatusException("Failed to parse search response", RestStatus.INTERNAL_SERVER_ERROR));
-            return null;
-        }).when(mlPromptManager).validateUniquePromptName(any(), any(), any());
+        when(mlPromptManager.validateUniquePromptName(any(), any()))
+            .thenThrow(new OpenSearchStatusException("Failed to parse search response", RestStatus.INTERNAL_SERVER_ERROR));
 
         updatePromptTransportAction.doExecute(task, mlUpdatePromptRequest, actionListener);
 

--- a/plugin/src/test/java/org/opensearch/ml/action/prompt/UpdatePromptTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prompt/UpdatePromptTransportActionTests.java
@@ -120,7 +120,7 @@ public class UpdatePromptTransportActionTests extends OpenSearchTestCase {
         mlUpdatePromptRequest = MLUpdatePromptRequest.builder().promptId("prompt_id").mlUpdatePromptInput(mlUpdatePromptInput).build();
 
         SearchResponse searchResponse = createSearchResponse(0);
-        when(mlPromptManager.validateUniquePromptName(any(), any())).thenReturn(searchResponse);
+        when(mlPromptManager.searchPromptByName(any(), any())).thenReturn(searchResponse);
     }
 
     @Test
@@ -242,21 +242,21 @@ public class UpdatePromptTransportActionTests extends OpenSearchTestCase {
 
     public void testDoExecute_fail_withPromptNameAlreadyExists() throws IOException {
         SearchResponse searchResponse = createSearchResponse(1);
-        when(mlPromptManager.validateUniquePromptName(any(), any())).thenReturn(searchResponse);
+        when(mlPromptManager.searchPromptByName(any(), any())).thenReturn(searchResponse);
 
         updatePromptTransportAction.doExecute(task, mlUpdatePromptRequest, actionListener);
 
         ArgumentCaptor<IllegalArgumentException> argumentCaptor = ArgumentCaptor.forClass(IllegalArgumentException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
-            "The name you provided is already being used by another Prompt with ID: prompt_id",
+            "The name you provided is already being used by another Prompt with ID: prompt_id . The conflicting name you provided: test_prompt",
             argumentCaptor.getValue().getMessage()
         );
     }
 
     public void testDoExecute_fail_searchResponseParsing() throws IOException {
         SearchResponse searchResponse = createSearchResponse(0);
-        when(mlPromptManager.validateUniquePromptName(any(), any()))
+        when(mlPromptManager.searchPromptByName(any(), any()))
             .thenThrow(new OpenSearchStatusException("Failed to parse search response", RestStatus.INTERNAL_SERVER_ERROR));
 
         updatePromptTransportAction.doExecute(task, mlUpdatePromptRequest, actionListener);

--- a/plugin/src/test/java/org/opensearch/ml/prompt/MLPromptManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/prompt/MLPromptManagerTests.java
@@ -336,7 +336,10 @@ public class MLPromptManagerTests extends OpenSearchTestCase {
         ArgumentCaptor<IllegalArgumentException> argumentCaptor = ArgumentCaptor.forClass(IllegalArgumentException.class);
         verify(getInputParameterListener).onFailure(argumentCaptor.capture());
         IllegalArgumentException exception = argumentCaptor.getValue();
-        assertEquals("Forgot to provide a key. Provide a correct pull_prompt syntax: pull_prompt(prompt_id).<key>", exception.getMessage());
+        assertEquals(
+            "Invalid pull_prompt syntax is provided: pull_prompt(prompt_id). Expected: pull_prompt(prompt_id).key",
+            exception.getMessage()
+        );
     }
 
     @Test


### PR DESCRIPTION
### Description
Enables prompt execution through predict model. This PR also allow unique name across prompts

### Related Issues
Resolves #3711
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
