### PR TITLE
Fix is_async status of agent execution task

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/MLTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLTask.java
@@ -73,6 +73,7 @@ public class MLTask implements ToXContentObject, Writeable {
     @Setter
     private String error;
     private User user; // TODO: support document level access control later
+    @Setter
     private boolean async;
     @Setter
     private Map<String, Object> remoteJob;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
@@ -407,6 +407,7 @@ public class MLAgentExecutor implements Executable, SettingsChangeListener {
                 agentResponse.put(PARENT_INTERACTION_ID, parentInteractionId);
             }
             mlTask.setResponse(agentResponse);
+            mlTask.setAsync(true);
 
             indexMLTask(mlTask, ActionListener.wrap(indexResponse -> {
                 String taskId = indexResponse.getId();


### PR DESCRIPTION
### Description
When an agent is executed in async mode and the task is retrieved, we see the is_async parameter in response as false.

```
GET /_plugins/_ml/tasks/<task_id>
{
    ...
    "is_async": false,
    "response": {
        ...
    }
}
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
