### PR TITLE
fix MLTaskState enum serialization errors

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -130,8 +130,8 @@ public class MLTaskManager implements SettingsChangeListener {
                 .must(
                     QueryBuilders
                         .boolQuery()
-                        .should(QueryBuilders.termQuery(STATE_FIELD, CREATED))
-                        .should(QueryBuilders.termQuery(STATE_FIELD, RUNNING))
+                        .should(QueryBuilders.termQuery(STATE_FIELD, CREATED.name()))
+                        .should(QueryBuilders.termQuery(STATE_FIELD, RUNNING.name()))
                 );
 
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(boolQuery);


### PR DESCRIPTION
### Description
Fix the search query enum serialization errors. The enum cannot be serialized and needs to be converted to String. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
