### PR TITLE
exclude commons-beanutils

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -28,7 +28,9 @@ dependencies {
     implementation ("org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}")
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation group: 'org.reflections', name: 'reflections', version: '0.9.12'
-    implementation group: 'org.tribuo', name: 'tribuo-clustering-kmeans', version: '4.3.2'
+    implementation (group: 'org.tribuo', name: 'tribuo-clustering-kmeans', version: '4.3.2') {
+        exclude group: "commons-beanutils", module: "commons-beanutils"
+    }
     implementation group: 'org.tribuo', name: 'tribuo-regression-sgd', version: '4.3.2'
     implementation group: 'org.tribuo', name: 'tribuo-anomaly-libsvm', version: '4.3.2'
     implementation group: 'org.tribuo', name: 'tribuo-classification-sgd', version: '4.3.2'
@@ -99,6 +101,7 @@ configurations.all {
     resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.25.5'
     resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
     resolutionStrategy.force 'software.amazon.awssdk:bom:2.30.18'
+    resolutionStrategy.force 'commons-beanutils:commons-beanutils:1.11.0'
 }
 
 


### PR DESCRIPTION
### Description
exclude commons-beanutils and force from 1.9.4 to 1.11.0

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
