### PR TITLE
[BUG] Latest ML Commons code fail with compilation error

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/resources/MLResourceSharingExtension.java
+++ b/plugin/src/main/java/org/opensearch/ml/resources/MLResourceSharingExtension.java
@@ -19,7 +19,17 @@ public class MLResourceSharingExtension implements ResourceSharingExtension {
 
     @Override
     public Set<ResourceProvider> getResourceProviders() {
-        return Set.of(new ResourceProvider(ML_MODEL_GROUP_RESOURCE_TYPE, ML_MODEL_GROUP_INDEX));
+        return Set.of(new ResourceProvider() {
+            @Override
+            public String resourceType() {
+                return ML_MODEL_GROUP_RESOURCE_TYPE;
+            }
+
+            @Override
+            public String resourceIndexName() {
+                return ML_MODEL_GROUP_INDEX;
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
### Description
Latest ML Commons code fails with a compilation error of "ResourceProvider is abstract; cannot be instantiated". ResourceProvider class is from Security plugin and there is a recent refactoring task https://github.com/opensearch-project/security/pull/5755 moved ResourceProvider as an interface. This caused the issue. So converting that instantiation code as an anonymous class implementation.

### Related Issues
Resolves #4401

### Check List
- [X] New functionality includes testing.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
