### PR TITLE
Adds check to enable resource sharing for protected types supplied in cluster setting

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/DeleteModelGroupTransportAction.java
@@ -6,7 +6,9 @@
 package org.opensearch.ml.action.model_group;
 
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_RESOURCE_TYPE;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+import static org.opensearch.ml.helper.ModelAccessControlHelper.shouldUseResourceAuthz;
 import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_MODEL_GROUP_ID;
 
 import org.opensearch.ExceptionsHelper;
@@ -27,7 +29,6 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
-import org.opensearch.ml.common.ResourceSharingClientAccessor;
 import org.opensearch.ml.common.exception.MLValidationException;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.model_group.MLModelGroupDeleteAction;
@@ -96,7 +97,7 @@ public class DeleteModelGroupTransportAction extends HandledTransportAction<Acti
             ActionListener<DeleteResponse> wrappedListener = ActionListener.runBefore(actionListener, context::restore);
 
             // if resource sharing feature is enabled, access will be automatically checked by security plugin, so no need to check again
-            if (ResourceSharingClientAccessor.getInstance().getResourceSharingClient() != null) {
+            if (shouldUseResourceAuthz(ML_MODEL_GROUP_RESOURCE_TYPE)) {
                 checkForAssociatedModels(modelGroupId, tenantId, wrappedListener);
             } else {
                 validateAndDeleteModelGroup(modelGroupId, tenantId, wrappedListener);

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/GetModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/GetModelGroupTransportAction.java
@@ -8,6 +8,8 @@ package org.opensearch.ml.action.model_group;
 import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_RESOURCE_TYPE;
+import static org.opensearch.ml.helper.ModelAccessControlHelper.shouldUseResourceAuthz;
 
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
@@ -27,7 +29,6 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.ml.common.MLModelGroup;
-import org.opensearch.ml.common.ResourceSharingClientAccessor;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.model_group.MLModelGroupGetAction;
 import org.opensearch.ml.common.transport.model_group.MLModelGroupGetRequest;
@@ -186,7 +187,7 @@ public class GetModelGroupTransportAction extends HandledTransportAction<ActionR
     ) {
         // if resource sharing feature is enabled, security plugin will have automatically evaluated access to this model group, hence no
         // need to validate again
-        if (ResourceSharingClientAccessor.getInstance().getResourceSharingClient() != null) {
+        if (shouldUseResourceAuthz(ML_MODEL_GROUP_RESOURCE_TYPE)) {
             wrappedListener.onResponse(MLModelGroupGetResponse.builder().mlModelGroup(mlModelGroup).build());
             return;
         }

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/TransportUpdateModelGroupAction.java
@@ -8,6 +8,8 @@ package org.opensearch.ml.action.model_group;
 import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_RESOURCE_TYPE;
+import static org.opensearch.ml.helper.ModelAccessControlHelper.shouldUseResourceAuthz;
 import static org.opensearch.ml.utils.MLExceptionUtils.logException;
 
 import java.time.Instant;
@@ -35,7 +37,6 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.MLModelGroup;
-import org.opensearch.ml.common.ResourceSharingClientAccessor;
 import org.opensearch.ml.common.exception.MLValidationException;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.model_group.MLUpdateModelGroupAction;
@@ -149,7 +150,7 @@ public class TransportUpdateModelGroupAction extends HandledTransportAction<Acti
                                     )) {
                                     // NOTE all sharing and revoking must happen through share API exposed by security plugin
                                     // client == null -> feature is disabled, follow old route
-                                    if (ResourceSharingClientAccessor.getInstance().getResourceSharingClient() == null) {
+                                    if (!shouldUseResourceAuthz(ML_MODEL_GROUP_RESOURCE_TYPE)) {
                                         // TODO: At some point, this call must be replaced by the one above, (i.e. no user info to
                                         // be stored in model-group index)
                                         if (modelAccessControlHelper.isSecurityEnabledAndModelAccessControlEnabled(user)) {

--- a/plugin/src/main/java/org/opensearch/ml/helper/ModelAccessControlHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/ModelAccessControlHelper.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.helper;
 import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_RESOURCE_TYPE;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MODEL_ACCESS_CONTROL_ENABLED;
 
 import java.util.Collections;
@@ -97,8 +98,8 @@ public class ModelAccessControlHelper {
             listener.onResponse(true);
             return;
         }
-        if (ResourceSharingClientAccessor.getInstance().getResourceSharingClient() != null) {
-            ResourceSharingClient resourceSharingClient = ResourceSharingClientAccessor.getInstance().getResourceSharingClient();
+        if (shouldUseResourceAuthz(ML_MODEL_GROUP_RESOURCE_TYPE)) {
+            ResourceSharingClient resourceSharingClient = getResourceSharingClient();
             resourceSharingClient.verifyAccess(modelGroupId, ML_MODEL_GROUP_INDEX, action, ActionListener.wrap(isAuthorized -> {
                 if (!isAuthorized) {
                     listener
@@ -172,8 +173,8 @@ public class ModelAccessControlHelper {
             listener.onResponse(true);
             return;
         }
-        if (ResourceSharingClientAccessor.getInstance().getResourceSharingClient() != null) {
-            ResourceSharingClient resourceSharingClient = ResourceSharingClientAccessor.getInstance().getResourceSharingClient();
+        if (shouldUseResourceAuthz(ML_MODEL_GROUP_RESOURCE_TYPE)) {
+            ResourceSharingClient resourceSharingClient = getResourceSharingClient();
             resourceSharingClient.verifyAccess(modelGroupId, ML_MODEL_GROUP_INDEX, action, ActionListener.wrap(isAuthorized -> {
                 if (!isAuthorized) {
                     listener
@@ -285,6 +286,20 @@ public class ModelAccessControlHelper {
                     wrappedListener.onResponse(true);
             }
         }
+    }
+
+    /**
+     * Checks whether to utilize new ResourceAuthz
+     * @param resourceType for which to decide whether to use resource authz
+     * @return true if the resource-sharing feature is enabled, false otherwise.
+     */
+    public static boolean shouldUseResourceAuthz(String resourceType) {
+        var client = getResourceSharingClient();
+        return client != null && client.isFeatureEnabledForType(resourceType);
+    }
+
+    public static ResourceSharingClient getResourceSharingClient() {
+        return ResourceSharingClientAccessor.getInstance().getResourceSharingClient();
     }
 
     public boolean skipModelAccessControl(User user) {

--- a/plugin/src/test/java/org/opensearch/ml/resources/MLResourceSharingExtensionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/resources/MLResourceSharingExtensionTests.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
+import static org.opensearch.ml.helper.ModelAccessControlHelper.getResourceSharingClient;
 
 import java.util.Iterator;
 import java.util.Set;
@@ -71,15 +72,11 @@ public class MLResourceSharingExtensionTests {
         MLResourceSharingExtension ext = new MLResourceSharingExtension();
         ResourceSharingClient mockClient = mock(ResourceSharingClient.class);
 
-        assertThat(ResourceSharingClientAccessor.getInstance().getResourceSharingClient(), is(nullValue()));
+        assertThat(getResourceSharingClient(), is(nullValue()));
 
         ext.assignResourceSharingClient(mockClient);
 
-        assertThat(
-            "Accessor should hold the client passed to extension",
-            ResourceSharingClientAccessor.getInstance().getResourceSharingClient(),
-            equalTo(mockClient)
-        );
+        assertThat("Accessor should hold the client passed to extension", getResourceSharingClient(), equalTo(mockClient));
     }
 
     @Test
@@ -90,16 +87,12 @@ public class MLResourceSharingExtensionTests {
 
         // Prime with the first client
         ResourceSharingClientAccessor.getInstance().setResourceSharingClient(first);
-        assertThat(ResourceSharingClientAccessor.getInstance().getResourceSharingClient(), equalTo(first));
+        assertThat(getResourceSharingClient(), equalTo(first));
 
         // Now assign a new one via the extension
         ext.assignResourceSharingClient(second);
 
-        assertThat(
-            "Accessor should be updated to the new client",
-            ResourceSharingClientAccessor.getInstance().getResourceSharingClient(),
-            equalTo(second)
-        );
+        assertThat("Accessor should be updated to the new client", getResourceSharingClient(), equalTo(second));
     }
 
     @Test


### PR DESCRIPTION
Depends on: https://github.com/opensearch-project/security/pull/5677

### Description
Adds capability to automatically switch to old access-control if model-group is excluded from protected resources setting.


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
