### PR TITLE
Adding query planning tool search template validation and integration tests

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningPromptTemplate.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningPromptTemplate.java
@@ -201,14 +201,14 @@ public class QueryPlanningPromptTemplate {
             + "- If no perfect match exists, pick the closest by the criteria above. Never output “none” or invent an id.";
 
     public static final String TEMPLATE_SELECTION_INPUTS = "question: ${parameters.query_text}\n"
-        + "templates: ${parameters.search_templates}";
+        + "search_templates: ${parameters.search_templates}";
 
     public static final String TEMPLATE_SELECTION_EXAMPLES = "Example A: \n"
         + "question: 'what shoes are highly rated'\n"
-        + "templates:\n"
+        + "search_templates :\n"
         + "[\n"
-        + "{'id':'product-search-template','description':'Searches products in an e-commerce store.'},\n"
-        + "{'id':'sales-value-analysis-template','description':'Aggregates sales value for top-selling products.'}\n"
+        + "{'template_id':'product-search-template','template_description':'Searches products in an e-commerce store.'},\n"
+        + "{'template_id':'sales-value-analysis-template','template_description':'Aggregates sales value for top-selling products.'}\n"
         + "]\n"
         + "Example output : 'product-search-template'";
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
@@ -96,6 +96,38 @@ public class QueryPlanningToolTests {
     }
 
     @Test
+    public void testCreateWithInvalidSearchTemplatesDescription() throws IllegalArgumentException {
+        Map<String, Object> params = new HashMap<>();
+        params.put("generation_type", "user_templates");
+        params.put(MODEL_ID_FIELD, "test_model_id");
+        params
+            .put(
+                SYSTEM_PROMPT_FIELD,
+                "You are a query generation agent. Generate a dsl query for the following question: ${parameters.query_text}"
+            );
+        params.put("query_text", "help me find some books related to wind");
+        params.put("search_templates", "[{'template_id': 'template_id', 'template_des': 'test_description'}]");
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> factory.create(params));
+        assertEquals("search_templates field entries must have a template_description", exception.getMessage());
+    }
+
+    @Test
+    public void testCreateWithInvalidSearchTemplatesID() throws IllegalArgumentException {
+        Map<String, Object> params = new HashMap<>();
+        params.put("generation_type", "user_templates");
+        params.put(MODEL_ID_FIELD, "test_model_id");
+        params
+            .put(
+                SYSTEM_PROMPT_FIELD,
+                "You are a query generation agent. Generate a dsl query for the following question: ${parameters.query_text}"
+            );
+        params.put("query_text", "help me find some books related to wind");
+        params.put("search_templates", "[{'templateid': 'template_id', 'template_description': 'test_description'}]");
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> factory.create(params));
+        assertEquals("search_templates field entries must have a template_id", exception.getMessage());
+    }
+
+    @Test
     public void testRun() throws ExecutionException, InterruptedException {
         String matchQueryString = "{\"query\":{\"match\":{\"title\":\"wind\"}}}";
         doAnswer(invocation -> {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestQueryPlanningToolIT.java
@@ -6,7 +6,10 @@
 package org.opensearch.ml.rest;
 
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED;
+import static org.opensearch.ml.engine.tools.QueryPlanningTool.GENERATION_TYPE_FIELD;
 import static org.opensearch.ml.engine.tools.QueryPlanningTool.MODEL_ID_FIELD;
+import static org.opensearch.ml.engine.tools.QueryPlanningTool.SEARCH_TEMPLATES_FIELD;
+import static org.opensearch.ml.engine.tools.QueryPlanningTool.USER_SEARCH_TEMPLATES_TYPE_FIELD;
 
 import java.io.IOException;
 import java.util.List;
@@ -95,6 +98,50 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
         deleteAgent(agentId);
     }
 
+    @Test
+    public void testAgentWithQueryPlanningTool_SearchTemplates() throws IOException {
+        if (OPENAI_KEY == null) {
+            return;
+        }
+
+        // Create Search Templates
+        String templateBody = "{\"script\":{\"lang\":\"mustache\",\"source\":{\"query\":{\"match\":{\"type\":\"{{type}}\"}}}}}";
+        Response response = createSearchTemplate("type_search_template", templateBody);
+        templateBody = "{\"script\":{\"lang\":\"mustache\",\"source\":{\"query\":{\"term\":{\"type\":\"{{type}}\"}}}}}";
+        response = createSearchTemplate("type_search_template_2", templateBody);
+
+        // Register agent with search template IDs
+        String agentName = "Test_AgentWithQueryPlanningTool_SearchTemplates";
+        String searchTemplates = "[{"
+            + "\"template_id\":\"type_search_template\","
+            + "\"template_description\":\"this templates searches for flowers that match the given type this uses a match query\""
+            + "},{"
+            + "\"template_id\":\"type_search_template_2\","
+            + "\"template_description\":\"this templates searches for flowers that match the given type this uses a term query\""
+            + "},{"
+            + "\"template_id\":\"brand_search_template\","
+            + "\"template_description\":\"this templates searches for products that match the given brand\""
+            + "}]";
+        String agentId = registerQueryPlanningAgentWithSearchTemplates(agentName, queryPlanningModelId, searchTemplates);
+        assertNotNull(agentId);
+
+        String query = "{\"parameters\": {\"query_text\": \"List 5 iris flowers of type setosa\"}}";
+        Response agentResponse = executeAgent(agentId, query);
+        String responseBody = TestHelper.httpEntityToString(agentResponse.getEntity());
+
+        Map<String, Object> responseMap = gson.fromJson(responseBody, Map.class);
+
+        List<Map<String, Object>> inferenceResults = (List<Map<String, Object>>) responseMap.get("inference_results");
+        Map<String, Object> firstResult = inferenceResults.get(0);
+        List<Map<String, Object>> outputArray = (List<Map<String, Object>>) firstResult.get("output");
+        Map<String, Object> output = (Map<String, Object>) outputArray.get(0);
+        String result = output.get("result").toString();
+
+        assertTrue(result.contains("query"));
+        assertTrue(result.contains("term"));
+        deleteAgent(agentId);
+    }
+
     private String registerAgentWithQueryPlanningTool(String agentName, String modelId) throws IOException {
         MLToolSpec listIndexTool = MLToolSpec
             .builder()
@@ -111,6 +158,44 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
             .name("MyQueryPlanningTool")
             .description("A tool for planning queries")
             .parameters(Map.of(MODEL_ID_FIELD, modelId))
+            .includeOutputInAgentResponse(true)
+            .build();
+
+        MLAgent agent = MLAgent
+            .builder()
+            .name(agentName)
+            .type("flow")
+            .description("Test agent with QueryPlanningTool")
+            .tools(List.of(listIndexTool, queryPlanningTool))
+            .build();
+
+        return registerAgent(agentName, agent);
+    }
+
+    private String registerQueryPlanningAgentWithSearchTemplates(String agentName, String modelId, String searchTemplates)
+        throws IOException {
+        MLToolSpec listIndexTool = MLToolSpec
+            .builder()
+            .type("ListIndexTool")
+            .name("MyListIndexTool")
+            .description("A tool for list indices")
+            .parameters(Map.of("index", IRIS_INDEX, "question", "what fields are in the index?"))
+            .includeOutputInAgentResponse(true)
+            .build();
+
+        MLToolSpec queryPlanningTool = MLToolSpec
+            .builder()
+            .type("QueryPlanningTool")
+            .name("MyQueryPlanningTool")
+            .description("A tool for planning queries")
+            .parameters(
+                Map
+                    .ofEntries(
+                        Map.entry(MODEL_ID_FIELD, modelId),
+                        Map.entry(GENERATION_TYPE_FIELD, USER_SEARCH_TEMPLATES_TYPE_FIELD),
+                        Map.entry(SEARCH_TEMPLATES_FIELD, searchTemplates)
+                    )
+            )
             .includeOutputInAgentResponse(true)
             .build();
 
@@ -173,6 +258,18 @@ public class RestQueryPlanningToolIT extends MLCommonsRestTestCase {
                 "/_plugins/_ml/agents/" + agentId + "/_execute",
                 null,
                 new StringEntity(query),
+                List.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
+            );
+    }
+
+    private Response createSearchTemplate(String templateName, String templateBody) throws IOException {
+        return TestHelper
+            .makeRequest(
+                client(),
+                "PUT",
+                "/_scripts/" + templateName,
+                null,
+                new StringEntity(templateBody),
                 List.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
             );
     }


### PR DESCRIPTION
### Description
- Adds field validation for QueryPlanningTool field `search_templates` to require both `template_id` and `template_description`
- Adds null check for StoredScript response, defaults to default search template if script response is null
- Adds integration tests for Search template field

Additionally includes changes from https://github.com/opensearch-project/ml-commons/pull/4176, will rebase once its merged

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
