### PR TITLE
GET memory API

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -72,6 +72,7 @@ public class MemoryContainerConstants {
     public static final String SEARCH_MEMORIES_PATH = MEMORIES_PATH + "/_search";
     public static final String DELETE_MEMORY_PATH = MEMORIES_PATH + "/{" + PARAMETER_MEMORY_ID + "}";
     public static final String UPDATE_MEMORY_PATH = MEMORIES_PATH + "/{" + PARAMETER_MEMORY_ID + "}";
+    public static final String GET_MEMORY_PATH = MEMORIES_PATH + "/{" + PARAMETER_MEMORY_ID + "}";
 
     // Memory types are defined in MemoryType enum
 

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
@@ -105,7 +105,7 @@ public class MLFeatureEnabledSetting {
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_EXECUTE_TOOL_ENABLED, it -> isExecuteToolEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_AGENTIC_SEARCH_ENABLED, it -> isAgenticSearchEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_MCP_CONNECTOR_ENABLED, it -> isMcpConnectorEnabled = it);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_AGENTIC_MEMORY_ENABLED, it -> isMcpConnectorEnabled = it);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_AGENTIC_MEMORY_ENABLED, it -> isAgenticMemoryEnabled = it);
     }
 
     /**

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryAction.java
@@ -9,7 +9,7 @@ import org.opensearch.action.ActionType;
 
 public class MLGetMemoryAction extends ActionType<MLGetMemoryResponse> {
     public static final MLGetMemoryAction INSTANCE = new MLGetMemoryAction();
-    public static final String NAME = "\"cluster:admin/opensearch/ml/memory_containers/memory/get";
+    public static final String NAME = "cluster:admin/opensearch/ml/memory_containers/memory/get";
 
     private MLGetMemoryAction() {
         super(NAME, MLGetMemoryResponse::new);

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryAction.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer.memory;
+
+import org.opensearch.action.ActionType;
+
+public class MLGetMemoryAction extends ActionType<MLGetMemoryResponse> {
+    public static final MLGetMemoryAction INSTANCE = new MLGetMemoryAction();
+    public static final String NAME = "\"cluster:admin/opensearch/ml/memory_containers/memory/get";
+
+    private MLGetMemoryAction() {
+        super(NAME, MLGetMemoryResponse::new);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryRequest.java
@@ -57,7 +57,7 @@ public class MLGetMemoryRequest extends ActionRequest {
         ActionRequestValidationException exception = null;
 
         if (this.memoryContainerId == null || this.memoryId == null) {
-            exception = addValidationError("memoryContainerId  and memoryId id can not be null", exception);
+            exception = addValidationError("memoryContainerId and memoryId id can not be null", exception);
         }
 
         return exception;

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryRequest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer.memory;
+
+import static org.opensearch.action.ValidateActions.addValidationError;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@ToString
+public class MLGetMemoryRequest extends ActionRequest {
+
+    String memoryContainerId;
+    String memoryId;
+
+    @Builder
+    public MLGetMemoryRequest(String memoryContainerId, String memoryId) {
+        this.memoryContainerId = memoryContainerId;
+        this.memoryId = memoryId;
+    }
+
+    public MLGetMemoryRequest(StreamInput in) throws IOException {
+        super(in);
+        this.memoryContainerId = in.readString();
+        this.memoryId = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(this.memoryContainerId);
+        out.writeString(this.memoryId);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException exception = null;
+
+        if (this.memoryContainerId == null || this.memoryId == null) {
+            exception = addValidationError("memoryContainerId  and memoryId id can not be null", exception);
+        }
+
+        return exception;
+    }
+
+    public static MLGetMemoryRequest fromActionRequest(ActionRequest actionRequest) {
+        if (actionRequest instanceof MLGetMemoryRequest) {
+            return (MLGetMemoryRequest) actionRequest;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionRequest.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLGetMemoryRequest(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionRequest into MLMemoryGetRequest", e);
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer.memory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.memorycontainer.MLMemory;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class MLGetMemoryResponse extends ActionResponse implements ToXContentObject {
+    MLMemory mlMemory;
+
+    @Builder
+    public MLGetMemoryResponse(MLMemory mlMemory) {
+        this.mlMemory = mlMemory;
+    }
+
+    public MLGetMemoryResponse(StreamInput in) throws IOException {
+        super(in);
+        mlMemory = new MLMemory(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        mlMemory.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
+        return mlMemory.toXContent(xContentBuilder, params);
+    }
+
+    public static MLGetMemoryResponse fromActionResponse(ActionResponse actionResponse) {
+        if (actionResponse instanceof MLGetMemoryResponse) {
+            return (MLGetMemoryResponse) actionResponse;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionResponse.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLGetMemoryResponse(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionResponse into MLMemoryGetResponse", e);
+        }
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryRequestTest.java
@@ -62,7 +62,7 @@ public class MLGetMemoryRequestTest {
         ActionRequestValidationException exception = requestWithNulls.validate();
         assertNotNull(exception);
         assertEquals(1, exception.validationErrors().size());
-        assertTrue(exception.validationErrors().get(0).contains("memoryContainerId  and memoryId id can not be null"));
+        assertTrue(exception.validationErrors().get(0).contains("memoryContainerId and memoryId id can not be null"));
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryRequestTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer.memory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+public class MLGetMemoryRequestTest {
+
+    private MLGetMemoryRequest requestNormal;
+    private MLGetMemoryRequest requestWithNulls;
+
+    @Before
+    public void setUp() {
+        requestNormal = MLGetMemoryRequest.builder().memoryContainerId("container-123").memoryId("memory-456").build();
+
+        requestWithNulls = MLGetMemoryRequest.builder().memoryContainerId(null).memoryId(null).build();
+    }
+
+    @Test
+    public void testBuilderNormal() {
+        assertNotNull(requestNormal);
+        assertEquals("container-123", requestNormal.getMemoryContainerId());
+        assertEquals("memory-456", requestNormal.getMemoryId());
+    }
+
+    @Test
+    public void testStreamInputOutput() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        requestNormal.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        MLGetMemoryRequest deserialized = new MLGetMemoryRequest(in);
+
+        assertEquals(requestNormal.getMemoryContainerId(), deserialized.getMemoryContainerId());
+        assertEquals(requestNormal.getMemoryId(), deserialized.getMemoryId());
+    }
+
+    @Test
+    public void testValidateSuccess() {
+        ActionRequestValidationException exception = requestNormal.validate();
+        assertNull(exception);
+    }
+
+    @Test
+    public void testValidateWithNullValues() {
+        ActionRequestValidationException exception = requestWithNulls.validate();
+        assertNotNull(exception);
+        assertEquals(1, exception.validationErrors().size());
+        assertTrue(exception.validationErrors().get(0).contains("memoryContainerId  and memoryId id can not be null"));
+    }
+
+    @Test
+    public void testFromActionRequestSameInstance() {
+        MLGetMemoryRequest result = MLGetMemoryRequest.fromActionRequest(requestNormal);
+        assertEquals(requestNormal, result);
+    }
+
+    @Test
+    public void testFromActionRequestDifferentInstance() throws IOException {
+        // Create a mock ActionRequest that's not MLGetMemoryRequest
+        ActionRequest mockRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                super.writeTo(out);
+                out.writeString("test-container");
+                out.writeString("test-memory");
+            }
+        };
+
+        MLGetMemoryRequest result = MLGetMemoryRequest.fromActionRequest(mockRequest);
+        assertNotNull(result);
+        assertEquals("test-container", result.getMemoryContainerId());
+        assertEquals("test-memory", result.getMemoryId());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void testFromActionRequestIOException() {
+        // Create a mock ActionRequest that throws IOException
+        ActionRequest mockRequest = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException("Test exception");
+            }
+        };
+
+        MLGetMemoryRequest.fromActionRequest(mockRequest);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLGetMemoryResponseTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer.memory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Instant;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.memorycontainer.MLMemory;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+
+public class MLGetMemoryResponseTest {
+
+    private MLGetMemoryResponse responseNormal;
+    private MLMemory testMemory;
+
+    @Before
+    public void setUp() {
+        testMemory = MLMemory
+            .builder()
+            .sessionId("test-session")
+            .memory("Test memory content")
+            .memoryType(MemoryType.RAW_MESSAGE)
+            .userId("test-user")
+            .createdTime(Instant.now())
+            .lastUpdatedTime(Instant.now())
+            .build();
+
+        responseNormal = MLGetMemoryResponse.builder().mlMemory(testMemory).build();
+    }
+
+    @Test
+    public void testBuilderNormal() {
+        assertNotNull(responseNormal);
+        assertNotNull(responseNormal.getMlMemory());
+        assertEquals("test-session", responseNormal.getMlMemory().getSessionId());
+        assertEquals("Test memory content", responseNormal.getMlMemory().getMemory());
+        assertEquals(MemoryType.RAW_MESSAGE, responseNormal.getMlMemory().getMemoryType());
+        assertEquals("test-user", responseNormal.getMlMemory().getUserId());
+    }
+
+    @Test
+    public void testStreamInputOutput() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        responseNormal.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        MLGetMemoryResponse deserialized = new MLGetMemoryResponse(in);
+
+        assertNotNull(deserialized.getMlMemory());
+        assertEquals(responseNormal.getMlMemory().getSessionId(), deserialized.getMlMemory().getSessionId());
+        assertEquals(responseNormal.getMlMemory().getMemory(), deserialized.getMlMemory().getMemory());
+        assertEquals(responseNormal.getMlMemory().getMemoryType(), deserialized.getMlMemory().getMemoryType());
+        assertEquals(responseNormal.getMlMemory().getUserId(), deserialized.getMlMemory().getUserId());
+    }
+
+    @Test
+    public void testFromActionResponseSameInstance() {
+        MLGetMemoryResponse result = MLGetMemoryResponse.fromActionResponse(responseNormal);
+        assertEquals(responseNormal, result);
+    }
+
+    @Test
+    public void testFromActionResponseDifferentInstance() throws IOException {
+        // Create a mock ActionResponse that's not MLGetMemoryResponse
+        ActionResponse mockResponse = new ActionResponse() {
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                testMemory.writeTo(out);
+            }
+        };
+
+        MLGetMemoryResponse result = MLGetMemoryResponse.fromActionResponse(mockResponse);
+        assertNotNull(result);
+        assertNotNull(result.getMlMemory());
+        assertEquals("test-session", result.getMlMemory().getSessionId());
+        assertEquals("Test memory content", result.getMlMemory().getMemory());
+        assertEquals(MemoryType.RAW_MESSAGE, result.getMlMemory().getMemoryType());
+        assertEquals("test-user", result.getMlMemory().getUserId());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void testFromActionResponseIOException() {
+        // Create a mock ActionResponse that throws IOException
+        ActionResponse mockResponse = new ActionResponse() {
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException("Test exception");
+            }
+        };
+
+        MLGetMemoryResponse.fromActionResponse(mockResponse);
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        responseNormal.toXContent(builder, null);
+        String jsonString = builder.toString();
+
+        assertNotNull(jsonString);
+        assertTrue(jsonString.contains("test-session"));
+        assertTrue(jsonString.contains("Test memory content"));
+        assertTrue(jsonString.contains("RAW_MESSAGE"));
+        assertTrue(jsonString.contains("test-user"));
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportGetMemoryAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportGetMemoryAction.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.memorycontainer.memory;
+
+import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.memorycontainer.MLMemory;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryAction;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryRequest;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryResponse;
+import org.opensearch.ml.helper.MemoryContainerHelper;
+import org.opensearch.ml.utils.RestActionUtils;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class TransportGetMemoryAction extends HandledTransportAction<ActionRequest, MLGetMemoryResponse> {
+
+    final Client client;
+    final NamedXContentRegistry xContentRegistry;
+    final MemoryContainerHelper memoryContainerHelper;
+
+    @Inject
+    public TransportGetMemoryAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        MemoryContainerHelper memoryContainerHelper
+    ) {
+        super(MLGetMemoryAction.NAME, transportService, actionFilters, MLGetMemoryRequest::new);
+        this.client = client;
+        this.xContentRegistry = xContentRegistry;
+        this.memoryContainerHelper = memoryContainerHelper;
+    }
+
+    @Override
+    protected void doExecute(Task task, ActionRequest request, ActionListener<MLGetMemoryResponse> actionListener) {
+        MLGetMemoryRequest getRequest = MLGetMemoryRequest.fromActionRequest(request);
+        String memoryContainerId = getRequest.getMemoryContainerId();
+        String memoryId = getRequest.getMemoryId();
+
+        // Get memory container to validate access and get memory index name
+        memoryContainerHelper.getMemoryContainer(memoryContainerId, ActionListener.wrap(container -> {
+            // Validate access permissions
+            User user = RestActionUtils.getUserContext(client);
+            if (!memoryContainerHelper.checkMemoryContainerAccess(user, container)) {
+                actionListener
+                    .onFailure(
+                        new OpenSearchStatusException(
+                            "User doesn't have permissions to get memories in this container",
+                            RestStatus.FORBIDDEN
+                        )
+                    );
+                return;
+            }
+
+            // Validate and get memory index name
+            if (!memoryContainerHelper.validateMemoryIndexExists(container, "GET", actionListener)) {
+                return;
+            }
+            String memoryIndexName = memoryContainerHelper.getMemoryIndexName(container);
+
+            // Get the memory document
+            GetRequest getMemoryRequest = new GetRequest(memoryIndexName, memoryId);
+
+            try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+                client
+                    .get(
+                        getMemoryRequest,
+                        ActionListener
+                            .wrap(getResponse -> processResponse(getResponse, memoryId, memoryContainerId, actionListener), exception -> {
+                                log.error("Failed to get memory {} from container {}", memoryId, memoryContainerId, exception);
+                                actionListener.onFailure(exception);
+                            })
+                    );
+            } catch (Exception e) {
+                log.error("Failed to get memory {} from container {}", memoryId, memoryContainerId, e);
+                actionListener.onFailure(e);
+            }
+
+        }, actionListener::onFailure));
+    }
+
+    private void processResponse(
+        GetResponse getResponse,
+        String memoryId,
+        String memoryContainerId,
+        ActionListener<MLGetMemoryResponse> actionListener
+    ) {
+        try {
+            if (getResponse.isExists()) {
+                try (
+                    XContentParser parser = jsonXContent
+                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString())
+                ) {
+                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                    MLMemory mlMemory = MLMemory.parse(parser);
+                    MLGetMemoryResponse response = MLGetMemoryResponse.builder().mlMemory(mlMemory).build();
+                    actionListener.onResponse(response);
+                } catch (Exception e) {
+                    log.error("Failed to parse memory response for id: {}", memoryId, e);
+                    actionListener.onFailure(e);
+                }
+            } else {
+                actionListener.onFailure(new OpenSearchStatusException("Memory not found with id: " + memoryId, RestStatus.NOT_FOUND));
+            }
+        } catch (Exception e) {
+            log.error("Failed to process memory response for id: {} from container {}", memoryId, memoryContainerId, e);
+            actionListener.onFailure(e);
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -108,6 +108,7 @@ import org.opensearch.ml.action.memorycontainer.TransportDeleteMemoryContainerAc
 import org.opensearch.ml.action.memorycontainer.TransportGetMemoryContainerAction;
 import org.opensearch.ml.action.memorycontainer.memory.TransportAddMemoriesAction;
 import org.opensearch.ml.action.memorycontainer.memory.TransportDeleteMemoryAction;
+import org.opensearch.ml.action.memorycontainer.memory.TransportGetMemoryAction;
 import org.opensearch.ml.action.memorycontainer.memory.TransportSearchMemoriesAction;
 import org.opensearch.ml.action.memorycontainer.memory.TransportUpdateMemoryAction;
 import org.opensearch.ml.action.model_group.DeleteModelGroupTransportAction;
@@ -201,6 +202,7 @@ import org.opensearch.ml.common.transport.memorycontainer.MLMemoryContainerDelet
 import org.opensearch.ml.common.transport.memorycontainer.MLMemoryContainerGetAction;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLAddMemoriesAction;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLDeleteMemoryAction;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryAction;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLSearchMemoriesAction;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryAction;
 import org.opensearch.ml.common.transport.model.MLModelDeleteAction;
@@ -313,6 +315,7 @@ import org.opensearch.ml.rest.RestMLGetAgentAction;
 import org.opensearch.ml.rest.RestMLGetConfigAction;
 import org.opensearch.ml.rest.RestMLGetConnectorAction;
 import org.opensearch.ml.rest.RestMLGetControllerAction;
+import org.opensearch.ml.rest.RestMLGetMemoryAction;
 import org.opensearch.ml.rest.RestMLGetMemoryContainerAction;
 import org.opensearch.ml.rest.RestMLGetModelAction;
 import org.opensearch.ml.rest.RestMLGetModelGroupAction;
@@ -534,6 +537,7 @@ public class MachineLearningPlugin extends Plugin
                 new ActionHandler<>(MLSearchMemoriesAction.INSTANCE, TransportSearchMemoriesAction.class),
                 new ActionHandler<>(MLDeleteMemoryAction.INSTANCE, TransportDeleteMemoryAction.class),
                 new ActionHandler<>(MLUpdateMemoryAction.INSTANCE, TransportUpdateMemoryAction.class),
+                new ActionHandler<>(MLGetMemoryAction.INSTANCE, TransportGetMemoryAction.class),
                 new ActionHandler<>(MLRegisterAgentAction.INSTANCE, TransportRegisterAgentAction.class),
                 new ActionHandler<>(MLSearchAgentAction.INSTANCE, TransportSearchAgentAction.class),
                 new ActionHandler<>(SearchInteractionsAction.INSTANCE, SearchInteractionsTransportAction.class),
@@ -940,6 +944,7 @@ public class MachineLearningPlugin extends Plugin
         RestMemorySearchConversationsAction restSearchConversationsAction = new RestMemorySearchConversationsAction(
             mlFeatureEnabledSetting
         );
+        RestMLGetMemoryAction restMLGetMemoryAction = new RestMLGetMemoryAction();
         RestMemorySearchInteractionsAction restSearchInteractionsAction = new RestMemorySearchInteractionsAction();
         RestMemoryGetConversationAction restGetConversationAction = new RestMemoryGetConversationAction();
         RestMemoryGetInteractionAction restGetInteractionAction = new RestMemoryGetInteractionAction();
@@ -1013,6 +1018,7 @@ public class MachineLearningPlugin extends Plugin
                 restMLSearchMemoriesAction,
                 restMLDeleteMemoryAction,
                 restMLUpdateMemoryAction,
+                restMLGetMemoryAction,
                 restSearchConversationsAction,
                 restSearchInteractionsAction,
                 restGetConversationAction,

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -944,7 +944,7 @@ public class MachineLearningPlugin extends Plugin
         RestMemorySearchConversationsAction restSearchConversationsAction = new RestMemorySearchConversationsAction(
             mlFeatureEnabledSetting
         );
-        RestMLGetMemoryAction restMLGetMemoryAction = new RestMLGetMemoryAction();
+        RestMLGetMemoryAction restMLGetMemoryAction = new RestMLGetMemoryAction(mlFeatureEnabledSetting);
         RestMemorySearchInteractionsAction restSearchInteractionsAction = new RestMemorySearchInteractionsAction();
         RestMemoryGetConversationAction restGetConversationAction = new RestMemoryGetConversationAction();
         RestMemoryGetInteractionAction restGetInteractionAction = new RestMemoryGetInteractionAction();

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetMemoryAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetMemoryAction.java
@@ -8,12 +8,16 @@ package org.opensearch.ml.rest;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.GET_MEMORY_PATH;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_ID;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
 import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryAction;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryRequest;
 import org.opensearch.rest.BaseRestHandler;
@@ -27,10 +31,14 @@ import com.google.common.collect.ImmutableList;
 public class RestMLGetMemoryAction extends BaseRestHandler {
     private static final String ML_GET_MEMORY_ACTION = "ml_get_memory_action";
 
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
     /**
      * Constructor
      */
-    public RestMLGetMemoryAction() {}
+    public RestMLGetMemoryAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
 
     @Override
     public String getName() {
@@ -44,6 +52,9 @@ public class RestMLGetMemoryAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (!mlFeatureEnabledSetting.isAgenticMemoryEnabled()) {
+            throw new OpenSearchStatusException(ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE, RestStatus.FORBIDDEN);
+        }
         MLGetMemoryRequest mlMemoryGetRequest = getRequest(request);
         return channel -> client.execute(MLGetMemoryAction.INSTANCE, mlMemoryGetRequest, new RestToXContentListener<>(channel));
     }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetMemoryAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLGetMemoryAction.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.GET_MEMORY_PATH;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_ID;
+import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryAction;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+public class RestMLGetMemoryAction extends BaseRestHandler {
+    private static final String ML_GET_MEMORY_ACTION = "ml_get_memory_action";
+
+    /**
+     * Constructor
+     */
+    public RestMLGetMemoryAction() {}
+
+    @Override
+    public String getName() {
+        return ML_GET_MEMORY_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList.of(new Route(RestRequest.Method.GET, String.format(Locale.ROOT, GET_MEMORY_PATH)));
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        MLGetMemoryRequest mlMemoryGetRequest = getRequest(request);
+        return channel -> client.execute(MLGetMemoryAction.INSTANCE, mlMemoryGetRequest, new RestToXContentListener<>(channel));
+    }
+
+    /**
+     * Creates a MLMemoryGetRequest from a RestRequest
+     *
+     * @param request RestRequest
+     * @return MLMemoryGetRequest
+     */
+    @VisibleForTesting
+    MLGetMemoryRequest getRequest(RestRequest request) throws IOException {
+        String memoryContainerId = getParameterId(request, PARAMETER_MEMORY_CONTAINER_ID);
+        String memoryId = getParameterId(request, PARAMETER_MEMORY_ID);
+        return new MLGetMemoryRequest(memoryContainerId, memoryId);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportGetMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportGetMemoryActionTests.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.memorycontainer.memory;
+
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.memorycontainer.MLMemory;
+import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
+import org.opensearch.ml.common.memorycontainer.MemoryStorageConfig;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryRequest;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryResponse;
+import org.opensearch.ml.helper.MemoryContainerHelper;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class TransportGetMemoryActionTests extends OpenSearchTestCase {
+
+    private static final String MEMORY_CONTAINER_ID = "test-memory-container-id";
+    private static final String MEMORY_ID = "test-memory-id";
+    private static final String MEMORY_INDEX_NAME = "ml-static-memory-test-container";
+    private static final String USER_NAME = "test-user";
+    private static final String OWNER_NAME = "owner-user";
+
+    private TransportGetMemoryAction action;
+
+    @Mock
+    private Client client;
+    @Mock
+    private NamedXContentRegistry xContentRegistry;
+    @Mock
+    private MemoryContainerHelper memoryContainerHelper;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private Task task;
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private ActionListener<MLGetMemoryResponse> actionListener;
+
+    private ActionRequest actionRequest;
+    private User testUser;
+    private User ownerUser;
+    private User adminUser;
+    private ThreadContext threadContext;
+    private MLMemoryContainer testMemoryContainer;
+    private MLMemory testMemory;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        // Setup test users using User.parse() with correct format: name|backend_roles|roles
+        testUser = User.parse(USER_NAME + "||");  // No backend roles or roles
+        ownerUser = User.parse(OWNER_NAME + "||");  // No backend roles or roles
+        adminUser = User.parse("admin-user||all_access");  // Has all_access role
+
+        // Setup thread context
+        Settings settings = Settings.builder().build();
+        threadContext = new ThreadContext(settings);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        // Setup action request
+        actionRequest = mock(ActionRequest.class);
+
+        // Setup test memory container
+        MemoryStorageConfig storageConfig = MemoryStorageConfig
+            .builder()
+            .memoryIndexName(MEMORY_INDEX_NAME)
+            .semanticStorageEnabled(false)
+            .build();
+
+        testMemoryContainer = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .description("Test memory container")
+            .owner(ownerUser)
+            .tenantId("test-tenant")
+            .createdTime(Instant.now())
+            .lastUpdatedTime(Instant.now())
+            .memoryStorageConfig(storageConfig)
+            .build();
+
+        // Setup test memory
+        testMemory = MLMemory
+            .builder()
+            .sessionId("test-session")
+            .memory("Test memory content")
+            .memoryType(MemoryType.RAW_MESSAGE)
+            .userId("test-user")
+            .createdTime(Instant.now())
+            .lastUpdatedTime(Instant.now())
+            .build();
+
+        // Create action
+        action = new TransportGetMemoryAction(transportService, actionFilters, client, xContentRegistry, memoryContainerHelper);
+
+        // Setup user context
+        threadContext.putTransient(org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, OWNER_NAME + "||");
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(User.class), any(MLMemoryContainer.class))).thenReturn(true);
+
+        // Setup memory index validation to pass
+        when(memoryContainerHelper.validateMemoryIndexExists(any(MLMemoryContainer.class), any(String.class), any(ActionListener.class)))
+            .thenReturn(true);
+
+        // Setup memory index name
+        when(memoryContainerHelper.getMemoryIndexName(testMemoryContainer)).thenReturn(MEMORY_INDEX_NAME);
+    }
+
+    public void testConstructor() {
+        assertNotNull(action);
+    }
+
+    public void testDoExecuteSuccess() {
+        // Setup request
+        MLGetMemoryRequest getRequest = new MLGetMemoryRequest(MEMORY_CONTAINER_ID, MEMORY_ID);
+
+        // Setup memory container helper to return container
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(testMemoryContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+
+        // Setup client to return successful response
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.get.GetResponse> listener = invocation.getArgument(1);
+            org.opensearch.action.get.GetResponse getResponse = mock(org.opensearch.action.get.GetResponse.class);
+            when(getResponse.isExists()).thenReturn(true);
+            when(getResponse.getSourceAsString()).thenReturn(createMemoryJson());
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(org.opensearch.action.get.GetRequest.class), any(ActionListener.class));
+
+        // Execute
+        action.doExecute(task, getRequest, actionListener);
+
+        verify(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+        verify(memoryContainerHelper).checkMemoryContainerAccess(any(User.class), any(MLMemoryContainer.class));
+        verify(memoryContainerHelper).validateMemoryIndexExists(any(MLMemoryContainer.class), any(String.class), any(ActionListener.class));
+        verify(memoryContainerHelper).getMemoryIndexName(testMemoryContainer);
+        verify(client).get(any(org.opensearch.action.get.GetRequest.class), any(ActionListener.class));
+
+        // Capture and verify the success response content
+        ArgumentCaptor<MLGetMemoryResponse> responseCaptor = forClass(MLGetMemoryResponse.class);
+        verify(actionListener).onResponse(responseCaptor.capture());
+
+        MLGetMemoryResponse capturedResponse = responseCaptor.getValue();
+        assertNotNull(capturedResponse);
+
+        // Verify the memory content in the response matches the JSON that was returned
+        MLMemory returnedMemory = capturedResponse.getMlMemory();
+        assertNotNull(returnedMemory);
+
+        // Get the expected JSON content that was actually returned by the mock
+        String expectedJson = createMemoryJson();
+
+        // Verify the memory content matches what was in the JSON
+        assertEquals("test-session", returnedMemory.getSessionId());
+        assertEquals("Test memory content", returnedMemory.getMemory());
+        assertEquals(MemoryType.RAW_MESSAGE, returnedMemory.getMemoryType());
+        assertEquals("test-user", returnedMemory.getUserId());
+        assertNotNull(returnedMemory.getCreatedTime());
+        assertNotNull(returnedMemory.getLastUpdatedTime());
+        assertTrue(expectedJson.contains("\"session_id\":\"test-session\""));
+        assertTrue(expectedJson.contains("\"memory\":\"Test memory content\""));
+        assertTrue(expectedJson.contains("\"memory_type\":\"RAW_MESSAGE\""));
+        assertTrue(expectedJson.contains("\"user_id\":\"test-user\""));
+    }
+
+    public void testDoExecuteWithUnauthorizedUser() {
+        // Setup request
+        MLGetMemoryRequest getRequest = new MLGetMemoryRequest(MEMORY_CONTAINER_ID, MEMORY_ID);
+
+        // Setup memory container helper to return container
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(testMemoryContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+
+        // Setup access control to deny access
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(User.class), any(MLMemoryContainer.class))).thenReturn(false);
+
+        // Execute
+        action.doExecute(task, getRequest, actionListener);
+
+        // Verify memory container helper was called
+        verify(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+
+        // Verify access control was checked
+        verify(memoryContainerHelper).checkMemoryContainerAccess(any(User.class), any(MLMemoryContainer.class));
+
+        // Capture the actual exception that was passed to the action listener
+        ArgumentCaptor<Exception> exceptionCaptor = forClass(Exception.class);
+        verify(actionListener).onFailure(exceptionCaptor.capture());
+
+        // Verify the exact error message and status
+        Exception capturedException = exceptionCaptor.getValue();
+        assertTrue(capturedException instanceof OpenSearchStatusException);
+        OpenSearchStatusException statusException = (OpenSearchStatusException) capturedException;
+        assertEquals("User doesn't have permissions to get memories in this container", statusException.getMessage());
+        assertEquals(RestStatus.FORBIDDEN, statusException.status());
+    }
+
+    public void testDoExecuteWithParsingException() {
+        // Setup request
+        MLGetMemoryRequest getRequest = new MLGetMemoryRequest(MEMORY_CONTAINER_ID, MEMORY_ID);
+
+        // Setup memory container helper to return container
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(testMemoryContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(User.class), any(MLMemoryContainer.class))).thenReturn(true);
+
+        // Setup memory index validation to pass
+        when(memoryContainerHelper.validateMemoryIndexExists(any(MLMemoryContainer.class), any(String.class), any(ActionListener.class)))
+            .thenReturn(true);
+
+        // Setup memory index name
+        when(memoryContainerHelper.getMemoryIndexName(testMemoryContainer)).thenReturn(MEMORY_INDEX_NAME);
+
+        // Setup client to return response with invalid JSON
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.get.GetResponse> listener = invocation.getArgument(1);
+            org.opensearch.action.get.GetResponse getResponse = mock(org.opensearch.action.get.GetResponse.class);
+            when(getResponse.isExists()).thenReturn(true);
+            when(getResponse.getSourceAsString()).thenReturn("invalid-json-content");
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(org.opensearch.action.get.GetRequest.class), any(ActionListener.class));
+
+        // Execute
+        action.doExecute(task, getRequest, actionListener);
+
+        // Verify memory container helper was called
+        verify(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+
+        // Verify access control was checked
+        verify(memoryContainerHelper).checkMemoryContainerAccess(any(User.class), any(MLMemoryContainer.class));
+
+        // Verify memory index validation was called
+        verify(memoryContainerHelper).validateMemoryIndexExists(any(MLMemoryContainer.class), any(String.class), any(ActionListener.class));
+
+        // Verify memory index name was retrieved
+        verify(memoryContainerHelper).getMemoryIndexName(testMemoryContainer);
+
+        // Verify client.get was called
+        verify(client).get(any(org.opensearch.action.get.GetRequest.class), any(ActionListener.class));
+
+        // Verify failure response due to parsing error
+        verify(actionListener).onFailure(any(Exception.class));
+    }
+
+    @Test
+    public void testDoExecuteWithNoResponse() {
+        // Setup request
+        MLGetMemoryRequest getRequest = new MLGetMemoryRequest(MEMORY_CONTAINER_ID, MEMORY_ID);
+
+        // Setup memory container helper to return container
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(testMemoryContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+
+        // Setup client to return response with isExists() as false
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.get.GetResponse> listener = invocation.getArgument(1);
+            org.opensearch.action.get.GetResponse getResponse = mock(org.opensearch.action.get.GetResponse.class);
+            when(getResponse.isExists()).thenReturn(false);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(org.opensearch.action.get.GetRequest.class), any(ActionListener.class));
+
+        // Execute
+        action.doExecute(task, getRequest, actionListener);
+
+        verify(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+        verify(memoryContainerHelper).checkMemoryContainerAccess(any(User.class), any(MLMemoryContainer.class));
+        verify(memoryContainerHelper).validateMemoryIndexExists(any(MLMemoryContainer.class), any(String.class), any(ActionListener.class));
+        verify(memoryContainerHelper).getMemoryIndexName(testMemoryContainer);
+        verify(client).get(any(org.opensearch.action.get.GetRequest.class), any(ActionListener.class));
+
+        // Capture and verify the failure response
+        ArgumentCaptor<Exception> exceptionCaptor = forClass(Exception.class);
+        verify(actionListener).onFailure(exceptionCaptor.capture());
+
+        // Verify the exact error message and status
+        Exception capturedException = exceptionCaptor.getValue();
+        assertTrue(capturedException instanceof OpenSearchStatusException);
+        OpenSearchStatusException statusException = (OpenSearchStatusException) capturedException;
+        assertEquals("Memory not found with id: " + MEMORY_ID, statusException.getMessage());
+        assertEquals(RestStatus.NOT_FOUND, statusException.status());
+    }
+
+    @Test
+    public void testDoExecuteWithClientGetFailure() {
+        // Setup request
+        MLGetMemoryRequest getRequest = new MLGetMemoryRequest(MEMORY_CONTAINER_ID, MEMORY_ID);
+
+        // Setup memory container helper to return container
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(testMemoryContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+
+        // Setup client to throw an exception when get() is called
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.get.GetResponse> listener = invocation.getArgument(1);
+            // Simulate a client failure by calling onFailure directly
+            listener.onFailure(new RuntimeException("Client get operation failed"));
+            return null;
+        }).when(client).get(any(org.opensearch.action.get.GetRequest.class), any(ActionListener.class));
+
+        // Execute
+        action.doExecute(task, getRequest, actionListener);
+
+        verify(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+        verify(memoryContainerHelper).checkMemoryContainerAccess(any(User.class), any(MLMemoryContainer.class));
+        verify(memoryContainerHelper).validateMemoryIndexExists(any(MLMemoryContainer.class), any(String.class), any(ActionListener.class));
+        verify(memoryContainerHelper).getMemoryIndexName(testMemoryContainer);
+        verify(client).get(any(org.opensearch.action.get.GetRequest.class), any(ActionListener.class));
+
+        ArgumentCaptor<Exception> exceptionCaptor = forClass(Exception.class);
+        verify(actionListener).onFailure(exceptionCaptor.capture());
+
+        // Verify the exact error message
+        Exception capturedException = exceptionCaptor.getValue();
+        assertTrue(capturedException instanceof RuntimeException);
+        assertEquals("Client get operation failed", capturedException.getMessage());
+    }
+
+    @Test
+    public void testDoExecuteWithProcessResponseException() {
+        // Setup request
+        MLGetMemoryRequest getRequest = new MLGetMemoryRequest(MEMORY_CONTAINER_ID, MEMORY_ID);
+
+        // Setup memory container helper to return container
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(testMemoryContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.get.GetResponse> listener = invocation.getArgument(1);
+            org.opensearch.action.get.GetResponse getResponse = mock(org.opensearch.action.get.GetResponse.class);
+            when(getResponse.isExists()).thenThrow(new RuntimeException("Outer try block failure"));
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(org.opensearch.action.get.GetRequest.class), any(ActionListener.class));
+
+        action.doExecute(task, getRequest, actionListener);
+
+        verify(memoryContainerHelper).getMemoryContainer(any(String.class), any(ActionListener.class));
+        verify(memoryContainerHelper).checkMemoryContainerAccess(any(User.class), any(MLMemoryContainer.class));
+        verify(memoryContainerHelper).validateMemoryIndexExists(any(MLMemoryContainer.class), any(String.class), any(ActionListener.class));
+        verify(memoryContainerHelper).getMemoryIndexName(testMemoryContainer);
+        verify(client).get(any(org.opensearch.action.get.GetRequest.class), any(ActionListener.class));
+        ArgumentCaptor<Exception> exceptionCaptor = forClass(Exception.class);
+        verify(actionListener).onFailure(exceptionCaptor.capture());
+
+        // Verify the exact error message
+        Exception capturedException = exceptionCaptor.getValue();
+        assertTrue(capturedException instanceof RuntimeException);
+        assertEquals("Outer try block failure", capturedException.getMessage());
+    }
+
+    // ========== Helper Methods ==========
+
+    private String createMemoryJson() {
+        // Use epoch timestamps instead of ISO format to avoid parsing errors
+        long currentTimeEpoch = System.currentTimeMillis();
+        return "{"
+            + "\"session_id\":\"test-session\","
+            + "\"memory\":\"Test memory content\","
+            + "\"memory_type\":\"RAW_MESSAGE\","
+            + "\"user_id\":\"test-user\","
+            + "\"created_time\":"
+            + currentTimeEpoch
+            + ","
+            + "\"last_updated_time\":"
+            + currentTimeEpoch
+            + "}";
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetMemoryActionTests.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_ID;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryAction;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLGetMemoryRequest;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestMLGetMemoryActionTests extends OpenSearchTestCase {
+
+    private RestMLGetMemoryAction restMLGetMemoryAction;
+
+    NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        restMLGetMemoryAction = new RestMLGetMemoryAction();
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<Object> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLGetMemoryAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
+    }
+
+    @Test
+    public void testConstructor() {
+        RestMLGetMemoryAction mlGetMemoryAction = new RestMLGetMemoryAction();
+        assertNotNull(mlGetMemoryAction);
+    }
+
+    @Test
+    public void testGetName() {
+        String actionName = restMLGetMemoryAction.getName();
+        assertFalse(Strings.isNullOrEmpty(actionName));
+        assertEquals("ml_get_memory_action", actionName);
+    }
+
+    @Test
+    public void testRoutes() {
+        List<RestHandler.Route> routes = restMLGetMemoryAction.routes();
+        assertNotNull(routes);
+        assertFalse(routes.isEmpty());
+        RestHandler.Route route = routes.get(0);
+        assertEquals(RestRequest.Method.GET, route.getMethod());
+        assertEquals("/_plugins/_ml/memory_containers/{memory_container_id}/memories/{memory_id}", route.getPath());
+    }
+
+    @Test
+    public void testRoutePathConstant() {
+        List<RestHandler.Route> routes = restMLGetMemoryAction.routes();
+        RestHandler.Route route = routes.get(0);
+
+        // Verify the route path matches the expected pattern
+        assertTrue(route.getPath().contains("/_plugins/_ml/memory_containers/"));
+        assertTrue(route.getPath().contains("/memories/"));
+        assertTrue(route.getPath().contains("{memory_container_id}"));
+        assertTrue(route.getPath().contains("{memory_id}"));
+        assertEquals(RestRequest.Method.GET, route.getMethod());
+    }
+
+    @Test
+    public void testPrepareRequest() throws Exception {
+        RestRequest request = getRestRequest("memory_container_id", "memory_id");
+        restMLGetMemoryAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLGetMemoryRequest> argumentCaptor = ArgumentCaptor.forClass(MLGetMemoryRequest.class);
+        verify(client, times(1)).execute(eq(MLGetMemoryAction.INSTANCE), argumentCaptor.capture(), any());
+        MLGetMemoryRequest mlGetMemoryRequest = argumentCaptor.getValue();
+        assertNotNull(mlGetMemoryRequest);
+        assertEquals("memory_container_id", mlGetMemoryRequest.getMemoryContainerId());
+        assertEquals("memory_id", mlGetMemoryRequest.getMemoryId());
+    }
+
+    @Test
+    public void testGetRequestMethod() throws Exception {
+        RestRequest request = getRestRequest("container-123", "memory-456");
+        MLGetMemoryRequest mlGetMemoryRequest = restMLGetMemoryAction.getRequest(request);
+
+        assertNotNull(mlGetMemoryRequest);
+        assertEquals("container-123", mlGetMemoryRequest.getMemoryContainerId());
+        assertEquals("memory-456", mlGetMemoryRequest.getMemoryId());
+    }
+
+    private RestRequest getRestRequest(String memoryContainerId, String memoryId) {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, memoryContainerId);
+        params.put(PARAMETER_MEMORY_ID, memoryId);
+
+        return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.GET)
+            .withPath("/_plugins/_ml/memory_containers/" + memoryContainerId + "/memory/" + memoryId)
+            .withParams(params)
+            .build();
+    }
+}


### PR DESCRIPTION
### Description
Get Memory API:
```
GET /_plugins/_ml/memory_containers/{memory_container_id}/memories/{memory_id}
```
Response:
```
{
    "session_id": "sess_cd423e34-bc8d-48cc-bf96-4667b043f0df",
    "memory": "My name is John and I work at TechCorp as a software engineer",
    "memory_type": "RAW_MESSAGE",
    "agent_id": "agent_123",
    "role": "user",
    "created_time": 1754421423498,
    "last_updated_time": 1754421423498
}
```

When invalid memory container is presented:
```
{
    "error": {
        "root_cause": [
            {
                "type": "status_exception",
                "reason": "Memory container not found"
            }
        ],
        "type": "status_exception",
        "reason": "Memory container not found"
    },
    "status": 404
}
```

When invalid memory ID is presented:
```
{
    "error": {
        "root_cause": [
            {
                "type": "status_exception",
                "reason": "Memory not found with id: rrrr"
            }
        ],
        "type": "status_exception",
        "reason": "Memory not found with id: rrrr"
    },
    "status": 404
}
```
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
