### PR TITLE
Fixed NPE for connector retrying policy

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
@@ -286,7 +286,10 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                     if (connector == null) {
                         wrappedListener
                             .onFailure(
-                                new OpenSearchStatusException("Connector needs to be updated with inline request", RestStatus.BAD_REQUEST)
+                                new OpenSearchStatusException(
+                                    "Cannot update connector settings for this model. The model was created with a connector_id and does not have an inline connector.",
+                                    RestStatus.BAD_REQUEST
+                                )
                             );
                         return;
                     }

--- a/plugin/src/test/java/org/opensearch/ml/action/models/UpdateModelTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/UpdateModelTransportActionTests.java
@@ -752,7 +752,10 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
         transportUpdateModelAction.doExecute(task, prepareRemoteRequest("REMOTE_INTERNAL"), actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals("Connector needs to be updated with inline request", argumentCaptor.getValue().getMessage());
+        assertEquals(
+            "Cannot update connector settings for this model. The model was created with a connector_id and does not have an inline connector.",
+            argumentCaptor.getValue().getMessage()
+        );
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixed NPE for connector when retrying

### Related Issues
Resolves https://github.com/opensearch-project/ml-commons/issues/3906

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
