### PR TITLE
Fix tool not found in MCP memory issue

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/TransportMcpToolsRemoveOnNodesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/TransportMcpToolsRemoveOnNodesAction.java
@@ -112,7 +112,7 @@ public class TransportMcpToolsRemoveOnNodesAction extends
                         );
                     errors.get().add(toolName);
                     return Mono.empty();
-                }).subscribe();
+                }).doOnSuccess(x -> McpAsyncServerHolder.IN_MEMORY_MCP_TOOLS.remove(toolName)).subscribe();
             }
             return Mono.empty();
         }).doOnComplete(() -> log.debug("Successfully removed tools on node: {}", clusterService.localNode().getId())).subscribe();


### PR DESCRIPTION
### Description
When registering a new tool and remove it immediately, there could be an error like below:
```
Tools: [My_SearchIndexTool] are removed successfully in index but failed to remove from mcp server in memory with error: Tools: [My_SearchIndexTool] not found on node: 84yLg-Q8TvSw7d7MpwwXAw
```
This happens when a tool is not registered first time, the reason is an internal map is maintaining the tools, and during removing, the tool is not been removed from the map then when re-registering the tool, it can't be added into the MCP server memory.

### Related Issues
NA

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
