### PR TITLE
force runtime class path commons-beanutils:commons-beanutils:1.11.0 to avoid transitive dependency

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -99,14 +99,6 @@ configurations.all {
     resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.25.5'
     resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
     resolutionStrategy.force 'software.amazon.awssdk:bom:2.30.18'
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        if (details.requested.group == 'commons-beanutils') {
-            details.useVersion '1.11.0'
-        }
-        if (details.requested.group == 'org.apache.commons' && details.requested.name == 'commons-beanutils2') {
-            details.useVersion '2.0.0-M2'
-        }
-    }
 }
 
 jacocoTestReport {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -671,3 +671,12 @@ forbiddenPatterns {
     exclude '**/*.pdf'
     exclude '**/*.jpg'
 }
+
+configurations {
+    runtimeClasspath {
+        resolutionStrategy {
+            // CVE-48734: tribuo-clustering-kmeans:'4.2.1 causes a transitive dependency on beanutils:1.94
+            force 'commons-beanutils:commons-beanutils:1.11.0'
+        }
+    }
+}


### PR DESCRIPTION
### Description
This should resolve CVE-48734 I tested locally by running `./gradlew clean assemble` opening the snapshot zip and seeing `commons-beanutils-1.11.0.jar` instead of `commons-beanutils-1.9.4.jar`

### Related Issues

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
