### PR TITLE
[MCP Connector] MCP Connectors for streamable HTTP

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -113,6 +113,8 @@ public class CommonValue {
     public static final String MCP_CONNECTOR_ID_FIELD = "mcp_connector_id";
     public static final String MCP_DEFAULT_SSE_ENDPOINT = "/sse";
     public static final String SSE_ENDPOINT_FILED = "sse_endpoint";
+    public static final String MCP_DEFAULT_ENDPOINT = "/mcp/";
+    public static final String ENDPOINT_FILED = "endpoint";
 
     // TOOL Constants
     public static final String TOOL_INPUT_SCHEMA_FIELD = "input_schema";

--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -112,9 +112,9 @@ public class CommonValue {
     public static final String MCP_CONNECTORS_FIELD = "mcp_connectors";
     public static final String MCP_CONNECTOR_ID_FIELD = "mcp_connector_id";
     public static final String MCP_DEFAULT_SSE_ENDPOINT = "/sse";
-    public static final String SSE_ENDPOINT_FILED = "sse_endpoint";
-    public static final String MCP_DEFAULT_ENDPOINT = "/mcp/";
-    public static final String ENDPOINT_FILED = "endpoint";
+    public static final String SSE_ENDPOINT_FIELD = "sse_endpoint";
+    public static final String MCP_DEFAULT_STREAMABLE_HTTP_ENDPOINT = "/mcp/";
+    public static final String ENDPOINT_FIELD = "endpoint";
 
     // TOOL Constants
     public static final String TOOL_INPUT_SCHEMA_FIELD = "input_schema";

--- a/common/src/main/java/org/opensearch/ml/common/connector/ConnectorProtocols.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/ConnectorProtocols.java
@@ -13,8 +13,9 @@ public class ConnectorProtocols {
     public static final String HTTP = "http";
     public static final String AWS_SIGV4 = "aws_sigv4";
     public static final String MCP_SSE = "mcp_sse";
+    public static final String MCP_STREAMABLE_HTTP = "mcp_streamable_http";
 
-    public static final List<String> VALID_PROTOCOLS = Arrays.asList(AWS_SIGV4, HTTP, MCP_SSE);
+    public static final List<String> VALID_PROTOCOLS = Arrays.asList(AWS_SIGV4, HTTP, MCP_SSE, MCP_STREAMABLE_HTTP);
 
     public static void validateProtocol(String protocol) {
         if (protocol == null) {

--- a/common/src/main/java/org/opensearch/ml/common/connector/McpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/McpConnector.java
@@ -358,6 +358,9 @@ public class McpConnector implements Connector {
         if (updateContent.getConnectorClientConfig() != null) {
             this.connectorClientConfig = updateContent.getConnectorClientConfig();
         }
+        if (updateContent.getUrl() != null && updateContent.getUrl().isBlank()) {
+            throw new IllegalArgumentException("MCP Connector url is blank");
+        }
         if (updateContent.getUrl() != null) {
             this.url = updateContent.getUrl();
         }

--- a/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
@@ -20,7 +20,6 @@ import static org.opensearch.ml.common.CommonValue.PARAMETERS_FIELD;
 import static org.opensearch.ml.common.CommonValue.PROTOCOL_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.URL_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_1_0;
 import static org.opensearch.ml.common.CommonValue.VERSION_FIELD;
 import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_STREAMABLE_HTTP;
 import static org.opensearch.ml.common.connector.ConnectorProtocols.validateProtocol;
@@ -37,7 +36,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.text.StringSubstitutor;
-import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -193,6 +191,7 @@ public class McpStreamableHttpConnector implements Connector {
     }
 
     protected Map<String, String> createDecryptedHeaders(Map<String, String> headers) {
+        // TODO: Change this to return empty MAP in all createDecryptedHeaders functions across connectors
         if (headers == null) {
             return null;
         }
@@ -276,7 +275,6 @@ public class McpStreamableHttpConnector implements Connector {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        Version streamOutputVersion = out.getVersion();
         out.writeString(protocol);
         out.writeOptionalString(name);
         out.writeOptionalString(version);
@@ -318,13 +316,11 @@ public class McpStreamableHttpConnector implements Connector {
         } else {
             out.writeBoolean(false);
         }
-        if (streamOutputVersion.onOrAfter(VERSION_3_1_0)) {
-            if (parameters != null) {
-                out.writeBoolean(true);
-                out.writeMap(parameters, StreamOutput::writeString, StreamOutput::writeString);
-            } else {
-                out.writeBoolean(false);
-            }
+        if (parameters != null) {
+            out.writeBoolean(true);
+            out.writeMap(parameters, StreamOutput::writeString, StreamOutput::writeString);
+        } else {
+            out.writeBoolean(false);
         }
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
@@ -358,6 +358,9 @@ public class McpStreamableHttpConnector implements Connector {
         if (updateContent.getConnectorClientConfig() != null) {
             this.connectorClientConfig = updateContent.getConnectorClientConfig();
         }
+        if (updateContent.getUrl() != null && updateContent.getUrl().isBlank()) {
+            throw new IllegalArgumentException("MCP Connector url is blank");
+        }
         if (updateContent.getUrl() != null) {
             this.url = updateContent.getUrl();
         }

--- a/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
@@ -1,0 +1,479 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.connector;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.ACCESS_FIELD;
+import static org.opensearch.ml.common.CommonValue.BACKEND_ROLES_FIELD;
+import static org.opensearch.ml.common.CommonValue.CLIENT_CONFIG_FIELD;
+import static org.opensearch.ml.common.CommonValue.CREATED_TIME_FIELD;
+import static org.opensearch.ml.common.CommonValue.CREDENTIAL_FIELD;
+import static org.opensearch.ml.common.CommonValue.DESCRIPTION_FIELD;
+import static org.opensearch.ml.common.CommonValue.HEADERS_FIELD;
+import static org.opensearch.ml.common.CommonValue.LAST_UPDATED_TIME_FIELD;
+import static org.opensearch.ml.common.CommonValue.NAME_FIELD;
+import static org.opensearch.ml.common.CommonValue.OWNER_FIELD;
+import static org.opensearch.ml.common.CommonValue.PARAMETERS_FIELD;
+import static org.opensearch.ml.common.CommonValue.PROTOCOL_FIELD;
+import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.URL_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_1_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_FIELD;
+import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_STREAMABLE_HTTP;
+import static org.opensearch.ml.common.connector.ConnectorProtocols.validateProtocol;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.text.StringSubstitutor;
+import org.opensearch.Version;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.AccessMode;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@NoArgsConstructor
+@EqualsAndHashCode
+@Getter
+@org.opensearch.ml.common.annotation.Connector(MCP_STREAMABLE_HTTP)
+public class McpStreamableHttpConnector implements Connector {
+
+    protected String name;
+    protected String description;
+    protected String version;
+    protected String protocol;
+
+    protected Map<String, String> credential;
+    protected Map<String, String> decryptedHeaders;
+    protected Map<String, String> parameters;
+    @Setter
+    protected Map<String, String> decryptedCredential;
+    @Setter
+    protected List<String> backendRoles;
+    @Setter
+    protected User owner;
+    @Setter
+    protected AccessMode access;
+    @Setter
+    protected Instant createdTime;
+    @Setter
+    protected Instant lastUpdateTime;
+    @Setter
+    protected ConnectorClientConfig connectorClientConfig;
+    @Setter
+    protected String tenantId;
+    @Setter
+    @Getter
+    protected String url;
+    @Setter
+    protected Map<String, String> headers;
+
+    @Builder
+    public McpStreamableHttpConnector(
+        String name,
+        String description,
+        String version,
+        String protocol,
+        Map<String, String> credential,
+        List<String> backendRoles,
+        AccessMode accessMode,
+        User owner,
+        ConnectorClientConfig connectorClientConfig,
+        String tenantId,
+        String url,
+        Map<String, String> headers,
+        Map<String, String> parameters
+    ) {
+        validateProtocol(protocol);
+        this.name = name;
+        this.description = description;
+        this.version = version;
+        this.protocol = protocol;
+        this.credential = credential;
+        this.backendRoles = backendRoles;
+        this.access = accessMode;
+        this.owner = owner;
+        this.connectorClientConfig = connectorClientConfig;
+        this.tenantId = tenantId;
+        this.url = url;
+        this.headers = headers;
+        this.parameters = parameters;
+    }
+
+    public McpStreamableHttpConnector(String protocol, XContentParser parser) throws IOException {
+        this.protocol = protocol;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case NAME_FIELD:
+                    name = parser.text();
+                    break;
+                case VERSION_FIELD:
+                    version = parser.text();
+                    break;
+                case DESCRIPTION_FIELD:
+                    description = parser.text();
+                    break;
+                case PROTOCOL_FIELD:
+                    this.protocol = parser.text();
+                    break;
+                case CREDENTIAL_FIELD:
+                    credential = new HashMap<>();
+                    credential.putAll(parser.mapStrings());
+                    break;
+                case BACKEND_ROLES_FIELD:
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    backendRoles = new ArrayList<>();
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        backendRoles.add(parser.text());
+                    }
+                    break;
+                case OWNER_FIELD:
+                    owner = User.parse(parser);
+                    break;
+                case ACCESS_FIELD:
+                    access = AccessMode.from(parser.text());
+                    break;
+                case CREATED_TIME_FIELD:
+                    createdTime = Instant.ofEpochMilli(parser.longValue());
+                    break;
+                case LAST_UPDATED_TIME_FIELD:
+                    lastUpdateTime = Instant.ofEpochMilli(parser.longValue());
+                    break;
+                case CLIENT_CONFIG_FIELD:
+                    connectorClientConfig = ConnectorClientConfig.parse(parser);
+                    break;
+                case TENANT_ID_FIELD:
+                    tenantId = parser.textOrNull();
+                    break;
+                case URL_FIELD:
+                    url = parser.textOrNull();
+                    break;
+                case HEADERS_FIELD:
+                    headers = new HashMap<>();
+                    headers.putAll(parser.mapStrings());
+                    break;
+                case PARAMETERS_FIELD:
+                    parameters = new HashMap<>();
+                    parameters.putAll(parser.mapStrings());
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+    }
+
+    protected Map<String, String> createDecryptedHeaders(Map<String, String> headers) {
+        if (headers == null) {
+            return null;
+        }
+        Map<String, String> decryptedHeaders = new HashMap<>();
+        StringSubstitutor substitutor = new StringSubstitutor(getDecryptedCredential(), "${credential.", "}");
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            decryptedHeaders.put(entry.getKey(), substitutor.replace(entry.getValue()));
+        }
+        return decryptedHeaders;
+    }
+
+    @Override
+    public void decrypt(String action, BiFunction<String, String, String> function, String tenantId) {
+        Map<String, String> decrypted = new HashMap<>();
+        for (String key : credential.keySet()) {
+            decrypted.put(key, function.apply(credential.get(key), tenantId));
+        }
+        this.decryptedCredential = decrypted;
+        this.decryptedHeaders = createDecryptedHeaders(headers);
+    }
+
+    @Override
+    public void encrypt(BiFunction<String, String, String> function, String tenantId) {
+        for (String key : credential.keySet()) {
+            String encrypted = function.apply(credential.get(key), tenantId);
+            credential.put(key, encrypted);
+        }
+    }
+
+    @Override
+    public Connector cloneConnector() {
+        try (BytesStreamOutput bytesStreamOutput = new BytesStreamOutput()) {
+            this.writeTo(bytesStreamOutput);
+            StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
+            return new McpStreamableHttpConnector(streamInput);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public McpStreamableHttpConnector(StreamInput input) throws IOException {
+        this.protocol = input.readString();
+        parseFromStream(input);
+    }
+
+    private void parseFromStream(StreamInput input) throws IOException {
+        Version streamInputVersion = input.getVersion();
+        this.name = input.readOptionalString();
+        this.version = input.readOptionalString();
+        this.description = input.readOptionalString();
+        if (input.readBoolean()) {
+            credential = input.readMap(StreamInput::readString, StreamInput::readString);
+        }
+        backendRoles = input.readOptionalStringList();
+        if (input.readBoolean()) {
+            this.access = input.readEnum(AccessMode.class);
+        }
+        if (input.readBoolean()) {
+            this.owner = new User(input);
+        }
+        this.createdTime = input.readOptionalInstant();
+        this.lastUpdateTime = input.readOptionalInstant();
+        if (input.readBoolean()) {
+            this.connectorClientConfig = new ConnectorClientConfig(input);
+        }
+        this.tenantId = input.readOptionalString();
+        this.url = input.readString();
+        if (input.readBoolean()) {
+            this.headers = input.readMap(s -> s.readString(), s -> s.readString());
+        }
+        if (streamInputVersion.onOrAfter(VERSION_3_1_0)) {
+            if (input.readBoolean()) {
+                this.parameters = input.readMap(s -> s.readString(), s -> s.readString());
+            }
+        }
+    }
+
+    @Override
+    public void removeCredential() {
+        this.credential = null;
+        this.decryptedCredential = null;
+        this.decryptedHeaders = null;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Version streamOutputVersion = out.getVersion();
+        out.writeString(protocol);
+        out.writeOptionalString(name);
+        out.writeOptionalString(version);
+        out.writeOptionalString(description);
+        if (credential != null) {
+            out.writeBoolean(true);
+            out.writeMap(credential, StreamOutput::writeString, StreamOutput::writeString);
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeOptionalStringCollection(backendRoles);
+        if (access != null) {
+            out.writeBoolean(true);
+            out.writeEnum(access);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (owner != null) {
+            out.writeBoolean(true);
+            owner.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeOptionalInstant(createdTime);
+        out.writeOptionalInstant(lastUpdateTime);
+        if (connectorClientConfig != null) {
+            out.writeBoolean(true);
+            connectorClientConfig.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeOptionalString(tenantId);
+
+        out.writeString(url);
+
+        if (headers != null) {
+            out.writeBoolean(true);
+            out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (streamOutputVersion.onOrAfter(VERSION_3_1_0)) {
+            if (parameters != null) {
+                out.writeBoolean(true);
+                out.writeMap(parameters, StreamOutput::writeString, StreamOutput::writeString);
+            } else {
+                out.writeBoolean(false);
+            }
+        }
+    }
+
+    @Override
+    public void update(MLCreateConnectorInput updateContent, BiFunction<String, String, String> function) {
+        if (updateContent.getName() != null) {
+            this.name = updateContent.getName();
+        }
+        if (updateContent.getDescription() != null) {
+            this.description = updateContent.getDescription();
+        }
+        if (updateContent.getVersion() != null) {
+            this.version = updateContent.getVersion();
+        }
+        if (updateContent.getProtocol() != null) {
+            this.protocol = updateContent.getProtocol();
+        }
+        if (updateContent.getCredential() != null && !updateContent.getCredential().isEmpty()) {
+            this.credential = updateContent.getCredential();
+            encrypt(function, this.tenantId);
+        }
+        if (updateContent.getBackendRoles() != null) {
+            this.backendRoles = updateContent.getBackendRoles();
+        }
+        if (updateContent.getAccess() != null) {
+            this.access = updateContent.getAccess();
+        }
+        if (updateContent.getConnectorClientConfig() != null) {
+            this.connectorClientConfig = updateContent.getConnectorClientConfig();
+        }
+        if (updateContent.getUrl() != null) {
+            this.url = updateContent.getUrl();
+        }
+        if (updateContent.getHeaders() != null) {
+            this.headers = updateContent.getHeaders();
+        }
+        if (updateContent.getParameters() != null) {
+            this.parameters = updateContent.getParameters();
+        }
+    }
+
+    @Override
+    public <T> void parseResponse(T orElse, List<ModelTensor> modelTensors, boolean b) throws IOException {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (name != null) {
+            builder.field(NAME_FIELD, name);
+        }
+        if (version != null) {
+            builder.field(VERSION_FIELD, version);
+        }
+        if (description != null) {
+            builder.field(DESCRIPTION_FIELD, description);
+        }
+        if (protocol != null) {
+            builder.field(PROTOCOL_FIELD, protocol);
+        }
+        if (credential != null) {
+            builder.field(CREDENTIAL_FIELD, credential);
+        }
+        if (backendRoles != null) {
+            builder.field(BACKEND_ROLES_FIELD, backendRoles);
+        }
+        if (owner != null) {
+            builder.field(OWNER_FIELD, owner);
+        }
+        if (access != null) {
+            builder.field(ACCESS_FIELD, access.getValue());
+        }
+        if (createdTime != null) {
+            builder.field(CREATED_TIME_FIELD, createdTime.toEpochMilli());
+        }
+        if (lastUpdateTime != null) {
+            builder.field(LAST_UPDATED_TIME_FIELD, lastUpdateTime.toEpochMilli());
+        }
+        if (connectorClientConfig != null) {
+            builder.field(CLIENT_CONFIG_FIELD, connectorClientConfig);
+        }
+        if (tenantId != null) {
+            builder.field(TENANT_ID_FIELD, tenantId);
+        }
+        if (url != null) {
+            builder.field(URL_FIELD, url);
+        }
+        if (headers != null) {
+            builder.field(HEADERS_FIELD, headers);
+        }
+        if (parameters != null) {
+            builder.field(PARAMETERS_FIELD, parameters);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void validateConnectorURL(List<String> urlRegexes) {
+        boolean hasMatchedUrl = false;
+        for (String urlRegex : urlRegexes) {
+            Pattern pattern = Pattern.compile(urlRegex);
+            Matcher matcher = pattern.matcher(url);
+            if (matcher.matches()) {
+                hasMatchedUrl = true;
+                break;
+            }
+        }
+        if (!hasMatchedUrl) {
+            throw new IllegalArgumentException("Connector URL is not matching the trusted connector endpoint regex");
+        }
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public List<ConnectorAction> getActions() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public void addAction(ConnectorAction action) {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public String getActionEndpoint(String action, Map<String, String> parameters) {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public String getActionHttpMethod(String action) {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public <T> T createPayload(String action, Map<String, String> parameters) {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public Optional<ConnectorAction> findAction(String action) {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
@@ -239,7 +239,6 @@ public class McpStreamableHttpConnector implements Connector {
     }
 
     private void parseFromStream(StreamInput input) throws IOException {
-        Version streamInputVersion = input.getVersion();
         this.name = input.readOptionalString();
         this.version = input.readOptionalString();
         this.description = input.readOptionalString();
@@ -263,10 +262,8 @@ public class McpStreamableHttpConnector implements Connector {
         if (input.readBoolean()) {
             this.headers = input.readMap(s -> s.readString(), s -> s.readString());
         }
-        if (streamInputVersion.onOrAfter(VERSION_3_1_0)) {
-            if (input.readBoolean()) {
-                this.parameters = input.readMap(s -> s.readString(), s -> s.readString());
-            }
+        if (input.readBoolean()) {
+            this.parameters = input.readMap(s -> s.readString(), s -> s.readString());
         }
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -109,12 +109,15 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
                 throw new IllegalArgumentException("Connector protocol is null");
             }
             if ((!protocol.equals(MCP_SSE) && !protocol.equals(MCP_STREAMABLE_HTTP)) && (credential == null || credential.isEmpty())) {
-                throw new IllegalArgumentException("Connector credential is null or empty list");
+                throw new IllegalArgumentException("MCP Connector credential is null or empty list");
             }
             if (actions != null) {
                 for (ConnectorAction action : actions) {
                     action.validatePrePostProcessFunctions(parameters);
                 }
+            }
+            if ((protocol.equals(MCP_SSE) || protocol.equals(MCP_STREAMABLE_HTTP)) && (url == null || url.isBlank())) {
+                throw new IllegalArgumentException("MCP Connector url is null or blank");
             }
         }
         this.name = name;

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -99,6 +99,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
         Map<String, String> headers
     ) {
         if (!dryRun && !updateConnector) {
+
             if (name == null) {
                 throw new IllegalArgumentException("Connector name is null");
             }
@@ -108,15 +109,16 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
             if (protocol == null) {
                 throw new IllegalArgumentException("Connector protocol is null");
             }
-            if ((!protocol.equals(MCP_SSE) && !protocol.equals(MCP_STREAMABLE_HTTP)) && (credential == null || credential.isEmpty())) {
-                throw new IllegalArgumentException("MCP Connector credential is null or empty list");
+            boolean isMcpConnector = (protocol.equals(MCP_SSE) || protocol.equals(MCP_STREAMABLE_HTTP));
+            if ((credential == null || credential.isEmpty()) && !isMcpConnector) {
+                throw new IllegalArgumentException("Connector credential is null or empty list");
             }
             if (actions != null) {
                 for (ConnectorAction action : actions) {
                     action.validatePrePostProcessFunctions(parameters);
                 }
             }
-            if ((protocol.equals(MCP_SSE) || protocol.equals(MCP_STREAMABLE_HTTP)) && (url == null || url.isBlank())) {
+            if ((url == null || url.isBlank()) && isMcpConnector) {
                 throw new IllegalArgumentException("MCP Connector url is null or blank");
             }
         }

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -9,6 +9,8 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
 import static org.opensearch.ml.common.CommonValue.VERSION_3_0_0;
+import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_SSE;
+import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_STREAMABLE_HTTP;
 import static org.opensearch.ml.common.utils.StringUtils.getParameterMap;
 
 import java.io.IOException;
@@ -106,7 +108,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
             if (protocol == null) {
                 throw new IllegalArgumentException("Connector protocol is null");
             }
-            if (credential == null || credential.isEmpty()) {
+            if ((!protocol.equals(MCP_SSE) && !protocol.equals(MCP_STREAMABLE_HTTP)) && (credential == null || credential.isEmpty())) {
                 throw new IllegalArgumentException("Connector credential is null or empty list");
             }
             if (actions != null) {

--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorProtocolsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorProtocolsTest.java
@@ -17,14 +17,14 @@ public class ConnectorProtocolsTest {
     @Test
     public void validateProtocol_Null() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Connector protocol is null. Please use one of [aws_sigv4, http, mcp_sse]");
+        exceptionRule.expectMessage("Connector protocol is null. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]");
         ConnectorProtocols.validateProtocol(null);
     }
 
     @Test
     public void validateProtocol_WrongValue() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse]");
+        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]");
         ConnectorProtocols.validateProtocol("abc");
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -62,7 +62,7 @@ public class HttpConnectorTest {
     @Test
     public void constructor_InvalidProtocol() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse]");
+        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]");
 
         HttpConnector.builder().protocol("wrong protocol").build();
     }

--- a/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
@@ -55,7 +55,7 @@ public class McpConnectorTest {
     @Test
     public void constructor_InvalidProtocol() {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse]");
+        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]");
 
         McpConnector.builder().protocol("wrong protocol").build();
     }

--- a/common/src/test/java/org/opensearch/ml/common/connector/McpStreamableHttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/McpStreamableHttpConnectorTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.connector;
+
+import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_STREAMABLE_HTTP;
+import static org.opensearch.ml.common.connector.RetryBackoffPolicy.CONSTANT;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.AccessMode;
+import org.opensearch.ml.common.TestHelper;
+import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
+import org.opensearch.search.SearchModule;
+
+public class McpStreamableHttpConnectorTest {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    BiFunction<String, String, String> encryptFunction;
+    BiFunction<String, String, String> decryptFunction;
+
+    String TEST_CONNECTOR_JSON_STRING =
+        "{\"name\":\"test_mcp_streamable_http_connector_name\",\"version\":\"1\",\"description\":\"this is a test mcp streamable http connector\",\"protocol\":\"mcp_streamable_http\",\"credential\":{\"key\":\"test_key_value\"},\"backend_roles\":[\"role1\",\"role2\"],\"access\":\"public\",\"client_config\":{\"max_connection\":30,\"connection_timeout\":30000,\"read_timeout\":30000,\"retry_backoff_millis\":10,\"retry_timeout_seconds\":10,\"max_retry_times\":-1,\"retry_backoff_policy\":\"constant\"},\"url\":\"https://test.com\",\"headers\":{\"api_key\":\"${credential.key}\"},\"parameters\":{\"endpoint\":\"/custom/endpoint\"}}";
+
+    @Before
+    public void setUp() {
+        encryptFunction = (credential, tenantId) -> "encrypted_" + credential;
+        decryptFunction = (credential, tenantId) -> credential.replace("encrypted_", "");
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_Builder() {
+        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]");
+        McpStreamableHttpConnector.builder().protocol("wrong protocol").build();
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_StreamInput() throws IOException {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        BytesStreamOutput output = new BytesStreamOutput();
+        connector.writeTo(output);
+        McpStreamableHttpConnector connector2 = new McpStreamableHttpConnector(output.bytes().streamInput());
+        Assert.assertEquals(connector, connector2);
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_ToXContent() throws IOException {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        connector.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String connectorStr = TestHelper.xContentBuilderToString(builder);
+        Assert.assertFalse(connectorStr.contains("encrypted_"));
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_Parse() throws IOException {
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                TEST_CONNECTOR_JSON_STRING
+            );
+        parser.nextToken();
+        
+        McpStreamableHttpConnector connector = new McpStreamableHttpConnector("mcp_streamable_http", parser);
+        Assert.assertEquals("test_mcp_streamable_http_connector_name", connector.getName());
+        Assert.assertEquals("mcp_streamable_http", connector.getProtocol());
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_Encrypt() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        connector.encrypt(encryptFunction, "test_tenant");
+        Assert.assertEquals("encrypted_test_key_value", connector.getCredential().get("key"));
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_Decrypt() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        connector.encrypt(encryptFunction, "test_tenant");
+        connector.decrypt("", decryptFunction, "test_tenant");
+        Assert.assertEquals("test_key_value", connector.getDecryptedCredential().get("key"));
+        Assert.assertEquals("test_key_value", connector.getDecryptedHeaders().get("api_key"));
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_CloneConnector() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        Connector clonedConnector = connector.cloneConnector();
+        Assert.assertEquals(connector, clonedConnector);
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_RemoveCredential() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        connector.removeCredential();
+        Assert.assertNull(connector.getCredential());
+        Assert.assertNull(connector.getDecryptedCredential());
+        Assert.assertNull(connector.getDecryptedHeaders());
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_Update() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        Map<String, String> updatedCredential = new HashMap<>();
+        updatedCredential.put("new_key", "new_value");
+        MLCreateConnectorInput updateInput = MLCreateConnectorInput.builder()
+            .name("updated_name")
+            .description("updated_description")
+            .version("2")
+            .protocol(MCP_STREAMABLE_HTTP)
+            .credential(updatedCredential)
+            .build();
+        connector.update(updateInput, encryptFunction);
+        Assert.assertEquals("updated_name", connector.getName());
+        Assert.assertEquals("updated_description", connector.getDescription());
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_ValidateConnectorURL() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        List<String> urlRegexes = Arrays.asList(".*test\\.com.*");
+        connector.validateConnectorURL(urlRegexes);
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_ValidateConnectorURL_Invalid() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        List<String> urlRegexes = Arrays.asList(".*invalid\\.com.*");
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Connector URL is not matching the trusted connector endpoint regex");
+        connector.validateConnectorURL(urlRegexes);
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_GetParameters() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        Map<String, String> parameters = connector.getParameters();
+        Assert.assertNotNull(parameters);
+        Assert.assertEquals("/custom/endpoint", parameters.get("endpoint"));
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_UnsupportedOperations() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        
+        exceptionRule.expect(UnsupportedOperationException.class);
+        exceptionRule.expectMessage("Not implemented.");
+        connector.getActions();
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_UnsupportedOperations_AddAction() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        
+        exceptionRule.expect(UnsupportedOperationException.class);
+        exceptionRule.expectMessage("Not implemented.");
+        connector.addAction(null);
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_UnsupportedOperations_GetActionEndpoint() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        
+        exceptionRule.expect(UnsupportedOperationException.class);
+        exceptionRule.expectMessage("Not implemented.");
+        connector.getActionEndpoint("test", Collections.emptyMap());
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_UnsupportedOperations_GetActionHttpMethod() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        
+        exceptionRule.expect(UnsupportedOperationException.class);
+        exceptionRule.expectMessage("Not implemented.");
+        connector.getActionHttpMethod("test");
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_UnsupportedOperations_CreatePayload() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        
+        exceptionRule.expect(UnsupportedOperationException.class);
+        exceptionRule.expectMessage("Not implemented.");
+        connector.createPayload("test", Collections.emptyMap());
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_UnsupportedOperations_FindAction() {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        
+        exceptionRule.expect(UnsupportedOperationException.class);
+        exceptionRule.expectMessage("Not implemented.");
+        connector.findAction("test");
+    }
+
+    @Test
+    public void testMcpStreamableHttpConnector_UnsupportedOperations_ParseResponse() throws IOException {
+        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+        
+        exceptionRule.expect(UnsupportedOperationException.class);
+        exceptionRule.expectMessage("Not implemented.");
+        connector.parseResponse(null, Collections.emptyList(), false);
+    }
+
+    public static McpStreamableHttpConnector createMcpStreamableHttpConnector() {
+        Map<String, String> credential = new HashMap<>();
+        credential.put("key", "test_key_value");
+
+        List<String> backendRoles = Arrays.asList("role1", "role2");
+
+        ConnectorClientConfig clientConfig = ConnectorClientConfig.builder()
+            .maxConnections(30)
+            .connectionTimeout(30000)
+            .readTimeout(30000)
+            .retryBackoffMillis(10)
+            .retryTimeoutSeconds(10)
+            .maxRetryTimes(-1)
+            .retryBackoffPolicy(CONSTANT)
+            .build();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("api_key", "${credential.key}");
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("endpoint", "/custom/endpoint");
+
+        return McpStreamableHttpConnector
+            .builder()
+            .name("test_mcp_streamable_http_connector_name")
+            .version("1")
+            .description("this is a test mcp streamable http connector")
+            .protocol(MCP_STREAMABLE_HTTP)
+            .credential(credential)
+            .backendRoles(backendRoles)
+            .accessMode(AccessMode.PUBLIC)
+            .connectorClientConfig(clientConfig)
+            .url("https://test.com")
+            .headers(headers)
+            .parameters(parameters)
+            .build();
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/connector/McpStreamableHttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/McpStreamableHttpConnectorTest.java
@@ -84,7 +84,7 @@ public class McpStreamableHttpConnectorTest {
                 TEST_CONNECTOR_JSON_STRING
             );
         parser.nextToken();
-        
+
         McpStreamableHttpConnector connector = new McpStreamableHttpConnector("mcp_streamable_http", parser);
         Assert.assertEquals("test_mcp_streamable_http_connector_name", connector.getName());
         Assert.assertEquals("mcp_streamable_http", connector.getProtocol());
@@ -127,7 +127,8 @@ public class McpStreamableHttpConnectorTest {
         McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
         Map<String, String> updatedCredential = new HashMap<>();
         updatedCredential.put("new_key", "new_value");
-        MLCreateConnectorInput updateInput = MLCreateConnectorInput.builder()
+        MLCreateConnectorInput updateInput = MLCreateConnectorInput
+            .builder()
             .name("updated_name")
             .description("updated_description")
             .version("2")
@@ -166,7 +167,7 @@ public class McpStreamableHttpConnectorTest {
     @Test
     public void testMcpStreamableHttpConnector_UnsupportedOperations() {
         McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
-        
+
         exceptionRule.expect(UnsupportedOperationException.class);
         exceptionRule.expectMessage("Not implemented.");
         connector.getActions();
@@ -175,7 +176,7 @@ public class McpStreamableHttpConnectorTest {
     @Test
     public void testMcpStreamableHttpConnector_UnsupportedOperations_AddAction() {
         McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
-        
+
         exceptionRule.expect(UnsupportedOperationException.class);
         exceptionRule.expectMessage("Not implemented.");
         connector.addAction(null);
@@ -184,7 +185,7 @@ public class McpStreamableHttpConnectorTest {
     @Test
     public void testMcpStreamableHttpConnector_UnsupportedOperations_GetActionEndpoint() {
         McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
-        
+
         exceptionRule.expect(UnsupportedOperationException.class);
         exceptionRule.expectMessage("Not implemented.");
         connector.getActionEndpoint("test", Collections.emptyMap());
@@ -193,7 +194,7 @@ public class McpStreamableHttpConnectorTest {
     @Test
     public void testMcpStreamableHttpConnector_UnsupportedOperations_GetActionHttpMethod() {
         McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
-        
+
         exceptionRule.expect(UnsupportedOperationException.class);
         exceptionRule.expectMessage("Not implemented.");
         connector.getActionHttpMethod("test");
@@ -202,7 +203,7 @@ public class McpStreamableHttpConnectorTest {
     @Test
     public void testMcpStreamableHttpConnector_UnsupportedOperations_CreatePayload() {
         McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
-        
+
         exceptionRule.expect(UnsupportedOperationException.class);
         exceptionRule.expectMessage("Not implemented.");
         connector.createPayload("test", Collections.emptyMap());
@@ -211,7 +212,7 @@ public class McpStreamableHttpConnectorTest {
     @Test
     public void testMcpStreamableHttpConnector_UnsupportedOperations_FindAction() {
         McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
-        
+
         exceptionRule.expect(UnsupportedOperationException.class);
         exceptionRule.expectMessage("Not implemented.");
         connector.findAction("test");
@@ -220,7 +221,7 @@ public class McpStreamableHttpConnectorTest {
     @Test
     public void testMcpStreamableHttpConnector_UnsupportedOperations_ParseResponse() throws IOException {
         McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
-        
+
         exceptionRule.expect(UnsupportedOperationException.class);
         exceptionRule.expectMessage("Not implemented.");
         connector.parseResponse(null, Collections.emptyList(), false);
@@ -232,7 +233,8 @@ public class McpStreamableHttpConnectorTest {
 
         List<String> backendRoles = Arrays.asList("role1", "role2");
 
-        ConnectorClientConfig clientConfig = ConnectorClientConfig.builder()
+        ConnectorClientConfig clientConfig = ConnectorClientConfig
+            .builder()
             .maxConnections(30)
             .connectionTimeout(30000)
             .readTimeout(30000)

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -186,7 +186,7 @@ public class MLCreateConnectorInputTests {
                 .addAllBackendRoles(false)
                 .build();
         });
-        assertEquals("MCP Connector credential is null or empty list", exception.getMessage());
+        assertEquals("Connector credential is null or empty list", exception.getMessage());
     }
 
     @Test
@@ -206,7 +206,7 @@ public class MLCreateConnectorInputTests {
                 .addAllBackendRoles(false)
                 .build();
         });
-        assertEquals("MCP Connector credential is null or empty list", exception.getMessage());
+        assertEquals("Connector credential is null or empty list", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -10,6 +10,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_SSE;
+import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_STREAMABLE_HTTP;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -205,6 +207,94 @@ public class MLCreateConnectorInputTests {
                 .build();
         });
         assertEquals("Connector credential is null or empty list", exception.getMessage());
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_McpSseWithNullCredential_ShouldNotThrow() {
+        // MCP SSE connectors should be allowed to have null credentials
+        MLCreateConnectorInput connector = MLCreateConnectorInput
+            .builder()
+            .name(TEST_CONNECTOR_NAME)
+            .description(TEST_CONNECTOR_DESCRIPTION)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(MCP_SSE)
+            .parameters(Map.of(TEST_PARAM_KEY, TEST_PARAM_VALUE))
+            .credential(null)
+            .actions(List.of())
+            .access(AccessMode.PUBLIC)
+            .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
+            .addAllBackendRoles(false)
+            .build();
+
+        assertNotNull(connector);
+        assertEquals(MCP_SSE, connector.getProtocol());
+        assertNull(connector.getCredential());
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_McpSseWithEmptyCredential_ShouldNotThrow() {
+        // MCP SSE connectors should be allowed to have empty credentials
+        MLCreateConnectorInput connector = MLCreateConnectorInput
+            .builder()
+            .name(TEST_CONNECTOR_NAME)
+            .description(TEST_CONNECTOR_DESCRIPTION)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(MCP_SSE)
+            .parameters(Map.of(TEST_PARAM_KEY, TEST_PARAM_VALUE))
+            .credential(Map.of())
+            .actions(List.of())
+            .access(AccessMode.PUBLIC)
+            .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
+            .addAllBackendRoles(false)
+            .build();
+
+        assertNotNull(connector);
+        assertEquals(MCP_SSE, connector.getProtocol());
+        assertTrue(connector.getCredential().isEmpty());
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_McpStreamableHttpWithNullCredential_ShouldNotThrow() {
+        // MCP Streamable HTTP connectors should be allowed to have null credentials
+        MLCreateConnectorInput connector = MLCreateConnectorInput
+            .builder()
+            .name(TEST_CONNECTOR_NAME)
+            .description(TEST_CONNECTOR_DESCRIPTION)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(MCP_STREAMABLE_HTTP)
+            .parameters(Map.of(TEST_PARAM_KEY, TEST_PARAM_VALUE))
+            .credential(null)
+            .actions(List.of())
+            .access(AccessMode.PUBLIC)
+            .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
+            .addAllBackendRoles(false)
+            .build();
+
+        assertNotNull(connector);
+        assertEquals(MCP_STREAMABLE_HTTP, connector.getProtocol());
+        assertNull(connector.getCredential());
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_McpStreamableHttpWithEmptyCredential_ShouldNotThrow() {
+        // MCP Streamable HTTP connectors should be allowed to have empty credentials
+        MLCreateConnectorInput connector = MLCreateConnectorInput
+            .builder()
+            .name(TEST_CONNECTOR_NAME)
+            .description(TEST_CONNECTOR_DESCRIPTION)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(MCP_STREAMABLE_HTTP)
+            .parameters(Map.of(TEST_PARAM_KEY, TEST_PARAM_VALUE))
+            .credential(Map.of())
+            .actions(List.of())
+            .access(AccessMode.PUBLIC)
+            .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
+            .addAllBackendRoles(false)
+            .build();
+
+        assertNotNull(connector);
+        assertEquals(MCP_STREAMABLE_HTTP, connector.getProtocol());
+        assertTrue(connector.getCredential().isEmpty());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -186,7 +186,7 @@ public class MLCreateConnectorInputTests {
                 .addAllBackendRoles(false)
                 .build();
         });
-        assertEquals("Connector credential is null or empty list", exception.getMessage());
+        assertEquals("MCP Connector credential is null or empty list", exception.getMessage());
     }
 
     @Test
@@ -206,7 +206,7 @@ public class MLCreateConnectorInputTests {
                 .addAllBackendRoles(false)
                 .build();
         });
-        assertEquals("Connector credential is null or empty list", exception.getMessage());
+        assertEquals("MCP Connector credential is null or empty list", exception.getMessage());
     }
 
     @Test
@@ -224,6 +224,7 @@ public class MLCreateConnectorInputTests {
             .access(AccessMode.PUBLIC)
             .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
             .addAllBackendRoles(false)
+            .url("https://test.com") // Add valid URL for MCP connector
             .build();
 
         assertNotNull(connector);
@@ -246,6 +247,7 @@ public class MLCreateConnectorInputTests {
             .access(AccessMode.PUBLIC)
             .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
             .addAllBackendRoles(false)
+            .url("https://test.com") // Add valid URL for MCP connector
             .build();
 
         assertNotNull(connector);
@@ -268,6 +270,7 @@ public class MLCreateConnectorInputTests {
             .access(AccessMode.PUBLIC)
             .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
             .addAllBackendRoles(false)
+            .url("https://test.com") // Add valid URL for MCP connector
             .build();
 
         assertNotNull(connector);
@@ -290,6 +293,7 @@ public class MLCreateConnectorInputTests {
             .access(AccessMode.PUBLIC)
             .backendRoles(Arrays.asList(TEST_ROLE1, TEST_ROLE2))
             .addAllBackendRoles(false)
+            .url("https://test.com") // Add valid URL for MCP connector
             .build();
 
         assertNotNull(connector);
@@ -463,6 +467,65 @@ public class MLCreateConnectorInputTests {
         // No exception for missing mandatory fields when dryRun is true
         assertTrue(input.isDryRun());
         assertNull(input.getName()); // Name is not set, but no exception due to dryRun
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_McpSseWithNullUrl_ShouldThrowException() {
+        testMcpUrlValidation(MCP_SSE, null);
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_McpSseWithBlankUrl_ShouldThrowException() {
+        testMcpUrlValidation(MCP_SSE, "   ");
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_McpStreamableHttpWithNullUrl_ShouldThrowException() {
+        testMcpUrlValidation(MCP_STREAMABLE_HTTP, null);
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_McpStreamableHttpWithBlankUrl_ShouldThrowException() {
+        testMcpUrlValidation(MCP_STREAMABLE_HTTP, "   ");
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_McpSseWithValidUrl_ShouldNotThrowException() {
+        testMcpValidUrl(MCP_SSE);
+    }
+
+    @Test
+    public void constructorMLCreateConnectorInput_McpStreamableHttpWithValidUrl_ShouldNotThrowException() {
+        testMcpValidUrl(MCP_STREAMABLE_HTTP);
+    }
+
+    private void testMcpUrlValidation(String protocol, String url) {
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLCreateConnectorInput
+                .builder()
+                .name(TEST_CONNECTOR_NAME)
+                .version(TEST_CONNECTOR_VERSION)
+                .protocol(protocol)
+                .credential(null) // MCP connectors allow null credential
+                .url(url)
+                .build();
+        });
+        assertEquals("MCP Connector url is null or blank", exception.getMessage());
+    }
+
+    private void testMcpValidUrl(String protocol) {
+        MLCreateConnectorInput connector = MLCreateConnectorInput
+            .builder()
+            .name(TEST_CONNECTOR_NAME)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(protocol)
+            .credential(null)
+            .url("https://test.com")
+            .build();
+
+        assertNotNull(connector);
+        assertEquals(protocol, connector.getProtocol());
+        assertEquals("https://test.com", connector.getUrl());
     }
 
     // Helper method to create XContentParser from a JSON string

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     implementation('net.minidev:json-smart:2.5.2')
     implementation group: 'org.json', name: 'json', version: '20231013'
     implementation group: 'software.amazon.awssdk', name: 'netty-nio-client', version: "2.30.18"
-    api('io.modelcontextprotocol.sdk:mcp:0.9.0')
+    api('io.modelcontextprotocol.sdk:mcp:0.12.1')
     testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -756,7 +756,7 @@ public class AgentUtils {
                     return;
                 }
                 connector.decrypt("", (credential, tid) -> encryptor.decrypt(credential, tenantId), tenantId);
-                
+
                 List<MLToolSpec> mcpToolSpecs;
                 if (connector instanceof McpConnector) {
                     McpConnectorExecutor connectorExecutor = MLEngineClassLoader
@@ -770,7 +770,7 @@ public class AgentUtils {
                     log.error("Unsupported connector type for connector: " + connectorId);
                     mcpToolSpecs = Collections.emptyList();
                 }
-                
+
                 toolListener.onResponse(mcpToolSpecs);
             } catch (Exception e) {
                 log.error("Failed to get tools from connector: " + connectorId, e);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -73,15 +73,18 @@ import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLToolSpec;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.McpConnector;
+import org.opensearch.ml.common.connector.McpStreamableHttpConnector;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.engine.MLEngineClassLoader;
 import org.opensearch.ml.engine.algorithms.remote.McpConnectorExecutor;
+import org.opensearch.ml.engine.algorithms.remote.McpStreamableHttpConnectorExecutor;
 import org.opensearch.ml.engine.encryptor.Encryptor;
 import org.opensearch.ml.engine.function_calling.FunctionCalling;
 import org.opensearch.ml.engine.tools.McpSseTool;
+import org.opensearch.ml.engine.tools.McpStreamableHttpTool;
 import org.opensearch.remote.metadata.client.GetDataObjectRequest;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.common.SdkClientUtils;
@@ -747,15 +750,27 @@ public class AgentUtils {
     ) {
         getConnector(connectorId, tenantId, sdkClient, client, ActionListener.wrap(connector -> {
             try {
-                if (!(connector instanceof McpConnector)) {
-                    log.error("Connector with ID " + connectorId + " is not of type McpConnector");
+                if (!(connector instanceof McpConnector) && !(connector instanceof McpStreamableHttpConnector)) {
+                    log.error("Connector with ID " + connectorId + " is not of type McpConnector or McpStreamableHttpConnector");
                     toolListener.onResponse(Collections.emptyList());
                     return;
                 }
                 connector.decrypt("", (credential, tid) -> encryptor.decrypt(credential, tenantId), tenantId);
-                McpConnectorExecutor connectorExecutor = MLEngineClassLoader
-                    .initInstance(connector.getProtocol(), connector, Connector.class);
-                List<MLToolSpec> mcpToolSpecs = connectorExecutor.getMcpToolSpecs();
+                
+                List<MLToolSpec> mcpToolSpecs;
+                if (connector instanceof McpConnector) {
+                    McpConnectorExecutor connectorExecutor = MLEngineClassLoader
+                        .initInstance(connector.getProtocol(), connector, Connector.class);
+                    mcpToolSpecs = connectorExecutor.getMcpToolSpecs();
+                } else if (connector instanceof McpStreamableHttpConnector) {
+                    McpStreamableHttpConnectorExecutor connectorExecutor = MLEngineClassLoader
+                        .initInstance(connector.getProtocol(), connector, Connector.class);
+                    mcpToolSpecs = connectorExecutor.getMcpToolSpecs();
+                } else {
+                    log.error("Unsupported connector type for connector: " + connectorId);
+                    mcpToolSpecs = Collections.emptyList();
+                }
+                
                 toolListener.onResponse(mcpToolSpecs);
             } catch (Exception e) {
                 log.error("Failed to get tools from connector: " + connectorId, e);
@@ -917,6 +932,9 @@ public class AgentUtils {
             if (tool instanceof McpSseTool) {
                 // TODO: make this more general, avoid checking specific tool type
                 ((McpSseTool) tool).getMcpSyncClient().closeGracefully();
+            } else if (tool instanceof McpStreamableHttpTool) {
+                // TODO: make this more general, avoid checking specific tool type
+                ((McpStreamableHttpTool) tool).getMcpSyncClient().closeGracefully();
             }
         }
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -762,16 +762,18 @@ public class AgentUtils {
                     McpConnectorExecutor connectorExecutor = MLEngineClassLoader
                         .initInstance(connector.getProtocol(), connector, Connector.class);
                     mcpToolSpecs = connectorExecutor.getMcpToolSpecs();
-                } else if (connector instanceof McpStreamableHttpConnector) {
+                    toolListener.onResponse(mcpToolSpecs);
+                    return;
+                }
+                if (connector instanceof McpStreamableHttpConnector) {
                     McpStreamableHttpConnectorExecutor connectorExecutor = MLEngineClassLoader
                         .initInstance(connector.getProtocol(), connector, Connector.class);
                     mcpToolSpecs = connectorExecutor.getMcpToolSpecs();
-                } else {
-                    log.error("Unsupported connector type for connector: " + connectorId);
-                    mcpToolSpecs = Collections.emptyList();
+                    toolListener.onResponse(mcpToolSpecs);
+                    return;
                 }
-
-                toolListener.onResponse(mcpToolSpecs);
+                log.error("Unsupported connector type for connector: " + connectorId);
+                toolListener.onResponse(Collections.emptyList());
             } catch (Exception e) {
                 log.error("Failed to get tools from connector: " + connectorId, e);
                 toolListener.onResponse(Collections.emptyList());

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
@@ -48,7 +48,6 @@ import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
@@ -57,15 +56,6 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
 
     @Getter
     private McpConnector connector;
-    @Setter
-    @Getter
-    private TokenBucket rateLimiter;
-    @Setter
-    @Getter
-    private Map<String, TokenBucket> userRateLimiterMap;
-    @Setter
-    @Getter
-    private MLGuard mlGuard;
 
     public McpConnectorExecutor(Connector connector) {
         super.initialize(connector);
@@ -144,6 +134,21 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
 
     @Override
     public ScriptService getScriptService() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public TokenBucket getRateLimiter() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public Map<String, TokenBucket> getUserRateLimiterMap() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public MLGuard getMlGuard() {
         throw new UnsupportedOperationException("Not implemented.");
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
@@ -18,7 +18,6 @@ import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_SSE;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,9 +77,6 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
         String sseEndpoint = connector.getParameters() != null && connector.getParameters().containsKey(SSE_ENDPOINT_FIELD)
             ? connector.getParameters().get(SSE_ENDPOINT_FIELD)
             : MCP_DEFAULT_SSE_ENDPOINT;
-        if (mcpServerUrl == null) {
-            return Collections.emptyList();
-        }
         List<MLToolSpec> mcpToolSpecs = new ArrayList<>();
         try {
             Duration connectionTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getConnectionTimeout());

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
@@ -11,7 +11,7 @@ import static org.opensearch.ml.common.CommonValue.MCP_TOOLS_FIELD;
 import static org.opensearch.ml.common.CommonValue.MCP_TOOL_DESCRIPTION_FIELD;
 import static org.opensearch.ml.common.CommonValue.MCP_TOOL_INPUT_SCHEMA_FIELD;
 import static org.opensearch.ml.common.CommonValue.MCP_TOOL_NAME_FIELD;
-import static org.opensearch.ml.common.CommonValue.SSE_ENDPOINT_FILED;
+import static org.opensearch.ml.common.CommonValue.SSE_ENDPOINT_FIELD;
 import static org.opensearch.ml.common.CommonValue.TOOL_INPUT_SCHEMA_FIELD;
 import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_SSE;
 
@@ -75,8 +75,8 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
 
     public List<MLToolSpec> getMcpToolSpecs() {
         String mcpServerUrl = connector.getUrl();
-        String sseEndpoint = connector.getParameters() != null && connector.getParameters().containsKey(SSE_ENDPOINT_FILED)
-            ? connector.getParameters().get(SSE_ENDPOINT_FILED)
+        String sseEndpoint = connector.getParameters() != null && connector.getParameters().containsKey(SSE_ENDPOINT_FIELD)
+            ? connector.getParameters().get(SSE_ENDPOINT_FIELD)
             : MCP_DEFAULT_SSE_ENDPOINT;
         if (mcpServerUrl == null) {
             return Collections.emptyList();
@@ -87,8 +87,10 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
             Duration readTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getReadTimeout());
 
             Consumer<HttpRequest.Builder> headerConfig = builder -> {
-                for (Map.Entry<String, String> entry : connector.getDecryptedHeaders().entrySet()) {
-                    builder.header(entry.getKey(), entry.getValue());
+                if (connector.getDecryptedHeaders() != null) {
+                    for (Map.Entry<String, String> entry : connector.getDecryptedHeaders().entrySet()) {
+                        builder.header(entry.getKey(), entry.getValue());
+                    }
                 }
             };
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
@@ -19,7 +19,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,9 +78,6 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
         String endpoint = connector.getParameters() != null && connector.getParameters().containsKey(ENDPOINT_FIELD)
             ? connector.getParameters().get(ENDPOINT_FIELD)
             : MCP_DEFAULT_STREAMABLE_HTTP_ENDPOINT;
-        if (mcpServerUrl == null) {
-            return Collections.emptyList();
-        }
         List<MLToolSpec> mcpToolSpecs = new ArrayList<>();
         try {
             Duration connectionTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getConnectionTimeout());

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
@@ -5,8 +5,8 @@
 
 package org.opensearch.ml.engine.algorithms.remote;
 
-import static org.opensearch.ml.common.CommonValue.ENDPOINT_FILED;
-import static org.opensearch.ml.common.CommonValue.MCP_DEFAULT_ENDPOINT;
+import static org.opensearch.ml.common.CommonValue.ENDPOINT_FIELD;
+import static org.opensearch.ml.common.CommonValue.MCP_DEFAULT_STREAMABLE_HTTP_ENDPOINT;
 import static org.opensearch.ml.common.CommonValue.MCP_SYNC_CLIENT;
 import static org.opensearch.ml.common.CommonValue.MCP_TOOLS_FIELD;
 import static org.opensearch.ml.common.CommonValue.MCP_TOOL_DESCRIPTION_FIELD;
@@ -76,9 +76,9 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
 
     public List<MLToolSpec> getMcpToolSpecs() {
         String mcpServerUrl = connector.getUrl();
-        String endpoint = connector.getParameters() != null && connector.getParameters().containsKey(ENDPOINT_FILED)
-            ? connector.getParameters().get(ENDPOINT_FILED)
-            : MCP_DEFAULT_ENDPOINT;
+        String endpoint = connector.getParameters() != null && connector.getParameters().containsKey(ENDPOINT_FIELD)
+            ? connector.getParameters().get(ENDPOINT_FIELD)
+            : MCP_DEFAULT_STREAMABLE_HTTP_ENDPOINT;
         if (mcpServerUrl == null) {
             return Collections.emptyList();
         }
@@ -88,8 +88,10 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
             Duration readTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getReadTimeout());
 
             Consumer<HttpRequest.Builder> headerConfig = builder -> {
-                for (Map.Entry<String, String> entry : connector.getDecryptedHeaders().entrySet()) {
-                    builder.header(entry.getKey(), entry.getValue());
+                if (connector.getDecryptedHeaders() != null) {
+                    for (Map.Entry<String, String> entry : connector.getDecryptedHeaders().entrySet()) {
+                        builder.header(entry.getKey(), entry.getValue());
+                    }
                 }
             };
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.remote;
+
+import static org.opensearch.ml.common.CommonValue.ENDPOINT_FILED;
+import static org.opensearch.ml.common.CommonValue.MCP_DEFAULT_ENDPOINT;
+import static org.opensearch.ml.common.CommonValue.MCP_SYNC_CLIENT;
+import static org.opensearch.ml.common.CommonValue.MCP_TOOLS_FIELD;
+import static org.opensearch.ml.common.CommonValue.MCP_TOOL_DESCRIPTION_FIELD;
+import static org.opensearch.ml.common.CommonValue.MCP_TOOL_INPUT_SCHEMA_FIELD;
+import static org.opensearch.ml.common.CommonValue.MCP_TOOL_NAME_FIELD;
+import static org.opensearch.ml.common.CommonValue.TOOL_INPUT_SCHEMA_FIELD;
+import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_STREAMABLE_HTTP;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.util.TokenBucket;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.McpStreamableHttpConnector;
+import org.opensearch.ml.common.exception.MLException;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.model.MLGuard;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.engine.annotation.ConnectorExecutor;
+import org.opensearch.ml.engine.tools.McpStreamableHttpTool;
+import org.opensearch.script.ScriptService;
+import org.opensearch.transport.client.Client;
+
+import com.google.gson.Gson;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@ConnectorExecutor(MCP_STREAMABLE_HTTP)
+public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecutor {
+
+    @Getter
+    private McpStreamableHttpConnector connector;
+    @Setter
+    @Getter
+    private TokenBucket rateLimiter;
+    @Setter
+    @Getter
+    private Map<String, TokenBucket> userRateLimiterMap;
+    @Setter
+    @Getter
+    private MLGuard mlGuard;
+
+    public McpStreamableHttpConnectorExecutor(Connector connector) {
+        super.initialize(connector);
+        this.connector = (McpStreamableHttpConnector) connector;
+    }
+
+    public List<MLToolSpec> getMcpToolSpecs() {
+        String mcpServerUrl = connector.getUrl();
+        String endpoint = connector.getParameters() != null && connector.getParameters().containsKey(ENDPOINT_FILED)
+            ? connector.getParameters().get(ENDPOINT_FILED)
+            : MCP_DEFAULT_ENDPOINT;
+        if (mcpServerUrl == null) {
+            return Collections.emptyList();
+        }
+        List<MLToolSpec> mcpToolSpecs = new ArrayList<>();
+        try {
+            Duration connectionTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getConnectionTimeout());
+            Duration readTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getReadTimeout());
+
+            Consumer<HttpRequest.Builder> headerConfig = builder -> {
+                for (Map.Entry<String, String> entry : connector.getDecryptedHeaders().entrySet()) {
+                    builder.header(entry.getKey(), entry.getValue());
+                }
+            };
+
+            // Create streamable HTTP transport
+            McpClientTransport transport = HttpClientStreamableHttpTransport
+                .builder(mcpServerUrl)
+                .endpoint(endpoint)
+                .customizeClient(clientBuilder -> {
+                    clientBuilder.connectTimeout(connectionTimeout);
+                    clientBuilder.followRedirects(HttpClient.Redirect.NORMAL);
+                })
+                .customizeRequest(headerConfig)
+                .build();
+
+            // Create and initialize client
+            McpSyncClient client = McpClient
+                .sync(transport)
+                .requestTimeout(readTimeout)
+                .capabilities(McpSchema.ClientCapabilities.builder().roots(false).build())
+                .build();
+
+            client.initialize();
+            McpSchema.ListToolsResult tools = client.listTools();
+
+            // Process the results
+            Gson gson = new Gson();
+            String json = gson.toJson(tools, McpSchema.ListToolsResult.class);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = gson.fromJson(json, Map.class);
+
+            @SuppressWarnings("unchecked")
+            List<Object> mcpTools = (List<Object>) map.get(MCP_TOOLS_FIELD);
+
+            for (Object tool : mcpTools) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> toolMap = (Map<String, Object>) tool;
+                Map<String, String> attributes = new HashMap<>();
+                attributes.put(TOOL_INPUT_SCHEMA_FIELD, StringUtils.toJson(toolMap.get(MCP_TOOL_INPUT_SCHEMA_FIELD)));
+
+                String description = (toolMap.containsKey(MCP_TOOL_DESCRIPTION_FIELD))
+                    ? StringUtils.processTextDoc(toolMap.get(MCP_TOOL_DESCRIPTION_FIELD).toString())
+                    : McpStreamableHttpTool.DEFAULT_DESCRIPTION;
+                MLToolSpec mlToolSpec = MLToolSpec
+                    .builder()
+                    .type(McpStreamableHttpTool.TYPE)
+                    .name(toolMap.get(MCP_TOOL_NAME_FIELD).toString())
+                    .description(description)
+                    .attributes(attributes)
+                    .build();
+                mlToolSpec.addRuntimeResource(MCP_SYNC_CLIENT, client);
+                mcpToolSpecs.add(mlToolSpec);
+            }
+
+            return mcpToolSpecs;
+        } catch (Exception e) {
+            throw new MLException("Unexpected error while getting MCP tools", e);
+        }
+    }
+
+    @Override
+    public ScriptService getScriptService() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public Client getClient() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public Logger getLogger() {
+        return log;
+    }
+
+    @Override
+    public void invokeRemoteService(
+        String action,
+        MLInput mlInput,
+        Map<String, String> parameters,
+        String payload,
+        ExecutionContext executionContext,
+        ActionListener<Tuple<Integer, ModelTensors>> actionListener
+    ) {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
@@ -49,7 +49,6 @@ import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTranspor
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
@@ -58,15 +57,6 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
 
     @Getter
     private McpStreamableHttpConnector connector;
-    @Setter
-    @Getter
-    private TokenBucket rateLimiter;
-    @Setter
-    @Getter
-    private Map<String, TokenBucket> userRateLimiterMap;
-    @Setter
-    @Getter
-    private MLGuard mlGuard;
 
     public McpStreamableHttpConnectorExecutor(Connector connector) {
         super.initialize(connector);
@@ -149,6 +139,21 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
 
     @Override
     public ScriptService getScriptService() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public TokenBucket getRateLimiter() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public Map<String, TokenBucket> getUserRateLimiterMap() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public MLGuard getMlGuard() {
         throw new UnsupportedOperationException("Not implemented.");
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
@@ -18,7 +18,11 @@ import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_STREAMAB
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.apache.logging.log4j.Logger;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
@@ -18,10 +18,7 @@ import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_STREAMAB
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Consumer;
 
 import org.apache.logging.log4j.Logger;
@@ -65,9 +62,10 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
 
     public List<MLToolSpec> getMcpToolSpecs() {
         String mcpServerUrl = connector.getUrl();
-        String endpoint = connector.getParameters() != null && connector.getParameters().containsKey(ENDPOINT_FIELD)
-            ? connector.getParameters().get(ENDPOINT_FIELD)
-            : MCP_DEFAULT_STREAMABLE_HTTP_ENDPOINT;
+        String endpoint = Optional
+            .ofNullable(connector.getParameters())
+            .map(params -> params.get(ENDPOINT_FIELD))
+            .orElse(MCP_DEFAULT_STREAMABLE_HTTP_ENDPOINT);
         List<MLToolSpec> mcpToolSpecs = new ArrayList<>();
         try {
             Duration connectionTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getConnectionTimeout());

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/McpStreamableHttpTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/McpStreamableHttpTool.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.tools;
+
+import static org.opensearch.ml.common.CommonValue.MCP_SYNC_CLIENT;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.spi.tools.Parser;
+import org.opensearch.ml.common.spi.tools.ToolAnnotation;
+import org.opensearch.ml.common.spi.tools.WithModelTool;
+import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.common.utils.ToolUtils;
+import com.google.common.annotations.VisibleForTesting;
+
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * This tool supports running any MCP streamable HTTP model.
+ */
+@Log4j2
+@ToolAnnotation(McpStreamableHttpTool.TYPE)
+public class McpStreamableHttpTool implements WithModelTool {
+    public static final String TYPE = "McpStreamableHttpTool";
+
+    @Setter
+    @Getter
+    private String name = TYPE;
+    @Getter
+    @Setter
+    private Map<String, Object> attributes;
+    @VisibleForTesting
+    public static String DEFAULT_DESCRIPTION = "A tool from MCP Streamable HTTP Server";
+    @Getter
+    @Setter
+    private String description = DEFAULT_DESCRIPTION;
+    @Getter
+    private McpSyncClient mcpSyncClient;
+    @Setter
+    @Getter
+    @VisibleForTesting
+    private Parser<?, ?> outputParser;
+
+    public McpStreamableHttpTool(McpSyncClient mcpSyncClient) {
+        this.mcpSyncClient = mcpSyncClient;
+    }
+
+    @Override
+    public <T> void run(Map<String, String> originalParameters, ActionListener<T> listener) {
+        try {
+            Map<String, String> parameters = ToolUtils.extractInputParameters(originalParameters, attributes);
+            String input = parameters.get("input");
+            Map<String, Object> inputArgs = StringUtils.fromJson(input, "input");
+            McpSchema.CallToolResult result = mcpSyncClient.callTool(new McpSchema.CallToolRequest(this.name, inputArgs));
+            String resultJson = StringUtils.toJson(result.content());
+            @SuppressWarnings("unchecked")
+            T response = (T) resultJson;
+            listener.onResponse(response);
+        } catch (Exception e) {
+            log.error("Failed to call MCP streamable HTTP tool: {}", this.getName(), e);
+            listener.onFailure(e);
+        }
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String getVersion() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public void setName(String s) {
+        this.name = s;
+    }
+
+    @Override
+    public boolean validate(Map<String, String> parameters) {
+        if (parameters == null || parameters.size() == 0) {
+            return false;
+        }
+        return true;
+    }
+
+    public static class Factory implements WithModelTool.Factory<McpStreamableHttpTool> {
+        private static Factory INSTANCE;
+
+        public static Factory getInstance() {
+            if (INSTANCE != null) {
+                return INSTANCE;
+            }
+            synchronized (McpStreamableHttpTool.class) {
+                if (INSTANCE != null) {
+                    return INSTANCE;
+                }
+                INSTANCE = new Factory();
+                return INSTANCE;
+            }
+        }
+
+        public void init() {}
+
+        @Override
+        public McpStreamableHttpTool create(Map<String, Object> map) {
+            return new McpStreamableHttpTool((McpSyncClient) map.get(MCP_SYNC_CLIENT));
+        }
+
+        @Override
+        public String getDefaultDescription() {
+            return DEFAULT_DESCRIPTION;
+        }
+
+        @Override
+        public String getDefaultType() {
+            return TYPE;
+        }
+
+        @Override
+        public String getDefaultVersion() {
+            return null;
+        }
+
+        @Override
+        public List<String> getAllModelKeys() {
+            return List.of();
+        }
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/McpStreamableHttpTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/McpStreamableHttpTool.java
@@ -16,6 +16,7 @@ import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.common.spi.tools.WithModelTool;
 import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.common.utils.ToolUtils;
+
 import com.google.common.annotations.VisibleForTesting;
 
 import io.modelcontextprotocol.client.McpSyncClient;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -73,7 +73,9 @@ import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLToolSpec;
 import org.opensearch.ml.common.connector.AwsConnector;
 import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.connector.McpConnector;
+import org.opensearch.ml.common.connector.McpStreamableHttpConnector;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
@@ -83,10 +85,12 @@ import org.opensearch.ml.common.utils.ToolUtils;
 import org.opensearch.ml.engine.MLEngineClassLoader;
 import org.opensearch.ml.engine.MLStaticMockBase;
 import org.opensearch.ml.engine.algorithms.remote.McpConnectorExecutor;
+import org.opensearch.ml.engine.algorithms.remote.McpStreamableHttpConnectorExecutor;
 import org.opensearch.ml.engine.encryptor.Encryptor;
 import org.opensearch.ml.engine.function_calling.FunctionCalling;
 import org.opensearch.ml.engine.function_calling.FunctionCallingFactory;
 import org.opensearch.ml.engine.tools.McpSseTool;
+import org.opensearch.ml.engine.tools.McpStreamableHttpTool;
 import org.opensearch.remote.metadata.client.GetDataObjectRequest;
 import org.opensearch.remote.metadata.client.GetDataObjectResponse;
 import org.opensearch.remote.metadata.client.SdkClient;
@@ -1897,5 +1901,103 @@ public class AgentUtilsTest extends MLStaticMockBase {
         Assert.assertEquals("", output.get(TOOL_CALL_ID));
         Assert.assertTrue(output.containsKey(FINAL_ANSWER));
         Assert.assertTrue(output.get(FINAL_ANSWER).contains("[]"));
+    }
+
+    @Test
+    public void testGetMcpToolSpecs_McpStreamableHttpConnectorSuccess() throws Exception {
+        stubGetConnector();
+        List<MLToolSpec> expected = List
+            .of(MLToolSpec.builder().type(McpStreamableHttpTool.TYPE).name("StreamableHttpTool").description("mock").build());
+
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            // mock McpStreamableHttpConnector, McpStreamableHttpConnectorExecutor, agent, and listener
+            mockMcpStreamableHttpConnector(connStatic);
+            McpStreamableHttpConnectorExecutor exec = mock(McpStreamableHttpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenReturn(expected);
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            MLAgent mlAgent = mockAgent("[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]", "tenant");
+            ActionListener<List<MLToolSpec>> listener = mock(ActionListener.class);
+
+            // run and verify
+            AgentUtils.getMcpToolSpecs(mlAgent, client, sdkClient, null, listener);
+            verify(listener).onResponse(expected);
+        }
+    }
+
+    @Test
+    public void testGetMcpToolSpecs_UnsupportedConnectorType() throws Exception {
+        stubGetConnector();
+        try (MockedStatic<Connector> connStatic = mockStatic(Connector.class)) {
+            // Mock an unsupported connector type (neither McpConnector nor McpStreamableHttpConnector)
+            HttpConnector mockConnector = mock(HttpConnector.class);
+            when(mockConnector.getProtocol()).thenReturn("http");
+            doNothing().when(mockConnector).decrypt(anyString(), any(), anyString());
+            connStatic.when(() -> Connector.createConnector(any(XContentParser.class))).thenReturn(mockConnector);
+
+            MLAgent agent = mockAgent("[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]", "tenant");
+            ActionListener<List<MLToolSpec>> listener = mock(ActionListener.class);
+
+            AgentUtils.getMcpToolSpecs(agent, client, sdkClient, null, listener);
+            verify(listener).onResponse(Collections.emptyList());
+        }
+    }
+
+    @Test
+    public void testGetMcpToolSpecs_ExceptionInGetMcpToolSpecs() throws Exception {
+        stubGetConnector();
+
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            // mock McpConnector, McpConnectorExecutor, agent, and listener
+            mockMcpConnector(connStatic);
+            McpConnectorExecutor exec = mock(McpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenThrow(new RuntimeException("Test exception"));
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            MLAgent mlAgent = mockAgent("[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]", "tenant");
+            ActionListener<List<MLToolSpec>> listener = mock(ActionListener.class);
+
+            // run and verify
+            AgentUtils.getMcpToolSpecs(mlAgent, client, sdkClient, null, listener);
+            verify(listener).onResponse(Collections.emptyList());
+        }
+    }
+
+    @Test
+    public void testGetMcpToolSpecs_ExceptionInGetConnector() throws Exception {
+        // Mock getConnector to throw an exception
+        threadContext = new ThreadContext(Settings.builder().build());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenAnswer(inv -> {
+            CompletionStage<GetDataObjectResponse> stage = mock(CompletionStage.class);
+            when(stage.whenComplete(any())).thenAnswer(cbInv -> {
+                BiConsumer<GetDataObjectResponse, Throwable> cb = cbInv.getArgument(0);
+                cb.accept(null, new RuntimeException("Failed to get connector"));
+                return stage;
+            });
+            return stage;
+        });
+
+        MLAgent mlAgent = mockAgent("[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]", "tenant");
+        ActionListener<List<MLToolSpec>> listener = mock(ActionListener.class);
+
+        AgentUtils.getMcpToolSpecs(mlAgent, client, sdkClient, null, listener);
+        verify(listener).onResponse(Collections.emptyList());
+    }
+
+    // Helper method to mock McpStreamableHttpConnector
+    private void mockMcpStreamableHttpConnector(MockedStatic<Connector> connectorStatic) {
+        McpStreamableHttpConnector mockConnector = mock(McpStreamableHttpConnector.class);
+        when(mockConnector.getProtocol()).thenReturn("mcp_streamable_http");
+        doNothing().when(mockConnector).decrypt(anyString(), any(), anyString());
+        connectorStatic.when(() -> Connector.createConnector(any(XContentParser.class))).thenReturn(mockConnector);
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
@@ -109,14 +109,12 @@ public class McpConnectorExecutorTest extends MLStaticMockBase {
     public void testUnimplementedMethods_ThrowUnsupportedOperationException() {
         McpConnectorExecutor exec = new McpConnectorExecutor(mockConnector);
 
-        // Test invokeRemoteService throws UnsupportedOperationException
         assertThrows(UnsupportedOperationException.class, () -> exec.invokeRemoteService(null, null, null, null, null, null));
-
-        // Test getScriptService throws UnsupportedOperationException
         assertThrows(UnsupportedOperationException.class, () -> exec.getScriptService());
-
-        // Test getClient throws UnsupportedOperationException
         assertThrows(UnsupportedOperationException.class, () -> exec.getClient());
+        assertThrows(UnsupportedOperationException.class, () -> exec.getRateLimiter());
+        assertThrows(UnsupportedOperationException.class, () -> exec.getMlGuard());
+        assertThrows(UnsupportedOperationException.class, () -> exec.getUserRateLimiterMap());
 
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
@@ -94,4 +94,30 @@ public class McpConnectorExecutorTest extends MLStaticMockBase {
         }
     }
 
+    @Test
+    public void getMcpToolSpecs_throwsOnListToolsError() {
+        when(mcpClient.initialize()).thenReturn(null);
+        when(mcpClient.listTools()).thenThrow(new RuntimeException("Error listing tools"));
+        try (MockedStatic<McpClient> mocked = mockStatic(McpClient.class)) {
+            mocked.when(() -> McpClient.sync(any(McpClientTransport.class))).thenReturn(builder);
+            McpConnectorExecutor exec = new McpConnectorExecutor(mockConnector);
+            assertThrows(RuntimeException.class, () -> exec.getMcpToolSpecs());
+        }
+    }
+
+    @Test
+    public void testUnimplementedMethods_ThrowUnsupportedOperationException() {
+        McpConnectorExecutor exec = new McpConnectorExecutor(mockConnector);
+
+        // Test invokeRemoteService throws UnsupportedOperationException
+        assertThrows(UnsupportedOperationException.class, () -> exec.invokeRemoteService(null, null, null, null, null, null));
+
+        // Test getScriptService throws UnsupportedOperationException
+        assertThrows(UnsupportedOperationException.class, () -> exec.getScriptService());
+
+        // Test getClient throws UnsupportedOperationException
+        assertThrows(UnsupportedOperationException.class, () -> exec.getClient());
+
+    }
+
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
@@ -94,4 +94,32 @@ public class McpStreamableHttpConnectorExecutorTest extends MLStaticMockBase {
         }
     }
 
+    @Test
+    public void getMcpToolSpecs_throwsOnListToolsError() {
+
+        when(mcpClient.initialize()).thenReturn(null);
+        when(mcpClient.listTools()).thenThrow(new RuntimeException("Error listing tools"));
+        try (MockedStatic<McpClient> mocked = mockStatic(McpClient.class)) {
+            mocked.when(() -> McpClient.sync(any(McpClientTransport.class))).thenReturn(builder);
+            McpStreamableHttpConnectorExecutor exec = new McpStreamableHttpConnectorExecutor(mockConnector);
+
+            assertThrows(RuntimeException.class, () -> exec.getMcpToolSpecs());
+        }
+    }
+
+    @Test
+    public void testUnimplementedMethods_ThrowUnsupportedOperationException() {
+        McpStreamableHttpConnectorExecutor exec = new McpStreamableHttpConnectorExecutor(mockConnector);
+
+        // Test invokeRemoteService throws UnsupportedOperationException
+        assertThrows(UnsupportedOperationException.class, () -> exec.invokeRemoteService(null, null, null, null, null, null));
+
+        // Test getScriptService throws UnsupportedOperationException
+        assertThrows(UnsupportedOperationException.class, () -> exec.getScriptService());
+
+        // Test getClient throws UnsupportedOperationException
+        assertThrows(UnsupportedOperationException.class, () -> exec.getClient());
+
+    }
+
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.remote;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.connector.McpStreamableHttpConnector;
+import org.opensearch.ml.engine.MLStaticMockBase;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+
+public class McpStreamableHttpConnectorExecutorTest extends MLStaticMockBase {
+
+    @Mock
+    private McpStreamableHttpConnector mockConnector;
+    @Mock
+    private McpSyncClient mcpClient;
+    @Mock
+    private McpClient.SyncSpec builder;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        Map<String, String> decryptedHeaders = Map.of("Authorization", "Bearer secret-token");
+
+        when(mockConnector.getUrl()).thenReturn("http://random-url");
+        when(mockConnector.getDecryptedHeaders()).thenReturn(decryptedHeaders);
+
+        /* ---------- stub the fluent builder chain ------------------------ */
+        when(builder.requestTimeout(any())).thenReturn(builder);
+        when(builder.capabilities(any())).thenReturn(builder);
+        when(builder.build()).thenReturn(mcpClient);
+    }
+
+    @Test
+    public void testGetMcpToolSpecs_Success() throws Exception {
+        // Mock the MCP client and schema
+        McpSchema.ListToolsResult mockResult = createMockListToolsResult();
+        when(mcpClient.listTools()).thenReturn(mockResult);
+
+        // Mock the transport builder
+        try (MockedStatic<io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport> transportMock = 
+             mockStatic(io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.class)) {
+            
+            io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.Builder transportBuilder = 
+                org.mockito.Mockito.mock(io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.Builder.class);
+            io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport transport = 
+                org.mockito.Mockito.mock(io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.class);
+            
+            transportMock.when(() -> io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.builder(any()))
+                .thenReturn(transportBuilder);
+            when(transportBuilder.endpoint(any())).thenReturn(transportBuilder);
+            when(transportBuilder.customizeClient(any())).thenReturn(transportBuilder);
+            when(transportBuilder.customizeRequest(any())).thenReturn(transportBuilder);
+            when(transportBuilder.build()).thenReturn(transport);
+
+            // Mock McpClient.sync
+            try (MockedStatic<McpClient> clientMock = mockStatic(McpClient.class)) {
+                clientMock.when(() -> McpClient.sync(transport)).thenReturn(builder);
+
+                McpStreamableHttpConnectorExecutor exec = new McpStreamableHttpConnectorExecutor(mockConnector);
+                List<MLToolSpec> result = exec.getMcpToolSpecs();
+
+                Assert.assertNotNull(result);
+                Assert.assertEquals(1, result.size());
+                Assert.assertEquals("test_tool", result.get(0).getName());
+                Assert.assertEquals("McpStreamableHttpTool", result.get(0).getType());
+            }
+        }
+    }
+
+    @Test
+    public void testGetMcpToolSpecs_Exception() throws Exception {
+        when(mcpClient.listTools()).thenThrow(new RuntimeException("MCP server error"));
+
+        // Mock the transport builder
+        try (MockedStatic<io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport> transportMock = 
+             mockStatic(io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.class)) {
+            
+            io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.Builder transportBuilder = 
+                org.mockito.Mockito.mock(io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.Builder.class);
+            io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport transport = 
+                org.mockito.Mockito.mock(io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.class);
+            
+            transportMock.when(() -> io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.builder(any()))
+                .thenReturn(transportBuilder);
+            when(transportBuilder.endpoint(any())).thenReturn(transportBuilder);
+            when(transportBuilder.customizeClient(any())).thenReturn(transportBuilder);
+            when(transportBuilder.customizeRequest(any())).thenReturn(transportBuilder);
+            when(transportBuilder.build()).thenReturn(transport);
+
+            // Mock McpClient.sync
+            try (MockedStatic<McpClient> clientMock = mockStatic(McpClient.class)) {
+                clientMock.when(() -> McpClient.sync(transport)).thenReturn(builder);
+
+                McpStreamableHttpConnectorExecutor exec = new McpStreamableHttpConnectorExecutor(mockConnector);
+                
+                Exception exception = assertThrows(Exception.class, () -> exec.getMcpToolSpecs());
+                Assert.assertTrue(exception.getMessage().contains("Unexpected error while getting MCP tools"));
+            }
+        }
+    }
+
+    @Test
+    public void testGetMcpToolSpecs_NullUrl() {
+        when(mockConnector.getUrl()).thenReturn(null);
+
+        McpStreamableHttpConnectorExecutor exec = new McpStreamableHttpConnectorExecutor(mockConnector);
+        List<MLToolSpec> result = exec.getMcpToolSpecs();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testUnsupportedOperations() {
+        McpStreamableHttpConnectorExecutor exec = new McpStreamableHttpConnectorExecutor(mockConnector);
+
+        assertThrows(UnsupportedOperationException.class, () -> exec.getScriptService());
+        assertThrows(UnsupportedOperationException.class, () -> exec.getClient());
+        assertThrows(UnsupportedOperationException.class, () -> exec.invokeRemoteService(
+            "test", null, null, null, null, null));
+    }
+
+    @Test
+    public void testGetLogger() {
+        McpStreamableHttpConnectorExecutor exec = new McpStreamableHttpConnectorExecutor(mockConnector);
+        Assert.assertNotNull(exec.getLogger());
+    }
+
+    private McpSchema.ListToolsResult createMockListToolsResult() {
+        McpSchema.Tool tool = McpSchema.Tool.builder()
+            .name("test_tool")
+            .description("A test tool")
+            .build();
+
+        return new McpSchema.ListToolsResult(List.of(tool), null);
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
@@ -111,14 +111,12 @@ public class McpStreamableHttpConnectorExecutorTest extends MLStaticMockBase {
     public void testUnimplementedMethods_ThrowUnsupportedOperationException() {
         McpStreamableHttpConnectorExecutor exec = new McpStreamableHttpConnectorExecutor(mockConnector);
 
-        // Test invokeRemoteService throws UnsupportedOperationException
         assertThrows(UnsupportedOperationException.class, () -> exec.invokeRemoteService(null, null, null, null, null, null));
-
-        // Test getScriptService throws UnsupportedOperationException
         assertThrows(UnsupportedOperationException.class, () -> exec.getScriptService());
-
-        // Test getClient throws UnsupportedOperationException
         assertThrows(UnsupportedOperationException.class, () -> exec.getClient());
+        assertThrows(UnsupportedOperationException.class, () -> exec.getRateLimiter());
+        assertThrows(UnsupportedOperationException.class, () -> exec.getMlGuard());
+        assertThrows(UnsupportedOperationException.class, () -> exec.getUserRateLimiterMap());
 
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
@@ -56,15 +56,19 @@ public class McpStreamableHttpConnectorExecutorTest extends MLStaticMockBase {
         when(mcpClient.listTools()).thenReturn(mockResult);
 
         // Mock the transport builder
-        try (MockedStatic<io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport> transportMock = 
-             mockStatic(io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.class)) {
-            
-            io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.Builder transportBuilder = 
-                org.mockito.Mockito.mock(io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.Builder.class);
-            io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport transport = 
-                org.mockito.Mockito.mock(io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.class);
-            
-            transportMock.when(() -> io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.builder(any()))
+        try (
+            MockedStatic<io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport> transportMock = mockStatic(
+                io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.class
+            )
+        ) {
+
+            io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.Builder transportBuilder = org.mockito.Mockito
+                .mock(io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.Builder.class);
+            io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport transport = org.mockito.Mockito
+                .mock(io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.class);
+
+            transportMock
+                .when(() -> io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport.builder(any()))
                 .thenReturn(transportBuilder);
             when(transportBuilder.endpoint(any())).thenReturn(transportBuilder);
             when(transportBuilder.customizeClient(any())).thenReturn(transportBuilder);
@@ -135,8 +139,7 @@ public class McpStreamableHttpConnectorExecutorTest extends MLStaticMockBase {
 
         assertThrows(UnsupportedOperationException.class, () -> exec.getScriptService());
         assertThrows(UnsupportedOperationException.class, () -> exec.getClient());
-        assertThrows(UnsupportedOperationException.class, () -> exec.invokeRemoteService(
-            "test", null, null, null, null, null));
+        assertThrows(UnsupportedOperationException.class, () -> exec.invokeRemoteService("test", null, null, null, null, null));
     }
 
     @Test
@@ -146,10 +149,7 @@ public class McpStreamableHttpConnectorExecutorTest extends MLStaticMockBase {
     }
 
     private McpSchema.ListToolsResult createMockListToolsResult() {
-        McpSchema.Tool tool = McpSchema.Tool.builder()
-            .name("test_tool")
-            .description("A test tool")
-            .build();
+        McpSchema.Tool tool = McpSchema.Tool.builder().name("test_tool").description("A test tool").build();
 
         return new McpSchema.ListToolsResult(List.of(tool), null);
     }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpStreamableHttpToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpStreamableHttpToolTests.java
@@ -51,7 +51,7 @@ public class McpStreamableHttpToolTests {
     public void testRun_Success() {
         // Mock the MCP client response
         McpSchema.CallToolResult mockResult = new McpSchema.CallToolResult("test response", false);
-        
+
         when(mcpSyncClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(mockResult);
 
         // Execute the tool
@@ -150,7 +150,7 @@ public class McpStreamableHttpToolTests {
     public void testFactory_Create() {
         McpStreamableHttpTool.Factory factory = McpStreamableHttpTool.Factory.getInstance();
         Tool createdTool = factory.create(Map.of(MCP_SYNC_CLIENT, mcpSyncClient));
-        
+
         assertTrue(createdTool instanceof McpStreamableHttpTool);
         assertEquals("McpStreamableHttpTool", createdTool.getType());
     }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpStreamableHttpToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpStreamableHttpToolTests.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.CommonValue.MCP_SYNC_CLIENT;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.spi.tools.Tool;
+
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+
+public class McpStreamableHttpToolTests {
+
+    @Mock
+    private McpSyncClient mcpSyncClient;
+
+    @Mock
+    private ActionListener<String> listener;
+
+    private Tool tool;
+    private Map<String, String> validParams;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        // Initialize the tool with the mocked mcp client
+        tool = McpStreamableHttpTool.Factory.getInstance().create(Map.of(MCP_SYNC_CLIENT, mcpSyncClient));
+        validParams = Map.of("input", "{\"foo\":\"bar\"}");
+    }
+
+    @Test
+    public void testRun_Success() {
+        // Mock the MCP client response
+        McpSchema.CallToolResult mockResult = new McpSchema.CallToolResult("test response", false);
+        
+        when(mcpSyncClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(mockResult);
+
+        // Execute the tool
+        tool.run(validParams, listener);
+
+        // Verify the client was called and listener was notified
+        verify(mcpSyncClient).callTool(any(McpSchema.CallToolRequest.class));
+        verify(listener).onResponse("[{\"text\":\"test response\"}]");
+        verify(listener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testRun_ClientException() {
+        // Mock the MCP client to throw an exception
+        RuntimeException testException = new RuntimeException("MCP client error");
+        when(mcpSyncClient.callTool(any(McpSchema.CallToolRequest.class))).thenThrow(testException);
+
+        // Execute the tool
+        tool.run(validParams, listener);
+
+        // Verify the client was called and listener was notified of failure
+        verify(mcpSyncClient).callTool(any(McpSchema.CallToolRequest.class));
+        verify(listener).onFailure(testException);
+        verify(listener, never()).onResponse(any());
+    }
+
+    @Test
+    public void testRun_InvalidInput() {
+        Map<String, String> invalidParams = Map.of("input", "invalid json");
+
+        // Execute the tool with invalid input
+        tool.run(invalidParams, listener);
+
+        // Verify the listener was notified of failure
+        verify(listener).onFailure(any());
+        verify(listener, never()).onResponse(any());
+    }
+
+    @Test
+    public void testValidate_ValidParams() {
+        assertTrue(tool.validate(validParams));
+    }
+
+    @Test
+    public void testValidate_EmptyParams() {
+        assertFalse(tool.validate(Collections.emptyMap()));
+    }
+
+    @Test
+    public void testValidate_NullParams() {
+        assertFalse(tool.validate(null));
+    }
+
+    @Test
+    public void testGetType() {
+        assertEquals("McpStreamableHttpTool", tool.getType());
+    }
+
+    @Test
+    public void testGetVersion() {
+        assertNull(tool.getVersion());
+    }
+
+    @Test
+    public void testGetName() {
+        assertEquals("McpStreamableHttpTool", tool.getName());
+    }
+
+    @Test
+    public void testSetName() {
+        String newName = "CustomToolName";
+        tool.setName(newName);
+        assertEquals(newName, tool.getName());
+    }
+
+    @Test
+    public void testGetDescription() {
+        assertEquals("A tool from MCP Streamable HTTP Server", tool.getDescription());
+    }
+
+    @Test
+    public void testSetDescription() {
+        String newDescription = "Custom description";
+        tool.setDescription(newDescription);
+        assertEquals(newDescription, tool.getDescription());
+    }
+
+    @Test
+    public void testFactory_Singleton() {
+        McpStreamableHttpTool.Factory factory1 = McpStreamableHttpTool.Factory.getInstance();
+        McpStreamableHttpTool.Factory factory2 = McpStreamableHttpTool.Factory.getInstance();
+        assertEquals(factory1, factory2);
+    }
+
+    @Test
+    public void testFactory_Create() {
+        McpStreamableHttpTool.Factory factory = McpStreamableHttpTool.Factory.getInstance();
+        Tool createdTool = factory.create(Map.of(MCP_SYNC_CLIENT, mcpSyncClient));
+        
+        assertTrue(createdTool instanceof McpStreamableHttpTool);
+        assertEquals("McpStreamableHttpTool", createdTool.getType());
+    }
+
+    @Test
+    public void testFactory_GetDefaultDescription() {
+        McpStreamableHttpTool.Factory factory = McpStreamableHttpTool.Factory.getInstance();
+        assertEquals("A tool from MCP Streamable HTTP Server", factory.getDefaultDescription());
+    }
+
+    @Test
+    public void testFactory_GetDefaultType() {
+        McpStreamableHttpTool.Factory factory = McpStreamableHttpTool.Factory.getInstance();
+        assertEquals("McpStreamableHttpTool", factory.getDefaultType());
+    }
+
+    @Test
+    public void testFactory_GetDefaultVersion() {
+        McpStreamableHttpTool.Factory factory = McpStreamableHttpTool.Factory.getInstance();
+        assertNull(factory.getDefaultVersion());
+    }
+
+    @Test
+    public void testFactory_GetAllModelKeys() {
+        McpStreamableHttpTool.Factory factory = McpStreamableHttpTool.Factory.getInstance();
+        assertTrue(factory.getAllModelKeys().isEmpty());
+    }
+
+    @Test
+    public void testFactory_Init() {
+        McpStreamableHttpTool.Factory factory = McpStreamableHttpTool.Factory.getInstance();
+        // Should not throw any exception
+        factory.init();
+    }
+}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -82,7 +82,8 @@ dependencies {
     implementation (group: 'com.google.guava', name: 'guava', version: '32.1.3-jre') {
 	exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
-    implementation group: 'com.google.code.gson', name: 'gson', version: "${versions.gson}"
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.13.2'
+    api "com.google.errorprone:error_prone_annotations:${versions.error_prone_annotations}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${versions.commonslang}"
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
@@ -440,6 +441,14 @@ configurations.all {
     resolutionStrategy.force "software.amazon.awssdk:regions:${versions.aws}"
     resolutionStrategy.force "software.amazon.awssdk:netty-nio-client:${versions.aws}"
     resolutionStrategy.force "software.amazon.awssdk:s3:${versions.aws}"
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
+    resolutionStrategy.force 'com.networknt:json-schema-validator:1.5.7'
+    resolutionStrategy.force 'com.fasterxml.jackson:jackson-bom:2.18.3'
+    resolutionStrategy.force 'org.yaml:snakeyaml:2.3'
+    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.18.3'
+    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.3'
+    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.18.3'
+    resolutionStrategy.force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.3'
 }
 
 apply plugin: 'com.netflix.nebula.ospackage'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -82,8 +82,7 @@ dependencies {
     implementation (group: 'com.google.guava', name: 'guava', version: '32.1.3-jre') {
 	exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.13.2'
-    api "com.google.errorprone:error_prone_annotations:${versions.error_prone_annotations}"
+    implementation group: 'com.google.code.gson', name: 'gson', version: "${versions.gson}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${versions.commonslang}"
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -266,6 +266,7 @@ import org.opensearch.ml.engine.tools.IndexMappingTool;
 import org.opensearch.ml.engine.tools.ListIndexTool;
 import org.opensearch.ml.engine.tools.MLModelTool;
 import org.opensearch.ml.engine.tools.McpSseTool;
+import org.opensearch.ml.engine.tools.McpStreamableHttpTool;
 import org.opensearch.ml.engine.tools.QueryPlanningTool;
 import org.opensearch.ml.engine.tools.SearchIndexTool;
 import org.opensearch.ml.engine.tools.VisualizationsTool;
@@ -775,6 +776,7 @@ public class MachineLearningPlugin extends Plugin
         MLModelTool.Factory.getInstance().init(client);
         IndexInsightTool.Factory.getInstance().init(client);
         McpSseTool.Factory.getInstance().init();
+        McpStreamableHttpTool.Factory.getInstance().init();
         AgentTool.Factory.getInstance().init(client);
         ListIndexTool.Factory.getInstance().init(client, clusterService);
         IndexMappingTool.Factory.getInstance().init(client);
@@ -786,6 +788,7 @@ public class MachineLearningPlugin extends Plugin
         toolFactories.put(MLModelTool.TYPE, MLModelTool.Factory.getInstance());
         toolFactories.put(IndexInsightTool.TYPE, IndexInsightTool.Factory.getInstance());
         toolFactories.put(McpSseTool.TYPE, McpSseTool.Factory.getInstance());
+        toolFactories.put(McpStreamableHttpTool.TYPE, McpStreamableHttpTool.Factory.getInstance());
         toolFactories.put(AgentTool.TYPE, AgentTool.Factory.getInstance());
         toolFactories.put(ListIndexTool.TYPE, ListIndexTool.Factory.getInstance());
         toolFactories.put(IndexMappingTool.TYPE, IndexMappingTool.Factory.getInstance());

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
@@ -633,6 +633,7 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             .version("1")
             .protocol(ConnectorProtocols.MCP_SSE)
             .credential(credential)
+            .url("test")
             .build();
         MLCreateConnectorRequest request = new MLCreateConnectorRequest(mlCreateConnectorInput);
         action.doExecute(task, request, actionListener);


### PR DESCRIPTION
### Description
Similar to SSE connectors people can now create streamable HTTP connectors and use them in agents

Only change is the connector creation:
```
{
  "name": "My MCP Connector",
  "description": "The connector to MCP server",
  "version": 1,
  "protocol": "mcp_streamable_http",
  "credential": {
    "mcp_server_key": "testmcp"
  },
  "parameters":{
    "endpoint": "/mcp/"
  },
  "url": "http://localhost:9900",
  "headers": {
    "Authorization": "Bearer ${credential.mcp_server_key}"
  }
}
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
