### PR TITLE
add backendrole in container for access control and update container

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -19,6 +19,7 @@ public class MemoryContainerConstants {
     public static final String CREATED_TIME_FIELD = "created_time";
     public static final String LAST_UPDATED_TIME_FIELD = "last_updated_time";
     public static final String MEMORY_STORAGE_CONFIG_FIELD = "configuration";
+    public static final String BACKEND_ROLES_FIELD = "backend_roles"; // back_end roles as specified by the owner/admin
 
     // Field names for MemoryConfiguration
     public static final String DISABLE_HISTORY_FIELD = "disable_history";
@@ -91,6 +92,7 @@ public class MemoryContainerConstants {
     public static final String WORKING_MEMORIES_PATH = MEMORIES_PATH + "/working";
     public static final String SEARCH_MEMORIES_PATH = MEMORIES_PATH + "/_search";
     public static final String DELETE_MEMORY_PATH = MEMORIES_PATH + "/{" + PARAMETER_MEMORY_ID + "}";
+    public static final String UPDATE_MEMORY_CONTAINER_PATH = BASE_MEMORY_CONTAINERS_PATH + "/{" + PARAMETER_MEMORY_CONTAINER_ID + "}";
     public static final String UPDATE_MEMORY_PATH = MEMORIES_PATH + "/{" + PARAMETER_MEMORY_ID + "}";
     public static final String GET_MEMORY_PATH = MEMORIES_PATH + "/{" + PARAMETER_MEMORY_ID + "}";
     public static final String GET_WORKING_MEMORY_PATH = WORKING_MEMORIES_PATH + "/{" + PARAMETER_WORKING_MEMORY_ID + "}";

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLCreateMemoryContainerInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLCreateMemoryContainerInput.java
@@ -9,10 +9,13 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
@@ -22,16 +25,19 @@ import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class MLCreateMemoryContainerInput implements ToXContentObject, Writeable {
 
     public static final String NAME_FIELD = "name";
     public static final String DESCRIPTION_FIELD = "description";
     public static final String MEMORY_CONFIG_FIELD = "configuration";
+    public static final String BACKEND_ROLES_FIELD = "backend_roles";
 
     private String name;
     private String description;
     private MemoryConfiguration configuration;
     private String tenantId;
+    private List<String> backendRoles;
 
     @Builder(toBuilder = true)
     public MLCreateMemoryContainerInput(String name, String description, MemoryConfiguration configuration, String tenantId) {
@@ -44,6 +50,24 @@ public class MLCreateMemoryContainerInput implements ToXContentObject, Writeable
         this.tenantId = tenantId;
     }
 
+    @Builder(toBuilder = true)
+    public MLCreateMemoryContainerInput(
+        String name,
+        String description,
+        MemoryConfiguration configuration,
+        String tenantId,
+        List<String> backendRoles
+    ) {
+        if (name == null) {
+            throw new IllegalArgumentException("name is null");
+        }
+        this.name = name;
+        this.description = description;
+        this.configuration = configuration;
+        this.tenantId = tenantId;
+        this.backendRoles = backendRoles;
+    }
+
     public MLCreateMemoryContainerInput(StreamInput in) throws IOException {
         this.name = in.readString();
         this.description = in.readOptionalString();
@@ -53,6 +77,9 @@ public class MLCreateMemoryContainerInput implements ToXContentObject, Writeable
             this.configuration = null;
         }
         this.tenantId = in.readOptionalString();
+        if (in.readBoolean()) {
+            backendRoles = in.readStringList();
+        }
     }
 
     @Override
@@ -66,6 +93,12 @@ public class MLCreateMemoryContainerInput implements ToXContentObject, Writeable
             out.writeBoolean(false);
         }
         out.writeOptionalString(tenantId);
+        if (!CollectionUtils.isEmpty(backendRoles)) {
+            out.writeBoolean(true);
+            out.writeStringCollection(backendRoles);
+        } else {
+            out.writeBoolean(false);
+        }
     }
 
     @Override
@@ -81,6 +114,9 @@ public class MLCreateMemoryContainerInput implements ToXContentObject, Writeable
         if (tenantId != null) {
             builder.field(TENANT_ID_FIELD, tenantId);
         }
+        if (!CollectionUtils.isEmpty(backendRoles)) {
+            builder.field(BACKEND_ROLES_FIELD, backendRoles);
+        }
         builder.endObject();
         return builder;
     }
@@ -90,6 +126,7 @@ public class MLCreateMemoryContainerInput implements ToXContentObject, Writeable
         String description = null;
         MemoryConfiguration configuration = null;
         String tenantId = null;
+        List<String> backendRoles = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -109,6 +146,13 @@ public class MLCreateMemoryContainerInput implements ToXContentObject, Writeable
                 case TENANT_ID_FIELD:
                     tenantId = parser.text();
                     break;
+                case BACKEND_ROLES_FIELD:
+                    backendRoles = new ArrayList<>();
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        backendRoles.add(parser.text());
+                    }
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -121,6 +165,7 @@ public class MLCreateMemoryContainerInput implements ToXContentObject, Writeable
             .description(description)
             .configuration(configuration)
             .tenantId(tenantId)
+            .backendRoles(backendRoles)
             .build();
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLUpdateMemoryContainerAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLUpdateMemoryContainerAction.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer.memory;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.update.UpdateResponse;
+
+public class MLUpdateMemoryContainerAction extends ActionType<UpdateResponse> {
+    public static final MLUpdateMemoryContainerAction INSTANCE = new MLUpdateMemoryContainerAction();
+    public static final String NAME = "cluster:admin/opensearch/ml/memory_containers/update";
+
+    private MLUpdateMemoryContainerAction() {
+        super(NAME, UpdateResponse::new);
+    }
+
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLUpdateMemoryContainerInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLUpdateMemoryContainerInput.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer.memory;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BACKEND_ROLES_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DESCRIPTION_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAME_FIELD;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MLUpdateMemoryContainerInput implements ToXContentObject, Writeable {
+    private String name;
+    private String description;
+    private List<String> backendRoles;
+
+    @Builder
+    public MLUpdateMemoryContainerInput(String name, String description, List<String> backendRoles) {
+        this.name = name;
+        this.description = description;
+        this.backendRoles = backendRoles;
+    }
+
+    public MLUpdateMemoryContainerInput(StreamInput in) throws IOException {
+        this.name = in.readOptionalString();
+        this.description = in.readOptionalString();
+        if (in.readBoolean()) {
+            backendRoles = in.readStringList();
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(name);
+        out.writeOptionalString(description);
+
+        if (!CollectionUtils.isEmpty(backendRoles)) {
+            out.writeBoolean(true);
+            out.writeStringCollection(backendRoles);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        if (name != null) {
+            builder.field(NAME_FIELD, name);
+        }
+        if (description != null) {
+            builder.field(DESCRIPTION_FIELD, description);
+        }
+        if (!CollectionUtils.isEmpty(backendRoles)) {
+            builder.field(BACKEND_ROLES_FIELD, backendRoles);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static MLUpdateMemoryContainerInput parse(XContentParser parser) throws IOException {
+        String name = null;
+        String description = null;
+        List<String> backendRoles = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case NAME_FIELD:
+                    name = parser.text();
+                    break;
+                case DESCRIPTION_FIELD:
+                    description = parser.text();
+                    break;
+                case BACKEND_ROLES_FIELD:
+                    backendRoles = new ArrayList<>();
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        backendRoles.add(parser.text());
+                    }
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+
+        return MLUpdateMemoryContainerInput.builder().name(name).description(description).backendRoles(backendRoles).build();
+    }
+
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLUpdateMemoryContainerRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLUpdateMemoryContainerRequest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer.memory;
+
+import static org.opensearch.action.ValidateActions.addValidationError;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class MLUpdateMemoryContainerRequest extends ActionRequest {
+    @Setter
+    private MLUpdateMemoryContainerInput mlUpdateMemoryContainerInput;
+    private String memoryContainerId;
+
+    @Builder
+    public MLUpdateMemoryContainerRequest(String memoryContainerId, MLUpdateMemoryContainerInput mlUpdateMemoryContainerInput) {
+        this.memoryContainerId = memoryContainerId;
+        this.mlUpdateMemoryContainerInput = mlUpdateMemoryContainerInput;
+    }
+
+    public MLUpdateMemoryContainerRequest(StreamInput in) throws IOException {
+        super(in);
+        this.memoryContainerId = in.readString();
+        this.mlUpdateMemoryContainerInput = new MLUpdateMemoryContainerInput(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(memoryContainerId);
+        mlUpdateMemoryContainerInput.writeTo(out);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException exception = null;
+        if (mlUpdateMemoryContainerInput == null) {
+            exception = addValidationError("Update memory container input can't be null", exception);
+        }
+        if (memoryContainerId == null) {
+            exception = addValidationError("Memory container id can't be null", exception);
+        }
+        return exception;
+    }
+
+    public static MLUpdateMemoryContainerRequest fromActionRequest(ActionRequest actionRequest) {
+        if (actionRequest instanceof MLUpdateMemoryContainerRequest) {
+            return (MLUpdateMemoryContainerRequest) actionRequest;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionRequest.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLUpdateMemoryContainerRequest(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionRequest into MLUpdateMemoryContainerRequest", e);
+        }
+    }
+
+}

--- a/common/src/main/resources/index-mappings/ml_memory_container.json
+++ b/common/src/main/resources/index-mappings/ml_memory_container.json
@@ -76,6 +76,15 @@
       }
     },
     "owner": USER_MAPPING_PLACEHOLDER,
+    "backend_roles": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
     "tenant_id": {
       "type": "keyword"
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -146,6 +146,7 @@ public class TransportCreateMemoryContainerAction extends
             .createdTime(now)
             .lastUpdatedTime(now)
             .configuration(input.getConfiguration())
+            .backendRoles(input.getBackendRoles())
             .build();
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContrainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContrainerAction.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.memorycontainer;
+
+import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BACKEND_ROLES_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DESCRIPTION_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAME_FIELD;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryAction;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerRequest;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryRequest;
+import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.helper.MemoryContainerHelper;
+import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.ml.utils.RestActionUtils;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class TransportUpdateMemoryContrainerAction extends HandledTransportAction<ActionRequest, UpdateResponse> {
+
+    final Client client;
+    final SdkClient sdkClient;
+    final NamedXContentRegistry xContentRegistry;
+    final ConnectorAccessControlHelper connectorAccessControlHelper;
+    final MLFeatureEnabledSetting mlFeatureEnabledSetting;
+    final MLModelManager mlModelManager;
+    final MemoryContainerHelper memoryContainerHelper;
+
+    @Inject
+    public TransportUpdateMemoryContrainerAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client,
+        SdkClient sdkClient,
+        NamedXContentRegistry xContentRegistry,
+        ConnectorAccessControlHelper connectorAccessControlHelper,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting,
+        MLModelManager mlModelManager,
+        MemoryContainerHelper memoryContainerHelper
+    ) {
+        super(MLUpdateMemoryAction.NAME, transportService, actionFilters, MLUpdateMemoryRequest::new);
+        this.client = client;
+        this.sdkClient = sdkClient;
+        this.xContentRegistry = xContentRegistry;
+        this.connectorAccessControlHelper = connectorAccessControlHelper;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+        this.mlModelManager = mlModelManager;
+        this.memoryContainerHelper = memoryContainerHelper;
+    }
+
+    @Override
+    protected void doExecute(Task task, ActionRequest request, ActionListener<UpdateResponse> actionListener) {
+        if (!mlFeatureEnabledSetting.isAgenticMemoryEnabled()) {
+            actionListener
+                .onFailure(
+                    new OpenSearchStatusException(MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE, RestStatus.FORBIDDEN)
+                );
+            return;
+        }
+
+        MLUpdateMemoryContainerRequest mlUpdateMemoryContainerRequest = MLUpdateMemoryContainerRequest.fromActionRequest(request);
+        String memoryContainerId = mlUpdateMemoryContainerRequest.getMemoryContainerId();
+        String newName = mlUpdateMemoryContainerRequest.getMlUpdateMemoryContainerInput().getName();
+        String newDescription = mlUpdateMemoryContainerRequest.getMlUpdateMemoryContainerInput().getDescription();
+        List<String> allowedBackendRoles = mlUpdateMemoryContainerRequest.getMlUpdateMemoryContainerInput().getBackendRoles();
+
+        // Get memory container to validate access and get memory index name
+        memoryContainerHelper.getMemoryContainer(memoryContainerId, ActionListener.wrap(container -> {
+            // Validate access permissions
+            User user = RestActionUtils.getUserContext(client);
+            if (!memoryContainerHelper.checkMemoryContainerAccess(user, container)) {
+                actionListener
+                    .onFailure(
+                        new OpenSearchStatusException(
+                            "User doesn't have permissions to update memories in this container",
+                            RestStatus.FORBIDDEN
+                        )
+                    );
+                return;
+            }
+
+            // Prepare the update
+            Map<String, Object> updateFields = new HashMap<>();
+            if (newName != null) {
+                updateFields.put(NAME_FIELD, newName);
+            }
+            if (newDescription != null) {
+                updateFields.put(DESCRIPTION_FIELD, newDescription);
+            }
+            if (allowedBackendRoles != null) {
+                updateFields.put(BACKEND_ROLES_FIELD, allowedBackendRoles);
+            }
+            updateFields.put(LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli());
+            performUpdate(ML_MEMORY_CONTAINER_INDEX, memoryContainerId, updateFields, actionListener);
+        }, actionListener::onFailure));
+    }
+
+    private void performUpdate(
+        String indexName,
+        String memoryContainerId,
+        Map<String, Object> updateFields,
+        ActionListener<UpdateResponse> listener
+    ) {
+        UpdateRequest updateRequest = new UpdateRequest(indexName, memoryContainerId).doc(updateFields);
+
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            client.update(updateRequest, ActionListener.runBefore(listener, context::restore));
+        } catch (Exception e) {
+            log.error("Failed to update memory container {}", memoryContainerId, e);
+            listener.onFailure(e);
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
@@ -9,6 +9,8 @@ import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 
+import java.util.List;
+
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.common.inject.Inject;
@@ -137,6 +139,12 @@ public class MemoryContainerHelper {
         User owner = mlMemoryContainer.getOwner();
         if (owner != null && owner.getName() != null && owner.getName().equals(user.getName())) {
             return true;
+        }
+
+        List<String> allowedBackendRoles = mlMemoryContainer.getBackendRoles();
+        // Check if user has any of the allowed backend roles
+        if (allowedBackendRoles != null && !allowedBackendRoles.isEmpty() && user.getBackendRoles() != null) {
+            return allowedBackendRoles.stream().anyMatch(role -> user.getBackendRoles().contains(role));
         }
 
         // Check if user has matching backend roles

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLUpdateMemoryContainerAction.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.UPDATE_MEMORY_CONTAINER_PATH;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
+import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerAction;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerInput;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+public class RestMLUpdateMemoryContainerAction extends BaseRestHandler {
+    private static final String ML_UPDATE_MEMORY_CONTAINER_ACTION = "ml_update_memory_container_action";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    /**
+     * Constructor
+     */
+    public RestMLUpdateMemoryContainerAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
+
+    @Override
+    public String getName() {
+        return ML_UPDATE_MEMORY_CONTAINER_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList.of(new Route(RestRequest.Method.PUT, UPDATE_MEMORY_CONTAINER_PATH));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (!mlFeatureEnabledSetting.isAgenticMemoryEnabled()) {
+            throw new OpenSearchStatusException(ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE, RestStatus.FORBIDDEN);
+        }
+
+        MLUpdateMemoryContainerRequest mlUpdateMemoryContainerRequest = getRequest(request);
+        return channel -> client
+            .execute(MLUpdateMemoryContainerAction.INSTANCE, mlUpdateMemoryContainerRequest, new RestToXContentListener<>(channel));
+    }
+
+    /**
+     * Creates a MLUpdateMemoryContainerRequest from a RestRequest
+     */
+    @VisibleForTesting
+    MLUpdateMemoryContainerRequest getRequest(RestRequest request) throws IOException {
+        if (!request.hasContent()) {
+            throw new IllegalArgumentException("Update memory container request has empty body");
+        }
+
+        String memoryContainerId = getParameterId(request, PARAMETER_MEMORY_CONTAINER_ID);
+
+        XContentParser parser = request.contentParser();
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        MLUpdateMemoryContainerInput mlUpdateMemoryContainerInput = MLUpdateMemoryContainerInput.parse(parser);
+
+        return MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .mlUpdateMemoryContainerInput(mlUpdateMemoryContainerInput)
+            .build();
+    }
+
+}


### PR DESCRIPTION
### Description
Add back_end Roles in the memory container for access control. Add Update Container API to update back_end_roles to allow other users to access memory.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
