### PR TITLE
Keep .plugins-ml-config index for Integration test

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/MLCommonsRestTestCase.java
@@ -279,7 +279,7 @@ public abstract class MLCommonsRestTestCase extends OpenSearchRestTestCase {
 
             for (Map<String, Object> index : parserList) {
                 String indexName = (String) index.get("index");
-                if (indexName != null && !".opendistro_security".equals(indexName)) {
+                if (indexName != null && !".opendistro_security".equals(indexName) && !".plugins-ml-config".equals(indexName)) {
                     adminClient().performRequest(new Request("DELETE", "/" + indexName));
                 }
             }

--- a/plugin/src/test/java/org/opensearch/ml/tools/ListIndexToolIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/tools/ListIndexToolIT.java
@@ -40,7 +40,7 @@ public class ListIndexToolIT extends RestBaseAgentToolsIT {
     private List<String> createIndices(int count) throws IOException {
         List<String> indices = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            String indexName = "test" + StringUtils.toRootLowerCase(randomAlphaOfLength(5));
+            String indexName = "test" + StringUtils.toRootLowerCase(randomAlphaOfLength(7));
             createIndex(indexName, Settings.EMPTY);
             indices.add(indexName);
         }


### PR DESCRIPTION
### Description

1. Don't delete `.plugins-ml-config` index for Integration test, As the master key stores in this index, delete and recreate will cause the value in [Encryptor](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java#L81) is not consistent for encrypt and decrypt.

A exception flow may looks like 

- cluster initialized -> masterkey KeyA -> value in Encryptor is masterkey KeyA
- IT1 run finish -> remove `.plugins-ml-config` index
- IT2 start to run create a connect will use masterkey KeyA persistent in [Encryptor](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/encryptor/EncryptorImpl.java#L130-L132) 
- MLSyncUpJob run every 10s -> will create a new `.plugins-ml-config` and reset masterkey in Encryptor as KeyB
- IT2 call predict of model use the connector which just created, the masterkey has changed to KeyB in Encryptor, so the `tag mismatch` exception happened.

### Related Issues

https://github.com/opensearch-project/ml-commons/pull/3963#issuecomment-3077347757
https://github.com/opensearch-project/ml-commons/issues/2560

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
