### PR TITLE
[MCP Server] Fix tool name bug and support ObjectType returning tools

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/transport/mcpserver/requests/register/McpToolRegisterInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/mcpserver/requests/register/McpToolRegisterInput.java
@@ -31,6 +31,9 @@ public class McpToolRegisterInput extends McpToolBaseInput {
         if (super.getType() == null) {
             throw new IllegalArgumentException(TYPE_NOT_SHOWN_EXCEPTION_MESSAGE);
         }
+        if (super.getName() == null) {
+            super.setName(super.getType());
+        }
     }
 
     public McpToolRegisterInput(
@@ -42,11 +45,10 @@ public class McpToolRegisterInput extends McpToolBaseInput {
         Instant createdTime,
         Instant lastUpdateTime
     ) {
-        super(name, type, description, parameters, attributes, createdTime, lastUpdateTime);
+        super(name == null ? type : name, type, description, parameters, attributes, createdTime, lastUpdateTime);
         if (type == null) {
             throw new IllegalArgumentException(TYPE_NOT_SHOWN_EXCEPTION_MESSAGE);
         }
-
     }
 
     public static McpToolRegisterInput parse(XContentParser parser) throws IOException {
@@ -88,6 +90,10 @@ public class McpToolRegisterInput extends McpToolBaseInput {
                     parser.skipChildren();
                     break;
             }
+        }
+        // If name is null, default to type
+        if (name == null && type != null) {
+            name = type;
         }
         return new McpToolRegisterInput(name, type, description, params, attributes, createdTime, lastUpdateTime);
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/McpToolsHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/McpToolsHelper.java
@@ -83,8 +83,8 @@ public class McpToolsHelper {
         return new McpStatelessServerFeatures.AsyncToolSpecification(
             new McpSchema.Tool(toolName, String.valueOf(description), schema),
             (ctx, request) -> Mono.create(sink -> {
-                ActionListener<String> actionListener = ActionListener
-                    .wrap(r -> sink.success(new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(r)), false)), e -> {
+                ActionListener<Object> actionListener = ActionListener
+                    .wrap(r -> sink.success(new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(r.toString())), false)), e -> {
                         log.error("Failed to execute tool, tool name: {}", toolName, e);
                         sink.error(e);
                     });


### PR DESCRIPTION
### Description
### Changes
-  Modified type conversion in MCP server to use .toString() instead of direct string casting. Updated line 86 McpToolsHelper.java to handle non-string objects returned by output processors
- When Tool Name is not provided we automatically take the tool type as name

### Background
With the addition of output processors in 3.3, tools can now return non-string objects (e.g., Extract JSON returns HashMap). The existing MCP server code assumed all tool responses were strings wrapped in generic types, causing ClassCastException when trying to cast HashMap to String.

### Solution
Changed the conversion logic to accept any Object type and convert to string using .toString(), maintaining compatibility with both legacy string responses and new output processor results.

This ensures MCP server works with all tool types while preserving existing
functionality.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
