### PR TITLE
Initiate query planning tool

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
@@ -42,7 +42,7 @@ public class QueryPlanningTool implements WithModelTool {
     @Setter
     private Map<String, Object> attributes;
     @VisibleForTesting
-    static String DEFAULT_DESCRIPTION = "Use this tool to generate query plans for a given query text.";
+    static String DEFAULT_DESCRIPTION = "Use this tool to generate opensearch query dsl for a given natural language question.";
     @Getter
     @Setter
     private String description = DEFAULT_DESCRIPTION;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.spi.tools.Parser;
+import org.opensearch.ml.common.spi.tools.ToolAnnotation;
+import org.opensearch.ml.common.spi.tools.WithModelTool;
+import org.opensearch.ml.repackage.com.google.common.annotations.VisibleForTesting;
+import org.opensearch.transport.client.Client;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * This tool supports different types of query planning,
+ * llmGenerated, systemSearchTemplates or userSearchTemplates.
+ * //TODO only support llmGenerated for now.
+ * //TODO to add in systemSearchTemplates or userSearchTemplates when searchTemplatesTool is implemented.
+ */
+@Log4j2
+@ToolAnnotation(QueryPlanningTool.TYPE)
+public class QueryPlanningTool implements WithModelTool {
+    public static final String TYPE = "QueryPlanningTool";
+    public static final String MODEL_ID_FIELD = "model_id";
+    private final MLModelTool queryGenerationTool;
+    public static final String PROMPT_FIELD = "prompt";
+    private static final String GENERATION_TYPE_FIELD = "generation_type";
+    private static final String LLM_GENERATED_TYPE_FIELD = "llmGenerated";
+    private final String generationType;
+    @Setter
+    @Getter
+    private String name = TYPE;
+    @Getter
+    @Setter
+    private Map<String, Object> attributes;
+    @VisibleForTesting
+    static String DEFAULT_DESCRIPTION = "Use this tool to generate query plans for a given query text.";
+    @Getter
+    @Setter
+    private String description = DEFAULT_DESCRIPTION;
+    private String defaultPrompt =
+        "You are an OpenSearch Query DSL generation assistant; using the provided index mapping ${parameters.ListIndexTool.output:-}, specified fields ${parameters.fields:-}, and the given sample queries as examples, generate an OpenSearch Query DSL to retrieve the most relevant documents for the user provided natural language question: ${parameters.query_text}\n";
+    @Getter
+    private Client client;
+    @Getter
+    private String modelId;
+    @Setter
+    @Getter
+    @VisibleForTesting
+    private Parser outputParser;
+    @Setter
+    @Getter
+    private String responseField;
+
+    public QueryPlanningTool(Client client, String modelId, String generationType, MLModelTool queryGenerationTool) {
+        this.client = client;
+        this.modelId = modelId;
+        this.generationType = generationType;
+        this.queryGenerationTool = queryGenerationTool;
+    }
+
+    @Override
+    public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
+        if (!parameters.containsKey(PROMPT_FIELD)) {
+            parameters.put(PROMPT_FIELD, defaultPrompt);
+        }
+        ActionListener<List<ModelTensors>> modelListener = ActionListener.wrap(r -> {
+            try {
+                @SuppressWarnings("unchecked")
+                T result = (T) outputParser.parse(r);
+                listener.onResponse(result);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }, listener::onFailure);
+        queryGenerationTool.run(parameters, modelListener);
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String getVersion() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public void setName(String s) {
+        this.name = s;
+    }
+
+    @Override
+    public boolean validate(Map<String, String> parameters) {
+        if (parameters == null || parameters.size() == 0) {
+            return false;
+        }
+        return true;
+    }
+
+    public static class Factory implements WithModelTool.Factory<QueryPlanningTool> {
+        private Client client;
+
+        private static Factory INSTANCE;
+
+        public static Factory getInstance() {
+            if (INSTANCE != null) {
+                return INSTANCE;
+            }
+            synchronized (QueryPlanningTool.class) {
+                if (INSTANCE != null) {
+                    return INSTANCE;
+                }
+                INSTANCE = new Factory();
+                return INSTANCE;
+            }
+        }
+
+        public void init(Client client) {
+            this.client = client;
+        }
+
+        @Override
+        public QueryPlanningTool create(Map<String, Object> map) {
+
+            MLModelTool queryGenerationTool = MLModelTool.Factory.getInstance().create(map);
+
+            String type = (String) map.get(GENERATION_TYPE_FIELD);
+            if (type == null || type.isEmpty()) {
+                type = LLM_GENERATED_TYPE_FIELD;
+            }
+
+            // TODO to add in , SYSTEM_SEARCH_TEMPLATES_TYPE_FIELD, USER_SEARCH_TEMPLATES_TYPE_FIELD when searchTemplatesTool is
+            // implemented.
+            if (!LLM_GENERATED_TYPE_FIELD.equals(type)) {
+                throw new IllegalArgumentException("Invalid generation type: " + type + ". The current supported types are llmGenerated.");
+            }
+            return new QueryPlanningTool(client, (String) map.get(MODEL_ID_FIELD), type, queryGenerationTool);
+        }
+
+        @Override
+        public String getDefaultDescription() {
+            return DEFAULT_DESCRIPTION;
+        }
+
+        @Override
+        public String getDefaultType() {
+            return TYPE;
+        }
+
+        @Override
+        public String getDefaultVersion() {
+            return null;
+        }
+
+        @Override
+        public List<String> getAllModelKeys() {
+            return List.of(MODEL_ID_FIELD);
+        }
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
@@ -9,9 +9,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.opensearch.ml.engine.tools.QueryPlanningTool.DEFAULT_DESCRIPTION;
 import static org.opensearch.ml.engine.tools.QueryPlanningTool.MODEL_ID_FIELD;
 
@@ -26,6 +28,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.core.action.ActionListener;
@@ -46,11 +49,13 @@ public class QueryPlanningToolTests {
     private Map<String, String> validParams;
     private Map<String, String> emptyParams;
 
+    private QueryPlanningTool.Factory factory;
+
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
         MLModelTool.Factory.getInstance().init(client);
-        QueryPlanningTool.Factory.getInstance().init(client);
+        factory = new QueryPlanningTool.Factory();
         validParams = new HashMap<>();
         validParams.put("prompt", "test prompt");
         emptyParams = Collections.emptyMap();
@@ -73,7 +78,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(client, "test_model_id", "llmGenerated", queryGenerationTool);
+        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool);
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         // test try to update the prompt
@@ -97,7 +102,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(client, "test_model_id", "llmGenerated", queryGenerationTool);
+        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool);
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("query_text", "help me find some books related to wind");
@@ -114,7 +119,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(client, "test_model_id", "llmGenerated", queryGenerationTool);
+        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool);
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("query_text", "help me find some books related to wind");
@@ -132,7 +137,25 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(client, "test_model_id", "llmGenerated", queryGenerationTool);
+        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool);
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
+        validParams.put("query_text", "help me find some books related to wind");
+        tool.run(validParams, listener);
+        String multiMatchQueryString =
+            "{ \"query\": { \"multi_match\" : { \"query\":    \"help me find some books related to wind\",  \"fields\": [\"*\"] } } }";
+        assertEquals(multiMatchQueryString, future.get());
+    }
+
+    @Test
+    public void testRun_PredictionReturnsNullString_ReturnDefaultQuery() throws ExecutionException, InterruptedException {
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(1);
+            listener.onResponse("null");
+            return null;
+        }).when(queryGenerationTool).run(any(), any());
+
+        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool);
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("query_text", "help me find some books related to wind");
@@ -168,4 +191,82 @@ public class QueryPlanningToolTests {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
+    @Test
+    public void testRunWithNoPrompt() {
+        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("query_text", "some query");
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = mock(ActionListener.class);
+
+        tool.run(parameters, listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        doAnswer(invocation -> {
+            Map<String, String> params = invocation.getArgument(0);
+            assertNotNull(params.get("prompt"));
+            return null;
+        }).when(queryGenerationTool).run(captor.capture(), any());
+    }
+
+    @Test
+    public void testRunWithInvalidParameters() {
+        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool);
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = mock(ActionListener.class);
+
+        tool.run(Collections.emptyMap(), listener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        org.mockito.Mockito.verify(listener).onFailure(captor.capture());
+        assertEquals("Empty parameters for QueryPlanningTool: {}", captor.getValue().getMessage());
+    }
+
+    @Test
+    public void testRunModelReturnsNull() {
+        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("query_text", "some query");
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<String> modelListener = invocation.getArgument(1);
+            modelListener.onResponse(null);
+            return null;
+        }).when(queryGenerationTool).run(any(), any());
+
+        tool.run(parameters, listener);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        org.mockito.Mockito.verify(listener).onResponse(captor.capture());
+        assertNotNull(captor.getValue());
+    }
+
+    @Test
+    public void testSetName() {
+        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool);
+        tool.setName("NewName");
+        assertEquals("NewName", tool.getName());
+    }
+
+    @Test
+    public void testFactoryCreateWithEmptyType() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(QueryPlanningTool.MODEL_ID_FIELD, "modelId");
+        Tool tool = factory.create(map);
+        assertEquals(QueryPlanningTool.TYPE, tool.getName());
+        assertEquals("llmGenerated", ((QueryPlanningTool) tool).getGenerationType());
+        assertNotNull(tool);
+    }
+
+    @Test
+    public void testFactoryCreateWithInvalidType() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("generation_type", "invalid");
+        map.put(QueryPlanningTool.MODEL_ID_FIELD, "modelId");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> factory.create(map));
+        assertEquals("Invalid generation type: invalid. The current supported types are llmGenerated.", exception.getMessage());
+    }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.opensearch.ml.engine.tools.QueryPlanningTool.DEFAULT_DESCRIPTION;
+import static org.opensearch.ml.engine.tools.QueryPlanningTool.MODEL_ID_FIELD;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.ml.repackage.com.google.common.collect.ImmutableMap;
+import org.opensearch.transport.client.Client;
+
+public class QueryPlanningToolTests {
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private MLModelTool queryGenerationTool;
+
+    private Map<String, String> validParams;
+    private Map<String, String> emptyParams;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        MLModelTool.Factory.getInstance().init(client);
+        QueryPlanningTool.Factory.getInstance().init(client);
+        validParams = new HashMap<>();
+        validParams.put("prompt", "test prompt");
+        emptyParams = Collections.emptyMap();
+    }
+
+    @Test
+    public void testFactoryCreate() {
+        Map<String, Object> map = Map.of(MODEL_ID_FIELD, "test_model_id");
+        Tool tool = QueryPlanningTool.Factory.getInstance().create(map);
+        assertNotNull(tool);
+        assertEquals(QueryPlanningTool.TYPE, tool.getName());
+    }
+
+    @Test
+    public void testRun() throws ExecutionException, InterruptedException {
+        String matchQueryString = "{\"query\":{\"match\":{\"title\":\"wind\"}}}";
+        ModelTensor modelTensor = ModelTensor.builder().dataAsMap(ImmutableMap.of("response", matchQueryString)).build();
+        ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(List.of(modelTensor)).build();
+        List<ModelTensors> modelTensorsList = List.of(modelTensors);
+
+        doAnswer(invocation -> {
+            ActionListener<List<ModelTensors>> listener = invocation.getArgument(1);
+            listener.onResponse(modelTensorsList);
+            return null;
+        }).when(queryGenerationTool).run(any(), any());
+
+        QueryPlanningTool tool = new QueryPlanningTool(client, "test_model_id", "llmGenerated", queryGenerationTool);
+        tool.setOutputParser(o -> {
+            List<ModelTensors> outputs = (List<ModelTensors>) o;
+            return outputs.get(0).getMlModelTensors().get(0).getDataAsMap().get("response");
+        });
+
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
+        // test try to update the prompt
+        validParams
+            .put("prompt", "You are a query generation agent. Generate a dsl query for the following question: ${parameters.query_text}");
+        validParams.put("query_text", "help me find some books related to wind");
+        tool.run(validParams, listener);
+
+        assertEquals(matchQueryString, future.get());
+    }
+
+    @Test
+    public void testValidate() {
+        Tool tool = QueryPlanningTool.Factory.getInstance().create(Collections.emptyMap());
+        assertTrue(tool.validate(validParams));
+        assertFalse(tool.validate(emptyParams));
+        assertFalse(tool.validate(null));
+    }
+
+    @Test
+    public void testToolGetters() {
+        Tool tool = QueryPlanningTool.Factory.getInstance().create(Collections.emptyMap());
+        assertEquals(QueryPlanningTool.TYPE, tool.getName());
+        assertEquals(QueryPlanningTool.TYPE, tool.getType());
+        assertEquals(DEFAULT_DESCRIPTION, tool.getDescription());
+        assertNull(tool.getVersion());
+    }
+
+    @Test
+    public void testFactoryGetAllModelKeys() {
+        List<String> allModelKeys = QueryPlanningTool.Factory.getInstance().getAllModelKeys();
+        assertEquals(List.of(MODEL_ID_FIELD), allModelKeys);
+    }
+}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -226,6 +226,7 @@ integTest {
     if (System.getProperty("test.debug") != null) {
         jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
     }
+    jvmArgs '--add-opens', 'java.base/java.time=ALL-UNNAMED'
 
     // Set this to true this if you want to see the logs in the terminal test output.
     // note: if left false the log output will still show in your IDE

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -238,6 +238,7 @@ import org.opensearch.ml.engine.tools.IndexMappingTool;
 import org.opensearch.ml.engine.tools.ListIndexTool;
 import org.opensearch.ml.engine.tools.MLModelTool;
 import org.opensearch.ml.engine.tools.McpSseTool;
+import org.opensearch.ml.engine.tools.QueryPlanningTool;
 import org.opensearch.ml.engine.tools.SearchIndexTool;
 import org.opensearch.ml.engine.tools.VisualizationsTool;
 import org.opensearch.ml.engine.utils.AgentModelsSearcher;
@@ -720,6 +721,7 @@ public class MachineLearningPlugin extends Plugin
         SearchIndexTool.Factory.getInstance().init(client, xContentRegistry);
         VisualizationsTool.Factory.getInstance().init(client);
         ConnectorTool.Factory.getInstance().init(client);
+        QueryPlanningTool.Factory.getInstance().init(client);
 
         toolFactories.put(MLModelTool.TYPE, MLModelTool.Factory.getInstance());
         toolFactories.put(McpSseTool.TYPE, McpSseTool.Factory.getInstance());
@@ -729,7 +731,7 @@ public class MachineLearningPlugin extends Plugin
         toolFactories.put(SearchIndexTool.TYPE, SearchIndexTool.Factory.getInstance());
         toolFactories.put(VisualizationsTool.TYPE, VisualizationsTool.Factory.getInstance());
         toolFactories.put(ConnectorTool.TYPE, ConnectorTool.Factory.getInstance());
-
+        toolFactories.put(QueryPlanningTool.TYPE, QueryPlanningTool.Factory.getInstance());
         if (externalToolFactories != null) {
             toolFactories.putAll(externalToolFactories);
         }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
@@ -30,7 +30,6 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
     private static final String AWS_SECRET_ACCESS_KEY = System.getenv("AWS_SECRET_ACCESS_KEY");
     private static final String AWS_SESSION_TOKEN = System.getenv("AWS_SESSION_TOKEN");
     private static final String GITHUB_CI_AWS_REGION = "us-west-2";
-
     private final String bedrockClaudeModelConnectorEntity = "{\n"
         + "    \"name\": \"Amazon Bedrock Claude 3.7-sonnet connector\",\n"
         + "    \"description\": \"connector for base agent with tools\",\n"
@@ -71,6 +70,9 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
     @Before
     public void setup() throws IOException, InterruptedException {
         ingestIrisIndexData();
+        if (AWS_ACCESS_KEY_ID == null) {
+            return;
+        }
         queryPlanningModelId = registerQueryPlanningModel();
     }
 
@@ -81,6 +83,9 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
 
     @Test
     public void testAgentWithQueryPlanningTool_DefaultPrompt() throws IOException {
+        if (AWS_ACCESS_KEY_ID == null) {
+            return;
+        }
         String agentName = "Test_QueryPlanningAgent_DefaultPrompt";
         String agentId = registerAgentWithQueryPlanningTool(agentName, queryPlanningModelId);
         assertNotNull(agentId);
@@ -186,19 +191,4 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
     private void deleteAgent(String agentId) throws IOException {
         TestHelper.makeRequest(client(), "DELETE", "/_plugins/_ml/agents/" + agentId, null, "", List.of());
     }
-
-    public String registerModel(String modelContent) throws IOException {
-        Response response = TestHelper
-            .makeRequest(
-                client(),
-                "POST",
-                "/_plugins/_ml/models/_register",
-                null,
-                new StringEntity(modelContent),
-                List.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
-            );
-        Map<String, String> responseMap = gson.fromJson(TestHelper.httpEntityToString(response.getEntity()), Map.class);
-        return responseMap.get("task_id");
-    }
-
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.opensearch.ml.engine.tools.QueryPlanningTool.MODEL_ID_FIELD;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.client.Response;
+import org.opensearch.ml.common.agent.MLAgent;
+import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.utils.TestHelper;
+
+public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
+
+    private static final String IRIS_INDEX = "iris_data";
+    private String queryPlanningModelId;
+    private static final String AWS_ACCESS_KEY_ID = System.getenv("AWS_ACCESS_KEY_ID");
+    private static final String AWS_SECRET_ACCESS_KEY = System.getenv("AWS_SECRET_ACCESS_KEY");
+    private static final String AWS_SESSION_TOKEN = System.getenv("AWS_SESSION_TOKEN");
+    private static final String GITHUB_CI_AWS_REGION = "us-west-2";
+
+    private final String bedrockClaudeModelConnectorEntity = "{\n"
+        + "    \"name\": \"Amazon Bedrock Claude 3.7-sonnet connector\",\n"
+        + "    \"description\": \"connector for base agent with tools\",\n"
+        + "    \"version\": 1,\n"
+        + "    \"protocol\": \"aws_sigv4\",\n"
+        + "    \"parameters\": {\n"
+        + "      \"region\": \""
+        + GITHUB_CI_AWS_REGION
+        + "\",\n"
+        + "      \"service_name\": \"bedrock\",\n"
+        + "      \"model\": \"us.anthropic.claude-3-7-sonnet-20250219-v1:0\",\n"
+        + "      \"system_prompt\":\"please help answer the user question. \"\n"
+        + "    },\n"
+        + "    \"credential\": {\n"
+        + "      \"access_key\":\" "
+        + AWS_ACCESS_KEY_ID
+        + "\",\n"
+        + "      \"secret_key\": \""
+        + AWS_SECRET_ACCESS_KEY
+        + "\",\n"
+        + "      \"session_token\": \""
+        + AWS_SESSION_TOKEN
+        + "\"\n"
+        + "    },\n"
+        + "    \"actions\": [\n"
+        + "      {\n"
+        + "        \"action_type\": \"predict\",\n"
+        + "        \"method\": \"POST\",\n"
+        + "        \"url\": \"https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse\",\n"
+        + "        \"headers\": {\n"
+        + "          \"content-type\": \"application/json\"\n"
+        + "        },\n"
+        + "        \"request_body\": \"{ \\\"system\\\": [{\\\"text\\\": \\\"${parameters.system_prompt}\\\"}], \\\"messages\\\": [{\\\"role\\\":\\\"user\\\",\\\"content\\\":[{\\\"text\\\":\\\"${parameters.prompt}\\\"}]}]}\"\n"
+        + "      }\n"
+        + "    ]\n"
+        + "}";
+
+    @Before
+    public void setup() throws IOException, InterruptedException {
+        ingestIrisIndexData();
+        queryPlanningModelId = registerQueryPlanningModel();
+    }
+
+    @After
+    public void deleteIndices() throws IOException {
+        deleteIndex(IRIS_INDEX);
+    }
+
+    @Test
+    public void testAgentWithQueryPlanningTool_DefaultPrompt() throws IOException {
+        String agentName = "Test_QueryPlanningAgent_DefaultPrompt";
+        String agentId = registerAgentWithQueryPlanningTool(agentName, queryPlanningModelId);
+        assertNotNull(agentId);
+
+        String query = "{\"parameters\": {\"query_text\": \"How many iris flowers of type setosa are there?\"}}";
+        Response response = executeAgent(agentId, query);
+        String responseBody = TestHelper.httpEntityToString(response.getEntity());
+
+        Map<String, Object> responseMap = gson.fromJson(responseBody, Map.class);
+
+        List<Map<String, Object>> inferenceResults = (List<Map<String, Object>>) responseMap.get("inference_results");
+        Map<String, Object> firstResult = inferenceResults.get(0);
+        List<Map<String, Object>> outputArray = (List<Map<String, Object>>) firstResult.get("output");
+        Map<String, Object> output = (Map<String, Object>) outputArray.get(0);
+        String result = output.get("result").toString();
+
+        assertTrue(result.contains("query"));
+        deleteAgent(agentId);
+    }
+
+    private String registerAgentWithQueryPlanningTool(String agentName, String modelId) throws IOException {
+        MLToolSpec listIndexTool = MLToolSpec
+            .builder()
+            .type("ListIndexTool")
+            .name("MyListIndexTool")
+            .description("A tool for list indices")
+            .parameters(Map.of("index", IRIS_INDEX, "question", "what fields are in the index?"))
+            .includeOutputInAgentResponse(true)
+            .build();
+
+        MLToolSpec queryPlanningTool = MLToolSpec
+            .builder()
+            .type("QueryPlanningTool")
+            .name("MyQueryPlanningTool")
+            .description("A tool for planning queries")
+            .parameters(Map.of(MODEL_ID_FIELD, modelId))
+            .includeOutputInAgentResponse(true)
+            .build();
+
+        MLAgent agent = MLAgent
+            .builder()
+            .name(agentName)
+            .type("flow")
+            .description("Test agent with QueryPlanningTool")
+            .tools(List.of(listIndexTool, queryPlanningTool))
+            .build();
+
+        return registerAgent(agentName, agent);
+    }
+
+    private String registerQueryPlanningModel() throws IOException, InterruptedException {
+        String bedrockClaudeModelName = "bedrock claude model " + randomAlphaOfLength(5);
+        return registerRemoteModel(bedrockClaudeModelConnectorEntity, bedrockClaudeModelName, true);
+    }
+
+    private void ingestIrisIndexData() throws IOException {
+        String bulkRequestBody = "{\"index\":{\"_index\":\""
+            + IRIS_INDEX
+            + "\",\"_id\":\"1\"}}\n"
+            + "{\"petal_length_in_cm\":1.4,\"petal_width_in_cm\":0.2,\"sepal_length_in_cm\":5.1,\"sepal_width_in_cm\":3.5,\"species\":\"setosa\"}\n"
+            + "{\"index\":{\"_index\":\""
+            + IRIS_INDEX
+            + "\",\"_id\":\"2\"}}\n"
+            + "{\"petal_length_in_cm\":4.5,\"petal_width_in_cm\":1.5,\"sepal_length_in_cm\":6.4,\"sepal_width_in_cm\":2.9,\"species\":\"versicolor\"}\n";
+        TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                "/_bulk",
+                null,
+                new StringEntity(bulkRequestBody),
+                List.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
+            );
+        TestHelper.makeRequest(client(), "POST", "/" + IRIS_INDEX + "/_refresh", null, "", List.of());
+    }
+
+    private String registerAgent(String agentName, MLAgent agent) throws IOException {
+        Response response = TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                "/_plugins/_ml/agents/_register",
+                null,
+                new StringEntity(gson.toJson(agent)),
+                List.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
+            );
+        Map<String, String> responseMap = gson.fromJson(TestHelper.httpEntityToString(response.getEntity()), Map.class);
+        return responseMap.get("agent_id");
+    }
+
+    private Response executeAgent(String agentId, String query) throws IOException {
+        return TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                "/_plugins/_ml/agents/" + agentId + "/_execute",
+                null,
+                new StringEntity(query),
+                List.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
+            );
+    }
+
+    private void deleteAgent(String agentId) throws IOException {
+        TestHelper.makeRequest(client(), "DELETE", "/_plugins/_ml/agents/" + agentId, null, "", List.of());
+    }
+
+    public String registerModel(String modelContent) throws IOException {
+        Response response = TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                "/_plugins/_ml/models/_register",
+                null,
+                new StringEntity(modelContent),
+                List.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
+            );
+        Map<String, String> responseMap = gson.fromJson(TestHelper.httpEntityToString(response.getEntity()), Map.class);
+        return responseMap.get("task_id");
+    }
+
+}


### PR DESCRIPTION
### Description
This query planner tool is going to take a query text as a nature language question. Based on the question, the agent should intelligently identify relevant indices and construct appropriate queries. This includes:

    * generating queries using an LLM (Large Language Model).
    * Or Leveraging default search/query templates.
    * Or Use user defined search/query templates、


Interface：

```
POST /_plugins/_ml/agents/_register
{
  "name": "Test agent for embedding model",
  "type": "flow",
  "description": "this is a test agent",
  "tools": [
    {
      "type": "QueryPlanningTool",
      "description": "A general query generation tool to answer any question",
      "parameters": {
        "type": "llmGenerated",
        "model_id": "h5AUWo0BkIylWTeYT4SU",
        "prompt": "\n\nHuman:You are a query generation agent for OpenSearch. You will always generate a query dsl string only.Please generate the query dsl for the question ${parameters.query_text}"
      }
    }
  ]
}
```

In this PR, we will first introduce `llmGenerated` type first, and we will introduce the rest two types when templateSearchTool is available. 


### Related Issues
https://github.com/opensearch-project/ml-commons/issues/4005

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
