### PR TITLE
upgrade dependencies to make it compatible with AD

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ subprojects {
 
     configurations.all {
         // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
-        resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
+        resolutionStrategy.force "com.google.guava:guava:33.4.5-jre"
         resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
         resolutionStrategy.force "io.netty:netty-buffer:${versions.netty}"
         resolutionStrategy.force "io.netty:netty-codec:${versions.netty}"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -86,8 +86,11 @@ shadowJar {
     destinationDirectory = file("${project.buildDir}/distributions")
     archiveClassifier.set(null)
     exclude 'META-INF/maven/com.google.guava/**'
-    exclude 'com/google/thirdparty/**'
-    relocate 'com.google.common', 'org.opensearch.ml.repackage.com.google.common' // dependency of cron-utils
+
+    exclude 'org/jspecify/**'
+    // Relocate Guava to avoid conflicts with other plugins
+    relocate 'com.google.common', 'org.opensearch.ml.repackage.com.google.common'
+    relocate 'com.google.thirdparty', 'org.opensearch.ml.repackage.com.google.thirdparty'
 }
 
 jar {


### PR DESCRIPTION
### Description
In AD Detection Insights feature, we're calling ml-commons metrics correlation algorithm from AD which adds ml-commons as a runtime dependency. So making some dependency updates to make AD and ml-commons run in the same JVM runtime inside that container and communicate via transport actions.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
