### PR TITLE
Add feature flag for agentic search

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -219,7 +219,8 @@ public final class MLCommonsSettings {
     public static final Setting<Boolean> ML_COMMONS_AGENTIC_SEARCH_ENABLED = Setting
         .boolSetting("plugins.ml_commons.agentic_search_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final String ML_COMMONS_AGENTIC_SEARCH_DISABLED_MESSAGE =
-        "The Agentic Search feature is not enabled. To enable, please update the setting " + ML_COMMONS_AGENTIC_SEARCH_ENABLED.getKey();
+        "The QueryPlanningTool tool for Agentic Search is not enabled. To enable, please update the setting "
+            + ML_COMMONS_AGENTIC_SEARCH_ENABLED.getKey();
 
     public static final Setting<Boolean> ML_COMMONS_MCP_CONNECTOR_ENABLED = Setting
         .boolSetting("plugins.ml_commons.mcp_connector_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -216,6 +216,11 @@ public final class MLCommonsSettings {
     public static final Setting<Boolean> ML_COMMONS_MEMORY_FEATURE_ENABLED = Setting
         .boolSetting("plugins.ml_commons.memory_feature_enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
+    public static final Setting<Boolean> ML_COMMONS_AGENTIC_SEARCH_ENABLED = Setting
+        .boolSetting("plugins.ml_commons.agentic_search_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
+    public static final String ML_COMMONS_AGENTIC_SEARCH_DISABLED_MESSAGE =
+        "The Agentic Search feature is not enabled. To enable, please update the setting " + ML_COMMONS_AGENTIC_SEARCH_ENABLED.getKey();
+
     public static final Setting<Boolean> ML_COMMONS_MCP_CONNECTOR_ENABLED = Setting
         .boolSetting("plugins.ml_commons.mcp_connector_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final String ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE =

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.common.settings;
 
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONTROLLER_ENABLED;
@@ -52,6 +53,8 @@ public class MLFeatureEnabledSetting {
 
     private volatile Boolean isExecuteToolEnabled;
 
+    private volatile Boolean isAgenticSearchEnabled;
+
     private final List<SettingsChangeListener> listeners = new ArrayList<>();
 
     public MLFeatureEnabledSetting(ClusterService clusterService, Settings settings) {
@@ -68,6 +71,7 @@ public class MLFeatureEnabledSetting {
         isMetricCollectionEnabled = ML_COMMONS_METRIC_COLLECTION_ENABLED.get(settings);
         isStaticMetricCollectionEnabled = ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED.get(settings);
         isExecuteToolEnabled = ML_COMMONS_EXECUTE_TOOL_ENABLED.get(settings);
+        isAgenticSearchEnabled = ML_COMMONS_AGENTIC_SEARCH_ENABLED.get(settings);
 
         clusterService
             .getClusterSettings()
@@ -91,6 +95,7 @@ public class MLFeatureEnabledSetting {
             .getClusterSettings()
             .addSettingsUpdateConsumer(MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED, it -> isRagSearchPipelineEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_EXECUTE_TOOL_ENABLED, it -> isExecuteToolEnabled = it);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_AGENTIC_SEARCH_ENABLED, it -> isAgenticSearchEnabled = it);
     }
 
     /**
@@ -194,5 +199,9 @@ public class MLFeatureEnabledSetting {
         for (SettingsChangeListener listener : listeners) {
             listener.onMultiTenancyEnabledChanged(isEnabled);
         }
+    }
+
+    public boolean isAgenticSearchEnabled() {
+        return isAgenticSearchEnabled;
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
@@ -11,6 +11,7 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CON
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONTROLLER_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_LOCAL_MODEL_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_SERVER_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_METRIC_COLLECTION_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
@@ -55,6 +56,8 @@ public class MLFeatureEnabledSetting {
 
     private volatile Boolean isAgenticSearchEnabled;
 
+    private volatile Boolean isMcpConnectorEnabled;
+
     private final List<SettingsChangeListener> listeners = new ArrayList<>();
 
     public MLFeatureEnabledSetting(ClusterService clusterService, Settings settings) {
@@ -72,6 +75,7 @@ public class MLFeatureEnabledSetting {
         isStaticMetricCollectionEnabled = ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED.get(settings);
         isExecuteToolEnabled = ML_COMMONS_EXECUTE_TOOL_ENABLED.get(settings);
         isAgenticSearchEnabled = ML_COMMONS_AGENTIC_SEARCH_ENABLED.get(settings);
+        isMcpConnectorEnabled = ML_COMMONS_MCP_CONNECTOR_ENABLED.get(settings);
 
         clusterService
             .getClusterSettings()
@@ -96,6 +100,7 @@ public class MLFeatureEnabledSetting {
             .addSettingsUpdateConsumer(MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED, it -> isRagSearchPipelineEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_EXECUTE_TOOL_ENABLED, it -> isExecuteToolEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_AGENTIC_SEARCH_ENABLED, it -> isAgenticSearchEnabled = it);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_MCP_CONNECTOR_ENABLED, it -> isMcpConnectorEnabled = it);
     }
 
     /**
@@ -203,5 +208,9 @@ public class MLFeatureEnabledSetting {
 
     public boolean isAgenticSearchEnabled() {
         return isAgenticSearchEnabled;
+    }
+
+    public boolean isMcpConnectorEnabled() {
+        return isMcpConnectorEnabled;
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/settings/MLFeatureEnabledSettingTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/settings/MLFeatureEnabledSettingTests.java
@@ -44,7 +44,9 @@ public class MLFeatureEnabledSettingTests {
                     MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED,
                     MLCommonsSettings.ML_COMMONS_METRIC_COLLECTION_ENABLED,
                     MLCommonsSettings.ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED,
-                    MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_ENABLED
+                    MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED
                 )
         );
         when(mockClusterService.getClusterSettings()).thenReturn(mockClusterSettings);
@@ -66,6 +68,8 @@ public class MLFeatureEnabledSettingTests {
             .put("plugins.ml_commons.rag_pipeline_feature_enabled", true)
             .put("plugins.ml_commons.metrics_collection_enabled", true)
             .put("plugins.ml_commons.metrics_static_collection_enabled", true)
+            .put("plugins.ml_commons.mcp_connector_enabled", true)
+            .put("plugins.ml_commons.agentic_search_enabled", true)
             .build();
 
         MLFeatureEnabledSetting setting = new MLFeatureEnabledSetting(mockClusterService, settings);
@@ -82,6 +86,8 @@ public class MLFeatureEnabledSettingTests {
         assertTrue(setting.isRagSearchPipelineEnabled());
         assertTrue(setting.isMetricCollectionEnabled());
         assertTrue(setting.isStaticMetricCollectionEnabled());
+        assertTrue(setting.isMcpConnectorEnabled());
+        assertTrue(setting.isAgenticSearchEnabled());
     }
 
     @Test
@@ -100,6 +106,8 @@ public class MLFeatureEnabledSettingTests {
             .put("plugins.ml_commons.rag_pipeline_feature_enabled", false)
             .put("plugins.ml_commons.metrics_collection_enabled", false)
             .put("plugins.ml_commons.metrics_static_collection_enabled", false)
+            .put("plugins.ml_commons.mcp_connector_enabled", false)
+            .put("plugins.ml_commons.agentic_search_enabled", false)
             .build();
 
         MLFeatureEnabledSetting setting = new MLFeatureEnabledSetting(mockClusterService, settings);
@@ -116,6 +124,8 @@ public class MLFeatureEnabledSettingTests {
         assertFalse(setting.isRagSearchPipelineEnabled());
         assertFalse(setting.isMetricCollectionEnabled());
         assertFalse(setting.isStaticMetricCollectionEnabled());
+        assertFalse(setting.isMcpConnectorEnabled());
+        assertFalse(setting.isAgenticSearchEnabled());
     }
 
     @Test

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
@@ -402,13 +402,11 @@ public class MLAgentExecutor implements Executable, SettingsChangeListener {
             return;
         }
         List<MLToolSpec> tools = mlAgent.getTools();
-        for (MLToolSpec tool : tools) {
-            if (tool.getType().equals(QueryPlanningTool.TYPE)) {
-                if (!agenticSearchIsEnabled) {
+        if (tools != null) {
+            for (MLToolSpec tool : tools) {
+                if (tool.getType().equals(QueryPlanningTool.TYPE) && !agenticSearchIsEnabled) {
                     listener.onFailure(new OpenSearchException(ML_COMMONS_AGENTIC_SEARCH_DISABLED_MESSAGE));
                     return;
-                } else {
-                    log.info("Searching for tool {}", tool.getName());
                 }
             }
         }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
@@ -15,9 +15,7 @@ import static org.opensearch.ml.common.MLTask.STATE_FIELD;
 import static org.opensearch.ml.common.MLTask.TASK_ID_FIELD;
 import static org.opensearch.ml.common.output.model.ModelTensorOutput.INFERENCE_RESULT_FIELD;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_DISABLED_MESSAGE;
-import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE;
-import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED;
 import static org.opensearch.ml.common.utils.MLTaskUtils.updateMLTaskDirectly;
 
 import java.security.AccessController;
@@ -63,6 +61,7 @@ import org.opensearch.ml.common.output.Output;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.settings.SettingsChangeListener;
 import org.opensearch.ml.common.spi.memory.Memory;
 import org.opensearch.ml.common.spi.tools.Tool;
@@ -112,8 +111,7 @@ public class MLAgentExecutor implements Executable, SettingsChangeListener {
     private Map<String, Memory.Factory> memoryFactoryMap;
     private volatile Boolean isMultiTenancyEnabled;
     private Encryptor encryptor;
-    private static volatile boolean mcpConnectorIsEnabled;
-    private static volatile boolean agenticSearchIsEnabled;
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
     public MLAgentExecutor(
         Client client,
@@ -123,7 +121,7 @@ public class MLAgentExecutor implements Executable, SettingsChangeListener {
         NamedXContentRegistry xContentRegistry,
         Map<String, Tool.Factory> toolFactories,
         Map<String, Memory.Factory> memoryFactoryMap,
-        Boolean isMultiTenancyEnabled,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting,
         Encryptor encryptor
     ) {
         this.client = client;
@@ -133,12 +131,9 @@ public class MLAgentExecutor implements Executable, SettingsChangeListener {
         this.xContentRegistry = xContentRegistry;
         this.toolFactories = toolFactories;
         this.memoryFactoryMap = memoryFactoryMap;
-        this.isMultiTenancyEnabled = isMultiTenancyEnabled;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
         this.encryptor = encryptor;
-        this.mcpConnectorIsEnabled = ML_COMMONS_MCP_CONNECTOR_ENABLED.get(clusterService.getSettings());
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_MCP_CONNECTOR_ENABLED, it -> mcpConnectorIsEnabled = it);
-        this.agenticSearchIsEnabled = ML_COMMONS_AGENTIC_SEARCH_ENABLED.get(clusterService.getSettings());
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_AGENTIC_SEARCH_ENABLED, it -> agenticSearchIsEnabled = it);
+        this.isMultiTenancyEnabled = mlFeatureEnabledSetting.isMultiTenancyEnabled();
     }
 
     @Override
@@ -396,7 +391,7 @@ public class MLAgentExecutor implements Executable, SettingsChangeListener {
         ActionListener<Output> listener
     ) {
         String mcpConnectorConfigJSON = (mlAgent.getParameters() != null) ? mlAgent.getParameters().get(MCP_CONNECTORS_FIELD) : null;
-        if (mcpConnectorConfigJSON != null && !mcpConnectorIsEnabled) {
+        if (mcpConnectorConfigJSON != null && !mlFeatureEnabledSetting.isMcpConnectorEnabled()) {
             // MCP connector provided as tools but MCP feature is disabled, so abort.
             listener.onFailure(new OpenSearchException(ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE));
             return;
@@ -404,7 +399,7 @@ public class MLAgentExecutor implements Executable, SettingsChangeListener {
         List<MLToolSpec> tools = mlAgent.getTools();
         if (tools != null) {
             for (MLToolSpec tool : tools) {
-                if (tool.getType().equals(QueryPlanningTool.TYPE) && !agenticSearchIsEnabled) {
+                if (tool.getType().equals(QueryPlanningTool.TYPE) && !mlFeatureEnabledSetting.isAgenticSearchEnabled()) {
                     listener.onFailure(new OpenSearchException(ML_COMMONS_AGENTIC_SEARCH_DISABLED_MESSAGE));
                     return;
                 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutorTest.java
@@ -10,9 +10,11 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.CLUSTER_MANAGER_ROLE;
+import static org.opensearch.ml.common.CommonValue.MCP_CONNECTORS_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_DISABLED_MESSAGE;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED;
 import static org.opensearch.ml.engine.algorithms.agent.MLAgentExecutor.MEMORY_ID;
 import static org.opensearch.ml.engine.algorithms.agent.MLAgentExecutor.QUESTION;
@@ -800,7 +802,7 @@ public class MLAgentExecutorTest {
     }
 
     @Test
-    public void test_query_planning_requires_agentic_search_enabled() throws IOException {
+    public void test_query_planning_agentic_search_disabled() throws IOException {
         // Create an MLAgent with QueryPlanningTool
         MLAgent mlAgentWithQueryPlanning = new MLAgent(
             "test",
@@ -875,6 +877,161 @@ public class MLAgentExecutorTest {
         Exception exception = exceptionCaptor.getValue();
         Assert.assertTrue(exception instanceof OpenSearchException);
         Assert.assertEquals(exception.getMessage(), ML_COMMONS_AGENTIC_SEARCH_DISABLED_MESSAGE);
+    }
+
+    @Test
+    public void test_mcp_connector_requires_mcp_connector_enabled() throws IOException {
+        // Create an MLAgent with MCP connectors in parameters
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(MCP_CONNECTORS_FIELD, "[{\"connector_id\": \"test-connector\"}]");
+
+        MLAgent mlAgentWithMcpConnectors = new MLAgent(
+            "test",
+            MLAgentType.FLOW.name(),
+            "test",
+            new LLMSpec("test_model", Map.of("test_key", "test_value")),
+            Collections.emptyList(),
+            parameters,
+            new MLMemorySpec("memoryType", "123", 0),
+            Instant.EPOCH,
+            Instant.EPOCH,
+            "test",
+            false,
+            null
+        );
+
+        // Create GetResponse with the MLAgent that has MCP connectors
+        XContentBuilder content = mlAgentWithMcpConnectors.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
+        BytesReference bytesReference = BytesReference.bytes(content);
+        GetResult getResult = new GetResult("indexName", "test-agent-id", 111l, 111l, 111l, true, bytesReference, null, null);
+        GetResponse agentGetResponse = new GetResponse(getResult);
+
+        // Create a new MLAgentExecutor with MCP connector disabled
+        MLFeatureEnabledSetting disabledMcpSetting = Mockito.mock(MLFeatureEnabledSetting.class);
+        when(disabledMcpSetting.isMultiTenancyEnabled()).thenReturn(false);
+        when(disabledMcpSetting.isMcpConnectorEnabled()).thenReturn(false);
+        when(disabledMcpSetting.isAgenticSearchEnabled()).thenReturn(true);
+
+        MLAgentExecutor mlAgentExecutorWithDisabledMcp = Mockito
+            .spy(
+                new MLAgentExecutor(
+                    client,
+                    sdkClient,
+                    settings,
+                    clusterService,
+                    xContentRegistry,
+                    toolFactories,
+                    memoryMap,
+                    disabledMcpSetting,
+                    null
+                )
+            );
+
+        // Mock the agent get response
+        Mockito.doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(agentGetResponse);
+            return null;
+        }).when(client).get(Mockito.any(GetRequest.class), Mockito.any(ActionListener.class));
+
+        // Mock the agent runner
+        Mockito.doReturn(mlAgentRunner).when(mlAgentExecutorWithDisabledMcp).getAgentRunner(Mockito.any());
+
+        // Execute the agent
+        mlAgentExecutorWithDisabledMcp.execute(getAgentMLInput(), agentActionListener);
+
+        // Verify that the execution fails with the correct error message
+        Mockito.verify(agentActionListener).onFailure(exceptionCaptor.capture());
+        Exception exception = exceptionCaptor.getValue();
+        Assert.assertTrue(exception instanceof OpenSearchException);
+        Assert.assertEquals(exception.getMessage(), ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE);
+    }
+
+    @Test
+    public void test_query_planning_agentic_search_enabled() throws IOException {
+        // Create an MLAgent with QueryPlanningTool
+        MLAgent mlAgentWithQueryPlanning = new MLAgent(
+            "test",
+            MLAgentType.FLOW.name(),
+            "test",
+            new LLMSpec("test_model", Map.of("test_key", "test_value")),
+            List
+                .of(
+                    new MLToolSpec(
+                        "QueryPlanningTool",
+                        "QueryPlanningTool",
+                        "QueryPlanningTool",
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        false,
+                        Collections.emptyMap(),
+                        null,
+                        null
+                    )
+                ),
+            Map.of("test", "test"),
+            new MLMemorySpec("memoryType", "123", 0),
+            Instant.EPOCH,
+            Instant.EPOCH,
+            "test",
+            false,
+            null
+        );
+
+        // Create GetResponse with the MLAgent that has QueryPlanningTool
+        XContentBuilder content = mlAgentWithQueryPlanning.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
+        BytesReference bytesReference = BytesReference.bytes(content);
+        GetResult getResult = new GetResult("indexName", "test-agent-id", 111l, 111l, 111l, true, bytesReference, null, null);
+        GetResponse agentGetResponse = new GetResponse(getResult);
+
+        // Create a new MLAgentExecutor with agentic search enabled
+        MLFeatureEnabledSetting enabledSearchSetting = Mockito.mock(MLFeatureEnabledSetting.class);
+        when(enabledSearchSetting.isMultiTenancyEnabled()).thenReturn(false);
+        when(enabledSearchSetting.isMcpConnectorEnabled()).thenReturn(true);
+        when(enabledSearchSetting.isAgenticSearchEnabled()).thenReturn(true);
+
+        MLAgentExecutor mlAgentExecutorWithEnabledSearch = Mockito
+            .spy(
+                new MLAgentExecutor(
+                    client,
+                    sdkClient,
+                    settings,
+                    clusterService,
+                    xContentRegistry,
+                    toolFactories,
+                    memoryMap,
+                    enabledSearchSetting,
+                    null
+                )
+            );
+
+        // Mock the agent get response
+        Mockito.doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(agentGetResponse);
+            return null;
+        }).when(client).get(Mockito.any(GetRequest.class), Mockito.any(ActionListener.class));
+
+        // Mock the agent runner
+        Mockito.doReturn(mlAgentRunner).when(mlAgentExecutorWithEnabledSearch).getAgentRunner(Mockito.any());
+
+        // Mock successful execution
+        ModelTensor modelTensor = ModelTensor.builder().name("response").dataAsMap(ImmutableMap.of("test_key", "test_value")).build();
+        Mockito.doAnswer(invocation -> {
+            ActionListener<ModelTensor> listener = invocation.getArgument(2);
+            listener.onResponse(modelTensor);
+            return null;
+        }).when(mlAgentRunner).run(Mockito.any(), Mockito.any(), Mockito.any());
+
+        // Execute the agent
+        mlAgentExecutorWithEnabledSearch.execute(getAgentMLInput(), agentActionListener);
+
+        // Verify that the execution succeeds
+        Mockito.verify(agentActionListener).onResponse(objectCaptor.capture());
+        ModelTensorOutput output = (ModelTensorOutput) objectCaptor.getValue();
+        Assert.assertEquals(1, output.getMlModelOutputs().size());
+        Assert.assertEquals(1, output.getMlModelOutputs().get(0).getMlModelTensors().size());
+        Assert.assertEquals(modelTensor, output.getMlModelOutputs().get(0).getMlModelTensors().get(0));
     }
 
     private AgentMLInput getAgentMLInput() {

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
@@ -7,11 +7,14 @@ package org.opensearch.ml.action.agents;
 
 import static org.opensearch.ml.common.CommonValue.MCP_CONNECTORS_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_DISABLED_MESSAGE;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.opensearch.OpenSearchException;
@@ -26,12 +29,14 @@ import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.agent.MLAgent;
+import org.opensearch.ml.common.agent.MLToolSpec;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentAction;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentRequest;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentResponse;
 import org.opensearch.ml.engine.algorithms.agent.MLPlanExecuteAndReflectAgentRunner;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
+import org.opensearch.ml.engine.tools.QueryPlanningTool;
 import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.ml.utils.TenantAwareHelper;
 import org.opensearch.remote.metadata.client.PutDataObjectRequest;
@@ -52,6 +57,7 @@ public class TransportRegisterAgentAction extends HandledTransportAction<ActionR
 
     private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
     private volatile boolean mcpConnectorIsEnabled;
+    private volatile boolean agenticSearchIsEnabled;
 
     @Inject
     public TransportRegisterAgentAction(
@@ -71,6 +77,8 @@ public class TransportRegisterAgentAction extends HandledTransportAction<ActionR
         this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
         this.mcpConnectorIsEnabled = ML_COMMONS_MCP_CONNECTOR_ENABLED.get(clusterService.getSettings());
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_MCP_CONNECTOR_ENABLED, it -> mcpConnectorIsEnabled = it);
+        this.agenticSearchIsEnabled = ML_COMMONS_AGENTIC_SEARCH_ENABLED.get(clusterService.getSettings());
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_AGENTIC_SEARCH_ENABLED, it -> agenticSearchIsEnabled = it);
     }
 
     @Override
@@ -88,6 +96,19 @@ public class TransportRegisterAgentAction extends HandledTransportAction<ActionR
             listener.onFailure(new OpenSearchException(ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE));
             return;
         }
+
+        List<MLToolSpec> tools = agent.getTools();
+        for (MLToolSpec tool : tools) {
+            if (tool.getType().equals(QueryPlanningTool.TYPE)) {
+                if (!agenticSearchIsEnabled) {
+                    listener.onFailure(new OpenSearchException(ML_COMMONS_AGENTIC_SEARCH_DISABLED_MESSAGE));
+                    return;
+                } else {
+                    log.info("Searching for tool {}", tool.getName());
+                }
+            }
+        }
+
         Instant now = Instant.now();
         boolean isHiddenAgent = RestActionUtils.isSuperAdminUser(clusterService, client);
         MLAgent mlAgent = agent.toBuilder().createdTime(now).lastUpdateTime(now).isHidden(isHiddenAgent).build();

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -730,7 +730,7 @@ public class MachineLearningPlugin extends Plugin
         SearchIndexTool.Factory.getInstance().init(client, xContentRegistry);
         VisualizationsTool.Factory.getInstance().init(client);
         ConnectorTool.Factory.getInstance().init(client);
-        QueryPlanningTool.Factory.getInstance().init(client);
+        QueryPlanningTool.Factory.getInstance().init(client, mlFeatureEnabledSetting);
 
         toolFactories.put(MLModelTool.TYPE, MLModelTool.Factory.getInstance());
         toolFactories.put(McpSseTool.TYPE, McpSseTool.Factory.getInstance());
@@ -1179,7 +1179,9 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MCP_SERVER_ENABLED,
                 MLCommonsSettings.ML_COMMONS_METRIC_COLLECTION_ENABLED,
-                MLCommonsSettings.ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED
+                MLCommonsSettings.ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED,
+                MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_ENABLED,
+                MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -763,7 +763,7 @@ public class MachineLearningPlugin extends Plugin
             xContentRegistry,
             toolFactories,
             memoryFactoryMap,
-            mlFeatureEnabledSetting.isMultiTenancyEnabled(),
+            mlFeatureEnabledSetting,
             encryptor
         );
         MLEngineClassLoader.register(FunctionName.LOCAL_SAMPLE_CALCULATOR, localSampleCalculator);

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1179,8 +1179,7 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MCP_SERVER_ENABLED,
                 MLCommonsSettings.ML_COMMONS_METRIC_COLLECTION_ENABLED,
-                MLCommonsSettings.ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED,
-                MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_ENABLED
+                MLCommonsSettings.ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED
             );
         return settings;
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/agents/RegisterAgentTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agents/RegisterAgentTransportActionTests.java
@@ -11,9 +11,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.CommonValue.MCP_CONNECTORS_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_DISABLED_MESSAGE;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED;
 import static org.opensearch.ml.engine.algorithms.agent.MLPlanExecuteAndReflectAgentRunner.EXECUTOR_AGENT_ID_FIELD;
 
@@ -48,6 +50,7 @@ import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentRequest;
 import org.opensearch.ml.common.transport.agent.MLRegisterAgentResponse;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
+import org.opensearch.ml.engine.tools.QueryPlanningTool;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
 import org.opensearch.tasks.Task;
@@ -373,10 +376,10 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
     }
 
     @Test
-    public void test_execute_registerAgent_QueryPlanningTool_Validation() {
+    public void test_execute_registerAgent_QueryPlanningTool_AgenticSearchDisabled() {
         // Create an MLAgent with QueryPlanningTool
         MLToolSpec queryPlanningTool = new MLToolSpec(
-            "QueryPlanningTool",
+            QueryPlanningTool.TYPE,
             "QueryPlanningTool",
             "QueryPlanningTool",
             Collections.emptyMap(),
@@ -399,10 +402,102 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
         MLRegisterAgentRequest request = mock(MLRegisterAgentRequest.class);
         when(request.getMlAgent()).thenReturn(mlAgent);
 
+        // Explicitly disable agentic search feature
+        when(mlFeatureEnabledSetting.isAgenticSearchEnabled()).thenReturn(false);
+
         transportRegisterAgentAction.doExecute(task, request, actionListener);
 
         ArgumentCaptor<OpenSearchException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(ML_COMMONS_AGENTIC_SEARCH_DISABLED_MESSAGE, argumentCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void test_execute_registerAgent_QueryPlanningTool_AgenticSearchEnabled() {
+        // Create an MLAgent with QueryPlanningTool
+        MLToolSpec queryPlanningTool = new MLToolSpec(
+            QueryPlanningTool.TYPE,
+            "QueryPlanningTool",
+            "QueryPlanningTool",
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            false,
+            Collections.emptyMap(),
+            null,
+            null
+        );
+
+        MLAgent mlAgent = MLAgent
+            .builder()
+            .name("agent")
+            .type(MLAgentType.CONVERSATIONAL.name())
+            .description("description")
+            .llm(new LLMSpec("model_id", new HashMap<>()))
+            .tools(List.of(queryPlanningTool))
+            .build();
+
+        MLRegisterAgentRequest request = mock(MLRegisterAgentRequest.class);
+        when(request.getMlAgent()).thenReturn(mlAgent);
+
+        // Enable agentic search feature
+        when(mlFeatureEnabledSetting.isAgenticSearchEnabled()).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLAgentIndex(any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> al = invocation.getArgument(1);
+            al.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(), any());
+
+        transportRegisterAgentAction.doExecute(task, request, actionListener);
+
+        ArgumentCaptor<MLRegisterAgentResponse> argumentCaptor = ArgumentCaptor.forClass(MLRegisterAgentResponse.class);
+        verify(actionListener).onResponse(argumentCaptor.capture());
+        assertNotNull(argumentCaptor.getValue());
+        assertEquals("AGENT_ID", argumentCaptor.getValue().getAgentId());
+    }
+
+    @Test
+    public void test_execute_registerAgent_MCPConnectorDisabled() {
+        // Create an MLAgent with MCP connectors in parameters
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(MCP_CONNECTORS_FIELD, "[{\"connector_id\": \"test-connector\"}]");
+
+        MLAgent mlAgent = MLAgent
+            .builder()
+            .name("agent")
+            .type(MLAgentType.CONVERSATIONAL.name())
+            .description("description")
+            .llm(new LLMSpec("model_id", new HashMap<>()))
+            .parameters(parameters)
+            .build();
+
+        MLRegisterAgentRequest request = mock(MLRegisterAgentRequest.class);
+        when(request.getMlAgent()).thenReturn(mlAgent);
+
+        // Disable MCP connector feature using mlFeatureEnabledSetting
+        when(mlFeatureEnabledSetting.isMcpConnectorEnabled()).thenReturn(false);
+
+        // Recreate the action with disabled MCP connector setting
+        TransportRegisterAgentAction disabledAction = new TransportRegisterAgentAction(
+            transportService,
+            actionFilters,
+            client,
+            sdkClient,
+            mlIndicesHandler,
+            clusterService,
+            mlFeatureEnabledSetting
+        );
+
+        disabledAction.doExecute(task, request, actionListener);
+
+        ArgumentCaptor<OpenSearchException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE, argumentCaptor.getValue().getMessage());
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.rest;
 
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED;
 import static org.opensearch.ml.engine.tools.QueryPlanningTool.MODEL_ID_FIELD;
 
 import java.io.IOException;
@@ -90,6 +91,8 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
         assertNotNull(agentId);
 
         String query = "{\"parameters\": {\"query_text\": \"How many iris flowers of type setosa are there?\"}}";
+        // enable agentic search
+        updateClusterSettings(ML_COMMONS_AGENTIC_SEARCH_ENABLED.getKey(), true);
         Response response = executeAgent(agentId, query);
         String responseBody = TestHelper.httpEntityToString(response.getEntity());
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
@@ -73,6 +73,8 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
         if (AWS_ACCESS_KEY_ID == null) {
             return;
         }
+        // enable agentic search
+        updateClusterSettings(ML_COMMONS_AGENTIC_SEARCH_ENABLED.getKey(), true);
         queryPlanningModelId = registerQueryPlanningModel();
     }
 
@@ -91,8 +93,6 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
         assertNotNull(agentId);
 
         String query = "{\"parameters\": {\"query_text\": \"How many iris flowers of type setosa are there?\"}}";
-        // enable agentic search
-        updateClusterSettings(ML_COMMONS_AGENTIC_SEARCH_ENABLED.getKey(), true);
         Response response = executeAgent(agentId, query);
         String responseBody = TestHelper.httpEntityToString(response.getEntity());
 

--- a/plugin/src/test/java/org/opensearch/ml/settings/MLFeatureEnabledSettingTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/settings/MLFeatureEnabledSettingTests.java
@@ -11,11 +11,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONTROLLER_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_LOCAL_MODEL_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_SERVER_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_METRIC_COLLECTION_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
@@ -72,7 +74,9 @@ public class MLFeatureEnabledSettingTests {
                             ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED,
                             ML_COMMONS_METRIC_COLLECTION_ENABLED,
                             ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED,
-                            ML_COMMONS_EXECUTE_TOOL_ENABLED
+                            ML_COMMONS_EXECUTE_TOOL_ENABLED,
+                            ML_COMMONS_AGENTIC_SEARCH_ENABLED,
+                            ML_COMMONS_MCP_CONNECTOR_ENABLED
                         )
                 )
             );


### PR DESCRIPTION
### Description
Add the feature flag `plugins.ml_commons.mcp_connector_enabled` defaulted to false for agentic search feature.

Prevent registering and executing agents with queryPlannerTool.

### Related Issues
Resolves  https://github.com/opensearch-project/ml-commons/issues/4005

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
