### PR TITLE
Claude interface

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -111,6 +111,7 @@ public class AgentUtils {
     public static final String LLM_RESPONSE_FILTER = "llm_response_filter";
     public static final String TOOL_RESULT = "tool_result";
     public static final String TOOL_CALL_ID = "tool_call_id";
+    public static final String LLM_INTERFACE_BEDROCK_CONVERSE = "bedrock/converse";
     public static final String LLM_INTERFACE_BEDROCK_CONVERSE_CLAUDE = "bedrock/converse/claude";
     public static final String LLM_INTERFACE_OPENAI_V1_CHAT_COMPLETIONS = "openai/v1/chat/completions";
     public static final String LLM_INTERFACE_BEDROCK_CONVERSE_DEEPSEEK_R1 = "bedrock/converse/deepseek_r1";

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/FunctionCallingFactory.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/FunctionCallingFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.engine.function_calling;
 
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_BEDROCK_CONVERSE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_BEDROCK_CONVERSE_CLAUDE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_BEDROCK_CONVERSE_DEEPSEEK_R1;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_OPENAI_V1_CHAT_COMPLETIONS;
@@ -21,6 +22,8 @@ public class FunctionCallingFactory {
         }
 
         switch (llmInterface.trim().toLowerCase(Locale.ROOT)) {
+            case LLM_INTERFACE_BEDROCK_CONVERSE:
+                return new BedrockConverseFunctionCalling();
             case LLM_INTERFACE_BEDROCK_CONVERSE_CLAUDE:
                 return new BedrockConverseFunctionCalling();
             case LLM_INTERFACE_OPENAI_V1_CHAT_COMPLETIONS:

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -21,6 +21,7 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.DEFAULT_DATET
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_REASON_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_REASON_TOOL_USE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_GEN_INPUT;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_BEDROCK_CONVERSE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_BEDROCK_CONVERSE_CLAUDE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_EXCLUDE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
@@ -1897,5 +1898,16 @@ public class AgentUtilsTest extends MLStaticMockBase {
         Assert.assertEquals("", output.get(TOOL_CALL_ID));
         Assert.assertTrue(output.containsKey(FINAL_ANSWER));
         Assert.assertTrue(output.get(FINAL_ANSWER).contains("[]"));
+    }
+
+    @Test
+    public void testFunctionCallingFactory_BedrockConverseInterface() {
+        FunctionCalling genericFunctionCalling = FunctionCallingFactory.create(LLM_INTERFACE_BEDROCK_CONVERSE);
+        FunctionCalling specificFunctionCalling = FunctionCallingFactory.create(LLM_INTERFACE_BEDROCK_CONVERSE_CLAUDE);
+
+        Assert.assertNotNull("Generic bedrock/converse interface should create function calling instance", genericFunctionCalling);
+        Assert.assertNotNull("Specific bedrock/converse/claude interface should create function calling instance", specificFunctionCalling);
+        Assert.assertEquals("Both interfaces should return the same type",
+            genericFunctionCalling.getClass(), specificFunctionCalling.getClass());
     }
 }


### PR DESCRIPTION
### Description
Create `bedrock/converse` interface while keeping backwards compatibility with `bedrock/converse/claude`

### Related Issues
Resolves https://github.com/opensearch-project/ml-commons/issues/4122
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
