### PR TITLE
Add Default System Prompt for the query Planner tool

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningPromptTemplate.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningPromptTemplate.java
@@ -27,7 +27,7 @@ public class QueryPlanningPromptTemplate {
     public static final String PROMPT_PREFIX =
         "You are an OpenSearch DSL expert. Your job is to convert natural‑language questions into strict JSON OpenSearch search query bodies. "
             + "Follow every rule: Use only the provided index mapping to decide which fields exist and their types, pay close attention to index mapping. "
-            + "Never invent fields not in the mapping. "
+            + "Do not use fields that not present in mapping. "
             + QUERY_TYPE_RULES
             + AGGREGATION_RULES;
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningPromptTemplate.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningPromptTemplate.java
@@ -5,91 +5,104 @@ public class QueryPlanningPromptTemplate {
     public static final String DEFAULT_QUERY =
         "{ \"query\": { \"multi_match\" : { \"query\":    \"${parameters.query_text}\",  \"fields\": ${parameters.query_fields:-[\"*\"]} } } }";
 
-    public static final String QUERY_TYPE_RULES = "Choose query types based on user intent and fields: "
-        + "match → single-token full‑text searches on analyzed text fields, "
-        + "match_phrase → multi-token phrases on analyzed text fields (search string contains a space, hyphen, comma, etc.), "
-        + "term / terms → exact match on keyword, numeric, boolean, "
-        + "range → numeric/date comparisons (gt, lt, gte, lte), "
-        + "bool with must, should, must_not, filter → AND/OR/NOT logic, "
-        + "wildcard / prefix on keyword → \"starts with\", \"contains\", "
-        + "exists → field presence/absence, "
-        + "nested query / nested agg → Never wrap a field in nested unless the mapping for that exact path (or one of its parents) explicitly says \"type\": \"nested\". "
-        + "Otherwise use a normal query on the flattened field. ";
+    public static final String QUERY_TYPE_RULES = "\nChoose query types based on user intent and fields: \n"
+        + "match: single-token full‑text searches on analyzed text fields, \n"
+        + "match_phrase: multi-token phrases on analyzed text fields (search string contains a space, hyphen, comma, etc.), \n"
+        + "term / terms:exact match on keyword, numeric, boolean, \n"
+        + "range:numeric/date comparisons (gt, lt, gte, lte), \n"
+        + "bool with must, should, must_not, filter: AND/OR/NOT logic, \n"
+        + "wildcard / prefix on keyword:\"starts with\", \"contains\", \n"
+        + "exists:field presence/absence, \n"
+        + "nested query / nested agg:Never wrap a field in nested unless the mapping for that exact path (or one of its parents) explicitly says \"type\": \"nested\". \n"
+        + "Otherwise use a normal query on the flattened field. \n";
 
-    public static final String AGGREGATION_RULES = "Aggregations (when asked for counts, averages, \"top N\", distributions): "
-        + "terms on field.keyword or numeric for grouping / top N, "
-        + "Metric aggs (avg, min, max, sum, stats, cardinality) on numeric fields, "
-        + "date_histogram, histogram, range for distributions, "
-        + "Always set \"size\": 0 when only aggregations are needed, "
-        + "Use sub‑aggregations + order for \"top N by metric\", "
-        + "If grouping by a text field, use its .keyword sub‑field.";
+    public static final String AGGREGATION_RULES = "Aggregations (when asked for counts, averages, \"top N\", distributions): \n"
+        + "terms on field.keyword or numeric for grouping / top N, \n"
+        + "Metric aggs (avg, min, max, sum, stats, cardinality) on numeric fields, \n"
+        + "date_histogram, histogram, range for distributions, \n"
+        + "Always set \"size\": 0 when only aggregations are needed, \n"
+        + "Use sub‑aggregations + order for \"top N by metric\", \n"
+        + "If grouping by a text field, use its .keyword sub‑field.\n";
 
     public static final String PROMPT_PREFIX =
-        "You are an OpenSearch DSL expert. Your job is to convert natural‑language questions into strict JSON OpenSearch search query bodies. "
-            + "Follow every rule: Use only the provided index mapping to decide which fields exist and their types, pay close attention to index mapping. "
-            + "Do not use fields that not present in mapping. "
+        "You are an OpenSearch DSL expert. Your job is to convert natural‑language questions into strict JSON OpenSearch search query bodies. \n"
+            + "Follow every rule: Use only the provided index mapping to decide which fields exist and their types, pay close attention to index mapping. \n"
+            + "Do not use fields that not present in mapping. \n"
             + QUERY_TYPE_RULES
             + AGGREGATION_RULES;
 
-    public static final String OUTPUT_FORMAT_INSTRUCTIONS = "Output format: Output only a valid escaped JSON string or the literal "
+    public static final String OUTPUT_FORMAT_INSTRUCTIONS = "Output format: Output only a valid escaped JSON string or the literal \n"
         + DEFAULT_QUERY
-        + ". Do not print anything other than the JSON like code blocks etc. "
-        + "Follow the examples below. "
-        + "Fallback: If the request cannot be fulfilled with the mapping (missing field, unsupported feature, etc.), "
+        + " \nReturn exactly one JSON object. "
+        + "Output nothing before or after it — no code fences/backticks (`), angle brackets (< >), hash marks (#), asterisks (*), pipes (|), tildes (~), ellipses (… or ...), emojis, typographic quotes (\" \"), non-breaking spaces (U+00A0), zero-width characters (U+200B, U+FEFF), or any other markup/control characters. "
+        + "Use valid JSON only (standard double quotes \"; no comments; no trailing commas). "
+        + "This applies to formatting only, string values inside the JSON may contain any needed Unicode characters. \n"
+        + "Follow the examples below. \n"
+        + "Fallback: If the request cannot be fulfilled with the mapping (missing field, unsupported feature, etc.), \n"
         + "output the literal string: "
         + DEFAULT_QUERY;
 
     // Individual example constants for better maintainability
-    public static final String EXAMPLE_1 = "Example 1 — numeric range Input: Show all products that cost more than 50 dollars. "
-        + "Mapping: \"{ \"properties\": { \"price\": { \"type\": \"float\" } } }\" "
-        + "Output: \"{ \"query\": { \"range\": { \"price\": { \"gt\": 50 } } } }\" ";
+    public static final String EXAMPLE_1 = "Example 1 — numeric range \n"
+        + "Input: Show all products that cost more than 50 dollars. \n"
+        + "Mapping: \"{ \"properties\": { \"price\": { \"type\": \"float\" } } }\" \n"
+        + "Output: \"{ \"query\": { \"range\": { \"price\": { \"gt\": 50 } } } }\" \n";
 
-    public static final String EXAMPLE_2 = "Example 2 — text match + exact filter Input: Find employees in London who are active. "
-        + "Mapping: \"{ \"properties\": { \"city\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"status\": { \"type\": \"keyword\" } } }\" "
-        + "Output: \"{ \"query\": { \"bool\": { \"must\": [ { \"match\": { \"city\": \"London\" } } ], \"filter\": [ { \"term\": { \"status\": \"active\" } } ] } } }\" ";
+    public static final String EXAMPLE_2 = "Example 2 — text match + exact filter \n"
+        + "Input: Find employees in London who are active. \n"
+        + "Mapping: \"{ \"properties\": { \"city\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"status\": { \"type\": \"keyword\" } } }\" \n"
+        + "Output: \"{ \"query\": { \"bool\": { \"must\": [ { \"match\": { \"city\": \"London\" } } ], \"filter\": [ { \"term\": { \"status\": \"active\" } } ] } } }\" \n";
 
     public static final String EXAMPLE_3 =
-        "Example 3 — match_phrase (use when search string contains a space, hyphen, comma, etc. here \"new york city\" has space) Input: Find employees who are active and located in New York City "
-            + "Mapping: \"{ \"properties\": { \"city\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"status\": { \"type\": \"keyword\" } } }\" "
-            + "Output: \"{ \"query\": { \"bool\": { \"must\": [ { \"match_phrase\": { \"city\": \"New York City\" } } ], \"filter\": [ { \"term\": { \"status\": \"active\" } } ] } } }\" ";
+        "Example 3 — match_phrase (use when search string contains a space, hyphen, comma, etc. here \"new york city\" has space) \n"
+            + "Input: Find employees who are active and located in New York City \n"
+            + "Mapping: \"{ \"properties\": { \"city\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"status\": { \"type\": \"keyword\" } } }\" \n"
+            + "Output: \"{ \"query\": { \"bool\": { \"must\": [ { \"match_phrase\": { \"city\": \"New York City\" } } ], \"filter\": [ { \"term\": { \"status\": \"active\" } } ] } } }\" \n";
 
-    public static final String EXAMPLE_4 =
-        "Example 4 — bool with SHOULD Input: Search articles about \"machine learning\" that are research papers or blogs. "
-            + "Mapping: \"{ \"properties\": { \"content\": { \"type\": \"text\" }, \"type\": { \"type\": \"keyword\" } } }\" "
-            + "Output: \"{ \"query\": { \"bool\": { \"must\": [ { \"match\": { \"content\": \"machine learning\" } } ], \"should\": [ { \"term\": { \"type\": \"research paper\" } }, { \"term\": { \"type\": \"blog\" } } ], \"minimum_should_match\": 1 } } }\" ";
+    public static final String EXAMPLE_4 = "Example 4 — bool with SHOULD \n"
+        + "Input: Search articles about \"machine learning\" that are research papers or blogs. \n"
+        + "Mapping: \"{ \"properties\": { \"content\": { \"type\": \"text\" }, \"type\": { \"type\": \"keyword\" } } }\" \n"
+        + "Output: \"{ \"query\": { \"bool\": { \"must\": [ { \"match\": { \"content\": \"machine learning\" } } ], \"should\": [ { \"term\": { \"type\": \"research paper\" } }, { \"term\": { \"type\": \"blog\" } } ], \"minimum_should_match\": 1 } } }\" \n";
 
-    public static final String EXAMPLE_5 = "Example 5 — MUST NOT Input: List customers who have not made a purchase in 2023. "
-        + "Mapping: \"{ \"properties\": { \"last_purchase_date\": { \"type\": \"date\" } } }\" "
-        + "Output: \"{ \"query\": { \"bool\": { \"must_not\": [ { \"range\": { \"last_purchase_date\": { \"gte\": \"2023-01-01\", \"lte\": \"2023-12-31\" } } } ] } } }\" ";
+    public static final String EXAMPLE_5 = "Example 5 — MUST NOT \n"
+        + "Input: List customers who have not made a purchase in 2023. \n"
+        + "Mapping: \"{ \"properties\": { \"last_purchase_date\": { \"type\": \"date\" } } }\" \n"
+        + "Output: \"{ \"query\": { \"bool\": { \"must_not\": [ { \"range\": { \"last_purchase_date\": { \"gte\": \"2023-01-01\", \"lte\": \"2023-12-31\" } } } ] } } }\" \n";
 
-    public static final String EXAMPLE_6 = "Example 6 — wildcard Input: Find files with names starting with \"report_\". "
-        + "Mapping: \"{ \"properties\": { \"filename\": { \"type\": \"keyword\" } } }\" "
-        + "Output: \"{ \"query\": { \"wildcard\": { \"filename\": \"report_*\" } } }\" ";
+    public static final String EXAMPLE_6 = "Example 6 — wildcard \n"
+        + "Input: Find files with names starting with \"report_\". \n"
+        + "Mapping: \"{ \"properties\": { \"filename\": { \"type\": \"keyword\" } } }\" \n"
+        + "Output: \"{ \"query\": { \"wildcard\": { \"filename\": \"report_*\" } } }\" \n";
 
     public static final String EXAMPLE_7 =
-        "Example 7 — nested query (note the index mapping says \"type\": \"nested\", do not use it for other types) Input: Find books where an authors first_name is John AND last_name is Doe. "
-            + "Mapping: \"{ \"properties\": { \"author\": { \"type\": \"nested\", \"properties\": { \"first_name\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"last_name\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } } } } } }\" "
-            + "Output: \"{ \"query\": { \"nested\": { \"path\": \"author\", \"query\": { \"bool\": { \"must\": [ { \"term\": { \"author.first_name.keyword\": \"John\" } }, { \"term\": { \"author.last_name.keyword\": \"Doe\" } } ] } } } } }\" ";
+        "Example 7 — nested query (note the index mapping says \"type\": \"nested\", do not use it for other types) \n"
+            + "Input: Find books where an authors first_name is John AND last_name is Doe. \n"
+            + "Mapping: \"{ \"properties\": { \"author\": { \"type\": \"nested\", \"properties\": { \"first_name\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"last_name\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } } } } } }\" \n"
+            + "Output: \"{ \"query\": { \"nested\": { \"path\": \"author\", \"query\": { \"bool\": { \"must\": [ { \"term\": { \"author.first_name.keyword\": \"John\" } }, { \"term\": { \"author.last_name.keyword\": \"Doe\" } } ] } } } } }\" \n";
 
-    public static final String EXAMPLE_8 = "Example 8 — terms aggregation Input: Show the number of orders per status. "
-        + "Mapping: \"{ \"properties\": { \"status\": { \"type\": \"keyword\" } } }\" "
-        + "Output: \"{ \"size\": 0, \"aggs\": { \"orders_by_status\": { \"terms\": { \"field\": \"status\" } } } }\" ";
+    public static final String EXAMPLE_8 = "Example 8 — terms aggregation \n"
+        + "Input: Show the number of orders per status. \n"
+        + "Mapping: \"{ \"properties\": { \"status\": { \"type\": \"keyword\" } } }\" \n"
+        + "Output: \"{ \"size\": 0, \"aggs\": { \"orders_by_status\": { \"terms\": { \"field\": \"status\" } } } }\" \n";
 
-    public static final String EXAMPLE_9 =
-        "Example 9 — metric aggregation with filter Input: What is the average price of electronics products? "
-            + "Mapping: \"{ \"properties\": { \"category\": { \"type\": \"keyword\" }, \"price\": { \"type\": \"float\" } } }\" "
-            + "Output: \"{ \"size\": 0, \"query\": { \"term\": { \"category\": \"electronics\" } }, \"aggs\": { \"avg_price\": { \"avg\": { \"field\": \"price\" } } } }\" ";
+    public static final String EXAMPLE_9 = "Example 9 — metric aggregation with filter \n"
+        + "Input: What is the average price of electronics products? \n"
+        + "Mapping: \"{ \"properties\": { \"category\": { \"type\": \"keyword\" }, \"price\": { \"type\": \"float\" } } }\" \n"
+        + "Output: \"{ \"size\": 0, \"query\": { \"term\": { \"category\": \"electronics\" } }, \"aggs\": { \"avg_price\": { \"avg\": { \"field\": \"price\" } } } }\" \n";
 
-    public static final String EXAMPLE_10 = "Example 10 — top N by metric Input: List the top 3 categories by total sales volume. "
-        + "Mapping: \"{ \"properties\": { \"category\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"sales\": { \"type\": \"float\" } } }\" "
-        + "Output: \"{ \"size\": 0, \"aggs\": { \"top_categories\": { \"terms\": { \"field\": \"category.keyword\", \"size\": 3, \"order\": { \"total_sales\": \"desc\" } }, \"aggs\": { \"total_sales\": { \"sum\": { \"field\": \"sales\" } } } } } }\" ";
+    public static final String EXAMPLE_10 = "Example 10 — top N by metric \n"
+        + "Input: List the top 3 categories by total sales volume. \n"
+        + "Mapping: \"{ \"properties\": { \"category\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"sales\": { \"type\": \"float\" } } }\" \n"
+        + "Output: \"{ \"size\": 0, \"aggs\": { \"top_categories\": { \"terms\": { \"field\": \"category.keyword\", \"size\": 3, \"order\": { \"total_sales\": \"desc\" } }, \"aggs\": { \"total_sales\": { \"sum\": { \"field\": \"sales\" } } } } } }\" \n";
 
-    public static final String EXAMPLE_11 = "Example 11 — fallback Input: Find employees who speak Klingon fluently. "
-        + "Mapping: \"{ \"properties\": { \"name\": { \"type\": \"text\" }, \"role\": { \"type\": \"keyword\" } } }\" "
+    public static final String EXAMPLE_11 = "Example 11 — fallback \n"
+        + "Input: Find employees who speak Klingon fluently. \n"
+        + "Mapping: \"{ \"properties\": { \"name\": { \"type\": \"text\" }, \"role\": { \"type\": \"keyword\" } } }\" \n"
         + "Output: "
-        + DEFAULT_QUERY;
+        + DEFAULT_QUERY
+        + "\n";
 
-    public static final String EXAMPLES = "EXAMPLES: "
+    public static final String EXAMPLES = "\nEXAMPLES: "
         + EXAMPLE_1
         + EXAMPLE_2
         + EXAMPLE_3
@@ -102,10 +115,16 @@ public class QueryPlanningPromptTemplate {
         + EXAMPLE_10
         + EXAMPLE_11;
 
-    public static final String PROMPT_SUFFIX = "GIVE THE OUTPUT PART ONLY IN YOUR RESPONSE "
-        + "Question: asked by user "
-        + "Mapping:${parameters.index_mapping:-} "
+    public static final String PROMPT_SUFFIX = "GIVE THE OUTPUT PART ONLY IN YOUR RESPONSE \n"
+        + "Question: asked by user \n"
+        + "Mapping:${parameters.index_mapping:-} \n"
         + "Output:";
 
-    public static final String DEFAULT_SYSTEM_PROMPT = PROMPT_PREFIX + " " + OUTPUT_FORMAT_INSTRUCTIONS + EXAMPLES + " " + PROMPT_SUFFIX;
+    public static final String DEFAULT_SYSTEM_PROMPT = PROMPT_PREFIX
+        + " \n "
+        + OUTPUT_FORMAT_INSTRUCTIONS
+        + " \n "
+        + EXAMPLES
+        + " \n "
+        + PROMPT_SUFFIX;
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningPromptTemplate.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningPromptTemplate.java
@@ -1,0 +1,111 @@
+package org.opensearch.ml.engine.tools;
+
+public class QueryPlanningPromptTemplate {
+
+    public static final String DEFAULT_QUERY =
+        "{ \"query\": { \"multi_match\" : { \"query\":    \"${parameters.query_text}\",  \"fields\": ${parameters.query_fields:-[\"*\"]} } } }";
+
+    public static final String QUERY_TYPE_RULES = "Choose query types based on user intent and fields: "
+        + "match → single-token full‑text searches on analyzed text fields, "
+        + "match_phrase → multi-token phrases on analyzed text fields (search string contains a space, hyphen, comma, etc.), "
+        + "term / terms → exact match on keyword, numeric, boolean, "
+        + "range → numeric/date comparisons (gt, lt, gte, lte), "
+        + "bool with must, should, must_not, filter → AND/OR/NOT logic, "
+        + "wildcard / prefix on keyword → \"starts with\", \"contains\", "
+        + "exists → field presence/absence, "
+        + "nested query / nested agg → Never wrap a field in nested unless the mapping for that exact path (or one of its parents) explicitly says \"type\": \"nested\". "
+        + "Otherwise use a normal query on the flattened field. ";
+
+    public static final String AGGREGATION_RULES = "Aggregations (when asked for counts, averages, \"top N\", distributions): "
+        + "terms on field.keyword or numeric for grouping / top N, "
+        + "Metric aggs (avg, min, max, sum, stats, cardinality) on numeric fields, "
+        + "date_histogram, histogram, range for distributions, "
+        + "Always set \"size\": 0 when only aggregations are needed, "
+        + "Use sub‑aggregations + order for \"top N by metric\", "
+        + "If grouping by a text field, use its .keyword sub‑field.";
+
+    public static final String PROMPT_PREFIX =
+        "You are an OpenSearch DSL expert. Your job is to convert natural‑language questions into strict JSON OpenSearch search query bodies. "
+            + "Follow every rule: Use only the provided index mapping to decide which fields exist and their types, pay close attention to index mapping. "
+            + "Never invent fields not in the mapping. "
+            + QUERY_TYPE_RULES
+            + AGGREGATION_RULES;
+
+    public static final String OUTPUT_FORMAT_INSTRUCTIONS = "Output format: Output only a valid escaped JSON string or the literal "
+        + DEFAULT_QUERY
+        + ". Do not print anything other than the JSON like code blocks etc. "
+        + "Follow the examples below. "
+        + "Fallback: If the request cannot be fulfilled with the mapping (missing field, unsupported feature, etc.), "
+        + "output the literal string: "
+        + DEFAULT_QUERY;
+
+    // Individual example constants for better maintainability
+    public static final String EXAMPLE_1 = "Example 1 — numeric range Input: Show all products that cost more than 50 dollars. "
+        + "Mapping: \"{ \"properties\": { \"price\": { \"type\": \"float\" } } }\" "
+        + "Output: \"{ \"query\": { \"range\": { \"price\": { \"gt\": 50 } } } }\" ";
+
+    public static final String EXAMPLE_2 = "Example 2 — text match + exact filter Input: Find employees in London who are active. "
+        + "Mapping: \"{ \"properties\": { \"city\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"status\": { \"type\": \"keyword\" } } }\" "
+        + "Output: \"{ \"query\": { \"bool\": { \"must\": [ { \"match\": { \"city\": \"London\" } } ], \"filter\": [ { \"term\": { \"status\": \"active\" } } ] } } }\" ";
+
+    public static final String EXAMPLE_3 =
+        "Example 3 — match_phrase (use when search string contains a space, hyphen, comma, etc. here \"new york city\" has space) Input: Find employees who are active and located in New York City "
+            + "Mapping: \"{ \"properties\": { \"city\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"status\": { \"type\": \"keyword\" } } }\" "
+            + "Output: \"{ \"query\": { \"bool\": { \"must\": [ { \"match_phrase\": { \"city\": \"New York City\" } } ], \"filter\": [ { \"term\": { \"status\": \"active\" } } ] } } }\" ";
+
+    public static final String EXAMPLE_4 =
+        "Example 4 — bool with SHOULD Input: Search articles about \"machine learning\" that are research papers or blogs. "
+            + "Mapping: \"{ \"properties\": { \"content\": { \"type\": \"text\" }, \"type\": { \"type\": \"keyword\" } } }\" "
+            + "Output: \"{ \"query\": { \"bool\": { \"must\": [ { \"match\": { \"content\": \"machine learning\" } } ], \"should\": [ { \"term\": { \"type\": \"research paper\" } }, { \"term\": { \"type\": \"blog\" } } ], \"minimum_should_match\": 1 } } }\" ";
+
+    public static final String EXAMPLE_5 = "Example 5 — MUST NOT Input: List customers who have not made a purchase in 2023. "
+        + "Mapping: \"{ \"properties\": { \"last_purchase_date\": { \"type\": \"date\" } } }\" "
+        + "Output: \"{ \"query\": { \"bool\": { \"must_not\": [ { \"range\": { \"last_purchase_date\": { \"gte\": \"2023-01-01\", \"lte\": \"2023-12-31\" } } } ] } } }\" ";
+
+    public static final String EXAMPLE_6 = "Example 6 — wildcard Input: Find files with names starting with \"report_\". "
+        + "Mapping: \"{ \"properties\": { \"filename\": { \"type\": \"keyword\" } } }\" "
+        + "Output: \"{ \"query\": { \"wildcard\": { \"filename\": \"report_*\" } } }\" ";
+
+    public static final String EXAMPLE_7 =
+        "Example 7 — nested query (note the index mapping says \"type\": \"nested\", do not use it for other types) Input: Find books where an authors first_name is John AND last_name is Doe. "
+            + "Mapping: \"{ \"properties\": { \"author\": { \"type\": \"nested\", \"properties\": { \"first_name\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"last_name\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } } } } } }\" "
+            + "Output: \"{ \"query\": { \"nested\": { \"path\": \"author\", \"query\": { \"bool\": { \"must\": [ { \"term\": { \"author.first_name.keyword\": \"John\" } }, { \"term\": { \"author.last_name.keyword\": \"Doe\" } } ] } } } } }\" ";
+
+    public static final String EXAMPLE_8 = "Example 8 — terms aggregation Input: Show the number of orders per status. "
+        + "Mapping: \"{ \"properties\": { \"status\": { \"type\": \"keyword\" } } }\" "
+        + "Output: \"{ \"size\": 0, \"aggs\": { \"orders_by_status\": { \"terms\": { \"field\": \"status\" } } } }\" ";
+
+    public static final String EXAMPLE_9 =
+        "Example 9 — metric aggregation with filter Input: What is the average price of electronics products? "
+            + "Mapping: \"{ \"properties\": { \"category\": { \"type\": \"keyword\" }, \"price\": { \"type\": \"float\" } } }\" "
+            + "Output: \"{ \"size\": 0, \"query\": { \"term\": { \"category\": \"electronics\" } }, \"aggs\": { \"avg_price\": { \"avg\": { \"field\": \"price\" } } } }\" ";
+
+    public static final String EXAMPLE_10 = "Example 10 — top N by metric Input: List the top 3 categories by total sales volume. "
+        + "Mapping: \"{ \"properties\": { \"category\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }, \"sales\": { \"type\": \"float\" } } }\" "
+        + "Output: \"{ \"size\": 0, \"aggs\": { \"top_categories\": { \"terms\": { \"field\": \"category.keyword\", \"size\": 3, \"order\": { \"total_sales\": \"desc\" } }, \"aggs\": { \"total_sales\": { \"sum\": { \"field\": \"sales\" } } } } } }\" ";
+
+    public static final String EXAMPLE_11 = "Example 11 — fallback Input: Find employees who speak Klingon fluently. "
+        + "Mapping: \"{ \"properties\": { \"name\": { \"type\": \"text\" }, \"role\": { \"type\": \"keyword\" } } }\" "
+        + "Output: "
+        + DEFAULT_QUERY;
+
+    public static final String EXAMPLES = "EXAMPLES: "
+        + EXAMPLE_1
+        + EXAMPLE_2
+        + EXAMPLE_3
+        + EXAMPLE_4
+        + EXAMPLE_5
+        + EXAMPLE_6
+        + EXAMPLE_7
+        + EXAMPLE_8
+        + EXAMPLE_9
+        + EXAMPLE_10
+        + EXAMPLE_11;
+
+    public static final String PROMPT_SUFFIX = "GIVE THE OUTPUT PART ONLY IN YOUR RESPONSE "
+        + "Question: asked by user "
+        + "Mapping:${parameters.index_mapping:-} "
+        + "Output:";
+
+    public static final String DEFAULT_SYSTEM_PROMPT = PROMPT_PREFIX + " " + OUTPUT_FORMAT_INSTRUCTIONS + EXAMPLES + " " + PROMPT_SUFFIX;
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.engine.tools;
 
+import static org.opensearch.ml.common.utils.StringUtils.gson;
 import static org.opensearch.ml.engine.tools.QueryPlanningPromptTemplate.DEFAULT_QUERY;
 import static org.opensearch.ml.engine.tools.QueryPlanningPromptTemplate.DEFAULT_SYSTEM_PROMPT;
 
@@ -64,6 +65,12 @@ public class QueryPlanningTool implements WithModelTool {
         }
         if (!parameters.containsKey(SYSTEM_PROMPT_FIELD)) {
             parameters.put(SYSTEM_PROMPT_FIELD, DEFAULT_SYSTEM_PROMPT);
+        }
+        if (parameters.containsKey("index_mapping")) {
+            parameters.put("index_mapping", gson.toJson(parameters.get("index_mapping")));
+        }
+        if (parameters.containsKey("query_fields")) {
+            parameters.put("query_fields", gson.toJson(parameters.get("query_fields")));
         }
         ActionListener<T> modelListener = ActionListener.wrap(r -> {
             try {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
@@ -35,6 +35,8 @@ public class QueryPlanningTool implements WithModelTool {
     public static final String MODEL_ID_FIELD = "model_id";
     private final MLModelTool queryGenerationTool;
     public static final String SYSTEM_PROMPT_FIELD = "system_prompt";
+    public static final String INDEX_MAPPING_FIELD = "index_mapping";
+    public static final String QUERY_FIELDS_FIELD = "query_fields";
     private static final String GENERATION_TYPE_FIELD = "generation_type";
     private static final String LLM_GENERATED_TYPE_FIELD = "llmGenerated";
     @Getter
@@ -66,11 +68,11 @@ public class QueryPlanningTool implements WithModelTool {
         if (!parameters.containsKey(SYSTEM_PROMPT_FIELD)) {
             parameters.put(SYSTEM_PROMPT_FIELD, DEFAULT_SYSTEM_PROMPT);
         }
-        if (parameters.containsKey("index_mapping")) {
-            parameters.put("index_mapping", gson.toJson(parameters.get("index_mapping")));
+        if (parameters.containsKey(INDEX_MAPPING_FIELD)) {
+            parameters.put(INDEX_MAPPING_FIELD, gson.toJson(parameters.get(INDEX_MAPPING_FIELD)));
         }
-        if (parameters.containsKey("query_fields")) {
-            parameters.put("query_fields", gson.toJson(parameters.get("query_fields")));
+        if (parameters.containsKey(QUERY_FIELDS_FIELD)) {
+            parameters.put(QUERY_FIELDS_FIELD, gson.toJson(parameters.get(QUERY_FIELDS_FIELD)));
         }
         ActionListener<T> modelListener = ActionListener.wrap(r -> {
             try {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
@@ -5,6 +5,9 @@
 
 package org.opensearch.ml.engine.tools;
 
+import static org.opensearch.ml.engine.tools.QueryPlanningPromptTemplate.DEFAULT_QUERY;
+import static org.opensearch.ml.engine.tools.QueryPlanningPromptTemplate.DEFAULT_SYSTEM_PROMPT;
+
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +33,7 @@ public class QueryPlanningTool implements WithModelTool {
     public static final String TYPE = "QueryPlanningTool";
     public static final String MODEL_ID_FIELD = "model_id";
     private final MLModelTool queryGenerationTool;
-    public static final String PROMPT_FIELD = "prompt";
+    public static final String SYSTEM_PROMPT_FIELD = "system_prompt";
     private static final String GENERATION_TYPE_FIELD = "generation_type";
     private static final String LLM_GENERATED_TYPE_FIELD = "llmGenerated";
     @Getter
@@ -46,10 +49,6 @@ public class QueryPlanningTool implements WithModelTool {
     @Getter
     @Setter
     private String description = DEFAULT_DESCRIPTION;
-    private String defaultQuery =
-        "{ \"query\": { \"multi_match\" : { \"query\":    \"${parameters.query_text}\",  \"fields\": ${parameters.query_fields:-[\"*\"]} } } }";
-    private String defaultPrompt =
-        "You are an OpenSearch Query DSL generation assistant; try using the optional provided index mapping ${parameters.index_mapping:-}, specified fields ${parameters.query_fields:-}, and the given sample queries as examples, generate an OpenSearch Query DSL to retrieve the most relevant documents for the user provided natural language question: ${parameters.query_text}, please return the query dsl only in a string format, no other texts.\n";
 
     public QueryPlanningTool(String generationType, MLModelTool queryGenerationTool) {
         this.generationType = generationType;
@@ -63,15 +62,15 @@ public class QueryPlanningTool implements WithModelTool {
             listener.onFailure(new IllegalArgumentException("Empty parameters for QueryPlanningTool: " + parameters));
             return;
         }
-        if (!parameters.containsKey(PROMPT_FIELD)) {
-            parameters.put(PROMPT_FIELD, defaultPrompt);
+        if (!parameters.containsKey(SYSTEM_PROMPT_FIELD)) {
+            parameters.put(SYSTEM_PROMPT_FIELD, DEFAULT_SYSTEM_PROMPT);
         }
         ActionListener<T> modelListener = ActionListener.wrap(r -> {
             try {
                 String queryString = (String) r;
                 if (queryString == null || queryString.isBlank() || queryString.equals("null")) {
                     StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
-                    String defaultQueryString = substitutor.replace(this.defaultQuery);
+                    String defaultQueryString = substitutor.replace(DEFAULT_QUERY);
                     listener.onResponse((T) defaultQueryString);
                 } else {
                     listener.onResponse((T) queryString);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
@@ -87,7 +87,10 @@ public class QueryPlanningToolTests {
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         // test try to update the prompt
         validParams
-            .put(SYSTEM_PROMPT_FIELD, "You are a query generation agent. Generate a dsl query for the following question: ${parameters.query_text}");
+            .put(
+                SYSTEM_PROMPT_FIELD,
+                "You are a query generation agent. Generate a dsl query for the following question: ${parameters.query_text}"
+            );
         validParams.put("query_text", "help me find some books related to wind");
         tool.run(validParams, listener);
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
@@ -16,7 +16,9 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.opensearch.ml.engine.tools.QueryPlanningTool.DEFAULT_DESCRIPTION;
+import static org.opensearch.ml.engine.tools.QueryPlanningTool.INDEX_MAPPING_FIELD;
 import static org.opensearch.ml.engine.tools.QueryPlanningTool.MODEL_ID_FIELD;
+import static org.opensearch.ml.engine.tools.QueryPlanningTool.QUERY_FIELDS_FIELD;
 import static org.opensearch.ml.engine.tools.QueryPlanningTool.SYSTEM_PROMPT_FIELD;
 
 import java.util.Collections;
@@ -59,7 +61,7 @@ public class QueryPlanningToolTests {
         MLModelTool.Factory.getInstance().init(client);
         factory = new QueryPlanningTool.Factory();
         validParams = new HashMap<>();
-        validParams.put("prompt", "test prompt");
+        validParams.put(SYSTEM_PROMPT_FIELD, "test prompt");
         emptyParams = Collections.emptyMap();
     }
 
@@ -85,7 +87,7 @@ public class QueryPlanningToolTests {
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         // test try to update the prompt
         validParams
-            .put("prompt", "You are a query generation agent. Generate a dsl query for the following question: ${parameters.query_text}");
+            .put(SYSTEM_PROMPT_FIELD, "You are a query generation agent. Generate a dsl query for the following question: ${parameters.query_text}");
         validParams.put("query_text", "help me find some books related to wind");
         tool.run(validParams, listener);
 
@@ -203,7 +205,7 @@ public class QueryPlanningToolTests {
         ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
         doAnswer(invocation -> {
             Map<String, String> params = invocation.getArgument(0);
-            assertNotNull(params.get("prompt"));
+            assertNotNull(params.get(SYSTEM_PROMPT_FIELD));
             return null;
         }).when(queryGenerationTool).run(captor.capture(), any());
     }
@@ -274,8 +276,8 @@ public class QueryPlanningToolTests {
         QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("query_text", "test query");
-        parameters.put("index_mapping", "{\"properties\":{\"title\":{\"type\":\"text\"}}}");
-        parameters.put("query_fields", "[\"title\", \"content\"]");
+        parameters.put(INDEX_MAPPING_FIELD, "{\"properties\":{\"title\":{\"type\":\"text\"}}}");
+        parameters.put(QUERY_FIELDS_FIELD, "[\"title\", \"content\"]");
         // No system_prompt - should use default
 
         @SuppressWarnings("unchecked")
@@ -296,12 +298,12 @@ public class QueryPlanningToolTests {
 
         // All parameters should be processed
         assertTrue(capturedParams.containsKey("query_text"));
-        assertTrue(capturedParams.containsKey("index_mapping"));
-        assertTrue(capturedParams.containsKey("query_fields"));
+        assertTrue(capturedParams.containsKey(INDEX_MAPPING_FIELD));
+        assertTrue(capturedParams.containsKey(QUERY_FIELDS_FIELD));
         assertTrue(capturedParams.containsKey(SYSTEM_PROMPT_FIELD));
 
         // Processed parameters should be JSON strings
-        assertTrue(capturedParams.get("index_mapping").startsWith("\""));
-        assertTrue(capturedParams.get("query_fields").startsWith("\""));
+        assertTrue(capturedParams.get(INDEX_MAPPING_FIELD).startsWith("\""));
+        assertTrue(capturedParams.get(QUERY_FIELDS_FIELD).startsWith("\""));
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
@@ -269,8 +269,6 @@ public class QueryPlanningToolTests {
         assertEquals("Invalid generation type: invalid. The current supported types are llmGenerated.", exception.getMessage());
     }
 
-
-
     @Test
     public void testAllParameterProcessing() {
         QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool);
@@ -279,29 +277,29 @@ public class QueryPlanningToolTests {
         parameters.put("index_mapping", "{\"properties\":{\"title\":{\"type\":\"text\"}}}");
         parameters.put("query_fields", "[\"title\", \"content\"]");
         // No system_prompt - should use default
-        
+
         @SuppressWarnings("unchecked")
         ActionListener<String> listener = mock(ActionListener.class);
-        
+
         doAnswer(invocation -> {
             ActionListener<String> modelListener = invocation.getArgument(1);
             modelListener.onResponse("{\"query\":{\"match\":{\"title\":\"test\"}}}");
             return null;
         }).when(queryGenerationTool).run(any(), any());
-        
+
         tool.run(parameters, listener);
-        
+
         ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
         verify(queryGenerationTool).run(captor.capture(), any());
-        
+
         Map<String, String> capturedParams = captor.getValue();
-        
+
         // All parameters should be processed
         assertTrue(capturedParams.containsKey("query_text"));
         assertTrue(capturedParams.containsKey("index_mapping"));
         assertTrue(capturedParams.containsKey("query_fields"));
         assertTrue(capturedParams.containsKey(SYSTEM_PROMPT_FIELD));
-        
+
         // Processed parameters should be JSON strings
         assertTrue(capturedParams.get("index_mapping").startsWith("\""));
         assertTrue(capturedParams.get("query_fields").startsWith("\""));

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
@@ -40,8 +40,7 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
         + GITHUB_CI_AWS_REGION
         + "\",\n"
         + "      \"service_name\": \"bedrock\",\n"
-        + "      \"model\": \"us.anthropic.claude-3-7-sonnet-20250219-v1:0\",\n"
-        + "      \"system_prompt\":\"please help answer the user question. \"\n"
+        + "      \"model\": \"us.anthropic.claude-3-7-sonnet-20250219-v1:0\"\n"
         + "    },\n"
         + "    \"credential\": {\n"
         + "      \"access_key\":\" "
@@ -62,7 +61,7 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
         + "        \"headers\": {\n"
         + "          \"content-type\": \"application/json\"\n"
         + "        },\n"
-        + "        \"request_body\": \"{ \\\"system\\\": [{\\\"text\\\": \\\"${parameters.system_prompt}\\\"}], \\\"messages\\\": [{\\\"role\\\":\\\"user\\\",\\\"content\\\":[{\\\"text\\\":\\\"${parameters.prompt}\\\"}]}]}\"\n"
+        + "        \"request_body\": \"{ \\\"system\\\": [{\\\"text\\\": \\\"${parameters.system_prompt}\\\"}], \\\"messages\\\": [{\\\"role\\\":\\\"user\\\",\\\"content\\\":[{\\\"text\\\":\\\"${parameters.query_text}\\\"}]}]}\"\n"
         + "      }\n"
         + "    ]\n"
         + "}";


### PR DESCRIPTION
### Description
This change adds a default system prompt to the query planner tool

Create Model:
```
{
    "name": "My OpenAI model: gpt-4o",
    "function_name": "remote",
    "description": "test model",
    "connector": {
        "name": "My openai connector: gpt-4",
        "description": "The connector to openai chat model",
        "version": 1,
        "protocol": "http",
        "parameters": {
            "model": "gpt-4o"
        },
        "credential": {
            "openAI_key": <YOUR API KEY>
        },
        "actions": [
            {
                "action_type": "predict",
                "method": "POST",
                "url": "https://api.openai.com/v1/chat/completions",
                "headers": {
                    "Authorization": "Bearer ${credential.openAI_key}"
                },
                "request_body": "{ \"model\": \"${parameters.model}\", \"messages\": [{\"role\":\"system\",\"content\":\"${parameters.system_prompt}\"},{\"role\":\"user\",\"content\":\"${parameters.query_text}\"}] }"

            }
        ]
    }
}
```

2. Create a Flow Agent with query planner tool:
```
{
    "name": "Test agent for embedding model",
    "type": "flow",
    "description": "this is a test agent",
    "tools": [
        {
            "type": "QueryPlanningTool",
            "description": "A general query generation tool to answer any question",
            "parameters": {
                "type": "llmGenerated",
                "model_id": "0NGhbpgBL0QLh2nyEyTN"
            }
        }
    ]
}
```

3. Execute the model 

```
{
    "parameters": {
        "query_text": "Show all products that cost more than 50 dollars.",
        "index_mapping": {
            "properties": {
                "price": {
                    "type": "float"
                },
                "name":{
                    "type": "text"
                }
            }
        },
        "response_filter": "$.choices[0].message.content",
        "query_fields": ["price"]

    }
}
```

Response:
```
{
    "inference_results": [
        {
            "output": [
                {
                    "name": "response",
                    "result": "{\"query\":{\"range\":{\"price\":{\"gt\":50.0}}}}"
                }
            ]
        }
    ]
}
```

The Default System Prompt:
```
You are an OpenSearch DSL expert. Your job is to convert natural‑language questions into strict JSON OpenSearch search query bodies. 
Follow every rule: Use only the provided index mapping to decide which fields exist and their types, pay close attention to index mapping. 
Do not use fields that not present in mapping. 

Choose query types based on user intent and fields: 
match: single-token full‑text searches on analyzed text fields, 
match_phrase: multi-token phrases on analyzed text fields (search string contains a space, hyphen, comma, etc.), 
term / terms:exact match on keyword, numeric, boolean, 
range:numeric/date comparisons (gt, lt, gte, lte), 
bool with must, should, must_not, filter: AND/OR/NOT logic, 
wildcard / prefix on keyword:"starts with", "contains", 
exists:field presence/absence, 
nested query / nested agg:Never wrap a field in nested unless the mapping for that exact path (or one of its parents) explicitly says "type": "nested". 
Otherwise use a normal query on the flattened field. 
Aggregations (when asked for counts, averages, "top N", distributions): 
terms on field.keyword or numeric for grouping / top N, 
Metric aggs (avg, min, max, sum, stats, cardinality) on numeric fields, 
date_histogram, histogram, range for distributions, 
Always set "size": 0 when only aggregations are needed, 
Use sub‑aggregations + order for "top N by metric", 
If grouping by a text field, use its .keyword sub‑field.
 
 Output format: Output only a valid escaped JSON string or the literal 
{"size":10,"query":{"match_all":{}}} 
Return exactly one JSON object. Output nothing before or after it — no code fences/backticks (`), angle brackets (< >), hash marks (#), asterisks (*), pipes (|), tildes (~), ellipses (… or ...), emojis, typographic quotes (" "), non-breaking spaces (U+00A0), zero-width characters (U+200B, U+FEFF), or any other markup/control characters. Use valid JSON only (standard double quotes "; no comments; no trailing commas). This applies to formatting only, string values inside the JSON may contain any needed Unicode characters. 
Follow the examples below. 
When Query Fields are provided, prioritize incorporating them into the generated query.Fallback: If the request cannot be fulfilled with the mapping (missing field, unsupported feature, etc.), 
output the literal string: {"size":10,"query":{"match_all":{}}} 
 
EXAMPLES: Example 1 — numeric range 
Input: Show all products that cost more than 50 dollars. 
Mapping: { "properties": { "price": { "type": "float" }, "cost": { "type": "float" } } }
query_fields: [price]Output: "{ "query": { "range": { "price": { "gt": 50 } } } }" 
Example 2 — text match + exact filter 
Input: Find employees in London who are active. 
Mapping: "{ "properties": { "city": { "type": "text", "fields": { "keyword": { "type": "keyword" } } }, "status": { "type": "keyword" } } }" 
query_fields: [city, status]Output: "{ "query": { "bool": { "must": [ { "match": { "city": "London" } } ], "filter": [ { "term": { "status": "active" } } ] } } }" 
Example 3 — match_phrase (use when search string contains a space, hyphen, comma, etc. here "new york city" has space) 
Input: Find employees who are active and located in New York City 
Mapping: "{ "properties": { "city": { "type": "text", "fields": { "keyword": { "type": "keyword" } } }, "status": { "type": "keyword" } } }" 
Output: "{ "query": { "bool": { "must": [ { "match_phrase": { "city": "New York City" } } ], "filter": [ { "term": { "status": "active" } } ] } } }" 
Example 4 — bool with SHOULD 
Input: Search articles about "machine learning" that are research papers or blogs. 
Mapping: "{ "properties": { "content": { "type": "text" }, "type": { "type": "keyword" } } }" 
Output: "{ "query": { "bool": { "must": [ { "match": { "content": "machine learning" } } ], "should": [ { "term": { "type": "research paper" } }, { "term": { "type": "blog" } } ], "minimum_should_match": 1 } } }" 
Example 5 — MUST NOT 
Input: List customers who have not made a purchase in 2023. 
Mapping: "{ "properties": { "last_purchase_date": { "type": "date" } } }" 
Output: "{ "query": { "bool": { "must_not": [ { "range": { "last_purchase_date": { "gte": "2023-01-01", "lte": "2023-12-31" } } } ] } } }" 
Example 6 — wildcard 
Input: Find files with names starting with "report_". 
Mapping: "{ "properties": { "filename": { "type": "keyword" } } }" 
Output: "{ "query": { "wildcard": { "filename": "report_*" } } }" 
Example 7 — nested query (note the index mapping says "type": "nested", do not use it for other types) 
Input: Find books where an authors first_name is John AND last_name is Doe. 
Mapping: "{ "properties": { "author": { "type": "nested", "properties": { "first_name": { "type": "text", "fields": { "keyword": { "type": "keyword" } } }, "last_name": { "type": "text", "fields": { "keyword": { "type": "keyword" } } } } } } }" 
Output: "{ "query": { "nested": { "path": "author", "query": { "bool": { "must": [ { "term": { "author.first_name.keyword": "John" } }, { "term": { "author.last_name.keyword": "Doe" } } ] } } } } }" 
Example 8 — terms aggregation 
Input: Show the number of orders per status. 
Mapping: "{ "properties": { "status": { "type": "keyword" } } }" 
Output: "{ "size": 0, "aggs": { "orders_by_status": { "terms": { "field": "status" } } } }" 
Example 9 — metric aggregation with filter 
Input: What is the average price of electronics products? 
Mapping: "{ "properties": { "category": { "type": "keyword" }, "price": { "type": "float" } } }" 
Output: "{ "size": 0, "query": { "term": { "category": "electronics" } }, "aggs": { "avg_price": { "avg": { "field": "price" } } } }" 
Example 10 — top N by metric 
Input: List the top 3 categories by total sales volume. 
Mapping: "{ "properties": { "category": { "type": "text", "fields": { "keyword": { "type": "keyword" } } }, "sales": { "type": "float" } } }" 
Output: "{ "size": 0, "aggs": { "top_categories": { "terms": { "field": "category.keyword", "size": 3, "order": { "total_sales": "desc" } }, "aggs": { "total_sales": { "sum": { "field": "sales" } } } } } }" 
Example 11 — fallback 
Input: Find employees who speak Klingon fluently. 
Mapping: "{ "properties": { "name": { "type": "text" }, "role": { "type": "keyword" } } }" 
Output: {"size":10,"query":{"match_all":{}}}
 
 GIVE THE OUTPUT PART ONLY IN YOUR RESPONSE 
Question: asked by user 
Mapping :${parameters.index_mapping:-} 
Query Fields: ${parameters.query_fields:-} Output:

```
### Related Issues
Resolves  https://github.com/opensearch-project/ml-commons/issues/4005

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
