### PR TITLE
properly handles commons-beanutils to 1.11.0 fixes CVE-48734

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -99,9 +99,15 @@ configurations.all {
     resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.25.5'
     resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
     resolutionStrategy.force 'software.amazon.awssdk:bom:2.30.18'
-    resolutionStrategy.force 'org.apache.commons:commons-beanutils:2.0.0'
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'commons-beanutils') {
+            details.useVersion '1.11.0'
+        }
+        if (details.requested.group == 'org.apache.commons' && details.requested.name == 'commons-beanutils2') {
+            details.useVersion '2.0.0-M2'
+        }
+    }
 }
-
 
 jacocoTestReport {
     reports {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -99,6 +99,7 @@ configurations.all {
     resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.25.5'
     resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
     resolutionStrategy.force 'software.amazon.awssdk:bom:2.30.18'
+    resolutionStrategy.force 'org.apache.commons:commons-beanutils:2.0.0'
 }
 
 


### PR DESCRIPTION
### Description
the previous PR (https://github.com/opensearch-project/ml-commons/pull/3915) didnt convert the dependency to a different version. This PR does

I'm borrowing from https://github.com/opensearch-project/query-insights/pull/370/files I tested locally to see before and after this time. 


### Related Issues
Solves  https://github.com/opensearch-project/ml-commons/pull/3915 properly

### Testing
You can see the dependency is now `commons-beanutils:commons-beanutils:1.9.4 -> 1.11.0
`
```
 ./gradlew :opensearch-ml-algorithms:dependencyInsight \
    --dependency commons-beanutils \
    --configuration runtimeClasspath

=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.11.1
  OS Info               : Mac OS X 15.5 (aarch64)
  JDK Version           : 21 (Amazon Corretto JDK)
  JAVA_HOME             : /Users/iflorbri/.sdkman/candidates/java/21.0.5-amzn
  Random Testing Seed   : 2158C0CF9FB74BA9
  Crypto Standard       : any-supported
=======================================

> Task :opensearch-ml-algorithms:dependencyInsight
commons-beanutils:commons-beanutils:1.11.0 (selected by rule)
  Variant runtime:
    | Attribute Name                 | Provided     | Requested    |
    |--------------------------------|--------------|--------------|
    | org.gradle.status              | release      |              |
    | org.gradle.category            | library      | library      |
    | org.gradle.libraryelements     | jar          | jar          |
    | org.gradle.usage               | java-runtime | java-runtime |
    | org.gradle.dependency.bundling |              | external     |
    | org.gradle.jvm.environment     |              | standard-jvm |
    | org.gradle.jvm.version         |              | 21           |

commons-beanutils:commons-beanutils:1.9.4 -> 1.11.0
\--- com.opencsv:opencsv:5.4
     \--- org.tribuo:tribuo-data:4.2.1
          +--- org.tribuo:tribuo-clustering-kmeans:4.2.1
          |    \--- runtimeClasspath
          +--- org.tribuo:tribuo-regression-sgd:4.2.1
          |    \--- runtimeClasspath
          +--- org.tribuo:tribuo-classification-sgd:4.2.1
          |    \--- runtimeClasspath
          +--- org.tribuo:tribuo-common-sgd:4.2.1
          |    +--- org.tribuo:tribuo-regression-sgd:4.2.1 (*)
          |    \--- org.tribuo:tribuo-classification-sgd:4.2.1 (*)
          +--- org.tribuo:tribuo-anomaly-core:4.2.1
          |    \--- org.tribuo:tribuo-anomaly-libsvm:4.2.1
          |         \--- runtimeClasspath
          \--- org.tribuo:tribuo-common-tree:4.2.1
               \--- org.tribuo:tribuo-classification-core:4.2.1
                    \--- org.tribuo:tribuo-classification-sgd:4.2.1 (*)

```

The previous Pr did 
```
    resolutionStrategy.force 'org.apache.commons:commons-beanutils:2.0.0'
```
But when you check with :opensearch-ml-algorithms:dependencyInsight
it shows up as commons-beanutils:commons-beanutils:1.9.4

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
