### PR TITLE
Fix dimension update flow to allow embedding type update

### DIFF
--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -258,6 +258,30 @@ public class MemoryConfigurationTests {
     }
 
     @Test
+    public void testUpdate_SparseEncodingAutoClearsDimension() {
+        // Start with TEXT_EMBEDDING model that has dimension
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("text-model-id")
+            .dimension(1536)
+            .build();
+
+        // Update to SPARSE_ENCODING - dimension should auto-clear
+        MemoryConfiguration updateContent = MemoryConfiguration
+            .builder()
+            .embeddingModelType(FunctionName.SPARSE_ENCODING)
+            .embeddingModelId("sparse-model-id")
+            .build();
+
+        config.update(updateContent);
+
+        assertEquals(FunctionName.SPARSE_ENCODING, config.getEmbeddingModelType());
+        assertEquals("sparse-model-id", config.getEmbeddingModelId());
+        assertNull(config.getDimension()); // Dimension should be auto-cleared
+    }
+
+    @Test
     public void testUpdate_NullValuesNotUpdated() {
         MemoryConfiguration config = MemoryConfiguration.builder().llmId("original-llm-id").build();
 


### PR DESCRIPTION
### Problem

  Users cannot update memory containers from `TEXT_EMBEDDING` to `SPARSE_ENCODING` models before adding strategies. When attempting to switch model types, validation fails with "Dimension is not allowed for SPARSE_ENCODING" because the dimension field cannot be cleared back to null.

###  Root Cause

  OpenSearch Update API's .doc() method merges nested objects rather than replacing them. Omitted fields retain their old values, so the dimension field persists even when switching to SPARSE_ENCODING (which doesn't use dimensions).

### Solution

  Implemented model-type-aware dimension handling:

  1. Auto-clear dimension - update() method automatically sets dimension to null when embedding type is SPARSE_ENCODING
  2. Explicit null serialization - toXContent() outputs "dimension": null for SPARSE_ENCODING to remove the field during OpenSearch merge
  3. Parse explicit nulls - parse() handles both omitted fields and explicit {"dimension": null} in JSON

###  Changes

  - MemoryConfiguration.java:
    - toXContent(): Explicitly output null for SPARSE_ENCODING models
    - parse(): Handle VALUE_NULL token for dimension field
    - update(): Auto-clear dimension when type is SPARSE_ENCODING
  - MemoryConfigurationTests.java: Added testUpdate_SparseEncodingAutoClearsDimension()

### Testing

  - ✅ Unit test coverage added
  - ✅ Manual testing confirmed dimension field is removed from storage
  - ✅ Build passes (code coverage separate issue)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
