### PR TITLE
Refactor checks to ML Indices to return true when MultiTenancy enabled

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
@@ -174,7 +174,7 @@ public class MLAgentExecutor implements Executable, SettingsChangeListener {
             .fetchSourceContext(fetchSourceContext)
             .build();
 
-        if (MLIndicesHandler.doesMultiTenantIndexExists(clusterService, mlFeatureEnabledSetting.isMultiTenancyEnabled(), ML_AGENT_INDEX)) {
+        if (MLIndicesHandler.doesMultiTenantIndexExist(clusterService, mlFeatureEnabledSetting.isMultiTenancyEnabled(), ML_AGENT_INDEX)) {
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
                 sdkClient
                     .getDataObjectAsync(getDataObjectRequest, client.threadPool().executor("opensearch_ml_general"))

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
@@ -68,6 +68,7 @@ import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.engine.Executable;
 import org.opensearch.ml.engine.annotation.Function;
 import org.opensearch.ml.engine.encryptor.Encryptor;
+import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.engine.memory.ConversationIndexMemory;
 import org.opensearch.ml.engine.memory.ConversationIndexMessage;
 import org.opensearch.ml.engine.tools.QueryPlanningTool;
@@ -173,7 +174,7 @@ public class MLAgentExecutor implements Executable, SettingsChangeListener {
             .fetchSourceContext(fetchSourceContext)
             .build();
 
-        if (clusterService.state().metadata().hasIndex(ML_AGENT_INDEX)) {
+        if (MLIndicesHandler.doesMultiTenantIndexExists(clusterService, mlFeatureEnabledSetting.isMultiTenancyEnabled(), ML_AGENT_INDEX)) {
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
                 sdkClient
                     .getDataObjectAsync(getDataObjectRequest, client.threadPool().executor("opensearch_ml_general"))

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import lombok.NonNull;
 import org.opensearch.OpenSearchWrapperException;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -37,6 +36,7 @@ import org.opensearch.transport.client.Client;
 import com.google.common.annotations.VisibleForTesting;
 
 import lombok.AccessLevel;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.log4j.Log4j2;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
@@ -54,6 +54,17 @@ public class MLIndicesHandler {
         }
     }
 
+    /**
+     * Determines whether an index exists on non-multi tenancy enabled environments. Otherwise,
+     * returns true when multiTenancy is Enabled
+     *
+     * @param clusterService the cluster service
+     * @param isMultiTenancyEnabled whether multi-tenancy is enabled
+     * @param indexName - the index to search
+     * @return boolean indicating the existence of an index. Returns true if multitenancy is enabled.
+     * @implNote It is recommended that if your environment enables multi tenancy, your plugin indices are
+     * pre-populated otherwise this method will result in unwanted early returns without checking the clusterService
+     */
     public static boolean doesMultiTenantIndexExists(ClusterService clusterService, boolean isMultiTenancyEnabled, String indexName) {
         return isMultiTenancyEnabled || clusterService.state().metadata().hasIndex(indexName);
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import lombok.NonNull;
 import org.opensearch.OpenSearchWrapperException;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -44,9 +45,11 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 @Log4j2
 public class MLIndicesHandler {
-
+    @NonNull
     ClusterService clusterService;
+    @NonNull
     Client client;
+    @NonNull
     MLFeatureEnabledSetting mlFeatureEnabledSetting;
     private static final Map<String, AtomicBoolean> indexMappingUpdated = new HashMap<>();
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/indices/MLIndicesHandler.java
@@ -67,8 +67,8 @@ public class MLIndicesHandler {
      * @param isMultiTenancyEnabled whether multi-tenancy is enabled
      * @param indexName - the index to search
      * @return boolean indicating the existence of an index. Returns true if multitenancy is enabled.
-     * @implNote It is recommended that if your environment enables multi tenancy, your plugin indices are
-     * pre-populated otherwise this method will result in unwanted early returns without checking the clusterService
+     * @implNote This method assumes if your environment enables multi tenancy, then your plugin indices are
+     * pre-populated. If this is incorrect, it will result in unwanted early returns without checking the clusterService.
      */
     public static boolean doesMultiTenantIndexExist(ClusterService clusterService, boolean isMultiTenancyEnabled, String indexName) {
         return isMultiTenancyEnabled || clusterService.state().metadata().hasIndex(indexName);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/indices/MLIndicesHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/indices/MLIndicesHandlerTest.java
@@ -35,6 +35,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
@@ -74,6 +75,9 @@ public class MLIndicesHandlerTest {
     @Mock
     private ThreadPool threadPool;
 
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
     Settings settings;
     ThreadContext threadContext;
     MLIndicesHandler indicesHandler;
@@ -102,7 +106,7 @@ public class MLIndicesHandlerTest {
         threadContext = new ThreadContext(settings);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
-        indicesHandler = new MLIndicesHandler(clusterService, client);
+        indicesHandler = new MLIndicesHandler(clusterService, client, mlFeatureEnabledSetting);
     }
 
     @Test

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/ExecuteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/ExecuteConnectorTransportAction.java
@@ -26,6 +26,7 @@ import org.opensearch.ml.common.transport.connector.MLExecuteConnectorRequest;
 import org.opensearch.ml.engine.MLEngineClassLoader;
 import org.opensearch.ml.engine.algorithms.remote.RemoteConnectorExecutor;
 import org.opensearch.ml.engine.encryptor.EncryptorImpl;
+import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.script.ScriptService;
 import org.opensearch.tasks.Task;
@@ -74,7 +75,8 @@ public class ExecuteConnectorTransportAction extends HandledTransportAction<Acti
         String connectorId = executeConnectorRequest.getConnectorId();
         String connectorAction = ConnectorAction.ActionType.EXECUTE.name();
 
-        if (clusterService.state().metadata().hasIndex(ML_CONNECTOR_INDEX)) {
+        if (MLIndicesHandler
+            .doesMultiTenantIndexExists(clusterService, mlFeatureEnabledSetting.isMultiTenancyEnabled(), ML_CONNECTOR_INDEX)) {
             ActionListener<Connector> listener = ActionListener.wrap(connector -> {
                 if (connectorAccessControlHelper.validateConnectorAccess(client, connector)) {
                     // adding tenantID as null, because we are not implement multi-tenancy for this feature yet.

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/ExecuteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/ExecuteConnectorTransportAction.java
@@ -76,7 +76,7 @@ public class ExecuteConnectorTransportAction extends HandledTransportAction<Acti
         String connectorAction = ConnectorAction.ActionType.EXECUTE.name();
 
         if (MLIndicesHandler
-            .doesMultiTenantIndexExists(clusterService, mlFeatureEnabledSetting.isMultiTenancyEnabled(), ML_CONNECTOR_INDEX)) {
+            .doesMultiTenantIndexExist(clusterService, mlFeatureEnabledSetting.isMultiTenancyEnabled(), ML_CONNECTOR_INDEX)) {
             ActionListener<Connector> listener = ActionListener.wrap(connector -> {
                 if (connectorAccessControlHelper.validateConnectorAccess(client, connector)) {
                     // adding tenantID as null, because we are not implement multi-tenancy for this feature yet.

--- a/plugin/src/main/java/org/opensearch/ml/action/handler/MLSearchHandler.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/handler/MLSearchHandler.java
@@ -138,7 +138,7 @@ public class MLSearchHandler {
                 .wrap(wrappedListener::onResponse, e -> wrapListenerToHandleSearchIndexNotFound(e, wrappedListener));
             if (modelAccessControlHelper.skipModelAccessControl(user)
                 || !MLIndicesHandler
-                    .doesMultiTenantIndexExists(
+                    .doesMultiTenantIndexExist(
                         clusterService,
                         mlFeatureEnabledSetting.isMultiTenancyEnabled(),
                         CommonValue.ML_MODEL_GROUP_INDEX

--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/CancelBatchJobTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/CancelBatchJobTransportAction.java
@@ -55,6 +55,7 @@ import org.opensearch.ml.engine.MLEngineClassLoader;
 import org.opensearch.ml.engine.algorithms.remote.ConnectorUtils;
 import org.opensearch.ml.engine.algorithms.remote.RemoteConnectorExecutor;
 import org.opensearch.ml.engine.encryptor.EncryptorImpl;
+import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.model.MLModelManager;
@@ -199,7 +200,12 @@ public class CancelBatchJobTransportAction extends HandledTransportAction<Action
                         if (model.getConnector() != null) {
                             Connector connector = model.getConnector();
                             executeConnector(connector, mlInput, actionListener);
-                        } else if (clusterService.state().metadata().hasIndex(ML_CONNECTOR_INDEX)) {
+                        } else if (MLIndicesHandler
+                            .doesMultiTenantIndexExists(
+                                clusterService,
+                                mlFeatureEnabledSetting.isMultiTenancyEnabled(),
+                                ML_CONNECTOR_INDEX
+                            )) {
                             ActionListener<Connector> listener = ActionListener
                                 .wrap(connector -> { executeConnector(connector, mlInput, actionListener); }, e -> {
                                     log.error("Failed to get connector {}", model.getConnectorId(), e);

--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/CancelBatchJobTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/CancelBatchJobTransportAction.java
@@ -201,7 +201,7 @@ public class CancelBatchJobTransportAction extends HandledTransportAction<Action
                             Connector connector = model.getConnector();
                             executeConnector(connector, mlInput, actionListener);
                         } else if (MLIndicesHandler
-                            .doesMultiTenantIndexExists(
+                            .doesMultiTenantIndexExist(
                                 clusterService,
                                 mlFeatureEnabledSetting.isMultiTenancyEnabled(),
                                 ML_CONNECTOR_INDEX

--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
@@ -392,7 +392,7 @@ public class GetTaskTransportAction extends HandledTransportAction<ActionRequest
                                             actionListener
                                         );
                                     } else if (MLIndicesHandler
-                                        .doesMultiTenantIndexExists(
+                                        .doesMultiTenantIndexExist(
                                             clusterService,
                                             mlFeatureEnabledSetting.isMultiTenancyEnabled(),
                                             ML_CONNECTOR_INDEX

--- a/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/tasks/GetTaskTransportAction.java
@@ -82,6 +82,7 @@ import org.opensearch.ml.engine.MLEngineClassLoader;
 import org.opensearch.ml.engine.algorithms.remote.ConnectorUtils;
 import org.opensearch.ml.engine.algorithms.remote.RemoteConnectorExecutor;
 import org.opensearch.ml.engine.encryptor.EncryptorImpl;
+import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.engine.utils.S3Utils;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
@@ -390,7 +391,12 @@ public class GetTaskTransportAction extends HandledTransportAction<ActionRequest
                                             remoteJob,
                                             actionListener
                                         );
-                                    } else if (clusterService.state().metadata().hasIndex(ML_CONNECTOR_INDEX)) {
+                                    } else if (MLIndicesHandler
+                                        .doesMultiTenantIndexExists(
+                                            clusterService,
+                                            mlFeatureEnabledSetting.isMultiTenancyEnabled(),
+                                            ML_CONNECTOR_INDEX
+                                        )) {
                                         ActionListener<Connector> listener = ActionListener.wrap(connector -> {
                                             executeConnector(
                                                 connector,

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -599,6 +599,7 @@ public class MachineLearningPlugin extends Plugin
         Settings settings = environment.settings();
         Path dataPath = environment.dataFiles()[0];
 
+        mlFeatureEnabledSetting = new MLFeatureEnabledSetting(clusterService, settings);
         mlIndicesHandler = new MLIndicesHandler(clusterService, client, mlFeatureEnabledSetting);
 
         SdkClient sdkClient = SdkClientFactory
@@ -665,7 +666,6 @@ public class MachineLearningPlugin extends Plugin
         mlInputDatasetHandler = new MLInputDatasetHandler(client);
         modelAccessControlHelper = new ModelAccessControlHelper(clusterService, settings);
         connectorAccessControlHelper = new ConnectorAccessControlHelper(clusterService, settings);
-        mlFeatureEnabledSetting = new MLFeatureEnabledSetting(clusterService, settings);
         mlModelManager = new MLModelManager(
             clusterService,
             scriptService,

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -599,7 +599,7 @@ public class MachineLearningPlugin extends Plugin
         Settings settings = environment.settings();
         Path dataPath = environment.dataFiles()[0];
 
-        mlIndicesHandler = new MLIndicesHandler(clusterService, client);
+        mlIndicesHandler = new MLIndicesHandler(clusterService, client, mlFeatureEnabledSetting);
 
         SdkClient sdkClient = SdkClientFactory
             .createSdkClient(
@@ -802,7 +802,13 @@ public class MachineLearningPlugin extends Plugin
         MLToolExecutor toolExecutor = new MLToolExecutor(client, sdkClient, settings, clusterService, xContentRegistry, toolFactories);
         MLEngineClassLoader.register(FunctionName.TOOL, toolExecutor);
 
-        MLSearchHandler mlSearchHandler = new MLSearchHandler(client, xContentRegistry, modelAccessControlHelper, clusterService);
+        MLSearchHandler mlSearchHandler = new MLSearchHandler(
+            client,
+            xContentRegistry,
+            modelAccessControlHelper,
+            clusterService,
+            mlFeatureEnabledSetting
+        );
         MLModelAutoReDeployer mlModelAutoRedeployer = new MLModelAutoReDeployer(
             clusterService,
             client,

--- a/plugin/src/test/java/org/opensearch/ml/action/models/SearchModelTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/SearchModelTransportActionTests.java
@@ -114,7 +114,9 @@ public class SearchModelTransportActionTests extends OpenSearchTestCase {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         sdkClient = SdkClientFactory.createSdkClient(client, NamedXContentRegistry.EMPTY, Collections.emptyMap());
-        mlSearchHandler = spy(new MLSearchHandler(client, namedXContentRegistry, modelAccessControlHelper, clusterService));
+        mlSearchHandler = spy(
+            new MLSearchHandler(client, namedXContentRegistry, modelAccessControlHelper, clusterService, mlFeatureEnabledSetting)
+        );
         searchModelTransportAction = new SearchModelTransportAction(
             transportService,
             actionFilters,


### PR DESCRIPTION
### Description
Currently in environments where MultiTenancy is Enabled and indices are pre-populated outside of the local environment **there is a cache invalidation issue**. When this occurs there exists a local cold node that checks that the index exists. 

```
clusterService.state().metadata().hasIndex(indexName)
```

Instead we want to check that multi-tenancy is enabled and return early that we can assert logic that has the above line can continue.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Testing
-  ./gradlew spotlessApply
- ./gradlew test

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
