### PR TITLE
[Bug] fix: Suppres NONE event in add memories response and add UT coverage

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -383,20 +383,8 @@ List<String> jacocoExclusions = [
         'org.opensearch.ml.utils.ParseUtils',
         'org.opensearch.ml.jobs.processors.MLStatsJobProcessor',
         'org.opensearch.ml.jobs.processors.MLJobProcessor',
-        // Memory container related exclusions
         'org.opensearch.ml.action.memorycontainer.memory.TransportAddMemoriesAction',
-        'org.opensearch.ml.action.memorycontainer.memory.TransportSearchMemoriesAction',
-        'org.opensearch.ml.action.memorycontainer.memory.TransportDeleteMemoryAction',
-        'org.opensearch.ml.action.memorycontainer.memory.TransportUpdateMemoryAction',
-        'org.opensearch.ml.action.memorycontainer.memory.TransportAddMemoriesAction.*',
-        'org.opensearch.ml.action.memorycontainer.memory.TransportSearchMemoriesAction.*',
-        'org.opensearch.ml.action.memorycontainer.memory.TransportDeleteMemoryAction.*',
-        'org.opensearch.ml.action.memorycontainer.memory.TransportUpdateMemoryAction.*',
-        'org.opensearch.ml.rest.RestMLAddMemoriesAction',
-        'org.opensearch.ml.rest.RestMLSearchMemoriesAction',
-        'org.opensearch.ml.rest.RestMLDeleteMemoryAction',
-        'org.opensearch.ml.rest.RestMLUpdateMemoryAction',
-        'org.opensearch.ml.utils.MemorySearchQueryBuilder'
+        'org.opensearch.ml.action.memorycontainer.memory.TransportAddMemoriesAction.*'
 ]
 
 jacocoTestCoverageVerification {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryOperationsService.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryOperationsService.java
@@ -125,16 +125,8 @@ public class MemoryOperationsService {
                     break;
 
                 case NONE:
-                    results
-                        .add(
-                            MemoryResult
-                                .builder()
-                                .memoryId(decision.getId())
-                                .memory(decision.getText())
-                                .event(MemoryEvent.NONE)
-                                .oldMemory(null)
-                                .build()
-                        );
+                    // NONE events are not included in the response
+                    // They represent facts that didn't change and don't need user visibility
                     break;
             }
         }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLAddMemoriesAction.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.rest;
 
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORIES_PATH;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
@@ -77,11 +78,5 @@ public class RestMLAddMemoriesAction extends BaseRestHandler {
         mlAddMemoryInput.setMemoryContainerId(memoryContainerId);
 
         return new MLAddMemoriesRequest(mlAddMemoryInput);
-    }
-
-    private static void ensureExpectedToken(XContentParser.Token expected, XContentParser.Token actual, XContentParser parser) {
-        if (actual != expected) {
-            throw new IllegalArgumentException("Expected token [" + expected + "] but found [" + actual + "]");
-        }
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportDeleteMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportDeleteMemoryActionTests.java
@@ -100,6 +100,9 @@ public class TransportDeleteMemoryActionTests extends OpenSearchTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
+        // Mock ML feature settings
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
         // Setup mock container
         mockContainer = MLMemoryContainer
             .builder()

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportDeleteMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportDeleteMemoryActionTests.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.memorycontainer.memory;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
+import org.opensearch.ml.common.memorycontainer.MemoryStorageConfig;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLDeleteMemoryRequest;
+import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.helper.MemoryContainerHelper;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class TransportDeleteMemoryActionTests extends OpenSearchTestCase {
+
+    @Mock
+    private TransportService transportService;
+
+    @Mock
+    private ActionFilters actionFilters;
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private SdkClient sdkClient;
+
+    @Mock
+    private NamedXContentRegistry xContentRegistry;
+
+    @Mock
+    private ConnectorAccessControlHelper connectorAccessControlHelper;
+
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Mock
+    private MemoryContainerHelper memoryContainerHelper;
+
+    @Mock
+    private ThreadPool threadPool;
+
+    private ThreadContext threadContext;
+
+    @Mock
+    private Task task;
+
+    @Mock
+    private ActionListener<DeleteResponse> actionListener;
+
+    private TransportDeleteMemoryAction transportDeleteMemoryAction;
+
+    private MLMemoryContainer mockContainer;
+    private User mockUser;
+    private Settings settings;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        settings = Settings.builder().build();
+
+        // Setup thread context with real instance
+        threadContext = new ThreadContext(settings);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        // Setup mock container
+        mockContainer = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .description("Test container")
+            .memoryStorageConfig(MemoryStorageConfig.builder().memoryIndexName("test-memory-index").build())
+            .build();
+
+        // Setup mock user
+        mockUser = User.parse("test-user|test-backend-role");
+
+        // Initialize transport action
+        transportDeleteMemoryAction = spy(
+            new TransportDeleteMemoryAction(
+                transportService,
+                actionFilters,
+                client,
+                sdkClient,
+                xContentRegistry,
+                connectorAccessControlHelper,
+                mlFeatureEnabledSetting,
+                memoryContainerHelper
+            )
+        );
+    }
+
+    @Test
+    public void testDoExecute_Success() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        MLDeleteMemoryRequest deleteRequest = new MLDeleteMemoryRequest(memoryContainerId, memoryId);
+
+        DeleteResponse mockDeleteResponse = mock(DeleteResponse.class);
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess (user is null from RestActionUtils.getUserContext)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+        when(memoryContainerHelper.validateMemoryIndexExists(eq(mockContainer), eq("delete"), any())).thenReturn(true);
+
+        // Mock getMemoryIndexName
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer)).thenReturn("test-memory-index");
+
+        // Mock delete operation
+        doAnswer(invocation -> {
+            DeleteRequest request = invocation.getArgument(0);
+            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
+            assertEquals("test-memory-index", request.index());
+            assertEquals(memoryId, request.id());
+            listener.onResponse(mockDeleteResponse);
+            return null;
+        }).when(client).delete(any(DeleteRequest.class), any());
+
+        // Act
+        transportDeleteMemoryAction.doExecute(task, deleteRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(isNull(), eq(mockContainer));
+        verify(memoryContainerHelper, times(1)).validateMemoryIndexExists(eq(mockContainer), eq("delete"), any());
+        verify(client, times(1)).delete(any(DeleteRequest.class), any());
+        verify(actionListener, times(1)).onResponse(mockDeleteResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testDoExecute_GetContainerFailure() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        MLDeleteMemoryRequest deleteRequest = new MLDeleteMemoryRequest(memoryContainerId, memoryId);
+
+        Exception expectedError = new RuntimeException("Container not found");
+
+        // Mock getMemoryContainer to fail
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onFailure(expectedError);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Act
+        transportDeleteMemoryAction.doExecute(task, deleteRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, never()).checkMemoryContainerAccess(any(), any());
+        verify(client, never()).delete(any(), any());
+        verify(actionListener, times(1)).onFailure(expectedError);
+        verify(actionListener, never()).onResponse(any());
+    }
+
+    @Test
+    public void testDoExecute_AccessDenied() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        MLDeleteMemoryRequest deleteRequest = new MLDeleteMemoryRequest(memoryContainerId, memoryId);
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess to return false (user is null)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(false);
+
+        // Act
+        transportDeleteMemoryAction.doExecute(task, deleteRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(isNull(), eq(mockContainer));
+        verify(memoryContainerHelper, never()).validateMemoryIndexExists(any(), any(), any());
+        verify(client, never()).delete(any(), any());
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) capturedError).status());
+        assertTrue(capturedError.getMessage().contains("doesn't have permissions"));
+    }
+
+    @Test
+    public void testDoExecute_MemoryIndexNotExists() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        MLDeleteMemoryRequest deleteRequest = new MLDeleteMemoryRequest(memoryContainerId, memoryId);
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess (user is null from RestActionUtils.getUserContext)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists to return false
+        when(memoryContainerHelper.validateMemoryIndexExists(eq(mockContainer), eq("delete"), any())).thenReturn(false);
+
+        // Act
+        transportDeleteMemoryAction.doExecute(task, deleteRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(isNull(), eq(mockContainer));
+        verify(memoryContainerHelper, times(1)).validateMemoryIndexExists(eq(mockContainer), eq("delete"), any());
+        verify(memoryContainerHelper, never()).getMemoryIndexName(any());
+        verify(client, never()).delete(any(), any());
+        // validateMemoryIndexExists handles the error response
+    }
+
+    @Test
+    public void testDoExecute_DeleteFailure() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        MLDeleteMemoryRequest deleteRequest = new MLDeleteMemoryRequest(memoryContainerId, memoryId);
+
+        Exception deleteError = new RuntimeException("Delete failed");
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess (user is null from RestActionUtils.getUserContext)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+        when(memoryContainerHelper.validateMemoryIndexExists(eq(mockContainer), eq("delete"), any())).thenReturn(true);
+
+        // Mock getMemoryIndexName
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer)).thenReturn("test-memory-index");
+
+        // Mock delete operation to fail
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
+            listener.onFailure(deleteError);
+            return null;
+        }).when(client).delete(any(DeleteRequest.class), any());
+
+        // Act
+        transportDeleteMemoryAction.doExecute(task, deleteRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(isNull(), eq(mockContainer));
+        verify(memoryContainerHelper, times(1)).validateMemoryIndexExists(eq(mockContainer), eq("delete"), any());
+        verify(client, times(1)).delete(any(DeleteRequest.class), any());
+        verify(actionListener, times(1)).onFailure(deleteError);
+        verify(actionListener, never()).onResponse(any());
+    }
+
+    @Test
+    public void testDoExecute_ExceptionDuringDelete() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        MLDeleteMemoryRequest deleteRequest = new MLDeleteMemoryRequest(memoryContainerId, memoryId);
+
+        RuntimeException unexpectedError = new RuntimeException("Unexpected error");
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess (user is null from RestActionUtils.getUserContext)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+        when(memoryContainerHelper.validateMemoryIndexExists(eq(mockContainer), eq("delete"), any())).thenReturn(true);
+
+        // Mock getMemoryIndexName
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer)).thenReturn("test-memory-index");
+
+        // Mock client.delete to throw exception
+        doThrow(unexpectedError).when(client).delete(any(DeleteRequest.class), any());
+
+        // Act
+        transportDeleteMemoryAction.doExecute(task, deleteRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(isNull(), eq(mockContainer));
+        verify(memoryContainerHelper, times(1)).validateMemoryIndexExists(eq(mockContainer), eq("delete"), any());
+        verify(client, times(1)).delete(any(), any());
+        verify(actionListener, times(1)).onFailure(unexpectedError);
+        verify(actionListener, never()).onResponse(any());
+    }
+
+    @Test
+    public void testDoExecute_NullContainer() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        MLDeleteMemoryRequest deleteRequest = new MLDeleteMemoryRequest(memoryContainerId, memoryId);
+
+        // Mock getMemoryContainer to return null container
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(null);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess to handle null
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(null))).thenReturn(false);
+
+        // Act
+        transportDeleteMemoryAction.doExecute(task, deleteRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(any(), eq(null));
+        verify(client, never()).delete(any(), any());
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue() instanceof OpenSearchStatusException);
+    }
+
+    @Test
+    public void testFromActionRequest() {
+        // Test that MLDeleteMemoryRequest.fromActionRequest works correctly
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        MLDeleteMemoryRequest originalRequest = new MLDeleteMemoryRequest(memoryContainerId, memoryId);
+
+        MLDeleteMemoryRequest convertedRequest = MLDeleteMemoryRequest.fromActionRequest(originalRequest);
+
+        assertEquals(memoryContainerId, convertedRequest.getMemoryContainerId());
+        assertEquals(memoryId, convertedRequest.getMemoryId());
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportSearchMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportSearchMemoriesActionTests.java
@@ -1,0 +1,825 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.memorycontainer.memory;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
+import org.opensearch.ml.common.memorycontainer.MemoryStorageConfig;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLSearchMemoriesInput;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLSearchMemoriesRequest;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLSearchMemoriesResponse;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MemorySearchResult;
+import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.helper.MemoryContainerHelper;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class TransportSearchMemoriesActionTests extends OpenSearchTestCase {
+
+    @Mock
+    private TransportService transportService;
+
+    @Mock
+    private ActionFilters actionFilters;
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private ConnectorAccessControlHelper connectorAccessControlHelper;
+
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Mock
+    private NamedXContentRegistry xContentRegistry;
+
+    @Mock
+    private MemoryContainerHelper memoryContainerHelper;
+
+    @Mock
+    private ThreadPool threadPool;
+
+    private ThreadContext threadContext;
+
+    @Mock
+    private Task task;
+
+    @Mock
+    private ActionListener<MLSearchMemoriesResponse> actionListener;
+
+    private TransportSearchMemoriesAction transportSearchMemoriesAction;
+
+    private MLMemoryContainer mockContainer;
+    private Settings settings;
+
+    // Helper method to create a real SearchHit (since SearchHit is final and can't be mocked)
+    private SearchHit createSearchHit(int docId, String id, Map<String, Object> sourceMap, float score) throws Exception {
+        XContentBuilder content = XContentFactory.jsonBuilder();
+        content.map(sourceMap);
+        SearchHit hit = new SearchHit(docId, id, null, null);
+        hit.sourceRef(BytesReference.bytes(content));
+        hit.score(score);
+        return hit;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        settings = Settings.builder().build();
+
+        // Setup thread context with real instance
+        threadContext = new ThreadContext(settings);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        // Setup mock container with semantic storage
+        mockContainer = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .description("Test container")
+            .memoryStorageConfig(
+                MemoryStorageConfig
+                    .builder()
+                    .memoryIndexName("test-memory-index")
+                    .semanticStorageEnabled(true)
+                    .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                    .embeddingModelId("embedding-model-123")
+                    .dimension(768)
+                    .maxInferSize(5)
+                    .build()
+            )
+            .build();
+
+        // Initialize transport action
+        transportSearchMemoriesAction = spy(
+            new TransportSearchMemoriesAction(
+                transportService,
+                actionFilters,
+                client,
+                connectorAccessControlHelper,
+                mlFeatureEnabledSetting,
+                xContentRegistry,
+                memoryContainerHelper
+            )
+        );
+    }
+
+    @Test
+    public void testDoExecute_SuccessWithSemanticSearch() throws Exception {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String query = "machine learning concepts";
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(memoryContainerId).query(query).build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        // Mock search response
+        SearchResponse mockSearchResponse = mock(SearchResponse.class);
+
+        // Create source content for the search hit
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("memory", "Machine learning is a subset of AI");
+        sourceMap.put("session_id", "session-123");
+        sourceMap.put("memory_type", "FACT");
+        sourceMap.put("created_time", 1700000000000L);
+        sourceMap.put("last_updated_time", 1700000000000L);
+
+        // Create a real SearchHit instead of mocking (SearchHit is final class)
+        XContentBuilder content = XContentFactory.jsonBuilder();
+        content.map(sourceMap);
+        SearchHit searchHit = new SearchHit(0, "memory-123", null, null);
+        searchHit.sourceRef(BytesReference.bytes(content));
+        searchHit.score(0.95f);
+
+        // Create SearchHits with the real SearchHit
+        SearchHit[] hits = new SearchHit[] { searchHit };
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 0.95f);
+        when(mockSearchResponse.getHits()).thenReturn(searchHits);
+        when(mockSearchResponse.isTimedOut()).thenReturn(false);
+
+        // Mock getMemoryContainer with 3 parameters (memoryContainerId, tenantId, listener)
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        // Mock checkMemoryContainerAccess (user is null from RestActionUtils.getUserContext)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+
+        // Mock search operation
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            // Verify search request
+            assertEquals("test-memory-index", request.indices()[0]);
+            assertNotNull(request.source());
+            // Note: Size limit has been removed in the actual implementation
+
+            listener.onResponse(mockSearchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any());
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any(), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(isNull(), eq(mockContainer));
+        verify(client, times(1)).search(any(SearchRequest.class), any());
+
+        ArgumentCaptor<MLSearchMemoriesResponse> responseCaptor = ArgumentCaptor.forClass(MLSearchMemoriesResponse.class);
+        verify(actionListener, times(1)).onResponse(responseCaptor.capture());
+        verify(actionListener, never()).onFailure(any());
+
+        MLSearchMemoriesResponse response = responseCaptor.getValue();
+        assertNotNull(response);
+        assertEquals(1, response.getHits().size());
+        assertEquals("memory-123", response.getHits().get(0).getMemoryId());
+        assertEquals(0.95f, response.getHits().get(0).getScore(), 0.001);
+    }
+
+    @Test
+    public void testDoExecute_SuccessWithoutSemanticSearch() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String query = "machine learning";
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(memoryContainerId).query(query).build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        // Setup container without semantic storage
+        MLMemoryContainer containerWithoutSemantic = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .memoryStorageConfig(MemoryStorageConfig.builder().memoryIndexName("test-memory-index").semanticStorageEnabled(false).build())
+            .build();
+
+        // Mock search response
+        SearchResponse mockSearchResponse = mock(SearchResponse.class);
+        SearchHits searchHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0.0f);
+        when(mockSearchResponse.getHits()).thenReturn(searchHits);
+        when(mockSearchResponse.isTimedOut()).thenReturn(false);
+
+        // Mock getMemoryContainer with 3 parameters (memoryContainerId, tenantId, listener)
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(containerWithoutSemantic);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        // Mock checkMemoryContainerAccess (user is null from RestActionUtils.getUserContext)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(containerWithoutSemantic))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+
+        // Mock search operation
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            // Verify it uses match query for non-semantic search
+            assertNotNull(request.source());
+            assertNotNull(request.source().query());
+
+            listener.onResponse(mockSearchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any());
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any(), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(isNull(), eq(containerWithoutSemantic));
+        verify(client, times(1)).search(any(SearchRequest.class), any());
+
+        ArgumentCaptor<MLSearchMemoriesResponse> responseCaptor = ArgumentCaptor.forClass(MLSearchMemoriesResponse.class);
+        verify(actionListener, times(1)).onResponse(responseCaptor.capture());
+        verify(actionListener, never()).onFailure(any());
+
+        MLSearchMemoriesResponse response = responseCaptor.getValue();
+        assertNotNull(response);
+        assertEquals(0, response.getHits().size());
+    }
+
+    @Test
+    public void testDoExecute_GetContainerFailure() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(memoryContainerId).query("test query").build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        Exception expectedError = new RuntimeException("Container not found");
+
+        // Mock getMemoryContainer to fail
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onFailure(expectedError);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any(), any());
+        verify(memoryContainerHelper, never()).checkMemoryContainerAccess(any(), any());
+        verify(client, never()).search(any(), any());
+        verify(actionListener, times(1)).onFailure(expectedError);
+        verify(actionListener, never()).onResponse(any());
+    }
+
+    @Test
+    public void testDoExecute_AccessDenied() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(memoryContainerId).query("test query").build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        // Mock getMemoryContainer with 3 parameters (memoryContainerId, tenantId, listener)
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        // Mock checkMemoryContainerAccess to return false (user is null)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(false);
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any(), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(isNull(), eq(mockContainer));
+        verify(client, never()).search(any(), any());
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) capturedError).status());
+        assertTrue(capturedError.getMessage().contains("doesn't have permissions"));
+    }
+
+    @Test
+    public void testDoExecute_SearchFailure() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(memoryContainerId).query("test query").build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        Exception searchError = new RuntimeException("Search failed");
+
+        // Mock getMemoryContainer with 3 parameters (memoryContainerId, tenantId, listener)
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        // Mock checkMemoryContainerAccess (user is null from RestActionUtils.getUserContext)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+
+        // Mock search operation to fail
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onFailure(searchError);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any());
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any(), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(isNull(), eq(mockContainer));
+        verify(client, times(1)).search(any(SearchRequest.class), any());
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        verify(actionListener, never()).onResponse(any());
+
+        // TransportSearchMemoriesAction wraps the error in an OpenSearchException
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof org.opensearch.OpenSearchException);
+        assertTrue(capturedError.getMessage().contains("Search execution failed"));
+        assertNotNull(capturedError.getCause());
+        assertEquals("Search failed", capturedError.getCause().getMessage());
+    }
+
+    @Test
+    public void testDoExecute_WithSparseEncoding() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String query = "test query";
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(memoryContainerId).query(query).build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        // Setup container with sparse encoding
+        MLMemoryContainer sparseContainer = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .memoryStorageConfig(
+                MemoryStorageConfig
+                    .builder()
+                    .memoryIndexName("test-memory-index")
+                    .semanticStorageEnabled(true)
+                    .embeddingModelType(FunctionName.SPARSE_ENCODING)
+                    .embeddingModelId("sparse-model-123")
+                    .maxInferSize(10)
+                    .build()
+            )
+            .build();
+
+        // Mock search response
+        SearchResponse mockSearchResponse = mock(SearchResponse.class);
+        SearchHits searchHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0.0f);
+        when(mockSearchResponse.getHits()).thenReturn(searchHits);
+        when(mockSearchResponse.isTimedOut()).thenReturn(false);
+
+        // Mock getMemoryContainer with 3 parameters (memoryContainerId, tenantId, listener)
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(sparseContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        // Mock checkMemoryContainerAccess (user is null from RestActionUtils.getUserContext)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(sparseContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+
+        // Mock search operation
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            // Verify search request for sparse encoding
+            assertEquals("test-memory-index", request.indices()[0]);
+            // Note: Size limit has been removed in the actual implementation
+
+            listener.onResponse(mockSearchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any());
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any(), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(isNull(), eq(sparseContainer));
+        verify(client, times(1)).search(any(SearchRequest.class), any());
+
+        ArgumentCaptor<MLSearchMemoriesResponse> responseCaptor = ArgumentCaptor.forClass(MLSearchMemoriesResponse.class);
+        verify(actionListener, times(1)).onResponse(responseCaptor.capture());
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testDoExecute_ParseMemorySearchResult() throws Exception {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String query = "test query";
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(memoryContainerId).query(query).build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        // Mock search response with multiple results
+        SearchResponse mockSearchResponse = mock(SearchResponse.class);
+
+        // Create multiple search hits using real SearchHit objects
+        Map<String, Object> sourceMap1 = new HashMap<>();
+        sourceMap1.put("memory", "First memory");
+        sourceMap1.put("session_id", "session-1");
+        sourceMap1.put("user_id", "user-1");
+        sourceMap1.put("agent_id", "agent-1");
+        sourceMap1.put("memory_type", "RAW_MESSAGE");
+        sourceMap1.put("role", "user");
+        sourceMap1.put("tags", Map.of("key1", "value1"));
+        sourceMap1.put("created_time", 1700000000000L);
+        sourceMap1.put("last_updated_time", 1700000001000L);
+
+        SearchHit hit1 = createSearchHit(0, "memory-1", sourceMap1, 0.9f);
+
+        Map<String, Object> sourceMap2 = new HashMap<>();
+        sourceMap2.put("memory", "Second memory");
+        sourceMap2.put("session_id", "session-2");
+        sourceMap2.put("memory_type", "FACT");
+
+        SearchHit hit2 = createSearchHit(1, "memory-2", sourceMap2, 0.8f);
+
+        SearchHit[] hits = new SearchHit[] { hit1, hit2 };
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(2, TotalHits.Relation.EQUAL_TO), 0.9f);
+        when(mockSearchResponse.getHits()).thenReturn(searchHits);
+        when(mockSearchResponse.isTimedOut()).thenReturn(false);
+
+        // Mock getMemoryContainer with 3 parameters (memoryContainerId, tenantId, listener)
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        // Mock checkMemoryContainerAccess (user is null from RestActionUtils.getUserContext)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+
+        // Mock search operation
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mockSearchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any());
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        ArgumentCaptor<MLSearchMemoriesResponse> responseCaptor = ArgumentCaptor.forClass(MLSearchMemoriesResponse.class);
+        verify(actionListener, times(1)).onResponse(responseCaptor.capture());
+
+        MLSearchMemoriesResponse response = responseCaptor.getValue();
+        assertNotNull(response);
+        assertEquals(2, response.getHits().size());
+
+        // Verify first result
+        MemorySearchResult result1 = response.getHits().get(0);
+        assertEquals("memory-1", result1.getMemoryId());
+        assertEquals("First memory", result1.getMemory());
+        assertEquals(0.9f, result1.getScore(), 0.001);
+        assertEquals("session-1", result1.getSessionId());
+        assertEquals("user-1", result1.getUserId());
+        assertEquals("agent-1", result1.getAgentId());
+        assertEquals(MemoryType.RAW_MESSAGE, result1.getMemoryType());
+        assertEquals("user", result1.getRole());
+        assertNotNull(result1.getTags());
+        assertEquals("value1", result1.getTags().get("key1"));
+
+        // Verify second result
+        MemorySearchResult result2 = response.getHits().get(1);
+        assertEquals("memory-2", result2.getMemoryId());
+        assertEquals("Second memory", result2.getMemory());
+        assertEquals(0.8f, result2.getScore(), 0.001);
+        assertEquals(MemoryType.FACT, result2.getMemoryType());
+    }
+
+    @Test
+    public void testDoExecute_TimedOut() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(memoryContainerId).query("test query").build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        // Mock search response with timeout
+        SearchResponse mockSearchResponse = mock(SearchResponse.class);
+        SearchHits searchHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0.0f);
+        when(mockSearchResponse.getHits()).thenReturn(searchHits);
+        when(mockSearchResponse.isTimedOut()).thenReturn(true);
+
+        // Mock getMemoryContainer with 3 parameters (memoryContainerId, tenantId, listener)
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        // Mock checkMemoryContainerAccess (user is null from RestActionUtils.getUserContext)
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+
+        // Mock search operation
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mockSearchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any());
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        ArgumentCaptor<MLSearchMemoriesResponse> responseCaptor = ArgumentCaptor.forClass(MLSearchMemoriesResponse.class);
+        verify(actionListener, times(1)).onResponse(responseCaptor.capture());
+
+        MLSearchMemoriesResponse response = responseCaptor.getValue();
+        assertNotNull(response);
+        assertTrue(response.isTimedOut());
+        assertEquals(0, response.getHits().size());
+    }
+
+    @Test
+    public void testDoExecute_NullInput() {
+        // Arrange
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(null).tenantId(null).build();
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        verify(actionListener, never()).onResponse(any());
+
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof IllegalArgumentException);
+        assertEquals("Search memories input is required", capturedError.getMessage());
+
+        // Verify no other operations were performed
+        verify(memoryContainerHelper, never()).getMemoryContainer(any(), any(), any());
+        verify(client, never()).search(any(), any());
+    }
+
+    @Test
+    public void testDoExecute_BlankMemoryContainerId() {
+        // Arrange - test with blank (empty string) memory container ID
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId("").query("test query").build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        verify(actionListener, never()).onResponse(any());
+
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof IllegalArgumentException);
+        assertEquals("Memory container ID is required", capturedError.getMessage());
+
+        // Verify no other operations were performed
+        verify(memoryContainerHelper, never()).getMemoryContainer(any(), any(), any());
+        verify(client, never()).search(any(), any());
+    }
+
+    @Test
+    public void testDoExecute_NullMemoryContainerId() {
+        // Arrange - test with null memory container ID
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(null).query("test query").build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        verify(actionListener, never()).onResponse(any());
+
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof IllegalArgumentException);
+        assertEquals("Memory container ID is required", capturedError.getMessage());
+
+        // Verify no other operations were performed
+        verify(memoryContainerHelper, never()).getMemoryContainer(any(), any(), any());
+        verify(client, never()).search(any(), any());
+    }
+
+    @Test
+    public void testDoExecute_MultiTenancyEnabledWithNullTenantId() {
+        // Arrange - when multi-tenancy is enabled, null tenant ID should fail
+        String memoryContainerId = "container-123";
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(memoryContainerId).query("test query").build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest
+            .builder()
+            .mlSearchMemoriesInput(input)
+            .tenantId(null)  // null tenant ID when multi-tenancy is enabled
+            .build();
+
+        // Mock multi-tenancy to be enabled
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        verify(actionListener, never()).onResponse(any());
+
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof org.opensearch.OpenSearchStatusException);
+        assertEquals("You don't have permission to access this resource", capturedError.getMessage());
+
+        // Verify no other operations were performed
+        verify(memoryContainerHelper, never()).getMemoryContainer(any(), any(), any());
+        verify(client, never()).search(any(), any());
+    }
+
+    @Test
+    public void testDoExecute_WhitespaceOnlyMemoryContainerId() {
+        // Arrange - test with whitespace-only memory container ID
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId("   ").query("test query").build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        verify(actionListener, never()).onResponse(any());
+
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof IllegalArgumentException);
+        assertEquals("Memory container ID is required", capturedError.getMessage());
+
+        // Verify no other operations were performed
+        verify(memoryContainerHelper, never()).getMemoryContainer(any(), any(), any());
+        verify(client, never()).search(any(), any());
+    }
+
+    @Test
+    public void testSearchMemories_ParseSearchResponseFailure() {
+        // Arrange - create a scenario where parseSearchResponse throws an exception
+        String memoryContainerId = "container-123";
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(memoryContainerId).query("test query").build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        // Mock getMemoryContainer with 3 parameters
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        // Mock checkMemoryContainerAccess
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(true);
+
+        // Create a malformed SearchResponse that will cause parseSearchResponse to fail
+        // We'll mock a SearchResponse with null hits which should cause NPE in parseSearchResponse
+        SearchResponse malformedResponse = mock(SearchResponse.class);
+        when(malformedResponse.getHits()).thenReturn(null);  // This will cause NPE in parseSearchResponse
+
+        // Mock search operation to return malformed response
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(malformedResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any());
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        verify(actionListener, never()).onResponse(any());
+
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof org.opensearch.OpenSearchException);
+        assertTrue(capturedError.getMessage().contains("Failed to parse search response"));
+        assertNotNull(capturedError.getCause());
+
+        // Verify that search was called but parsing failed
+        verify(client, times(1)).search(any(SearchRequest.class), any());
+    }
+
+    @Test
+    public void testSearchMemories_SearchHitWithMissingFields() {
+        // Arrange - test parseSearchResponse with SearchHits missing required fields
+        String memoryContainerId = "container-123";
+        MLSearchMemoriesInput input = MLSearchMemoriesInput.builder().memoryContainerId(memoryContainerId).query("test query").build();
+        MLSearchMemoriesRequest searchRequest = MLSearchMemoriesRequest.builder().mlSearchMemoriesInput(input).tenantId(null).build();
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        // Mock checkMemoryContainerAccess
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(mockContainer))).thenReturn(true);
+
+        // Create SearchHit with sourceRef that will cause issues during parsing
+        SearchHit hitWithBadSource = new SearchHit(1, "mem_1", null, null);
+        // Set a sourceRef with invalid JSON that will cause parsing issues
+        String invalidJson = "{invalid json}";
+        hitWithBadSource.sourceRef(new BytesArray(invalidJson.getBytes()));
+
+        SearchHit[] hits = new SearchHit[] { hitWithBadSource };
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+
+        SearchResponse searchResponseWithBadHit = mock(SearchResponse.class);
+        when(searchResponseWithBadHit.getHits()).thenReturn(searchHits);
+        when(searchResponseWithBadHit.isTimedOut()).thenReturn(false);
+        when(searchResponseWithBadHit.getTook()).thenReturn(new TimeValue(100));
+
+        // Mock search operation
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponseWithBadHit);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any());
+
+        // Act
+        transportSearchMemoriesAction.doExecute(task, searchRequest, actionListener);
+
+        // Assert
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        verify(actionListener, never()).onResponse(any());
+
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof org.opensearch.OpenSearchException);
+        assertTrue(capturedError.getMessage().contains("Failed to parse search response"));
+
+        // Verify search was called
+        verify(client, times(1)).search(any(SearchRequest.class), any());
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportSearchMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportSearchMemoriesActionTests.java
@@ -119,6 +119,9 @@ public class TransportSearchMemoriesActionTests extends OpenSearchTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
+        // Mock ML feature settings
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
         // Setup mock container with semantic storage
         mockContainer = MLMemoryContainer
             .builder()
@@ -761,8 +764,14 @@ public class TransportSearchMemoriesActionTests extends OpenSearchTestCase {
         verify(actionListener, never()).onResponse(any());
 
         Exception capturedError = errorCaptor.getValue();
-        assertTrue(capturedError instanceof org.opensearch.OpenSearchException);
-        assertTrue(capturedError.getMessage().contains("Failed to parse search response"));
+        assertTrue(
+            "Expected OpenSearchException but got: " + capturedError.getClass().getName(),
+            capturedError instanceof org.opensearch.OpenSearchException
+        );
+        assertTrue(
+            "Expected message to contain 'Failed to parse search response' but got: " + capturedError.getMessage(),
+            capturedError.getMessage().contains("Failed to parse search response")
+        );
         assertNotNull(capturedError.getCause());
 
         // Verify that search was called but parsing failed

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
@@ -1,0 +1,621 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.memorycontainer.memory;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.get.GetResult;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
+import org.opensearch.ml.common.memorycontainer.MemoryStorageConfig;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryInput;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryRequest;
+import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.helper.MemoryContainerHelper;
+import org.opensearch.ml.helper.MemoryEmbeddingHelper;
+import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class TransportUpdateMemoryActionTests extends OpenSearchTestCase {
+
+    @Mock
+    private TransportService transportService;
+
+    @Mock
+    private ActionFilters actionFilters;
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private SdkClient sdkClient;
+
+    @Mock
+    private NamedXContentRegistry xContentRegistry;
+
+    @Mock
+    private ConnectorAccessControlHelper connectorAccessControlHelper;
+
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Mock
+    private MLModelManager mlModelManager;
+
+    @Mock
+    private MemoryContainerHelper memoryContainerHelper;
+
+    @Mock
+    private MemoryEmbeddingHelper memoryEmbeddingHelper;
+
+    @Mock
+    private ThreadPool threadPool;
+
+    private ThreadContext threadContext;
+
+    @Mock
+    private Task task;
+
+    @Mock
+    private ActionListener<UpdateResponse> actionListener;
+
+    private TransportUpdateMemoryAction transportUpdateMemoryAction;
+
+    private MLMemoryContainer mockContainer;
+    private Settings settings;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        settings = Settings.builder().build();
+
+        // Setup thread context with real instance
+        threadContext = new ThreadContext(settings);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        // Setup mock container with semantic storage
+        mockContainer = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .description("Test container")
+            .memoryStorageConfig(
+                MemoryStorageConfig
+                    .builder()
+                    .memoryIndexName("test-memory-index")
+                    .semanticStorageEnabled(true)
+                    .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                    .embeddingModelId("embedding-model-123")
+                    .dimension(768)
+                    .build()
+            )
+            .build();
+
+        // Initialize transport action
+        transportUpdateMemoryAction = spy(
+            new TransportUpdateMemoryAction(
+                transportService,
+                actionFilters,
+                client,
+                sdkClient,
+                xContentRegistry,
+                connectorAccessControlHelper,
+                mlFeatureEnabledSetting,
+                mlModelManager,
+                memoryContainerHelper,
+                memoryEmbeddingHelper
+            )
+        );
+    }
+
+    @Test
+    public void testDoExecute_Success() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        String newText = "Updated memory content";
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().text(newText).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        UpdateResponse mockUpdateResponse = mock(UpdateResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        GetResult mockGetResult = mock(GetResult.class);
+
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("memory", "original memory");
+
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+        when(memoryContainerHelper.validateMemoryIndexExists(eq(mockContainer), eq("update"), any())).thenReturn(true);
+
+        // Mock getMemoryIndexName
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer)).thenReturn("test-memory-index");
+
+        // Mock get operation
+        doAnswer(invocation -> {
+            GetRequest request = invocation.getArgument(0);
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            assertEquals("test-memory-index", request.index());
+            assertEquals(memoryId, request.id());
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        // Mock embedding generation
+        doAnswer(invocation -> {
+            ActionListener<Object> listener = invocation.getArgument(2);
+            Map<String, Float> embedding = new HashMap<>();
+            embedding.put("test", 0.5f);
+            listener.onResponse(embedding);
+            return null;
+        }).when(memoryEmbeddingHelper).generateEmbedding(anyString(), any(), any());
+
+        // Mock update operation
+        doAnswer(invocation -> {
+            UpdateRequest request = invocation.getArgument(0);
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            assertEquals("test-memory-index", request.index());
+            assertEquals(memoryId, request.id());
+            listener.onResponse(mockUpdateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), any());
+
+        // Act
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(any(), eq(mockContainer));
+        verify(memoryContainerHelper, times(1)).validateMemoryIndexExists(eq(mockContainer), eq("update"), any());
+        verify(client, times(1)).get(any(GetRequest.class), any());
+        verify(memoryEmbeddingHelper, times(1)).generateEmbedding(eq(newText), any(), any());
+        verify(client, times(1)).update(any(UpdateRequest.class), any());
+        verify(actionListener, times(1)).onResponse(mockUpdateResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testDoExecute_GetContainerFailure() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().text("new text").build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        Exception expectedError = new RuntimeException("Container not found");
+
+        // Mock getMemoryContainer to fail
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onFailure(expectedError);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Act
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, never()).checkMemoryContainerAccess(any(), any());
+        verify(client, never()).get(any(), any());
+        verify(client, never()).update(any(), any());
+        verify(actionListener, times(1)).onFailure(expectedError);
+        verify(actionListener, never()).onResponse(any());
+    }
+
+    @Test
+    public void testDoExecute_AccessDenied() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().text("new text").build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess to return false
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(false);
+
+        // Act
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(any(), eq(mockContainer));
+        verify(memoryContainerHelper, never()).validateMemoryIndexExists(any(), any(), any());
+        verify(client, never()).get(any(), any());
+        verify(client, never()).update(any(), any());
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) capturedError).status());
+        assertTrue(capturedError.getMessage().contains("doesn't have permissions"));
+    }
+
+    @Test
+    public void testDoExecute_MemoryNotFound() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().text("new text").build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        when(mockGetResponse.isExists()).thenReturn(false);
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+        when(memoryContainerHelper.validateMemoryIndexExists(eq(mockContainer), eq("update"), any())).thenReturn(true);
+
+        // Mock getMemoryIndexName
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer)).thenReturn("test-memory-index");
+
+        // Mock get operation to return not found
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        // Act
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(any(), eq(mockContainer));
+        verify(memoryContainerHelper, times(1)).validateMemoryIndexExists(eq(mockContainer), eq("update"), any());
+        verify(client, times(1)).get(any(GetRequest.class), any());
+        verify(client, never()).update(any(), any());
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.NOT_FOUND, ((OpenSearchStatusException) capturedError).status());
+        assertTrue(capturedError.getMessage().contains("Memory not found"));
+    }
+
+    @Test
+    public void testDoExecute_WithoutSemanticStorage() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        String newText = "Updated memory content";
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().text(newText).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        // Setup container without semantic storage
+        MLMemoryContainer containerWithoutSemantic = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .memoryStorageConfig(MemoryStorageConfig.builder().memoryIndexName("test-memory-index").semanticStorageEnabled(false).build())
+            .build();
+
+        UpdateResponse mockUpdateResponse = mock(UpdateResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("memory", "original memory");
+
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(containerWithoutSemantic);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(containerWithoutSemantic))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+        when(memoryContainerHelper.validateMemoryIndexExists(eq(containerWithoutSemantic), eq("update"), any())).thenReturn(true);
+
+        // Mock getMemoryIndexName
+        when(memoryContainerHelper.getMemoryIndexName(containerWithoutSemantic)).thenReturn("test-memory-index");
+
+        // Mock get operation
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        // Mock update operation
+        doAnswer(invocation -> {
+            UpdateRequest request = invocation.getArgument(0);
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+
+            // Verify no embedding field is added
+            Map<String, Object> updateFields = (Map<String, Object>) request.doc().sourceAsMap();
+            assertFalse(updateFields.containsKey("memory_embedding"));
+            assertTrue(updateFields.containsKey("memory"));
+            assertEquals(newText, updateFields.get("memory"));
+
+            listener.onResponse(mockUpdateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), any());
+
+        // Act
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(any(), eq(containerWithoutSemantic));
+        verify(memoryContainerHelper, times(1)).validateMemoryIndexExists(eq(containerWithoutSemantic), eq("update"), any());
+        verify(client, times(1)).get(any(GetRequest.class), any());
+        verify(memoryEmbeddingHelper, never()).generateEmbedding(any(), any(), any()); // No embedding generation
+        verify(client, times(1)).update(any(UpdateRequest.class), any());
+        verify(actionListener, times(1)).onResponse(mockUpdateResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testDoExecute_EmbeddingGenerationFailure() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        String newText = "Updated memory content";
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().text(newText).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("memory", "original memory");
+
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        Exception embeddingError = new RuntimeException("Embedding generation failed");
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+        when(memoryContainerHelper.validateMemoryIndexExists(eq(mockContainer), eq("update"), any())).thenReturn(true);
+
+        // Mock getMemoryIndexName
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer)).thenReturn("test-memory-index");
+
+        // Mock get operation
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        // Mock embedding generation to fail
+        doAnswer(invocation -> {
+            ActionListener<Object> listener = invocation.getArgument(2);
+            listener.onFailure(embeddingError);
+            return null;
+        }).when(memoryEmbeddingHelper).generateEmbedding(anyString(), any(), any());
+
+        // Mock update operation (should still happen without embedding)
+        UpdateResponse mockUpdateResponse = mock(UpdateResponse.class);
+        doAnswer(invocation -> {
+            UpdateRequest request = invocation.getArgument(0);
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+
+            // Verify no embedding field is added due to failure
+            Map<String, Object> updateFields = (Map<String, Object>) request.doc().sourceAsMap();
+            assertFalse(updateFields.containsKey("memory_embedding"));
+            assertTrue(updateFields.containsKey("memory"));
+            assertEquals(newText, updateFields.get("memory"));
+
+            listener.onResponse(mockUpdateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), any());
+
+        // Act
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(any(), eq(mockContainer));
+        verify(memoryContainerHelper, times(1)).validateMemoryIndexExists(eq(mockContainer), eq("update"), any());
+        verify(client, times(1)).get(any(GetRequest.class), any());
+        verify(memoryEmbeddingHelper, times(1)).generateEmbedding(eq(newText), any(), any());
+        verify(client, times(1)).update(any(UpdateRequest.class), any()); // Update should still happen without embedding
+        verify(actionListener, times(1)).onResponse(mockUpdateResponse); // Should succeed even without embedding
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testDoExecute_UpdateFailure() {
+        // Arrange
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        String newText = "Updated memory content";
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().text(newText).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("memory", "original memory");
+
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        Exception updateError = new RuntimeException("Update failed");
+
+        // Setup container without semantic storage for simpler test
+        MLMemoryContainer containerWithoutSemantic = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .memoryStorageConfig(MemoryStorageConfig.builder().memoryIndexName("test-memory-index").semanticStorageEnabled(false).build())
+            .build();
+
+        // Mock getMemoryContainer
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onResponse(containerWithoutSemantic);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any());
+
+        // Mock checkMemoryContainerAccess
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(containerWithoutSemantic))).thenReturn(true);
+
+        // Mock validateMemoryIndexExists
+        when(memoryContainerHelper.validateMemoryIndexExists(eq(containerWithoutSemantic), eq("update"), any())).thenReturn(true);
+
+        // Mock getMemoryIndexName
+        when(memoryContainerHelper.getMemoryIndexName(containerWithoutSemantic)).thenReturn("test-memory-index");
+
+        // Mock get operation
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        // Mock update operation to fail
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onFailure(updateError);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), any());
+
+        // Act
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        // Assert
+        verify(memoryContainerHelper, times(1)).getMemoryContainer(eq(memoryContainerId), any());
+        verify(memoryContainerHelper, times(1)).checkMemoryContainerAccess(any(), eq(containerWithoutSemantic));
+        verify(memoryContainerHelper, times(1)).validateMemoryIndexExists(eq(containerWithoutSemantic), eq("update"), any());
+        verify(client, times(1)).get(any(GetRequest.class), any());
+        verify(client, times(1)).update(any(UpdateRequest.class), any());
+        verify(actionListener, times(1)).onFailure(updateError);
+        verify(actionListener, never()).onResponse(any());
+    }
+
+    @Test
+    public void testFromActionRequest() {
+        // Test that MLUpdateMemoryRequest.fromActionRequest works correctly
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().text("updated text").build();
+        MLUpdateMemoryRequest originalRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId("container-123")
+            .memoryId("memory-456")
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        MLUpdateMemoryRequest convertedRequest = MLUpdateMemoryRequest.fromActionRequest(originalRequest);
+
+        assertEquals(input, convertedRequest.getMlUpdateMemoryInput());
+    }
+
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
@@ -113,6 +113,9 @@ public class TransportUpdateMemoryActionTests extends OpenSearchTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
+        // Mock ML feature settings
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
         // Setup mock container with semantic storage
         mockContainer = MLMemoryContainer
             .builder()

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLAddMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLAddMemoriesActionTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORIES_PATH;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLAddMemoriesAction;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLAddMemoriesRequest;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLAddMemoriesResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestMLAddMemoriesActionTests extends OpenSearchTestCase {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private RestMLAddMemoriesAction restMLAddMemoriesAction;
+    private NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        restMLAddMemoriesAction = new RestMLAddMemoriesAction();
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<MLAddMemoriesResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLAddMemoriesAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
+    }
+
+    public void testGetName() {
+        assertEquals("ml_add_memories_action", restMLAddMemoriesAction.getName());
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = restMLAddMemoriesAction.routes();
+        assertNotNull(routes);
+        assertEquals(1, routes.size());
+        assertEquals(RestRequest.Method.POST, routes.get(0).getMethod());
+        assertEquals(MEMORIES_PATH, routes.get(0).getPath());
+    }
+
+    public void testPrepareRequest() throws Exception {
+        RestRequest request = getRestRequest();
+        restMLAddMemoriesAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLAddMemoriesRequest> argumentCaptor = ArgumentCaptor.forClass(MLAddMemoriesRequest.class);
+        verify(client, times(1)).execute(eq(MLAddMemoriesAction.INSTANCE), argumentCaptor.capture(), any());
+
+        MLAddMemoriesRequest capturedRequest = argumentCaptor.getValue();
+        assertNotNull(capturedRequest);
+    }
+
+    public void testPrepareRequestWithoutContent() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "test-container-id");
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath(MEMORIES_PATH)
+            .withParams(params)
+            .build();
+
+        Exception exception = expectThrows(Exception.class, () -> { restMLAddMemoriesAction.handleRequest(request, channel, client); });
+
+        assertTrue(exception.getMessage().contains("empty body"));
+    }
+
+    public void testPrepareRequestWithMissingContainerId() throws Exception {
+        String requestContent = "{\"messages\":[{\"role\":\"user\",\"content\":\"test message\"}]}";
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath(MEMORIES_PATH)
+            .withContent(new BytesArray(requestContent), MediaType.fromMediaType("application/json"))
+            .build();
+
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> {
+            restMLAddMemoriesAction.handleRequest(request, channel, client);
+        });
+
+        assertNotNull(exception);
+    }
+
+    private RestRequest getRestRequest() {
+        String requestContent = "{\"messages\":[{\"role\":\"user\",\"content\":\"test message\"}]}";
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "test-container-id");
+
+        return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath(MEMORIES_PATH)
+            .withParams(params)
+            .withContent(new BytesArray(requestContent), MediaType.fromMediaType("application/json"))
+            .build();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLAddMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLAddMemoriesActionTests.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORIES_PATH;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
 
@@ -29,6 +30,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLAddMemoriesAction;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLAddMemoriesRequest;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLAddMemoriesResponse;
@@ -50,12 +52,16 @@ public class RestMLAddMemoriesActionTests extends OpenSearchTestCase {
     private ThreadPool threadPool;
 
     @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Mock
     RestChannel channel;
 
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        restMLAddMemoriesAction = new RestMLAddMemoriesAction();
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        restMLAddMemoriesAction = new RestMLAddMemoriesAction(mlFeatureEnabledSetting);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
         client = spy(new NodeClient(Settings.EMPTY, threadPool));

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteMemoryActionTests.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DELETE_MEMORY_PATH;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_ID;
@@ -29,6 +30,7 @@ import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLDeleteMemoryAction;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLDeleteMemoryRequest;
 import org.opensearch.rest.RestChannel;
@@ -49,12 +51,16 @@ public class RestMLDeleteMemoryActionTests extends OpenSearchTestCase {
     private ThreadPool threadPool;
 
     @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Mock
     RestChannel channel;
 
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        restMLDeleteMemoryAction = new RestMLDeleteMemoryAction();
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        restMLDeleteMemoryAction = new RestMLDeleteMemoryAction(mlFeatureEnabledSetting);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
         client = spy(new NodeClient(Settings.EMPTY, threadPool));

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteMemoryActionTests.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DELETE_MEMORY_PATH;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_ID;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLDeleteMemoryAction;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLDeleteMemoryRequest;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestMLDeleteMemoryActionTests extends OpenSearchTestCase {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private RestMLDeleteMemoryAction restMLDeleteMemoryAction;
+    private NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        restMLDeleteMemoryAction = new RestMLDeleteMemoryAction();
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLDeleteMemoryAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
+    }
+
+    public void testGetName() {
+        assertEquals("ml_delete_memory_action", restMLDeleteMemoryAction.getName());
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = restMLDeleteMemoryAction.routes();
+        assertNotNull(routes);
+        assertEquals(1, routes.size());
+        assertEquals(RestRequest.Method.DELETE, routes.get(0).getMethod());
+        assertEquals(DELETE_MEMORY_PATH, routes.get(0).getPath());
+    }
+
+    public void testPrepareRequest() throws Exception {
+        RestRequest request = getRestRequest();
+        restMLDeleteMemoryAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLDeleteMemoryRequest> argumentCaptor = ArgumentCaptor.forClass(MLDeleteMemoryRequest.class);
+        verify(client, times(1)).execute(eq(MLDeleteMemoryAction.INSTANCE), argumentCaptor.capture(), any());
+
+        MLDeleteMemoryRequest capturedRequest = argumentCaptor.getValue();
+        assertNotNull(capturedRequest);
+        assertEquals("test-container-id", capturedRequest.getMemoryContainerId());
+        assertEquals("test-memory-id", capturedRequest.getMemoryId());
+    }
+
+    public void testPrepareRequestWithMissingContainerId() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_ID, "test-memory-id");
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.DELETE)
+            .withPath(DELETE_MEMORY_PATH)
+            .withParams(params)
+            .build();
+
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> {
+            restMLDeleteMemoryAction.handleRequest(request, channel, client);
+        });
+
+        assertNotNull(exception);
+    }
+
+    public void testPrepareRequestWithMissingMemoryId() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "test-container-id");
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.DELETE)
+            .withPath(DELETE_MEMORY_PATH)
+            .withParams(params)
+            .build();
+
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> {
+            restMLDeleteMemoryAction.handleRequest(request, channel, client);
+        });
+
+        assertNotNull(exception);
+    }
+
+    public void testPrepareRequestWithEmptyIds() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "");
+        params.put(PARAMETER_MEMORY_ID, "");
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.DELETE)
+            .withPath(DELETE_MEMORY_PATH)
+            .withParams(params)
+            .build();
+
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> {
+            restMLDeleteMemoryAction.handleRequest(request, channel, client);
+        });
+
+        assertNotNull(exception);
+    }
+
+    public void testPrepareRequestWithSpecialCharacters() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "container-with-dashes-123");
+        params.put(PARAMETER_MEMORY_ID, "memory_with_underscores_456");
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.DELETE)
+            .withPath(DELETE_MEMORY_PATH)
+            .withParams(params)
+            .build();
+
+        restMLDeleteMemoryAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLDeleteMemoryRequest> argumentCaptor = ArgumentCaptor.forClass(MLDeleteMemoryRequest.class);
+        verify(client, times(1)).execute(eq(MLDeleteMemoryAction.INSTANCE), argumentCaptor.capture(), any());
+
+        MLDeleteMemoryRequest capturedRequest = argumentCaptor.getValue();
+        assertNotNull(capturedRequest);
+        assertEquals("container-with-dashes-123", capturedRequest.getMemoryContainerId());
+        assertEquals("memory_with_underscores_456", capturedRequest.getMemoryId());
+    }
+
+    private RestRequest getRestRequest() {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "test-container-id");
+        params.put(PARAMETER_MEMORY_ID, "test-memory-id");
+
+        return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.DELETE)
+            .withPath(DELETE_MEMORY_PATH)
+            .withParams(params)
+            .build();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchMemoriesActionTests.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SEARCH_MEMORIES_PATH;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLSearchMemoriesAction;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLSearchMemoriesRequest;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLSearchMemoriesResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestMLSearchMemoriesActionTests extends OpenSearchTestCase {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private RestMLSearchMemoriesAction restMLSearchMemoriesAction;
+    private NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
+    @Mock
+    MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+        restMLSearchMemoriesAction = new RestMLSearchMemoriesAction(mlFeatureEnabledSetting);
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<MLSearchMemoriesResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLSearchMemoriesAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
+    }
+
+    public void testGetName() {
+        assertEquals("ml_search_memories_action", restMLSearchMemoriesAction.getName());
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = restMLSearchMemoriesAction.routes();
+        assertNotNull(routes);
+        assertEquals(2, routes.size());
+
+        // Check both POST and GET routes are registered
+        boolean hasPost = false;
+        boolean hasGet = false;
+        for (RestHandler.Route route : routes) {
+            if (route.getMethod() == RestRequest.Method.POST) {
+                hasPost = true;
+                assertEquals(SEARCH_MEMORIES_PATH, route.getPath());
+            }
+            if (route.getMethod() == RestRequest.Method.GET) {
+                hasGet = true;
+                assertEquals(SEARCH_MEMORIES_PATH, route.getPath());
+            }
+        }
+        assertTrue(hasPost);
+        assertTrue(hasGet);
+    }
+
+    public void testPrepareRequestWithPost() throws Exception {
+        RestRequest request = getRestRequest(RestRequest.Method.POST);
+        restMLSearchMemoriesAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLSearchMemoriesRequest> argumentCaptor = ArgumentCaptor.forClass(MLSearchMemoriesRequest.class);
+        verify(client, times(1)).execute(eq(MLSearchMemoriesAction.INSTANCE), argumentCaptor.capture(), any());
+
+        MLSearchMemoriesRequest capturedRequest = argumentCaptor.getValue();
+        assertNotNull(capturedRequest);
+    }
+
+    public void testPrepareRequestWithGet() throws Exception {
+        RestRequest request = getRestRequest(RestRequest.Method.GET);
+        restMLSearchMemoriesAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLSearchMemoriesRequest> argumentCaptor = ArgumentCaptor.forClass(MLSearchMemoriesRequest.class);
+        verify(client, times(1)).execute(eq(MLSearchMemoriesAction.INSTANCE), argumentCaptor.capture(), any());
+
+        MLSearchMemoriesRequest capturedRequest = argumentCaptor.getValue();
+        assertNotNull(capturedRequest);
+    }
+
+    public void testPrepareRequestWithoutContent() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "test-container-id");
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath(SEARCH_MEMORIES_PATH)
+            .withParams(params)
+            .build();
+
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> {
+            restMLSearchMemoriesAction.handleRequest(request, channel, client);
+        });
+
+        assertTrue(exception.getMessage().contains("empty body"));
+    }
+
+    public void testPrepareRequestWithMissingContainerId() throws Exception {
+        String requestContent = "{\"query\":\"test search query\"}";
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath(SEARCH_MEMORIES_PATH)
+            .withContent(new BytesArray(requestContent), MediaType.fromMediaType("application/json"))
+            .build();
+
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> {
+            restMLSearchMemoriesAction.handleRequest(request, channel, client);
+        });
+
+        assertNotNull(exception);
+    }
+
+    public void testPrepareRequestWithMultiTenancy() throws Exception {
+        // Test that multi-tenancy setting is checked
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+        
+        RestRequest request = getRestRequest(RestRequest.Method.POST);
+        restMLSearchMemoriesAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLSearchMemoriesRequest> argumentCaptor = ArgumentCaptor.forClass(MLSearchMemoriesRequest.class);
+        verify(client, times(1)).execute(eq(MLSearchMemoriesAction.INSTANCE), argumentCaptor.capture(), any());
+        
+        MLSearchMemoriesRequest capturedRequest = argumentCaptor.getValue();
+        assertNotNull(capturedRequest);
+        
+        // Verify that multi-tenancy setting was checked
+        verify(mlFeatureEnabledSetting, times(1)).isMultiTenancyEnabled();
+    }
+
+    private RestRequest getRestRequest(RestRequest.Method method) {
+        String requestContent = "{\"query\":\"test search query\"}";
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "test-container-id");
+
+        return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(method)
+            .withPath(SEARCH_MEMORIES_PATH)
+            .withParams(params)
+            .withContent(new BytesArray(requestContent), MediaType.fromMediaType("application/json"))
+            .build();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchMemoriesActionTests.java
@@ -61,6 +61,7 @@ public class RestMLSearchMemoriesActionTests extends OpenSearchTestCase {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         restMLSearchMemoriesAction = new RestMLSearchMemoriesAction(mlFeatureEnabledSetting);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLUpdateMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLUpdateMemoryActionTests.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_ID;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.UPDATE_MEMORY_PATH;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryAction;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryRequest;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestMLUpdateMemoryActionTests extends OpenSearchTestCase {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private RestMLUpdateMemoryAction restMLUpdateMemoryAction;
+    private NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        restMLUpdateMemoryAction = new RestMLUpdateMemoryAction();
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLUpdateMemoryAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
+    }
+
+    public void testGetName() {
+        assertEquals("ml_update_memory_action", restMLUpdateMemoryAction.getName());
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = restMLUpdateMemoryAction.routes();
+        assertNotNull(routes);
+        assertEquals(1, routes.size());
+        assertEquals(RestRequest.Method.PUT, routes.get(0).getMethod());
+        assertEquals(UPDATE_MEMORY_PATH, routes.get(0).getPath());
+    }
+
+    public void testPrepareRequest() throws Exception {
+        RestRequest request = getRestRequest();
+        restMLUpdateMemoryAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLUpdateMemoryRequest> argumentCaptor = ArgumentCaptor.forClass(MLUpdateMemoryRequest.class);
+        verify(client, times(1)).execute(eq(MLUpdateMemoryAction.INSTANCE), argumentCaptor.capture(), any());
+
+        MLUpdateMemoryRequest capturedRequest = argumentCaptor.getValue();
+        assertNotNull(capturedRequest);
+        assertEquals("test-container-id", capturedRequest.getMemoryContainerId());
+        assertEquals("test-memory-id", capturedRequest.getMemoryId());
+    }
+
+    public void testPrepareRequestWithoutContent() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "test-container-id");
+        params.put(PARAMETER_MEMORY_ID, "test-memory-id");
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.PUT)
+            .withPath(UPDATE_MEMORY_PATH)
+            .withParams(params)
+            .build();
+
+        Exception exception = expectThrows(Exception.class, () -> { restMLUpdateMemoryAction.handleRequest(request, channel, client); });
+
+        assertTrue(exception.getMessage().contains("empty body"));
+    }
+
+    public void testPrepareRequestWithMissingContainerId() throws Exception {
+        String requestContent = "{\"text\":\"new text\"}";
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_ID, "test-memory-id");
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.PUT)
+            .withPath(UPDATE_MEMORY_PATH)
+            .withParams(params)
+            .withContent(new BytesArray(requestContent), MediaType.fromMediaType("application/json"))
+            .build();
+
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> {
+            restMLUpdateMemoryAction.handleRequest(request, channel, client);
+        });
+
+        assertNotNull(exception);
+    }
+
+    public void testPrepareRequestWithMissingMemoryId() throws Exception {
+        String requestContent = "{\"text\":\"new text\"}";
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "test-container-id");
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.PUT)
+            .withPath(UPDATE_MEMORY_PATH)
+            .withParams(params)
+            .withContent(new BytesArray(requestContent), MediaType.fromMediaType("application/json"))
+            .build();
+
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> {
+            restMLUpdateMemoryAction.handleRequest(request, channel, client);
+        });
+
+        assertNotNull(exception);
+    }
+
+    public void testPrepareRequestWithEmptyText() throws Exception {
+        String requestContent = "{\"text\":\"\"}";
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "test-container-id");
+        params.put(PARAMETER_MEMORY_ID, "test-memory-id");
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.PUT)
+            .withPath(UPDATE_MEMORY_PATH)
+            .withParams(params)
+            .withContent(new BytesArray(requestContent), MediaType.fromMediaType("application/json"))
+            .build();
+
+        // Empty text is not allowed
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> {
+            restMLUpdateMemoryAction.handleRequest(request, channel, client);
+        });
+
+        assertNotNull(exception);
+        assertTrue(exception.getMessage().contains("empty") || exception.getMessage().contains("null"));
+    }
+
+    public void testPrepareRequestWithLongText() throws Exception {
+        // Test with a very long text content
+        StringBuilder longText = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            longText.append("This is line ").append(i).append(" of a long text. ");
+        }
+        String requestContent = "{\"text\":\"" + longText.toString().replace("\"", "\\\"") + "\"}";
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "test-container-id");
+        params.put(PARAMETER_MEMORY_ID, "test-memory-id");
+
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.PUT)
+            .withPath(UPDATE_MEMORY_PATH)
+            .withParams(params)
+            .withContent(new BytesArray(requestContent), MediaType.fromMediaType("application/json"))
+            .build();
+
+        restMLUpdateMemoryAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLUpdateMemoryRequest> argumentCaptor = ArgumentCaptor.forClass(MLUpdateMemoryRequest.class);
+        verify(client, times(1)).execute(eq(MLUpdateMemoryAction.INSTANCE), argumentCaptor.capture(), any());
+
+        MLUpdateMemoryRequest capturedRequest = argumentCaptor.getValue();
+        assertNotNull(capturedRequest);
+    }
+
+    private RestRequest getRestRequest() {
+        String requestContent = "{\"text\":\"updated memory content\"}";
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAMETER_MEMORY_CONTAINER_ID, "test-container-id");
+        params.put(PARAMETER_MEMORY_ID, "test-memory-id");
+
+        return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.PUT)
+            .withPath(UPDATE_MEMORY_PATH)
+            .withParams(params)
+            .withContent(new BytesArray(requestContent), MediaType.fromMediaType("application/json"))
+            .build();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLUpdateMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLUpdateMemoryActionTests.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_ID;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.UPDATE_MEMORY_PATH;
@@ -31,6 +32,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryAction;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryRequest;
 import org.opensearch.rest.RestChannel;
@@ -51,12 +53,16 @@ public class RestMLUpdateMemoryActionTests extends OpenSearchTestCase {
     private ThreadPool threadPool;
 
     @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Mock
     RestChannel channel;
 
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        restMLUpdateMemoryAction = new RestMLUpdateMemoryAction();
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        restMLUpdateMemoryAction = new RestMLUpdateMemoryAction(mlFeatureEnabledSetting);
 
         threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
         client = spy(new NodeClient(Settings.EMPTY, threadPool));


### PR DESCRIPTION
### Description
This PR specifically used to address comments or concerns in Memory API

- Add UT coverage for memories API
- suppres NONE event in add memories response
- Use XContentParserUtils.ensureExpectedToken instead of overriding

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
