### PR TITLE
Fix exposed connector URL in error message

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
@@ -182,7 +182,7 @@ public interface Connector extends ToXContentObject, Writeable {
                 }
             }
             if (!hasMatchedUrl) {
-                throw new IllegalArgumentException("Connector URL is not matching the trusted connector endpoint regex, URL is: " + url);
+                throw new IllegalArgumentException("Connector URL is not matching the trusted connector endpoint regex");
             }
         }
     }

--- a/common/src/main/java/org/opensearch/ml/common/connector/McpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/McpConnector.java
@@ -438,7 +438,7 @@ public class McpConnector implements Connector {
             }
         }
         if (!hasMatchedUrl) {
-            throw new IllegalArgumentException("Connector URL is not matching the trusted connector endpoint regex, URL is: " + url);
+            throw new IllegalArgumentException("Connector URL is not matching the trusted connector endpoint regex");
         }
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
@@ -547,7 +547,7 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(
-            "Connector URL is not matching the trusted connector endpoint regex, URL is: https://api.openai1.com/v1/completions",
+            "Connector URL is not matching the trusted connector endpoint regex",
             argumentCaptor.getValue().getMessage()
         );
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
@@ -546,10 +546,7 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
         action.doExecute(task, request, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals(
-            "Connector URL is not matching the trusted connector endpoint regex",
-            argumentCaptor.getValue().getMessage()
-        );
+        assertEquals("Connector URL is not matching the trusted connector endpoint regex", argumentCaptor.getValue().getMessage());
     }
 
     public void test_connector_creation_success_deepseek() {


### PR DESCRIPTION
### Description
This pull request addresses a security concern where user input, in this case specifically the connector URL was being exposed in error messages. Exposing such information can inadvertently leak sensitive data and does not align with security best practices.

Fix:
Updated the error handling logic to avoid printing the connector URL in error messages, thereby preventing potential information disclosure.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
