### PR TITLE
allow higher maximum number of batch inference job tasks

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -52,7 +52,7 @@ public final class MLCommonsSettings {
             ML_PLUGIN_SETTING_PREFIX + "max_batch_inference_tasks",
             100,
             0,
-            Integer.MAX_VALUE,
+            10000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
@@ -62,7 +62,7 @@ public final class MLCommonsSettings {
             ML_PLUGIN_SETTING_PREFIX + "max_batch_ingestion_tasks",
             100,
             0,
-            Integer.MAX_VALUE,
+            10000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );


### PR DESCRIPTION
### Description
Based on cx feedbacks, a higher maximum limit number of batch jobs is needed since sometimes cx has more than thousands of live batch jobs. Updating this maximum limit to avoid running into upper limits in the future.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased batch inference capacity: default task limit raised from 10 to 100 and maximum limit raised from 500 to 10,000.
  * Increased batch ingestion capacity: default task limit raised from 10 to 100 and maximum limit raised from 500 to 10,000.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->