### PR TITLE
[FEATURE] Predict Stream

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -367,6 +367,10 @@ public class HttpConnector extends AbstractConnector {
     }
 
     private boolean neededStreamParameterInPayload(Map<String, String> parameters) {
+        if (parameters == null) {
+            return false;
+        }
+
         boolean isStream = parameters.containsKey("stream");
         if (!isStream) {
             return false;

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -19,12 +19,14 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -35,6 +37,9 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -351,10 +356,35 @@ public class HttpConnector extends AbstractConnector {
 
             if (!isJson(payload)) {
                 throw new IllegalArgumentException("Invalid payload: " + payload);
+            } else if (neededStreamParameterInPayload(parameters)) {
+                JsonObject jsonObject = JsonParser.parseString(payload).getAsJsonObject();
+                jsonObject.addProperty("stream", true);
+                payload = jsonObject.toString();
             }
             return (T) payload;
         }
         return (T) parameters.get("http_body");
+    }
+
+    private boolean neededStreamParameterInPayload(Map<String, String> parameters) {
+        boolean isStream = parameters.containsKey("stream");
+        if (!isStream) {
+            return false;
+        }
+
+        String llmInterface = parameters.get("_llm_interface");
+        if (llmInterface.isBlank()) {
+            return false;
+        }
+
+        llmInterface = llmInterface.trim().toLowerCase(Locale.ROOT);
+        llmInterface = StringEscapeUtils.unescapeJava(llmInterface);
+        switch (llmInterface) {
+            case "openai/v1/chat/completions":
+                return true;
+            default:
+                return false;
+        }
     }
 
     protected String fillNullParameters(Map<String, String> parameters, String payload) {

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -488,5 +488,5 @@ public final class MLCommonsSettings {
 
     // Feature flag for streaming feature
     public static final Setting<Boolean> ML_COMMONS_STREAM_ENABLED = Setting
-        .boolSetting("plugins.ml_commons.stream_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .boolSetting(ML_PLUGIN_SETTING_PREFIX + "stream_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -485,4 +485,8 @@ public final class MLCommonsSettings {
             Setting.Property.NodeScope,
             Setting.Property.Final
         );
+
+    // Feature flag for streaming feature
+    public static final Setting<Boolean> ML_COMMONS_STREAM_ENABLED = Setting
+        .boolSetting("plugins.ml_commons.stream_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
@@ -22,6 +22,7 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_OFF
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_STREAM_ENABLED;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,6 +65,8 @@ public class MLFeatureEnabledSetting {
 
     private volatile Boolean isIndexInsightEnabled;
 
+    private volatile Boolean isStreamEnabled;
+
     private final List<SettingsChangeListener> listeners = new ArrayList<>();
 
     public MLFeatureEnabledSetting(ClusterService clusterService, Settings settings) {
@@ -84,6 +87,7 @@ public class MLFeatureEnabledSetting {
         isMcpConnectorEnabled = ML_COMMONS_MCP_CONNECTOR_ENABLED.get(settings);
         isAgenticMemoryEnabled = ML_COMMONS_AGENTIC_MEMORY_ENABLED.get(settings);
         isIndexInsightEnabled = ML_COMMONS_INDEX_INSIGHT_FEATURE_ENABLED.get(settings);
+        isStreamEnabled = ML_COMMONS_STREAM_ENABLED.get(settings);
 
         clusterService
             .getClusterSettings()
@@ -110,6 +114,7 @@ public class MLFeatureEnabledSetting {
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_AGENTIC_SEARCH_ENABLED, it -> isAgenticSearchEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_MCP_CONNECTOR_ENABLED, it -> isMcpConnectorEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_AGENTIC_MEMORY_ENABLED, it -> isAgenticMemoryEnabled = it);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_STREAM_ENABLED, it -> isStreamEnabled = it);
         clusterService
             .getClusterSettings()
             .addSettingsUpdateConsumer(ML_COMMONS_INDEX_INSIGHT_FEATURE_ENABLED, it -> isIndexInsightEnabled = it);
@@ -242,5 +247,12 @@ public class MLFeatureEnabledSetting {
 
     public boolean isIndexInsightEnabled() {
         return isIndexInsightEnabled;
+    }
+
+    /** Whether the streaming feature is enabled. If disabled, APIs in ml-commons will block stream.
+     * @return whether the streaming is enabled.
+     */
+    public boolean isStreamEnabled() {
+        return isStreamEnabled;
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/prediction/MLPredictionStreamTaskAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/prediction/MLPredictionStreamTaskAction.java
@@ -1,0 +1,13 @@
+package org.opensearch.ml.common.transport.prediction;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.ml.common.transport.MLTaskResponse;
+
+public class MLPredictionStreamTaskAction extends ActionType<MLTaskResponse> {
+    public static final MLPredictionStreamTaskAction INSTANCE = new MLPredictionStreamTaskAction();
+    public static final String NAME = "cluster:admin/opensearch/ml/predict/stream";
+
+    private MLPredictionStreamTaskAction() {
+        super(NAME, MLTaskResponse::new);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/prediction/MLPredictionStreamTaskAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/prediction/MLPredictionStreamTaskAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.prediction;
 
 import org.opensearch.action.ActionType;

--- a/common/src/main/java/org/opensearch/ml/common/transport/prediction/MLPredictionTaskRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/prediction/MLPredictionTaskRequest.java
@@ -23,6 +23,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.transport.MLTaskRequest;
+import org.opensearch.transport.TransportChannel;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -35,6 +36,10 @@ import lombok.experimental.FieldDefaults;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 @ToString
 public class MLPredictionTaskRequest extends MLTaskRequest {
+
+    @Getter
+    @Setter
+    private transient TransportChannel streamingChannel;
 
     String modelId;
     MLInput mlInput;

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -229,6 +229,52 @@ public class HttpConnectorTest {
     }
 
     @Test
+    public void createPayload_WithStreamParameter_OpenAI() {
+        String requestBody = "{\"model\": \"gpt-3.5-turbo\", \"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "Hello world");
+        parameters.put("stream", "true");
+        parameters.put("_llm_interface", "openai/v1/chat/completions");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+        Assert
+            .assertEquals(
+                "{\"model\":\"gpt-3.5-turbo\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello world\"}],\"stream\":true}",
+                payload
+            );
+    }
+
+    @Test
+    public void createPayload_WithoutStreamParameter() {
+        String requestBody = "{\"model\": \"gpt-3.5-turbo\", \"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "Hello world");
+        parameters.put("_llm_interface", "openai/v1/chat/completions");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+        Assert.assertEquals("{\"model\": \"gpt-3.5-turbo\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello world\"}]}", payload);
+    }
+
+    @Test
+    public void createPayload_WithStreamParameter_UnsupportedInterface() {
+        String requestBody = "{\"input\": \"${parameters.input}\"}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "Hello world");
+        parameters.put("stream", "true");
+        parameters.put("_llm_interface", "invalid/interface");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        Assert.assertEquals("{\"input\": \"Hello world\"}", payload);
+    }
+
+    @Test
     public void parseResponse_modelTensorJson() throws IOException {
         HttpConnector connector = createHttpConnector();
 

--- a/common/src/test/java/org/opensearch/ml/common/settings/MLCommonsSettingsTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/settings/MLCommonsSettingsTests.java
@@ -102,4 +102,9 @@ public class MLCommonsSettingsTests {
             "The Agentic Memory APIs are not enabled. To enable, please update the setting plugins.ml_commons.agentic_memory_enabled";
         assertEquals(expectedMessage, MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE);
     }
+
+    @Test
+    public void testStreamDisabledByDefault() {
+        assertFalse(MLCommonsSettings.ML_COMMONS_STREAM_ENABLED.getDefault(null));
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/settings/MLFeatureEnabledSettingTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/settings/MLFeatureEnabledSettingTests.java
@@ -48,7 +48,8 @@ public class MLFeatureEnabledSettingTests {
                     MLCommonsSettings.ML_COMMONS_AGENTIC_SEARCH_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED,
                     MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_ENABLED,
-                    MLCommonsSettings.ML_COMMONS_INDEX_INSIGHT_FEATURE_ENABLED
+                    MLCommonsSettings.ML_COMMONS_INDEX_INSIGHT_FEATURE_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_STREAM_ENABLED
                 )
         );
         when(mockClusterService.getClusterSettings()).thenReturn(mockClusterSettings);
@@ -73,6 +74,7 @@ public class MLFeatureEnabledSettingTests {
             .put("plugins.ml_commons.mcp_connector_enabled", true)
             .put("plugins.ml_commons.agentic_search_enabled", true)
             .put("plugins.ml_commons.agentic_memory_enabled", true)
+            .put("plugins.ml_commons.stream_enabled", true)
             .build();
 
         MLFeatureEnabledSetting setting = new MLFeatureEnabledSetting(mockClusterService, settings);
@@ -92,6 +94,7 @@ public class MLFeatureEnabledSettingTests {
         assertTrue(setting.isMcpConnectorEnabled());
         assertTrue(setting.isAgenticSearchEnabled());
         assertTrue(setting.isAgenticMemoryEnabled());
+        assertTrue(setting.isStreamEnabled());
     }
 
     @Test
@@ -113,6 +116,7 @@ public class MLFeatureEnabledSettingTests {
             .put("plugins.ml_commons.mcp_connector_enabled", false)
             .put("plugins.ml_commons.agentic_search_enabled", false)
             .put("plugins.ml_commons.agentic_memory_enabled", false)
+            .put("plugins.ml_commons.stream_enabled", false)
             .build();
 
         MLFeatureEnabledSetting setting = new MLFeatureEnabledSetting(mockClusterService, settings);
@@ -132,6 +136,7 @@ public class MLFeatureEnabledSettingTests {
         assertFalse(setting.isMcpConnectorEnabled());
         assertFalse(setting.isAgenticSearchEnabled());
         assertFalse(setting.isAgenticMemoryEnabled());
+        assertFalse(setting.isStreamEnabled());
     }
 
     @Test

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -71,6 +71,9 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.30.18')
     api 'software.amazon.awssdk:auth:2.30.18'
     implementation 'software.amazon.awssdk:apache-client'
+    implementation ('software.amazon.awssdk:bedrockruntime') {
+        exclude group: 'io.netty'
+    }
     implementation ('com.amazonaws:aws-encryption-sdk-java:2.4.1') {
         exclude group: 'org.bouncycastle', module: 'bcprov-ext-jdk18on'
     }
@@ -90,6 +93,8 @@ dependencies {
     testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
+    api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.12.0'
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp-sse', version: '4.12.0'
 }
 
 lombok {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/Predictable.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/Predictable.java
@@ -14,6 +14,7 @@ import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.engine.encryptor.Encryptor;
+import org.opensearch.transport.TransportChannel;
 
 /**
  * This is machine learning algorithms predict interface.
@@ -41,6 +42,10 @@ public interface Predictable {
     }
 
     default void asyncPredict(MLInput mlInput, ActionListener<MLTaskResponse> actionListener) {
+        asyncPredict(mlInput, actionListener, null);
+    }
+
+    default void asyncPredict(MLInput mlInput, ActionListener<MLTaskResponse> actionListener, TransportChannel channel) {
         actionListener.onFailure(new IllegalStateException(METHOD_NOT_IMPLEMENTED_ERROR_MSG));
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutor.java
@@ -5,8 +5,17 @@
 
 package org.opensearch.ml.engine.algorithms.remote;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorClientConfig;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.transport.MLTaskResponse;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -21,6 +30,25 @@ public abstract class AbstractConnectorExecutor implements RemoteConnectorExecut
             connectorClientConfig = connector.getConnectorClientConfig();
         } else {
             connectorClientConfig = new ConnectorClientConfig();
+        }
+    }
+
+    public void sendContentResponse(String content, boolean isLast, StreamPredictActionListener<MLTaskResponse, ?> actionListener) {
+        List<ModelTensor> modelTensors = new ArrayList<>();
+        Map<String, Object> dataMap = Map.of("content", content, "is_last", isLast);
+
+        modelTensors.add(ModelTensor.builder().name("response").dataAsMap(dataMap).build());
+        ModelTensorOutput output = ModelTensorOutput
+            .builder()
+            .mlModelOutputs(List.of(ModelTensors.builder().mlModelTensors(modelTensors).build()))
+            .build();
+        MLTaskResponse response = MLTaskResponse.builder().output(output).build();
+        actionListener.onStreamResponse(response, isLast);
+    }
+
+    public void sendCompletionResponse(AtomicBoolean isStreamClosed, StreamPredictActionListener<MLTaskResponse, ?> actionListener) {
+        if (isStreamClosed.compareAndSet(false, true)) {
+            sendContentResponse("", true, actionListener);
         }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -6,16 +7,22 @@
 package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.opensearch.ml.common.connector.ConnectorProtocols.AWS_SIGV4;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_BEDROCK_CONVERSE_CLAUDE;
+import static org.opensearch.ml.engine.algorithms.agent.MLChatAgentRunner.LLM_INTERFACE;
 import static software.amazon.awssdk.http.SdkHttpMethod.GET;
 import static software.amazon.awssdk.http.SdkHttpMethod.POST;
 
 import java.security.AccessController;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.util.TokenBucket;
@@ -26,18 +33,31 @@ import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.engine.annotation.ConnectorExecutor;
 import org.opensearch.ml.engine.httpclient.MLHttpClientFactory;
 import org.opensearch.script.ScriptService;
+import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.client.Client;
 
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
+import okhttp3.OkHttpClient;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.internal.http.async.SimpleHttpContentPublisher;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDeltaEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
+import software.amazon.awssdk.services.bedrockruntime.model.Message;
 
 @Log4j2
 @ConnectorExecutor(AWS_SIGV4)
@@ -63,6 +83,16 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
 
     private SdkAsyncHttpClient httpClient;
 
+    private OkHttpClient okHttpClient;
+
+    private BedrockRuntimeAsyncClient bedrockRuntimeAsyncClient;
+
+    @Setter
+    @Getter
+    private StreamTransportService streamTransportService;
+
+    private AtomicBoolean isStreamClosed = new AtomicBoolean(false);
+
     public AwsConnectorExecutor(Connector connector) {
         super.initialize(connector);
         this.connector = (AwsConnector) connector;
@@ -70,6 +100,19 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
         Duration readTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getReadTimeout());
         Integer maxConnection = super.getConnectorClientConfig().getMaxConnections();
         this.httpClient = MLHttpClientFactory.getAsyncHttpClient(connectionTimeout, readTimeout, maxConnection);
+        this.bedrockRuntimeAsyncClient = buildBedrockRuntimeAsyncClient(httpClient);
+        try {
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                this.okHttpClient = new OkHttpClient.Builder()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(1, TimeUnit.MINUTES)
+                    .retryOnConnectionFailure(true)
+                    .build();
+                return null;
+            });
+        } catch (PrivilegedActionException e) {
+            throw new RuntimeException("Failed to build OkHttpClient.", e);
+        }
     }
 
     @Override
@@ -126,6 +169,70 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
         }
     }
 
+    @Override
+    public void invokeRemoteServiceStream(
+        String action,
+        MLInput mlInput,
+        Map<String, String> parameters,
+        String payload,
+        ExecutionContext executionContext,
+        StreamPredictActionListener<MLTaskResponse, ?> actionListener
+    ) {
+        try {
+            String llmInterface = parameters.get(LLM_INTERFACE);
+            llmInterface = llmInterface.trim().toLowerCase(Locale.ROOT);
+            llmInterface = StringEscapeUtils.unescapeJava(llmInterface);
+            validateLLMInterface(llmInterface);
+
+            ConverseStreamRequest request = ConverseStreamRequest
+                .builder()
+                .modelId(parameters.get("model"))
+                .messages(Message.builder().role("user").content(ContentBlock.builder().text(parameters.get("inputs")).build()).build())
+                .build();
+
+            ConverseStreamResponseHandler handler = ConverseStreamResponseHandler.builder().onResponse(response -> {
+                // Handle initial response
+                log.debug("Initial converse stream response: {}", response);
+            }).onError(error -> {
+                // Handle errors
+                log.error("Converse stream error: {}", error.getMessage());
+            }).onComplete(() -> {
+                // Handle completion
+                log.debug("Converse stream complete");
+                sendCompletionResponse(isStreamClosed, actionListener);
+            }).subscriber(event -> {
+                log.debug("Converse stream event: {}", event);
+                switch (event.sdkEventType()) {
+                    case CONTENT_BLOCK_DELTA:
+                        ContentBlockDeltaEvent contentEvent = (ContentBlockDeltaEvent) event;
+                        String chunk = contentEvent.delta().text();
+                        sendContentResponse(chunk, false, actionListener);
+                        break;
+                    default:
+                        // Ignore the other event types for now.
+                        break;
+                }
+            }).build();
+            bedrockRuntimeAsyncClient.converseStream(request, handler);
+        } catch (Exception e) {
+            log.error("Failed to execute streaming", e);
+            actionListener.onFailure(new MLException("Fail to execute streaming", e));
+        }
+    }
+
+    private BedrockRuntimeAsyncClient buildBedrockRuntimeAsyncClient(SdkAsyncHttpClient sdkAsyncHttpClient) {
+        AwsSessionCredentials credentials = AwsSessionCredentials
+            .create(connector.getAccessKey(), connector.getSecretKey(), connector.getSessionToken());
+        AwsCredentialsProvider awsCredentialsProvider = StaticCredentialsProvider.create(credentials);
+
+        return BedrockRuntimeAsyncClient
+            .builder()
+            .region(Region.of(connector.getRegion()))
+            .credentialsProvider(awsCredentialsProvider)
+            .httpClient(sdkAsyncHttpClient)
+            .build();
+    }
+
     private SdkHttpFullRequest signRequest(SdkHttpFullRequest request) {
         String accessKey = connector.getAccessKey();
         String secretKey = connector.getSecretKey();
@@ -134,5 +241,14 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
         String region = connector.getRegion();
 
         return ConnectorUtils.signRequest(request, accessKey, secretKey, sessionToken, signingName, region);
+    }
+
+    private void validateLLMInterface(String llmInterface) {
+        switch (llmInterface) {
+            case LLM_INTERFACE_BEDROCK_CONVERSE_CLAUDE:
+                break;
+            default:
+                throw new MLException(String.format("Unsupported llm interface: %s", llmInterface));
+        }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
@@ -6,18 +6,24 @@
 package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.opensearch.ml.common.connector.ConnectorProtocols.HTTP;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_OPENAI_V1_CHAT_COMPLETIONS;
+import static org.opensearch.ml.engine.algorithms.agent.MLChatAgentRunner.LLM_INTERFACE;
+import static org.opensearch.ml.engine.function_calling.OpenaiV1ChatCompletionsFunctionCalling.FINISH_REASON_PATH;
 import static software.amazon.awssdk.http.SdkHttpMethod.GET;
 import static software.amazon.awssdk.http.SdkHttpMethod.POST;
 
 import java.net.URL;
 import java.security.AccessController;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.util.TokenBucket;
@@ -28,14 +34,26 @@ import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.transport.MLTaskResponse;
+import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.engine.annotation.ConnectorExecutor;
 import org.opensearch.ml.engine.httpclient.MLHttpClientFactory;
 import org.opensearch.script.ScriptService;
+import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.client.Client;
+
+import com.jayway.jsonpath.JsonPath;
 
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.internal.http2.StreamResetException;
+import okhttp3.sse.EventSource;
+import okhttp3.sse.EventSourceListener;
+import okhttp3.sse.EventSources;
 import software.amazon.awssdk.core.internal.http.async.SimpleHttpContentPublisher;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
@@ -68,6 +86,11 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
 
     private SdkAsyncHttpClient httpClient;
 
+    private OkHttpClient okHttpClient;
+    @Setter
+    @Getter
+    private StreamTransportService streamTransportService;
+
     public HttpJsonConnectorExecutor(Connector connector) {
         super.initialize(connector);
         this.connector = (HttpConnector) connector;
@@ -75,6 +98,18 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
         Duration readTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getReadTimeout());
         Integer maxConnection = super.getConnectorClientConfig().getMaxConnections();
         this.httpClient = MLHttpClientFactory.getAsyncHttpClient(connectionTimeout, readTimeout, maxConnection);
+        try {
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                this.okHttpClient = new OkHttpClient.Builder()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(1, TimeUnit.MINUTES)
+                    .retryOnConnectionFailure(true)
+                    .build();
+                return null;
+            });
+        } catch (PrivilegedActionException e) {
+            throw new RuntimeException("Failed to build OkHttpClient.", e);
+        }
     }
 
     @Override
@@ -133,6 +168,36 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
         }
     }
 
+    @Override
+    public void invokeRemoteServiceStream(
+        String action,
+        MLInput mlInput,
+        Map<String, String> parameters,
+        String payload,
+        ExecutionContext executionContext,
+        StreamPredictActionListener<MLTaskResponse, ?> actionListener
+    ) {
+        try {
+            String llmInterface = parameters.get(LLM_INTERFACE);
+            llmInterface = llmInterface.trim().toLowerCase(Locale.ROOT);
+            llmInterface = StringEscapeUtils.unescapeJava(llmInterface);
+            validateLLMInterface(llmInterface);
+
+            log.info("Creating SSE connection for streaming request");
+            EventSourceListener listener = new HTTPEventSourceListener(actionListener, llmInterface);
+            Request request = ConnectorUtils.buildOKHttpRequestPOST(action, connector, parameters, payload);
+
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                EventSources.createFactory(okHttpClient).newEventSource(request, listener);
+                return null;
+            });
+
+        } catch (Exception e) {
+            log.error("Failed to execute streaming", e);
+            actionListener.onFailure(new MLException("Fail to execute streaming", e));
+        }
+    }
+
     private void validateHttpClientParameters(String action, Map<String, String> parameters) throws Exception {
         String endpoint = connector.getActionEndpoint(action, parameters);
         URL url = new URL(endpoint);
@@ -140,5 +205,102 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
         String host = url.getHost();
         int port = url.getPort();
         MLHttpClientFactory.validate(protocol, host, port, connectorPrivateIpEnabled);
+    }
+
+    private void validateLLMInterface(String llmInterface) {
+        switch (llmInterface) {
+            case LLM_INTERFACE_OPENAI_V1_CHAT_COMPLETIONS:
+                break;
+            default:
+                throw new MLException(String.format("Unsupported llm interface: %s", llmInterface));
+        }
+    }
+
+    public final class HTTPEventSourceListener extends EventSourceListener {
+        private StreamPredictActionListener<MLTaskResponse, ?> streamActionListener;
+        private final String llmInterface;
+        private volatile AtomicBoolean isStreamClosed;
+
+        public HTTPEventSourceListener(StreamPredictActionListener<MLTaskResponse, ?> streamActionListener, String llmInterface) {
+            this.streamActionListener = streamActionListener;
+            this.llmInterface = llmInterface;
+            this.isStreamClosed = new AtomicBoolean(false);
+        }
+
+        /***
+         * Callback when the SSE endpoint connection is made.
+         * @param eventSource the event source
+         * @param response the response
+         */
+        @Override
+        public void onOpen(EventSource eventSource, Response response) {
+            log.debug("Connected to SSE Endpoint.");
+        }
+
+        /***
+         * For each event received from the SSE endpoint
+         * @param eventSource The event source
+         * @param id The id of the event
+         * @param type The type of the event which is used to filter
+         * @param data The event data
+         */
+        @Override
+        public void onEvent(EventSource eventSource, String id, String type, String data) {
+            log.debug("The data is: {}", data);
+            switch (llmInterface) {
+                case LLM_INTERFACE_OPENAI_V1_CHAT_COMPLETIONS:
+                    onOpenAIEvent(data);
+                    break;
+                default:
+                    throw new MLException(String.format("Unsupported llm interface: %s", llmInterface));
+            }
+        }
+
+        /***
+         * When the connection is closed we receive this even which is currently only logged.
+         * @param eventSource The event source
+         */
+        @Override
+        public void onClosed(EventSource eventSource) {
+            log.debug("SSE CLOSED.");
+        }
+
+        /***
+         * If there is any failure we log the error and the stack trace
+         * During stream resets with no errors we set the connected flag to false to allow the main thread to attempt a re-connect
+         * @param eventSource The event source
+         * @param t The error object
+         * @param response The response
+         */
+        @Override
+        public void onFailure(EventSource eventSource, Throwable t, Response response) {
+            log.error("SSE failure.");
+            if (t != null) {
+                log.error("Error: " + t.getMessage(), t);
+                if (t instanceof StreamResetException && t.getMessage().contains("NO_ERROR")) {
+                    // TODO: reconnect
+                } else {
+                    streamActionListener.onFailure(new MLException("SSE failure.", t));
+                }
+            }
+        }
+
+        private void onOpenAIEvent(String data) {
+            if (data.contentEquals("[DONE]")) {
+                sendCompletionResponse(isStreamClosed, streamActionListener);
+                return;
+            }
+            Map<String, Object> dataMap = StringUtils.fromJson(data, "data");
+            String llmFinishReason = JsonPath.read(dataMap, FINISH_REASON_PATH);
+            if (llmFinishReason != null && llmFinishReason.contentEquals("stop")) {
+                sendCompletionResponse(isStreamClosed, streamActionListener);
+                return;
+            }
+            String deltaContent = JsonPath.read(dataMap, "$.choices[0].delta.content");
+            if (deltaContent != null && !deltaContent.isEmpty()) {
+                log.debug("Streaming content: {}", deltaContent);
+                sendContentResponse(deltaContent, false, streamActionListener);
+            }
+        }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
@@ -34,6 +34,7 @@ import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.engine.annotation.ConnectorExecutor;
 import org.opensearch.ml.engine.tools.McpSseTool;
@@ -172,5 +173,17 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
         ActionListener<Tuple<Integer, ModelTensors>> actionListener
     ) {
         throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public void invokeRemoteServiceStream(
+        String action,
+        MLInput mlInput,
+        Map<String, String> parameters,
+        String payload,
+        ExecutionContext executionContext,
+        StreamPredictActionListener<MLTaskResponse, ?> actionListener
+    ) {
+        throw new UnsupportedOperationException("Streaming is not supported for MCP connector");
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
@@ -36,6 +36,7 @@ import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.model.MLGuard;
 import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.engine.annotation.ConnectorExecutor;
 import org.opensearch.ml.engine.tools.McpStreamableHttpTool;
@@ -179,5 +180,17 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
         ActionListener<Tuple<Integer, ModelTensors>> actionListener
     ) {
         throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public void invokeRemoteServiceStream(
+        String action,
+        MLInput mlInput,
+        Map<String, String> parameters,
+        String payload,
+        ExecutionContext executionContext,
+        StreamPredictActionListener<MLTaskResponse, ?> actionListener
+    ) {
+        throw new UnsupportedOperationException("Streaming is not supported for MCP connector.");
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
@@ -35,6 +35,7 @@ import org.opensearch.ml.engine.annotation.Function;
 import org.opensearch.ml.engine.encryptor.Encryptor;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.script.ScriptService;
+import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.client.Client;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -71,7 +72,7 @@ public class RemoteModel implements Predictable {
     }
 
     @Override
-    public void asyncPredict(MLInput mlInput, ActionListener<MLTaskResponse> actionListener) {
+    public void asyncPredict(MLInput mlInput, ActionListener<MLTaskResponse> actionListener, TransportChannel channel) {
         if (!isModelReady()) {
             actionListener
                 .onFailure(
@@ -85,7 +86,7 @@ public class RemoteModel implements Predictable {
                 actionType = ((RemoteInferenceInputDataSet) mlInput.getInputDataset()).getActionType();
             }
             actionType = actionType == null ? ActionType.PREDICT : actionType;
-            connectorExecutor.executeAction(actionType.toString(), mlInput, actionListener);
+            connectorExecutor.executeAction(actionType.toString(), mlInput, actionListener, channel);
         } catch (RuntimeException e) {
             log.error("Failed to call remote model.", e);
             actionListener.onFailure(e);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/StreamPredictActionListener.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/StreamPredictActionListener.java
@@ -1,0 +1,55 @@
+package org.opensearch.ml.engine.algorithms.remote;
+
+import java.io.IOException;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.transport.TransportChannel;
+import org.opensearch.transport.TransportRequest;
+
+public class StreamPredictActionListener<Response extends TransportResponse, Request extends TransportRequest>
+    implements
+        ActionListener<Response> {
+
+    private final TransportChannel channel;
+
+    public StreamPredictActionListener(TransportChannel channel) {
+        this.channel = channel;
+    }
+
+    /**
+     * Send streaming responses
+     * This allows multiple responses to be sent for a single request.
+     *
+     * @param response    the intermediate response to send
+     * @param isLastBatch whether this response is the last one
+     */
+    public void onStreamResponse(Response response, boolean isLastBatch) {
+        assert response != null;
+        channel.sendResponseBatch(response);
+        if (isLastBatch) {
+            channel.completeStream();
+        }
+    }
+
+    /**
+     * Reuse ActionListener method to send the last stream response
+     * This maintains compatibility on data node side
+     *
+     * @param response the response to send
+     */
+    @Override
+    public final void onResponse(Response response) {
+        onStreamResponse(response, true);
+    }
+
+    @Override
+    public void onFailure(Exception e) {
+        try {
+            channel.sendResponse(e);
+        } catch (IOException exc) {
+            channel.completeStream();
+            throw new RuntimeException(exc);
+        }
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/MLEngineTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/MLEngineTest.java
@@ -542,7 +542,6 @@ public class MLEngineTest extends MLStaticMockBase {
     public void testDeploy_withPredictableActionListener_successful() throws IOException {
         String encryptedAccessKey = mlEngine.encrypt("access-key", null);
         String encryptedSecretKey = mlEngine.encrypt("secret-key", null);
-        String encryptedSessionToken = mlEngine.encrypt("session-token", null);
         String testConnector = String.format(Locale.ROOT, """
             {
                 "name": "sagemaker: t2ppl",
@@ -551,8 +550,7 @@ public class MLEngineTest extends MLStaticMockBase {
                 "protocol": "aws_sigv4",
                 "credential": {
                     "access_key": "%s",
-                    "secret_key": "%s",
-                    "session_token": "%s"
+                    "secret_key": "%s"
                 },
                 "parameters": {
                     "region": "us-east-1",
@@ -572,7 +570,7 @@ public class MLEngineTest extends MLStaticMockBase {
                     }
                 ]
             }
-            """, encryptedAccessKey, encryptedSecretKey, encryptedSessionToken);
+            """, encryptedAccessKey, encryptedSecretKey);
 
         XContentParser parser = XContentType.JSON
             .xContent()

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/MLEngineTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/MLEngineTest.java
@@ -542,6 +542,7 @@ public class MLEngineTest extends MLStaticMockBase {
     public void testDeploy_withPredictableActionListener_successful() throws IOException {
         String encryptedAccessKey = mlEngine.encrypt("access-key", null);
         String encryptedSecretKey = mlEngine.encrypt("secret-key", null);
+        String encryptedSessionToken = mlEngine.encrypt("session-token", null);
         String testConnector = String.format(Locale.ROOT, """
             {
                 "name": "sagemaker: t2ppl",
@@ -550,7 +551,8 @@ public class MLEngineTest extends MLStaticMockBase {
                 "protocol": "aws_sigv4",
                 "credential": {
                     "access_key": "%s",
-                    "secret_key": "%s"
+                    "secret_key": "%s",
+                    "session_token": "%s"
                 },
                 "parameters": {
                     "region": "us-east-1",
@@ -570,7 +572,7 @@ public class MLEngineTest extends MLStaticMockBase {
                     }
                 ]
             }
-            """, encryptedAccessKey, encryptedSecretKey);
+            """, encryptedAccessKey, encryptedSecretKey, encryptedSessionToken);
 
         XContentParser parser = XContentType.JSON
             .xContent()

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
@@ -31,10 +31,6 @@ public class AbstractConnectorExecutorTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        when(mockConnector.getAccessKey()).thenReturn("test_access_key");
-        when(mockConnector.getSecretKey()).thenReturn("test_secret_key");
-        when(mockConnector.getSessionToken()).thenReturn("test_session_token");
-        when(mockConnector.getRegion()).thenReturn("us-east-1");
         executor = new AwsConnectorExecutor(mockConnector);
         connectorClientConfig = new ConnectorClientConfig();
     }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
@@ -3,16 +3,26 @@ package org.opensearch.ml.engine.algorithms.remote;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.ml.common.connector.AwsConnector;
 import org.opensearch.ml.common.connector.ConnectorClientConfig;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.transport.MLTaskResponse;
 
 public class AbstractConnectorExecutorTest {
     @Mock
     private AwsConnector mockConnector;
+
+    @Mock
+    private StreamPredictActionListener<MLTaskResponse, ?> mockActionListener;
 
     private ConnectorClientConfig connectorClientConfig;
 
@@ -21,6 +31,10 @@ public class AbstractConnectorExecutorTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+        when(mockConnector.getAccessKey()).thenReturn("test_access_key");
+        when(mockConnector.getSecretKey()).thenReturn("test_secret_key");
+        when(mockConnector.getSessionToken()).thenReturn("test_session_token");
+        when(mockConnector.getRegion()).thenReturn("us-east-1");
         executor = new AwsConnectorExecutor(mockConnector);
         connectorClientConfig = new ConnectorClientConfig();
     }
@@ -41,5 +55,50 @@ public class AbstractConnectorExecutorTest {
         assertEquals(ConnectorClientConfig.MAX_CONNECTION_DEFAULT_VALUE, executor.getConnectorClientConfig().getMaxConnections());
         assertEquals(ConnectorClientConfig.CONNECTION_TIMEOUT_DEFAULT_VALUE, executor.getConnectorClientConfig().getConnectionTimeout());
         assertEquals(ConnectorClientConfig.READ_TIMEOUT_DEFAULT_VALUE, executor.getConnectorClientConfig().getReadTimeout());
+    }
+
+    @Test
+    public void testSendContentResponse() {
+        String content = "test content";
+        boolean isLast = false;
+
+        executor.sendContentResponse(content, isLast, mockActionListener);
+
+        ArgumentCaptor<MLTaskResponse> responseCaptor = ArgumentCaptor.forClass(MLTaskResponse.class);
+        ArgumentCaptor<Boolean> isLastCaptor = ArgumentCaptor.forClass(Boolean.class);
+
+        verify(mockActionListener).onStreamResponse(responseCaptor.capture(), isLastCaptor.capture());
+
+        MLTaskResponse response = responseCaptor.getValue();
+        ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
+        ModelTensors tensors = output.getMlModelOutputs().get(0);
+        ModelTensor tensor = tensors.getMlModelTensors().get(0);
+
+        assertEquals("response", tensor.getName());
+        assertEquals(content, tensor.getDataAsMap().get("content"));
+        assertEquals(isLast, tensor.getDataAsMap().get("is_last"));
+        assertEquals(isLast, isLastCaptor.getValue());
+    }
+
+    @Test
+    public void testSendContentResponseWithLastFlag() {
+        String content = "final content";
+        boolean isLast = true;
+
+        executor.sendContentResponse(content, isLast, mockActionListener);
+
+        ArgumentCaptor<MLTaskResponse> responseCaptor = ArgumentCaptor.forClass(MLTaskResponse.class);
+        ArgumentCaptor<Boolean> isLastCaptor = ArgumentCaptor.forClass(Boolean.class);
+
+        verify(mockActionListener).onStreamResponse(responseCaptor.capture(), isLastCaptor.capture());
+
+        assertTrue(isLastCaptor.getValue());
+    }
+
+    @Test
+    public void testSendCompletionResponseAlreadyClosed() {
+        AtomicBoolean isStreamClosed = new AtomicBoolean(true);
+        executor.sendCompletionResponse(isStreamClosed, mockActionListener);
+        verify(mockActionListener, never()).onStreamResponse(any(), anyBoolean());
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.connector.AbstractConnector.ACCESS_KEY_FIELD;
 import static org.opensearch.ml.common.connector.AbstractConnector.SECRET_KEY_FIELD;
-import static org.opensearch.ml.common.connector.AbstractConnector.SESSION_TOKEN_FIELD;
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
 import static org.opensearch.ml.common.connector.HttpConnector.REGION_FIELD;
 import static org.opensearch.ml.common.connector.HttpConnector.SERVICE_NAME_FIELD;
@@ -106,16 +105,9 @@ public class AwsConnectorExecutorTest {
             new ModelTensor("tensor2", new Number[0], new long[0], MLResultDataType.STRING, null, null, dataAsMap)
         );
 
-    @Mock
-    AwsConnector awsConnector;
-
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        when(awsConnector.getAccessKey()).thenReturn("test_access_key");
-        when(awsConnector.getSecretKey()).thenReturn("test_secret_key");
-        when(awsConnector.getSessionToken()).thenReturn("test_session_token");
-        when(awsConnector.getRegion()).thenReturn("us-east-1");
         encryptor = new EncryptorImpl(null, "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
         when(scriptService.compile(any(), any()))
             .then(invocation -> new TestTemplateService.MockTemplateScript.Factory("{\"result\": \"hello world\"}"));
@@ -151,14 +143,7 @@ public class AwsConnectorExecutorTest {
             .requestBody("{\"input\": \"${parameters.input}\"}")
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector
             .awsConnectorBuilder()
@@ -205,14 +190,7 @@ public class AwsConnectorExecutorTest {
             .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector
             .awsConnectorBuilder()
@@ -251,14 +229,7 @@ public class AwsConnectorExecutorTest {
             .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap
             .of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker", "input_docs_processed_step_size", "2");
         Connector connector = AwsConnector
@@ -310,14 +281,7 @@ public class AwsConnectorExecutorTest {
             .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap
             .of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker", "input_docs_processed_step_size", "1");
         Connector connector = AwsConnector
@@ -377,14 +341,7 @@ public class AwsConnectorExecutorTest {
             .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap
             .of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker", "input_docs_processed_step_size", "1");
         Connector connector = AwsConnector
@@ -441,14 +398,7 @@ public class AwsConnectorExecutorTest {
             .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap
             .of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker", "input_docs_processed_step_size", "1");
         Connector connector = AwsConnector
@@ -507,14 +457,7 @@ public class AwsConnectorExecutorTest {
             .requestBody("{\"input\": \"${parameters.input}\"}")
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector
             .awsConnectorBuilder()
@@ -559,14 +502,7 @@ public class AwsConnectorExecutorTest {
             .requestBody("{\"input\": \"${parameters.input}\"}")
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap
             .of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker", "input_docs_processed_step_size", "-1");
         Connector connector = AwsConnector
@@ -609,14 +545,7 @@ public class AwsConnectorExecutorTest {
             .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector
             .awsConnectorBuilder()
@@ -660,14 +589,7 @@ public class AwsConnectorExecutorTest {
             )
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker");
         Connector connector = AwsConnector
             .awsConnectorBuilder()
@@ -707,14 +629,7 @@ public class AwsConnectorExecutorTest {
             .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_BEDROCK_EMBEDDING_INPUT)
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "bedrock");
         Connector connector = AwsConnector
             .awsConnectorBuilder()
@@ -753,14 +668,7 @@ public class AwsConnectorExecutorTest {
             .requestBody("{\"input\": ${parameters.input}}")
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap.of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "bedrock");
         Connector connector = AwsConnector
             .awsConnectorBuilder()
@@ -800,14 +708,7 @@ public class AwsConnectorExecutorTest {
             .preProcessFunction(MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT)
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         Map<String, String> parameters = ImmutableMap
             .of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker", "input_docs_processed_step_size", "5");
         // execute with retry disabled
@@ -871,7 +772,7 @@ public class AwsConnectorExecutorTest {
 
     @Test
     public void testGetRetryBackoffPolicy() {
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(awsConnector));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(mock(AwsConnector.class)));
 
         ConnectorClientConfig.ConnectorClientConfigBuilder configBuilder = ConnectorClientConfig
             .builder()
@@ -906,7 +807,7 @@ public class AwsConnectorExecutorTest {
         ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig(10, 10, 10, 1, 10, -1, RetryBackoffPolicy.CONSTANT);
         ExecutionContext executionContext = new ExecutionContext(123);
         ActionListener<Tuple<Integer, ModelTensors>> actionListener = mock(ActionListener.class);
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(awsConnector));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(mock(AwsConnector.class)));
         ExecutorService executorService = mock(ExecutorService.class);
 
         doAnswer(new Answer() {
@@ -953,7 +854,7 @@ public class AwsConnectorExecutorTest {
         ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig(10, 10, 10, 1, 10, 5, RetryBackoffPolicy.CONSTANT);
         ExecutionContext executionContext = new ExecutionContext(123);
         ActionListener<Tuple<Integer, ModelTensors>> actionListener = mock(ActionListener.class);
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(awsConnector));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(mock(AwsConnector.class)));
         ExecutorService executorService = mock(ExecutorService.class);
 
         doAnswer(new Answer() {
@@ -1000,7 +901,7 @@ public class AwsConnectorExecutorTest {
         ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig(10, 10, 10, 1, 10, -1, RetryBackoffPolicy.CONSTANT);
         ExecutionContext executionContext = new ExecutionContext(123);
         ActionListener<Tuple<Integer, ModelTensors>> actionListener = mock(ActionListener.class);
-        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(awsConnector));
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(mock(AwsConnector.class)));
         ExecutorService executorService = mock(ExecutorService.class);
 
         doAnswer(new Answer() {
@@ -1047,7 +948,12 @@ public class AwsConnectorExecutorTest {
 
     @Test
     public void testInvokeRemoteServiceStream_ValidInterface() {
-        AwsConnectorExecutor executor = new AwsConnectorExecutor(awsConnector);
+        AwsConnector mockConnector = mock(AwsConnector.class);
+        when(mockConnector.getAccessKey()).thenReturn("test-access-key");
+        when(mockConnector.getSecretKey()).thenReturn("test-secret-key");
+        when(mockConnector.getRegion()).thenReturn("us-east-1");
+
+        AwsConnectorExecutor executor = new AwsConnectorExecutor(mockConnector);
         MLInput mlInput = mock(MLInput.class);
         Map<String, String> parameters = Map.of("_llm_interface", "bedrock/converse/claude", "model", "claude-v2", "inputs", "test input");
         String payload = "test payload";
@@ -1060,7 +966,12 @@ public class AwsConnectorExecutorTest {
 
     @Test
     public void testInvokeRemoteServiceStream_WithException() {
-        AwsConnectorExecutor executor = new AwsConnectorExecutor(awsConnector);
+        AwsConnector mockConnector = mock(AwsConnector.class);
+        when(mockConnector.getAccessKey()).thenReturn("test-access-key");
+        when(mockConnector.getSecretKey()).thenReturn("test-secret-key");
+        when(mockConnector.getRegion()).thenReturn("us-east-1");
+
+        AwsConnectorExecutor executor = new AwsConnectorExecutor(mockConnector);
         MLInput mlInput = mock(MLInput.class);
         Map<String, String> parameters = Map.of("llm_interface", "invalid_interface", "model", "claude-v2", "inputs", "test input");
         String payload = "test payload";

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
@@ -264,7 +264,7 @@ public class AwsConnectorExecutorTest {
             );
 
         Mockito.verify(actionListener, times(0)).onFailure(any());
-        Mockito.verify(executor, times(3)).preparePayloadAndInvoke(anyString(), any(), any(), any());
+        Mockito.verify(executor, times(3)).preparePayloadAndInvoke(anyString(), any(), any(), any(), null);
     }
 
     @Test

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
@@ -6,9 +6,11 @@
 package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.BATCH_PREDICT_STATUS;
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.CANCEL_BATCH_PREDICT;
@@ -23,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,6 +45,8 @@ import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.script.ScriptService;
 
 import com.google.common.collect.ImmutableMap;
+
+import okhttp3.Request;
 
 public class ConnectorUtilsTest {
 
@@ -272,7 +275,7 @@ public class ConnectorUtilsTest {
             .build();
         RemoteInferenceInputDataSet remoteInferenceInputDataSet = ConnectorUtils
             .processInput(PREDICT.name(), mlInput, connector, new HashMap<>(), scriptService);
-        Assert.assertNotNull(remoteInferenceInputDataSet.getParameters());
+        assertNotNull(remoteInferenceInputDataSet.getParameters());
         assertEquals(1, remoteInferenceInputDataSet.getParameters().size());
         assertEquals(expectedProcessedInput, remoteInferenceInputDataSet.getParameters().get(resultKey));
     }
@@ -458,5 +461,124 @@ public class ConnectorUtilsTest {
             .actions(Arrays.asList(predictAction))
             .build();
         ConnectorUtils.buildSdkRequest("PREDICT", connector, Collections.emptyMap(), "{}", software.amazon.awssdk.http.SdkHttpMethod.POST);
+    }
+
+    @Test
+    public void testBuildOKHttpRequestPOST_WithPayload() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("http://test.com/mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .headers(ImmutableMap.of("Authorization", "Bearer token123"))  // Add headers to action
+            .build();
+
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .build();
+
+        connector = spy(connector);
+        when(connector.getDecryptedHeaders()).thenReturn(ImmutableMap.of("Authorization", "Bearer token123"));
+
+        Map<String, String> parameters = ImmutableMap.of("input", "test input");
+        String payload = "{\"input\": \"test input\"}";
+
+        Request request = ConnectorUtils.buildOKHttpRequestPOST(PREDICT.name(), connector, parameters, payload);
+
+        assertEquals("POST", request.method());
+        assertEquals("http://test.com/mock", request.url().toString());
+        assertEquals("Bearer token123", request.header("Authorization"));
+        assertEquals("", request.header("Accept-Encoding"));
+        assertEquals("text/event-stream", request.header("Accept"));
+        assertEquals("no-cache", request.header("Cache-Control"));
+        assertNotNull(request.body());
+    }
+
+    @Test
+    public void testBuildOKHttpRequestPOST_NullPayload() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Content length is 0. Aborting request to remote model");
+
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("http://test.com/mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .build();
+
+        Map<String, String> parameters = new HashMap<>();
+        ConnectorUtils.buildOKHttpRequestPOST(PREDICT.name(), connector, parameters, null);
+    }
+
+    @Test
+    public void testBuildOKHttpRequestPOST_NoHeaders() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("http://test.com/mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .build();
+
+        Map<String, String> parameters = new HashMap<>();
+        String payload = "{\"input\": \"test input\"}";
+
+        Request request = ConnectorUtils.buildOKHttpRequestPOST(PREDICT.name(), connector, parameters, payload);
+
+        assertEquals("POST", request.method());
+        assertEquals("http://test.com/mock", request.url().toString());
+        assertNull(request.header("Authorization"));
+        assertEquals("", request.header("Accept-Encoding"));
+        assertEquals("text/event-stream", request.header("Accept"));
+        assertEquals("no-cache", request.header("Cache-Control"));
+    }
+
+    @Test
+    public void testBuildOKHttpRequestPOST_WithParameters() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("http://test.com/mock/${parameters.model}")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .build();
+
+        Map<String, String> parameters = ImmutableMap.of("model", "gpt-3.5", "input", "test input");
+        String payload = "{\"input\": \"test input\"}";
+
+        Request request = ConnectorUtils.buildOKHttpRequestPOST(PREDICT.name(), connector, parameters, payload);
+
+        assertEquals("POST", request.method());
+        assertEquals("http://test.com/mock/gpt-3.5", request.url().toString());
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtilsTest.java
@@ -471,7 +471,7 @@ public class ConnectorUtilsTest {
             .method("POST")
             .url("http://test.com/mock")
             .requestBody("{\"input\": \"${parameters.input}\"}")
-            .headers(ImmutableMap.of("Authorization", "Bearer token123"))  // Add headers to action
+            .headers(ImmutableMap.of("Authorization", "Bearer token123"))
             .build();
 
         Connector connector = HttpConnector

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
@@ -6,7 +6,9 @@
 package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -15,6 +17,7 @@ import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PRED
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Before;
@@ -33,8 +36,10 @@ import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.transport.MLTaskResponse;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -264,6 +269,66 @@ public class HttpJsonConnectorExecutorTest {
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener, times(1)).onFailure(argumentCaptor.capture());
         assert argumentCaptor.getValue() instanceof NullPointerException;
+    }
+
+    @Test
+    public void testInvokeRemoteServiceStream_ValidInterface() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("http://openai.com/mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .build();
+
+        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        StreamPredictActionListener<MLTaskResponse, ?> actionListener = mock(StreamPredictActionListener.class);
+
+        Map<String, String> parameters = ImmutableMap.of("_llm_interface", "openai/v1/chat/completions", "input", "test input");
+        String payload = "{\"input\": \"test input\"}";
+        executor.invokeRemoteServiceStream(PREDICT.name(), createMLInput(), parameters, payload, new ExecutionContext(0), actionListener);
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testInvokeRemoteServiceStream_WithException() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("http://openai.com/mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .build();
+
+        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        StreamPredictActionListener<MLTaskResponse, ?> streamActionListener = mock(StreamPredictActionListener.class);
+
+        Map<String, String> parameters = ImmutableMap.of("_llm_interface", "invalid_interface", "input", "test input");
+        String payload = "{\"input\": \"test input\"}";
+
+        executor
+            .invokeRemoteServiceStream(PREDICT.name(), createMLInput(), parameters, payload, new ExecutionContext(0), streamActionListener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(streamActionListener, times(1)).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof MLException);
+        assertEquals("Fail to execute streaming", captor.getValue().getMessage());
     }
 
     private MLInput createMLInput() {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
@@ -110,12 +110,11 @@ public class McpConnectorExecutorTest extends MLStaticMockBase {
         McpConnectorExecutor exec = new McpConnectorExecutor(mockConnector);
 
         assertThrows(UnsupportedOperationException.class, () -> exec.invokeRemoteService(null, null, null, null, null, null));
+        assertThrows(UnsupportedOperationException.class, () -> exec.invokeRemoteServiceStream(null, null, null, null, null, null));
         assertThrows(UnsupportedOperationException.class, () -> exec.getScriptService());
         assertThrows(UnsupportedOperationException.class, () -> exec.getClient());
         assertThrows(UnsupportedOperationException.class, () -> exec.getRateLimiter());
         assertThrows(UnsupportedOperationException.class, () -> exec.getMlGuard());
         assertThrows(UnsupportedOperationException.class, () -> exec.getUserRateLimiterMap());
-
     }
-
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.connector.AbstractConnector.ACCESS_KEY_FIELD;
 import static org.opensearch.ml.common.connector.AbstractConnector.SECRET_KEY_FIELD;
-import static org.opensearch.ml.common.connector.AbstractConnector.SESSION_TOKEN_FIELD;
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
 import static org.opensearch.ml.common.connector.HttpConnector.REGION_FIELD;
 import static org.opensearch.ml.common.connector.HttpConnector.SERVICE_NAME_FIELD;
@@ -102,14 +101,7 @@ public class RemoteConnectorExecutorTest {
             .requestBody("{\"input\": \"${parameters.input}\"}")
             .build();
         Map<String, String> credential = ImmutableMap
-            .of(
-                ACCESS_KEY_FIELD,
-                encryptor.encrypt("test_key", null),
-                SECRET_KEY_FIELD,
-                encryptor.encrypt("test_secret_key", null),
-                SESSION_TOKEN_FIELD,
-                encryptor.encrypt("test_session_token", null)
-            );
+            .of(ACCESS_KEY_FIELD, encryptor.encrypt("test_key", null), SECRET_KEY_FIELD, encryptor.encrypt("test_secret_key", null));
         return AwsConnector
             .awsConnectorBuilder()
             .name("test connector")
@@ -123,7 +115,6 @@ public class RemoteConnectorExecutorTest {
     }
 
     private AwsConnectorExecutor getExecutor(Connector connector) {
-        connector.decrypt(PREDICT.name(), (c, tenantId) -> encryptor.decrypt(c, null), null);
         AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
         Settings settings = Settings.builder().build();
         ThreadContext threadContext = new ThreadContext(settings);
@@ -362,7 +353,7 @@ public class RemoteConnectorExecutorTest {
 
     @Test
     public void executeAction_WithTransportChannel() {
-        Map<String, String> parameters = ImmutableMap.of(SERVICE_NAME_FIELD, "sagemaker", REGION_FIELD, "us-west-2");
+        Map<String, String> parameters = ImmutableMap.of(SERVICE_NAME_FIELD, "bedrock", REGION_FIELD, "us-west-2");
         Connector connector = getConnector(parameters);
         AwsConnectorExecutor executor = getExecutor(connector);
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
@@ -134,7 +134,7 @@ public class RemoteConnectorExecutorTest {
         Exception exception = Assert
             .assertThrows(
                 IllegalArgumentException.class,
-                () -> executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener)
+                () -> executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener, null)
             );
         assert exception.getMessage().contains("Some parameter placeholder not filled in payload: role");
     }
@@ -154,7 +154,7 @@ public class RemoteConnectorExecutorTest {
         String actionType = inputDataSet.getActionType().toString();
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(inputDataSet).build();
 
-        executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener);
+        executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener, null);
         Mockito
             .verify(executor, times(1))
             .invokeRemoteService(any(), any(), any(), argThat(argument -> argument.contains("You are a ${parameters.role}")), any(), any());
@@ -177,7 +177,7 @@ public class RemoteConnectorExecutorTest {
         Exception exception = Assert
             .assertThrows(
                 IllegalArgumentException.class,
-                () -> executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener)
+                () -> executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener, null)
             );
         assert exception.getMessage().contains("Some parameter placeholder not filled in payload: role");
     }
@@ -209,7 +209,7 @@ public class RemoteConnectorExecutorTest {
         Exception exception = Assert
             .assertThrows(
                 IllegalArgumentException.class,
-                () -> executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener)
+                () -> executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener, null)
             );
         assert exception.getMessage().contains("Some parameter placeholder not filled in payload: role");
     }
@@ -234,7 +234,7 @@ public class RemoteConnectorExecutorTest {
             .inputDataset(inputDataSet)
             .build();
 
-        executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener);
+        executor.preparePayloadAndInvoke(actionType, mlInput, null, actionListener, null);
         verify(actionListener).onFailure(argThat(e -> e instanceof IOException && e.getMessage().contains("UT test IOException")));
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/StreamPredictActionListenerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/StreamPredictActionListenerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.transport.MLTaskResponse;
+import org.opensearch.transport.TransportChannel;
+import org.opensearch.transport.TransportRequest;
+
+public class StreamPredictActionListenerTest {
+
+    @Mock
+    private TransportChannel mockChannel;
+
+    @Mock
+    private MLTaskResponse mockResponse;
+
+    private StreamPredictActionListener<MLTaskResponse, TransportRequest> listener;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        listener = new StreamPredictActionListener<>(mockChannel);
+    }
+
+    @Test
+    public void testOnStreamResponse_NotLastBatch() {
+        listener.onStreamResponse(mockResponse, false);
+
+        verify(mockChannel).sendResponseBatch(mockResponse);
+        verify(mockChannel, never()).completeStream();
+    }
+
+    @Test
+    public void testOnStreamResponse_LastBatch() {
+        listener.onStreamResponse(mockResponse, true);
+
+        verify(mockChannel).sendResponseBatch(mockResponse);
+        verify(mockChannel).completeStream();
+    }
+
+    @Test
+    public void testOnResponse_CallsOnStreamResponseWithLastBatch() {
+        listener.onResponse(mockResponse);
+
+        verify(mockChannel).sendResponseBatch(mockResponse);
+        verify(mockChannel).completeStream();
+    }
+
+    @Test
+    public void testOnFailure_WithErrorMessage() {
+        Exception testException = new RuntimeException("Test error message");
+
+        listener.onFailure(testException);
+
+        ArgumentCaptor<MLTaskResponse> responseCaptor = ArgumentCaptor.forClass(MLTaskResponse.class);
+        verify(mockChannel).sendResponseBatch(responseCaptor.capture());
+        verify(mockChannel).completeStream();
+
+        MLTaskResponse errorResponse = responseCaptor.getValue();
+        ModelTensorOutput output = (ModelTensorOutput) errorResponse.getOutput();
+        ModelTensor errorTensor = output.getMlModelOutputs().get(0).getMlModelTensors().get(0);
+
+        assertEquals("error", errorTensor.getName());
+        assertEquals("Test error message", errorTensor.getDataAsMap().get("error"));
+        assertEquals(true, errorTensor.getDataAsMap().get("is_last"));
+    }
+
+    @Test
+    public void testOnFailure_WithNullErrorMessage() {
+        Exception testException = new RuntimeException((String) null);
+
+        listener.onFailure(testException);
+
+        ArgumentCaptor<MLTaskResponse> responseCaptor = ArgumentCaptor.forClass(MLTaskResponse.class);
+        verify(mockChannel).sendResponseBatch(responseCaptor.capture());
+        verify(mockChannel).completeStream();
+
+        MLTaskResponse errorResponse = responseCaptor.getValue();
+        ModelTensorOutput output = (ModelTensorOutput) errorResponse.getOutput();
+        ModelTensor errorTensor = output.getMlModelOutputs().get(0).getMlModelTensors().get(0);
+
+        assertEquals("error", errorTensor.getName());
+        assertEquals("Request failed", errorTensor.getDataAsMap().get("error"));
+        assertEquals(true, errorTensor.getDataAsMap().get("is_last"));
+    }
+
+    @Test
+    public void testOnFailure_WithEmptyErrorMessage() {
+        Exception testException = new RuntimeException("  ");
+
+        listener.onFailure(testException);
+
+        ArgumentCaptor<MLTaskResponse> responseCaptor = ArgumentCaptor.forClass(MLTaskResponse.class);
+        verify(mockChannel).sendResponseBatch(responseCaptor.capture());
+
+        MLTaskResponse errorResponse = responseCaptor.getValue();
+        ModelTensorOutput output = (ModelTensorOutput) errorResponse.getOutput();
+        ModelTensor errorTensor = output.getMlModelOutputs().get(0).getMlModelTensors().get(0);
+
+        assertEquals("Request failed", errorTensor.getDataAsMap().get("error"));
+    }
+
+    @Test
+    public void testOnFailure_SendResponseBatchThrowsException() {
+        Exception testException = new RuntimeException("Test error");
+        doThrow(new RuntimeException("Send batch failed")).when(mockChannel).sendResponseBatch(any());
+
+        listener.onFailure(testException);
+
+        verify(mockChannel).sendResponseBatch(any(MLTaskResponse.class));
+        verify(mockChannel).completeStream();
+    }
+}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -430,6 +430,10 @@ configurations.all {
     resolutionStrategy.force "org.opensearch:opensearch:${opensearch_version}"
     resolutionStrategy.force "org.bouncycastle:bcprov-jdk18on:1.78.1"
     resolutionStrategy.force 'io.projectreactor:reactor-core:3.7.0'
+    resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10"
+    resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.9.23"
+    resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10"
+    resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-common:1.9.23"
     resolutionStrategy.force 'commons-beanutils:commons-beanutils:1.11.0'
     resolutionStrategy.force "com.google.code.gson:gson:${versions.gson}"
     resolutionStrategy.force "software.amazon.awssdk:bom:${versions.aws}"

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -349,6 +349,7 @@ List<String> jacocoExclusions = [
         'org.opensearch.ml.task.MLTaskManager',
         'org.opensearch.ml.task.MLTrainingTaskRunner',
         'org.opensearch.ml.task.MLPredictTaskRunner',
+        'org.opensearch.ml.task.MLPredictTaskRunner.*',
         'org.opensearch.ml.task.MLTaskDispatcher',
         'org.opensearch.ml.task.MLTrainAndPredictTaskRunner',
         'org.opensearch.ml.task.MLExecuteTaskRunner',
@@ -377,7 +378,9 @@ List<String> jacocoExclusions = [
         'org.opensearch.ml.action.memorycontainer.memory.TransportAddMemoriesAction',
         'org.opensearch.ml.action.memorycontainer.memory.TransportAddMemoriesAction.*',
         'org.opensearch.ml.rest.RestMLDeleteMemoryAction',
-        'org.opensearch.ml.rest.RestMLDeleteMemoryAction.*'
+        'org.opensearch.ml.rest.RestMLDeleteMemoryAction.*',
+        'org.opensearch.ml.rest.RestMLPredictionStreamAction',
+        'org.opensearch.ml.rest.RestMLPredictionStreamAction.*'
 ]
 
 jacocoTestCoverageVerification {

--- a/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionStreamTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionStreamTaskAction.java
@@ -13,6 +13,7 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -87,7 +88,7 @@ public class TransportPredictionStreamTaskAction extends HandledTransportAction<
         ModelAccessControlHelper modelAccessControlHelper,
         MLFeatureEnabledSetting mlFeatureEnabledSetting,
         Settings settings,
-        StreamTransportService streamTransportService
+        @Nullable StreamTransportService streamTransportService
     ) {
         super(MLPredictionStreamTaskAction.NAME, transportService, actionFilters, MLPredictionTaskRequest::new);
         this.mlPredictTaskRunner = mlPredictTaskRunner;
@@ -108,13 +109,17 @@ public class TransportPredictionStreamTaskAction extends HandledTransportAction<
             .getClusterSettings()
             .addSettingsUpdateConsumer(ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE, it -> enableAutomaticDeployment = it);
 
-        streamTransportService
-            .registerRequestHandler(
-                MLPredictionStreamTaskAction.NAME,
-                STREAM_PREDICT_THREAD_POOL,
-                MLPredictionTaskRequest::new,
-                this::messageReceived
-            );
+        if (streamTransportService != null) {
+            streamTransportService
+                .registerRequestHandler(
+                    MLPredictionStreamTaskAction.NAME,
+                    STREAM_PREDICT_THREAD_POOL,
+                    MLPredictionTaskRequest::new,
+                    this::messageReceived
+                );
+        } else {
+            log.warn("StreamTransportService is not available.");
+        }
     }
 
     public static StreamTransportService getStreamTransportService() {

--- a/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionStreamTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/prediction/TransportPredictionStreamTaskAction.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.prediction;
+
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.STREAM_PREDICT_THREAD_POOL;
+import static org.opensearch.ml.utils.MLExceptionUtils.LOCAL_MODEL_DISABLED_ERR_MSG;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.MLTaskResponse;
+import org.opensearch.ml.common.transport.prediction.MLPredictionStreamTaskAction;
+import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
+import org.opensearch.ml.engine.algorithms.remote.StreamPredictActionListener;
+import org.opensearch.ml.helper.ModelAccessControlHelper;
+import org.opensearch.ml.model.MLModelCacheHelper;
+import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.task.MLPredictTaskRunner;
+import org.opensearch.ml.task.MLTaskRunner;
+import org.opensearch.ml.utils.MLNodeUtils;
+import org.opensearch.ml.utils.RestActionUtils;
+import org.opensearch.ml.utils.TenantAwareHelper;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.StreamTransportService;
+import org.opensearch.transport.TransportChannel;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class TransportPredictionStreamTaskAction extends HandledTransportAction<ActionRequest, MLTaskResponse> {
+    MLTaskRunner<MLPredictionTaskRequest, MLTaskResponse> mlPredictTaskRunner;
+
+    TransportService transportService;
+
+    MLModelCacheHelper modelCacheHelper;
+
+    Client client;
+
+    SdkClient sdkClient;
+
+    ClusterService clusterService;
+
+    MLModelManager mlModelManager;
+
+    ModelAccessControlHelper modelAccessControlHelper;
+
+    private volatile boolean enableAutomaticDeployment;
+
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    public static StreamTransportService streamTransportService;
+
+    @Inject
+    public TransportPredictionStreamTaskAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        MLModelCacheHelper modelCacheHelper,
+        MLPredictTaskRunner mlPredictTaskRunner,
+        ClusterService clusterService,
+        Client client,
+        SdkClient sdkClient,
+        MLModelManager mlModelManager,
+        ModelAccessControlHelper modelAccessControlHelper,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting,
+        Settings settings,
+        StreamTransportService streamTransportService
+    ) {
+        super(MLPredictionStreamTaskAction.NAME, transportService, actionFilters, MLPredictionTaskRequest::new);
+        this.mlPredictTaskRunner = mlPredictTaskRunner;
+        this.transportService = transportService;
+        this.modelCacheHelper = modelCacheHelper;
+        this.clusterService = clusterService;
+        this.client = client;
+        this.sdkClient = sdkClient;
+        this.mlModelManager = mlModelManager;
+        this.modelAccessControlHelper = modelAccessControlHelper;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+        this.streamTransportService = streamTransportService;
+        enableAutomaticDeployment = ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE.get(settings);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE, it -> enableAutomaticDeployment = it);
+
+        streamTransportService
+            .registerRequestHandler(
+                MLPredictionStreamTaskAction.NAME,
+                STREAM_PREDICT_THREAD_POOL,
+                MLPredictionTaskRequest::new,
+                this::messageReceived
+            );
+    }
+
+    public void messageReceived(MLPredictionTaskRequest request, TransportChannel channel, Task task) {
+        StreamPredictActionListener<MLTaskResponse, MLPredictionTaskRequest> streamListener = new StreamPredictActionListener<>(channel);
+        doExecute(task, request, streamListener, channel);
+    }
+
+    @Override
+    protected void doExecute(Task task, ActionRequest request, ActionListener<MLTaskResponse> listener) {
+        // This should never be called for streaming action
+        listener.onFailure(new UnsupportedOperationException("Use doExecute with TransportChannel for streaming requests"));
+    }
+
+    protected void doExecute(Task task, ActionRequest request, ActionListener<MLTaskResponse> listener, TransportChannel channel) {
+        MLPredictionTaskRequest mlPredictionTaskRequest = MLPredictionTaskRequest.fromActionRequest(request);
+        mlPredictionTaskRequest.setStreamingChannel(channel);
+
+        String modelId = mlPredictionTaskRequest.getModelId();
+        String tenantId = mlPredictionTaskRequest.getTenantId();
+        if (!TenantAwareHelper.validateTenantId(mlFeatureEnabledSetting, tenantId, listener)) {
+            return;
+        }
+        User user = mlPredictionTaskRequest.getUser();
+        if (user == null) {
+            user = RestActionUtils.getUserContext(client);
+            mlPredictionTaskRequest.setUser(user);
+        }
+        final User userInfo = user;
+
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<MLTaskResponse> wrappedListener = ActionListener.runBefore(listener, context::restore);
+            MLModel cachedMlModel = modelCacheHelper.getModelInfo(modelId);
+            ActionListener<MLModel> modelActionListener = new ActionListener<>() {
+                @Override
+                public void onResponse(MLModel mlModel) {
+                    context.restore();
+                    modelCacheHelper.setModelInfo(modelId, mlModel);
+                    FunctionName functionName = mlModel.getAlgorithm();
+                    if (FunctionName.isDLModel(functionName) && !mlFeatureEnabledSetting.isLocalModelEnabled()) {
+                        throw new IllegalStateException(LOCAL_MODEL_DISABLED_ERR_MSG);
+                    }
+                    mlPredictionTaskRequest.getMlInput().setAlgorithm(functionName);
+                    modelAccessControlHelper
+                        .validateModelGroupAccess(
+                            userInfo,
+                            mlFeatureEnabledSetting,
+                            tenantId,
+                            mlModel.getModelGroupId(),
+                            client,
+                            sdkClient,
+                            ActionListener.wrap(access -> {
+                                if (!access) {
+                                    wrappedListener
+                                        .onFailure(
+                                            new OpenSearchStatusException(
+                                                "User Doesn't have privilege to perform this operation on this model",
+                                                RestStatus.FORBIDDEN
+                                            )
+                                        );
+                                } else {
+                                    if (modelCacheHelper.getIsModelEnabled(modelId) != null
+                                        && !modelCacheHelper.getIsModelEnabled(modelId)) {
+                                        wrappedListener
+                                            .onFailure(new OpenSearchStatusException("Model is disabled.", RestStatus.FORBIDDEN));
+                                    } else {
+                                        if (FunctionName.isDLModel(functionName)) {
+                                            if (modelCacheHelper.getRateLimiter(modelId) != null
+                                                && !modelCacheHelper.getRateLimiter(modelId).request()) {
+                                                wrappedListener
+                                                    .onFailure(
+                                                        new OpenSearchStatusException(
+                                                            "Request is throttled at model level.",
+                                                            RestStatus.TOO_MANY_REQUESTS
+                                                        )
+                                                    );
+                                            } else if (userInfo != null
+                                                && modelCacheHelper.getUserRateLimiter(modelId, userInfo.getName()) != null
+                                                && !modelCacheHelper.getUserRateLimiter(modelId, userInfo.getName()).request()) {
+                                                wrappedListener
+                                                    .onFailure(
+                                                        new OpenSearchStatusException(
+                                                            "Request is throttled at user level. If you think there's an issue, please contact your cluster admin.",
+                                                            RestStatus.TOO_MANY_REQUESTS
+                                                        )
+                                                    );
+                                            } else {
+                                                wrappedListener
+                                                    .onFailure(
+                                                        new OpenSearchStatusException(
+                                                            "Non-streaming requests are not supported by the streaming transport action",
+                                                            RestStatus.BAD_REQUEST
+                                                        )
+                                                    );
+                                            }
+                                        } else {
+                                            validateInputSchema(modelId, mlPredictionTaskRequest.getMlInput());
+                                            executePredictStream(mlPredictionTaskRequest, wrappedListener, modelId);
+                                        }
+                                    }
+                                }
+                            }, wrappedListener::onFailure)
+                        );
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    log.error("Failed to find model {}", modelId, e);
+                    wrappedListener.onFailure(e);
+                }
+            };
+
+            if (cachedMlModel != null) {
+                modelActionListener.onResponse(cachedMlModel);
+            } else {
+                // For multi-node cluster, the function name is null in cache, so should always get model first.
+                mlModelManager.getModel(modelId, tenantId, modelActionListener);
+            }
+        } catch (Exception e) {
+            log.error("Failed to predict " + mlPredictionTaskRequest.toString(), e);
+            listener.onFailure(e);
+        }
+    }
+
+    private void executePredictStream(
+        MLPredictionTaskRequest mlPredictionTaskRequest,
+        ActionListener<MLTaskResponse> wrappedListener,
+        String modelId
+    ) {
+        String requestId = mlPredictionTaskRequest.getRequestID();
+        long startTime = System.nanoTime();
+
+        FunctionName functionName = modelCacheHelper
+            .getOptionalFunctionName(modelId)
+            .orElse(mlPredictionTaskRequest.getMlInput().getAlgorithm());
+
+        mlPredictTaskRunner
+            .run(functionName, mlPredictionTaskRequest, streamTransportService, ActionListener.runAfter(wrappedListener, () -> {
+                long endTime = System.nanoTime();
+                double durationInMs = (endTime - startTime) / 1e6;
+                modelCacheHelper.addPredictRequestDuration(modelId, durationInMs);
+                modelCacheHelper.refreshLastAccessTime(modelId);
+                log.debug("completed predict request {} for model {}", requestId, modelId);
+            }));
+    }
+
+    public void validateInputSchema(String modelId, MLInput mlInput) {
+        if (modelCacheHelper.getModelInterface(modelId) != null && modelCacheHelper.getModelInterface(modelId).get("input") != null) {
+            String inputSchemaString = modelCacheHelper.getModelInterface(modelId).get("input");
+            try {
+                String InputString = mlInput.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS).toString();
+                // Process the parameters field in the input dataset to convert it back to its original datatype, instead of a string
+                String processedInputString = MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(InputString, inputSchemaString);
+                MLNodeUtils.validateSchema(inputSchemaString, processedInputString);
+            } catch (Exception e) {
+                throw new OpenSearchStatusException(
+                    "Error validating input schema, if you think this is expected, please update your 'input' field in the 'interface' field for this model: "
+                        + e.getMessage(),
+                    RestStatus.BAD_REQUEST
+                );
+            }
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionStreamAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionStreamAction.java
@@ -1,0 +1,372 @@
+
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_BASE_URI;
+import static org.opensearch.ml.plugin.MachineLearningPlugin.STREAM_PREDICT_THREAD_POOL;
+import static org.opensearch.ml.utils.MLExceptionUtils.BATCH_INFERENCE_DISABLED_ERR_MSG;
+import static org.opensearch.ml.utils.MLExceptionUtils.LOCAL_MODEL_DISABLED_ERR_MSG;
+import static org.opensearch.ml.utils.MLExceptionUtils.REMOTE_INFERENCE_DISABLED_ERR_MSG;
+import static org.opensearch.ml.utils.MLExceptionUtils.STREAM_DISABLED_ERR_MSG;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_ALGORITHM;
+import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_ID;
+import static org.opensearch.ml.utils.RestActionUtils.getActionTypeFromRestRequest;
+import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
+import static org.opensearch.ml.utils.TenantAwareHelper.getTenantID;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.lease.Releasable;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.support.XContentHttpChunk;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.http.HttpChunk;
+import org.opensearch.ml.action.prediction.TransportPredictionStreamTaskAction;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.connector.ConnectorAction.ActionType;
+import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.input.remote.RemoteInferenceMLInput;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.MLTaskResponse;
+import org.opensearch.ml.common.transport.prediction.MLPredictionStreamTaskAction;
+import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
+import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.StreamingRestChannel;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.StreamTransportResponseHandler;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportRequestOptions;
+import org.opensearch.transport.client.node.NodeClient;
+import org.opensearch.transport.stream.StreamTransportResponse;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+import lombok.extern.log4j.Log4j2;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Log4j2
+public class RestMLPredictionStreamAction extends BaseRestHandler {
+
+    private static final String ML_PREDICTION_STREAM_ACTION = "ml_prediction_streaming_action";
+
+    private MLModelManager modelManager;
+
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    private ClusterService clusterService;
+
+    /**
+     * Constructor
+     */
+    public RestMLPredictionStreamAction(
+        MLModelManager modelManager,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting,
+        ClusterService clusterService
+    ) {
+        this.modelManager = modelManager;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+        this.clusterService = clusterService;
+    }
+
+    @Override
+    public String getName() {
+        return ML_PREDICTION_STREAM_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList
+            .of(
+                new Route(
+                    RestRequest.Method.POST,
+                    String.format(Locale.ROOT, "%s/models/{%s}/_predict/stream", ML_BASE_URI, PARAMETER_MODEL_ID)
+                )
+            );
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (!mlFeatureEnabledSetting.isStreamEnabled()) {
+            throw new IllegalStateException(STREAM_DISABLED_ERR_MSG);
+        }
+
+        String userAlgorithm = request.param(PARAMETER_ALGORITHM);
+        String modelId = getParameterId(request, PARAMETER_MODEL_ID);
+        Optional<FunctionName> functionName = modelManager.getOptionalModelFunctionName(modelId);
+
+        return channel -> {
+            StreamingRestChannel streamingChannel = (StreamingRestChannel) channel;
+
+            // Set streaming headers
+            Map<String, List<String>> headers = Map
+                .of(
+                    "Content-Type",
+                    List.of("text/event-stream"),
+                    "Cache-Control",
+                    List.of("no-cache"),
+                    "Connection",
+                    List.of("keep-alive")
+                );
+            streamingChannel.prepareResponse(RestStatus.OK, headers);
+
+            // Use Flux with cache check
+            Flux.from(streamingChannel).ofType(HttpChunk.class).concatMap(chunk -> {
+                final CompletableFuture<HttpChunk> future = new CompletableFuture<>();
+                try {
+                    BytesReference chunkContent = chunk.content();
+
+                    // Check if model is in cache
+                    if (functionName.isPresent()) {
+                        MLPredictionTaskRequest taskRequest = getRequest(modelId, functionName.get().name(), request, chunkContent);
+                        executeStreamingRequest(client, taskRequest, streamingChannel, future);
+                    } else {
+                        // Model not in cache - load it first
+                        loadModelAndExecuteStreaming(client, modelId, userAlgorithm, request, chunkContent, streamingChannel, future);
+                    }
+
+                } catch (IOException e) {
+                    future.completeExceptionally(e);
+                }
+
+                return Mono.fromCompletionStage(future);
+            }).doOnNext(streamingChannel::sendChunk).onErrorComplete(ex -> {
+                // Error handling
+                try {
+                    streamingChannel.sendResponse(new BytesRestResponse(streamingChannel, (Exception) ex));
+                    return true;
+                } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }).subscribe();
+        };
+    }
+
+    private void loadModelAndExecuteStreaming(
+        NodeClient client,
+        String modelId,
+        String userAlgorithm,
+        RestRequest request,
+        BytesReference chunkContent,
+        StreamingRestChannel channel,
+        CompletableFuture<HttpChunk> future
+    ) {
+        ActionListener<MLModel> listener = ActionListener.wrap(mlModel -> {
+            try {
+                String modelType = mlModel.getAlgorithm().name();
+                String modelAlgorithm = Objects.requireNonNullElse(userAlgorithm, modelType);
+
+                MLPredictionTaskRequest taskRequest = getRequest(modelId, modelAlgorithm, request, chunkContent);
+                executeStreamingRequest(client, taskRequest, channel, future);
+            } catch (IOException e) {
+                future.completeExceptionally(e);
+            }
+        }, future::completeExceptionally);
+
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            modelManager
+                .getModel(
+                    modelId,
+                    getTenantID(mlFeatureEnabledSetting.isMultiTenancyEnabled(), request),
+                    ActionListener.runBefore(listener, context::restore)
+                );
+        }
+    }
+
+    private void executeStreamingRequest(
+        NodeClient client,
+        MLPredictionTaskRequest taskRequest,
+        StreamingRestChannel channel,
+        CompletableFuture<HttpChunk> future
+    ) {
+        StreamTransportResponseHandler<MLTaskResponse> handler = new StreamTransportResponseHandler<MLTaskResponse>() {
+            @Override
+            public void handleStreamResponse(StreamTransportResponse<MLTaskResponse> streamResponse) {
+                try {
+                    MLTaskResponse response = streamResponse.nextResponse();
+                    if (response != null) {
+                        HttpChunk responseChunk = convertToHttpChunk(response);
+                        channel.sendChunk(responseChunk);
+
+                        // Recursively handle the next response
+                        client.threadPool().executor(STREAM_PREDICT_THREAD_POOL).execute(() -> handleStreamResponse(streamResponse));
+                    } else {
+                        log.info("No more responses, closing stream");
+                        future.complete(XContentHttpChunk.last());
+                    }
+                } catch (Exception e) {
+                    future.completeExceptionally(e);
+                    log.error("Error in stream handling", e);
+                }
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                future.completeExceptionally(exp);
+            }
+
+            @Override
+            public String executor() {
+                return ThreadPool.Names.SAME;
+            }
+
+            @Override
+            public MLTaskResponse read(StreamInput in) throws IOException {
+                return new MLTaskResponse(in);
+            }
+        };
+
+        // Send the streaming request using transport service
+        TransportPredictionStreamTaskAction.streamTransportService
+            .sendRequest(
+                clusterService.localNode(),
+                MLPredictionStreamTaskAction.NAME,
+                taskRequest,
+                TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build(),
+                handler
+            );
+    }
+
+    @Override
+    public boolean supportsContentStream() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsStreaming() {
+        return true;
+    }
+
+    @Override
+    public boolean allowsUnsafeBuffers() {
+        return true;
+    }
+
+    /**
+     * Creates a MLPredictionTaskRequest from a RestRequest
+     *
+     * @param request RestRequest
+     * @return MLPredictionTaskRequest
+     */
+    @VisibleForTesting
+    MLPredictionTaskRequest getRequest(String modelId, String algorithm, RestRequest request, BytesReference content) throws IOException {
+        ActionType actionType = ActionType.from(getActionTypeFromRestRequest(request));
+        if (FunctionName.REMOTE.name().equals(algorithm) && !mlFeatureEnabledSetting.isRemoteInferenceEnabled()) {
+            throw new IllegalStateException(REMOTE_INFERENCE_DISABLED_ERR_MSG);
+        } else if (FunctionName.isDLModel(FunctionName.from(algorithm.toUpperCase(Locale.ROOT)))
+            && !mlFeatureEnabledSetting.isLocalModelEnabled()) {
+            throw new IllegalStateException(LOCAL_MODEL_DISABLED_ERR_MSG);
+        } else if (ActionType.BATCH_PREDICT == actionType && !mlFeatureEnabledSetting.isOfflineBatchInferenceEnabled()) {
+            throw new IllegalStateException(BATCH_INFERENCE_DISABLED_ERR_MSG);
+        } else if (!ActionType.isValidActionInModelPrediction(actionType)) {
+            throw new IllegalArgumentException("Wrong action type in the rest request path!");
+        }
+
+        XContentParser parser = request
+            .getMediaType()
+            .xContent()
+            .createParser(request.getXContentRegistry(), LoggingDeprecationHandler.INSTANCE, content.streamInput());
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        MLInput mlInput = MLInput.parse(parser, algorithm, actionType);
+        if (FunctionName.REMOTE.name().contentEquals(algorithm)) {
+            RemoteInferenceMLInput input = (RemoteInferenceMLInput) mlInput;
+            RemoteInferenceInputDataSet inputDataSet = (RemoteInferenceInputDataSet) input.getInputDataset();
+            inputDataSet.getParameters().put("stream", String.valueOf(true));
+            return new MLPredictionTaskRequest(modelId, input, null, null);
+        }
+        return new MLPredictionTaskRequest(modelId, mlInput, null, null);
+    }
+
+    private HttpChunk convertToHttpChunk(MLTaskResponse response) throws IOException {
+        String content = "";
+        boolean isLast = false;
+
+        // Extract content and is_last flag
+        try {
+            ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
+            if (output != null && !output.getMlModelOutputs().isEmpty()) {
+                ModelTensors modelTensors = output.getMlModelOutputs().get(0);
+                if (!modelTensors.getMlModelTensors().isEmpty()) {
+                    Map<String, ?> dataMap = modelTensors.getMlModelTensors().get(0).getDataAsMap();
+                    if (dataMap.containsKey("content")) {
+                        content = (String) dataMap.get("content");
+                    }
+                    if (dataMap.containsKey("is_last")) {
+                        isLast = Boolean.TRUE.equals(dataMap.get("is_last"));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to extract content from response", e);
+            content = "";
+        }
+
+        // Create ModelTensorOutput structure
+        Map<String, Object> chunkData = new LinkedHashMap<>();
+        chunkData.put("content", content);
+        chunkData.put("is_last", isLast);
+
+        ModelTensor tensor = ModelTensor.builder().name("response").dataAsMap(chunkData).build();
+        ModelTensors tensors = ModelTensors.builder().mlModelTensors(List.of(tensor)).build();
+        ModelTensorOutput tensorOutput = ModelTensorOutput.builder().mlModelOutputs(List.of(tensors)).build();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        tensorOutput.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String jsonData = builder.toString();
+
+        String sseData = "data: " + jsonData + "\n\n";
+        BytesReference bytesRef = BytesReference.fromByteBuffer(ByteBuffer.wrap(sseData.getBytes()));
+
+        return new HttpChunk() {
+            @Override
+            public void close() {
+                if (bytesRef instanceof Releasable) {
+                    ((Releasable) bytesRef).close();
+                }
+            }
+
+            @Override
+            public boolean isLast() {
+                return false;
+            }
+
+            @Override
+            public BytesReference content() {
+                return bytesRef;
+            }
+        };
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionStreamAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLPredictionStreamAction.java
@@ -65,6 +65,7 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.StreamingRestChannel;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.StreamTransportResponseHandler;
+import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportRequestOptions;
 import org.opensearch.transport.client.node.NodeClient;
@@ -263,6 +264,7 @@ public class RestMLPredictionStreamAction extends BaseRestHandler {
                         client.threadPool().executor(STREAM_PREDICT_THREAD_POOL).execute(() -> handleStreamResponse(streamResponse));
                     } else {
                         log.info("No more responses, closing stream");
+                        streamResponse.close();
                         future.complete(XContentHttpChunk.last());
                     }
                 } catch (Exception e) {
@@ -288,7 +290,8 @@ public class RestMLPredictionStreamAction extends BaseRestHandler {
         };
 
         // Send the streaming request using transport service
-        TransportPredictionStreamTaskAction.streamTransportService
+        StreamTransportService streamTransportService = TransportPredictionStreamTaskAction.getStreamTransportService();
+        streamTransportService
             .sendRequest(
                 clusterService.localNode(),
                 MLPredictionStreamTaskAction.NAME,

--- a/plugin/src/main/java/org/opensearch/ml/task/MLExecuteTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLExecuteTaskRunner.java
@@ -74,6 +74,11 @@ public class MLExecuteTaskRunner extends MLTaskRunner<MLExecuteTaskRequest, MLEx
     }
 
     @Override
+    protected String getTransportStreamActionName() {
+        return MLExecuteTaskAction.NAME;
+    }
+
+    @Override
     protected TransportResponseHandler<MLExecuteTaskResponse> getResponseHandler(ActionListener<MLExecuteTaskResponse> listener) {
         return new ActionListenerResponseHandler<>(listener, MLExecuteTaskResponse::new);
     }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -168,7 +168,7 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
                     channel.completeStream();
                     streamResponse.close();
                 } catch (Exception e) {
-                    streamResponse.cancel("Test error", e);
+                    streamResponse.cancel("Stream error", e);
                 }
             }
 

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskRunner.java
@@ -124,6 +124,8 @@ public abstract class MLTaskRunner<Request extends MLTaskRequest, Response exten
 
     protected abstract String getTransportActionName();
 
+    protected abstract String getTransportStreamActionName();
+
     protected abstract TransportResponseHandler<Response> getResponseHandler(ActionListener<Response> listener);
 
     protected abstract void executeTask(Request request, ActionListener<Response> listener);

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTrainAndPredictTaskRunner.java
@@ -80,6 +80,11 @@ public class MLTrainAndPredictTaskRunner extends MLTaskRunner<MLTrainingTaskRequ
     }
 
     @Override
+    protected String getTransportStreamActionName() {
+        return MLTrainAndPredictionTaskAction.NAME;
+    }
+
+    @Override
     protected TransportResponseHandler<MLTaskResponse> getResponseHandler(ActionListener<MLTaskResponse> listener) {
         return new ActionListenerResponseHandler<>(listener, MLTaskResponse::new);
     }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTrainingTaskRunner.java
@@ -92,6 +92,11 @@ public class MLTrainingTaskRunner extends MLTaskRunner<MLTrainingTaskRequest, ML
     }
 
     @Override
+    protected String getTransportStreamActionName() {
+        return MLTrainingTaskAction.NAME;
+    }
+
+    @Override
     protected TransportResponseHandler<MLTaskResponse> getResponseHandler(ActionListener<MLTaskResponse> listener) {
         return new ActionListenerResponseHandler<>(listener, MLTaskResponse::new);
     }

--- a/plugin/src/main/java/org/opensearch/ml/utils/MLExceptionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/MLExceptionUtils.java
@@ -30,6 +30,8 @@ public class MLExceptionUtils {
         "Controller is currently disabled. To enable it, update the setting \"plugins.ml_commons.controller_enabled\" to true.";
     public static final String OFFLINE_BATCH_INGESTION_DISABLED_ERR_MSG =
         "Offline batch ingestion is currently disabled. To enable it, update the setting \"plugins.ml_commons.offline_batch_ingestion_enabled\" to true.";
+    public static final String STREAM_DISABLED_ERR_MSG =
+        "Streaming is currently disabled. To enable it, update the setting \"plugins.ml_commons.stream_enabled\" to true.";
 
     public static String getRootCauseMessage(final Throwable throwable) {
         String message = ExceptionUtils.getRootCauseMessage(throwable);

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -323,6 +323,9 @@ public class RestActionUtils {
         String path = request.path();
         String[] segments = path.split("/");
         String methodName = segments[segments.length - 1];
+        if ("stream".equals(methodName)) {
+            methodName = segments[segments.length - 2];
+        }
         methodName = methodName.startsWith("_") ? methodName.substring(1) : methodName;
 
         // find the action type for "/_plugins/_ml/_predict/<algorithm>/<model_id>"

--- a/plugin/src/test/java/org/opensearch/ml/action/prediction/TransportPredictionStreamTaskActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/prediction/TransportPredictionStreamTaskActionTests.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.prediction;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.breaker.CircuitBreaker;
+import org.opensearch.core.common.breaker.CircuitBreakingException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.dataframe.DataFrame;
+import org.opensearch.ml.common.dataframe.DataFrameBuilder;
+import org.opensearch.ml.common.dataset.DataFrameInputDataset;
+import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.exception.MLResourceNotFoundException;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.input.parameter.clustering.KMeansParams;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.MLTaskResponse;
+import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
+import org.opensearch.ml.helper.ModelAccessControlHelper;
+import org.opensearch.ml.model.MLModelCacheHelper;
+import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.task.MLPredictTaskRunner;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.StreamTransportService;
+import org.opensearch.transport.TransportChannel;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class TransportPredictionStreamTaskActionTests extends OpenSearchTestCase {
+    @Mock
+    private MLPredictTaskRunner mlPredictTaskRunner;
+
+    @Mock
+    private TransportService transportService;
+
+    @Mock
+    private MLModelCacheHelper modelCacheHelper;
+
+    @Mock
+    private Client client;
+    SdkClient sdkClient;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private MLModelManager mlModelManager;
+
+    @Mock
+    private ActionListener<MLTaskResponse> actionListener;
+
+    @Mock
+    private MLModel model;
+
+    @Mock
+    private ModelAccessControlHelper modelAccessControlHelper;
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Mock
+    ActionFilters actionFilters;
+
+    MLPredictionTaskRequest mlPredictionTaskRequest;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    private TransportPredictionStreamTaskAction transportPredictionStreamTaskAction;
+
+    ThreadContext threadContext;
+
+    @Mock
+    ThreadPool threadPool;
+
+    private MLInput mlInput;
+
+    @Mock
+    private StreamTransportService streamTransportService;
+
+    @Mock
+    private TransportChannel transportChannel;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        User user = User.parse("admin|role-1|all_access");
+
+        DataFrame dataFrame = DataFrameBuilder.load(Collections.singletonList(new HashMap<String, Object>() {
+            {
+                put("key1", 2.0D);
+            }
+        }));
+        mlInput = MLInput
+            .builder()
+            .algorithm(FunctionName.KMEANS)
+            .parameters(KMeansParams.builder().centroids(1).build())
+            .inputDataset(DataFrameInputDataset.builder().dataFrame(dataFrame).build())
+            .build();
+
+        mlPredictionTaskRequest = MLPredictionTaskRequest.builder().modelId("test_id").mlInput(mlInput).user(user).build();
+        sdkClient = SdkClientFactory.createSdkClient(client, NamedXContentRegistry.EMPTY, Collections.emptyMap());
+        Settings settings = Settings.builder().put(ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE.getKey(), true).build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, new HashSet<>(Arrays.asList(ML_COMMONS_MODEL_AUTO_DEPLOY_ENABLE)));
+
+        threadContext = new ThreadContext(settings);
+        when(clusterService.getSettings()).thenReturn(settings);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(mlFeatureEnabledSetting.isLocalModelEnabled()).thenReturn(true);
+
+        transportPredictionStreamTaskAction = spy(
+            new TransportPredictionStreamTaskAction(
+                transportService,
+                actionFilters,
+                modelCacheHelper,
+                mlPredictTaskRunner,
+                clusterService,
+                client,
+                sdkClient,
+                mlModelManager,
+                modelAccessControlHelper,
+                mlFeatureEnabledSetting,
+                settings,
+                streamTransportService
+            )
+        );
+    }
+
+    @Test
+    public void testGetStreamTransportService() {
+        StreamTransportService result = TransportPredictionStreamTaskAction.getStreamTransportService();
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testMessageReceived() {
+        Task task = mock(Task.class);
+        transportPredictionStreamTaskAction.messageReceived(mlPredictionTaskRequest, transportChannel, task);
+
+        verify(transportPredictionStreamTaskAction).doExecute(eq(task), eq(mlPredictionTaskRequest), any(), eq(transportChannel));
+    }
+
+    @Test
+    public void testDoExecuteWithoutChannel() {
+        transportPredictionStreamTaskAction.doExecute(null, mlPredictionTaskRequest, actionListener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof UnsupportedOperationException);
+        assertEquals("Use doExecute with TransportChannel for streaming requests", captor.getValue().getMessage());
+    }
+
+    @Test
+    public void testDoExecuteWithAccessDenied() {
+        when(modelCacheHelper.getModelInfo("test_id")).thenReturn(model);
+        when(model.getAlgorithm()).thenReturn(FunctionName.REMOTE);
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(6);
+            listener.onResponse(false);
+            return null;
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
+
+        Task task = mock(Task.class);
+        transportPredictionStreamTaskAction.doExecute(task, mlPredictionTaskRequest, actionListener, transportChannel);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) captor.getValue()).status());
+    }
+
+    @Test
+    public void testDoExecuteLocalModelNotSupported() {
+        when(modelCacheHelper.getModelInfo(anyString())).thenReturn(model);
+        when(model.getAlgorithm()).thenReturn(FunctionName.TEXT_EMBEDDING);
+        when(model.getModelGroupId()).thenReturn("test_group_id");
+        when(mlFeatureEnabledSetting.isLocalModelEnabled()).thenReturn(false);
+
+        transportPredictionStreamTaskAction.doExecute(null, mlPredictionTaskRequest, actionListener, transportChannel);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof UnsupportedOperationException);
+        assertEquals("Streaming is not supported for local model.", captor.getValue().getMessage());
+    }
+
+    @Test
+    public void testDoExecuteOpenSearchStatusException() {
+        when(modelCacheHelper.getModelInfo(anyString())).thenReturn(model);
+        when(model.getAlgorithm()).thenReturn(FunctionName.KMEANS);
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(6);
+            listener.onFailure(new OpenSearchStatusException("Testing OpenSearchStatusException", RestStatus.BAD_REQUEST));
+            return null;
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
+
+        doAnswer(invocation -> {
+            ((ActionListener<MLTaskResponse>) invocation.getArguments()[3]).onResponse(null);
+            return null;
+        }).when(mlPredictTaskRunner).run(any(), any(), any(), any());
+
+        transportPredictionStreamTaskAction.doExecute(null, mlPredictionTaskRequest, actionListener, transportChannel);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Testing OpenSearchStatusException", argumentCaptor.getValue().getMessage());
+    }
+
+    public void testDoExecuteMLResourceNotFoundException() {
+        when(modelCacheHelper.getModelInfo(anyString())).thenReturn(model);
+        when(model.getAlgorithm()).thenReturn(FunctionName.KMEANS);
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(6);
+            listener.onFailure(new MLResourceNotFoundException("Testing MLResourceNotFoundException"));
+            return null;
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
+
+        doAnswer(invocation -> {
+            ((ActionListener<MLTaskResponse>) invocation.getArguments()[3]).onResponse(null);
+            return null;
+        }).when(mlPredictTaskRunner).run(any(), any(), any(), any());
+
+        transportPredictionStreamTaskAction.doExecute(null, mlPredictionTaskRequest, actionListener, transportChannel);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(MLResourceNotFoundException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Testing MLResourceNotFoundException", argumentCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void testDoExecuteMLLimitExceededException() {
+        when(modelCacheHelper.getModelInfo(anyString())).thenReturn(model);
+        when(model.getAlgorithm()).thenReturn(FunctionName.TEXT_EMBEDDING);
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(6);
+            listener.onFailure(new CircuitBreakingException("Memory Circuit Breaker is open, please check your resources!", CircuitBreaker.Durability.TRANSIENT));
+            return null;
+        }).when(modelAccessControlHelper).validateModelGroupAccess(any(), any(), any(), any(), any(), any(), any());
+
+        doAnswer(invocation -> {
+            ((ActionListener<MLTaskResponse>) invocation.getArguments()[3]).onResponse(null);
+            return null;
+        }).when(mlPredictTaskRunner).run(any(), any(), any(), any());
+
+        transportPredictionStreamTaskAction.doExecute(null, mlPredictionTaskRequest, actionListener, transportChannel);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(CircuitBreakingException.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals("Memory Circuit Breaker is open, please check your resources!", argumentCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void testValidateInputSchemaSuccess() {
+        RemoteInferenceInputDataSet remoteInferenceInputDataSet = RemoteInferenceInputDataSet
+            .builder()
+            .parameters(
+                Map
+                    .of(
+                        "messages",
+                        "[{\\\"role\\\":\\\"system\\\",\\\"content\\\":\\\"You are a helpful assistant.\\\"},"
+                            + "{\\\"role\\\":\\\"user\\\",\\\"content\\\":\\\"Hello!\\\"}]"
+                    )
+            )
+            .build();
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(remoteInferenceInputDataSet).build();
+        Map<String, String> modelInterface = Map
+            .of(
+                "input",
+                "{\"properties\":{\"parameters\":{\"properties\":{\"messages\":{"
+                    + "\"description\":\"This is a test description field\",\"type\":\"string\"}}}}}"
+            );
+        when(modelCacheHelper.getModelInterface(any())).thenReturn(modelInterface);
+        transportPredictionStreamTaskAction.validateInputSchema("testId", mlInput);
+    }
+
+    @Test
+    public void testValidateInputSchemaFailed() {
+        exceptionRule.expect(OpenSearchStatusException.class);
+        RemoteInferenceInputDataSet remoteInferenceInputDataSet = RemoteInferenceInputDataSet
+            .builder()
+            .parameters(
+                Map
+                    .of(
+                        "messages",
+                        "[{\\\"role\\\":\\\"system\\\",\\\"content\\\":\\\"You are a helpful assistant.\\\"},"
+                            + "{\\\"role\\\":\\\"user\\\",\\\"content\\\":\\\"Hello!\\\"}]"
+                    )
+            )
+            .build();
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(remoteInferenceInputDataSet).build();
+        Map<String, String> modelInterface = Map
+            .of(
+                "input",
+                "{\"properties\":{\"parameters\":{\"properties\":{\"messages\":{"
+                    + "\"description\":\"This is a test description field\",\"type\":\"integer\"}}}}}"
+            );
+        when(modelCacheHelper.getModelInterface(any())).thenReturn(modelInterface);
+        transportPredictionStreamTaskAction.validateInputSchema("testId", mlInput);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/plugin/MachineLearningPluginTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/plugin/MachineLearningPluginTests.java
@@ -233,7 +233,7 @@ public class MachineLearningPluginTests {
         Settings settings = Settings.EMPTY;
         List<ExecutorBuilder<?>> executorBuilders = plugin.getExecutorBuilders(settings);
         assertNotNull(executorBuilders);
-        assertEquals(9, executorBuilders.size());
+        assertEquals(10, executorBuilders.size());
 
         // Verify we have the expected number of thread pools
         assertTrue(executorBuilders.size() > 5);
@@ -321,6 +321,7 @@ public class MachineLearningPluginTests {
         assertEquals("opensearch_ml_execute", MachineLearningPlugin.EXECUTE_THREAD_POOL);
         assertEquals("opensearch_ml_train", MachineLearningPlugin.TRAIN_THREAD_POOL);
         assertEquals("opensearch_ml_predict", MachineLearningPlugin.PREDICT_THREAD_POOL);
+        assertEquals("opensearch_ml_predict_stream", MachineLearningPlugin.STREAM_PREDICT_THREAD_POOL);
         assertEquals("opensearch_ml_register", MachineLearningPlugin.REGISTER_THREAD_POOL);
         assertEquals("opensearch_ml_deploy", MachineLearningPlugin.DEPLOY_THREAD_POOL);
         assertEquals("/_plugins/_ml", MachineLearningPlugin.ML_BASE_URI);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLPredictionStreamActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLPredictionStreamActionTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
+import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.rest.FakeRestRequest;
+
+public class RestMLPredictionStreamActionTests {
+
+    private RestMLPredictionStreamAction restAction;
+    private MLModelManager modelManager;
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+    private ClusterService clusterService;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        modelManager = mock(MLModelManager.class);
+        mlFeatureEnabledSetting = mock(MLFeatureEnabledSetting.class);
+        clusterService = mock(ClusterService.class);
+        restAction = new RestMLPredictionStreamAction(modelManager, mlFeatureEnabledSetting, clusterService);
+    }
+
+    @Test
+    public void testGetName() {
+        assertEquals("ml_prediction_stream_action", restAction.getName());
+    }
+
+    @Test
+    public void testRoutes() {
+        List<RestMLPredictionStreamAction.Route> routes = restAction.routes();
+        assertEquals(1, routes.size());
+
+        assertEquals(RestRequest.Method.POST, routes.get(0).getMethod());
+        assertTrue(routes.get(0).getPath().contains("/models/"));
+        assertTrue(routes.get(0).getPath().contains("/_predict/stream"));
+    }
+
+    @Test
+    public void testConstructor() {
+        assertNotNull(restAction);
+        RestMLPredictionStreamAction newAction = new RestMLPredictionStreamAction(modelManager, mlFeatureEnabledSetting, clusterService);
+        assertNotNull(newAction);
+        assertEquals("ml_prediction_stream_action", newAction.getName());
+    }
+
+    @Test
+    public void testGetRequestSuccessWithRemoteModel() throws IOException {
+        when(mlFeatureEnabledSetting.isRemoteInferenceEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+
+        FakeRestRequest request = createFakeRestRequestWithValidContent("/_plugins/_ml/models/test-model/_predict/stream");
+        BytesReference content = request.content();
+
+        MLPredictionTaskRequest result = restAction.getRequest("test-model", "REMOTE", request, content);
+
+        assertNotNull(result);
+        assertEquals("test-model", result.getModelId());
+        assertNotNull(result.getMlInput());
+        verify(mlFeatureEnabledSetting).isRemoteInferenceEnabled();
+        verify(mlFeatureEnabledSetting).isMultiTenancyEnabled();
+    }
+
+    private FakeRestRequest createFakeRestRequestWithValidContent(String path) throws IOException {
+        Map<String, String> params = new HashMap<>();
+        params.put("model_id", "test-model");
+
+        BytesReference content = BytesReference
+            .bytes(
+                XContentFactory
+                    .jsonBuilder()
+                    .startObject()
+                    .field("parameters")
+                    .startObject()
+                    .field("prompt", "Hello world")
+                    .endObject()
+                    .endObject()
+            );
+
+        return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath(path)
+            .withParams(params)
+            .withContent(content, XContentType.JSON)
+            .build();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/settings/MLFeatureEnabledSettingTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/settings/MLFeatureEnabledSettingTests.java
@@ -28,6 +28,7 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_OFF
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_RAG_PIPELINE_FEATURE_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_STREAM_ENABLED;
 
 import java.util.Set;
 
@@ -80,7 +81,8 @@ public class MLFeatureEnabledSettingTests {
                             ML_COMMONS_AGENTIC_SEARCH_ENABLED,
                             ML_COMMONS_AGENTIC_MEMORY_ENABLED,
                             ML_COMMONS_MCP_CONNECTOR_ENABLED,
-                            ML_COMMONS_INDEX_INSIGHT_FEATURE_ENABLED
+                            ML_COMMONS_INDEX_INSIGHT_FEATURE_ENABLED,
+                            ML_COMMONS_STREAM_ENABLED
                         )
                 )
             );

--- a/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
@@ -587,6 +587,43 @@ public class MLPredictTaskRunnerTests extends OpenSearchTestCase {
         taskRunner.validateOutputSchema("testId", modelTensorOutput);
     }
 
+    public void testIsStreamingRequest() {
+        MLInput mlInput = MLInput
+            .builder()
+            .algorithm(FunctionName.REMOTE)
+            .inputDataset(new TextDocsInputDataSet(List.of("test"), null))
+            .build();
+        MLPredictionTaskRequest request = MLPredictionTaskRequest.builder().modelId("test").mlInput(mlInput).build();
+
+        try {
+            java.lang.reflect.Method method = MLPredictTaskRunner.class
+                .getDeclaredMethod("isStreamingRequest", MLPredictionTaskRequest.class);
+            method.setAccessible(true);
+            boolean result = (boolean) method.invoke(taskRunner, request);
+            assertFalse(result);
+        } catch (Exception e) {
+            fail("Failed to test isStreamingRequest: " + e.getMessage());
+        }
+    }
+
+    public void testIsStreamingRequestWithStreamParameter() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("stream", "true");
+        RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet.builder().parameters(parameters).build();
+        MLInput mlInput = MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build();
+        MLPredictionTaskRequest request = MLPredictionTaskRequest.builder().modelId("test").mlInput(mlInput).build();
+
+        try {
+            java.lang.reflect.Method method = MLPredictTaskRunner.class
+                .getDeclaredMethod("isStreamingRequest", MLPredictionTaskRequest.class);
+            method.setAccessible(true);
+            boolean result = (boolean) method.invoke(taskRunner, request);
+            assertTrue(result);
+        } catch (Exception e) {
+            fail("Failed to test isStreamingRequest: " + e.getMessage());
+        }
+    }
+
     public void testValidateBatchPredictionSuccess_InitPollingJob() throws IOException {
         setupMocks(true, false, false, false);
         RemoteInferenceInputDataSet remoteInferenceInputDataSet = RemoteInferenceInputDataSet

--- a/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLPredictTaskRunnerTests.java
@@ -348,7 +348,7 @@ public class MLPredictTaskRunnerTests extends OpenSearchTestCase {
             actionListener
                 .onResponse(MLTaskResponse.builder().output(ModelTensorOutput.builder().mlModelOutputs(List.of()).build()).build());
             return null;
-        }).when(predictor).asyncPredict(any(), any());
+        }).when(predictor).asyncPredict(any(), any(), any());
         when(mlModelManager.getPredictor(anyString())).thenReturn(predictor);
         when(mlModelManager.getWorkerNodes(anyString(), eq(FunctionName.REMOTE), eq(true))).thenReturn(new String[] { "node1" });
         taskRunner.dispatchTask(FunctionName.REMOTE, textDocsInputRequest, transportService, listener);
@@ -469,7 +469,7 @@ public class MLPredictTaskRunnerTests extends OpenSearchTestCase {
             ActionListener<MLTaskResponse> actionListener = invocation.getArgument(1);
             actionListener.onResponse(MLTaskResponse.builder().output(modelTensorOutput).build());
             return null;
-        }).when(predictor).asyncPredict(any(), any());
+        }).when(predictor).asyncPredict(any(), any(), any());
 
         IndexResponse indexResponse = mock(IndexResponse.class);
         when(indexResponse.getId()).thenReturn("mockTaskId");
@@ -549,7 +549,7 @@ public class MLPredictTaskRunnerTests extends OpenSearchTestCase {
             actionListener
                 .onResponse(MLTaskResponse.builder().output(ModelTensorOutput.builder().mlModelOutputs(List.of()).build()).build());
             return null;
-        }).when(predictor).asyncPredict(any(), any());
+        }).when(predictor).asyncPredict(any(), any(), any());
 
         IndexResponse indexResponse = mock(IndexResponse.class);
         when(indexResponse.getId()).thenReturn("mockTaskId");
@@ -625,7 +625,7 @@ public class MLPredictTaskRunnerTests extends OpenSearchTestCase {
             ActionListener<MLTaskResponse> actionListener = invocation.getArgument(1);
             actionListener.onResponse(MLTaskResponse.builder().output(modelTensorOutput).build());
             return null;
-        }).when(predictor).asyncPredict(any(), any());
+        }).when(predictor).asyncPredict(any(), any(), any());
 
         IndexResponse indexResponse = mock(IndexResponse.class);
         when(indexResponse.getId()).thenReturn("mockTaskId");

--- a/plugin/src/test/java/org/opensearch/ml/task/TaskRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/TaskRunnerTests.java
@@ -84,6 +84,11 @@ public class TaskRunnerTests extends OpenSearchTestCase {
             }
 
             @Override
+            public String getTransportStreamActionName() {
+                return null;
+            }
+
+            @Override
             public TransportResponseHandler getResponseHandler(ActionListener listener) {
                 return null;
             }

--- a/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
@@ -327,6 +327,28 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
         Assert.assertFalse(isAdmin);
     }
 
+    @Test
+    public void testGetActionTypeFromRestRequest_Predict() {
+        FakeRestRequest request = createRestRequest(
+            Collections.emptyMap(),
+            "/_plugins/_ml/models/test-model/_predict",
+            RestRequest.Method.POST
+        );
+        String actionType = RestActionUtils.getActionTypeFromRestRequest(request);
+        assertEquals("predict", actionType);
+    }
+
+    @Test
+    public void testGetActionTypeFromRestRequest_PredictStream() {
+        FakeRestRequest request = createRestRequest(
+            Collections.emptyMap(),
+            "/_plugins/_ml/models/test-model/_predict/stream",
+            RestRequest.Method.POST
+        );
+        String actionType = RestActionUtils.getActionTypeFromRestRequest(request);
+        assertEquals("predict", actionType);
+    }
+
     public void testDoubleWrapper_handleIndexNotFound() {
         final IndexNotFoundException indexNotFoundException = new IndexNotFoundException("Index not found", ML_CONNECTOR_INDEX);
         final DummyActionListener actionListener = new DummyActionListener();


### PR DESCRIPTION
### Description
Add a new predict stream API as an experimental feature to support streaming predictions. The implementation currently utilized `transport-reactor-netty4` for REST streaming. This is a temporary solution as we need to do more research to determine a long-term approach because `transport-reactor-netty4` from the OpenSearch core is still experimental.

This predict stream API currently supports 2 models:
- [OpenAI Chat Completion model](https://platform.openai.com/docs/api-reference/completions)
- [Bedrock Converse Stream model](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html)

> Note: This PR only covers predict streaming, will open another PR to cover agent streaming

**API Endpoint:**
```
POST /_plugins/_ml/models/{model_id}/_predict/stream
```

**Sample workflow:**
```
// Enable feature flag
PUT /_cluster/settings
{
    "persistent": {
        "plugins.ml_commons.stream_enabled": true
    }
}

// Register OpenAI chat completion model
POST /_plugins/_ml/models/_register
{
    "name": "openai gpt 3.5 turbo",
    "function_name": "remote",
    "description": "openai model",
    "connector": {
        "name": "OpenAI Chat Connector",
        "description": "The connector to public OpenAI model service for GPT 3.5",
        "version": 1,
        "protocol": "http",
        "parameters": {
            "endpoint": "api.openai.com",
            "model": "gpt-3.5-turbo"
        },
        "credential": {
            "openAI_key": "<your_api_key>"
        },
        "actions": [
            {
                "action_type": "predict",
                "method": "POST",
                "url": "https://${parameters.endpoint}/v1/chat/completions",
                "headers": {
                    "Authorization": "Bearer ${credential.openAI_key}"
                },
                "request_body": "{ \"model\": \"${parameters.model}\", \"messages\": ${parameters.messages} }",
                "response_filter": "$.choices[0].delta.content"
            }
        ]
    }
}

// Run predict stream API
POST /_plugins/_ml/models/mm92cpkBiefJiMfDtq8_/_predict/stream
{
  "parameters": {
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Can you summarize Prince Hamlet of William Shakespeare in around 100 words?"
      }
    ],
    "_llm_interface": "openai/v1/chat/completions"
  }
}

// Sample response
data: {"inference_results":[{"output":[{"name":"response","dataAsMap":{"content":"Sure","is_last":false}}]}]}

data: {"inference_results":[{"output":[{"name":"response","dataAsMap":{"content":"!","is_last":false}}]}]}

data: {"inference_results":[{"output":[{"name":"response","dataAsMap":{"content":" \"","is_last":false}}]}]}

....
data: {"inference_results":[{"output":[{"name":"response","dataAsMap":{"content":" psyche","is_last":false}}]}]}

data: {"inference_results":[{"output":[{"name":"response","dataAsMap":{"content":".","is_last":false}}]}]}

data: {"inference_results":[{"output":[{"name":"response","dataAsMap":{"content":"","is_last":true}}]}]}
```

**Error handling:**
1. Invalid model ID
```
{
    "error": {
        "root_cause": [
            {
                "type": "status_exception",
                "reason": "Failed to find model"
            }
        ],
        "type": "status_exception",
        "reason": "Failed to find model"
    },
    "status": 404
}
```
2. Error from remote service (e.g., invalid payload, invalid API key, etc)
Error message will be sent as one chunk and the connection will be closed
```
data: {"error": "Error from remote service: {\n  \"error\": {\n    \"message\": \"Missing required parameter: 'messages[1].role'. You provided 'roles', did you mean to provide 'role'?\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"messages[1].role\",\n    \"code\": \"missing_required_parameter\"\n  }\n}"}
```
3. Error in the middle of streaming
Error message will be sent as one chunk and the connection will be closed
```
data: {"inference_results":[{"output":[{"name":"response","dataAsMap":{"content":"tering his father's ghost, who","is_last":false}}]}]}

data: {"inference_results":[{"output":[{"name":"response","dataAsMap":{"content":" claims Claudius murdered him, Hamlet struggles","is_last":false}}]}]}

data: {"error": "Error from remote service: Too many requests, please wait before trying again. You have sent too many requests.  Wait before trying again. (Service: bedrock, Status Code: 429, Request ID: xxx)"}
```

### Related Issues
Resolves https://github.com/opensearch-project/ml-commons/issues/3630

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).