### PR TITLE
Upgrade commons-text to fix CVE-2025-48924

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     compileOnly group: 'org.opensearch', name:'opensearch-security-spi', version:"${opensearch_build}"
 
-    compileOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
+    compileOnly group: 'org.apache.commons', name: 'commons-text', version: '1.14.0'
     compileOnly group: 'com.google.code.gson', name: 'gson', version: "${versions.gson}"
     compileOnly group: 'org.json', name: 'json', version: '20231013'
     testImplementation group: 'org.json', name: 'json', version: '20231013'

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation ("org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}")
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.14.0'
     implementation group: 'org.reflections', name: 'reflections', version: '0.9.12'
     implementation group: 'org.tribuo', name: 'tribuo-clustering-kmeans', version: '4.2.1'
     implementation group: 'org.tribuo', name: 'tribuo-regression-sgd', version: '4.2.1'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -90,10 +90,10 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: "${versions.gson}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${versions.commonslang}"
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.14.0'
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
     testImplementation group: 'commons-io', name: 'commons-io', version: '2.15.1'
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.14.0'
     implementation ('com.jayway.jsonpath:json-path:2.9.0') {
         exclude group: 'net.minidev', module: 'json-smart'
     }
@@ -473,7 +473,7 @@ configurations.all {
     resolutionStrategy.force 'commons-logging:commons-logging:1.2'
     resolutionStrategy.force 'org.objenesis:objenesis:3.2'
     resolutionStrategy.force 'net.java.dev.jna:jna:5.11.0'
-    resolutionStrategy.force 'org.apache.commons:commons-text:1.10.0'
+    resolutionStrategy.force 'org.apache.commons:commons-text:1.14.0'
     resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.25.5'
     resolutionStrategy.force 'org.apache.httpcomponents:httpcore:4.4.15'
     resolutionStrategy.force 'org.apache.httpcomponents:httpclient:4.5.14'

--- a/search-processors/build.gradle
+++ b/search-processors/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
     implementation group: 'org.json', name: 'json', version: '20231013'
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.14.0'
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 }
 


### PR DESCRIPTION
### Description
`commons-text` versions 1.10.0 - 1.13.0 have a transitive dependency on `commons-lang3` < 3.18.0 ([ref](https://mvnrepository.com/artifact/org.apache.commons/commons-text)), which causes this [CVE-2025-48924](https://github.com/advisories/GHSA-j288-q9x7-2f5v). Upgrading `commons-text` to 1.14.0 should fix this issue.

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-build/issues/5693

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
