### PR TITLE
Add global resource support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ml-algorithms/build/
 plugin/build/
 .DS_Store
 */bin/
+**/*.factorypath

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -6,6 +6,8 @@
 package org.opensearch.ml.common.settings;
 
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY;
+import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY;
+import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_GLOBAL_TENANT_ID_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_REGION_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_SERVICE_NAME_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_TYPE_KEY;
@@ -372,4 +374,14 @@ public final class MLCommonsSettings {
         .boolSetting("plugins.ml_commons.agentic_memory_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final String ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE =
         "The Agentic Memory APIs are not enabled. To enable, please update the setting " + ML_COMMONS_AGENTIC_MEMORY_ENABLED.getKey();
+
+    public static final Setting<String> REMOTE_METADATA_GLOBAL_TENANT_ID = Setting
+        .simpleString("plugins.ml-commons." + REMOTE_METADATA_GLOBAL_TENANT_ID_KEY, Setting.Property.NodeScope, Setting.Property.Final);
+
+    public static final Setting<String> REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL = Setting
+        .simpleString(
+            "plugins.ml-commons." + REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY,
+            Setting.Property.NodeScope,
+            Setting.Property.Final
+        );
 }

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     // Multi-tenant SDK Client
     implementation "org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}"
     implementation 'commons-beanutils:commons-beanutils:1.11.0'
+    implementation "org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}"
 
     def os = DefaultNativePlatform.currentOperatingSystem
     //arm/macos doesn't support GPU

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/MLEngine.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/MLEngine.java
@@ -150,6 +150,15 @@ public class MLEngine {
         return predictable;
     }
 
+    public void deploy(MLModel mlModel, Map<String, Object> params, ActionListener<Predictable> listener) {
+        Predictable predictable = MLEngineClassLoader.initInstance(mlModel.getAlgorithm(), null, MLAlgoParams.class);
+        predictable.initModelAsync(mlModel, params, encryptor).thenAccept((b) -> listener.onResponse(predictable)).exceptionally(e -> {
+            log.error("Failed to init init model", e);
+            listener.onFailure(new RuntimeException(e));
+            return null;
+        });
+    }
+
     public MLExecutable deployExecute(MLModel mlModel, Map<String, Object> params) {
         MLExecutable executable = MLEngineClassLoader.initInstance(mlModel.getAlgorithm(), null, MLAlgoParams.class);
         executable.initModel(mlModel, params);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/Predictable.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/Predictable.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.engine;
 
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
 
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.MLModel;
@@ -18,6 +19,8 @@ import org.opensearch.ml.engine.encryptor.Encryptor;
  * This is machine learning algorithms predict interface.
  */
 public interface Predictable {
+
+    String METHOD_NOT_IMPLEMENTED_ERROR_MSG = "Method is not implemented";
 
     /**
      * Predict with given input data and model.
@@ -34,11 +37,11 @@ public interface Predictable {
      * @return predicted results
      */
     default MLOutput predict(MLInput mlInput) {
-        throw new IllegalStateException("Method is not implemented");
+        throw new IllegalStateException(METHOD_NOT_IMPLEMENTED_ERROR_MSG);
     }
 
     default void asyncPredict(MLInput mlInput, ActionListener<MLTaskResponse> actionListener) {
-        actionListener.onFailure(new IllegalStateException("Method is not implemented"));
+        actionListener.onFailure(new IllegalStateException(METHOD_NOT_IMPLEMENTED_ERROR_MSG));
     }
 
     /**
@@ -47,7 +50,13 @@ public interface Predictable {
      * @param params other parameters
      * @param encryptor encryptor
      */
-    void initModel(MLModel model, Map<String, Object> params, Encryptor encryptor);
+    default void initModel(MLModel model, Map<String, Object> params, Encryptor encryptor) {
+        throw new IllegalStateException(METHOD_NOT_IMPLEMENTED_ERROR_MSG);
+    }
+
+    default CompletionStage<Boolean> initModelAsync(MLModel model, Map<String, Object> params, Encryptor encryptor) {
+        throw new IllegalStateException(METHOD_NOT_IMPLEMENTED_ERROR_MSG);
+    }
 
     /**
      * Close resources like deployed model.

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
@@ -7,15 +7,20 @@ package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.SDK_CLIENT;
+import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.SETTINGS;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -26,6 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.connector.Connector;
@@ -39,6 +45,7 @@ import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.engine.MLEngineClassLoader;
 import org.opensearch.ml.engine.MLStaticMockBase;
 import org.opensearch.ml.engine.encryptor.Encryptor;
+import org.opensearch.remote.metadata.client.SdkClient;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -53,11 +60,15 @@ public class RemoteModelTest extends MLStaticMockBase {
     @Mock
     RemoteConnectorExecutor remoteConnectorExecutor;
 
+    @Mock
+    SdkClient sdkClient;
+
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
 
     RemoteModel remoteModel;
     Encryptor encryptor;
+    Settings settings = Settings.builder().put("plugins.ml-commons.global_tenant_id", "_global_tenant_id").build();
 
     @Before
     public void setUp() {
@@ -66,6 +77,7 @@ public class RemoteModelTest extends MLStaticMockBase {
 
         encryptor = mock(Encryptor.class);
         when(encryptor.decrypt(any(), any())).thenReturn("test_api_key");
+        when(sdkClient.isGlobalResource(any(), any())).thenReturn(CompletableFuture.completedFuture(true));
     }
 
     @Test
@@ -110,7 +122,11 @@ public class RemoteModelTest extends MLStaticMockBase {
     private void asyncPredict_ModelDeployed_WrongInput(String expExceptionMessage) {
         Connector connector = createConnector(ImmutableMap.of("Authorization", "Bearer ${credential.key}"));
         when(mlModel.getConnector()).thenReturn(connector);
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        boolean initModelResult = remoteModel
+            .initModelAsync(mlModel, ImmutableMap.of(SDK_CLIENT, sdkClient, SETTINGS, settings), encryptor)
+            .toCompletableFuture()
+            .join();
+        assertTrue(initModelResult);
         ActionListener<MLTaskResponse> actionListener = mock(ActionListener.class);
         remoteModel.asyncPredict(mlInput, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -152,7 +168,10 @@ public class RemoteModelTest extends MLStaticMockBase {
             loader
                 .when(() -> MLEngineClassLoader.initInstance(connector.getProtocol(), connector, Connector.class))
                 .thenReturn(remoteConnectorExecutor);
-            remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+            remoteModel
+                .initModelAsync(mlModel, ImmutableMap.of(SDK_CLIENT, sdkClient, SETTINGS, settings), encryptor)
+                .toCompletableFuture()
+                .join();
             remoteModel.asyncPredict(mlInput, actionListener);
             ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
             verify(actionListener).onFailure(argumentCaptor.capture());
@@ -162,16 +181,16 @@ public class RemoteModelTest extends MLStaticMockBase {
     }
 
     @Test
-    public void initModel_Failure_With_RuntimeException() {
-        initModel_Failure_With_Throwable(new IllegalArgumentException("Tag mismatch!"), IllegalArgumentException.class, "Tag mismatch!");
+    public void initModelAsync_Failure_With_RuntimeException() {
+        initModelAsync_Failure_With_Throwable(new IllegalArgumentException("Tag mismatch!"), CompletionException.class, "Tag mismatch!");
     }
 
     @Test
-    public void initModel_Failure_With_Throwable() {
-        initModel_Failure_With_Throwable(new Error("Decryption Error!"), MLException.class, "Decryption Error!");
+    public void initModelAsync_Failure_With_Throwable() {
+        initModelAsync_Failure_With_Throwable(new Error("Decryption Error!"), CompletionException.class, "Decryption Error!");
     }
 
-    private void initModel_Failure_With_Throwable(
+    private void initModelAsync_Failure_With_Throwable(
         Throwable actualException,
         Class<? extends Throwable> expExcepClass,
         String expExceptionMessage
@@ -181,23 +200,32 @@ public class RemoteModelTest extends MLStaticMockBase {
         Connector connector = createConnector(null);
         when(mlModel.getConnector()).thenReturn(connector);
         doThrow(actualException).when(encryptor).decrypt(any(), any());
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        remoteModel
+            .initModelAsync(mlModel, ImmutableMap.of(SDK_CLIENT, sdkClient, SETTINGS, settings), encryptor)
+            .toCompletableFuture()
+            .join();
     }
 
     @Test
-    public void initModel_NullHeader() {
+    public void initModelAsync_NullHeader() {
         Connector connector = createConnector(null);
         when(mlModel.getConnector()).thenReturn(connector);
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        remoteModel
+            .initModelAsync(mlModel, ImmutableMap.of(SDK_CLIENT, sdkClient, SETTINGS, settings), encryptor)
+            .toCompletableFuture()
+            .join();
         Map<String, String> decryptedHeaders = connector.getDecryptedHeaders();
         assertNull(decryptedHeaders);
     }
 
     @Test
-    public void initModel_WithHeader() {
+    public void initModelAsync_WithHeader() {
         Connector connector = createConnector(ImmutableMap.of("Authorization", "Bearer ${credential.key}"));
         when(mlModel.getConnector()).thenReturn(connector);
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        remoteModel
+            .initModelAsync(mlModel, ImmutableMap.of(SDK_CLIENT, sdkClient, SETTINGS, settings), encryptor)
+            .toCompletableFuture()
+            .join();
         Map<String, String> decryptedHeaders = connector.getDecryptedHeaders();
         RemoteConnectorExecutor executor = remoteModel.getConnectorExecutor();
         Assert.assertNotNull(executor);
@@ -210,11 +238,14 @@ public class RemoteModelTest extends MLStaticMockBase {
     }
 
     @Test
-    public void initModel_setsTenantIdOnClonedConnector_whenMissing() {
+    public void initModelAsync_setsTenantIdOnClonedConnector_whenMissing() {
         Connector connector = createConnector(ImmutableMap.of("Authorization", "Bearer ${credential.key}"));
         when(mlModel.getConnector()).thenReturn(connector);
         when(mlModel.getTenantId()).thenReturn("tenantId");
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        remoteModel
+            .initModelAsync(mlModel, ImmutableMap.of(SDK_CLIENT, sdkClient, SETTINGS, settings), encryptor)
+            .toCompletableFuture()
+            .join();
         RemoteConnectorExecutor executor = remoteModel.getConnectorExecutor();
         remoteModel.close();
         assertNull(connector.getTenantId());
@@ -222,35 +253,44 @@ public class RemoteModelTest extends MLStaticMockBase {
     }
 
     @Test
-    public void initModel_bothTenantIdsNull() {
+    public void initModelAsync_bothTenantIdsNull() {
         Connector connector = createConnector(ImmutableMap.of("Authorization", "Bearer ${credential.key}"));
         when(mlModel.getConnector()).thenReturn(connector);
         when(mlModel.getTenantId()).thenReturn(null);
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        remoteModel
+            .initModelAsync(mlModel, ImmutableMap.of(SDK_CLIENT, sdkClient, SETTINGS, settings), encryptor)
+            .toCompletableFuture()
+            .join();
         RemoteConnectorExecutor executor = remoteModel.getConnectorExecutor();
         assertNull(connector.getTenantId());
         assertNull(executor.getConnector().getTenantId());
     }
 
     @Test
-    public void initModel_connectorHasTenantId() {
+    public void initModelAsync_connectorHasTenantId() {
         Connector connector = createConnector(ImmutableMap.of("Authorization", "Bearer ${credential.key}"));
         connector.setTenantId("connectorTenantId");
         when(mlModel.getConnector()).thenReturn(connector);
         when(mlModel.getTenantId()).thenReturn(null);
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        remoteModel
+            .initModelAsync(mlModel, ImmutableMap.of(SDK_CLIENT, sdkClient, SETTINGS, settings), encryptor)
+            .toCompletableFuture()
+            .join();
         RemoteConnectorExecutor executor = remoteModel.getConnectorExecutor();
         assertEquals("connectorTenantId", connector.getTenantId());
         assertEquals("connectorTenantId", executor.getConnector().getTenantId());
     }
 
     @Test
-    public void initModel_bothHaveTenantIds() {
+    public void initModelAsync_bothHaveTenantIds() {
         Connector connector = createConnector(ImmutableMap.of("Authorization", "Bearer ${credential.key}"));
         connector.setTenantId("connectorTenantId");
         when(mlModel.getConnector()).thenReturn(connector);
         when(mlModel.getTenantId()).thenReturn("modelTenantId");
-        remoteModel.initModel(mlModel, ImmutableMap.of(), encryptor);
+        remoteModel
+            .initModelAsync(mlModel, ImmutableMap.of(SDK_CLIENT, sdkClient, SETTINGS, settings), encryptor)
+            .toCompletableFuture()
+            .join();
         RemoteConnectorExecutor executor = remoteModel.getConnectorExecutor();
         assertEquals("connectorTenantId", connector.getTenantId());
         assertEquals("connectorTenantId", executor.getConnector().getTenantId());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteModelTest.java
@@ -18,6 +18,7 @@ import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.SETTINGS;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -117,6 +118,13 @@ public class RemoteModelTest extends MLStaticMockBase {
         when(mlInput.getInputDataset()).thenReturn(
                 new RemoteInferenceInputDataSet(Collections.emptyMap(), ConnectorAction.ActionType.BATCH_PREDICT));
         asyncPredict_ModelDeployed_WrongInput("no BATCH_PREDICT action found");
+    }
+
+    @Test
+    public void test_initModel_throwIllegalStateException() {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage("Method is not implemented");
+        remoteModel.initModel(mlModel, new HashMap<>(), encryptor);
     }
 
     private void asyncPredict_ModelDeployed_WrongInput(String expExceptionMessage) {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/TextEmbeddingDenseModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/TextEmbeddingDenseModelTest.java
@@ -556,6 +556,13 @@ public class TextEmbeddingDenseModelTest {
     }
 
     @Test
+    public void test_initModelAsync_throwIllegalStateException() {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage("Method is not implemented");
+        textEmbeddingDenseModel.initModelAsync(model, new HashMap<>(), encryptor);
+    }
+
+    @Test
     public void initModel_NullModelZipFile() {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("model file is null");

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -433,6 +433,15 @@ configurations.all {
     resolutionStrategy.force 'commons-beanutils:commons-beanutils:1.11.0'
     resolutionStrategy.force 'com.google.code.gson:gson:2.13.2'
     resolutionStrategy.force "com.google.errorprone:error_prone_annotations:${versions.error_prone_annotations}"
+    resolutionStrategy.force 'software.amazon.awssdk:bom:2.30.31'
+    resolutionStrategy.force 'software.amazon.awssdk:auth:2.30.31'
+    resolutionStrategy.force 'software.amazon.awssdk:aws-core:2.30.31'
+    resolutionStrategy.force 'software.amazon.awssdk:aws-query-protocol:2.30.31'
+    resolutionStrategy.force 'software.amazon.awssdk:aws-xml-protocol:2.30.31'
+    resolutionStrategy.force 'software.amazon.awssdk:protocol-core:2.30.31'
+    resolutionStrategy.force 'software.amazon.awssdk:regions:2.30.31'
+    resolutionStrategy.force 'software.amazon.awssdk:netty-nio-client:2.30.31'
+    resolutionStrategy.force 'software.amazon.awssdk:s3:2.30.31'
 }
 
 apply plugin: 'com.netflix.nebula.ospackage'

--- a/plugin/src/main/java/org/opensearch/ml/action/config/GetConfigTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/config/GetConfigTransportAction.java
@@ -10,9 +10,10 @@ import static org.opensearch.ml.common.CommonValue.MASTER_KEY;
 import static org.opensearch.ml.common.CommonValue.ML_CONFIG_INDEX;
 import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
 
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
-import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
@@ -28,6 +29,9 @@ import org.opensearch.ml.common.transport.config.MLConfigGetAction;
 import org.opensearch.ml.common.transport.config.MLConfigGetRequest;
 import org.opensearch.ml.common.transport.config.MLConfigGetResponse;
 import org.opensearch.ml.utils.TenantAwareHelper;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.common.SdkClientUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
@@ -41,6 +45,7 @@ import lombok.extern.log4j.Log4j2;
 public class GetConfigTransportAction extends HandledTransportAction<ActionRequest, MLConfigGetResponse> {
 
     Client client;
+    SdkClient sdkClient;
     NamedXContentRegistry xContentRegistry;
     private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
@@ -49,11 +54,13 @@ public class GetConfigTransportAction extends HandledTransportAction<ActionReque
         TransportService transportService,
         ActionFilters actionFilters,
         Client client,
+        SdkClient sdkClient,
         NamedXContentRegistry xContentRegistry,
         MLFeatureEnabledSetting mlFeatureEnabledSetting
     ) {
         super(MLConfigGetAction.NAME, transportService, actionFilters, MLConfigGetRequest::new);
         this.client = client;
+        this.sdkClient = sdkClient;
         this.xContentRegistry = xContentRegistry;
         this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
     }
@@ -68,7 +75,12 @@ public class GetConfigTransportAction extends HandledTransportAction<ActionReque
         }
 
         // In the get request tenantId will be used as a part of SDKClient migration
-        GetRequest getRequest = new GetRequest(ML_CONFIG_INDEX).id(configId);
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
+            .index(ML_CONFIG_INDEX)
+            .id(configId)
+            .tenantId(tenantId)
+            .build();
 
         if (configId.equals(MASTER_KEY)) {
             actionListener.onFailure(new OpenSearchStatusException("You are not allowed to access this config doc", RestStatus.FORBIDDEN));
@@ -76,36 +88,39 @@ public class GetConfigTransportAction extends HandledTransportAction<ActionReque
         }
 
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            client.get(getRequest, ActionListener.runBefore(ActionListener.wrap(r -> {
+            ActionListener<MLConfigGetResponse> wrappedListener = ActionListener.runBefore(actionListener, context::restore);
+            sdkClient.getDataObjectAsync(getDataObjectRequest).whenComplete((r, throwable) -> {
                 log.debug("Completed Get Agent Request, id:{}", configId);
-
-                if (r != null && r.isExists()) {
-                    try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, r.getSourceAsBytesRef())) {
-                        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-                        MLConfig mlConfig = MLConfig.parse(parser);
-                        actionListener.onResponse(MLConfigGetResponse.builder().mlConfig(mlConfig).build());
-                    } catch (Exception e) {
-                        log.error("Failed to parse ml config{}", r.getId(), e);
-                        actionListener.onFailure(e);
+                if (throwable != null) {
+                    Exception e = SdkClientUtils.unwrapAndConvertToException(throwable);
+                    if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null) {
+                        wrappedListener.onFailure(new OpenSearchStatusException("Fail to get config index", RestStatus.NOT_FOUND));
+                    } else {
+                        log.error("Failed to get ML config {}", configId, e);
+                        wrappedListener.onFailure(e);
                     }
                 } else {
-                    actionListener
-                        .onFailure(
-                            new OpenSearchStatusException(
-                                "Failed to find config with the provided config id: " + configId,
-                                RestStatus.NOT_FOUND
-                            )
-                        );
+                    GetResponse response = r.getResponse();
+                    if (response != null && response.isExists()) {
+                        try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())) {
+                            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                            MLConfig mlConfig = MLConfig.parse(parser);
+                            wrappedListener.onResponse(MLConfigGetResponse.builder().mlConfig(mlConfig).build());
+                        } catch (Exception e) {
+                            log.error("Failed to parse ml config{}", response.getId(), e);
+                            wrappedListener.onFailure(e);
+                        }
+                    } else {
+                        wrappedListener
+                            .onFailure(
+                                new OpenSearchStatusException(
+                                    "Failed to find config with the provided config id: " + configId,
+                                    RestStatus.NOT_FOUND
+                                )
+                            );
+                    }
                 }
-            }, e -> {
-                if (e instanceof IndexNotFoundException) {
-                    log.error("Failed to get agent index", e);
-                    actionListener.onFailure(new OpenSearchStatusException("Failed to get config index", RestStatus.NOT_FOUND));
-                } else {
-                    log.error("Failed to get ML config {}", configId, e);
-                    actionListener.onFailure(e);
-                }
-            }), context::restore));
+            });
         } catch (Exception e) {
             log.error("Failed to get ML config {}", configId, e);
             actionListener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/action/config/GetConfigTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/config/GetConfigTransportAction.java
@@ -94,7 +94,7 @@ public class GetConfigTransportAction extends HandledTransportAction<ActionReque
                 if (throwable != null) {
                     Exception e = SdkClientUtils.unwrapAndConvertToException(throwable);
                     if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null) {
-                        wrappedListener.onFailure(new OpenSearchStatusException("Fail to get config index", RestStatus.NOT_FOUND));
+                        wrappedListener.onFailure(new OpenSearchStatusException("Failed to get config index", RestStatus.NOT_FOUND));
                     } else {
                         log.error("Failed to get ML config {}", configId, e);
                         wrappedListener.onFailure(e);

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -38,6 +38,8 @@ import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.CONNECTOR_P
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.GUARDRAILS;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.RATE_LIMITER;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.SCRIPT_SERVICE;
+import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.SDK_CLIENT;
+import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.SETTINGS;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.USER_RATE_LIMITER_MAP;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.XCONTENT_REGISTRY;
 import static org.opensearch.ml.engine.algorithms.text_embedding.TextEmbeddingDenseModel.ML_ENGINE;
@@ -63,6 +65,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -179,6 +182,7 @@ public class MLModelManager {
     private final ThreadPool threadPool;
     private final NamedXContentRegistry xContentRegistry;
     private final ModelHelper modelHelper;
+    private Settings settings;
 
     private final MLModelCacheHelper modelCacheHelper;
     private final MLStats mlStats;
@@ -228,6 +232,7 @@ public class MLModelManager {
         this.threadPool = threadPool;
         this.xContentRegistry = xContentRegistry;
         this.modelHelper = modelHelper;
+        this.settings = settings;
         this.clusterService = clusterService;
         this.scriptService = scriptService;
         this.modelCacheHelper = modelCacheHelper;
@@ -1440,30 +1445,36 @@ public class MLModelManager {
         setupRateLimiter(modelId, eligibleNodeCount, mlModel.getRateLimiter());
         setupMLGuard(modelId, mlModel.getTenantId(), mlModel.getGuardrails());
         setupModelInterface(modelId, mlModel.getModelInterface());
-        if (mlModel.getConnector() != null || FunctionName.REMOTE != mlModel.getAlgorithm()) {
-            setupParamsAndPredictable(modelId, mlModel);
+        ActionListener<String> initModelActionListener = ActionListener.wrap(r -> {
             mlStats.getStat(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT).increment();
             modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
             modelCacheHelper.refreshLastAccessTime(modelId);
-            wrappedListener.onResponse("successful");
-            return;
+            wrappedListener.onResponse(r);
+        }, e -> {
+            log.error("Failed to deploy model, model id: {}", modelId, e);
+            wrappedListener.onFailure(e);
+        });
+        if (mlModel.getConnector() != null || FunctionName.REMOTE != mlModel.getAlgorithm()) {
+            setupParamsAndPredictable(modelId, mlModel, initModelActionListener);
         }
         log.info("Set connector {} for the model: {}", mlModel.getConnectorId(), modelId);
         getConnector(mlModel.getConnectorId(), mlModel.getTenantId(), ActionListener.wrap(connector -> {
             mlModel.setConnector(connector);
-            setupParamsAndPredictable(modelId, mlModel);
-            mlStats.getStat(MLNodeLevelStat.ML_DEPLOYED_MODEL_COUNT).increment();
-            modelCacheHelper.setModelState(modelId, MLModelState.DEPLOYED);
-            modelCacheHelper.refreshLastAccessTime(modelId);
-            wrappedListener.onResponse("successful");
+            setupParamsAndPredictable(modelId, mlModel, initModelActionListener);
             log.info("Completed setting connector {} in the model {}", mlModel.getConnectorId(), modelId);
         }, wrappedListener::onFailure));
     }
 
-    private void setupParamsAndPredictable(String modelId, MLModel mlModel) {
+    private void setupParamsAndPredictable(String modelId, MLModel mlModel, ActionListener<String> listener) {
         Map<String, Object> params = setUpParameterMap(modelId, mlModel.getTenantId());
-        Predictable predictable = mlEngine.deploy(mlModel, params);
-        modelCacheHelper.setPredictor(modelId, predictable);
+        ActionListener<Predictable> wrappedListener = ActionListener.wrap(r -> {
+            modelCacheHelper.setPredictor(modelId, r);
+            listener.onResponse("successful");
+        }, e -> {
+            log.error("Failed to deploy model", e);
+            listener.onFailure(e);
+        });
+        mlEngine.deploy(mlModel, params, wrappedListener);
     }
 
     private Map<String, Object> setUpParameterMap(String modelId, String tenantId) {
@@ -1497,6 +1508,8 @@ public class MLModelManager {
             log.info("Setting up ML guard parameter for ML predictor.");
         }
         params.put(CONNECTOR_PRIVATE_IP_ENABLED, mlFeatureEnabledSetting.isConnectorPrivateIpEnabled());
+        params.put(SDK_CLIENT, sdkClient);
+        params.put(SETTINGS, settings);
         return Collections.unmodifiableMap(params);
     }
 
@@ -1522,16 +1535,16 @@ public class MLModelManager {
                 setupMLGuard(modelId, mlModel.getTenantId(), mlModel.getGuardrails());
                 setupModelInterface(modelId, mlModel.getModelInterface());
                 if (mlModel.getAlgorithm() == FunctionName.REMOTE) {
+                    String completeModelCacheUpdateMessage = String
+                        .format(Locale.ROOT, "Completed the model cache update for the remote model %s", modelId);
                     if (mlModel.getConnector() != null) {
-                        setupParamsAndPredictable(modelId, mlModel);
-                        wrappedListener.onResponse("Successfully updated model cache for the remote model " + modelId);
-                        log.info("Completed the model cache update for the remote model {}", modelId);
+                        setupParamsAndPredictable(modelId, mlModel, wrappedListener);
+                        log.info(completeModelCacheUpdateMessage);
                     } else {
                         getConnector(mlModel.getConnectorId(), mlModel.getTenantId(), ActionListener.wrap(connector -> {
                             mlModel.setConnector(connector);
-                            setupParamsAndPredictable(modelId, mlModel);
-                            wrappedListener.onResponse("Successfully updated model cache for the remote model " + modelId);
-                            log.info("Completed the model cache update for the remote model {}", modelId);
+                            setupParamsAndPredictable(modelId, mlModel, wrappedListener);
+                            log.info(completeModelCacheUpdateMessage);
                         }, wrappedListener::onFailure));
                     }
                 }
@@ -1570,16 +1583,16 @@ public class MLModelManager {
                     int eligibleNodeCount = getWorkerNodes(modelId, mlModel.getAlgorithm()).length;
                     setupUserRateLimiterMap(modelId, eligibleNodeCount, controller.getUserRateLimiter());
                     if (mlModel.getAlgorithm() == FunctionName.REMOTE) {
+                        String deployModelControllerCompleteMessage = String
+                            .format(Locale.ROOT, "Deployed model controller for the remote model %s", modelId);
                         if (mlModel.getConnector() != null) {
-                            setupParamsAndPredictable(modelId, mlModel);
-                            wrappedListener.onResponse("Successfully deployed model controller for the remote model " + modelId);
-                            log.info("Deployed model controller for the remote model {}", modelId);
+                            setupParamsAndPredictable(modelId, mlModel, wrappedListener);
+                            log.info(deployModelControllerCompleteMessage);
                         } else {
                             getConnector(mlModel.getConnectorId(), mlModel.getTenantId(), ActionListener.wrap(connector -> {
                                 mlModel.setConnector(connector);
-                                setupParamsAndPredictable(modelId, mlModel);
-                                wrappedListener.onResponse("Successfully deployed model controller for the remote model " + modelId);
-                                log.info("Deployed model controller for the remote model {}", modelId);
+                                setupParamsAndPredictable(modelId, mlModel, wrappedListener);
+                                log.info(deployModelControllerCompleteMessage);
                             }, wrappedListener::onFailure));
                         }
                         return;
@@ -1608,16 +1621,16 @@ public class MLModelManager {
                 getModel(modelId, ActionListener.wrap(mlModel -> {
                     removeUserRateLimiterMap(modelId);
                     if (mlModel.getAlgorithm() == FunctionName.REMOTE) {
+                        String undeployModelControllerCompleteMessage = String
+                            .format(Locale.ROOT, "Undeployed model controller for the remote model %s", modelId);
                         if (mlModel.getConnector() != null) {
-                            setupParamsAndPredictable(modelId, mlModel);
-                            wrappedListener.onResponse("Successfully undeployed model controller for the remote model " + modelId);
-                            log.info("Undeployed model controller for the remote model {}", modelId);
+                            setupParamsAndPredictable(modelId, mlModel, wrappedListener);
+                            log.info(undeployModelControllerCompleteMessage);
                         } else {
                             getConnector(mlModel.getConnectorId(), mlModel.getTenantId(), ActionListener.wrap(connector -> {
                                 mlModel.setConnector(connector);
-                                setupParamsAndPredictable(modelId, mlModel);
-                                wrappedListener.onResponse("Successfully undeployed model controller for the remote model " + modelId);
-                                log.info("Undeployed model controller for the remote model {}", modelId);
+                                setupParamsAndPredictable(modelId, mlModel, wrappedListener);
+                                log.info(undeployModelControllerCompleteMessage);
                             }, wrappedListener::onFailure));
                         }
                         return;
@@ -1995,7 +2008,12 @@ public class MLModelManager {
                 return;
             }
 
-            parseAndReturnModel(getResponse, response.source().get(ALGORITHM_FIELD).toString(), modelId, listener);
+            parseAndReturnModel(
+                getResponse,
+                Optional.ofNullable(response.source().get(FUNCTION_NAME_FIELD)).orElse(response.source().get(ALGORITHM_FIELD)).toString(),
+                modelId,
+                listener
+            );
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -21,10 +21,14 @@ import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.REMOTE_METADATA_ENDPOINT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.REMOTE_METADATA_GLOBAL_TENANT_ID;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.REMOTE_METADATA_REGION;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.REMOTE_METADATA_SERVICE_NAME;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.REMOTE_METADATA_TYPE;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY;
+import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY;
+import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_GLOBAL_TENANT_ID_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_REGION_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_SERVICE_NAME_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_TYPE_KEY;
@@ -631,7 +635,13 @@ public class MachineLearningPlugin extends Plugin
                             Map.entry(REMOTE_METADATA_REGION_KEY, REMOTE_METADATA_REGION.get(settings)),
                             Map.entry(REMOTE_METADATA_SERVICE_NAME_KEY, REMOTE_METADATA_SERVICE_NAME.get(settings)),
                             Map.entry(TENANT_AWARE_KEY, "true"),
-                            Map.entry(TENANT_ID_FIELD_KEY, TENANT_ID_FIELD)
+                            Map.entry(TENANT_ID_FIELD_KEY, TENANT_ID_FIELD),
+                            Map.entry(REMOTE_METADATA_GLOBAL_TENANT_ID_KEY, REMOTE_METADATA_GLOBAL_TENANT_ID.get(settings)),
+                            Map
+                                .entry(
+                                    REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY,
+                                    REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL.get(settings)
+                                )
                         )
                     : Collections.emptyMap(),
                 // For node client / local cluster it won't use this thread pool
@@ -1255,7 +1265,9 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_ENABLED,
                 MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED,
                 MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_ENABLED,
-                MLCommonsSettings.ML_COMMONS_INDEX_INSIGHT_FEATURE_ENABLED
+                MLCommonsSettings.ML_COMMONS_INDEX_INSIGHT_FEATURE_ENABLED,
+                MLCommonsSettings.REMOTE_METADATA_GLOBAL_TENANT_ID,
+                MLCommonsSettings.REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL
             );
         return settings;
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/config/GetConfigTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/config/GetConfigTransportActionTests.java
@@ -43,6 +43,7 @@ import org.opensearch.ml.common.MLConfig;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.config.MLConfigGetRequest;
 import org.opensearch.ml.common.transport.config.MLConfigGetResponse;
+import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -55,6 +56,9 @@ public class GetConfigTransportActionTests extends OpenSearchTestCase {
 
     @Mock
     Client client;
+
+    @Mock
+    SdkClient sdkClient;
 
     @Mock
     NamedXContentRegistry xContentRegistry;
@@ -84,7 +88,7 @@ public class GetConfigTransportActionTests extends OpenSearchTestCase {
         mlConfigGetRequest = MLConfigGetRequest.builder().configId("test_id").build();
 
         getConfigTransportAction = spy(
-            new GetConfigTransportAction(transportService, actionFilters, client, xContentRegistry, mlFeatureEnabledSetting)
+            new GetConfigTransportAction(transportService, actionFilters, client, sdkClient, xContentRegistry, mlFeatureEnabledSetting)
         );
 
         Settings settings = Settings.builder().build();


### PR DESCRIPTION
### Description
## Overview
Global resource is resources that can be accessed by any tenant, this PR is to support global resource including connector, model and agent.

## Changes
- **Multi-tenant encryption**: Added logic to differentiate between global and tenant-specific resources for credential decryption
- **Remote metadata integration**: Migrated config retrieval to use SDK client with DynamoDB support
- **Configuration enhancement**: Added global tenant ID setting for cross-tenant resource management

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
