### PR TITLE
make credential optional in mcp connectors

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/McpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/McpConnector.java
@@ -206,19 +206,23 @@ public class McpConnector implements Connector {
 
     @Override
     public void decrypt(String action, BiFunction<String, String, String> function, String tenantId) {
-        Map<String, String> decrypted = new HashMap<>();
-        for (String key : credential.keySet()) {
-            decrypted.put(key, function.apply(credential.get(key), tenantId));
+        if (credential != null) {
+            Map<String, String> decrypted = new HashMap<>();
+            for (String key : credential.keySet()) {
+                decrypted.put(key, function.apply(credential.get(key), tenantId));
+            }
+            this.decryptedCredential = decrypted;
         }
-        this.decryptedCredential = decrypted;
         this.decryptedHeaders = createDecryptedHeaders(headers);
     }
 
     @Override
     public void encrypt(BiFunction<String, String, String> function, String tenantId) {
-        for (String key : credential.keySet()) {
-            String encrypted = function.apply(credential.get(key), tenantId);
-            credential.put(key, encrypted);
+        if (credential != null) {
+            for (String key : credential.keySet()) {
+                String encrypted = function.apply(credential.get(key), tenantId);
+                credential.put(key, encrypted);
+            }
         }
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
@@ -205,19 +205,23 @@ public class McpStreamableHttpConnector implements Connector {
 
     @Override
     public void decrypt(String action, BiFunction<String, String, String> function, String tenantId) {
-        Map<String, String> decrypted = new HashMap<>();
-        for (String key : credential.keySet()) {
-            decrypted.put(key, function.apply(credential.get(key), tenantId));
+        if (credential != null) {
+            Map<String, String> decrypted = new HashMap<>();
+            for (String key : credential.keySet()) {
+                decrypted.put(key, function.apply(credential.get(key), tenantId));
+            }
+            this.decryptedCredential = decrypted;
         }
-        this.decryptedCredential = decrypted;
         this.decryptedHeaders = createDecryptedHeaders(headers);
     }
 
     @Override
     public void encrypt(BiFunction<String, String, String> function, String tenantId) {
-        for (String key : credential.keySet()) {
-            String encrypted = function.apply(credential.get(key), tenantId);
-            credential.put(key, encrypted);
+        if (credential != null) {
+            for (String key : credential.keySet()) {
+                String encrypted = function.apply(credential.get(key), tenantId);
+                credential.put(key, encrypted);
+            }
         }
     }
 


### PR DESCRIPTION
### Description
At the moment, MCP connector requires a `credentials` field. However, credentials is not always needed for remote MCP servers. This PR will make it optional.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
