### PR TITLE
Add Execute Tool API

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/FunctionName.java
+++ b/common/src/main/java/org/opensearch/ml/common/FunctionName.java
@@ -31,7 +31,8 @@ public enum FunctionName {
     TEXT_SIMILARITY,
     QUESTION_ANSWERING,
     AGENT,
-    CONNECTOR;
+    CONNECTOR,
+    TOOL;
 
     public static FunctionName from(String value) {
         try {

--- a/common/src/main/java/org/opensearch/ml/common/input/execute/tool/ToolMLInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/execute/tool/ToolMLInput.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.input.execute.tool;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.opensearch.core.ParseField;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.input.Input;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.utils.StringUtils;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@org.opensearch.ml.common.annotation.MLInput(functionNames = { FunctionName.TOOL })
+public class ToolMLInput extends MLInput {
+    public static final String TOOL_NAME_FIELD = "tool_name";
+    public static final String PARAMETERS_FIELD = "parameters";
+
+    @Getter
+    @Setter
+    private String toolName;
+
+    public ToolMLInput(StreamInput in) throws IOException {
+        super(in);
+        this.toolName = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(toolName);
+    }
+
+    public static final NamedXContentRegistry.Entry XCONTENT_REGISTRY = new NamedXContentRegistry.Entry(
+        Input.class,
+        new ParseField(FunctionName.TOOL.name()),
+        it -> parse(it)
+    );
+
+    public static ToolMLInput parse(XContentParser parser) throws IOException {
+        return new ToolMLInput(parser, FunctionName.TOOL);
+    }
+
+    public ToolMLInput(XContentParser parser, FunctionName functionName) throws IOException {
+        this.algorithm = functionName;
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case TOOL_NAME_FIELD:
+                    toolName = parser.text();
+                    break;
+                case PARAMETERS_FIELD:
+                    Map<String, String> parameters = StringUtils.getParameterMap(parser.map());
+                    inputDataset = new RemoteInferenceInputDataSet(parameters);
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -237,6 +237,12 @@ public final class MLCommonsSettings {
     public static final Setting<Boolean> ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED = Setting
         .boolSetting("plugins.ml_commons.connector.private_ip_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
+    // Feature flag for execute tool API
+    public static final Setting<Boolean> ML_COMMONS_EXECUTE_TOOL_ENABLED = Setting
+        .boolSetting("plugins.ml_commons.execute_tools_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
+    public static final String ML_COMMONS_EXECUTE_TOOL_DISABLED_MESSAGE =
+        "The Execute Tool API is not enabled. To enable, please update the setting " + ML_COMMONS_EXECUTE_TOOL_ENABLED.getKey();
+
     public static final Setting<List<String>> ML_COMMONS_REMOTE_JOB_STATUS_FIELD = Setting
         .listSetting(
             "plugins.ml_commons.remote_job.status_field",

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/tool/MLToolExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/tool/MLToolExecutor.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.tool;
+
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_DISABLED_MESSAGE;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_ENABLED;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.input.Input;
+import org.opensearch.ml.common.input.execute.tool.ToolMLInput;
+import org.opensearch.ml.common.output.Output;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.spi.memory.Memory;
+import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.engine.Executable;
+import org.opensearch.ml.engine.annotation.Function;
+import org.opensearch.ml.engine.encryptor.Encryptor;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.transport.client.Client;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@Data
+@NoArgsConstructor
+@Function(FunctionName.TOOL)
+public class MLToolExecutor implements Executable {
+
+    private Client client;
+    private SdkClient sdkClient;
+    private Settings settings;
+    private ClusterService clusterService;
+    private NamedXContentRegistry xContentRegistry;
+    private Map<String, Tool.Factory> toolFactories;
+    private Map<String, Memory.Factory> memoryFactoryMap;
+    private Encryptor encryptor;
+    private static volatile boolean executeToolEnabled;
+
+    public MLToolExecutor(
+        Client client,
+        SdkClient sdkClient,
+        Settings settings,
+        ClusterService clusterService,
+        NamedXContentRegistry xContentRegistry,
+        Map<String, Tool.Factory> toolFactories,
+        Map<String, Memory.Factory> memoryFactoryMap,
+        Encryptor encryptor
+    ) {
+        this.client = client;
+        this.sdkClient = sdkClient;
+        this.settings = settings;
+        this.clusterService = clusterService;
+        this.xContentRegistry = xContentRegistry;
+        this.toolFactories = toolFactories;
+        this.memoryFactoryMap = memoryFactoryMap;
+        this.encryptor = encryptor;
+        this.executeToolEnabled = ML_COMMONS_EXECUTE_TOOL_ENABLED.get(clusterService.getSettings());
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_EXECUTE_TOOL_ENABLED, it -> executeToolEnabled = it);
+    }
+
+    @Override
+    public void execute(Input input, ActionListener<Output> listener) {
+        if (!executeToolEnabled) {
+            listener.onFailure(new OpenSearchException(ML_COMMONS_EXECUTE_TOOL_DISABLED_MESSAGE));
+            return;
+        }
+
+        if (!(input instanceof ToolMLInput)) {
+            throw new IllegalArgumentException("wrong input");
+        }
+        ToolMLInput toolMLInput = (ToolMLInput) input;
+        String toolName = toolMLInput.getToolName();
+
+        RemoteInferenceInputDataSet inputDataSet = (RemoteInferenceInputDataSet) toolMLInput.getInputDataset();
+        if (inputDataSet == null || inputDataSet.getParameters() == null) {
+            throw new IllegalArgumentException("Tool input data can not be empty.");
+        }
+        Map<String, String> parameters = inputDataSet.getParameters();
+
+        Tool.Factory toolFactory = toolFactories.get(toolName);
+        if (toolFactory == null) {
+            listener.onFailure(new IllegalArgumentException("Tool not found: " + toolName));
+            return;
+        }
+
+        try {
+            Tool tool = toolFactory.create(new HashMap<>(parameters));
+            if (!tool.validate(parameters)) {
+                listener.onFailure(new IllegalArgumentException("Invalid parameters for tool: " + toolName));
+                return;
+            }
+
+            tool.run(parameters, ActionListener.wrap(result -> {
+                List<ModelTensor> modelTensors = new ArrayList<>();
+                processOutput(result, modelTensors);
+                ModelTensors tensors = ModelTensors.builder().mlModelTensors(modelTensors).build();
+                listener.onResponse(new ModelTensorOutput(List.of(tensors)));
+            }, error -> {
+                log.error("Failed to execute tool: " + toolName, error);
+                listener.onFailure(error);
+            }));
+        } catch (Exception e) {
+            log.error("Failed to execute tool: " + toolName, e);
+            listener.onFailure(e);
+        }
+    }
+
+    private void processOutput(Object output, List<ModelTensor> modelTensors) {
+        if (output instanceof ModelTensorOutput) {
+            ModelTensorOutput modelTensorOutput = (ModelTensorOutput) output;
+            modelTensorOutput.getMlModelOutputs().forEach(outs -> modelTensors.addAll(outs.getMlModelTensors()));
+        } else if (output instanceof ModelTensor) {
+            modelTensors.add((ModelTensor) output);
+        } else if (output instanceof List) {
+            List<?> list = (List<?>) output;
+            if (!list.isEmpty()) {
+                if (list.get(0) instanceof ModelTensor) {
+                    modelTensors.addAll((List<ModelTensor>) list);
+                } else if (list.get(0) instanceof ModelTensors) {
+                    ((List<ModelTensors>) list).forEach(outs -> modelTensors.addAll(outs.getMlModelTensors()));
+                } else {
+                    String result = StringUtils.toJson(output);
+                    modelTensors.add(ModelTensor.builder().name("response").result(result).build());
+                }
+            }
+        } else {
+            String result = output instanceof String ? (String) output : StringUtils.toJson(output);
+            modelTensors.add(ModelTensor.builder().name("response").result(result).build());
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -221,6 +221,7 @@ import org.opensearch.ml.engine.algorithms.agent.MLAgentExecutor;
 import org.opensearch.ml.engine.algorithms.anomalylocalization.AnomalyLocalizerImpl;
 import org.opensearch.ml.engine.algorithms.metrics_correlation.MetricsCorrelation;
 import org.opensearch.ml.engine.algorithms.sample.LocalSampleCalculator;
+import org.opensearch.ml.engine.algorithms.tool.MLToolExecutor;
 import org.opensearch.ml.engine.analysis.DJLUtils;
 import org.opensearch.ml.engine.analysis.HFModelAnalyzer;
 import org.opensearch.ml.engine.analysis.HFModelAnalyzerProvider;
@@ -763,6 +764,19 @@ public class MachineLearningPlugin extends Plugin
 
         MetricsCorrelation metricsCorrelation = new MetricsCorrelation(client, settings, clusterService);
         MLEngineClassLoader.register(FunctionName.METRICS_CORRELATION, metricsCorrelation);
+
+        MLToolExecutor toolExecutor = new MLToolExecutor(
+            client,
+            sdkClient,
+            settings,
+            clusterService,
+            xContentRegistry,
+            toolFactories,
+            memoryFactoryMap,
+            encryptor
+        );
+        MLEngineClassLoader.register(FunctionName.TOOL, toolExecutor);
+
         MLSearchHandler mlSearchHandler = new MLSearchHandler(client, xContentRegistry, modelAccessControlHelper, clusterService);
         MLModelAutoReDeployer mlModelAutoRedeployer = new MLModelAutoReDeployer(
             clusterService,
@@ -1158,7 +1172,8 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MCP_SERVER_ENABLED,
                 MLCommonsSettings.ML_COMMONS_METRIC_COLLECTION_ENABLED,
-                MLCommonsSettings.ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED
+                MLCommonsSettings.ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED,
+                MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_ENABLED
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteAction.java
@@ -12,6 +12,7 @@ import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
 import static org.opensearch.ml.utils.MLExceptionUtils.AGENT_FRAMEWORK_DISABLED_ERR_MSG;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_AGENT_ID;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_ALGORITHM;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_TOOL_NAME;
 import static org.opensearch.ml.utils.RestActionUtils.getAlgorithm;
 import static org.opensearch.ml.utils.RestActionUtils.isAsync;
 import static org.opensearch.ml.utils.TenantAwareHelper.getTenantID;
@@ -28,6 +29,7 @@ import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.input.Input;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.input.execute.agent.AgentMLInput;
+import org.opensearch.ml.common.input.execute.tool.ToolMLInput;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskAction;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskRequest;
@@ -67,7 +69,8 @@ public class RestMLExecuteAction extends BaseRestHandler {
         return ImmutableList
             .of(
                 new Route(RestRequest.Method.POST, String.format(Locale.ROOT, "%s/_execute/{%s}", ML_BASE_URI, PARAMETER_ALGORITHM)),
-                new Route(RestRequest.Method.POST, String.format(Locale.ROOT, "%s/agents/{%s}/_execute", ML_BASE_URI, PARAMETER_AGENT_ID))
+                new Route(RestRequest.Method.POST, String.format(Locale.ROOT, "%s/agents/{%s}/_execute", ML_BASE_URI, PARAMETER_AGENT_ID)),
+                new Route(RestRequest.Method.POST, String.format(Locale.ROOT, "%s/tools/_execute/{%s}", ML_BASE_URI, PARAMETER_TOOL_NAME))
             );
     }
 
@@ -124,6 +127,11 @@ public class RestMLExecuteAction extends BaseRestHandler {
             ((AgentMLInput) input).setAgentId(agentId);
             ((AgentMLInput) input).setTenantId(tenantId);
             ((AgentMLInput) input).setIsAsync(async);
+        } else if (uri.startsWith(ML_BASE_URI + "/tools/")) {
+            String toolName = request.param(PARAMETER_TOOL_NAME);
+            functionName = FunctionName.TOOL;
+            input = MLInput.parse(parser, functionName.name());
+            ((ToolMLInput) input).setToolName(toolName);
         } else {
             String algorithm = getAlgorithm(request).toUpperCase(Locale.ROOT);
             functionName = FunctionName.from(algorithm);


### PR DESCRIPTION
### Description
**This is an experimental feature in 3.2**
Implement execute tool API for direct tool execution (internal and external from skills repo) without agent or memory storage. This is intended for a single tool execution. Tool parameters vary by type (e.g., PPLTool requires `question`,`index`, and `model_id` while SearchAlertsTool only needs `question`.

Sample request payload:
```
POST /_plugins/_ml/tools/_execute/{tool_name}
{
    "parameters": {
        "question": "...",
         "model_id": "...",
        ....
    }
}
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
