### PR TITLE
Fix error_prone_annotations jar hell

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -407,6 +407,7 @@ check.dependsOn jacocoTestCoverageVerification
 configurations.all {
     exclude group: "org.jetbrains", module: "annotations"
     exclude group: "com.google.guava", module: "failureaccess"
+    exclude group: "com.google.errorprone", module: "error_prone_annotations"
     resolutionStrategy.force "org.apache.commons:commons-lang3:${versions.commonslang}"
     resolutionStrategy.force 'commons-logging:commons-logging:1.2'
     resolutionStrategy.force 'org.objenesis:objenesis:3.2'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${versions.commonslang}"
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.19.0"
+    implementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
     testImplementation group: 'commons-io', name: 'commons-io', version: '2.15.1'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation ('com.jayway.jsonpath:json-path:2.9.0') {


### PR DESCRIPTION
### Description

1. Align log4j version with OpenSearch core
2. exclude error_prone_annotations 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
