### PR TITLE
fix the error status code and message for empty response

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
@@ -177,22 +177,28 @@ public class MLSdkAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandle
             return;
         }
 
+        // Handle error status codes (4xx, 5xx)
+        if (statusCode == null || statusCode < HttpStatus.SC_OK || statusCode > HttpStatus.SC_MULTIPLE_CHOICES) {
+            RestStatus status = (statusCode != null) ? RestStatus.fromCode(statusCode) : RestStatus.INTERNAL_SERVER_ERROR;
+            String errorMsg = Strings.isBlank(body)
+                ? String.format("Remote service returned error status %d with empty body", statusCode)
+                : REMOTE_SERVICE_ERROR + body;
+
+            log.error("Remote service returned error: {} with status: {}", errorMsg, status);
+            actionListener.onFailure(new OpenSearchStatusException(errorMsg, status));
+            return;
+        }
+
+        // Handle successful status codes with empty body (invalid for most operations)
         if (Strings.isBlank(body) && !action.equals(CANCEL_BATCH_PREDICT.toString())) {
-            log.error("Remote model response body is empty!");
-            actionListener.onFailure(new OpenSearchStatusException("No response from model", RestStatus.BAD_REQUEST));
-            return;
-        }
-
-        if (statusCode < HttpStatus.SC_OK || statusCode > HttpStatus.SC_MULTIPLE_CHOICES) {
-            log.error("Remote service returned error code: {} with body: {}", statusCode, body);
-            actionListener.onFailure(new OpenSearchStatusException(REMOTE_SERVICE_ERROR + body, RestStatus.fromCode(statusCode)));
-            return;
-        }
-
-        if (action.equals(CANCEL_BATCH_PREDICT.toString())) {
-            ModelTensors tensors = ModelTensors.builder().statusCode(statusCode).build();
-            tensors.setStatusCode(statusCode);
-            actionListener.onResponse(new Tuple<>(executionContext.getSequence(), tensors));
+            log.error("Remote model returned successful status {} but with empty response body", statusCode);
+            actionListener
+                .onFailure(
+                    new OpenSearchStatusException(
+                        "Remote service returned empty response body",
+                        RestStatus.BAD_GATEWAY  // 502 - indicates upstream returned invalid response
+                    )
+                );
             return;
         }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
@@ -221,7 +221,7 @@ public class MLSdkAsyncHttpResponseHandlerTest {
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener, times(1)).onFailure(captor.capture());
         assert captor.getValue() instanceof OpenSearchStatusException;
-        assert captor.getValue().getMessage().equals("No response from model");
+        assert captor.getValue().getMessage().equals("Remote service returned error status 500 with empty body");
     }
 
     @Test
@@ -302,7 +302,7 @@ public class MLSdkAsyncHttpResponseHandlerTest {
         mlSdkAsyncHttpResponseHandler.onStream(stream);
         ArgumentCaptor<OpenSearchStatusException> captor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
         verify(actionListener, times(1)).onFailure(captor.capture());
-        assert captor.getValue().getMessage().equals("No response from model");
+        assert captor.getValue().getMessage().equals("Remote service returned empty response body");
     }
 
     @Test


### PR DESCRIPTION
### Description
Current if model response is empty, ml-commons returns a 400 error code and error message showing the response is empty. This is problematic because it doesn't show the true status code from the remote service and several customers complained that this error code/message is hard for them to understand the real errors. 

This PR fixes this problem and shows better error code and message based on different type of errors received from the remote model service.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
