### PR TITLE
fix: add validations during create and update memory container

### DIFF
--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1,0 +1,972 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.memorycontainer.MemoryConfiguration.EmbeddingConfig;
+
+/**
+ * Unit tests for MemoryConfiguration class methods.
+ */
+public class MemoryConfigurationTests {
+
+    // ==================== validateStrategiesRequireModels Tests ====================
+
+    @Test
+    public void testValidateStrategiesRequireModels_NullConfig() {
+        // Should not throw exception
+        MemoryConfiguration.validateStrategiesRequireModels(null);
+    }
+
+    @Test
+    public void testValidateStrategiesRequireModels_NullStrategies() {
+        MemoryConfiguration config = MemoryConfiguration.builder().build();
+        // Should not throw exception
+        MemoryConfiguration.validateStrategiesRequireModels(config);
+    }
+
+    @Test
+    public void testValidateStrategiesRequireModels_EmptyStrategies() {
+        MemoryConfiguration config = MemoryConfiguration.builder().strategies(new ArrayList<>()).build();
+        // Should not throw exception
+        MemoryConfiguration.validateStrategiesRequireModels(config);
+    }
+
+    @Test
+    public void testValidateStrategiesRequireModels_BothModelsConfigured() {
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .id("test-id")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .namespace(Arrays.asList("test-namespace"))
+                    .build()
+            );
+
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .llmId("llm-model-id")
+            .embeddingModelId("embed-model-id")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(768)
+            .strategies(strategies)
+            .build();
+
+        // Should not throw exception
+        MemoryConfiguration.validateStrategiesRequireModels(config);
+    }
+
+    @Test
+    public void testValidateStrategiesRequireModels_MissingLlm() {
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .id("test-id")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .namespace(Arrays.asList("test-namespace"))
+                    .build()
+            );
+
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .embeddingModelId("embed-model-id")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(768)
+            .strategies(strategies)
+            .build();
+
+        try {
+            MemoryConfiguration.validateStrategiesRequireModels(config);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("LLM model (llm_id)"));
+        }
+    }
+
+    @Test
+    public void testValidateStrategiesRequireModels_MissingEmbedding() {
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .id("test-id")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .namespace(Arrays.asList("test-namespace"))
+                    .build()
+            );
+
+        MemoryConfiguration config = MemoryConfiguration.builder().llmId("llm-model-id").strategies(strategies).build();
+
+        try {
+            MemoryConfiguration.validateStrategiesRequireModels(config);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("embedding model"));
+        }
+    }
+
+    @Test
+    public void testValidateStrategiesRequireModels_MissingBoth() {
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .id("test-id")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .namespace(Arrays.asList("test-namespace"))
+                    .build()
+            );
+
+        MemoryConfiguration config = MemoryConfiguration.builder().strategies(strategies).build();
+
+        try {
+            MemoryConfiguration.validateStrategiesRequireModels(config);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("LLM model and embedding model"));
+        }
+    }
+
+    // ==================== update Tests ====================
+
+    @Test
+    public void testUpdate_UpdateLlmId() {
+        MemoryConfiguration config = MemoryConfiguration.builder().llmId("old-llm-id").build();
+
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().llmId("new-llm-id").build();
+
+        config.update(updateContent);
+        assertEquals("new-llm-id", config.getLlmId());
+    }
+
+    @Test
+    public void testUpdate_UpdateStrategies() {
+        MemoryConfiguration config = MemoryConfiguration.builder().build();
+
+        List<MemoryStrategy> newStrategies = new ArrayList<>();
+        newStrategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .id("new-strategy-id")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .namespace(Arrays.asList("new-namespace"))
+                    .build()
+            );
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().strategies(newStrategies).build();
+
+        config.update(updateContent);
+        assertEquals(1, config.getStrategies().size());
+        assertEquals("new-strategy-id", config.getStrategies().get(0).getId());
+    }
+
+    @Test
+    public void testUpdate_UpdateMaxInferSize() {
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .llmId("llm-id")
+            .maxInferSize(5)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("model-id")
+            .dimension(768)
+            .build();
+
+        MemoryConfiguration updateContent = MemoryConfiguration
+            .builder()
+            .llmId("llm-id")
+            .maxInferSize(8)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("model-id")
+            .dimension(768)
+            .build();
+
+        config.update(updateContent);
+        assertEquals(Integer.valueOf(8), config.getMaxInferSize());
+    }
+
+    @Test
+    public void testUpdate_UpdateEmbeddingModelId() {
+        MemoryConfiguration config = MemoryConfiguration.builder().build();
+
+        // Create valid updateContent with all required embedding fields
+        MemoryConfiguration updateContent = MemoryConfiguration
+            .builder()
+            .embeddingModelId("new-embed-id")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(768)
+            .build();
+
+        config.update(updateContent);
+        assertEquals("new-embed-id", config.getEmbeddingModelId());
+    }
+
+    @Test
+    public void testUpdate_UpdateEmbeddingModelType() {
+        MemoryConfiguration config = MemoryConfiguration.builder().build();
+
+        MemoryConfiguration updateContent = MemoryConfiguration
+            .builder()
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("model-id")
+            .dimension(768)
+            .build();
+
+        config.update(updateContent);
+        assertEquals(FunctionName.TEXT_EMBEDDING, config.getEmbeddingModelType());
+    }
+
+    @Test
+    public void testUpdate_UpdateDimension() {
+        MemoryConfiguration config = MemoryConfiguration.builder().build();
+
+        MemoryConfiguration updateContent = MemoryConfiguration
+            .builder()
+            .dimension(1024)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("model-id")
+            .build();
+
+        config.update(updateContent);
+        assertEquals(Integer.valueOf(1024), config.getDimension());
+    }
+
+    @Test
+    public void testUpdate_NullValuesNotUpdated() {
+        MemoryConfiguration config = MemoryConfiguration.builder().llmId("original-llm-id").build();
+
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().build(); // All nulls
+
+        config.update(updateContent);
+        assertEquals("original-llm-id", config.getLlmId()); // Should remain unchanged
+    }
+
+    @Test
+    public void testUpdate_IndexPrefixNotUpdated() {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("original-prefix").build();
+
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().indexPrefix("new-prefix").build();
+
+        config.update(updateContent);
+        // indexPrefix should NOT be updated (intentional in update() method)
+        assertEquals("original-prefix", config.getIndexPrefix());
+    }
+
+    // ==================== extractEmbeddingConfigFromMapping Tests ====================
+
+    @Test
+    public void testExtractEmbeddingConfigFromMapping_NullMapping() {
+        EmbeddingConfig result = MemoryConfiguration.extractEmbeddingConfigFromMapping(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractEmbeddingConfigFromMapping_NoEmbeddingField() {
+        Map<String, Object> mapping = new HashMap<>();
+        mapping.put("other_field", new HashMap<>());
+
+        EmbeddingConfig result = MemoryConfiguration.extractEmbeddingConfigFromMapping(mapping);
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractEmbeddingConfigFromMapping_EmbeddingFieldNotMap() {
+        Map<String, Object> mapping = new HashMap<>();
+        mapping.put("memory_embedding", "not-a-map");
+
+        EmbeddingConfig result = MemoryConfiguration.extractEmbeddingConfigFromMapping(mapping);
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractEmbeddingConfigFromMapping_TextEmbedding() {
+        Map<String, Object> embeddingField = new HashMap<>();
+        embeddingField.put("type", "knn_vector");
+        embeddingField.put("dimension", 768);
+
+        Map<String, Object> mapping = new HashMap<>();
+        mapping.put("memory_embedding", embeddingField);
+
+        EmbeddingConfig result = MemoryConfiguration.extractEmbeddingConfigFromMapping(mapping);
+        assertNotNull(result);
+        assertEquals(FunctionName.TEXT_EMBEDDING, result.getType());
+        assertEquals(Integer.valueOf(768), result.getDimension());
+    }
+
+    @Test
+    public void testExtractEmbeddingConfigFromMapping_SparseEncoding() {
+        Map<String, Object> embeddingField = new HashMap<>();
+        embeddingField.put("type", "rank_features");
+
+        Map<String, Object> mapping = new HashMap<>();
+        mapping.put("memory_embedding", embeddingField);
+
+        EmbeddingConfig result = MemoryConfiguration.extractEmbeddingConfigFromMapping(mapping);
+        assertNotNull(result);
+        assertEquals(FunctionName.SPARSE_ENCODING, result.getType());
+        assertNull(result.getDimension());
+    }
+
+    @Test
+    public void testExtractEmbeddingConfigFromMapping_UnknownType() {
+        Map<String, Object> embeddingField = new HashMap<>();
+        embeddingField.put("type", "unknown_type");
+
+        Map<String, Object> mapping = new HashMap<>();
+        mapping.put("memory_embedding", embeddingField);
+
+        EmbeddingConfig result = MemoryConfiguration.extractEmbeddingConfigFromMapping(mapping);
+        assertNull(result);
+    }
+
+    // ==================== asMap Tests ====================
+
+    @Test
+    public void testAsMap_WithMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("key", "value");
+
+        Map<String, Object> result = MemoryConfiguration.asMap(map);
+        assertNotNull(result);
+        assertEquals("value", result.get("key"));
+    }
+
+    @Test
+    public void testAsMap_WithNonMap() {
+        String notAMap = "not a map";
+
+        Map<String, Object> result = MemoryConfiguration.asMap(notAMap);
+        assertNull(result);
+    }
+
+    @Test
+    public void testAsMap_WithNull() {
+        Map<String, Object> result = MemoryConfiguration.asMap(null);
+        assertNull(result);
+    }
+
+    // ==================== asList Tests ====================
+
+    @Test
+    public void testAsList_WithList() {
+        List<String> list = new ArrayList<>();
+        list.add("item1");
+        list.add("item2");
+
+        List<?> result = MemoryConfiguration.asList(list);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("item1", result.get(0));
+    }
+
+    @Test
+    public void testAsList_WithNonList() {
+        String notAList = "not a list";
+
+        List<?> result = MemoryConfiguration.asList(notAList);
+        assertNull(result);
+    }
+
+    @Test
+    public void testAsList_WithNull() {
+        List<?> result = MemoryConfiguration.asList(null);
+        assertNull(result);
+    }
+
+    // ==================== extractModelIdFromPipeline Tests ====================
+
+    @Test
+    public void testExtractModelIdFromPipeline_NullPipeline() {
+        String result = MemoryConfiguration.extractModelIdFromPipeline(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractModelIdFromPipeline_NullProcessors() {
+        Map<String, Object> pipeline = new HashMap<>();
+        pipeline.put("other_field", "value");
+
+        String result = MemoryConfiguration.extractModelIdFromPipeline(pipeline);
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractModelIdFromPipeline_EmptyProcessors() {
+        Map<String, Object> pipeline = new HashMap<>();
+        pipeline.put("processors", new ArrayList<>());
+
+        String result = MemoryConfiguration.extractModelIdFromPipeline(pipeline);
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractModelIdFromPipeline_TextEmbeddingProcessor() {
+        Map<String, Object> textEmbeddingConfig = new HashMap<>();
+        textEmbeddingConfig.put("model_id", "test-model-id");
+        textEmbeddingConfig.put("field_map", new HashMap<>());
+
+        Map<String, Object> processor = new HashMap<>();
+        processor.put("text_embedding", textEmbeddingConfig);
+
+        List<Object> processors = new ArrayList<>();
+        processors.add(processor);
+
+        Map<String, Object> pipeline = new HashMap<>();
+        pipeline.put("processors", processors);
+
+        String result = MemoryConfiguration.extractModelIdFromPipeline(pipeline);
+        assertEquals("test-model-id", result);
+    }
+
+    @Test
+    public void testExtractModelIdFromPipeline_SparseEncodingProcessor() {
+        Map<String, Object> sparseEncodingConfig = new HashMap<>();
+        sparseEncodingConfig.put("model_id", "sparse-model-id");
+        sparseEncodingConfig.put("field_map", new HashMap<>());
+
+        Map<String, Object> processor = new HashMap<>();
+        processor.put("sparse_encoding", sparseEncodingConfig);
+
+        List<Object> processors = new ArrayList<>();
+        processors.add(processor);
+
+        Map<String, Object> pipeline = new HashMap<>();
+        pipeline.put("processors", processors);
+
+        String result = MemoryConfiguration.extractModelIdFromPipeline(pipeline);
+        assertEquals("sparse-model-id", result);
+    }
+
+    @Test
+    public void testExtractModelIdFromPipeline_ModelIdNotString() {
+        Map<String, Object> textEmbeddingConfig = new HashMap<>();
+        textEmbeddingConfig.put("model_id", 123); // Not a String
+
+        Map<String, Object> processor = new HashMap<>();
+        processor.put("text_embedding", textEmbeddingConfig);
+
+        List<Object> processors = new ArrayList<>();
+        processors.add(processor);
+
+        Map<String, Object> pipeline = new HashMap<>();
+        pipeline.put("processors", processors);
+
+        String result = MemoryConfiguration.extractModelIdFromPipeline(pipeline);
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractModelIdFromPipeline_MalformedProcessor() {
+        List<Object> processors = new ArrayList<>();
+        processors.add("not-a-map"); // Malformed processor
+
+        Map<String, Object> pipeline = new HashMap<>();
+        pipeline.put("processors", processors);
+
+        String result = MemoryConfiguration.extractModelIdFromPipeline(pipeline);
+        assertNull(result);
+    }
+
+    // ==================== compareEmbeddingConfig Tests ====================
+
+    @Test
+    public void testCompareEmbeddingConfig_TextEmbeddingMatch() {
+        MemoryConfiguration requested = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-prefix")
+            .embeddingModelId("model-id")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(768)
+            .build();
+
+        EmbeddingConfig existing = new EmbeddingConfig(FunctionName.TEXT_EMBEDDING, 768);
+
+        // Should not throw exception
+        MemoryConfiguration.compareEmbeddingConfig(requested, "model-id", existing);
+    }
+
+    @Test
+    public void testCompareEmbeddingConfig_SparseEncodingMatch() {
+        MemoryConfiguration requested = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-prefix")
+            .embeddingModelId("model-id")
+            .embeddingModelType(FunctionName.SPARSE_ENCODING)
+            .build();
+
+        EmbeddingConfig existing = new EmbeddingConfig(FunctionName.SPARSE_ENCODING, null);
+
+        // Should not throw exception
+        MemoryConfiguration.compareEmbeddingConfig(requested, "model-id", existing);
+    }
+
+    @Test
+    public void testCompareEmbeddingConfig_ModelIdMismatch() {
+        MemoryConfiguration requested = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-prefix")
+            .embeddingModelId("different-model-id")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(768)
+            .build();
+
+        EmbeddingConfig existing = new EmbeddingConfig(FunctionName.TEXT_EMBEDDING, 768);
+
+        try {
+            MemoryConfiguration.compareEmbeddingConfig(requested, "existing-model-id", existing);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("embedding_model_id"));
+            assertTrue(e.getMessage().contains("existing='existing-model-id'"));
+            assertTrue(e.getMessage().contains("requested='different-model-id'"));
+        }
+    }
+
+    @Test
+    public void testCompareEmbeddingConfig_ModelTypeMismatch() {
+        MemoryConfiguration requested = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-prefix")
+            .embeddingModelId("model-id")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(768)
+            .build();
+
+        EmbeddingConfig existing = new EmbeddingConfig(FunctionName.SPARSE_ENCODING, null);
+
+        try {
+            MemoryConfiguration.compareEmbeddingConfig(requested, "model-id", existing);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("embedding_model_type"));
+            assertTrue(e.getMessage().contains("existing='SPARSE_ENCODING'"));
+            assertTrue(e.getMessage().contains("requested='TEXT_EMBEDDING'"));
+        }
+    }
+
+    @Test
+    public void testCompareEmbeddingConfig_DimensionMismatch() {
+        MemoryConfiguration requested = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-prefix")
+            .embeddingModelId("model-id")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(1024)
+            .build();
+
+        EmbeddingConfig existing = new EmbeddingConfig(FunctionName.TEXT_EMBEDDING, 768);
+
+        try {
+            MemoryConfiguration.compareEmbeddingConfig(requested, "model-id", existing);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("dimension"));
+            assertTrue(e.getMessage().contains("existing=768"));
+            assertTrue(e.getMessage().contains("requested=1024"));
+        }
+    }
+
+    @Test
+    public void testCompareEmbeddingConfig_MultipleMismatches() {
+        MemoryConfiguration requested = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-prefix")
+            .embeddingModelId("different-model-id")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(1024)
+            .build();
+
+        EmbeddingConfig existing = new EmbeddingConfig(FunctionName.SPARSE_ENCODING, null);
+
+        try {
+            MemoryConfiguration.compareEmbeddingConfig(requested, "existing-model-id", existing);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // Should contain all three mismatches
+            assertTrue(e.getMessage().contains("embedding_model_id"));
+            assertTrue(e.getMessage().contains("embedding_model_type"));
+            assertTrue(e.getMessage().contains("test-prefix"));
+        }
+    }
+
+    // ==================== getIndexName Tests ====================
+
+    @Test
+    public void testGetIndexName_NullMemoryType() {
+        MemoryConfiguration config = MemoryConfiguration.builder().build();
+
+        String result = config.getIndexName(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testGetIndexName_SessionsDisabled() {
+        MemoryConfiguration config = MemoryConfiguration.builder().disableSession(true).build();
+
+        String result = config.getIndexName(MemoryType.SESSIONS);
+        assertNull(result);
+    }
+
+    @Test
+    public void testGetIndexName_HistoryDisabled() {
+        MemoryConfiguration config = MemoryConfiguration.builder().disableHistory(true).build();
+
+        String result = config.getIndexName(MemoryType.HISTORY);
+        assertNull(result);
+    }
+
+    @Test
+    public void testGetIndexName_SessionsEnabled() {
+        MemoryConfiguration config = MemoryConfiguration.builder().disableSession(false).build();
+
+        String result = config.getIndexName(MemoryType.SESSIONS);
+        assertNotNull(result);
+        assertTrue(result.endsWith("-memory-sessions"));
+    }
+
+    @Test
+    public void testGetIndexName_Working() {
+        MemoryConfiguration config = MemoryConfiguration.builder().build();
+
+        String result = config.getIndexName(MemoryType.WORKING);
+        assertNotNull(result);
+        assertTrue(result.endsWith("-memory-working"));
+    }
+
+    @Test
+    public void testGetIndexName_LongTerm() {
+        MemoryConfiguration config = MemoryConfiguration.builder().build();
+
+        String result = config.getIndexName(MemoryType.LONG_TERM);
+        assertNotNull(result);
+        assertTrue(result.endsWith("-memory-long-term"));
+    }
+
+    @Test
+    public void testGetIndexName_HistoryEnabled() {
+        MemoryConfiguration config = MemoryConfiguration.builder().disableHistory(false).build();
+
+        String result = config.getIndexName(MemoryType.HISTORY);
+        assertNotNull(result);
+        assertTrue(result.endsWith("-memory-history"));
+    }
+
+    // ==================== validate Tests ====================
+
+    @Test
+    public void testValidate_ValidConfiguration() {
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .embeddingModelId("model-id")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(768)
+            .build();
+
+        // Should not throw exception
+        config.validate();
+    }
+
+    @Test
+    public void testValidate_EmbeddingModelIdWithoutType() {
+        try {
+            MemoryConfiguration.builder().embeddingModelId("model-id").build();
+            fail("Expected IllegalArgumentException during construction");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("embedding_model_type") || e.getMessage().contains("required"));
+        }
+    }
+
+    @Test
+    public void testValidate_EmbeddingModelTypeWithoutId() {
+        try {
+            MemoryConfiguration.builder().embeddingModelType(FunctionName.TEXT_EMBEDDING).dimension(768).build();
+            fail("Expected IllegalArgumentException during construction");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("embedding_model_id") || e.getMessage().contains("required"));
+        }
+    }
+
+    @Test
+    public void testValidate_InvalidEmbeddingModelType() {
+        try {
+            MemoryConfiguration.builder().embeddingModelId("model-id").embeddingModelType(FunctionName.KMEANS).build();
+            fail("Expected IllegalArgumentException during construction");
+        } catch (IllegalArgumentException e) {
+            assertTrue(
+                e.getMessage().contains("TEXT_EMBEDDING")
+                    || e.getMessage().contains("SPARSE_ENCODING")
+                    || e.getMessage().contains("embedding model type")
+            );
+        }
+    }
+
+    @Test
+    public void testValidate_TextEmbeddingWithoutDimension() {
+        try {
+            MemoryConfiguration.builder().embeddingModelId("model-id").embeddingModelType(FunctionName.TEXT_EMBEDDING).build();
+            fail("Expected IllegalArgumentException during construction");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("dimension") || e.getMessage().contains("required"));
+        }
+    }
+
+    @Test
+    public void testValidate_SparseEncodingWithDimension() {
+        try {
+            MemoryConfiguration
+                .builder()
+                .embeddingModelId("model-id")
+                .embeddingModelType(FunctionName.SPARSE_ENCODING)
+                .dimension(768)
+                .build();
+            fail("Expected IllegalArgumentException during construction");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("dimension") || e.getMessage().contains("not allowed"));
+        }
+    }
+
+    @Test
+    public void testValidate_MaxInferSizeExceedsLimit() {
+        try {
+            MemoryConfiguration
+                .builder()
+                .llmId("llm-id")
+                .maxInferSize(15) // Exceeds limit of 10
+                .embeddingModelId("model-id")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .dimension(768)
+                .build();
+            fail("Expected IllegalArgumentException during construction");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("10") || e.getMessage().contains("exceed"));
+        }
+    }
+
+    // ==================== getSessionIndexName Tests ====================
+
+    @Test
+    public void testGetSessionIndexName_Enabled() {
+        MemoryConfiguration config = MemoryConfiguration.builder().disableSession(false).build();
+
+        String result = config.getSessionIndexName();
+        assertNotNull(result);
+        assertTrue(result.endsWith("-memory-sessions"));
+    }
+
+    @Test
+    public void testGetSessionIndexName_Disabled() {
+        MemoryConfiguration config = MemoryConfiguration.builder().disableSession(true).build();
+
+        String result = config.getSessionIndexName();
+        assertNull(result);
+    }
+
+    @Test
+    public void testGetSessionIndexName_WithCustomPrefix() {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("custom-prefix").disableSession(false).build();
+
+        String result = config.getSessionIndexName();
+        assertNotNull(result);
+        assertTrue(result.contains("custom-prefix"));
+        assertTrue(result.endsWith("-memory-sessions"));
+    }
+
+    // ==================== getWorkingMemoryIndexName Tests ====================
+
+    @Test
+    public void testGetWorkingMemoryIndexName_Default() {
+        MemoryConfiguration config = MemoryConfiguration.builder().build();
+
+        String result = config.getWorkingMemoryIndexName();
+        assertNotNull(result);
+        assertTrue(result.endsWith("-memory-working"));
+    }
+
+    @Test
+    public void testGetWorkingMemoryIndexName_WithCustomPrefix() {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("my-prefix").build();
+
+        String result = config.getWorkingMemoryIndexName();
+        assertNotNull(result);
+        assertTrue(result.contains("my-prefix"));
+        assertTrue(result.endsWith("-memory-working"));
+    }
+
+    @Test
+    public void testGetWorkingMemoryIndexName_WithSystemIndex() {
+        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(true).build();
+
+        String result = config.getWorkingMemoryIndexName();
+        assertNotNull(result);
+        assertTrue(result.contains(".plugins-ml-am-"));
+        assertTrue(result.endsWith("-memory-working"));
+    }
+
+    @Test
+    public void testGetWorkingMemoryIndexName_WithoutSystemIndex() {
+        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(false).build();
+
+        String result = config.getWorkingMemoryIndexName();
+        assertNotNull(result);
+        assertTrue(result.endsWith("-memory-working"));
+    }
+
+    // ==================== getLongMemoryIndexName Tests ====================
+
+    @Test
+    public void testGetLongMemoryIndexName_Default() {
+        MemoryConfiguration config = MemoryConfiguration.builder().build();
+
+        String result = config.getLongMemoryIndexName();
+        assertNotNull(result);
+        assertTrue(result.endsWith("-memory-long-term"));
+    }
+
+    @Test
+    public void testGetLongMemoryIndexName_WithCustomPrefix() {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("long-term-prefix").build();
+
+        String result = config.getLongMemoryIndexName();
+        assertNotNull(result);
+        assertTrue(result.contains("long-term-prefix"));
+        assertTrue(result.endsWith("-memory-long-term"));
+    }
+
+    @Test
+    public void testGetLongMemoryIndexName_WithSystemIndex() {
+        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(true).build();
+
+        String result = config.getLongMemoryIndexName();
+        assertNotNull(result);
+        assertTrue(result.contains(".plugins-ml-am-"));
+        assertTrue(result.endsWith("-memory-long-term"));
+    }
+
+    // ==================== getLongMemoryHistoryIndexName Tests ====================
+
+    @Test
+    public void testGetLongMemoryHistoryIndexName_Enabled() {
+        MemoryConfiguration config = MemoryConfiguration.builder().disableHistory(false).build();
+
+        String result = config.getLongMemoryHistoryIndexName();
+        assertNotNull(result);
+        assertTrue(result.endsWith("-memory-history"));
+    }
+
+    @Test
+    public void testGetLongMemoryHistoryIndexName_Disabled() {
+        MemoryConfiguration config = MemoryConfiguration.builder().disableHistory(true).build();
+
+        String result = config.getLongMemoryHistoryIndexName();
+        assertNull(result);
+    }
+
+    @Test
+    public void testGetLongMemoryHistoryIndexName_WithCustomPrefix() {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("history-prefix").disableHistory(false).build();
+
+        String result = config.getLongMemoryHistoryIndexName();
+        assertNotNull(result);
+        assertTrue(result.contains("history-prefix"));
+        assertTrue(result.endsWith("-memory-history"));
+    }
+
+    // ==================== getMemoryIndexMapping Tests ====================
+
+    @Test
+    public void testGetMemoryIndexMapping_NullSettings() {
+        MemoryConfiguration config = MemoryConfiguration.builder().build();
+
+        Map<String, Object> result = config.getMemoryIndexMapping("test-index");
+        assertNull(result);
+    }
+
+    @Test
+    public void testGetMemoryIndexMapping_NonExistentIndex() {
+        Map<String, Map<String, Object>> indexSettings = new HashMap<>();
+        Map<String, Object> mapping = new HashMap<>();
+        mapping.put("field1", "value1");
+        indexSettings.put("existing-index", mapping);
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexSettings(indexSettings).build();
+
+        Map<String, Object> result = config.getMemoryIndexMapping("non-existent-index");
+        assertNull(result);
+    }
+
+    @Test
+    public void testGetMemoryIndexMapping_ExistingIndex() {
+        Map<String, Map<String, Object>> indexSettings = new HashMap<>();
+        Map<String, Object> mapping = new HashMap<>();
+        mapping.put("field1", "value1");
+        mapping.put("field2", "value2");
+        indexSettings.put("test-index", mapping);
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexSettings(indexSettings).build();
+
+        Map<String, Object> result = config.getMemoryIndexMapping("test-index");
+        assertNotNull(result);
+        assertEquals("value1", result.get("field1"));
+        assertEquals("value2", result.get("field2"));
+    }
+
+    @Test
+    public void testGetMemoryIndexMapping_MultipleIndices() {
+        Map<String, Map<String, Object>> indexSettings = new HashMap<>();
+
+        Map<String, Object> mapping1 = new HashMap<>();
+        mapping1.put("type", "knn_vector");
+        mapping1.put("dimension", 768);
+        indexSettings.put("index1", mapping1);
+
+        Map<String, Object> mapping2 = new HashMap<>();
+        mapping2.put("type", "rank_features");
+        indexSettings.put("index2", mapping2);
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexSettings(indexSettings).build();
+
+        Map<String, Object> result1 = config.getMemoryIndexMapping("index1");
+        assertNotNull(result1);
+        assertEquals("knn_vector", result1.get("type"));
+        assertEquals(768, result1.get("dimension"));
+
+        Map<String, Object> result2 = config.getMemoryIndexMapping("index2");
+        assertNotNull(result2);
+        assertEquals("rank_features", result2.get("type"));
+    }
+
+    @Test
+    public void testGetMemoryIndexMapping_EmptySettings() {
+        Map<String, Map<String, Object>> indexSettings = new HashMap<>();
+        MemoryConfiguration config = MemoryConfiguration.builder().indexSettings(indexSettings).build();
+
+        Map<String, Object> result = config.getMemoryIndexMapping("any-index");
+        assertNull(result);
+    }
+}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -592,16 +592,10 @@ List<String> jacocoExclusions = [
         'org.opensearch.ml.utils.ParseUtils',
         'org.opensearch.ml.jobs.processors.MLStatsJobProcessor',
         'org.opensearch.ml.jobs.processors.MLJobProcessor',
-        'org.opensearch.ml.action.memorycontainer.memory.TransportAddMemoriesAction',
-        'org.opensearch.ml.action.memorycontainer.memory.TransportAddMemoriesAction.*',
-        'org.opensearch.ml.rest.RestMLDeleteMemoryAction',
-        'org.opensearch.ml.rest.RestMLDeleteMemoryAction.*',
         'org.opensearch.ml.rest.RestMLPredictionStreamAction',
         'org.opensearch.ml.rest.RestMLPredictionStreamAction.*',
         'org.opensearch.ml.rest.RestMLExecuteStreamAction',
         'org.opensearch.ml.rest.RestMLExecuteStreamAction.*',
-        'org.opensearch.ml.rest.RestMLCreateSessionAction',
-        'org.opensearch.ml.rest.RestMLCreateSessionAction.*'
 ]
 
 jacocoTestCoverageVerification {

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerModelValidator.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerModelValidator.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.helper;
+
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.EMBEDDING_MODEL_NOT_FOUND_ERROR;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.EMBEDDING_MODEL_TYPE_MISMATCH_ERROR;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LLM_MODEL_NOT_FOUND_ERROR;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LLM_MODEL_NOT_REMOTE_ERROR;
+
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.model.MLModelManager;
+import org.opensearch.transport.client.Client;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Helper class for validating ML models used in memory containers.
+ * Provides reusable validation logic for LLM and embedding models.
+ */
+@Log4j2
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MemoryContainerModelValidator {
+
+    /**
+     * Validates that the LLM model exists and is of REMOTE type.
+     *
+     * @param llmId         The LLM model ID to validate
+     * @param modelManager  The ML model manager
+     * @param client        The OpenSearch client
+     * @param listener      Action listener that receives true on success, or error on failure
+     */
+    public static void validateLlmModel(String llmId, MLModelManager modelManager, Client client, ActionListener<Boolean> listener) {
+        if (llmId == null) {
+            listener.onResponse(true);
+            return;
+        }
+
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<MLModel> wrappedListener = ActionListener.runBefore(ActionListener.wrap(llmModel -> {
+                if (llmModel.getAlgorithm() != FunctionName.REMOTE) {
+                    listener.onFailure(new IllegalArgumentException(String.format(LLM_MODEL_NOT_REMOTE_ERROR, llmModel.getAlgorithm())));
+                    return;
+                }
+                listener.onResponse(true);
+            }, e -> {
+                log.error("Failed to get LLM model: {}", llmId, e);
+                listener.onFailure(new IllegalArgumentException(String.format(LLM_MODEL_NOT_FOUND_ERROR, llmId)));
+            }), context::restore);
+
+            modelManager.getModel(llmId, wrappedListener);
+        }
+    }
+
+    /**
+     * Validates that the embedding model exists and its type matches the expected type.
+     *
+     * @param embeddingModelId  The embedding model ID to validate
+     * @param expectedType      The expected FunctionName type (TEXT_EMBEDDING or SPARSE_ENCODING)
+     * @param modelManager      The ML model manager
+     * @param client            The OpenSearch client
+     * @param listener          Action listener that receives true on success, or error on failure
+     */
+    public static void validateEmbeddingModel(
+        String embeddingModelId,
+        FunctionName expectedType,
+        MLModelManager modelManager,
+        Client client,
+        ActionListener<Boolean> listener
+    ) {
+        if (embeddingModelId == null) {
+            listener.onResponse(true);
+            return;
+        }
+
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<MLModel> wrappedListener = ActionListener.runBefore(ActionListener.wrap(embeddingModel -> {
+                FunctionName modelAlgorithm = embeddingModel.getAlgorithm();
+
+                // Model must be either the expected type or REMOTE
+                if (modelAlgorithm != expectedType && modelAlgorithm != FunctionName.REMOTE) {
+                    listener
+                        .onFailure(
+                            new IllegalArgumentException(String.format(EMBEDDING_MODEL_TYPE_MISMATCH_ERROR, expectedType, modelAlgorithm))
+                        );
+                    return;
+                }
+
+                listener.onResponse(true);
+            }, e -> {
+                log.error("Failed to get embedding model: {}", embeddingModelId, e);
+                listener.onFailure(new IllegalArgumentException(String.format(EMBEDDING_MODEL_NOT_FOUND_ERROR, embeddingModelId)));
+            }), context::restore);
+
+            modelManager.getModel(embeddingModelId, wrappedListener);
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerPipelineHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerPipelineHelper.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.helper;
+
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_EMBEDDING_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_FIELD;
+
+import java.io.IOException;
+
+import org.opensearch.action.ingest.GetPipelineRequest;
+import org.opensearch.action.ingest.PutPipelineRequest;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
+import org.opensearch.ml.engine.indices.MLIndicesHandler;
+import org.opensearch.transport.client.Client;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Helper class for creating and managing ingest pipelines for memory containers.
+ * Provides reusable pipeline creation logic for long-term memory indices.
+ */
+@Log4j2
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MemoryContainerPipelineHelper {
+
+    /**
+     * Creates an ingest pipeline and long-term memory index.
+     * <p>
+     * If embedding is configured, creates a text embedding pipeline first,
+     * then creates the long-term index with the pipeline attached.
+     * If no embedding is configured, creates the index without a pipeline.
+     *
+     * @param indexName       The long-term memory index name
+     * @param config          The memory configuration
+     * @param indicesHandler  The ML indices handler
+     * @param client          The OpenSearch client
+     * @param listener        Action listener that receives true on success, or error on failure
+     */
+    public static void createLongTermMemoryIngestPipeline(
+        String indexName,
+        MemoryConfiguration config,
+        MLIndicesHandler indicesHandler,
+        Client client,
+        ActionListener<Boolean> listener
+    ) {
+        try {
+            if (config.getEmbeddingModelType() != null) {
+                String pipelineName = indexName + "-embedding";
+
+                createTextEmbeddingPipeline(pipelineName, config, client, ActionListener.wrap(success -> {
+                    log.info("Successfully created text embedding pipeline: {}", pipelineName);
+                    indicesHandler.createLongTermMemoryIndex(pipelineName, indexName, config, listener);
+                }, e -> {
+                    log.error("Failed to create text embedding pipeline '{}'", pipelineName, e);
+                    listener.onFailure(e);
+                }));
+            } else {
+                indicesHandler.createLongTermMemoryIndex(null, indexName, config, listener);
+            }
+        } catch (Exception e) {
+            log.error("Failed to create long-term memory infrastructure for index: {}", indexName, e);
+            listener.onFailure(e);
+        }
+    }
+
+    /**
+     * Creates a text embedding pipeline for memory container.
+     * <p>
+     * Checks if the pipeline already exists (shared index scenario) and skips creation if it does.
+     * Otherwise, creates a new pipeline with the appropriate embedding processor.
+     *
+     * @param pipelineName  The pipeline name
+     * @param config        The memory configuration
+     * @param client        The OpenSearch client
+     * @param listener      Action listener that receives true on success, or error on failure
+     */
+    public static void createTextEmbeddingPipeline(
+        String pipelineName,
+        MemoryConfiguration config,
+        Client client,
+        ActionListener<Boolean> listener
+    ) {
+        // Check if pipeline already exists (shared index scenario)
+        client.admin().cluster().getPipeline(new GetPipelineRequest(pipelineName), ActionListener.wrap(response -> {
+            if (!response.pipelines().isEmpty()) {
+                // Pipeline exists - skip creation
+                log.info("Pipeline '{}' already exists (shared index scenario), skipping creation", pipelineName);
+                listener.onResponse(true);
+                return;
+            }
+
+            // Pipeline doesn't exist - create it
+            try {
+                createPipelineInternal(pipelineName, config, client, listener);
+            } catch (IOException e) {
+                log.error("Failed to build pipeline configuration for '{}'", pipelineName, e);
+                listener.onFailure(e);
+            }
+        }, error -> {
+            // Pipeline doesn't exist (404 error expected) - create it
+            try {
+                createPipelineInternal(pipelineName, config, client, listener);
+            } catch (IOException e) {
+                log.error("Failed to build pipeline configuration for '{}'", pipelineName, e);
+                listener.onFailure(e);
+            }
+        }));
+    }
+
+    /**
+     * Actually creates the ingest pipeline with embedding processor.
+     *
+     * @param pipelineName  The pipeline name
+     * @param config        The memory configuration
+     * @param client        The OpenSearch client
+     * @param listener      Action listener that receives true on success, or error on failure
+     * @throws IOException if XContentBuilder fails
+     */
+    private static void createPipelineInternal(
+        String pipelineName,
+        MemoryConfiguration config,
+        Client client,
+        ActionListener<Boolean> listener
+    ) throws IOException {
+        String processorName = config.getEmbeddingModelType() == FunctionName.TEXT_EMBEDDING ? "text_embedding" : "sparse_encoding";
+
+        XContentBuilder builder = XContentFactory
+            .jsonBuilder()
+            .startObject()
+            .field("description", "Agentic Memory Text embedding pipeline")
+            .startArray("processors")
+            .startObject()
+            .startObject(processorName)
+            .field("model_id", config.getEmbeddingModelId())
+            .startObject("field_map")
+            .field(MEMORY_FIELD, MEMORY_EMBEDDING_FIELD)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject();
+
+        PutPipelineRequest putRequest = new PutPipelineRequest(pipelineName, BytesReference.bytes(builder), XContentType.JSON);
+
+        client.admin().cluster().putPipeline(putRequest, ActionListener.wrap(response -> {
+            if (response.isAcknowledged()) {
+                log.info("Successfully created pipeline: {}", pipelineName);
+                listener.onResponse(true);
+            } else {
+                log.error("Pipeline creation not acknowledged: {}", pipelineName);
+                listener.onFailure(new IllegalStateException("Pipeline creation not acknowledged"));
+            }
+        }, e -> {
+            log.error("Failed to create pipeline '{}'", pipelineName, e);
+            listener.onFailure(e);
+        }));
+    }
+
+    /**
+     * Creates history index only if it's enabled in the configuration.
+     * <p>
+     * Checks the disableHistory flag and creates the history index if it's not disabled.
+     *
+     * @param config             The memory configuration
+     * @param historyIndexName   The history index name
+     * @param indicesHandler     The ML indices handler
+     * @param listener           Action listener that receives true on success, or error on failure
+     */
+    public static void createHistoryIndexIfEnabled(
+        MemoryConfiguration config,
+        String historyIndexName,
+        MLIndicesHandler indicesHandler,
+        ActionListener<Boolean> listener
+    ) {
+        if (!config.isDisableHistory()) {
+            log.debug("Creating history index: {}", historyIndexName);
+            indicesHandler.createLongTermMemoryHistoryIndex(historyIndexName, config, listener);
+        } else {
+            log.debug("History index disabled, skipping creation");
+            listener.onResponse(true);
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerSharedIndexValidator.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerSharedIndexValidator.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.helper;
+
+import java.util.Map;
+
+import org.opensearch.action.admin.indices.mapping.get.GetMappingsRequest;
+import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
+import org.opensearch.action.ingest.GetPipelineRequest;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
+import org.opensearch.transport.client.Client;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Helper class for validating shared index compatibility in memory containers.
+ * Multiple containers can share the same long-term memory index (via same index_prefix).
+ * This validator ensures that the embedding configuration is compatible across all containers
+ * sharing an index.
+ */
+@Log4j2
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MemoryContainerSharedIndexValidator {
+
+    /**
+     * Result of shared index validation.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ValidationResult {
+        /** Whether the long-term index already exists */
+        private final boolean indexExists;
+
+        /** Whether the requested configuration is compatible with existing index */
+        private final boolean compatible;
+
+        /** Model ID extracted from existing pipeline (null if index doesn't exist) */
+        private final String existingModelId;
+
+        /** Embedding configuration extracted from existing mapping (null if index doesn't exist) */
+        private final MemoryConfiguration.EmbeddingConfig existingConfig;
+    }
+
+    /**
+     * Validates that the requested embedding configuration is compatible with an existing shared index.
+     * <p>
+     * This method performs the following validation chain:
+     * 1. Check if long-term index exists (getMappings)
+     * 2. If exists: extract embedding config from mapping
+     * 3. If exists: retrieve and validate ingest pipeline
+     * 4. If exists: extract model_id from pipeline
+     * 5. Compare requested config with existing config
+     * <p>
+     * If the index doesn't exist, validation passes (safe to create).
+     * If the index exists but configs don't match, validation fails.
+     *
+     * @param requestedConfig    The memory configuration being requested
+     * @param longTermIndexName  The long-term memory index name
+     * @param client             The OpenSearch client
+     * @param listener           Action listener that receives ValidationResult on success, or error on failure
+     */
+    public static void validateSharedIndexCompatibility(
+        MemoryConfiguration requestedConfig,
+        String longTermIndexName,
+        Client client,
+        ActionListener<ValidationResult> listener
+    ) {
+        // Skip validation if no strategies (no long-term index will be created)
+        if (requestedConfig.getStrategies() == null || requestedConfig.getStrategies().isEmpty()) {
+            listener.onResponse(ValidationResult.builder().indexExists(false).compatible(true).build());
+            return;
+        }
+
+        log.debug("Validating shared index compatibility for: {}", longTermIndexName);
+
+        // Step 1: Check if index exists
+        client.admin().indices().getMappings(new GetMappingsRequest().indices(longTermIndexName), ActionListener.wrap(mappingResponse -> {
+            // Index exists - proceed with validation
+            validateExistingIndex(requestedConfig, longTermIndexName, mappingResponse, client, listener);
+        }, error -> {
+            // Handle errors during mapping retrieval
+            handleMappingError(longTermIndexName, error, listener);
+        }));
+    }
+
+    /**
+     * Validates the existing index by extracting and comparing embedding configuration.
+     */
+    private static void validateExistingIndex(
+        MemoryConfiguration requestedConfig,
+        String longTermIndexName,
+        GetMappingsResponse mappingResponse,
+        Client client,
+        ActionListener<ValidationResult> listener
+    ) {
+        // Step 2: Extract mapping metadata
+        MappingMetadata metadata = mappingResponse.getMappings().get(longTermIndexName);
+        if (metadata == null) {
+            log.error("Index '{}' exists but mapping metadata is null", longTermIndexName);
+            listener
+                .onFailure(
+                    new IllegalStateException(
+                        "Cannot validate memory container: Index '"
+                            + longTermIndexName
+                            + "' exists but mapping is unavailable. "
+                            + "This indicates a system issue. Please contact your administrator."
+                    )
+                );
+            return;
+        }
+
+        // Step 3: Extract embedding configuration from mapping
+        Map<String, Object> mappingMap = metadata.getSourceAsMap();
+        Map<String, Object> properties = MemoryConfiguration.asMap(mappingMap.get("properties"));
+
+        if (properties == null) {
+            log.error("Index '{}' mapping 'properties' field is null or not a Map", longTermIndexName);
+            listener
+                .onFailure(
+                    new IllegalStateException(
+                        "Cannot validate memory container: Index '"
+                            + longTermIndexName
+                            + "' has malformed mapping structure (properties field is missing or invalid)."
+                    )
+                );
+            return;
+        }
+
+        MemoryConfiguration.EmbeddingConfig existingConfig = MemoryConfiguration.extractEmbeddingConfigFromMapping(properties);
+
+        if (existingConfig == null) {
+            log
+                .error(
+                    "Index '{}' exists but has no embedding field in mapping. "
+                        + "This indicates a malformed or incompatible index structure.",
+                    longTermIndexName
+                );
+            listener
+                .onFailure(
+                    new IllegalArgumentException(
+                        "Cannot create memory container: Index '"
+                            + longTermIndexName
+                            + "' already exists "
+                            + "but the mapping is malformed or missing embedding configuration. "
+                            + "This index may have been created by another process or is corrupted. "
+                            + "Please use a different index_prefix to create your memory container."
+                    )
+                );
+            return;
+        }
+
+        // Step 4: Validate pipeline configuration
+        validatePipeline(requestedConfig, longTermIndexName, existingConfig, client, listener);
+    }
+
+    /**
+     * Validates the ingest pipeline configuration.
+     */
+    private static void validatePipeline(
+        MemoryConfiguration requestedConfig,
+        String longTermIndexName,
+        MemoryConfiguration.EmbeddingConfig existingConfig,
+        Client client,
+        ActionListener<ValidationResult> listener
+    ) {
+        String pipelineName = longTermIndexName + "-embedding";
+
+        client.admin().cluster().getPipeline(new GetPipelineRequest(pipelineName), ActionListener.wrap(pipelineResponse -> {
+            // Step 5: Extract model_id from pipeline
+            if (pipelineResponse.pipelines().isEmpty()) {
+                log
+                    .error(
+                        "Index '{}' exists but pipeline '{}' not found. " + "Index and pipeline are out of sync.",
+                        longTermIndexName,
+                        pipelineName
+                    );
+                listener
+                    .onFailure(
+                        new IllegalArgumentException(
+                            "Cannot create memory container: Index '"
+                                + longTermIndexName
+                                + "' exists "
+                                + "but the required ingest pipeline '"
+                                + pipelineName
+                                + "' is missing. "
+                                + "This indicates an incomplete or corrupted setup. "
+                                + "Please use a different index_prefix to create your memory container."
+                        )
+                    );
+                return;
+            }
+
+            Map<String, Object> pipelineSource = pipelineResponse.pipelines().get(0).getConfigAsMap();
+            String existingModelId = MemoryConfiguration.extractModelIdFromPipeline(pipelineSource);
+
+            if (existingModelId == null) {
+                log
+                    .error(
+                        "Pipeline '{}' exists but has no model_id configured. " + "Pipeline definition: {}",
+                        pipelineName,
+                        pipelineSource
+                    );
+                listener
+                    .onFailure(
+                        new IllegalArgumentException(
+                            "Cannot create memory container: Ingest pipeline '"
+                                + pipelineName
+                                + "' exists "
+                                + "but is not configured correctly (missing model_id in processor). "
+                                + "This indicates a malformed pipeline configuration. "
+                                + "Please use a different index_prefix to create your memory container."
+                        )
+                    );
+                return;
+            }
+
+            // Step 6: Compare configurations
+            compareConfigurations(requestedConfig, longTermIndexName, existingModelId, existingConfig, listener);
+        }, error -> { handlePipelineError(pipelineName, error, listener); }));
+    }
+
+    /**
+     * Compares requested configuration with existing configuration.
+     */
+    private static void compareConfigurations(
+        MemoryConfiguration requestedConfig,
+        String longTermIndexName,
+        String existingModelId,
+        MemoryConfiguration.EmbeddingConfig existingConfig,
+        ActionListener<ValidationResult> listener
+    ) {
+        try {
+            MemoryConfiguration.compareEmbeddingConfig(requestedConfig, existingModelId, existingConfig);
+
+            log
+                .info(
+                    "Validated compatibility with existing shared index '{}' (model: {}, type: {}, dimension: {})",
+                    longTermIndexName,
+                    existingModelId,
+                    existingConfig.getType(),
+                    existingConfig.getDimension()
+                );
+
+            listener
+                .onResponse(
+                    ValidationResult
+                        .builder()
+                        .indexExists(true)
+                        .compatible(true)
+                        .existingModelId(existingModelId)
+                        .existingConfig(existingConfig)
+                        .build()
+                );
+        } catch (IllegalArgumentException e) {
+            log
+                .error(
+                    "Container creation failed: embedding configuration mismatch. "
+                        + "Index: {}, Existing: [{}, {}, {}], Requested: [{}, {}, {}]. Error: {}",
+                    longTermIndexName,
+                    existingModelId,
+                    existingConfig.getType(),
+                    existingConfig.getDimension(),
+                    requestedConfig.getEmbeddingModelId(),
+                    requestedConfig.getEmbeddingModelType(),
+                    requestedConfig.getDimension(),
+                    e.getMessage()
+                );
+
+            listener.onFailure(e);
+        }
+    }
+
+    /**
+     * Handles errors during mapping retrieval.
+     */
+    private static void handleMappingError(String indexName, Exception error, ActionListener<ValidationResult> listener) {
+        // Index doesn't exist - safe to create
+        if (error instanceof IndexNotFoundException) {
+            log.debug("Long-term memory index '{}' does not exist, proceeding with creation", indexName);
+            listener.onResponse(ValidationResult.builder().indexExists(false).compatible(true).build());
+            return;
+        }
+
+        // Real error - log and fail
+        log
+            .error(
+                "Failed to retrieve mapping for index '{}'. Exception type: {}, Message: {}",
+                indexName,
+                error.getClass().getSimpleName(),
+                error.getMessage(),
+                error
+            );
+
+        listener
+            .onFailure(
+                new IllegalStateException(
+                    "Cannot validate memory container: Failed to retrieve index mapping for '"
+                        + indexName
+                        + "'. Error: "
+                        + error.getMessage()
+                )
+            );
+    }
+
+    /**
+     * Handles errors during pipeline retrieval.
+     */
+    private static void handlePipelineError(String pipelineName, Exception error, ActionListener<ValidationResult> listener) {
+        log.error("Failed to retrieve pipeline '{}' for validation: {}", pipelineName, error.getMessage(), error);
+
+        listener
+            .onFailure(
+                new IllegalStateException(
+                    "Cannot validate memory container: Failed to retrieve ingest pipeline '"
+                        + pipelineName
+                        + "' for validation. Error: "
+                        + error.getMessage()
+                )
+            );
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerActionTests.java
@@ -10,13 +10,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -39,6 +42,7 @@ import org.opensearch.ml.common.memorycontainer.MemoryStrategyType;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerInput;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerRequest;
+import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.helper.MemoryContainerHelper;
 import org.opensearch.ml.model.MLModelManager;
@@ -75,6 +79,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
     private MemoryContainerHelper memoryContainerHelper;
 
     @Mock
+    private MLIndicesHandler mlIndicesHandler;
+
+    @Mock
     private TransportService transportService;
 
     @Mock
@@ -105,7 +112,8 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
             connectorAccessControlHelper,
             mlFeatureEnabledSetting,
             mlModelManager,
-            memoryContainerHelper
+            memoryContainerHelper,
+            mlIndicesHandler
         );
     }
 
@@ -338,13 +346,17 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
             .builder()
             .indexPrefix("test")
             .llmId("llm-123")
+            .embeddingModelId("embedding-model-123")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
             .strategies(existingStrategies)
             .build();
 
         // Create update strategy (disable existing)
         MemoryStrategy updateStrategy = MemoryStrategy.builder().id("semantic_123").enabled(false).build();
+        MemoryConfiguration updateConfig = MemoryConfiguration.builder().strategies(Arrays.asList(updateStrategy)).build();
 
-        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().strategies(Arrays.asList(updateStrategy)).build();
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
 
         MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
             .builder()
@@ -419,6 +431,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
             .builder()
             .indexPrefix("test")
             .llmId("llm-123")
+            .embeddingModelId("embedding-model-123")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
             .strategies(existingStrategies)
             .build();
 
@@ -428,8 +443,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
             .namespace(Arrays.asList("session_id"))
             .strategyConfig(new HashMap<>())
             .build();
+        MemoryConfiguration updateConfig = MemoryConfiguration.builder().strategies(Arrays.asList(newStrategy)).build();
 
-        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().strategies(Arrays.asList(newStrategy)).build();
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
 
         MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
             .builder()
@@ -501,13 +517,17 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
             .builder()
             .indexPrefix("test")
             .llmId("llm-123")
+            .embeddingModelId("embedding-model-123")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
             .strategies(existingStrategies)
             .build();
 
         // Try to update non-existent strategy
         MemoryStrategy updateStrategy = MemoryStrategy.builder().id("nonexistent_999").enabled(false).build();
+        MemoryConfiguration updateConfig = MemoryConfiguration.builder().strategies(Arrays.asList(updateStrategy)).build();
 
-        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().strategies(Arrays.asList(updateStrategy)).build();
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
 
         MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
             .builder()
@@ -569,6 +589,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
             .builder()
             .indexPrefix("test")
             .llmId("llm-123")
+            .embeddingModelId("embedding-model-123")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
             .strategies(existingStrategies)
             .build();
 
@@ -579,8 +602,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
             .type(MemoryStrategyType.USER_PREFERENCE)  // Try to change type
             .enabled(false)
             .build();
+        MemoryConfiguration updateConfig = MemoryConfiguration.builder().strategies(Arrays.asList(updateStrategy)).build();
 
-        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().strategies(Arrays.asList(updateStrategy)).build();
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
 
         MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
             .builder()
@@ -642,6 +666,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
             .builder()
             .indexPrefix("test")
             .llmId("llm-123")
+            .embeddingModelId("embedding-model-123")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
             .strategies(existingStrategies)
             .build();
 
@@ -651,8 +678,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
             .id("semantic_123")
             .namespace(Arrays.asList("user_id", "session_id"))
             .build();
+        MemoryConfiguration updateConfig = MemoryConfiguration.builder().strategies(Arrays.asList(updateStrategy)).build();
 
-        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().strategies(Arrays.asList(updateStrategy)).build();
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
 
         MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
             .builder()
@@ -719,7 +747,10 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
             .strategies(new ArrayList<>())
             .build();
 
-        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().llmId(newLlmId).build();
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput
+            .builder()
+            .configuration(MemoryConfiguration.builder().llmId(newLlmId).build())
+            .build();
 
         MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
             .builder()
@@ -806,8 +837,7 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
 
         MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput
             .builder()
-            .llmId(newLlmId)
-            .strategies(Arrays.asList(updateStrategy))
+            .configuration(MemoryConfiguration.builder().llmId(newLlmId).strategies(Arrays.asList(updateStrategy)).build())
             .build();
 
         MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
@@ -880,7 +910,7 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
             .builder()
             .name(newName)
             .description(newDescription)
-            .llmId(newLlmId)
+            .configuration(MemoryConfiguration.builder().llmId(newLlmId).build())
             .build();
 
         MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
@@ -932,4 +962,1319 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
 
         verify(listener).onResponse(updateResponse);
     }
+
+    public void testUpdateContainer_AddStrategyWithoutModels_ShouldFail() {
+        // Test adding strategy to container without llm/embedding fails
+        String containerId = "test-container-id";
+
+        // Container with no strategies, no models
+        MemoryConfiguration currentConfig = MemoryConfiguration.builder().indexPrefix("test").build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        // Try to add strategy without providing models
+        MemoryStrategy newStrategy = MemoryStrategy.builder().type(MemoryStrategyType.SEMANTIC).namespace(Arrays.asList("user_id")).build();
+        MemoryConfiguration updateConfig = MemoryConfiguration.builder().strategies(Arrays.asList(newStrategy)).build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        action.doExecute(task, request, listener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof IllegalArgumentException);
+        assertTrue(captor.getValue().getMessage().contains("Strategies require both an LLM model and embedding model"));
+    }
+
+    public void testUpdateContainer_AddStrategyWithOnlyLlm_ShouldFail() {
+        // Test adding strategy when container has LLM but no embedding fails
+        String containerId = "test-container-id";
+
+        // Container with LLM but no embedding
+        MemoryConfiguration currentConfig = MemoryConfiguration.builder().indexPrefix("test").llmId("llm-123").build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        // Try to add strategy
+        MemoryStrategy newStrategy = MemoryStrategy.builder().type(MemoryStrategyType.SEMANTIC).namespace(Arrays.asList("user_id")).build();
+        MemoryConfiguration updateConfig = MemoryConfiguration.builder().strategies(Arrays.asList(newStrategy)).build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        action.doExecute(task, request, listener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof IllegalArgumentException);
+        assertTrue(captor.getValue().getMessage().contains("Missing: embedding model"));
+    }
+
+    public void testUpdateContainer_ChangeEmbeddingModel_ShouldFail() {
+        // Test that changing an existing embedding model fails when container has strategies
+        String containerId = "test-container-id";
+
+        // Container with strategies and existing embedding
+        List<MemoryStrategy> strategies = Arrays
+            .asList(MemoryStrategy.builder().id("strat-1").type(MemoryStrategyType.SEMANTIC).namespace(Arrays.asList("user_id")).build());
+
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("test")
+            .llmId("llm-123")
+            .embeddingModelId("old-embedding-123")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .strategies(strategies)
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        // Try to change embedding model
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .embeddingModelId("new-embedding-456")
+            .embeddingModelType(FunctionName.SPARSE_ENCODING)
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        action.doExecute(task, request, listener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof IllegalArgumentException);
+        assertTrue(captor.getValue().getMessage().contains("Cannot change embedding configuration once strategies are configured"));
+    }
+
+    public void testUpdateContainer_SameEmbeddingValues_ShouldSucceed() {
+        // Test that updating with same embedding values is allowed (idempotent) even when strategies exist
+        String containerId = "test-container-id";
+
+        // Container with strategies and existing embedding
+        List<MemoryStrategy> strategies = Arrays
+            .asList(MemoryStrategy.builder().id("strat-1").type(MemoryStrategyType.SEMANTIC).namespace(Arrays.asList("user_id")).build());
+
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("test")
+            .llmId("llm-123")
+            .embeddingModelId("embedding-123")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .strategies(strategies)
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        // Update with same embedding values
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .embeddingModelId("embedding-123")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        UpdateResponse updateResponse = new UpdateResponse(
+            new ShardId(new Index("test", "uuid"), 0),
+            containerId,
+            1L,
+            1L,
+            1L,
+            org.opensearch.action.DocWriteResponse.Result.UPDATED
+        );
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateListener = invocation.getArgument(1);
+            updateListener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        action.doExecute(task, request, listener);
+
+        verify(listener).onResponse(updateResponse);
+    }
+
+    public void testUpdateContainer_NoStrategies_AddEmbedding_ShouldSucceed() {
+        // Test that adding embedding config to a container with no strategies succeeds
+        String containerId = "test-container-id";
+
+        // Container with NO strategies and no embedding
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("test")
+            .llmId("llm-123")
+            .strategies(new ArrayList<>()) // Empty strategies = no long-term index
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        // Add embedding config
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .embeddingModelId("embedding-123")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        UpdateResponse updateResponse = new UpdateResponse(
+            new ShardId(new Index("test", "uuid"), 0),
+            containerId,
+            1L,
+            1L,
+            1L,
+            org.opensearch.action.DocWriteResponse.Result.UPDATED
+        );
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateListener = invocation.getArgument(1);
+            updateListener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        action.doExecute(task, request, listener);
+
+        // Should succeed - no strategies means no long-term index, so embedding can be added
+        verify(listener).onResponse(updateResponse);
+    }
+
+    public void testUpdateContainer_NoStrategies_ChangeEmbedding_ShouldSucceed() {
+        // Test that changing embedding config on a container with no strategies succeeds
+        String containerId = "test-container-id";
+
+        // Container with NO strategies but has existing embedding
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("test")
+            .llmId("llm-123")
+            .embeddingModelId("old-embedding-123")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .strategies(new ArrayList<>()) // Empty strategies = no long-term index
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        // Change embedding config to different values
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .embeddingModelId("new-embedding-456")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(768)
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        UpdateResponse updateResponse = new UpdateResponse(
+            new ShardId(new Index("test", "uuid"), 0),
+            containerId,
+            1L,
+            1L,
+            1L,
+            org.opensearch.action.DocWriteResponse.Result.UPDATED
+        );
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateListener = invocation.getArgument(1);
+            updateListener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        action.doExecute(task, request, listener);
+
+        // Should succeed - no strategies means no long-term index, so embedding can be changed
+        verify(listener).onResponse(updateResponse);
+    }
+
+    public void testUpdateContainer_TransitionToStrategies_SharedIndexExists_Success() {
+        // Test transition with shared index that exists and is compatible - covers createHistoryIndexOnly
+        String containerId = "test-container-id";
+        String llmId = "llm-model-100";
+        String embeddingModelId = "embedding-model-200";
+
+        // Container with NO strategies initially
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("shared-prefix")
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .strategies(new ArrayList<>())
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        // Update that ADDS strategies (triggers transition)
+        MemoryStrategy newStrategy = MemoryStrategy
+            .builder()
+            .type(MemoryStrategyType.SEMANTIC)
+            .namespace(Arrays.asList("user_id"))
+            .strategyConfig(new HashMap<>())
+            .build();
+
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .strategies(Arrays.asList(newStrategy))
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        // Mock container retrieval
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        // Mock LLM model validation
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.ml.common.MLModel> modelListener = invocation.getArgument(1);
+            org.opensearch.ml.common.MLModel llmModel = org.opensearch.ml.common.MLModel
+                .builder()
+                .modelId(llmId)
+                .algorithm(FunctionName.REMOTE)
+                .name("test-llm")
+                .build();
+            modelListener.onResponse(llmModel);
+            return null;
+        }).when(mlModelManager).getModel(eq(llmId), any());
+
+        // Mock embedding model validation
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.ml.common.MLModel> modelListener = invocation.getArgument(1);
+            org.opensearch.ml.common.MLModel embeddingModel = org.opensearch.ml.common.MLModel
+                .builder()
+                .modelId(embeddingModelId)
+                .algorithm(FunctionName.TEXT_EMBEDDING)
+                .name("test-embedding")
+                .build();
+            modelListener.onResponse(embeddingModel);
+            return null;
+        }).when(mlModelManager).getModel(eq(embeddingModelId), any());
+
+        // Mock admin clients
+        org.opensearch.transport.client.IndicesAdminClient indicesAdmin = mock(org.opensearch.transport.client.IndicesAdminClient.class);
+        org.opensearch.transport.client.ClusterAdminClient clusterAdmin = mock(org.opensearch.transport.client.ClusterAdminClient.class);
+        org.opensearch.transport.client.AdminClient adminClient = mock(org.opensearch.transport.client.AdminClient.class);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdmin);
+        when(adminClient.cluster()).thenReturn(clusterAdmin);
+
+        // Mock getMappings - index exists with compatible configuration
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse> mappingListener = invocation.getArgument(1);
+            org.opensearch.cluster.metadata.MappingMetadata mappingMetadata = mock(org.opensearch.cluster.metadata.MappingMetadata.class);
+            Map<String, Object> properties = new HashMap<>();
+            Map<String, Object> memoryEmbeddingField = new HashMap<>();
+            memoryEmbeddingField.put("type", "knn_vector");
+            memoryEmbeddingField.put("dimension", 384);
+            properties.put("memory_embedding", memoryEmbeddingField);
+            when(mappingMetadata.getSourceAsMap()).thenReturn(Map.of("properties", properties));
+
+            org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse mappingResponse = mock(
+                org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse.class
+            );
+            when(mappingResponse.getMappings()).thenReturn(Map.of(".plugins-ml-am-shared-prefix-memory-long-term", mappingMetadata));
+            mappingListener.onResponse(mappingResponse);
+            return null;
+        }).when(indicesAdmin).getMappings(any(), any());
+
+        // Mock getPipeline - create REAL PipelineConfiguration instead of mocking (it's final)
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.ingest.GetPipelineResponse> pipelineListener = invocation.getArgument(1);
+
+            // Create real PipelineConfiguration with correct JSON
+            String pipelineJson = "{\"processors\":[{\"text_embedding\":{\"model_id\":\"" + embeddingModelId + "\",\"field_map\":{}}}]}";
+            org.opensearch.ingest.PipelineConfiguration realPipelineConfig = new org.opensearch.ingest.PipelineConfiguration(
+                ".plugins-ml-am-shared-prefix-memory-long-term-embedding",
+                new org.opensearch.core.common.bytes.BytesArray(pipelineJson),
+                org.opensearch.common.xcontent.XContentType.JSON
+            );
+
+            org.opensearch.action.ingest.GetPipelineResponse pipelineResponse = mock(
+                org.opensearch.action.ingest.GetPipelineResponse.class
+            );
+            when(pipelineResponse.pipelines()).thenReturn(Arrays.asList(realPipelineConfig));
+            pipelineListener.onResponse(pipelineResponse);
+            return null;
+        }).when(clusterAdmin).getPipeline(any(), any());
+
+        // Mock history index creation - SUCCESS
+        doAnswer(invocation -> {
+            ActionListener<Boolean> historyListener = invocation.getArgument(2);
+            historyListener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).createLongTermMemoryHistoryIndex(any(), any(), any());
+
+        // Mock final update
+        UpdateResponse updateResponse = new UpdateResponse(
+            new ShardId(new Index("test", "uuid"), 0),
+            containerId,
+            1L,
+            1L,
+            1L,
+            org.opensearch.action.DocWriteResponse.Result.UPDATED
+        );
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateListener = invocation.getArgument(1);
+            updateListener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        action.doExecute(task, request, listener);
+
+        // Verify success - createHistoryIndexOnly executed successfully
+        verify(listener).onResponse(updateResponse);
+        verify(mlIndicesHandler).createLongTermMemoryHistoryIndex(any(), any(), any());
+        verify(mlIndicesHandler, never()).createLongTermMemoryIndex(any(), any(), any(), any());
+    }
+
+    public void testUpdateContainer_TransitionToStrategies_NewIndices_Success() {
+        // Test transition with new indices creation - covers createLongTermAndHistoryIndices success callbacks
+        String containerId = "test-container-id";
+        String llmId = "llm-model-300";
+        String embeddingModelId = "embedding-model-400";
+
+        // Container with NO strategies initially
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("new-index")
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(512)
+            .strategies(new ArrayList<>())
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        // Update that ADDS strategies
+        MemoryStrategy newStrategy = MemoryStrategy
+            .builder()
+            .type(MemoryStrategyType.SEMANTIC)
+            .namespace(Arrays.asList("session_id"))
+            .strategyConfig(new HashMap<>())
+            .build();
+
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(512)
+            .strategies(Arrays.asList(newStrategy))
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        // Mock container retrieval
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        // Mock model validations
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.ml.common.MLModel> modelListener = invocation.getArgument(1);
+            String modelId = invocation.getArgument(0);
+            org.opensearch.ml.common.MLModel model = org.opensearch.ml.common.MLModel
+                .builder()
+                .modelId(modelId)
+                .algorithm(modelId.equals(llmId) ? FunctionName.REMOTE : FunctionName.TEXT_EMBEDDING)
+                .name("test-model")
+                .build();
+            modelListener.onResponse(model);
+            return null;
+        }).when(mlModelManager).getModel(any(String.class), any());
+
+        // Mock admin clients
+        org.opensearch.transport.client.IndicesAdminClient indicesAdmin = mock(org.opensearch.transport.client.IndicesAdminClient.class);
+        org.opensearch.transport.client.ClusterAdminClient clusterAdmin = mock(org.opensearch.transport.client.ClusterAdminClient.class);
+        org.opensearch.transport.client.AdminClient adminClient = mock(org.opensearch.transport.client.AdminClient.class);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdmin);
+        when(adminClient.cluster()).thenReturn(clusterAdmin);
+
+        // Mock getMappings - index does NOT exist
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse> mappingListener = invocation.getArgument(1);
+            mappingListener.onFailure(new org.opensearch.index.IndexNotFoundException(".plugins-ml-am-new-index-memory-long-term"));
+            return null;
+        }).when(indicesAdmin).getMappings(any(), any());
+
+        // Mock getPipeline - pipeline doesn't exist yet (for createLongTermMemoryIngestPipeline)
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.ingest.GetPipelineResponse> pipelineListener = invocation.getArgument(1);
+            org.opensearch.action.ingest.GetPipelineResponse pipelineResponse = mock(
+                org.opensearch.action.ingest.GetPipelineResponse.class
+            );
+            when(pipelineResponse.pipelines()).thenReturn(Collections.emptyList());
+            pipelineListener.onResponse(pipelineResponse);
+            return null;
+        }).when(clusterAdmin).getPipeline(any(org.opensearch.action.ingest.GetPipelineRequest.class), any());
+
+        // Mock putPipeline - SUCCESS (create real AcknowledgedResponse)
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.support.clustermanager.AcknowledgedResponse> putListener = invocation.getArgument(1);
+            org.opensearch.action.support.clustermanager.AcknowledgedResponse response =
+                new org.opensearch.action.support.clustermanager.AcknowledgedResponse(true);
+            putListener.onResponse(response);
+            return null;
+        }).when(clusterAdmin).putPipeline(any(org.opensearch.action.ingest.PutPipelineRequest.class), any());
+
+        // Mock long-term index creation - SUCCESS
+        doAnswer(invocation -> {
+            ActionListener<Boolean> longTermListener = invocation.getArgument(3);
+            longTermListener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).createLongTermMemoryIndex(any(), any(), any(), any());
+
+        // Mock history index creation - SUCCESS
+        doAnswer(invocation -> {
+            ActionListener<Boolean> historyListener = invocation.getArgument(2);
+            historyListener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).createLongTermMemoryHistoryIndex(any(), any(), any());
+
+        // Mock final update - SUCCESS
+        UpdateResponse updateResponse = new UpdateResponse(
+            new ShardId(new Index("test", "uuid"), 0),
+            containerId,
+            1L,
+            1L,
+            1L,
+            org.opensearch.action.DocWriteResponse.Result.UPDATED
+        );
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateListener = invocation.getArgument(1);
+            updateListener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        action.doExecute(task, request, listener);
+
+        // Verify success - createLongTermAndHistoryIndices executed successfully with all callbacks
+        verify(listener).onResponse(updateResponse);
+        verify(mlIndicesHandler).createLongTermMemoryIndex(any(), any(), any(), any());
+        verify(mlIndicesHandler).createLongTermMemoryHistoryIndex(any(), any(), any());
+    }
+
+    public void testUpdateContainer_TransitionToStrategies_NewIndices_HistoryDisabled_Success() {
+        // Test transition with new indices but history disabled - covers disableHistory branch in createLongTermAndHistoryIndices
+        String containerId = "test-container-id";
+        String llmId = "llm-model-500";
+        String embeddingModelId = "embedding-model-600";
+
+        // Container with NO strategies and history DISABLED
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("no-hist")
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(256)
+            .disableHistory(true)
+            .strategies(new ArrayList<>())
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        // Update that ADDS strategies (history still disabled)
+        MemoryStrategy newStrategy = MemoryStrategy
+            .builder()
+            .type(MemoryStrategyType.SEMANTIC)
+            .namespace(Arrays.asList("app_id"))
+            .strategyConfig(new HashMap<>())
+            .build();
+
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(256)
+            .disableHistory(true)
+            .strategies(Arrays.asList(newStrategy))
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        // Mock container retrieval
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        // Mock model validations
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.ml.common.MLModel> modelListener = invocation.getArgument(1);
+            String modelId = invocation.getArgument(0);
+            org.opensearch.ml.common.MLModel model = org.opensearch.ml.common.MLModel
+                .builder()
+                .modelId(modelId)
+                .algorithm(modelId.equals(llmId) ? FunctionName.REMOTE : FunctionName.TEXT_EMBEDDING)
+                .name("test-model")
+                .build();
+            modelListener.onResponse(model);
+            return null;
+        }).when(mlModelManager).getModel(any(String.class), any());
+
+        // Mock admin clients
+        org.opensearch.transport.client.IndicesAdminClient indicesAdmin = mock(org.opensearch.transport.client.IndicesAdminClient.class);
+        org.opensearch.transport.client.ClusterAdminClient clusterAdmin = mock(org.opensearch.transport.client.ClusterAdminClient.class);
+        org.opensearch.transport.client.AdminClient adminClient = mock(org.opensearch.transport.client.AdminClient.class);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdmin);
+        when(adminClient.cluster()).thenReturn(clusterAdmin);
+
+        // Mock getMappings - index does NOT exist
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse> mappingListener = invocation.getArgument(1);
+            mappingListener.onFailure(new org.opensearch.index.IndexNotFoundException(".plugins-ml-am-no-hist-memory-long-term"));
+            return null;
+        }).when(indicesAdmin).getMappings(any(), any());
+
+        // Mock getPipeline - pipeline doesn't exist yet
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.ingest.GetPipelineResponse> pipelineListener = invocation.getArgument(1);
+            org.opensearch.action.ingest.GetPipelineResponse pipelineResponse = mock(
+                org.opensearch.action.ingest.GetPipelineResponse.class
+            );
+            when(pipelineResponse.pipelines()).thenReturn(Collections.emptyList());
+            pipelineListener.onResponse(pipelineResponse);
+            return null;
+        }).when(clusterAdmin).getPipeline(any(org.opensearch.action.ingest.GetPipelineRequest.class), any());
+
+        // Mock putPipeline - SUCCESS (create real AcknowledgedResponse)
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.support.clustermanager.AcknowledgedResponse> putListener = invocation.getArgument(1);
+            org.opensearch.action.support.clustermanager.AcknowledgedResponse response =
+                new org.opensearch.action.support.clustermanager.AcknowledgedResponse(true);
+            putListener.onResponse(response);
+            return null;
+        }).when(clusterAdmin).putPipeline(any(org.opensearch.action.ingest.PutPipelineRequest.class), any());
+
+        // Mock long-term index creation - SUCCESS
+        doAnswer(invocation -> {
+            ActionListener<Boolean> longTermListener = invocation.getArgument(3);
+            longTermListener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).createLongTermMemoryIndex(any(), any(), any(), any());
+
+        // Mock final update - SUCCESS
+        UpdateResponse updateResponse = new UpdateResponse(
+            new ShardId(new Index("test", "uuid"), 0),
+            containerId,
+            1L,
+            1L,
+            1L,
+            org.opensearch.action.DocWriteResponse.Result.UPDATED
+        );
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateListener = invocation.getArgument(1);
+            updateListener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        action.doExecute(task, request, listener);
+
+        // Verify success - history index NOT created because disabled
+        verify(listener).onResponse(updateResponse);
+        verify(mlIndicesHandler).createLongTermMemoryIndex(any(), any(), any(), any());
+        verify(mlIndicesHandler, never()).createLongTermMemoryHistoryIndex(any(), any(), any());
+    }
+
+    public void testUpdateContainer_TransitionToStrategies_LlmValidationFails() {
+        // Test LLM validation failure during transition
+        String containerId = "test-container-id";
+        String llmId = "invalid-llm";
+
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("test")
+            .llmId(llmId)
+            .strategies(new ArrayList<>())
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        MemoryStrategy newStrategy = MemoryStrategy
+            .builder()
+            .type(MemoryStrategyType.SEMANTIC)
+            .namespace(Arrays.asList("user_id"))
+            .strategyConfig(new HashMap<>())
+            .build();
+
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .llmId(llmId)
+            .embeddingModelId("embedding-123")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .strategies(Arrays.asList(newStrategy))
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        // Mock LLM validation failure
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.ml.common.MLModel> modelListener = invocation.getArgument(1);
+            modelListener.onFailure(new RuntimeException("LLM model not found"));
+            return null;
+        }).when(mlModelManager).getModel(eq(llmId), any());
+
+        action.doExecute(task, request, listener);
+
+        // Verify failure - LLM validation should fail
+        verify(listener).onFailure(any(Exception.class));
+        verify(listener, never()).onResponse(any());
+    }
+
+    public void testUpdateContainer_TransitionToStrategies_EmbeddingValidationFails() {
+        // Test embedding validation failure during transition
+        String containerId = "test-container-id";
+        String llmId = "llm-123";
+        String embeddingModelId = "invalid-embedding";
+
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("test")
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .strategies(new ArrayList<>())
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        MemoryStrategy newStrategy = MemoryStrategy
+            .builder()
+            .type(MemoryStrategyType.SEMANTIC)
+            .namespace(Arrays.asList("user_id"))
+            .strategyConfig(new HashMap<>())
+            .build();
+
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .strategies(Arrays.asList(newStrategy))
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        // Mock LLM validation success
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.ml.common.MLModel> modelListener = invocation.getArgument(1);
+            org.opensearch.ml.common.MLModel llmModel = org.opensearch.ml.common.MLModel
+                .builder()
+                .modelId(llmId)
+                .algorithm(FunctionName.REMOTE)
+                .name("test-llm")
+                .build();
+            modelListener.onResponse(llmModel);
+            return null;
+        }).when(mlModelManager).getModel(eq(llmId), any());
+
+        // Mock embedding validation failure
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.ml.common.MLModel> modelListener = invocation.getArgument(1);
+            modelListener.onFailure(new RuntimeException("Embedding model not found"));
+            return null;
+        }).when(mlModelManager).getModel(eq(embeddingModelId), any());
+
+        action.doExecute(task, request, listener);
+
+        // Verify failure - embedding validation should fail
+        verify(listener).onFailure(any(Exception.class));
+        verify(listener, never()).onResponse(any());
+    }
+
+    public void testUpdateContainer_TransitionToStrategies_SharedIndexIncompatible() {
+        // Test shared index compatibility failure
+        String containerId = "test-container-id";
+        String llmId = "llm-999";
+        String embeddingModelId = "embedding-999";
+
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("incompatible")
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .strategies(new ArrayList<>())
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        MemoryStrategy newStrategy = MemoryStrategy
+            .builder()
+            .type(MemoryStrategyType.SEMANTIC)
+            .namespace(Arrays.asList("user_id"))
+            .strategyConfig(new HashMap<>())
+            .build();
+
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(384)
+            .strategies(Arrays.asList(newStrategy))
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        // Mock model validations success
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.ml.common.MLModel> modelListener = invocation.getArgument(1);
+            String modelId = invocation.getArgument(0);
+            org.opensearch.ml.common.MLModel model = org.opensearch.ml.common.MLModel
+                .builder()
+                .modelId(modelId)
+                .algorithm(modelId.equals(llmId) ? FunctionName.REMOTE : FunctionName.TEXT_EMBEDDING)
+                .name("test-model")
+                .build();
+            modelListener.onResponse(model);
+            return null;
+        }).when(mlModelManager).getModel(any(String.class), any());
+
+        // Mock admin clients
+        org.opensearch.transport.client.IndicesAdminClient indicesAdmin = mock(org.opensearch.transport.client.IndicesAdminClient.class);
+        org.opensearch.transport.client.ClusterAdminClient clusterAdmin = mock(org.opensearch.transport.client.ClusterAdminClient.class);
+        org.opensearch.transport.client.AdminClient adminClient = mock(org.opensearch.transport.client.AdminClient.class);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdmin);
+        when(adminClient.cluster()).thenReturn(clusterAdmin);
+
+        // Mock getMappings - index exists with incompatible dimension
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse> mappingListener = invocation.getArgument(1);
+            org.opensearch.cluster.metadata.MappingMetadata metadata = mock(org.opensearch.cluster.metadata.MappingMetadata.class);
+            Map<String, Object> properties = new HashMap<>();
+            Map<String, Object> embeddingField = new HashMap<>();
+            embeddingField.put("type", "knn_vector");
+            embeddingField.put("dimension", 768); // Different dimension!
+            properties.put("memory_embedding", embeddingField);
+            when(metadata.getSourceAsMap()).thenReturn(Map.of("properties", properties));
+
+            org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse response = mock(
+                org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse.class
+            );
+            when(response.getMappings()).thenReturn(Map.of(".plugins-ml-am-incompatible-memory-long-term", metadata));
+            mappingListener.onResponse(response);
+            return null;
+        }).when(indicesAdmin).getMappings(any(), any());
+
+        // Mock getPipeline - different model ID
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.ingest.GetPipelineResponse> pipelineListener = invocation.getArgument(1);
+            org.opensearch.ingest.PipelineConfiguration pipelineConfig = mock(org.opensearch.ingest.PipelineConfiguration.class);
+            Map<String, Object> pipelineSource = Map
+                .of("processors", Arrays.asList(Map.of("text_embedding", Map.of("model_id", "different-model-id", "field_map", Map.of()))));
+            when(pipelineConfig.getConfigAsMap()).thenReturn(pipelineSource);
+
+            org.opensearch.action.ingest.GetPipelineResponse response = mock(org.opensearch.action.ingest.GetPipelineResponse.class);
+            when(response.pipelines()).thenReturn(Arrays.asList(pipelineConfig));
+            pipelineListener.onResponse(response);
+            return null;
+        }).when(clusterAdmin).getPipeline(any(), any());
+
+        action.doExecute(task, request, listener);
+
+        // Verify failure due to incompatible configuration
+        verify(listener).onFailure(any(Exception.class));
+        verify(listener, never()).onResponse(any());
+    }
+
+    public void testUpdateContainer_TransitionToStrategies_HistoryIndexCreationFails() {
+        // Test history index creation failure
+        String containerId = "test-container-id";
+        String llmId = "llm-555";
+        String embeddingModelId = "embedding-555";
+
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("history-fail")
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(256)
+            .strategies(new ArrayList<>())
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        MemoryStrategy newStrategy = MemoryStrategy
+            .builder()
+            .type(MemoryStrategyType.SEMANTIC)
+            .namespace(Arrays.asList("user_id"))
+            .strategyConfig(new HashMap<>())
+            .build();
+
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(256)
+            .strategies(Arrays.asList(newStrategy))
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        // Mock model validations success
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.ml.common.MLModel> modelListener = invocation.getArgument(1);
+            String modelId = invocation.getArgument(0);
+            org.opensearch.ml.common.MLModel model = org.opensearch.ml.common.MLModel
+                .builder()
+                .modelId(modelId)
+                .algorithm(modelId.equals(llmId) ? FunctionName.REMOTE : FunctionName.TEXT_EMBEDDING)
+                .name("test-model")
+                .build();
+            modelListener.onResponse(model);
+            return null;
+        }).when(mlModelManager).getModel(any(String.class), any());
+
+        // Mock admin clients and shared index validation - index doesn't exist
+        org.opensearch.transport.client.IndicesAdminClient indicesAdmin = mock(org.opensearch.transport.client.IndicesAdminClient.class);
+        org.opensearch.transport.client.ClusterAdminClient clusterAdmin = mock(org.opensearch.transport.client.ClusterAdminClient.class);
+        org.opensearch.transport.client.AdminClient adminClient = mock(org.opensearch.transport.client.AdminClient.class);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdmin);
+        when(adminClient.cluster()).thenReturn(clusterAdmin);
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse> mappingListener = invocation.getArgument(1);
+            mappingListener.onFailure(new org.opensearch.index.IndexNotFoundException(".plugins-ml-am-history-fail-memory-long-term"));
+            return null;
+        }).when(indicesAdmin).getMappings(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.ingest.GetPipelineResponse> pipelineListener = invocation.getArgument(1);
+            org.opensearch.action.ingest.GetPipelineResponse response = mock(org.opensearch.action.ingest.GetPipelineResponse.class);
+            when(response.pipelines()).thenReturn(Collections.emptyList());
+            pipelineListener.onResponse(response);
+            return null;
+        }).when(clusterAdmin).getPipeline(any(org.opensearch.action.ingest.GetPipelineRequest.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.support.clustermanager.AcknowledgedResponse> putListener = invocation.getArgument(1);
+            org.opensearch.action.support.clustermanager.AcknowledgedResponse response = mock(
+                org.opensearch.action.support.clustermanager.AcknowledgedResponse.class
+            );
+            when(response.isAcknowledged()).thenReturn(true);
+            putListener.onResponse(response);
+            return null;
+        }).when(clusterAdmin).putPipeline(any(org.opensearch.action.ingest.PutPipelineRequest.class), any());
+
+        // Mock long-term index creation success
+        doAnswer(invocation -> {
+            ActionListener<Boolean> longTermListener = invocation.getArgument(3);
+            longTermListener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).createLongTermMemoryIndex(any(), any(), any(), any());
+
+        // Mock history index creation FAILURE
+        doAnswer(invocation -> {
+            ActionListener<Boolean> historyListener = invocation.getArgument(2);
+            historyListener.onFailure(new RuntimeException("Failed to create history index"));
+            return null;
+        }).when(mlIndicesHandler).createLongTermMemoryHistoryIndex(any(), any(), any());
+
+        action.doExecute(task, request, listener);
+
+        // Verify failure - history index creation should fail
+        verify(listener).onFailure(any(Exception.class));
+        verify(listener, never()).onResponse(any());
+    }
+
+    public void testUpdateContainer_TransitionToStrategies_LongTermIndexCreationFails() {
+        // Test long-term index creation failure
+        String containerId = "test-container-id";
+        String llmId = "llm-777";
+        String embeddingModelId = "embedding-777";
+
+        MemoryConfiguration currentConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("longterm-fail")
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(128)
+            .strategies(new ArrayList<>())
+            .build();
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .configuration(currentConfig)
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        MemoryStrategy newStrategy = MemoryStrategy
+            .builder()
+            .type(MemoryStrategyType.SEMANTIC)
+            .namespace(Arrays.asList("user_id"))
+            .strategyConfig(new HashMap<>())
+            .build();
+
+        MemoryConfiguration updateConfig = MemoryConfiguration
+            .builder()
+            .llmId(llmId)
+            .embeddingModelId(embeddingModelId)
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(128)
+            .strategies(Arrays.asList(newStrategy))
+            .build();
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().configuration(updateConfig).build();
+
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        // Mock model validations success
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.ml.common.MLModel> modelListener = invocation.getArgument(1);
+            String modelId = invocation.getArgument(0);
+            org.opensearch.ml.common.MLModel model = org.opensearch.ml.common.MLModel
+                .builder()
+                .modelId(modelId)
+                .algorithm(modelId.equals(llmId) ? FunctionName.REMOTE : FunctionName.TEXT_EMBEDDING)
+                .name("test-model")
+                .build();
+            modelListener.onResponse(model);
+            return null;
+        }).when(mlModelManager).getModel(any(String.class), any());
+
+        // Mock admin clients
+        org.opensearch.transport.client.IndicesAdminClient indicesAdmin = mock(org.opensearch.transport.client.IndicesAdminClient.class);
+        org.opensearch.transport.client.ClusterAdminClient clusterAdmin = mock(org.opensearch.transport.client.ClusterAdminClient.class);
+        org.opensearch.transport.client.AdminClient adminClient = mock(org.opensearch.transport.client.AdminClient.class);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdmin);
+        when(adminClient.cluster()).thenReturn(clusterAdmin);
+
+        // Index doesn't exist
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse> mappingListener = invocation.getArgument(1);
+            mappingListener.onFailure(new org.opensearch.index.IndexNotFoundException(".plugins-ml-am-longterm-fail-memory-long-term"));
+            return null;
+        }).when(indicesAdmin).getMappings(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.ingest.GetPipelineResponse> pipelineListener = invocation.getArgument(1);
+            org.opensearch.action.ingest.GetPipelineResponse response = mock(org.opensearch.action.ingest.GetPipelineResponse.class);
+            when(response.pipelines()).thenReturn(Collections.emptyList());
+            pipelineListener.onResponse(response);
+            return null;
+        }).when(clusterAdmin).getPipeline(any(org.opensearch.action.ingest.GetPipelineRequest.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.support.clustermanager.AcknowledgedResponse> putListener = invocation.getArgument(1);
+            org.opensearch.action.support.clustermanager.AcknowledgedResponse response = mock(
+                org.opensearch.action.support.clustermanager.AcknowledgedResponse.class
+            );
+            when(response.isAcknowledged()).thenReturn(true);
+            putListener.onResponse(response);
+            return null;
+        }).when(clusterAdmin).putPipeline(any(org.opensearch.action.ingest.PutPipelineRequest.class), any());
+
+        // Mock long-term index creation FAILURE
+        doAnswer(invocation -> {
+            ActionListener<Boolean> longTermListener = invocation.getArgument(3);
+            longTermListener.onFailure(new RuntimeException("Failed to create long-term index"));
+            return null;
+        }).when(mlIndicesHandler).createLongTermMemoryIndex(any(), any(), any(), any());
+
+        action.doExecute(task, request, listener);
+
+        // Verify failure - long-term index creation should fail
+        verify(listener).onFailure(any(Exception.class));
+        verify(listener, never()).onResponse(any());
+    }
+
 }

--- a/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
@@ -1,816 +1,644 @@
-/*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package org.opensearch.ml.helper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ml.common.CommonValue.ML_AGENTIC_MEMORY_SYSTEM_INDEX_PREFIX;
 
+import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.Answers;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryType;
-import org.opensearch.remote.metadata.client.GetDataObjectRequest;
 import org.opensearch.remote.metadata.client.GetDataObjectResponse;
-import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest;
+import org.opensearch.remote.metadata.client.SearchDataObjectResponse;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.profile.SearchProfileShardResults;
+import org.opensearch.search.suggest.Suggest;
+import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.ClusterAdminClient;
 import org.opensearch.transport.client.IndicesAdminClient;
 
-public class MemoryContainerHelperTests {
+public class MemoryContainerHelperTests extends OpenSearchTestCase {
 
-    @Mock
     private Client client;
-
-    @Mock
-    private SdkClient sdkClient;
-
-    @Mock
-    private NamedXContentRegistry xContentRegistry;
-
-    @Mock
+    private org.opensearch.remote.metadata.client.SdkClient sdkClient;
     private ThreadPool threadPool;
-
     private ThreadContext threadContext;
-
-    @Mock
-    private ActionListener<MLMemoryContainer> listener;
-
     private MemoryContainerHelper helper;
 
-    @Mock
-    private AdminClient adminClient;
-
-    @Mock
-    private IndicesAdminClient indicesAdminClient;
-
     @Before
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-
-        // Create real ThreadContext since it's final and can't be mocked
-        Settings settings = Settings.builder().build();
-        threadContext = new ThreadContext(settings);
-
+    public void setUpTest() {
+        client = mock(Client.class, Answers.RETURNS_DEEP_STUBS);
+        sdkClient = mock(org.opensearch.remote.metadata.client.SdkClient.class);
+        threadPool = mock(ThreadPool.class);
+        threadContext = new ThreadContext(Settings.builder().build());
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
-        helper = new MemoryContainerHelper(client, sdkClient, xContentRegistry);
-
-        // Mock the admin client chain
-        when(client.admin()).thenReturn(adminClient);
-        when(adminClient.indices()).thenReturn(indicesAdminClient);
+        helper = new MemoryContainerHelper(client, sdkClient, NamedXContentRegistry.EMPTY);
     }
 
-    @Test
-    public void testGetMemoryContainerSuccess() {
-        String memoryContainerId = "container-123";
-        String mockJsonSource = "{\"name\":\"test-container\",\"memory_storage_config\":{\"memory_index_name\":\"test-index\"}}";
+    public void testGetMemoryContainerSuccess() throws Exception {
+        MLMemoryContainer container = createContainer();
+        String source = containerToJson(container);
 
-        // Create mock GetResponse
         GetResponse getResponse = mock(GetResponse.class);
         when(getResponse.isExists()).thenReturn(true);
-        when(getResponse.getSourceAsString()).thenReturn(mockJsonSource);
+        when(getResponse.getSourceAsString()).thenReturn(source);
 
-        // Create mock GetDataObjectResponse
-        GetDataObjectResponse getDataObjectResponse = mock(GetDataObjectResponse.class);
-        when(getDataObjectResponse.getResponse()).thenReturn(getResponse);
-        when(getDataObjectResponse.id()).thenReturn(memoryContainerId);
+        GetDataObjectResponse dataResponse = mock(GetDataObjectResponse.class);
+        when(dataResponse.getResponse()).thenReturn(getResponse);
 
-        // Create CompletableFuture with proper typed response
-        CompletableFuture<GetDataObjectResponse> future = new CompletableFuture<>();
-        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenReturn(future);
+        CompletableFuture<GetDataObjectResponse> future = CompletableFuture.completedFuture(dataResponse);
+        when(sdkClient.getDataObjectAsync(any())).thenReturn(future);
 
-        helper.getMemoryContainer(memoryContainerId, listener);
+        PlainActionFuture<MLMemoryContainer> listener = PlainActionFuture.newFuture();
+        helper.getMemoryContainer("container-id", listener);
 
-        // Complete the future with the mock response
-        future.complete(getDataObjectResponse);
-
-        // Verify sdkClient was called with GetDataObjectRequest
-        verify(sdkClient).getDataObjectAsync(any(GetDataObjectRequest.class));
+        MLMemoryContainer result = listener.actionGet();
+        assertEquals(container.getName(), result.getName());
+        assertEquals(container.getConfiguration().getIndexPrefix(), result.getConfiguration().getIndexPrefix());
     }
 
-    @Test
-    public void testGetMemoryContainerWithTenantId() {
-        String memoryContainerId = "container-123";
-        String tenantId = "tenant-456";
-        String mockJsonSource = "{\"name\":\"test-container\"}";
-
-        // Create mock GetResponse
-        GetResponse getResponse = mock(GetResponse.class);
-        when(getResponse.isExists()).thenReturn(true);
-        when(getResponse.getSourceAsString()).thenReturn(mockJsonSource);
-
-        // Create mock GetDataObjectResponse
-        GetDataObjectResponse getDataObjectResponse = mock(GetDataObjectResponse.class);
-        when(getDataObjectResponse.getResponse()).thenReturn(getResponse);
-        when(getDataObjectResponse.id()).thenReturn(memoryContainerId);
-
-        CompletableFuture<GetDataObjectResponse> future = new CompletableFuture<>();
-        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenReturn(future);
-
-        helper.getMemoryContainer(memoryContainerId, tenantId, listener);
-        future.complete(getDataObjectResponse);
-
-        // Verify sdkClient was called with GetDataObjectRequest
-        verify(sdkClient).getDataObjectAsync(any(GetDataObjectRequest.class));
-    }
-
-    @Test
     public void testGetMemoryContainerNotFound() {
-        String memoryContainerId = "container-123";
-
-        // Create mock GetResponse for non-existent container
         GetResponse getResponse = mock(GetResponse.class);
         when(getResponse.isExists()).thenReturn(false);
-        when(getResponse.getSourceAsString()).thenReturn(null);
 
-        // Create mock GetDataObjectResponse
-        GetDataObjectResponse getDataObjectResponse = mock(GetDataObjectResponse.class);
-        when(getDataObjectResponse.getResponse()).thenReturn(getResponse);
-        when(getDataObjectResponse.id()).thenReturn(memoryContainerId);
+        GetDataObjectResponse dataResponse = mock(GetDataObjectResponse.class);
+        when(dataResponse.getResponse()).thenReturn(getResponse);
 
+        CompletableFuture<GetDataObjectResponse> future = CompletableFuture.completedFuture(dataResponse);
+        when(sdkClient.getDataObjectAsync(any())).thenReturn(future);
+
+        PlainActionFuture<MLMemoryContainer> listener = PlainActionFuture.newFuture();
+        helper.getMemoryContainer("missing", listener);
+
+        OpenSearchStatusException exception = expectThrows(OpenSearchStatusException.class, listener::actionGet);
+        assertEquals(RestStatus.NOT_FOUND, exception.status());
+    }
+
+    public void testGetMemoryContainerIndexMissing() {
         CompletableFuture<GetDataObjectResponse> future = new CompletableFuture<>();
-        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenReturn(future);
+        future.completeExceptionally(new IndexNotFoundException("missing"));
+        when(sdkClient.getDataObjectAsync(any())).thenReturn(future);
 
-        helper.getMemoryContainer(memoryContainerId, listener);
-        future.complete(getDataObjectResponse);
+        PlainActionFuture<MLMemoryContainer> listener = PlainActionFuture.newFuture();
+        helper.getMemoryContainer("missing", listener);
 
-        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(listener).onFailure(exceptionCaptor.capture());
-        Exception exception = exceptionCaptor.getValue();
-        assertTrue(exception instanceof OpenSearchStatusException);
-        assertEquals("Memory container not found", exception.getMessage());
-        assertEquals(RestStatus.NOT_FOUND, ((OpenSearchStatusException) exception).status());
+        OpenSearchStatusException exception = expectThrows(OpenSearchStatusException.class, listener::actionGet);
+        assertEquals(RestStatus.NOT_FOUND, exception.status());
     }
 
-    @Test
-    public void testGetMemoryContainerIndexNotFoundException() {
-        String memoryContainerId = "container-123";
-
-        IndexNotFoundException indexNotFoundException = new IndexNotFoundException("index not found");
+    public void testGetMemoryContainerFailure() {
         CompletableFuture<GetDataObjectResponse> future = new CompletableFuture<>();
-        future.completeExceptionally(indexNotFoundException);
-        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenReturn(future);
+        future.completeExceptionally(new IllegalStateException("boom"));
+        when(sdkClient.getDataObjectAsync(any())).thenReturn(future);
 
-        helper.getMemoryContainer(memoryContainerId, listener);
+        PlainActionFuture<MLMemoryContainer> listener = PlainActionFuture.newFuture();
+        helper.getMemoryContainer("id", listener);
 
-        // Need to wait a bit for async completion
-        try {
-            Thread.sleep(100);
-        } catch (InterruptedException e) {}
-
-        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(listener).onFailure(exceptionCaptor.capture());
-        Exception exception = exceptionCaptor.getValue();
-        assertTrue(exception instanceof OpenSearchStatusException);
-        assertEquals("Memory container not found", exception.getMessage());
-        assertEquals(RestStatus.NOT_FOUND, ((OpenSearchStatusException) exception).status());
+        IllegalStateException exception = expectThrows(IllegalStateException.class, listener::actionGet);
+        assertEquals("boom", exception.getMessage());
     }
 
-    @Test
-    public void testGetMemoryContainerGeneralError() {
-        String memoryContainerId = "container-123";
+    public void testCheckMemoryContainerAccess() {
+        assertTrue(helper.checkMemoryContainerAccess(null, createContainer()));
 
-        RuntimeException runtimeException = new RuntimeException("General error");
-        CompletableFuture<GetDataObjectResponse> future = new CompletableFuture<>();
-        future.completeExceptionally(runtimeException);
-        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenReturn(future);
+        User admin = new User("admin", Collections.emptyList(), Arrays.asList("all_access"), Map.of());
+        assertTrue(helper.checkMemoryContainerAccess(admin, createContainer()));
 
-        helper.getMemoryContainer(memoryContainerId, listener);
+        User owner = new User("owner", Collections.emptyList(), Collections.emptyList(), Map.of());
+        MLMemoryContainer container = createContainerBuilder().owner(owner).build();
+        assertTrue(helper.checkMemoryContainerAccess(owner, container));
 
-        // Need to wait a bit for async completion
-        try {
-            Thread.sleep(100);
-        } catch (InterruptedException e) {}
+        User userWithRole = new User("user", Arrays.asList("roleB"), Collections.emptyList(), Map.of());
+        assertTrue(helper.checkMemoryContainerAccess(userWithRole, createContainer()));
 
-        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(listener).onFailure(exceptionCaptor.capture());
-        Exception exception = exceptionCaptor.getValue();
-        assertTrue(exception instanceof RuntimeException);
-        assertEquals("General error", exception.getMessage());
-    }
+        User unrelated = new User("user", Arrays.asList("roleZ"), Collections.emptyList(), Map.of());
+        assertFalse(helper.checkMemoryContainerAccess(unrelated, createContainer()));
 
-    @Test
-    public void testCheckMemoryContainerAccessWithNullUser() {
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").build();
-
-        assertTrue(helper.checkMemoryContainerAccess(null, container));
-    }
-
-    @Test
-    public void testCheckMemoryContainerAccessWithAdminUser() {
-        // User constructor: name, backend_roles, roles, custom_attributes
-        // The "all_access" should be in roles (third parameter), not backend_roles
-        User adminUser = new User("admin", Arrays.asList("backend-role"), Arrays.asList("all_access"), Map.of());
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").build();
-
-        assertTrue(helper.checkMemoryContainerAccess(adminUser, container));
-    }
-
-    @Test
-    public void testCheckMemoryContainerAccessAsOwner() {
-        // User constructor: name, backend_roles, roles, custom_attributes
-        User owner = new User("owner-user", Arrays.asList("backend-role1"), Arrays.asList("role1"), Map.of());
-        User accessingUser = new User("owner-user", Arrays.asList("backend-role2"), Arrays.asList("role2"), Map.of());
-
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").owner(owner).build();
-
-        assertTrue(helper.checkMemoryContainerAccess(accessingUser, container));
-    }
-
-    @Test
-    public void testCheckMemoryContainerAccessWithMatchingBackendRole() {
-        // User constructor: name, backend_roles, roles, custom_attributes
-        User owner = new User("owner-user", Arrays.asList("backend-role1", "backend-role2"), Arrays.asList("role1"), Map.of());
-        User accessingUser = new User("different-user", Arrays.asList("backend-role2", "backend-role3"), Arrays.asList("role2"), Map.of());
-
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").owner(owner).build();
-
-        assertTrue(helper.checkMemoryContainerAccess(accessingUser, container));
-    }
-
-    @Test
-    public void testCheckMemoryContainerAccessDenied() {
-        // User constructor: name, backend_roles, roles, custom_attributes
-        User owner = new User("owner-user", Arrays.asList("backend-role1"), Arrays.asList("role1"), Map.of());
-        User accessingUser = new User("different-user", Arrays.asList("backend-role2"), Arrays.asList("role2"), Map.of());
-
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").owner(owner).build();
-
-        assertFalse(helper.checkMemoryContainerAccess(accessingUser, container));
-    }
-
-    @Test
-    public void testCheckMemoryContainerAccessWithNullOwner() {
-        // User constructor: name, backend_roles, roles, custom_attributes
-        User accessingUser = new User("some-user", Arrays.asList("backend-role1"), Arrays.asList("role1"), Map.of());
-
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").owner(null).build();
-
-        assertFalse(helper.checkMemoryContainerAccess(accessingUser, container));
-    }
-
-    @Test
-    public void testGetMemoryIndexNameWithConfig() {
-        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("custom-memory-index").build();
-
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").configuration(config).build();
-
-        assertEquals(
-            ML_AGENTIC_MEMORY_SYSTEM_INDEX_PREFIX + "-custom-memory-index-memory-" + "sessions",
-            helper.getMemoryIndexName(container, MemoryType.SESSIONS)
+        // Test case where owner has backend roles and user has matching backend role
+        User ownerWithBackendRoles = new User(
+            "ownerWithRoles",
+            Arrays.asList("backend-role-1", "backend-role-2"),
+            Collections.emptyList(),
+            Map.of()
         );
+        User userWithMatchingBackendRole = new User("userWithRole", Arrays.asList("backend-role-1"), Collections.emptyList(), Map.of());
+        MLMemoryContainer containerWithOwnerBackendRoles = createContainerBuilder()
+            .owner(ownerWithBackendRoles)
+            .backendRoles(null) // No explicit backend roles on container
+            .build();
+        assertTrue(helper.checkMemoryContainerAccess(userWithMatchingBackendRole, containerWithOwnerBackendRoles));
 
-        config.setUseSystemIndex(false);
-        assertEquals("custom-memory-index-memory-" + "sessions", helper.getMemoryIndexName(container, MemoryType.SESSIONS));
+        // Test case where user has no matching backend roles
+        User userWithoutMatchingRole = new User("userNoMatch", Arrays.asList("other-role"), Collections.emptyList(), Map.of());
+        assertFalse(helper.checkMemoryContainerAccess(userWithoutMatchingRole, containerWithOwnerBackendRoles));
 
+        // Test case where container has empty backend roles list
+        MLMemoryContainer containerWithEmptyRoles = createContainerBuilder().backendRoles(Collections.emptyList()).owner(owner).build();
+        User userWithBackendRoles = new User("userWithRoles", Arrays.asList("role1"), Collections.emptyList(), Map.of());
+        assertFalse(helper.checkMemoryContainerAccess(userWithBackendRoles, containerWithEmptyRoles));
+
+        // Test case where user has null backend roles
+        User userWithNullBackendRoles = new User("userNull", null, Collections.emptyList(), Map.of());
+        assertFalse(helper.checkMemoryContainerAccess(userWithNullBackendRoles, createContainer()));
     }
 
-    @Test
-    public void testGetMemoryIndexNameWithoutConfig() {
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").configuration(null).build();
+    public void testCheckMemoryAccess() {
+        // Test with null user (security disabled)
+        assertTrue(helper.checkMemoryAccess(null, "any"));
 
-        assertNotNull(helper.getMemoryIndexName(container, MemoryType.SESSIONS));
+        User admin = new User("admin", Collections.emptyList(), Arrays.asList("all_access"), Map.of());
+        assertTrue(helper.checkMemoryAccess(admin, "any"));
+
+        // Test user with null roles
+        User adminWithNullRoles = new User("admin", null, null, Map.of());
+        assertFalse(helper.checkMemoryAccess(adminWithNullRoles, "owner"));
+
+        User owner = new User("owner", Collections.emptyList(), Collections.emptyList(), Map.of());
+        assertTrue(helper.checkMemoryAccess(owner, "owner"));
+
+        User other = new User("other", Collections.emptyList(), Collections.emptyList(), Map.of());
+        assertFalse(helper.checkMemoryAccess(other, "owner"));
     }
 
-    @Test
-    public void testGetMemoryIndexNameWithEmptyConfig() {
-        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix(null).build();
+    public void testGetMemoryIndexName() {
+        MemoryConfiguration configuration = MemoryConfiguration
+            .builder()
+            .indexPrefix("prefix")
+            .embeddingModelId("embedding")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(4)
+            .build();
 
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").configuration(config).build();
-
+        MLMemoryContainer container = createContainerBuilder().configuration(configuration).build();
+        assertNotNull(helper.getMemoryIndexName(container, MemoryType.LONG_TERM));
         assertNull(helper.getMemoryIndexName(container, null));
-    }
 
-    @Test
-    public void testCheckMemoryContainerAccessWithNullBackendRoles() {
-        // User constructor: name, backend_roles, roles, custom_attributes
-        User owner = new User("owner-user", null, Arrays.asList("role1"), Map.of());
-        User accessingUser = new User("different-user", Arrays.asList("backend-role1"), Arrays.asList("role2"), Map.of());
+        // Test with null configuration - returns default index name
+        MLMemoryContainer containerNullConfig = createContainerBuilder().configuration(null).build();
+        // When configuration is null, a default index name is used
+        assertNotNull(helper.getMemoryIndexName(containerNullConfig, MemoryType.LONG_TERM));
+        assertEquals(".plugins-ml-am-default-memory-long-term", helper.getMemoryIndexName(containerNullConfig, MemoryType.LONG_TERM));
 
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").owner(owner).build();
-
-        assertFalse(helper.checkMemoryContainerAccess(accessingUser, container));
-    }
-
-    @Test
-    public void testCheckMemoryContainerAccessBothNullBackendRoles() {
-        // User constructor: name, backend_roles, roles, custom_attributes
-        User owner = new User("owner-user", null, Arrays.asList("role1"), Map.of());
-        User accessingUser = new User("different-user", null, Arrays.asList("role2"), Map.of());
-
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").owner(owner).build();
-
-        assertFalse(helper.checkMemoryContainerAccess(accessingUser, container));
-    }
-
-    @Test
-    public void testCheckMemoryContainerAccessWithAllowedBackendRoles() {
-        // Test container with explicit backend roles (not from owner)
-        User accessingUser = new User("user1", Arrays.asList("backend-role-a"), Arrays.asList("role1"), Map.of());
-
-        MLMemoryContainer container = MLMemoryContainer
-            .builder()
-            .name("test-container")
-            .backendRoles(Arrays.asList("backend-role-a", "backend-role-b"))
-            .build();
-
-        assertTrue(helper.checkMemoryContainerAccess(accessingUser, container));
-    }
-
-    @Test
-    public void testCheckMemoryContainerAccessWithNonMatchingAllowedBackendRoles() {
-        // Test container with explicit backend roles that don't match user's roles
-        User accessingUser = new User("user1", Arrays.asList("backend-role-c"), Arrays.asList("role1"), Map.of());
-
-        MLMemoryContainer container = MLMemoryContainer
-            .builder()
-            .name("test-container")
-            .backendRoles(Arrays.asList("backend-role-a", "backend-role-b"))
-            .build();
-
-        assertFalse(helper.checkMemoryContainerAccess(accessingUser, container));
-    }
-
-    @Test
-    public void testCheckMemoryAccessWithNullUser() {
-        assertTrue(helper.checkMemoryAccess(null, "some-owner"));
-    }
-
-    @Test
-    public void testCheckMemoryAccessWithAdminUser() {
-        User adminUser = new User("admin", Arrays.asList("backend-role"), Arrays.asList("all_access"), Map.of());
-        assertTrue(helper.checkMemoryAccess(adminUser, "different-owner"));
-    }
-
-    @Test
-    public void testCheckMemoryAccessAsOwner() {
-        User user = new User("owner-user", Arrays.asList("backend-role"), Arrays.asList("role1"), Map.of());
-        assertTrue(helper.checkMemoryAccess(user, "owner-user"));
-    }
-
-    @Test
-    public void testCheckMemoryAccessDenied() {
-        User user = new User("user1", Arrays.asList("backend-role"), Arrays.asList("role1"), Map.of());
-        assertFalse(helper.checkMemoryAccess(user, "different-user"));
-    }
-
-    @Test
-    public void testIsAdminUserWithNullUser() {
-        assertFalse(helper.isAdminUser(null));
-    }
-
-    @Test
-    public void testIsAdminUserWithAdminRole() {
-        User adminUser = new User("admin", Arrays.asList("backend-role"), Arrays.asList("all_access"), Map.of());
-        assertTrue(helper.isAdminUser(adminUser));
-    }
-
-    @Test
-    public void testIsAdminUserWithoutAdminRole() {
-        User regularUser = new User("user1", Arrays.asList("backend-role"), Arrays.asList("role1"), Map.of());
-        assertFalse(helper.isAdminUser(regularUser));
-    }
-
-    @Test
-    public void testIsAdminUserWithNullRoles() {
-        User user = new User("user1", Arrays.asList("backend-role"), null, Map.of());
-        assertFalse(helper.isAdminUser(user));
-    }
-
-    @Test
-    public void testGetMemoryIndexNameWithSystemIndexEnabled() {
-        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test-prefix").useSystemIndex(true).build();
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").configuration(config).build();
-
-        String indexName = helper.getMemoryIndexName(container, MemoryType.WORKING);
-        assertNotNull(indexName);
-        assertTrue(indexName.contains("test-prefix"));
-        assertTrue(indexName.contains("working"));
-    }
-
-    @Test
-    public void testGetMemoryIndexNameWithSystemIndexDisabled() {
-        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test-prefix").useSystemIndex(false).build();
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").configuration(config).build();
-
-        String indexName = helper.getMemoryIndexName(container, MemoryType.LONG_TERM);
-        assertNotNull(indexName);
-        assertTrue(indexName.contains("test-prefix"));
-        assertTrue(indexName.contains("long-term"));
-        assertFalse(indexName.startsWith("."));
-    }
-
-    @Test
-    public void testGetMemoryIndexNameForAllMemoryTypes() {
-        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").configuration(config).build();
-
-        // Test all valid memory types
+        // Test all memory types - by default all are enabled
         assertNotNull(helper.getMemoryIndexName(container, MemoryType.SESSIONS));
         assertNotNull(helper.getMemoryIndexName(container, MemoryType.WORKING));
-        assertNotNull(helper.getMemoryIndexName(container, MemoryType.LONG_TERM));
         assertNotNull(helper.getMemoryIndexName(container, MemoryType.HISTORY));
     }
 
-    @Test
-    public void testCheckMemoryContainerAccessWithEmptyBackendRoles() {
-        User owner = new User("owner-user", Arrays.asList(), Arrays.asList("role1"), Map.of());
-        User accessingUser = new User("different-user", Arrays.asList("backend-role"), Arrays.asList("role2"), Map.of());
+    public void testSearchData() {
+        MemoryConfiguration configuration = MemoryConfiguration.builder().indexPrefix("prefix").build();
+        SearchDataObjectRequest request = SearchDataObjectRequest
+            .builder()
+            .indices("index")
+            .searchSourceBuilder(new SearchSourceBuilder())
+            .build();
 
-        MLMemoryContainer container = MLMemoryContainer.builder().name("test-container").owner(owner).build();
+        SearchResponse searchResponse = createSearchResponse(2);
+        SearchDataObjectResponse response = new SearchDataObjectResponse(searchResponse);
+        when(sdkClient.searchDataObjectAsync(any())).thenReturn(CompletableFuture.completedFuture(response));
 
-        assertFalse(helper.checkMemoryContainerAccess(accessingUser, container));
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        helper.searchData(configuration, request, future);
+        assertSame(searchResponse, future.actionGet());
+
+        CompletableFuture<SearchDataObjectResponse> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("search failure"));
+        when(sdkClient.searchDataObjectAsync(any())).thenReturn(failed);
+
+        PlainActionFuture<SearchResponse> failure = PlainActionFuture.newFuture();
+        helper.searchData(configuration, request, failure);
+        RuntimeException exception = expectThrows(RuntimeException.class, failure::actionGet);
+        assertEquals("search failure", exception.getMessage());
     }
 
-    @Test
-    public void testGetMemoryContainerParseException() {
-        String memoryContainerId = "container-123";
-        String invalidJsonSource = "{invalid json}";
+    public void testSearchDataWithSystemIndex() {
+        // Test search with system index
+        MemoryConfiguration systemConfig = MemoryConfiguration.builder().indexPrefix("prefix").useSystemIndex(true).build();
+        SearchDataObjectRequest request = SearchDataObjectRequest
+            .builder()
+            .indices("index")
+            .searchSourceBuilder(new SearchSourceBuilder())
+            .build();
 
-        // Create mock GetResponse with invalid JSON
-        GetResponse getResponse = mock(GetResponse.class);
-        when(getResponse.isExists()).thenReturn(true);
-        when(getResponse.getSourceAsString()).thenReturn(invalidJsonSource);
+        SearchResponse searchResponse = createSearchResponse(3);
+        SearchDataObjectResponse response = new SearchDataObjectResponse(searchResponse);
+        when(sdkClient.searchDataObjectAsync(any())).thenReturn(CompletableFuture.completedFuture(response));
 
-        // Create mock GetDataObjectResponse
-        GetDataObjectResponse getDataObjectResponse = mock(GetDataObjectResponse.class);
-        when(getDataObjectResponse.getResponse()).thenReturn(getResponse);
-        when(getDataObjectResponse.id()).thenReturn(memoryContainerId);
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        helper.searchData(systemConfig, request, future);
+        assertSame(searchResponse, future.actionGet());
 
-        CompletableFuture<GetDataObjectResponse> future = new CompletableFuture<>();
-        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenReturn(future);
+        // Test failure with system index
+        CompletableFuture<SearchDataObjectResponse> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("system index search failure"));
+        when(sdkClient.searchDataObjectAsync(any())).thenReturn(failed);
 
-        helper.getMemoryContainer(memoryContainerId, listener);
-        future.complete(getDataObjectResponse);
-
-        // Should handle parse exception
-        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(listener).onFailure(exceptionCaptor.capture());
-        assertNotNull(exceptionCaptor.getValue());
+        PlainActionFuture<SearchResponse> failure = PlainActionFuture.newFuture();
+        helper.searchData(systemConfig, request, failure);
+        RuntimeException exception = expectThrows(RuntimeException.class, failure::actionGet);
+        assertEquals("system index search failure", exception.getMessage());
     }
 
-    @Test
-    public void testGetDataWithSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(true).build();
-        org.opensearch.action.get.GetRequest getRequest = new org.opensearch.action.get.GetRequest("test-index", "doc-id");
-        ActionListener<GetResponse> listener = mock(ActionListener.class);
+    public void testDataOperations() {
+        MemoryConfiguration configuration = MemoryConfiguration.builder().indexPrefix("prefix").build();
 
-        helper.getData(config, getRequest, listener);
+        GetRequest getRequest = new GetRequest("index", "id");
+        PlainActionFuture<GetResponse> getFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(GetResponse.class));
+            return null;
+        }).when(client).get(eq(getRequest), any());
+        helper.getData(configuration, getRequest, getFuture);
+        assertNotNull(getFuture.actionGet());
 
-        verify(client).get(any(org.opensearch.action.get.GetRequest.class), any());
+        IndexRequest indexRequest = new IndexRequest("index");
+        PlainActionFuture<IndexResponse> indexFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(IndexResponse.class));
+            return null;
+        }).when(client).index(eq(indexRequest), any());
+        helper.indexData(configuration, indexRequest, indexFuture);
+        assertNotNull(indexFuture.actionGet());
+
+        UpdateRequest updateRequest = new UpdateRequest("index", "id");
+        PlainActionFuture<UpdateResponse> updateFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(UpdateResponse.class));
+            return null;
+        }).when(client).update(eq(updateRequest), any());
+        helper.updateData(configuration, updateRequest, updateFuture);
+        assertNotNull(updateFuture.actionGet());
+
+        DeleteRequest deleteRequest = new DeleteRequest("index", "id");
+        PlainActionFuture<DeleteResponse> deleteFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(DeleteResponse.class));
+            return null;
+        }).when(client).delete(eq(deleteRequest), any());
+        helper.deleteData(configuration, deleteRequest, deleteFuture);
+        assertNotNull(deleteFuture.actionGet());
     }
 
-    @Test
-    public void testGetDataWithoutSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(false).build();
-        org.opensearch.action.get.GetRequest getRequest = new org.opensearch.action.get.GetRequest("test-index", "doc-id");
-        ActionListener<GetResponse> listener = mock(ActionListener.class);
+    public void testDataOperationsWithSystemIndex() {
+        // Test operations with system index (useSystemIndex = true)
+        MemoryConfiguration systemConfig = MemoryConfiguration.builder().indexPrefix("prefix").useSystemIndex(true).build();
 
-        helper.getData(config, getRequest, listener);
+        GetRequest getRequest = new GetRequest("index", "id");
+        PlainActionFuture<GetResponse> getFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(GetResponse.class));
+            return null;
+        }).when(client).get(eq(getRequest), any());
+        helper.getData(systemConfig, getRequest, getFuture);
+        assertNotNull(getFuture.actionGet());
 
-        verify(client).get(any(org.opensearch.action.get.GetRequest.class), any());
+        IndexRequest indexRequest = new IndexRequest("index");
+        PlainActionFuture<IndexResponse> indexFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(IndexResponse.class));
+            return null;
+        }).when(client).index(eq(indexRequest), any());
+        helper.indexData(systemConfig, indexRequest, indexFuture);
+        assertNotNull(indexFuture.actionGet());
+
+        UpdateRequest updateRequest = new UpdateRequest("index", "id");
+        PlainActionFuture<UpdateResponse> updateFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(UpdateResponse.class));
+            return null;
+        }).when(client).update(eq(updateRequest), any());
+        helper.updateData(systemConfig, updateRequest, updateFuture);
+        assertNotNull(updateFuture.actionGet());
+
+        DeleteRequest deleteRequest = new DeleteRequest("index", "id");
+        PlainActionFuture<DeleteResponse> deleteFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(DeleteResponse.class));
+            return null;
+        }).when(client).delete(eq(deleteRequest), any());
+        helper.deleteData(systemConfig, deleteRequest, deleteFuture);
+        assertNotNull(deleteFuture.actionGet());
     }
 
-    @Test
-    public void testIndexDataWithSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(true).build();
-        org.opensearch.action.index.IndexRequest indexRequest = new org.opensearch.action.index.IndexRequest("test-index");
-        ActionListener<org.opensearch.action.index.IndexResponse> listener = mock(ActionListener.class);
+    public void testDeleteIndexAndBulk() {
+        MemoryConfiguration configuration = MemoryConfiguration.builder().indexPrefix("prefix").build();
+        DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest("index");
+        BulkRequest bulkRequest = new BulkRequest();
 
-        helper.indexData(config, indexRequest, listener);
+        AdminClient adminClient = mock(AdminClient.class);
+        ClusterAdminClient clusterAdminClient = mock(ClusterAdminClient.class);
+        IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.cluster()).thenReturn(clusterAdminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
 
-        verify(client).index(any(org.opensearch.action.index.IndexRequest.class), any());
+        PlainActionFuture<AcknowledgedResponse> deleteIndexFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<AcknowledgedResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(AcknowledgedResponse.class));
+            return null;
+        }).when(indicesAdminClient).delete(eq(deleteIndexRequest), any());
+        helper.deleteIndex(configuration, deleteIndexRequest, deleteIndexFuture);
+        assertNotNull(deleteIndexFuture.actionGet());
+
+        PlainActionFuture<BulkResponse> bulkFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(BulkResponse.class));
+            return null;
+        }).when(client).bulk(eq(bulkRequest), any());
+        helper.bulkIngestData(configuration, bulkRequest, bulkFuture);
+        assertNotNull(bulkFuture.actionGet());
     }
 
-    @Test
-    public void testIndexDataWithoutSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(false).build();
-        org.opensearch.action.index.IndexRequest indexRequest = new org.opensearch.action.index.IndexRequest("test-index");
-        ActionListener<org.opensearch.action.index.IndexResponse> listener = mock(ActionListener.class);
+    public void testDeleteIndexAndBulkWithSystemIndex() {
+        // Test with system index
+        MemoryConfiguration systemConfig = MemoryConfiguration.builder().indexPrefix("prefix").useSystemIndex(true).build();
+        DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest("index");
+        BulkRequest bulkRequest = new BulkRequest();
 
-        helper.indexData(config, indexRequest, listener);
+        AdminClient adminClient = mock(AdminClient.class);
+        IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
 
-        verify(client).index(any(org.opensearch.action.index.IndexRequest.class), any());
+        PlainActionFuture<AcknowledgedResponse> deleteIndexFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<AcknowledgedResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(AcknowledgedResponse.class));
+            return null;
+        }).when(indicesAdminClient).delete(eq(deleteIndexRequest), any());
+        helper.deleteIndex(systemConfig, deleteIndexRequest, deleteIndexFuture);
+        assertNotNull(deleteIndexFuture.actionGet());
+
+        PlainActionFuture<BulkResponse> bulkFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(BulkResponse.class));
+            return null;
+        }).when(client).bulk(eq(bulkRequest), any());
+        helper.bulkIngestData(systemConfig, bulkRequest, bulkFuture);
+        assertNotNull(bulkFuture.actionGet());
     }
 
-    @Test
-    public void testUpdateDataWithSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(true).build();
-        org.opensearch.action.update.UpdateRequest updateRequest = new org.opensearch.action.update.UpdateRequest("test-index", "doc-id");
-        ActionListener<org.opensearch.action.update.UpdateResponse> listener = mock(ActionListener.class);
+    public void testBulkIngestData() {
+        MemoryConfiguration configuration = MemoryConfiguration.builder().indexPrefix("prefix").build();
+        BulkRequest bulkRequest = new BulkRequest();
 
-        helper.updateData(config, updateRequest, listener);
-
-        verify(client).update(any(org.opensearch.action.update.UpdateRequest.class), any());
+        PlainActionFuture<BulkResponse> bulkFuture = PlainActionFuture.newFuture();
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(BulkResponse.class));
+            return null;
+        }).when(client).bulk(eq(bulkRequest), any());
+        helper.bulkIngestData(configuration, bulkRequest, bulkFuture);
+        assertNotNull(bulkFuture.actionGet());
     }
 
-    @Test
-    public void testUpdateDataWithoutSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(false).build();
-        org.opensearch.action.update.UpdateRequest updateRequest = new org.opensearch.action.update.UpdateRequest("test-index", "doc-id");
-        ActionListener<org.opensearch.action.update.UpdateResponse> listener = mock(ActionListener.class);
+    public void testDeleteByQuery() {
+        MemoryConfiguration configuration = MemoryConfiguration.builder().indexPrefix("prefix").build();
+        DeleteByQueryRequest request = new DeleteByQueryRequest("index");
+        PlainActionFuture<BulkByScrollResponse> future = PlainActionFuture.newFuture();
 
-        helper.updateData(config, updateRequest, listener);
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mock(BulkByScrollResponse.class));
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), eq(request), any());
 
-        verify(client).update(any(org.opensearch.action.update.UpdateRequest.class), any());
+        helper.deleteDataByQuery(configuration, request, future);
+        assertNotNull(future.actionGet());
     }
 
-    @Test
-    public void testDeleteDataWithSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(true).build();
-        org.opensearch.action.delete.DeleteRequest deleteRequest = new org.opensearch.action.delete.DeleteRequest("test-index", "doc-id");
-        ActionListener<org.opensearch.action.delete.DeleteResponse> listener = mock(ActionListener.class);
+    public void testDeleteByQueryWithSystemIndex() {
+        // Test delete by query with system index
+        MemoryConfiguration systemConfig = MemoryConfiguration.builder().indexPrefix("prefix").useSystemIndex(true).build();
+        DeleteByQueryRequest request = new DeleteByQueryRequest("index");
+        PlainActionFuture<BulkByScrollResponse> future = PlainActionFuture.newFuture();
 
-        helper.deleteData(config, deleteRequest, listener);
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mock(BulkByScrollResponse.class));
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), eq(request), any());
 
-        verify(client).delete(any(org.opensearch.action.delete.DeleteRequest.class), any());
+        helper.deleteDataByQuery(systemConfig, request, future);
+        assertNotNull(future.actionGet());
     }
 
-    @Test
-    public void testDeleteDataWithoutSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(false).build();
-        org.opensearch.action.delete.DeleteRequest deleteRequest = new org.opensearch.action.delete.DeleteRequest("test-index", "doc-id");
-        ActionListener<org.opensearch.action.delete.DeleteResponse> listener = mock(ActionListener.class);
+    public void testFiltersAndAdminHelpers() {
+        User user = new User("alice", Arrays.asList("role1"), Collections.emptyList(), Map.of());
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        helper.addUserBackendRolesFilter(user, searchSourceBuilder);
+        assertTrue(searchSourceBuilder.query() instanceof BoolQueryBuilder);
 
-        helper.deleteData(config, deleteRequest, listener);
+        // Test with existing BoolQueryBuilder
+        SearchSourceBuilder builderWithBoolQuery = new SearchSourceBuilder();
+        builderWithBoolQuery.query(QueryBuilders.boolQuery().must(QueryBuilders.matchAllQuery()));
+        helper.addUserBackendRolesFilter(user, builderWithBoolQuery);
+        assertTrue(builderWithBoolQuery.query() instanceof BoolQueryBuilder);
 
-        verify(client).delete(any(org.opensearch.action.delete.DeleteRequest.class), any());
+        // Test with existing non-BoolQueryBuilder
+        SearchSourceBuilder builderWithMatchQuery = new SearchSourceBuilder();
+        builderWithMatchQuery.query(QueryBuilders.matchAllQuery());
+        helper.addUserBackendRolesFilter(user, builderWithMatchQuery);
+        assertTrue(builderWithMatchQuery.query() instanceof BoolQueryBuilder);
+
+        SearchSourceBuilder ownerBuilder = new SearchSourceBuilder();
+        helper.addOwnerIdFilter(user, ownerBuilder);
+        assertTrue(ownerBuilder.query() instanceof BoolQueryBuilder);
+
+        QueryBuilder matchAll = QueryBuilders.matchAllQuery();
+        QueryBuilder filtered = helper.addOwnerIdFilter(user, matchAll);
+        assertTrue(filtered instanceof BoolQueryBuilder);
+
+        // Test addOwnerIdFilter with null user (security disabled)
+        QueryBuilder filteredWithNullUser = helper.addOwnerIdFilter(null, matchAll);
+        assertEquals(matchAll, filteredWithNullUser);
+
+        // Test addOwnerIdFilter with admin user
+        User admin = new User("admin", Collections.emptyList(), Arrays.asList("all_access"), Map.of());
+        QueryBuilder filteredWithAdmin = helper.addOwnerIdFilter(admin, matchAll);
+        assertEquals(matchAll, filteredWithAdmin);
+
+        SearchSourceBuilder containerBuilder = new SearchSourceBuilder();
+        helper.addContainerIdFilter("container", containerBuilder);
+        assertTrue(containerBuilder.query() instanceof BoolQueryBuilder);
+
+        // Test addContainerIdFilter with null/blank containerId
+        SearchSourceBuilder builderWithNullId = new SearchSourceBuilder();
+        helper.addContainerIdFilter(null, builderWithNullId);
+        assertNull(builderWithNullId.query());
+
+        SearchSourceBuilder builderWithBlankId = new SearchSourceBuilder();
+        helper.addContainerIdFilter("", builderWithBlankId);
+        assertNull(builderWithBlankId.query());
+
+        QueryBuilder containerFiltered = helper.addContainerIdFilter("container", matchAll);
+        assertTrue(containerFiltered instanceof BoolQueryBuilder);
+
+        // Test addContainerIdFilter QueryBuilder with null/blank containerId
+        QueryBuilder filteredWithNullId = helper.addContainerIdFilter(null, matchAll);
+        assertEquals(matchAll, filteredWithNullId);
+
+        QueryBuilder filteredWithBlankId = helper.addContainerIdFilter("", matchAll);
+        assertEquals(matchAll, filteredWithBlankId);
+
+        assertTrue(helper.isAdminUser(admin));
+        assertFalse(helper.isAdminUser(user));
+
+        // Test isAdminUser with null user
+        assertFalse(helper.isAdminUser(null));
+
+        // Test isAdminUser with empty roles
+        User userWithEmptyRoles = new User("user", Collections.emptyList(), Collections.emptyList(), Map.of());
+        assertFalse(helper.isAdminUser(userWithEmptyRoles));
+
+        // Test isAdminUser with null roles
+        User userWithNullRoles = new User("user", null, null, Map.of());
+        assertFalse(helper.isAdminUser(userWithNullRoles));
+
+        assertEquals("alice", helper.getOwnerId(user));
+        assertNull(helper.getOwnerId(null));
     }
 
-    @Test
-    public void testBulkIngestDataWithSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(true).build();
-        org.opensearch.action.bulk.BulkRequest bulkRequest = new org.opensearch.action.bulk.BulkRequest();
-        ActionListener<org.opensearch.action.bulk.BulkResponse> listener = mock(ActionListener.class);
+    public void testCountContainersWithPrefix() {
+        // Test with null prefix
+        PlainActionFuture<Long> nullFuture = PlainActionFuture.newFuture();
+        helper.countContainersWithPrefix(null, null, nullFuture);
+        assertEquals(0L, nullFuture.actionGet().longValue());
 
-        helper.bulkIngestData(config, bulkRequest, listener);
+        // Test with blank prefix
+        PlainActionFuture<Long> blankFuture = PlainActionFuture.newFuture();
+        helper.countContainersWithPrefix("", null, blankFuture);
+        assertEquals(0L, blankFuture.actionGet().longValue());
 
-        verify(client).bulk(any(org.opensearch.action.bulk.BulkRequest.class), any());
+        SearchResponse searchResponse = createSearchResponse(3);
+        SearchDataObjectResponse response = new SearchDataObjectResponse(searchResponse);
+        when(sdkClient.searchDataObjectAsync(any())).thenReturn(CompletableFuture.completedFuture(response));
+
+        PlainActionFuture<Long> future = PlainActionFuture.newFuture();
+        helper.countContainersWithPrefix("prefix", null, future);
+        assertEquals(3L, future.actionGet().longValue());
+
+        // Test with tenant ID
+        PlainActionFuture<Long> tenantFuture = PlainActionFuture.newFuture();
+        helper.countContainersWithPrefix("prefix", "tenant123", tenantFuture);
+        assertEquals(3L, tenantFuture.actionGet().longValue());
+
+        CompletableFuture<SearchDataObjectResponse> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("fail"));
+        when(sdkClient.searchDataObjectAsync(any())).thenReturn(failed);
+
+        PlainActionFuture<Long> failure = PlainActionFuture.newFuture();
+        helper.countContainersWithPrefix("prefix", null, failure);
+        RuntimeException exception = expectThrows(RuntimeException.class, failure::actionGet);
+        assertEquals("fail", exception.getMessage());
     }
 
-    @Test
-    public void testBulkIngestDataWithoutSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(false).build();
-        org.opensearch.action.bulk.BulkRequest bulkRequest = new org.opensearch.action.bulk.BulkRequest();
-        ActionListener<org.opensearch.action.bulk.BulkResponse> listener = mock(ActionListener.class);
-
-        helper.bulkIngestData(config, bulkRequest, listener);
-
-        verify(client).bulk(any(org.opensearch.action.bulk.BulkRequest.class), any());
+    private MLMemoryContainer createContainer() {
+        return createContainerBuilder().build();
     }
 
-    @Test
-    public void testGetOwnerIdWithUser() {
-        User user = new User("testuser", Arrays.asList("role1"), Arrays.asList("role2"), Map.of());
-        String ownerId = helper.getOwnerId(user);
-        assertEquals("testuser", ownerId);
+    private MLMemoryContainer.MLMemoryContainerBuilder createContainerBuilder() {
+        MemoryConfiguration configuration = MemoryConfiguration.builder().indexPrefix("prefix").build();
+        User owner = new User("owner", Collections.emptyList(), Collections.emptyList(), Map.of());
+        return MLMemoryContainer
+            .builder()
+            .name("container")
+            .description("desc")
+            .owner(owner)
+            .configuration(configuration)
+            .backendRoles(Arrays.asList("roleA", "roleB"));
     }
 
-    @Test
-    public void testGetOwnerIdWithNullUser() {
-        String ownerId = helper.getOwnerId(null);
-        assertNull(ownerId);
+    private String containerToJson(MLMemoryContainer container) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        container.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        return BytesReference.bytes(builder).utf8ToString();
     }
 
-    @Test
-    public void testAddUserBackendRolesFilter() {
-        User user = new User("testuser", Arrays.asList("backend-role1", "backend-role2"), Arrays.asList("role1"), Map.of());
-        org.opensearch.search.builder.SearchSourceBuilder searchSourceBuilder = new org.opensearch.search.builder.SearchSourceBuilder();
-
-        org.opensearch.search.builder.SearchSourceBuilder result = helper.addUserBackendRolesFilter(user, searchSourceBuilder);
-
-        assertNotNull(result);
-        assertNotNull(result.query());
-    }
-
-    @Test
-    public void testAddOwnerIdFilter() {
-        User user = new User("testuser", Arrays.asList("backend-role1"), Arrays.asList("role1"), Map.of());
-        org.opensearch.search.builder.SearchSourceBuilder searchSourceBuilder = new org.opensearch.search.builder.SearchSourceBuilder();
-
-        helper.addOwnerIdFilter(user, searchSourceBuilder);
-
-        assertNotNull(searchSourceBuilder.query());
-    }
-
-    @Test
-    public void testSearchDataWithSearchDataObjectRequestSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(true).build();
-        org.opensearch.remote.metadata.client.SearchDataObjectRequest searchRequest = mock(
-            org.opensearch.remote.metadata.client.SearchDataObjectRequest.class
+    private SearchResponse createSearchResponse(long totalHits) {
+        SearchHit[] hits = new SearchHit[0];
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), 1.0f);
+        org.opensearch.search.internal.InternalSearchResponse internal = new org.opensearch.search.internal.InternalSearchResponse(
+            searchHits,
+            InternalAggregations.EMPTY,
+            new Suggest(Collections.emptyList()),
+            new SearchProfileShardResults(Collections.emptyMap()),
+            false,
+            false,
+            1
         );
-        ActionListener<org.opensearch.action.search.SearchResponse> listener = mock(ActionListener.class);
-
-        CompletableFuture<org.opensearch.remote.metadata.client.SearchDataObjectResponse> future = new CompletableFuture<>();
-        when(sdkClient.searchDataObjectAsync(any())).thenReturn(future);
-
-        helper.searchData(config, searchRequest, listener);
-
-        verify(sdkClient).searchDataObjectAsync(any());
-    }
-
-    @Test
-    public void testSearchDataWithSearchDataObjectRequestNonSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(false).build();
-        org.opensearch.remote.metadata.client.SearchDataObjectRequest searchRequest = mock(
-            org.opensearch.remote.metadata.client.SearchDataObjectRequest.class
+        return new SearchResponse(
+            internal,
+            "",
+            1,
+            1,
+            0,
+            0,
+            org.opensearch.action.search.ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY
         );
-        ActionListener<org.opensearch.action.search.SearchResponse> listener = mock(ActionListener.class);
-
-        CompletableFuture<org.opensearch.remote.metadata.client.SearchDataObjectResponse> future = new CompletableFuture<>();
-        when(sdkClient.searchDataObjectAsync(any())).thenReturn(future);
-
-        helper.searchData(config, searchRequest, listener);
-
-        verify(sdkClient).searchDataObjectAsync(any());
     }
-
-    @Test
-    public void testDeleteIndexWithSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(true).build();
-        DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest("test-index");
-        ActionListener<AcknowledgedResponse> listener = mock(ActionListener.class);
-
-        helper.deleteIndex(config, deleteIndexRequest, listener);
-
-        verify(indicesAdminClient).delete(any(DeleteIndexRequest.class), any());
-    }
-
-    @Test
-    public void testDeleteIndexWithoutSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(false).build();
-        DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest("test-index");
-        ActionListener<AcknowledgedResponse> listener = mock(ActionListener.class);
-
-        helper.deleteIndex(config, deleteIndexRequest, listener);
-
-        verify(indicesAdminClient).delete(any(DeleteIndexRequest.class), any());
-    }
-
-    @Test
-    public void testDeleteIndexThreadContextHandling() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(true).build();
-        DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest("test-index");
-        ActionListener<AcknowledgedResponse> listener = mock(ActionListener.class);
-
-        helper.deleteIndex(config, deleteIndexRequest, listener);
-
-        // Verify that the client.admin().indices().delete() was called
-        verify(indicesAdminClient).delete(any(DeleteIndexRequest.class), any());
-
-        // Verify that threadPool and threadContext were accessed for system index
-        verify(client).threadPool();
-        verify(threadPool).getThreadContext();
-    }
-
-    @Test
-    public void testDeleteDataByQueryWithSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(true).build();
-        org.opensearch.index.reindex.DeleteByQueryRequest deleteByQueryRequest = new org.opensearch.index.reindex.DeleteByQueryRequest(
-            "test-index"
-        );
-        ActionListener<org.opensearch.index.reindex.BulkByScrollResponse> listener = mock(ActionListener.class);
-
-        helper.deleteDataByQuery(config, deleteByQueryRequest, listener);
-
-        // Verify that the client executed the delete by query action
-        verify(client).execute(any(), any(org.opensearch.index.reindex.DeleteByQueryRequest.class), any());
-        verify(client).threadPool();
-        verify(threadPool).getThreadContext();
-    }
-
-    @Test
-    public void testDeleteDataByQueryWithoutSystemIndex() {
-        MemoryConfiguration config = MemoryConfiguration.builder().useSystemIndex(false).build();
-        org.opensearch.index.reindex.DeleteByQueryRequest deleteByQueryRequest = new org.opensearch.index.reindex.DeleteByQueryRequest(
-            "test-index"
-        );
-        ActionListener<org.opensearch.index.reindex.BulkByScrollResponse> listener = mock(ActionListener.class);
-
-        helper.deleteDataByQuery(config, deleteByQueryRequest, listener);
-
-        // Verify that the client executed the delete by query action without thread context handling
-        verify(client).execute(any(), any(org.opensearch.index.reindex.DeleteByQueryRequest.class), any());
-    }
-
-    @Test
-    public void testCountContainersWithPrefixSuccess() {
-        String indexPrefix = "test-prefix";
-        String tenantId = "tenant-123";
-        ActionListener<Long> listener = mock(ActionListener.class);
-
-        // Mock SDK search response
-        CompletableFuture<org.opensearch.remote.metadata.client.SearchDataObjectResponse> future = new CompletableFuture<>();
-        when(sdkClient.searchDataObjectAsync(any(org.opensearch.remote.metadata.client.SearchDataObjectRequest.class))).thenReturn(future);
-
-        helper.countContainersWithPrefix(indexPrefix, tenantId, listener);
-
-        // Verify the SDK client was called with the right request
-        verify(sdkClient).searchDataObjectAsync(any(org.opensearch.remote.metadata.client.SearchDataObjectRequest.class));
-    }
-
-    @Test
-    public void testCountContainersWithPrefixNullPrefix() {
-        ActionListener<Long> listener = mock(ActionListener.class);
-
-        helper.countContainersWithPrefix(null, null, listener);
-
-        // Verify that the listener was called with 0
-        verify(listener).onResponse(0L);
-    }
-
-    @Test
-    public void testCountContainersWithPrefixBlankPrefix() {
-        ActionListener<Long> listener = mock(ActionListener.class);
-
-        helper.countContainersWithPrefix("   ", null, listener);
-
-        // Verify that the listener was called with 0
-        verify(listener).onResponse(0L);
-    }
-
-    @Test
-    public void testCountContainersWithPrefixWithoutTenant() {
-        String indexPrefix = "test-prefix";
-        ActionListener<Long> listener = mock(ActionListener.class);
-
-        // Mock SDK search response
-        CompletableFuture<org.opensearch.remote.metadata.client.SearchDataObjectResponse> future = new CompletableFuture<>();
-        when(sdkClient.searchDataObjectAsync(any(org.opensearch.remote.metadata.client.SearchDataObjectRequest.class))).thenReturn(future);
-
-        helper.countContainersWithPrefix(indexPrefix, null, listener);
-
-        // Verify the SDK client was called
-        verify(sdkClient).searchDataObjectAsync(any(org.opensearch.remote.metadata.client.SearchDataObjectRequest.class));
-    }
-
-    @Test
-    public void testAddOwnerIdFilterWithNullUser() {
-        org.opensearch.index.query.QueryBuilder baseQuery = org.opensearch.index.query.QueryBuilders.matchAllQuery();
-
-        org.opensearch.index.query.QueryBuilder result = helper.addOwnerIdFilter(null, baseQuery);
-
-        // For null user, should return the original query unchanged
-        assertEquals(baseQuery, result);
-    }
-
-    @Test
-    public void testAddOwnerIdFilterWithAdminUser() {
-        // Create admin user with all_access role - User.parse format is "username|backend-role1,backend-role2|role1,role2,..."
-        User adminUser = new User("admin", List.of("backend-role"), List.of("all_access"), List.of());
-        org.opensearch.index.query.QueryBuilder baseQuery = org.opensearch.index.query.QueryBuilders.matchAllQuery();
-
-        org.opensearch.index.query.QueryBuilder result = helper.addOwnerIdFilter(adminUser, baseQuery);
-
-        // For admin user, should return the original query unchanged
-        assertEquals(baseQuery, result);
-    }
-
-    @Test
-    public void testAddOwnerIdFilterWithRegularUser() {
-        User regularUser = User.parse("john|backend-role");
-        org.opensearch.index.query.QueryBuilder baseQuery = org.opensearch.index.query.QueryBuilders.matchAllQuery();
-
-        org.opensearch.index.query.QueryBuilder result = helper.addOwnerIdFilter(regularUser, baseQuery);
-
-        // For regular user, should wrap in a BoolQuery with owner filter
-        assertTrue(result instanceof org.opensearch.index.query.BoolQueryBuilder);
-        org.opensearch.index.query.BoolQueryBuilder boolQuery = (org.opensearch.index.query.BoolQueryBuilder) result;
-        assertEquals(1, boolQuery.must().size());
-        assertEquals(1, boolQuery.filter().size());
-    }
-
 }

--- a/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerPipelineHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerPipelineHelperTests.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.helper;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Before;
+import org.opensearch.action.ingest.GetPipelineRequest;
+import org.opensearch.action.ingest.GetPipelineResponse;
+import org.opensearch.action.ingest.PutPipelineRequest;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
+import org.opensearch.ml.engine.indices.MLIndicesHandler;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.AdminClient;
+import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.ClusterAdminClient;
+import org.opensearch.transport.client.IndicesAdminClient;
+
+public class MemoryContainerPipelineHelperTests extends OpenSearchTestCase {
+
+    private Client client;
+    private MLIndicesHandler indicesHandler;
+    private AdminClient adminClient;
+    private ClusterAdminClient clusterAdminClient;
+    private IndicesAdminClient indicesAdminClient;
+
+    @Before
+    public void setUpTest() {
+        client = mock(Client.class);
+        indicesHandler = mock(MLIndicesHandler.class);
+        adminClient = mock(AdminClient.class);
+        clusterAdminClient = mock(ClusterAdminClient.class);
+        indicesAdminClient = mock(IndicesAdminClient.class);
+
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.cluster()).thenReturn(clusterAdminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
+    }
+
+    public void testCreateLongTermMemoryIngestPipelineCreatesResources() {
+        MemoryConfiguration configuration = MemoryConfiguration
+            .builder()
+            .indexPrefix("prefix")
+            .embeddingModelId("embedding")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(8)
+            .build();
+
+        doAnswer(invocation -> {
+            ActionListener<GetPipelineResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException("missing"));
+            return null;
+        }).when(clusterAdminClient).getPipeline(any(GetPipelineRequest.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<AcknowledgedResponse> listener = invocation.getArgument(1);
+            listener.onResponse(acknowledgedTrue());
+            return null;
+        }).when(clusterAdminClient).putPipeline(any(PutPipelineRequest.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(3);
+            listener.onResponse(true);
+            return null;
+        }).when(indicesHandler).createLongTermMemoryIndex(any(), any(), any(), any());
+
+        PlainActionFuture<Boolean> future = PlainActionFuture.newFuture();
+        MemoryContainerPipelineHelper.createLongTermMemoryIngestPipeline("index", configuration, indicesHandler, client, future);
+
+        assertTrue(future.actionGet());
+        verify(indicesHandler).createLongTermMemoryIndex(eq("index-embedding"), eq("index"), eq(configuration), any());
+    }
+
+    public void testCreateLongTermMemoryIngestPipelineWithoutEmbedding() {
+        MemoryConfiguration configuration = MemoryConfiguration.builder().indexPrefix("prefix").build();
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(3);
+            listener.onResponse(true);
+            return null;
+        }).when(indicesHandler).createLongTermMemoryIndex(eq(null), eq("index"), eq(configuration), any());
+
+        PlainActionFuture<Boolean> future = PlainActionFuture.newFuture();
+        MemoryContainerPipelineHelper.createLongTermMemoryIngestPipeline("index", configuration, indicesHandler, client, future);
+
+        assertTrue(future.actionGet());
+    }
+
+    public void testCreateTextEmbeddingPipelineWhenPipelineExists() {
+        MemoryConfiguration configuration = MemoryConfiguration
+            .builder()
+            .indexPrefix("prefix")
+            .embeddingModelId("embedding")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(8)
+            .build();
+
+        GetPipelineResponse response = mock(GetPipelineResponse.class);
+        when(response.pipelines()).thenReturn(Collections.singletonList(null));
+        doAnswer(invocation -> {
+            ActionListener<GetPipelineResponse> listener = invocation.getArgument(1);
+            listener.onResponse(response);
+            return null;
+        }).when(clusterAdminClient).getPipeline(any(GetPipelineRequest.class), any());
+
+        AtomicBoolean putCalled = new AtomicBoolean(false);
+        doAnswer(invocation -> {
+            putCalled.set(true);
+            ActionListener<AcknowledgedResponse> listener = invocation.getArgument(1);
+            listener.onResponse(acknowledgedTrue());
+            return null;
+        }).when(clusterAdminClient).putPipeline(any(PutPipelineRequest.class), any());
+
+        PlainActionFuture<Boolean> future = PlainActionFuture.newFuture();
+        MemoryContainerPipelineHelper.createTextEmbeddingPipeline("index-embedding", configuration, client, future);
+
+        assertTrue(future.actionGet());
+        assertFalse(putCalled.get());
+    }
+
+    public void testCreateTextEmbeddingPipelineFailure() {
+        MemoryConfiguration configuration = MemoryConfiguration
+            .builder()
+            .indexPrefix("prefix")
+            .embeddingModelId("embedding")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(8)
+            .build();
+
+        doAnswer(invocation -> {
+            ActionListener<GetPipelineResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException("missing"));
+            return null;
+        }).when(clusterAdminClient).getPipeline(any(GetPipelineRequest.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<AcknowledgedResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException("put failure"));
+            return null;
+        }).when(clusterAdminClient).putPipeline(any(PutPipelineRequest.class), any());
+
+        PlainActionFuture<Boolean> future = PlainActionFuture.newFuture();
+        MemoryContainerPipelineHelper.createTextEmbeddingPipeline("index-embedding", configuration, client, future);
+
+        RuntimeException exception = expectThrows(RuntimeException.class, future::actionGet);
+        assertEquals("put failure", exception.getMessage());
+    }
+
+    public void testCreateHistoryIndexIfEnabled() {
+        MemoryConfiguration configuration = MemoryConfiguration
+            .builder()
+            .indexPrefix("prefix")
+            .embeddingModelId("embedding")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(8)
+            .build();
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(2);
+            listener.onResponse(true);
+            return null;
+        }).when(indicesHandler).createLongTermMemoryHistoryIndex(eq("history"), eq(configuration), any());
+
+        PlainActionFuture<Boolean> future = PlainActionFuture.newFuture();
+        MemoryContainerPipelineHelper.createHistoryIndexIfEnabled(configuration, "history", indicesHandler, future);
+        assertTrue(future.actionGet());
+
+        MemoryConfiguration disabled = MemoryConfiguration.builder().indexPrefix("prefix").disableHistory(true).build();
+
+        AtomicBoolean disabledCalled = new AtomicBoolean(false);
+        doAnswer(invocation -> {
+            disabledCalled.set(true);
+            ActionListener<Boolean> listener = invocation.getArgument(2);
+            listener.onResponse(true);
+            return null;
+        }).when(indicesHandler).createLongTermMemoryHistoryIndex(eq("history"), eq(disabled), any());
+
+        PlainActionFuture<Boolean> skip = PlainActionFuture.newFuture();
+        MemoryContainerPipelineHelper.createHistoryIndexIfEnabled(disabled, "history", indicesHandler, skip);
+        assertTrue(skip.actionGet());
+        assertFalse(disabledCalled.get());
+    }
+
+    private AcknowledgedResponse acknowledgedTrue() {
+        return new AcknowledgedResponse(true);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLDeleteMemoryActionTests.java
@@ -16,6 +16,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_ID;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_TYPE;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
 
 import java.util.HashMap;
 import java.util.List;
@@ -201,6 +202,22 @@ public class RestMLDeleteMemoryActionTests extends OpenSearchTestCase {
         assertEquals("container-with-dashes-123", capturedRequest.getMemoryContainerId());
         assertEquals(MemoryType.WORKING, capturedRequest.getMemoryType());
         assertEquals("memory_with_underscores_456", capturedRequest.getMemoryId());
+    }
+
+    public void testPrepareRequestWithAgenticMemoryDisabled() throws Exception {
+        // Create new instance with disabled setting
+        MLFeatureEnabledSetting disabledSetting = org.mockito.Mockito.mock(MLFeatureEnabledSetting.class);
+        when(disabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
+        RestMLDeleteMemoryAction actionWithDisabledFeature = new RestMLDeleteMemoryAction(disabledSetting);
+
+        RestRequest request = getRestRequest();
+
+        Exception exception = expectThrows(org.opensearch.OpenSearchStatusException.class, () -> {
+            actionWithDisabledFeature.handleRequest(request, channel, client);
+        });
+
+        assertNotNull(exception);
+        assertEquals(ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE, exception.getMessage());
     }
 
     private RestRequest getRestRequest() {


### PR DESCRIPTION
### Description
1. Now user create or update container with strategies declared but no llm/embedding model configured, we will throw an exception
2. Now user want to createor update a container on an existing, embedding (ingest pipeline) configured index with another embedding model, we will throw an exception
3. Now user update container with new strategies added, if previously no long-term index or history index setup, we will initiate the indices with proper validation
4. Fix the update memory container interface to make it same as create container
5. Add UT coverage so currently no agentic memory related class are in jacoco exclusion rules.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
