### PR TITLE
Parameter Passing for Predict via Remote Connector

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -359,7 +359,9 @@ public class HttpConnector extends AbstractConnector {
     }
 
     public String removeMissingParameterFields(String payload, Map<String, String> params) {
-        // Match: "xxx": "${parameters.yyy}" or "xxx": {parameters.yyy}
+        if (params == null) {
+            return payload;
+        }
         Pattern pattern = Pattern.compile(
                 "\\s*\"[^\"]+\"\\s*:\\s*(\"?\\$?\\{parameters\\.([^}]+)\\}\"?)\\s*,?"
         );
@@ -368,7 +370,7 @@ public class HttpConnector extends AbstractConnector {
 
         while (matcher.find()) {
             String paramName = matcher.group(2); // yyy
-            if (!params.containsKey(paramName)) {
+            if (!params.containsKey(paramName) && !"input".equals(paramName)) {
                 matcher.appendReplacement(sb, "");
             } else {
                 matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(0)));

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -358,13 +358,15 @@ public class HttpConnector extends AbstractConnector {
         return (T) parameters.get("http_body");
     }
 
+    /**
+     * Removes fields from the given JSON payload string that correspond to parameters
+     * not present in the provided parameter map.
+     */
     public String removeMissingParameterFields(String payload, Map<String, String> params) {
         if (params == null) {
             return payload;
         }
-        Pattern pattern = Pattern.compile(
-                "\\s*\"[^\"]+\"\\s*:\\s*(\"?\\$?\\{parameters\\.([^}]+)\\}\"?)\\s*,?"
-        );
+        Pattern pattern = Pattern.compile("\\s*\"[^\"]+\"\\s*:\\s*(\"?\\$?\\{parameters\\.([^}]+)\\}\"?)\\s*,?");
         Matcher matcher = pattern.matcher(payload);
         StringBuffer sb = new StringBuffer();
 
@@ -379,7 +381,6 @@ public class HttpConnector extends AbstractConnector {
         matcher.appendTail(sb);
         return sb.toString().replaceAll(",\\s*}", "}").replaceAll(",\\s*]", "]");
     }
-
 
     protected String fillNullParameters(Map<String, String> parameters, String payload) {
         List<String> bodyParams = findStringParametersWithNullDefaultValue(payload);

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -346,7 +346,6 @@ public class HttpConnector extends AbstractConnector {
             String payload = connectorAction.get().getRequestBody();
             payload = fillNullParameters(parameters, payload);
             parseParameters(parameters);
-            payload = removeMissingParameterFields(payload, parameters);
             StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
             payload = substitutor.replace(payload);
 
@@ -356,30 +355,6 @@ public class HttpConnector extends AbstractConnector {
             return (T) payload;
         }
         return (T) parameters.get("http_body");
-    }
-
-    /**
-     * Removes fields from the given JSON payload string that correspond to parameters
-     * not present in the provided parameter map.
-     */
-    public String removeMissingParameterFields(String payload, Map<String, String> params) {
-        if (params == null) {
-            return payload;
-        }
-        Pattern pattern = Pattern.compile("\\s*\"[^\"]+\"\\s*:\\s*(\"?\\$?\\{parameters\\.([^}]+)\\}\"?)\\s*,?");
-        Matcher matcher = pattern.matcher(payload);
-        StringBuffer sb = new StringBuffer();
-
-        while (matcher.find()) {
-            String paramName = matcher.group(2); // yyy
-            if (!params.containsKey(paramName) && !"input".equals(paramName)) {
-                matcher.appendReplacement(sb, "");
-            } else {
-                matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(0)));
-            }
-        }
-        matcher.appendTail(sb);
-        return sb.toString().replaceAll(",\\s*}", "}").replaceAll(",\\s*]", "]");
     }
 
     protected String fillNullParameters(Map<String, String> parameters, String payload) {

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -358,7 +358,7 @@ public class HttpConnector extends AbstractConnector {
         return (T) parameters.get("http_body");
     }
 
-    private String removeMissingParameterFields(String payload, Map<String, String> params) {
+    public String removeMissingParameterFields(String payload, Map<String, String> params) {
         // Match: "xxx": "${parameters.yyy}" or "xxx": {parameters.yyy}
         Pattern pattern = Pattern.compile(
                 "\\s*\"[^\"]+\"\\s*:\\s*(\"?\\$?\\{parameters\\.([^}]+)\\}\"?)\\s*,?"

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -78,7 +78,7 @@ public class StringUtils {
     }
     public static final String TO_STRING_FUNCTION_NAME = ".toString()";
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    public static final ObjectMapper MAPPER = new ObjectMapper();
 
     public static boolean isValidJsonString(String json) {
         if (json == null || json.isBlank()) {

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -407,4 +407,54 @@ public class HttpConnectorTest {
         Assert.assertEquals("test_tenant", connector.getTenantId());
     }
 
+    @Test
+    public void removeMissingParameterFields() {
+        HttpConnector connector = createHttpConnector();
+        Map<String, String> params = new HashMap<>();
+        params.put("input", "test value");
+        params.put("sparseEmbeddingFormat", "WORD");
+        params.put("content_type", "query");
+
+        String payload = "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\" }}";
+        String expected = "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\" }}";
+        String result = connector.removeMissingParameterFields(payload, params);
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void removeMissingParameterFields_MissingParameters() {
+        HttpConnector connector = createHttpConnector();
+        Map<String, String> params = new HashMap<>();
+        params.put("input", "test value");
+
+        String payload = "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\"}}";
+        String expected = "{\"input\": ${parameters.input}, \"parameters\": {}}";
+        String result = connector.removeMissingParameterFields(payload, params);
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void removeMissingParameterFields_MissingAll() {
+        HttpConnector connector = createHttpConnector();
+        Map<String, String> params = new HashMap<>();
+
+        String payload = "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\"}}";
+        String expected = "{ \"parameters\": {}}";
+        String result = connector.removeMissingParameterFields(payload, params);
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void removeMissingParameterFields_Nest() {
+        HttpConnector connector = createHttpConnector();
+        Map<String, String> params = new HashMap<>();
+        params.put("input", "test value");
+
+        // Case 1: Payload with valid parameter placeholders
+        String payload = "{\"input\": \"${parameters.input}\", \"parameters\": {\"nested\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\"}}}";
+        String expected = "{\"input\": \"${parameters.input}\", \"parameters\": {\"nested\": {}}}";
+        String result = connector.removeMissingParameterFields(payload, params);
+        Assert.assertEquals(expected, result);
+    }
+
 }

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -194,6 +194,22 @@ public class HttpConnectorTest {
     }
 
     @Test
+    public void createPayload_ExtraParams() {
+
+        String requestBody = "{\"input\": \"${parameters.input}\", \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\" }}";
+        String expected = "{\"input\": \"test value\", \"parameters\": {\"sparseEmbeddingFormat\": \"WORD\", \"content_type\": \"query\" }}";
+
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test value");
+        parameters.put("sparseEmbeddingFormat", "WORD");
+        parameters.put("content_type", "query");
+        String predictPayload = connector.createPayload(PREDICT.name(), parameters);
+        connector.validatePayload(predictPayload);
+        Assert.assertEquals(expected, predictPayload);
+    }
+
+    @Test
     public void parseResponse_modelTensorJson() throws IOException {
         HttpConnector connector = createHttpConnector();
 
@@ -439,7 +455,7 @@ public class HttpConnectorTest {
         Map<String, String> params = new HashMap<>();
 
         String payload = "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\"}}";
-        String expected = "{ \"parameters\": {}}";
+        String expected = "{\"input\": ${parameters.input}, \"parameters\": {}}";
         String result = connector.removeMissingParameterFields(payload, params);
         Assert.assertEquals(expected, result);
     }
@@ -450,7 +466,6 @@ public class HttpConnectorTest {
         Map<String, String> params = new HashMap<>();
         params.put("input", "test value");
 
-        // Case 1: Payload with valid parameter placeholders
         String payload = "{\"input\": \"${parameters.input}\", \"parameters\": {\"nested\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\"}}}";
         String expected = "{\"input\": \"${parameters.input}\", \"parameters\": {\"nested\": {}}}";
         String result = connector.removeMissingParameterFields(payload, params);

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -196,8 +196,10 @@ public class HttpConnectorTest {
     @Test
     public void createPayload_ExtraParams() {
 
-        String requestBody = "{\"input\": \"${parameters.input}\", \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\" }}";
-        String expected = "{\"input\": \"test value\", \"parameters\": {\"sparseEmbeddingFormat\": \"WORD\", \"content_type\": \"query\" }}";
+        String requestBody =
+            "{\"input\": \"${parameters.input}\", \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\" }}";
+        String expected =
+            "{\"input\": \"test value\", \"parameters\": {\"sparseEmbeddingFormat\": \"WORD\", \"content_type\": \"query\" }}";
 
         HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
         Map<String, String> parameters = new HashMap<>();
@@ -431,8 +433,10 @@ public class HttpConnectorTest {
         params.put("sparseEmbeddingFormat", "WORD");
         params.put("content_type", "query");
 
-        String payload = "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\" }}";
-        String expected = "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\" }}";
+        String payload =
+            "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\" }}";
+        String expected =
+            "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\" }}";
         String result = connector.removeMissingParameterFields(payload, params);
         Assert.assertEquals(expected, result);
     }
@@ -443,7 +447,8 @@ public class HttpConnectorTest {
         Map<String, String> params = new HashMap<>();
         params.put("input", "test value");
 
-        String payload = "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\"}}";
+        String payload =
+            "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\"}}";
         String expected = "{\"input\": ${parameters.input}, \"parameters\": {}}";
         String result = connector.removeMissingParameterFields(payload, params);
         Assert.assertEquals(expected, result);
@@ -454,7 +459,8 @@ public class HttpConnectorTest {
         HttpConnector connector = createHttpConnector();
         Map<String, String> params = new HashMap<>();
 
-        String payload = "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\"}}";
+        String payload =
+            "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\"}}";
         String expected = "{\"input\": ${parameters.input}, \"parameters\": {}}";
         String result = connector.removeMissingParameterFields(payload, params);
         Assert.assertEquals(expected, result);
@@ -466,7 +472,8 @@ public class HttpConnectorTest {
         Map<String, String> params = new HashMap<>();
         params.put("input", "test value");
 
-        String payload = "{\"input\": \"${parameters.input}\", \"parameters\": {\"nested\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\"}}}";
+        String payload =
+            "{\"input\": \"${parameters.input}\", \"parameters\": {\"nested\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\"}}}";
         String expected = "{\"input\": \"${parameters.input}\", \"parameters\": {\"nested\": {}}}";
         String result = connector.removeMissingParameterFields(payload, params);
         Assert.assertEquals(expected, result);

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -212,6 +212,23 @@ public class HttpConnectorTest {
     }
 
     @Test
+    public void createPayload_MissingParamsInvalidJson() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule
+            .expectMessage(
+                "Invalid payload: {\"input\": \"test value\", \"parameters\": {\"sparseEmbeddingFormat\": \"WORD\", \"content_type\": ${parameters.content_type} }}"
+            );
+        String requestBody =
+            "{\"input\": \"${parameters.input}\", \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": ${parameters.content_type} }}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test value");
+        parameters.put("sparseEmbeddingFormat", "WORD");
+        String predictPayload = connector.createPayload(PREDICT.name(), parameters);
+        connector.validatePayload(predictPayload);
+    }
+
+    @Test
     public void parseResponse_modelTensorJson() throws IOException {
         HttpConnector connector = createHttpConnector();
 
@@ -423,60 +440,6 @@ public class HttpConnectorTest {
 
         HttpConnector connector = new HttpConnector("http", parser);
         Assert.assertEquals("test_tenant", connector.getTenantId());
-    }
-
-    @Test
-    public void removeMissingParameterFields() {
-        HttpConnector connector = createHttpConnector();
-        Map<String, String> params = new HashMap<>();
-        params.put("input", "test value");
-        params.put("sparseEmbeddingFormat", "WORD");
-        params.put("content_type", "query");
-
-        String payload =
-            "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\" }}";
-        String expected =
-            "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\" }}";
-        String result = connector.removeMissingParameterFields(payload, params);
-        Assert.assertEquals(expected, result);
-    }
-
-    @Test
-    public void removeMissingParameterFields_MissingParameters() {
-        HttpConnector connector = createHttpConnector();
-        Map<String, String> params = new HashMap<>();
-        params.put("input", "test value");
-
-        String payload =
-            "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\"}}";
-        String expected = "{\"input\": ${parameters.input}, \"parameters\": {}}";
-        String result = connector.removeMissingParameterFields(payload, params);
-        Assert.assertEquals(expected, result);
-    }
-
-    @Test
-    public void removeMissingParameterFields_MissingAll() {
-        HttpConnector connector = createHttpConnector();
-        Map<String, String> params = new HashMap<>();
-
-        String payload =
-            "{\"input\": ${parameters.input}, \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": \"${parameters.content_type}\"}}";
-        String expected = "{\"input\": ${parameters.input}, \"parameters\": {}}";
-        String result = connector.removeMissingParameterFields(payload, params);
-        Assert.assertEquals(expected, result);
-    }
-
-    @Test
-    public void removeMissingParameterFields_Nest() {
-        HttpConnector connector = createHttpConnector();
-        Map<String, String> params = new HashMap<>();
-        params.put("input", "test value");
-
-        String payload =
-            "{\"input\": \"${parameters.input}\", \"parameters\": {\"nested\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\"}}}";
-        String expected = "{\"input\": \"${parameters.input}\", \"parameters\": {\"nested\": {}}}";
-        String result = connector.removeMissingParameterFields(payload, params);
-        Assert.assertEquals(expected, result);
     }
 
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -5,18 +5,13 @@
 
 package org.opensearch.ml.engine.algorithms.remote;
 
-import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-//import static org.opensearch.ml.common.dataset.SearchQueryInputDataset.xContentRegistry;
 import static org.opensearch.ml.engine.algorithms.remote.ConnectorUtils.SKIP_VALIDATE_MISSING_PARAMETERS;
 import static org.opensearch.ml.engine.algorithms.remote.ConnectorUtils.escapeRemoteInferenceInputData;
 import static org.opensearch.ml.engine.algorithms.remote.ConnectorUtils.processInput;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Logger;
@@ -30,7 +25,6 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.TokenBucket;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
@@ -46,7 +40,6 @@ import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.input.parameter.MLAlgoParams;
-//import org.opensearch.ml.common.input.parameter.textembedding.SparseEmbeddingFormat;
 import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
@@ -88,7 +81,7 @@ public interface RemoteConnectorExecutor {
                         MLInput
                             .builder()
                             .algorithm(FunctionName.TEXT_EMBEDDING)
-                            .parameters(mlInput.getParameters())
+//                            .parameters(mlInput.getParameters())
                             .inputDataset(TextDocsInputDataSet.builder().docs(textDocs).build())
                             .build(),
                         new ExecutionContext(sequence++),
@@ -203,23 +196,6 @@ public interface RemoteConnectorExecutor {
                 actionListener.onFailure(e);
             }
         }
-//        if (algoParams != null) {
-//            Map<String, String> parametersMap = new HashMap<>();
-//            String algoParamsStr = algoParams.toString();
-//            Pattern pattern = Pattern.compile("\\(([^)]+)\\)");
-//            Matcher matcher = pattern.matcher(algoParamsStr);
-//            if (matcher.find()) {
-//                String bracketContent = matcher.group(1);
-//                pattern = Pattern.compile("(\\w+)=([^,\\s]+)");
-//                matcher = pattern.matcher(bracketContent);
-//                while (matcher.find()) {
-//                    String fieldName = matcher.group(1);
-//                    String fieldValue = matcher.group(2);
-//                    parametersMap.put(fieldName, fieldValue);
-//                }
-//            }
-//            parameters.putAll(parametersMap);
-//        }
 
         RemoteInferenceInputDataSet inputData = processInput(action, mlInput, connector, parameters, getScriptService());
         if (inputData.getParameters() != null) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -10,10 +10,15 @@ import static org.opensearch.ml.engine.algorithms.remote.ConnectorUtils.escapeRe
 import static org.opensearch.ml.engine.algorithms.remote.ConnectorUtils.processInput;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
@@ -29,7 +34,9 @@ import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.core.xcontent.*;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
@@ -47,6 +54,8 @@ import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.Builder;
 
@@ -81,7 +90,7 @@ public interface RemoteConnectorExecutor {
                         MLInput
                             .builder()
                             .algorithm(FunctionName.TEXT_EMBEDDING)
-//                            .parameters(mlInput.getParameters())
+                            .parameters(mlInput.getParameters())
                             .inputDataset(TextDocsInputDataSet.builder().docs(textDocs).build())
                             .build(),
                         new ExecutionContext(sequence++),

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
@@ -181,17 +181,22 @@ public class RemoteConnectorExecutorTest {
         AwsConnectorExecutor executor = getExecutor(connector);
 
         RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
-                .builder()
-                .parameters(Map.of("input", "${parameters.input}"))
-                .actionType(PREDICT)
-                .build();
+            .builder()
+            .parameters(Map.of("input", "${parameters.input}"))
+            .actionType(PREDICT)
+            .build();
         String actionType = inputDataSet.getActionType().toString();
         AsymmetricTextEmbeddingParameters inputParams = AsymmetricTextEmbeddingParameters
-                .builder()
-                .sparseEmbeddingFormat(SparseEmbeddingFormat.WORD)
-                .embeddingContentType(null)
-                .build();
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).parameters(inputParams).inputDataset(inputDataSet).build();
+            .builder()
+            .sparseEmbeddingFormat(SparseEmbeddingFormat.WORD)
+            .embeddingContentType(null)
+            .build();
+        MLInput mlInput = MLInput
+            .builder()
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .parameters(inputParams)
+            .inputDataset(inputDataSet)
+            .build();
 
         try {
             Map<String, String> paramsMap = executor.getParams(mlInput);
@@ -210,17 +215,22 @@ public class RemoteConnectorExecutorTest {
         AwsConnectorExecutor executor = getExecutor(connector);
 
         RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
-                .builder()
-                .parameters(Map.of("input", "${parameters.input}"))
-                .actionType(PREDICT)
-                .build();
+            .builder()
+            .parameters(Map.of("input", "${parameters.input}"))
+            .actionType(PREDICT)
+            .build();
         String actionType = inputDataSet.getActionType().toString();
         AsymmetricTextEmbeddingParameters inputParams = AsymmetricTextEmbeddingParameters
-                .builder()
-                .sparseEmbeddingFormat(SparseEmbeddingFormat.WORD)
-                .embeddingContentType(AsymmetricTextEmbeddingParameters.EmbeddingContentType.PASSAGE)
-                .build();
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).parameters(inputParams).inputDataset(inputDataSet).build();
+            .builder()
+            .sparseEmbeddingFormat(SparseEmbeddingFormat.WORD)
+            .embeddingContentType(AsymmetricTextEmbeddingParameters.EmbeddingContentType.PASSAGE)
+            .build();
+        MLInput mlInput = MLInput
+            .builder()
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .parameters(inputParams)
+            .inputDataset(inputDataSet)
+            .build();
 
         try {
             Map<String, String> paramsMap = executor.getParams(mlInput);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
@@ -7,8 +7,10 @@ package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.connector.AbstractConnector.ACCESS_KEY_FIELD;
 import static org.opensearch.ml.common.connector.AbstractConnector.SECRET_KEY_FIELD;
@@ -32,6 +34,7 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ingest.TestTemplateService;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.connector.AwsConnector;
@@ -41,6 +44,8 @@ import org.opensearch.ml.common.connector.ConnectorClientConfig;
 import org.opensearch.ml.common.connector.RetryBackoffPolicy;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.input.parameter.MLAlgoParams;
+import org.opensearch.ml.common.input.parameter.clustering.KMeansParams;
 import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters;
 import org.opensearch.ml.common.input.parameter.textembedding.SparseEmbeddingFormat;
 import org.opensearch.ml.common.output.model.ModelTensors;
@@ -67,6 +72,9 @@ public class RemoteConnectorExecutorTest {
 
     @Mock
     ActionListener<Tuple<Integer, ModelTensors>> actionListener;
+
+    @Mock
+    private MLAlgoParams mlInputParams;
 
     @Before
     public void setUp() {
@@ -175,6 +183,62 @@ public class RemoteConnectorExecutorTest {
     }
 
     @Test
+    public void executePreparePayloadAndInvoke_PassingParameter() {
+        Map<String, String> parameters = ImmutableMap.of(SERVICE_NAME_FIELD, "sagemaker", REGION_FIELD, "us-west-2");
+        Connector connector = getConnector(parameters);
+        AwsConnectorExecutor executor = getExecutor(connector);
+
+        RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
+            .builder()
+            .parameters(Map.of("input", "You are a ${parameters.role}"))
+            .actionType(PREDICT)
+            .build();
+        String actionType = inputDataSet.getActionType().toString();
+        AsymmetricTextEmbeddingParameters inputParams = AsymmetricTextEmbeddingParameters
+            .builder()
+            .sparseEmbeddingFormat(SparseEmbeddingFormat.WORD)
+            .embeddingContentType(null)
+            .build();
+        MLInput mlInput = MLInput
+            .builder()
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .parameters(inputParams)
+            .inputDataset(inputDataSet)
+            .build();
+
+        Exception exception = Assert
+            .assertThrows(
+                IllegalArgumentException.class,
+                () -> executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener)
+            );
+        assert exception.getMessage().contains("Some parameter placeholder not filled in payload: role");
+    }
+
+    @Test
+    public void executePreparePayloadAndInvoke_GetParamsIOException() throws Exception {
+        Map<String, String> parameters = ImmutableMap.of(SERVICE_NAME_FIELD, "sagemaker", REGION_FIELD, "us-west-2");
+        Connector connector = getConnector(parameters);
+        AwsConnectorExecutor executor = getExecutor(connector);
+
+        RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
+            .builder()
+            .parameters(Map.of("input", "test input"))
+            .actionType(PREDICT)
+            .build();
+        String actionType = inputDataSet.getActionType().toString();
+        doThrow(new IOException("UT test IOException")).when(mlInputParams).toXContent(any(XContentBuilder.class), any());
+        MLInput mlInput = MLInput
+            .builder()
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .parameters(mlInputParams)
+            .inputDataset(inputDataSet)
+            .build();
+
+        executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener);
+        verify(actionListener).onFailure(argThat(e -> e instanceof IOException && e.getMessage().contains("UT test IOException")));
+    }
+
+    @Test
     public void executeGetParams_MissingParameter() {
         Map<String, String> parameters = ImmutableMap.of(SERVICE_NAME_FIELD, "sagemaker", REGION_FIELD, "us-west-2");
         Connector connector = getConnector(parameters);
@@ -199,7 +263,7 @@ public class RemoteConnectorExecutorTest {
             .build();
 
         try {
-            Map<String, String> paramsMap = executor.getParams(mlInput);
+            Map<String, String> paramsMap = RemoteConnectorExecutor.getParams(mlInput);
             Map<String, String> expectedMap = new HashMap<>();
             expectedMap.put("sparse_embedding_format", "WORD");
             Assert.assertEquals(expectedMap, paramsMap);
@@ -233,10 +297,46 @@ public class RemoteConnectorExecutorTest {
             .build();
 
         try {
-            Map<String, String> paramsMap = executor.getParams(mlInput);
+            Map<String, String> paramsMap = RemoteConnectorExecutor.getParams(mlInput);
             Map<String, String> expectedMap = new HashMap<>();
             expectedMap.put("sparse_embedding_format", "WORD");
             expectedMap.put("content_type", "PASSAGE");
+            Assert.assertEquals(expectedMap, paramsMap);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void executeGetParams_ConvertToString() {
+        Map<String, String> parameters = ImmutableMap.of(SERVICE_NAME_FIELD, "sagemaker", REGION_FIELD, "us-west-2");
+        Connector connector = getConnector(parameters);
+        AwsConnectorExecutor executor = getExecutor(connector);
+
+        RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
+            .builder()
+            .parameters(Map.of("input", "${parameters.input}"))
+            .actionType(PREDICT)
+            .build();
+        KMeansParams inputParams = KMeansParams
+            .builder()
+            .centroids(5)
+            .iterations(100)
+            .distanceType(KMeansParams.DistanceType.EUCLIDEAN)
+            .build();
+        MLInput mlInput = MLInput
+            .builder()
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .parameters(inputParams)
+            .inputDataset(inputDataSet)
+            .build();
+
+        try {
+            Map<String, String> paramsMap = RemoteConnectorExecutor.getParams(mlInput);
+            Map<String, String> expectedMap = new HashMap<>();
+            expectedMap.put("centroids", "5");
+            expectedMap.put("iterations", "100");
+            expectedMap.put("distance_type", "EUCLIDEAN");
             Assert.assertEquals(expectedMap, paramsMap);
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
### Description
This PR adds support for parameter propagation in the predict API when using `text_embedding` function by ensuring user-supplied parameters are correctly merged into the connector's request_body and included in the outgoing request.

### Related Issues
Resolves #4105
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
