### PR TITLE
Add provided dependency section to ml-client POM

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -108,6 +108,24 @@ publishing {
                         url = "https://github.com/opensearch-project/ml-commons"
                     }
                 }
+                // Add a dependencies section to signal that consumers of the client need to provide these
+                withXml {
+                    def dependencies = asNode().appendNode('dependencies')
+                    
+                    def addProvidedDependency = { group, artifact, version ->
+                        def dependency = dependencies.appendNode('dependency')
+                        dependency.appendNode('groupId', group)
+                        dependency.appendNode('artifactId', artifact)
+                        dependency.appendNode('version', version)
+                        dependency.appendNode('scope', 'provided')
+                    }
+
+                    addProvidedDependency('org.json', 'json', '20231013')
+                    addProvidedDependency('com.jayway.jsonpath', 'json-path', '2.9.0')
+                    addProvidedDependency('org.apache.commons', 'commons-text', '1.14.0')
+                    addProvidedDependency('com.fasterxml.jackson.core', 'jackson-annotations', "${versions.jackson_annotations}")
+                    addProvidedDependency('tools.jackson.core', 'jackson-databind', "${versions.jackson3_databind}")
+                }
             }
         }
 


### PR DESCRIPTION
### Description

The ML Client requires a few runtime dependencies that are not included in the shadow JAR, primarily associated with validation of ML Connector fields.  The requirement to have these dependencies by downstream consumers of the client is not documented nor obvious.

In the Maven dependency ecosystem, the [**`provided`** dependency scope](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope) is a clear indicator of a required runtime dependency that the project is not providing itself:
> **provided**
> This is much like compile, but indicates you expect the JDK or a container to provide the dependency at runtime. For example, when building a web application for the Java Enterprise Edition, you would set the dependency on the Servlet API and related Java EE APIs to scope provided because the web container provides those classes. A dependency with this scope is added to the classpath used for compilation and test, but not the runtime classpath. It is not transitive.

This PR appends a `<dependency>` section to the [published opensearch-ml-client POM file on the Central Repository](https://central.sonatype.com/artifact/org.opensearch/opensearch-ml-client). The additional section added will be:
```xml
<dependencies>
  <dependency>
    <groupId>org.json</groupId>
    <artifactId>json</artifactId>
    <version>20231013</version>
    <scope>provided</scope>
  </dependency>
  <dependency>
    <groupId>com.jayway.jsonpath</groupId>
    <artifactId>json-path</artifactId>
    <version>2.9.0</version>
    <scope>provided</scope>
  </dependency>
  <dependency>
    <groupId>org.apache.commons</groupId>
    <artifactId>commons-text</artifactId>
    <version>1.10.0</version>
    <scope>provided</scope>
  </dependency>
</dependencies>
```

Note that there is an additional dependency in `StringUtils` on `com.networknt:json-schema-validator:1.4.0`.  Currently this is not required by the ML Client, but if any future changes to the client include schema validation, that should be added to this list. 

_**This has no impact on actual included dependencies; it's simply a documentation signal to clearly indicate to consumers of this client that they must provide these dependencies themselves.**_

### Related Issues
 - Resolves #3860
 - Supercedes #3861 which can be closed (thanks @jngz-es for trying to fix!)

### Check List
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to specify external library dependencies that must be provided by the runtime environment rather than bundled with the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->