### PR TITLE
Add executeAgentApi to ml-client

### DIFF
--- a/client/src/main/java/org/opensearch/ml/client/MachineLearningClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MachineLearningClient.java
@@ -24,6 +24,7 @@ import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.input.Input;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.MLOutput;
+import org.opensearch.ml.common.transport.agent.MLExecuteAgentResponse;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentResponse;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorResponse;
@@ -490,6 +491,28 @@ public interface MachineLearningClient {
      * @param listener a listener to be notified of the result
      */
     void deleteAgent(String agentId, String tenantId, ActionListener<DeleteResponse> listener);
+
+    /**
+     * Execute agent
+     * @param agentId The id of the agent to execute
+     * @param method The method of the agent to execute
+     * @param parameters The parameters of the agent to execute
+     * @return the result future
+     */
+    default ActionFuture<MLExecuteAgentResponse> executeAgent(String agentId, String method, Map<String, String> parameters) {
+        PlainActionFuture<MLExecuteAgentResponse> actionFuture = PlainActionFuture.newFuture();
+        executeAgent(agentId, method, parameters, actionFuture);
+        return actionFuture;
+    }
+
+    /**
+     * Execute agent
+     * @param agentId The id of the agent to execute
+     * @param method The method of the agent to execute
+     * @param parameters The parameters of the agent to execute
+     * @param listener a listener to be notified of the result
+     */
+    void executeAgent(String agentId, String method, Map<String, String> parameters, ActionListener<MLExecuteAgentResponse> listener);
 
     /**
      * Get a list of ToolMetadata and return ActionFuture.

--- a/client/src/main/java/org/opensearch/ml/client/MachineLearningNodeClient.java
+++ b/client/src/main/java/org/opensearch/ml/client/MachineLearningNodeClient.java
@@ -36,6 +36,9 @@ import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.agent.MLAgentDeleteAction;
 import org.opensearch.ml.common.transport.agent.MLAgentDeleteRequest;
+import org.opensearch.ml.common.transport.agent.MLExecuteAgentAction;
+import org.opensearch.ml.common.transport.agent.MLExecuteAgentRequest;
+import org.opensearch.ml.common.transport.agent.MLExecuteAgentResponse;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentAction;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentRequest;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentResponse;
@@ -294,7 +297,25 @@ public class MachineLearningNodeClient implements MachineLearningClient {
     @Override
     public void deleteAgent(String agentId, String tenantId, ActionListener<DeleteResponse> listener) {
         MLAgentDeleteRequest agentDeleteRequest = new MLAgentDeleteRequest(agentId, tenantId);
-        client.execute(MLAgentDeleteAction.INSTANCE, agentDeleteRequest, ActionListener.wrap(listener::onResponse, listener::onFailure));
+        client.execute(MLAgentDeleteAction.INSTANCE, agentDeleteRequest, listener);
+    }
+
+    /**
+     * Execute agent
+     * @param agentId The id of the agent to execute
+     * @param method The method of the agent to execute
+     * @param parameters The parameters of the agent to execute
+     * @param listener a listener to be notified of the result
+     */
+    @Override
+    public void executeAgent(
+        String agentId,
+        String method,
+        Map<String, String> parameters,
+        ActionListener<MLExecuteAgentResponse> listener
+    ) {
+        MLExecuteAgentRequest mlExecuteAgentRequest = new MLExecuteAgentRequest(agentId, method, parameters);
+        client.execute(MLExecuteAgentAction.INSTANCE, mlExecuteAgentRequest, listener);
     }
 
     @Override

--- a/client/src/test/java/org/opensearch/ml/client/MachineLearningClientTest.java
+++ b/client/src/test/java/org/opensearch/ml/client/MachineLearningClientTest.java
@@ -48,6 +48,7 @@ import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
 import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.output.MLTrainingOutput;
+import org.opensearch.ml.common.transport.agent.MLExecuteAgentResponse;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentResponse;
 import org.opensearch.ml.common.transport.config.MLConfigGetResponse;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
@@ -105,6 +106,9 @@ public class MachineLearningClientTest {
 
     @Mock
     MLRegisterAgentResponse registerAgentResponse;
+
+    @Mock
+    MLExecuteAgentResponse executeAgentResponse;
 
     @Mock
     MLConfigGetResponse configGetResponse;
@@ -250,6 +254,16 @@ public class MachineLearningClientTest {
             @Override
             public void deleteAgent(String agentId, String tenantId, ActionListener<DeleteResponse> listener) {
                 listener.onResponse(deleteResponse);
+            }
+
+            @Override
+            public void executeAgent(
+                String agentId,
+                String method,
+                Map<String, String> parameters,
+                ActionListener<MLExecuteAgentResponse> listener
+            ) {
+                listener.onResponse(executeAgentResponse);
             }
 
             @Override
@@ -538,6 +552,25 @@ public class MachineLearningClientTest {
     @Test
     public void deleteAgent() {
         assertEquals(deleteResponse, machineLearningClient.deleteAgent("agentId").actionGet());
+    }
+
+    @Test
+    public void testExecuteAgent() {
+        String agentId = "879v9YwBjWKCe6Kg12Tx";
+        String method = "POST";
+        Map<String, String> parameters = Map.of("question", "what's the population increase of Seattle from 2021 to 2023");
+        String expectedResult = """
+            Based on the given context, the key information is:
+
+            The metro area population of Seattle in 2021 was 3,461,000.
+            The metro area population of Seattle in 2023 is 3,519,000.
+
+            To calculate the population increase from 2021 to 2023:
+
+            Population in 2023 (3,519,000) - Population in 2021 (3,461,000) = 58,000
+
+            Therefore, the population increase of Seattle from 2021 to 2023 is 58,000.""";
+        assertEquals(executeAgentResponse, machineLearningClient.executeAgent(agentId, method, parameters).actionGet());
     }
 
     @Test

--- a/common/src/main/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentAction.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.ml.common.transport.agent;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * ML execute agent action.
+ */
+public class MLExecuteAgentAction extends ActionType<MLExecuteAgentResponse> {
+    public static final MLExecuteAgentAction INSTANCE = new MLExecuteAgentAction();
+    public static final String NAME = "cluster:admin/opensearch/ml/agents/execute";
+
+    private MLExecuteAgentAction() {
+        super(NAME, MLExecuteAgentResponse::new);
+    }
+
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentRequest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.agent;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * ML execute agent request.
+ */
+@Getter
+public class MLExecuteAgentRequest extends ActionRequest {
+    private String agentId;
+    private String method;
+    private Map<String, String> parameters;
+
+    @Builder
+    public MLExecuteAgentRequest(String agentId, String method, Map<String, String> parameters) {
+        this.agentId = agentId;
+        this.method = method;
+        this.parameters = parameters;
+    }
+
+    public MLExecuteAgentRequest(StreamInput in) throws IOException {
+        super(in);
+        this.agentId = in.readString();
+        this.method = in.readString();
+        this.parameters = in.readMap(StreamInput::readString, StreamInput::readString);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(this.agentId);
+        out.writeString(this.method);
+        out.writeMap(this.parameters, StreamOutput::writeString, StreamOutput::writeString);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public static MLExecuteAgentRequest fromActionRequest(ActionRequest actionRequest) {
+        if (actionRequest instanceof MLExecuteAgentRequest) {
+            return (MLExecuteAgentRequest) actionRequest;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionRequest.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLExecuteAgentRequest(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionRequest into MLExecuteAgentRequest", e);
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentResponse.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.agent;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+/**
+ * ML execute agent response.
+ */
+public class MLExecuteAgentResponse extends ActionResponse implements ToXContentObject {
+
+    private List<Map<String, List<Map<String, String>>>> inferenceResults;
+
+    public MLExecuteAgentResponse(StreamInput in) throws IOException {
+        super(in);
+        int size = in.readVInt();
+        inferenceResults = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            Map<String, List<Map<String, String>>> inferenceResult = new HashMap<>();
+            int outputSize = in.readVInt();
+            List<Map<String, String>> outputList = new ArrayList<>(outputSize);
+            for (int j = 0; j < outputSize; j++) {
+                Map<String, String> outputMap = new HashMap<>();
+                if (in.readBoolean()) { // Check if 'name' field exists
+                    outputMap.put("name", in.readString());
+                }
+                outputMap.put("result", in.readString());
+                outputList.add(outputMap);
+            }
+            inferenceResult.put("output", outputList);
+            inferenceResults.add(inferenceResult);
+        }
+    }
+
+    public MLExecuteAgentResponse(List<Map<String, List<Map<String, String>>>> inferenceResults) {
+        this.inferenceResults = inferenceResults;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(inferenceResults.size());
+        for (Map<String, List<Map<String, String>>> inferenceResult : inferenceResults) {
+            List<Map<String, String>> outputList = inferenceResult.get("output");
+            out.writeVInt(outputList.size());
+            for (Map<String, String> outputMap : outputList) {
+                if (outputMap.containsKey("name")) {
+                    out.writeBoolean(true);
+                    out.writeString(outputMap.get("name"));
+                } else {
+                    out.writeBoolean(false);
+                }
+                out.writeString(outputMap.get("result"));
+            }
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.startArray("inference_results");
+        for (Map<String, List<Map<String, String>>> inferenceResult : inferenceResults) {
+            builder.startObject();
+            builder.startArray("output");
+            for (Map<String, String> outputMap : inferenceResult.get("output")) {
+                builder.startObject();
+                if (outputMap.containsKey("name")) {
+                    builder.field("name", outputMap.get("name"));
+                }
+                builder.field("result", outputMap.get("result"));
+                builder.endObject();
+            }
+            builder.endArray();
+            builder.endObject();
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+
+    public List<Map<String, List<Map<String, String>>>> getInferenceResults() {
+        return this.inferenceResults;
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentResponse.java
@@ -34,7 +34,7 @@ public class MLExecuteAgentResponse extends ActionResponse implements ToXContent
             List<Map<String, String>> outputList = new ArrayList<>(outputSize);
             for (int j = 0; j < outputSize; j++) {
                 Map<String, String> outputMap = new HashMap<>();
-                if (in.readBoolean()) { // Check if 'name' field exists
+                if (in.readBoolean()) {
                     outputMap.put("name", in.readString());
                 }
                 outputMap.put("result", in.readString());

--- a/common/src/test/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentActionTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentActionTests.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.agent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+public class MLExecuteAgentActionTests {
+
+    @Test
+    public void testExecuteAgentAction() {
+        assertNotNull(MLExecuteAgentAction.INSTANCE);
+        assertEquals(MLExecuteAgentAction.NAME, "cluster:admin/opensearch/ml/agents/execute");
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentRequestTests.java
@@ -6,15 +6,21 @@
 package org.opensearch.ml.common.transport.agent;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
 
 public class MLExecuteAgentRequestTests {
 
@@ -39,5 +45,37 @@ public class MLExecuteAgentRequestTests {
         assertEquals(request.getAgentId(), newRequest.getAgentId());
         assertEquals(request.getMethod(), newRequest.getMethod());
         assertEquals(request.getParameters(), newRequest.getParameters());
+    }
+
+    @Test
+    public void testValidate() {
+        MLExecuteAgentRequest request = new MLExecuteAgentRequest(agentId, method, parameters);
+        assertNull(request.validate());
+    }
+
+    @Test
+    public void testFromActionRequest_SelfConversion() {
+        MLExecuteAgentRequest request = new MLExecuteAgentRequest(agentId, method, parameters);
+        MLExecuteAgentRequest selfRequest = MLExecuteAgentRequest.fromActionRequest(request);
+        assertEquals(request, selfRequest);
+    }
+
+    @Test
+    public void testFromActionRequestWithIOException() {
+        ActionRequest actionRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException("test exception");
+            }
+        };
+
+        UncheckedIOException e = assertThrows(UncheckedIOException.class, () -> MLExecuteAgentRequest.fromActionRequest(actionRequest));
+        assertEquals("failed to parse ActionRequest into MLExecuteAgentRequest", e.getMessage());
+        assertEquals("test exception", e.getCause().getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentRequestTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.agent;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+public class MLExecuteAgentRequestTests {
+
+    private String agentId;
+    private String method;
+    private Map<String, String> parameters;
+
+    @Before
+    public void setUp() {
+        agentId = "test_agent_id";
+        method = "POST";
+        parameters = Collections.singletonMap("input", "foo");
+    }
+
+    @Test
+    public void testConstructorAndSerialization() throws IOException {
+        MLExecuteAgentRequest request = new MLExecuteAgentRequest(agentId, method, parameters);
+        BytesStreamOutput out = new BytesStreamOutput();
+        request.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        MLExecuteAgentRequest newRequest = new MLExecuteAgentRequest(in);
+        assertEquals(request.getAgentId(), newRequest.getAgentId());
+        assertEquals(request.getMethod(), newRequest.getMethod());
+        assertEquals(request.getParameters(), newRequest.getParameters());
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentResponseTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/agent/MLExecuteAgentResponseTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.agent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+public class MLExecuteAgentResponseTests {
+
+    private List<Map<String, List<Map<String, String>>>> inferenceResults;
+    private List<Map<String, List<Map<String, String>>>> inferenceResultsWithName;
+
+    @Before
+    public void setUp() {
+        Map<String, String> outputMap = Collections.singletonMap("result", "test result");
+        List<Map<String, String>> outputList = Collections.singletonList(outputMap);
+        Map<String, List<Map<String, String>>> inferenceResult = Collections.singletonMap("output", outputList);
+        inferenceResults = Collections.singletonList(inferenceResult);
+
+        Map<String, String> outputMapWithName = new HashMap<>();
+        outputMapWithName.put("name", "response");
+        outputMapWithName
+            .put(
+                "result",
+                "{\"size\":0.0,\"query\":{\"bool\":{\"must\":[{\"term\":{\"variety\":\"setosa\"}}]}},\"aggs\":{\"setosa_count\":{\"value_count\":{\"field\":\"variety\"}}}}"
+            );
+        List<Map<String, String>> outputListWithName = Collections.singletonList(outputMapWithName);
+        Map<String, List<Map<String, String>>> inferenceResultWithName = Collections.singletonMap("output", outputListWithName);
+        inferenceResultsWithName = Collections.singletonList(inferenceResultWithName);
+    }
+
+    @Test
+    public void testConstructorAndSerialization() throws IOException {
+        MLExecuteAgentResponse response = new MLExecuteAgentResponse(inferenceResults);
+        BytesStreamOutput out = new BytesStreamOutput();
+        response.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        MLExecuteAgentResponse newResponse = new MLExecuteAgentResponse(in);
+        assertEquals(inferenceResults.size(), newResponse.getInferenceResults().size());
+        assertEquals(
+            inferenceResults.get(0).get("output").get(0).get("result"),
+            newResponse.getInferenceResults().get(0).get("output").get(0).get("result")
+        );
+        assertNull(newResponse.getInferenceResults().get(0).get("output").get(0).get("name"));
+    }
+
+    @Test
+    public void testConstructorAndSerializationWithName() throws IOException {
+        MLExecuteAgentResponse response = new MLExecuteAgentResponse(inferenceResultsWithName);
+        BytesStreamOutput out = new BytesStreamOutput();
+        response.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        MLExecuteAgentResponse newResponse = new MLExecuteAgentResponse(in);
+        assertEquals(inferenceResultsWithName.size(), newResponse.getInferenceResults().size());
+        assertEquals(
+            inferenceResultsWithName.get(0).get("output").get(0).get("name"),
+            newResponse.getInferenceResults().get(0).get("output").get(0).get("name")
+        );
+        assertEquals(
+            inferenceResultsWithName.get(0).get("output").get(0).get("result"),
+            newResponse.getInferenceResults().get(0).get("output").get(0).get("result")
+        );
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/TransportExecuteAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/TransportExecuteAgentAction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.agents;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.ml.common.transport.agent.MLExecuteAgentAction;
+import org.opensearch.ml.common.transport.agent.MLExecuteAgentRequest;
+import org.opensearch.ml.common.transport.agent.MLExecuteAgentResponse;
+import org.opensearch.ml.engine.algorithms.agent.MLAgentExecutor;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+public class TransportExecuteAgentAction extends HandledTransportAction<MLExecuteAgentRequest, MLExecuteAgentResponse> {
+
+    private MLAgentExecutor mlAgentExecutor;
+
+    @Inject
+    public TransportExecuteAgentAction(TransportService transportService, ActionFilters actionFilters, MLAgentExecutor mlAgentExecutor) {
+        super(MLExecuteAgentAction.NAME, transportService, actionFilters, MLExecuteAgentRequest::new);
+        this.mlAgentExecutor = mlAgentExecutor;
+    }
+
+    @Override
+    protected void doExecute(Task task, MLExecuteAgentRequest request, ActionListener<MLExecuteAgentResponse> listener) {
+        mlAgentExecutor.executeAgent(request.getAgentId(), request.getMethod(), request.getParameters(), listener);
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -519,6 +519,7 @@ public class MachineLearningPlugin extends Plugin
                 new ActionHandler<>(MLAgentGetAction.INSTANCE, GetAgentTransportAction.class),
                 new ActionHandler<>(MLAgentDeleteAction.INSTANCE, DeleteAgentTransportAction.class),
                 new ActionHandler<>(MLAgentUpdateAction.INSTANCE, UpdateAgentTransportAction.class),
+                new ActionHandler<>(MLExecuteAgentAction.INSTANCE, TransportExecuteAgentAction.class),
                 new ActionHandler<>(UpdateConversationAction.INSTANCE, UpdateConversationTransportAction.class),
                 new ActionHandler<>(UpdateInteractionAction.INSTANCE, UpdateInteractionTransportAction.class),
                 new ActionHandler<>(GetTracesAction.INSTANCE, GetTracesTransportAction.class),
@@ -904,6 +905,7 @@ public class MachineLearningPlugin extends Plugin
         RestMLGetAgentAction restMLGetAgentAction = new RestMLGetAgentAction(mlFeatureEnabledSetting);
         RestMLDeleteAgentAction restMLDeleteAgentAction = new RestMLDeleteAgentAction(mlFeatureEnabledSetting);
         RestMLUpdateAgentAction restMLUpdateAgentAction = new RestMLUpdateAgentAction(mlFeatureEnabledSetting);
+        RestMLExecuteAgentAction restMLExecuteAgentAction = new RestMLExecuteAgentAction(mlFeatureEnabledSetting);
         RestMemoryUpdateConversationAction restMemoryUpdateConversationAction = new RestMemoryUpdateConversationAction();
         RestMemoryUpdateInteractionAction restMemoryUpdateInteractionAction = new RestMemoryUpdateInteractionAction();
         RestMemoryGetTracesAction restMemoryGetTracesAction = new RestMemoryGetTracesAction();
@@ -971,6 +973,7 @@ public class MachineLearningPlugin extends Plugin
                 restMLGetAgentAction,
                 restMLDeleteAgentAction,
                 restMLUpdateAgentAction,
+                restMLExecuteAgentAction,
                 restMemoryUpdateConversationAction,
                 restMemoryUpdateInteractionAction,
                 restMemoryGetTracesAction,

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteAgentAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.agent.MLExecuteAgentAction;
+import org.opensearch.ml.common.transport.agent.MLExecuteAgentRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+
+public class RestMLExecuteAgentAction extends BaseRestHandler {
+
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    public RestMLExecuteAgentAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, "/_plugins/_ml/agents/{agent_id}/_execute"));
+    }
+
+    @Override
+    public String getName() {
+        return "ml_execute_agent_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        String agentId = request.param("agent_id");
+        XContentParser parser = request.contentParser();
+        Map<String, Object> params = parser.map();
+        Map<String, String> parameters = (Map<String, String>) params.get("parameters");
+
+        MLExecuteAgentRequest mlExecuteAgentRequest = new MLExecuteAgentRequest(agentId, request.method().name(), parameters);
+
+        return channel -> client.execute(MLExecuteAgentAction.INSTANCE, mlExecuteAgentRequest, new RestToXContentListener<>(channel));
+    }
+}


### PR DESCRIPTION
### Description
Add executeAgentApi to ml-client so the other plugins can consume executeAgentApi

### Related Issues
#4005 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
