### PR TITLE
Fix approver parsing bug in require-approval workflow

### DIFF
--- a/.github/workflows/require-approval.yml
+++ b/.github/workflows/require-approval.yml
@@ -36,7 +36,8 @@ jobs:
               # Check if the author is in the approvers list
               approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')
               is_approved=false
-              for approver in $approvers; do
+              IFS=',' read -ra APPROVER_ARRAY <<< "$approvers"
+              for approver in "${APPROVER_ARRAY[@]}"; do
                 if [[ "$approver" == "$author" ]]; then
                   is_approved=true
                   break


### PR DESCRIPTION
### Description
Fix a critical bug in the `require-approval.yml` workflow that was causing all maintainers to require manual approval even when they should be auto-approved.

### Root Cause
The workflow parsing logic was incorrectly handling the comma-separated list of approvers from CODEOWNERS:
1. It creates a comma-separated string: `b4sjoo,dhrubo-os,mingshl,...`
2. But then uses `for approver in $approvers` which splits on spaces, not commas
3. This treats the entire comma-separated list as a single "approver" name
4. The comparison `"b4sjoo,dhrubo-os,..." == "dhrubo-os"` always fails

### Impact
- All maintainers (dhrubo-os, ylwu-amzn, b4sjoo, etc.) incorrectly require manual approval
- Workflow automation is broken for legitimate maintainer PRs
- This affects productivity and violates the intended security model

### Solution
Use `IFS=',' read -ra APPROVER_ARRAY <<< "$approvers"` to properly split the comma-separated usernames into an array for correct comparison.

### Testing
Verified the fix works correctly:
```bash
# Before fix: treats entire list as one string
for approver in $approvers; do
  echo "Checking: '$approver'"  # Outputs entire comma-separated list
done

# After fix: properly splits on commas  
IFS=',' read -ra APPROVER_ARRAY <<< "$approvers"
for approver in "${APPROVER_ARRAY[@]}"; do
  echo "Checking: '$approver'"  # Outputs individual usernames
done
```

### Related Issues
This bug was introduced as a side effect of the security fix in PR #4247, which correctly fixed the substring matching vulnerability but inadvertently broke the parsing logic.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).