### PR TITLE
Fix OpenAI RAG integration tests: Replace Wikimedia image URL with Unsplash

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRAGSearchProcessorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRAGSearchProcessorIT.java
@@ -716,8 +716,7 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
         requestParameters.timeout = 60;
         requestParameters.imageFormat = "jpeg";
         requestParameters.imageType = "url";
-        requestParameters.imageData =
-            "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"; // imageContent;
+        requestParameters.imageData = "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800";
         Response response3 = performSearch(INDEX_NAME, "pipeline_test", 5, requestParameters);
         assertEquals(200, response2.getStatusLine().getStatusCode());
 
@@ -1070,8 +1069,7 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
         requestParameters.conversationId = conversationId;
         requestParameters.imageFormat = "jpeg";
         requestParameters.imageType = "url";
-        requestParameters.imageData =
-            "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg";
+        requestParameters.imageData = "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800";
         Response response2 = performSearch(INDEX_NAME, "pipeline_test", 5, requestParameters);
         assertEquals(200, response2.getStatusLine().getStatusCode());
 


### PR DESCRIPTION
### Description

The tests `testBM25WithOpenAIWithImage` and `testBM25WithOpenAIWithConversationAndImage` are failing with error:

```
"Error while downloading https://upload.wikimedia.org/wikipedia/commons/..."
"code": "invalid_image_url"
```
This seems to be a known issue with OpenAI's backend failing intermittently with wikimedia, facebook graph api, etc. Example reference [here](https://community.openai.com/t/responses-api-image-upload-error-worked-before/1289584/11)

- Replaced the Wikimedia Commons URL with an Unsplash image URL (`https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800`)
- Verified the new URL works reliably with OpenAI's API using direct API calls
- Both tests now pass successfully

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data sources for validation purposes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->