### PR TITLE
Fix unsupported operation exception in execute tool API

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/tool/MLToolExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/tool/MLToolExecutor.java
@@ -83,13 +83,14 @@ public class MLToolExecutor implements Executable {
         }
 
         try {
-            Tool tool = toolFactory.create(new HashMap<>(parameters));
-            if (!tool.validate(parameters)) {
+            Map<String, String> mutableParams = new HashMap<>(parameters);
+            Tool tool = toolFactory.create(mutableParams);
+            if (!tool.validate(mutableParams)) {
                 listener.onFailure(new IllegalArgumentException("Invalid parameters for tool: " + toolName));
                 return;
             }
 
-            tool.run(parameters, ActionListener.wrap(result -> {
+            tool.run(mutableParams, ActionListener.wrap(result -> {
                 List<ModelTensor> modelTensors = new ArrayList<>();
                 processOutput(result, modelTensors);
                 ModelTensors tensors = ModelTensors.builder().mlModelTensors(modelTensors).build();


### PR DESCRIPTION
### Description
There's an issue when executing `ReadFromScratchPadTool` or `WriteToScratchPadTool` with empty parameters through the execute tool API. While these tools should support empty parameter execution, they currently throw an exception:
```
POST /_plugins/_ml/tools/_execute/ReadFromScratchPadTool
{
  "parameters": {}
}

// Exception thrown
{
    "status": 500,
    "error": {
        "type": "NotSerializableExceptionWrapper",
        "reason": "System Error",
        "details": "unsupported_operation_exception: null"
    }
}
```

The issue is due to the immutable map implementations being passed to these tools. These tools expect to modify the parameters map during execution ([reference](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/ReadFromScratchPadTool.java#L116)). When they attempt to call parameters.put() on an immutable map, an UnsupportedOperationException is thrown.

To fix this issue, we need to ensure these tools always receive a mutable map by creating a mutable copy of the parameters before passing them to the tools. This will allow the tools to modify the parameters as needed during execution, even when starting with empty parameters.

Test with current fix:
```
POST /_plugins/_ml/tools/_execute/ReadFromScratchPadTool
{
  "parameters": {}
}


// Successful response
{
    "inference_results": [
        {
            "output": [
                {
                    "name": "response",
                    "result": "Scratchpad is empty."
                }
            ]
        }
    ]
}
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
