### PR TITLE
Fix CVE-2025-58057

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,15 +96,15 @@ subprojects {
         // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
         resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
         resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
-        resolutionStrategy.force 'io.netty:netty-buffer:4.1.125.Final'
-        resolutionStrategy.force 'io.netty:netty-codec:4.1.125.Final'
-        resolutionStrategy.force 'io.netty:netty-codec-http:4.1.125.Final'
-        resolutionStrategy.force 'io.netty:netty-codec-http2:4.1.125.Final'
-        resolutionStrategy.force 'io.netty:netty-common:4.1.125.Final'
-        resolutionStrategy.force 'io.netty:netty-handler:4.1.125.Final'
-        resolutionStrategy.force 'io.netty:netty-resolver:4.1.125.Final'
-        resolutionStrategy.force 'io.netty:netty-transport:4.1.125.Final'
-        resolutionStrategy.force 'io.netty:netty-transport-native-unix-common:4.1.125.Final'
+        resolutionStrategy.force "io.netty:netty-buffer:${versions.netty}"
+        resolutionStrategy.force "io.netty:netty-codec:${versions.netty}"
+        resolutionStrategy.force "io.netty:netty-codec-http:${versions.netty}"
+        resolutionStrategy.force "io.netty:netty-codec-http2:${versions.netty}"
+        resolutionStrategy.force "io.netty:netty-common:${versions.netty}"
+        resolutionStrategy.force "io.netty:netty-handler:${versions.netty}"
+        resolutionStrategy.force "io.netty:netty-resolver:${versions.netty}"
+        resolutionStrategy.force "io.netty:netty-transport:${versions.netty}"
+        resolutionStrategy.force "io.netty:netty-transport-native-unix-common:${versions.netty}"
     }
 
     apply plugin: 'com.diffplug.spotless'


### PR DESCRIPTION
### Description
Fix CVE-2025-58057

Force `netty-codec` to 4.1.125.Final
```
for project in opensearch-ml-algorithms opensearch-ml-client opensearch-ml-common opensearch-ml-memory opensearch-ml-plugin opensearch-ml-search-processors opensearch-ml-spi; do
  echo "=== $project ==="
  ./gradlew :$project:dependencies | grep netty-codec
done
=== opensearch-ml-algorithms ===
|    +--- io.netty:netty-codec-http:4.1.124.Final -> 4.1.125.Final
|    |    +--- io.netty:netty-codec:4.1.125.Final
|    |         \--- io.netty:netty-codec:4.1.125.Final (*)
|    +--- io.netty:netty-codec-http2:4.1.124.Final -> 4.1.125.Final
|    |    +--- io.netty:netty-codec:4.1.125.Final (*)
|    |    \--- io.netty:netty-codec-http:4.1.125.Final (*)
|    +--- io.netty:netty-codec:4.1.124.Final -> 4.1.125.Final (*)
|    |         +--- io.netty:netty-codec-http:4.1.124.Final -> 4.1.125.Final
|    |         |    +--- io.netty:netty-codec:4.1.125.Final
|    |         |         \--- io.netty:netty-codec:4.1.125.Final (*)
|    |         +--- io.netty:netty-codec-http2:4.1.124.Final -> 4.1.125.Final
|    |         |    +--- io.netty:netty-codec:4.1.125.Final (*)
|    |         |    \--- io.netty:netty-codec-http:4.1.125.Final (*)
|    |         +--- io.netty:netty-codec:4.1.124.Final -> 4.1.125.Final (*)
|    +--- io.netty:netty-codec-http:4.1.124.Final -> 4.1.125.Final
|    |    +--- io.netty:netty-codec:4.1.125.Final
|    |         \--- io.netty:netty-codec:4.1.125.Final (*)
|    +--- io.netty:netty-codec-http2:4.1.124.Final -> 4.1.125.Final
|    |    +--- io.netty:netty-codec:4.1.125.Final (*)
|    |    \--- io.netty:netty-codec-http:4.1.125.Final (*)
|    +--- io.netty:netty-codec:4.1.124.Final -> 4.1.125.Final (*)
|         +--- io.netty:netty-codec-http:4.1.124.Final -> 4.1.125.Final
|         |    +--- io.netty:netty-codec:4.1.125.Final
|         |         \--- io.netty:netty-codec:4.1.125.Final (*)
|         +--- io.netty:netty-codec-http2:4.1.124.Final -> 4.1.125.Final
|         |    +--- io.netty:netty-codec:4.1.125.Final (*)
|         |    \--- io.netty:netty-codec-http:4.1.125.Final (*)
|         +--- io.netty:netty-codec:4.1.124.Final -> 4.1.125.Final (*)
=== opensearch-ml-client ===
=== opensearch-ml-common ===
|    +--- io.netty:netty-codec-http:4.1.124.Final -> 4.1.125.Final
|    |    +--- io.netty:netty-codec:4.1.125.Final
|    |         \--- io.netty:netty-codec:4.1.125.Final (*)
|    +--- io.netty:netty-codec-http2:4.1.124.Final -> 4.1.125.Final
|    |    +--- io.netty:netty-codec:4.1.125.Final (*)
|    |    \--- io.netty:netty-codec-http:4.1.125.Final (*)
|    +--- io.netty:netty-codec:4.1.124.Final -> 4.1.125.Final (*)
|    +--- io.netty:netty-codec-http:4.1.124.Final -> 4.1.125.Final
|    |    +--- io.netty:netty-codec:4.1.125.Final
|    |         \--- io.netty:netty-codec:4.1.125.Final (*)
|    +--- io.netty:netty-codec-http2:4.1.124.Final -> 4.1.125.Final
|    |    +--- io.netty:netty-codec:4.1.125.Final (*)
|    |    \--- io.netty:netty-codec-http:4.1.125.Final (*)
|    +--- io.netty:netty-codec:4.1.124.Final -> 4.1.125.Final (*)
|    +--- io.netty:netty-codec-http:4.1.124.Final -> 4.1.125.Final
|    |    +--- io.netty:netty-codec:4.1.125.Final
|    |         \--- io.netty:netty-codec:4.1.125.Final (*)
|    +--- io.netty:netty-codec-http2:4.1.124.Final -> 4.1.125.Final
|    |    +--- io.netty:netty-codec:4.1.125.Final (*)
|    |    \--- io.netty:netty-codec-http:4.1.125.Final (*)
|    +--- io.netty:netty-codec:4.1.124.Final -> 4.1.125.Final (*)
=== opensearch-ml-memory ===
=== opensearch-ml-plugin ===
|    |    |         +--- io.netty:netty-codec-http:4.1.124.Final -> 4.1.125.Final
|    |    |         |    +--- io.netty:netty-codec:4.1.125.Final
|    |    |         +--- io.netty:netty-codec-http2:4.1.124.Final -> 4.1.125.Final
|    |    |         |    +--- io.netty:netty-codec:4.1.125.Final (*)
|    |    |         |    \--- io.netty:netty-codec-http:4.1.125.Final (*)
|    |    |         +--- io.netty:netty-codec:4.1.124.Final -> 4.1.125.Final (*)
|    |    |         +--- io.netty:netty-codec-http:4.1.124.Final -> 4.1.125.Final
|    |    |         |    +--- io.netty:netty-codec:4.1.125.Final
|    |    |         +--- io.netty:netty-codec-http2:4.1.124.Final -> 4.1.125.Final
|    |    |         |    +--- io.netty:netty-codec:4.1.125.Final (*)
|    |    |         |    \--- io.netty:netty-codec-http:4.1.125.Final (*)
|    |    |         +--- io.netty:netty-codec:4.1.124.Final -> 4.1.125.Final (*)
=== opensearch-ml-search-processors ===
=== opensearch-ml-spi ===
```

Couldn't find dependency insight for `netty-codec-compression`
```
for project in opensearch-ml-algorithms opensearch-ml-client opensearch-ml-common opensearch-ml-memory opensearch-ml-plugin opensearch-ml-search-processors opensearch-ml-spi; do
  echo "=== $project ==="
  ./gradlew :$project:dependencies | grep netty-codec-compression
done

=== opensearch-ml-algorithms ===
=== opensearch-ml-client ===
=== opensearch-ml-common ===
=== opensearch-ml-memory ===
=== opensearch-ml-plugin ===
=== opensearch-ml-search-processors ===
=== opensearch-ml-spi ===
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
