### PR TITLE
Decrease Disk Circuit Breaker Free Space Threshold to unblock CI

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/MLCommonsIntegTestCase.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.action;
 
 import static org.opensearch.ml.common.input.parameter.regression.LogisticRegressionParams.ObjectiveType.LOGMULTICLASS;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_DISK_FREE_SPACE_THRESHOLD;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_NATIVE_MEM_THRESHOLD;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_ONLY_RUN_ON_ML_NODE;
 import static org.opensearch.ml.utils.RestActionUtils.getAllNodes;
@@ -28,6 +29,8 @@ import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.unit.ByteSizeUnit;
+import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
@@ -439,6 +442,8 @@ public class MLCommonsIntegTestCase extends ParameterizedStaticSettingsOpenSearc
             .put(ML_COMMONS_ONLY_RUN_ON_ML_NODE.getKey(), false)
             // Set native memory threshold as 100 to prevent IT failures
             .put(ML_COMMONS_NATIVE_MEM_THRESHOLD.getKey(), 100)
+            // Set disk free space threshold to 100MB - low enough for CI environments
+            .put(ML_COMMONS_DISK_FREE_SPACE_THRESHOLD.getKey(), new ByteSizeValue(100L, ByteSizeUnit.MB))
             .build();
     }
 }


### PR DESCRIPTION
### Description
We are seeing Disk Circuit breaker exceptions on CI.

```
2> REPRODUCE WITH: ./gradlew ':opensearch-ml-plugin:test' --tests 'org.opensearch.ml.action.prediction.PredictionITTests.testPredictionWithDataFrame_FitRCF' -Dtests.seed=B829ADF0B377D5F4 -Dtests.security.manager=false -Dtests.locale=rm -Dtests.timezone=Canada/Newfoundland -Druntime.java=24
  2> CircuitBreakingException[Disk Circuit Breaker is open, please check your resources!]
        at __randomizedtesting.SeedInfo.seed([B829ADF0B377D5F4:201DE5E6606A60B0]:0)
        at org.opensearch.ml.utils.MLNodeUtils.checkOpenCircuitBreaker(MLNodeUtils.java:138)
        at org.opensearch.ml.task.MLTaskRunner.checkCBAndExecute(MLTaskRunner.java:157)

 ....
```

This happens because the default Threshold is 5 GB which is high for a CI environment ([code red](https://github.com/opensearch-project/ml-commons/blob/9e417e6f5e503cfffa4bcb417def38ba1880139f/plugin/src/main/java/org/opensearch/ml/breaker/DiskCircuitBreaker.java#L27))

The failures happen during the setup part of the failing tests:
[code ref](https://github.com/opensearch-project/ml-commons/blob/9e417e6f5e503cfffa4bcb417def38ba1880139f/plugin/src/test/java/org/opensearch/ml/action/prediction/PredictionITTests.java#L67-L83)
```
batchRcfModelId = trainBatchRCFWithDataFrame(500, false);
fitRcfModelId = trainFitRCFWithDataFrame(500, false);
linearRegressionModelId = trainLinearRegressionWithDataFrame(100, false);
logisticRegressionModelId = trainLogisticRegressionWithIrisData(irisIndexName, false);
```

I believe these operations involve indexing causing the disk space to go over the threshold. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
