### PR TITLE
Add robust input validation to MCP Server

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     compileOnly group: 'com.google.code.gson', name: 'gson', version: "${versions.gson}"
     compileOnly group: 'org.json', name: 'json', version: '20231013'
     testImplementation group: 'org.json', name: 'json', version: '20231013'
+    compileOnly('io.modelcontextprotocol.sdk:mcp:0.12.1')
+    testImplementation('io.modelcontextprotocol.sdk:mcp:0.12.1')
     implementation('com.google.guava:guava:32.1.3-jre') {
         exclude group: 'com.google.guava', module: 'failureaccess'
         exclude group: 'com.google.code.findbugs', module: 'jsr305'

--- a/common/src/main/java/org/opensearch/ml/common/transport/mcpserver/requests/server/MLMcpServerRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/mcpserver/requests/server/MLMcpServerRequest.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Set;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
@@ -16,25 +17,132 @@ import org.opensearch.core.common.io.stream.InputStreamStreamInput;
 import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.ml.common.utils.StringUtils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.modelcontextprotocol.spec.McpSchema;
 import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 
+@Log4j2
 public class MLMcpServerRequest extends ActionRequest {
+
+    private static final int MAX_ID_LENGTH = 1000;
+    private static final int MAX_REQUEST_SIZE = 10 * 1024 * 1024;
+    private static final Set<String> VALID_METHODS = Set
+        .of(
+            McpSchema.METHOD_INITIALIZE,
+            McpSchema.METHOD_NOTIFICATION_INITIALIZED,
+            McpSchema.METHOD_PING,
+            McpSchema.METHOD_NOTIFICATION_PROGRESS,
+            McpSchema.METHOD_TOOLS_LIST,
+            McpSchema.METHOD_TOOLS_CALL,
+            McpSchema.METHOD_NOTIFICATION_TOOLS_LIST_CHANGED,
+            McpSchema.METHOD_RESOURCES_LIST,
+            McpSchema.METHOD_RESOURCES_READ,
+            McpSchema.METHOD_NOTIFICATION_RESOURCES_LIST_CHANGED,
+            McpSchema.METHOD_NOTIFICATION_RESOURCES_UPDATED,
+            McpSchema.METHOD_RESOURCES_TEMPLATES_LIST,
+            McpSchema.METHOD_RESOURCES_SUBSCRIBE,
+            McpSchema.METHOD_RESOURCES_UNSUBSCRIBE,
+            McpSchema.METHOD_PROMPT_LIST,
+            McpSchema.METHOD_PROMPT_GET,
+            McpSchema.METHOD_NOTIFICATION_PROMPTS_LIST_CHANGED,
+            McpSchema.METHOD_COMPLETION_COMPLETE,
+            McpSchema.METHOD_LOGGING_SET_LEVEL,
+            McpSchema.METHOD_NOTIFICATION_MESSAGE,
+            McpSchema.METHOD_ROOTS_LIST,
+            McpSchema.METHOD_NOTIFICATION_ROOTS_LIST_CHANGED,
+            McpSchema.METHOD_SAMPLING_CREATE_MESSAGE,
+            McpSchema.METHOD_ELICITATION_CREATE
+        );
+
     @Getter
-    private String requestBody;
+    private McpSchema.JSONRPCMessage message;
 
     public MLMcpServerRequest(StreamInput in) throws IOException {
         super(in);
-        this.requestBody = in.readString();
+        validateAndParseRequest(in.readString());
     }
 
     public MLMcpServerRequest(String requestBody) {
-        this.requestBody = requestBody;
+        validateAndParseRequest(requestBody);
+    }
+
+    private void validateAndParseRequest(String requestBody) {
+        if (requestBody == null || requestBody.isEmpty()) {
+            throw new IllegalArgumentException("Request body cannot be null or empty");
+        }
+        if (requestBody.length() > MAX_REQUEST_SIZE) {
+            throw new IllegalArgumentException("Request body exceeds maximum size of " + MAX_REQUEST_SIZE + " bytes");
+        }
+
+        try {
+            message = McpSchema.deserializeJsonRpcMessage(new ObjectMapper(), requestBody);
+        } catch (Exception e) {
+            log.error("Parse error: " + e.getMessage(), e);
+            throw new IllegalArgumentException("Failed to parse JSON-RPC message: " + e.getMessage(), e);
+        }
+
+        validateMessage();
+    }
+
+    private void validateMessage() {
+        if (!McpSchema.JSONRPC_VERSION.equals(message.jsonrpc())) {
+            throw new IllegalArgumentException("Invalid jsonrpc version. Expected '2.0' but got '" + message.jsonrpc() + "'");
+        }
+
+        if (message instanceof McpSchema.JSONRPCRequest request) {
+            validateRequestId(request.id());
+            validateMethod(request.method());
+        } else if (message instanceof McpSchema.JSONRPCNotification notification) {
+            validateMethod(notification.method());
+        } else if (message instanceof McpSchema.JSONRPCResponse) {
+            throw new IllegalArgumentException("JSON-RPC responses are not accepted as incoming messages");
+        } else {
+            throw new IllegalArgumentException("Unknown JSON-RPC message type: " + message.getClass().getName());
+        }
+    }
+
+    private void validateRequestId(Object id) {
+        if (id == null) {
+            throw new IllegalArgumentException("Request ID cannot be null");
+        }
+        if (!(id instanceof String || id instanceof Integer || id instanceof Long)) {
+            throw new IllegalArgumentException("Request ID must be a string or integer, but got: " + id.getClass().getSimpleName());
+        }
+        if (id instanceof String) {
+            String idStr = (String) id;
+            if (idStr.length() > MAX_ID_LENGTH) {
+                throw new IllegalArgumentException("Request ID exceeds maximum length of " + MAX_ID_LENGTH + " characters");
+            }
+            if (!StringUtils.matchesSafePattern(idStr)) {
+                throw new IllegalArgumentException("Request ID " + StringUtils.SAFE_INPUT_DESCRIPTION);
+            }
+        }
+    }
+
+    private void validateMethod(String method) {
+        if (method == null || method.isEmpty()) {
+            throw new IllegalArgumentException("Method cannot be null or empty");
+        }
+        if (!VALID_METHODS.contains(method)) {
+            throw new IllegalArgumentException("Invalid MCP method: '" + method + "'. Must be one of the supported MCP methods.");
+        }
     }
 
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(requestBody);
+        // Serialize the message back to JSON string
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            String jsonString = objectMapper.writeValueAsString(message);
+            out.writeString(jsonString);
+        } catch (JsonProcessingException e) {
+            throw new IOException("Failed to serialize JSON-RPC message", e);
+        }
     }
 
     public static MLMcpServerRequest fromActionRequest(ActionRequest actionRequest) {

--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/TransportMcpServerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/TransportMcpServerAction.java
@@ -8,7 +8,6 @@ package org.opensearch.ml.action.mcpserver;
 import static org.opensearch.ml.common.CommonValue.ERROR_CODE_FIELD;
 import static org.opensearch.ml.common.CommonValue.ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.JSON_RPC_INTERNAL_ERROR;
-import static org.opensearch.ml.common.CommonValue.JSON_RPC_PARSE_ERROR;
 import static org.opensearch.ml.common.CommonValue.JSON_RPC_SERVER_NOT_READY_ERROR;
 import static org.opensearch.ml.common.CommonValue.MESSAGE_FIELD;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_SERVER_DISABLED_MESSAGE;
@@ -76,14 +75,8 @@ public class TransportMcpServerAction extends HandledTransportAction<ActionReque
                 return;
             }
 
-            final McpSchema.JSONRPCMessage message;
-            try {
-                message = McpSchema.deserializeJsonRpcMessage(objectMapper, mlMcpServerRequest.getRequestBody());
-            } catch (Exception e) {
-                log.error("Parse error: " + e.getMessage(), e);
-                handleError(null, JSON_RPC_PARSE_ERROR, "Parse error: " + e.getMessage(), listener);
-                return;
-            }
+            // Get the already-parsed and validated message from the request
+            final McpSchema.JSONRPCMessage message = mlMcpServerRequest.getMessage();
 
             if (message instanceof McpSchema.JSONRPCNotification) {
                 listener.onResponse(new MLMcpServerResponse(true, null, null));


### PR DESCRIPTION
### Description
Validates MCP server's input.
Restrict the method, id, and JSON RPC values to safe/ acceptable values

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
