### PR TITLE
make MLSdkAsyncHttpResponseHandler return IllegalArgumentException

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
@@ -206,6 +206,8 @@ public class MLSdkAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandle
             ModelTensors tensors = processOutput(action, body, connector, scriptService, parameters, mlGuard);
             tensors.setStatusCode(statusCode);
             actionListener.onResponse(new Tuple<>(executionContext.getSequence(), tensors));
+        } catch (IllegalArgumentException e) {
+            actionListener.onFailure(e);
         } catch (Exception e) {
             log.error("Failed to process response body: {}", body, e);
             actionListener.onFailure(new MLException("Fail to execute " + action + " in aws connector", e));


### PR DESCRIPTION
### Description
This is a mitigation for https://github.com/opensearch-project/ml-commons/issues/4170

But would need a more thorough code change so that clients can handle properly all situations.

### Related Issues
https://github.com/opensearch-project/ml-commons/issues/4170 can be closed but discussion can be done to consider different types of failures

### Testing
 ./gradlew spotlessApply
./gradlew test

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
