### PR TITLE
allow custom prompt in the agentic memory strategy

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -54,6 +54,7 @@ public class MemoryContainerConstants {
     public static final String SESSION_ID_FIELD = "session_id";
     public static final String WORKING_MEMORY_ID_FIELD = "working_memory_id";
     public static final String NAMESPACE_FIELD = "namespace";
+    public static final String STRATEGY_CONFIG_FIELD = "configuration";
     public static final String BINARY_DATA_FIELD = "binary_data";
     public static final String STRUCTURED_DATA_FIELD = "structured_data";
     public static final String NAMESPACE_SIZE_FIELD = "namespace_size";

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceAdditionalTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceAdditionalTests.java
@@ -24,6 +24,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryDecision;
+import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
@@ -45,11 +46,14 @@ public class MemoryProcessingServiceAdditionalTests {
     @Mock
     private ActionListener<List<MemoryDecision>> decisionsListener;
 
+    private MemoryStrategy memoryStrategy;
+
     private MemoryProcessingService memoryProcessingService;
 
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
+        memoryStrategy = new MemoryStrategy("id", true, "semantic", Arrays.asList("user_id"), new HashMap<>());
         memoryProcessingService = new MemoryProcessingService(client, xContentRegistry);
     }
 
@@ -68,7 +72,7 @@ public class MemoryProcessingServiceAdditionalTests {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(client).execute(any(), any(), any());
         verify(factsListener).onResponse(any(List.class));

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
@@ -24,6 +24,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryDecision;
+import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
@@ -45,12 +46,14 @@ public class MemoryProcessingServiceTests {
 
     @Mock
     private ActionListener<List<MemoryDecision>> decisionsListener;
+    private MemoryStrategy memoryStrategy;
 
     private MemoryProcessingService memoryProcessingService;
 
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
+        memoryStrategy = new MemoryStrategy("id", true, "semantic", Arrays.asList("user_id"), new HashMap<>());
         memoryProcessingService = new MemoryProcessingService(client, xContentRegistry);
     }
 
@@ -58,7 +61,7 @@ public class MemoryProcessingServiceTests {
     public void testExtractFactsFromConversation_NoStorageConfig() {
         List<MessageInput> messages = Arrays.asList(MessageInput.builder().contentText("Hello").role("user").build());
 
-        memoryProcessingService.extractFactsFromConversation(messages, null, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, null, factsListener);
 
         verify(factsListener).onResponse(any(List.class));
     }
@@ -70,7 +73,7 @@ public class MemoryProcessingServiceTests {
         MemoryConfiguration storageConfig = mock(MemoryConfiguration.class);
         when(storageConfig.getLlmId()).thenReturn(null);
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(factsListener).onResponse(any(List.class));
     }
@@ -94,7 +97,7 @@ public class MemoryProcessingServiceTests {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(client).execute(any(), any(), any());
     }
@@ -155,7 +158,7 @@ public class MemoryProcessingServiceTests {
         MemoryConfiguration storageConfig = mock(MemoryConfiguration.class);
         when(storageConfig.getLlmId()).thenReturn("llm-model-123");
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(client).execute(any(), any(), any());
     }
@@ -172,7 +175,7 @@ public class MemoryProcessingServiceTests {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(factsListener).onFailure(any(Exception.class));
     }
@@ -201,7 +204,7 @@ public class MemoryProcessingServiceTests {
         MemoryConfiguration storageConfig = mock(MemoryConfiguration.class);
         when(storageConfig.getLlmId()).thenReturn("llm-model-123");
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(client).execute(any(), any(), any());
     }
@@ -258,7 +261,7 @@ public class MemoryProcessingServiceTests {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(factsListener).onFailure(any(IllegalArgumentException.class));
     }
@@ -279,7 +282,7 @@ public class MemoryProcessingServiceTests {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(factsListener).onResponse(any(List.class));
     }
@@ -301,7 +304,7 @@ public class MemoryProcessingServiceTests {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(factsListener).onResponse(any(List.class));
     }
@@ -325,7 +328,7 @@ public class MemoryProcessingServiceTests {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(factsListener).onResponse(any(List.class));
     }
@@ -355,7 +358,7 @@ public class MemoryProcessingServiceTests {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(factsListener).onResponse(any(List.class));
     }
@@ -385,7 +388,7 @@ public class MemoryProcessingServiceTests {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(factsListener).onResponse(any(List.class));
     }
@@ -417,7 +420,7 @@ public class MemoryProcessingServiceTests {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(factsListener).onResponse(any(List.class));
     }
@@ -620,7 +623,7 @@ public class MemoryProcessingServiceTests {
             return null;
         }).when(client).execute(any(), any(), any());
 
-        memoryProcessingService.extractFactsFromConversation(messages, storageConfig, factsListener);
+        memoryProcessingService.extractFactsFromConversation(messages, memoryStrategy, storageConfig, factsListener);
 
         verify(factsListener).onResponse(any(List.class));
     }


### PR DESCRIPTION
### Description
Allow custom prompt in the memory configuration strategy.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
