### PR TITLE
Use AwsV4HttpSigner instead of Aws4Signer

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
@@ -58,21 +58,20 @@ import lombok.extern.log4j.Log4j2;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
-import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 
 @Log4j2
 public class ConnectorUtils {
 
-    private static final Aws4Signer signer;
+    private static final AwsV4HttpSigner signer;
     public static final String SKIP_VALIDATE_MISSING_PARAMETERS = "skip_validating_missing_parameters";
 
     static {
-        signer = Aws4Signer.create();
+        signer = AwsV4HttpSigner.create();
     }
 
     public static RemoteInferenceInputDataSet processInput(
@@ -293,14 +292,16 @@ public class ConnectorUtils {
             ? AwsBasicCredentials.create(accessKey, secretKey)
             : AwsSessionCredentials.create(accessKey, secretKey, sessionToken);
 
-        Aws4SignerParams params = Aws4SignerParams
-            .builder()
-            .awsCredentials(credentials)
-            .signingName(signingName)
-            .signingRegion(Region.of(region))
-            .build();
-
-        return signer.sign(request, params);
+        SignedRequest signedRequest = signer
+            .sign(
+                r -> r
+                    .identity(credentials)
+                    .request(request)
+                    .payload(request.contentStreamProvider().orElse(null))
+                    .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, signingName)
+                    .putProperty(AwsV4HttpSigner.REGION_NAME, region)
+            );
+        return (SdkHttpFullRequest) signedRequest.request();
     }
 
     public static SdkHttpFullRequest buildSdkRequest(


### PR DESCRIPTION
### Description
Use AwsV4HttpSigner instead of Aws4Signer (deprecated)

https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/auth/aws/signer/AwsV4HttpSigner.html
https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/signer/Aws4Signer.html

### Related Issues
Resolves #4100 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
