### PR TITLE
add refresh policy; add checkpoint id field

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLWorkingMemory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLWorkingMemory.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.INFER_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
@@ -68,6 +69,9 @@ public class MLWorkingMemory implements ToXContentObject, Writeable {
     private Instant lastUpdateTime;
     private String ownerId;
 
+    // Checkpoint field
+    private String checkpointId;
+
     @Builder
     public MLWorkingMemory(
         String memoryContainerId,
@@ -82,7 +86,8 @@ public class MLWorkingMemory implements ToXContentObject, Writeable {
         Map<String, String> tags,
         Instant createdTime,
         Instant lastUpdateTime,
-        String ownerId
+        String ownerId,
+        String checkpointId
     ) {
         // MAX_MESSAGES_PER_REQUEST limit removed for performance testing
 
@@ -100,6 +105,7 @@ public class MLWorkingMemory implements ToXContentObject, Writeable {
         this.createdTime = createdTime;
         this.lastUpdateTime = lastUpdateTime;
         this.ownerId = ownerId;
+        this.checkpointId = checkpointId;
     }
 
     public MLWorkingMemory(StreamInput in) throws IOException {
@@ -131,6 +137,7 @@ public class MLWorkingMemory implements ToXContentObject, Writeable {
         this.createdTime = in.readOptionalInstant();
         this.lastUpdateTime = in.readOptionalInstant();
         this.ownerId = in.readOptionalString();
+        this.checkpointId = in.readOptionalString();
     }
 
     @Override
@@ -177,6 +184,7 @@ public class MLWorkingMemory implements ToXContentObject, Writeable {
         out.writeOptionalInstant(createdTime);
         out.writeOptionalInstant(lastUpdateTime);
         out.writeOptionalString(ownerId);
+        out.writeOptionalString(checkpointId);
     }
 
     @Override
@@ -225,6 +233,9 @@ public class MLWorkingMemory implements ToXContentObject, Writeable {
         if (ownerId != null) {
             builder.field(OWNER_ID_FIELD, ownerId);
         }
+        if (checkpointId != null) {
+            builder.field(CHECKPOINT_ID_FIELD, checkpointId);
+        }
         builder.endObject();
         return builder;
     }
@@ -243,6 +254,7 @@ public class MLWorkingMemory implements ToXContentObject, Writeable {
         Instant createdTime = null;
         Instant lastUpdateTime = null;
         String ownerId = null;
+        String checkpointId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -293,6 +305,9 @@ public class MLWorkingMemory implements ToXContentObject, Writeable {
                 case OWNER_ID_FIELD:
                     ownerId = parser.text();
                     break;
+                case CHECKPOINT_ID_FIELD:
+                    checkpointId = parser.text();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -314,6 +329,7 @@ public class MLWorkingMemory implements ToXContentObject, Writeable {
             .createdTime(createdTime)
             .lastUpdateTime(lastUpdateTime)
             .ownerId(ownerId)
+            .checkpointId(checkpointId)
             .build();
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -86,6 +86,9 @@ public class MemoryContainerConstants {
     public static final String TEXT_FIELD = "text";
     public static final String UPDATE_CONTENT_FIELD = "update_content";
 
+    // Checkpoint field
+    public static final String CHECKPOINT_ID_FIELD = "checkpoint_id";
+
     // KNN index settings
     public static final String KNN_ENGINE = "lucene";
     public static final String KNN_SPACE_TYPE = "cosinesimil";

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.transport.memorycontainer.memory;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.INFER_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
@@ -69,6 +70,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
     private Map<String, Object> parameters;
     private String ownerId;
 
+    // Checkpoint field
+    private String checkpointId;
+
     public MLAddMemoriesInput(
         String memoryContainerId,
         PayloadType payloadType,
@@ -81,7 +85,8 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> metadata,
         Map<String, String> tags,
         Map<String, Object> parameters,
-        String ownerId
+        String ownerId,
+        String checkpointId
     ) {
         // MAX_MESSAGES_PER_REQUEST limit removed for performance testing
 
@@ -100,6 +105,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters.putAll(parameters);
         }
         this.ownerId = ownerId;
+        this.checkpointId = checkpointId;
         validate();
     }
 
@@ -144,6 +150,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters = in.readMap();
         }
         this.ownerId = in.readOptionalString();
+        this.checkpointId = in.readOptionalString();
     }
 
     @Override
@@ -193,6 +200,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(ownerId);
+        out.writeOptionalString(checkpointId);
     }
 
     @Override
@@ -239,6 +247,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         if (ownerId != null) {
             builder.field(OWNER_ID_FIELD, ownerId);
         }
+        if (checkpointId != null) {
+            builder.field(CHECKPOINT_ID_FIELD, checkpointId);
+        }
         if (withTimeStamp) {
             Instant now = Instant.now();
             builder.field(CREATED_TIME_FIELD, now.toEpochMilli());
@@ -260,6 +271,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> tags = null;
         Map<String, Object> parameters = null;
         String ownerId = null;
+        String checkpointId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -307,6 +319,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
                 case OWNER_ID_FIELD:
                     ownerId = parser.text();
                     break;
+                case CHECKPOINT_ID_FIELD:
+                    checkpointId = parser.text();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -327,6 +342,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             .tags(tags)
             .parameters(parameters)
             .ownerId(ownerId)
+            .checkpointId(checkpointId)
             .build();
     }
 

--- a/common/src/main/resources/index-mappings/ml_memory_working.json
+++ b/common/src/main/resources/index-mappings/ml_memory_working.json
@@ -26,6 +26,9 @@
     "message_id": {
       "type": "integer"
     },
+    "checkpoint_id": {
+      "type": "keyword"
+    },
     "binary_data": {
       "type": "binary"
     },

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
@@ -190,78 +190,53 @@ public class MLAddMemoriesInputTest {
         // Test null memoryContainerId
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> new MLAddMemoriesInput(
-                null,
-                PayloadType.CONVERSATIONAL,
-                testMessages,
-                null,
-                null,
-                null,
-                null,
-                false,
-                null,
-                null,
-                null,
-                "owner-1"
-            )
+            () -> MLAddMemoriesInput
+                .builder()
+                .memoryContainerId(null)
+                .payloadType(PayloadType.CONVERSATIONAL)
+                .messages(testMessages)
+                .ownerId("owner-1")
+                .build()
         );
         assertEquals("No memory container id provided", exception.getMessage());
 
         // Test null messages with infer=true
         exception = assertThrows(
             IllegalArgumentException.class,
-            () -> new MLAddMemoriesInput(
-                "container-1",
-                PayloadType.CONVERSATIONAL,
-                null,
-                null,
-                null,
-                null,
-                null,
-                true,
-                null,
-                null,
-                null,
-                "owner-1"
-            )
+            () -> MLAddMemoriesInput
+                .builder()
+                .memoryContainerId("container-1")
+                .payloadType(PayloadType.CONVERSATIONAL)
+                .messages(null)
+                .infer(true)
+                .ownerId("owner-1")
+                .build()
         );
         assertEquals("No messages provided when inferring memory", exception.getMessage());
 
         // Test empty messages with infer=true
         exception = assertThrows(
             IllegalArgumentException.class,
-            () -> new MLAddMemoriesInput(
-                "container-1",
-                PayloadType.CONVERSATIONAL,
-                new ArrayList<>(),
-                null,
-                null,
-                null,
-                null,
-                true,
-                null,
-                null,
-                null,
-                "owner-1"
-            )
+            () -> MLAddMemoriesInput
+                .builder()
+                .memoryContainerId("container-1")
+                .payloadType(PayloadType.CONVERSATIONAL)
+                .messages(new ArrayList<>())
+                .infer(true)
+                .ownerId("owner-1")
+                .build()
         );
         assertEquals("No messages provided when inferring memory", exception.getMessage());
 
         // Test valid case - null messages with infer=false should pass
-        MLAddMemoriesInput validInput = new MLAddMemoriesInput(
-            "container-1",
-            PayloadType.CONVERSATIONAL,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
-            null,
-            null,
-            "owner-1"
-        );
+        MLAddMemoriesInput validInput = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-1")
+            .payloadType(PayloadType.CONVERSATIONAL)
+            .messages(null)
+            .infer(false)
+            .ownerId("owner-1")
+            .build();
         assertNotNull(validInput);
     }
 
@@ -415,77 +390,50 @@ public class MLAddMemoriesInputTest {
     @Test
     public void testConstructorWithNullMemoryType() {
         // Test that null memoryType defaults to CONVERSATIONAL
-        MLAddMemoriesInput input = new MLAddMemoriesInput(
-            "container-123",
-            null, // null memoryType
-            testMessages,
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
-            null,
-            null,
-            "owner-123"
-        );
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .payloadType(null) // null memoryType
+            .messages(testMessages)
+            .ownerId("owner-123")
+            .build();
         assertEquals(PayloadType.CONVERSATIONAL, input.getPayloadType());
     }
 
     @Test
     public void testConstructorWithAllMemoryTypes() {
         // Test with CONVERSATIONAL type
-        MLAddMemoriesInput conversationalInput = new MLAddMemoriesInput(
-            "container-123",
-            PayloadType.CONVERSATIONAL,
-            testMessages,
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
-            null,
-            null,
-            "owner-123"
-        );
+        MLAddMemoriesInput conversationalInput = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .payloadType(PayloadType.CONVERSATIONAL)
+            .messages(testMessages)
+            .ownerId("owner-123")
+            .build();
         assertEquals(PayloadType.CONVERSATIONAL, conversationalInput.getPayloadType());
 
         // Test with DATA type
-        MLAddMemoriesInput dataInput = new MLAddMemoriesInput(
-            "container-123",
-            PayloadType.DATA,
-            testMessages,
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
-            null,
-            null,
-            "owner-123"
-        );
+        MLAddMemoriesInput dataInput = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .payloadType(PayloadType.DATA)
+            .messages(testMessages)
+            .ownerId("owner-123")
+            .build();
         assertEquals(PayloadType.DATA, dataInput.getPayloadType());
     }
 
     @Test
     public void testConstructorWithNullParameters() {
         // Test that null parameters creates empty map
-        MLAddMemoriesInput input = new MLAddMemoriesInput(
-            "container-123",
-            PayloadType.CONVERSATIONAL,
-            testMessages,
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
-            null,
-            null, // null parameters
-            "owner-123"
-        );
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .payloadType(PayloadType.CONVERSATIONAL)
+            .messages(testMessages)
+            .parameters(null) // null parameters
+            .ownerId("owner-123")
+            .build();
         assertNotNull(input.getParameters());
         assertTrue(input.getParameters().isEmpty());
     }
@@ -494,20 +442,14 @@ public class MLAddMemoriesInputTest {
     public void testConstructorWithEmptyParameters() {
         // Test that empty parameters creates empty map
         Map<String, Object> emptyParams = new HashMap<>();
-        MLAddMemoriesInput input = new MLAddMemoriesInput(
-            "container-123",
-            PayloadType.CONVERSATIONAL,
-            testMessages,
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
-            null,
-            emptyParams,
-            "owner-123"
-        );
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .payloadType(PayloadType.CONVERSATIONAL)
+            .messages(testMessages)
+            .parameters(emptyParams)
+            .ownerId("owner-123")
+            .build();
         assertNotNull(input.getParameters());
         assertTrue(input.getParameters().isEmpty());
     }
@@ -519,20 +461,14 @@ public class MLAddMemoriesInputTest {
         params.put("param1", "value1");
         params.put("param2", 42);
 
-        MLAddMemoriesInput input = new MLAddMemoriesInput(
-            "container-123",
-            PayloadType.CONVERSATIONAL,
-            testMessages,
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
-            null,
-            params,
-            "owner-123"
-        );
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .payloadType(PayloadType.CONVERSATIONAL)
+            .messages(testMessages)
+            .parameters(params)
+            .ownerId("owner-123")
+            .build();
         assertNotNull(input.getParameters());
         assertEquals(2, input.getParameters().size());
         assertEquals("value1", input.getParameters().get("param1"));
@@ -589,21 +525,14 @@ public class MLAddMemoriesInputTest {
     @Test
     public void testStreamInputOutputWithNullFields() throws IOException {
         // Test serialization with all optional fields as null
-        // Use constructor directly to avoid builder validation
-        MLAddMemoriesInput nullFieldsInput = new MLAddMemoriesInput(
-            "container-null",
-            PayloadType.CONVERSATIONAL,
-            null, // null messages is OK when infer=false
-            null,
-            null,
-            null,
-            null,
-            false, // infer=false allows null messages
-            null,
-            null,
-            null,
-            null
-        );
+        // Use builder with minimal fields
+        MLAddMemoriesInput nullFieldsInput = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-null")
+            .payloadType(PayloadType.CONVERSATIONAL)
+            .messages(null) // null messages is OK when infer=false
+            .infer(false) // infer=false allows null messages
+            .build();
 
         BytesStreamOutput out = new BytesStreamOutput();
         nullFieldsInput.writeTo(out);
@@ -794,20 +723,18 @@ public class MLAddMemoriesInputTest {
         Map<String, String> emptyTags = new HashMap<>();
         Map<String, Object> emptyParameters = new HashMap<>();
 
-        MLAddMemoriesInput inputEmptyMaps = new MLAddMemoriesInput(
-            "container-empty-maps",
-            PayloadType.DATA,
-            testMessages,
-            null,
-            null,
-            null,
-            emptyNamespace,
-            true,
-            emptyMetadata,
-            emptyTags,
-            emptyParameters,
-            "owner-empty"
-        );
+        MLAddMemoriesInput inputEmptyMaps = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-empty-maps")
+            .payloadType(PayloadType.DATA)
+            .messages(testMessages)
+            .namespace(emptyNamespace)
+            .infer(true)
+            .metadata(emptyMetadata)
+            .tags(emptyTags)
+            .parameters(emptyParameters)
+            .ownerId("owner-empty")
+            .build();
 
         BytesStreamOutput out = new BytesStreamOutput();
         inputEmptyMaps.writeTo(out);
@@ -830,20 +757,14 @@ public class MLAddMemoriesInputTest {
     @Test
     public void testValidateWithEmptyMessagesAndInferFalse() {
         // Test that empty messages with infer=false is valid
-        MLAddMemoriesInput validInput = new MLAddMemoriesInput(
-            "container-123",
-            PayloadType.CONVERSATIONAL,
-            new ArrayList<>(), // empty messages
-            null,
-            null,
-            null,
-            null,
-            false, // infer=false
-            null,
-            null,
-            null,
-            "owner-123"
-        );
+        MLAddMemoriesInput validInput = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .payloadType(PayloadType.CONVERSATIONAL)
+            .messages(new ArrayList<>()) // empty messages
+            .infer(false) // infer=false
+            .ownerId("owner-123")
+            .build();
 
         // Should not throw exception
         assertNotNull(validInput);
@@ -870,6 +791,75 @@ public class MLAddMemoriesInputTest {
 
         // Should throw IllegalArgumentException due to invalid memory type
         assertThrows(IllegalArgumentException.class, () -> { MLAddMemoriesInput.parse(parser, null); });
+    }
+
+    @Test
+    public void testCheckpointIdField() {
+        // Test with checkpoint_id field
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .checkpointId("checkpoint-123")
+            .ownerId("owner-checkpoint")
+            .build();
+
+        assertEquals("checkpoint-123", input.getCheckpointId());
+    }
+
+    @Test
+    public void testCheckpointIdSerialization() throws IOException {
+        // Test serialization with checkpoint_id field
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .checkpointId("checkpoint-456")
+            .ownerId("owner-checkpoint-ser")
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        input.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        MLAddMemoriesInput deserialized = new MLAddMemoriesInput(in);
+
+        assertEquals(input.getCheckpointId(), deserialized.getCheckpointId());
+    }
+
+    @Test
+    public void testParseWithCheckpointId() throws IOException {
+        // Test parsing with checkpoint_id field
+        String jsonString = "{"
+            + "\"memory_container_id\":\"container-123\","
+            + "\"messages\":["
+            + "{\"role\":\"user\",\"content\":[{\"type\":\"text\", \"text\": \"Test message\"}]}"
+            + "],"
+            + "\"checkpoint_id\":\"checkpoint-789\""
+            + "}";
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLAddMemoriesInput parsed = MLAddMemoriesInput.parse(parser, "container-123");
+
+        assertEquals("checkpoint-789", parsed.getCheckpointId());
+    }
+
+    @Test
+    public void testCheckpointIdSetter() {
+        // Test setter for checkpoint_id field
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .ownerId("owner-setters")
+            .build();
+
+        input.setCheckpointId("new-checkpoint-id");
+
+        assertEquals("new-checkpoint-id", input.getCheckpointId());
     }
 
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -15,6 +15,7 @@ import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
@@ -248,6 +249,7 @@ public class TransportCreateMemoryContainerAction extends
                         .tenantId(container.getTenantId())
                         .index(ML_MEMORY_CONTAINER_INDEX)
                         .dataObject(container)
+                        .refreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                         .build()
                 )
                 .whenComplete((r, throwable) -> {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryOperationsService.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryOperationsService.java
@@ -171,6 +171,7 @@ public class MemoryOperationsService {
             listener.onResponse(results);
             return;
         }
+        bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         ActionListener<BulkResponse> bulkResponseActionListener = ActionListener.wrap(bulkResponse -> {
             if (bulkResponse.hasFailures()) {
@@ -202,6 +203,7 @@ public class MemoryOperationsService {
                             .source(createMemoryHistory(memoryResult, namespace, input, input.getMemoryContainerId()))
                     );
             }
+            bulkHistoryRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             ActionListener<BulkResponse> bulkHistoryResponseListener = ActionListener.wrap(bulkHistoryResponse -> {
                 if (bulkHistoryResponse.hasFailures()) {
                     log.error("Bulk memory history operations had failures: {}", bulkHistoryResponse.buildFailureMessage());

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -30,6 +30,7 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.commons.authuser.User;
@@ -176,6 +177,7 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                                     now.getEpochSecond()
                                 )
                         );
+                    indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                     ActionListener<IndexResponse> responseActionListener = ActionListener.<IndexResponse>wrap(r -> {
                         input.getNamespace().put(SESSION_ID_FIELD, r.getId());
                         processAndIndexMemory(input, container, user, actionListener);
@@ -255,6 +257,7 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             mlAddMemoriesInput.toXContent(builder, ToXContent.EMPTY_PARAMS, true);
 
             indexRequest.source(builder);
+            indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             return indexRequest;
         } catch (IOException e) {
             logger.error("Failed to build index request source", e);

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
@@ -20,6 +20,7 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
@@ -127,6 +128,7 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
                 // Prepare the update
                 Map<String, Object> newDoc = constructNewDoc(updateRequest.getMlUpdateMemoryInput(), memoryType, originalDoc);
                 IndexRequest indexRequest = new IndexRequest(memoryIndexName).id(memoryId).source(newDoc);
+                indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                 memoryContainerHelper.indexData(container.getConfiguration(), indexRequest, actionListener);
 
             }, actionListener::onFailure);

--- a/plugin/src/main/java/org/opensearch/ml/action/session/TransportCreateSessionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/session/TransportCreateSessionAction.java
@@ -15,6 +15,7 @@ import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.commons.authuser.User;
@@ -128,6 +129,7 @@ public class TransportCreateSessionAction extends HandledTransportAction<MLCreat
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             session.toXContent(builder, ToXContent.EMPTY_PARAMS);
             indexRequest.source(builder);
+            indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             memoryContainerHelper.indexData(container.getConfiguration(), indexRequest, ActionListener.wrap(r -> {
                 MLCreateSessionResponse response = MLCreateSessionResponse.builder().sessionId(r.getId()).status("created").build();
                 actionListener.onResponse(response);


### PR DESCRIPTION
### Description
Test langgraph with Agentic Memory, see some issues
1. Working memory doesn't have checkpoint id field. Can save it to structured data but we can't sort by it because structured data is flat object.
2. Memory added, but not searchable immediately. That cause checkpoint becomes messy in a conversation. Need to add refresh policy.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
