### PR TITLE
fix dependency conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,15 @@ subprojects {
         resolutionStrategy.force "io.netty:netty-resolver:${versions.netty}"
         resolutionStrategy.force "io.netty:netty-transport:${versions.netty}"
         resolutionStrategy.force "io.netty:netty-transport-native-unix-common:${versions.netty}"
+        resolutionStrategy.force "software.amazon.awssdk:bom:${versions.aws}"
+        resolutionStrategy.force "software.amazon.awssdk:kms:${versions.aws}"
+        resolutionStrategy.force "software.amazon.awssdk:dynamodb:${versions.aws}"
+        resolutionStrategy.force "software.amazon.awssdk:dynamodb-enhanced:${versions.aws}"
+        resolutionStrategy.force "org.dafny:DafnyRuntime:4.9.0"
+    }
+
+    configurations.all {
+        exclude group: 'org.bouncycastle', module: 'bcprov-jdk18on'
     }
 
     apply plugin: 'com.diffplug.spotless'


### PR DESCRIPTION
### Description
Currently getting these errors:
```
./gradlew run
...
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':opensearch-ml-plugin:bundlePlugin'.
> Could not resolve all files for configuration ':opensearch-ml-plugin:runtimeClasspath'.
   > Could not resolve software.amazon.awssdk:kms:2.32.29.
     Required by:
         project :opensearch-ml-plugin > project :opensearch-ml-algorithms > software.amazon.awssdk:bom:2.32.29
         project :opensearch-ml-plugin > project :opensearch-ml-algorithms > org.opensearch:opensearch-remote-metadata-sdk-ddb-client:3.4.0.0-SNAPSHOT:20251106.022320-9
      > Conflict found for module 'software.amazon.awssdk:kms': between versions 2.32.29 and 2.26.3
   > Could not resolve software.amazon.awssdk:dynamodb:2.32.29.
     Required by:
         project :opensearch-ml-plugin > project :opensearch-ml-algorithms > software.amazon.awssdk:bom:2.32.29
         project :opensearch-ml-plugin > project :opensearch-ml-algorithms > software.amazon.awssdk:bom:2.32.29 > software.amazon.awssdk:dynamodb-enhanced:2.32.29
      > Conflict found for module 'software.amazon.awssdk:dynamodb': between versions 2.32.29 and 2.26.3
   > Could not resolve org.dafny:DafnyRuntime:4.9.0.
     Required by:
         project :opensearch-ml-plugin > project :opensearch-ml-algorithms > org.opensearch:opensearch-remote-metadata-sdk-ddb-client:3.4.0.0-SNAPSHOT:20251106.022320-9 > software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:3.9.0
         project :opensearch-ml-plugin > project :opensearch-ml-algorithms > org.opensearch:opensearch-remote-metadata-sdk-ddb-client:3.4.0.0-SNAPSHOT:20251106.022320-9 > software.amazon.cryptography:aws-cryptographic-material-providers:1.11.0
      > Conflict found for module 'org.dafny:DafnyRuntime': between versions 4.9.0 and 4.1.0
> There are 5 more failures with identical causes.
```
After fixing the dependencies, got jar hell errors:
```
| Caused by: java.lang.IllegalStateException: jar hell!
| class: META-INF.versions.9.org.bouncycastle.asn1.ASN1BitString
| jar1: /home/jzeng/github/ml-commons/plugin/build/testclusters/integTest-0/distro/3.4.0-ARCHIVE/plugins/.installing-12792768388509642459/bcprov-jdk18on-1.78.1.jar
| jar2: /home/jzeng/github/ml-commons/plugin/build/testclusters/integTest-0/distro/3.4.0-ARCHIVE/plugins/.installing-12792768388509642459/bc-fips-2.1.2.jar
```

This PR fixes the errors.
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
