### PR TITLE
Handle edge case of empty values of tool configs

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/agent/MLToolSpec.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/MLToolSpec.java
@@ -147,10 +147,10 @@ public class MLToolSpec implements ToXContentObject {
         if (type != null) {
             builder.field(TOOL_TYPE_FIELD, type);
         }
-        if (name != null) {
+        if (name != null && !name.isEmpty()) {
             builder.field(TOOL_NAME_FIELD, name);
         }
-        if (description != null) {
+        if (description != null && !description.isEmpty()) {
             builder.field(DESCRIPTION_FIELD, description);
         }
         if (attributes != null && !attributes.isEmpty()) {

--- a/common/src/test/java/org/opensearch/ml/common/agent/MLToolSpecTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/MLToolSpecTest.java
@@ -126,6 +126,84 @@ public class MLToolSpecTest {
     }
 
     @Test
+    public void toXContentEmptyName() throws IOException {
+        MLToolSpec specWithEmptyName = new MLToolSpec(
+            "test_type",
+            "",  // Empty name
+            "test_desc",
+            Map.of("test_key", "test_value"),
+            Collections.emptyMap(),
+            false,
+            Map.of("config_key", "config_value"),
+            null,
+            null
+        );
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        specWithEmptyName.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+
+        Assert.assertFalse(content.contains("name"));
+        Assert
+            .assertEquals(
+                "{\"type\":\"test_type\",\"description\":\"test_desc\",\"parameters\":{\"test_key\":\"test_value\"},\"include_output_in_agent_response\":false,\"config\":{\"config_key\":\"config_value\"}}",
+                content
+            );
+    }
+
+    @Test
+    public void toXContentEmptyDescription() throws IOException {
+        MLToolSpec specWithEmptyDesc = new MLToolSpec(
+            "test_type",
+            "test_name",
+            "",  // Empty description
+            Map.of("test_key", "test_value"),
+            Collections.emptyMap(),
+            false,
+            Map.of("config_key", "config_value"),
+            null,
+            null
+        );
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        specWithEmptyDesc.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+
+        Assert.assertFalse(content.contains("description"));
+        Assert
+            .assertEquals(
+                "{\"type\":\"test_type\",\"name\":\"test_name\",\"parameters\":{\"test_key\":\"test_value\"},\"include_output_in_agent_response\":false,\"config\":{\"config_key\":\"config_value\"}}",
+                content
+            );
+    }
+
+    @Test
+    public void toXContentEmptyParameters() throws IOException {
+        MLToolSpec specWithEmptyParams = new MLToolSpec(
+            "test_type",
+            "test_name",
+            "test_desc",
+            Collections.emptyMap(),  // Empty parameters
+            Collections.emptyMap(),
+            false,
+            Map.of("config_key", "config_value"),
+            null,
+            null
+        );
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        specWithEmptyParams.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+
+        Assert.assertFalse(content.contains("parameters"));
+        Assert
+            .assertEquals(
+                "{\"type\":\"test_type\",\"name\":\"test_name\",\"description\":\"test_desc\",\"include_output_in_agent_response\":false,\"config\":{\"config_key\":\"config_value\"}}",
+                content
+            );
+    }
+
+    @Test
     public void parse() throws IOException {
         String jsonStr =
             "{\"type\":\"test_type\",\"name\":\"test_name\",\"description\":\"test_desc\",\"parameters\":{\"test_key\":\"test_value\"},\"include_output_in_agent_response\":false,\"config\":{\"configKey\":\"configValue\"}}";


### PR DESCRIPTION
### Description
Handle edge case of empty values for name/description of tool configs

### Related Issues
Resolves https://github.com/opensearch-project/ml-commons/issues/4477

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Serialization now omits empty name, empty description, and empty parameter collections from tool specifications for cleaner, more concise output.

* **Tests**
  * Added tests verifying that empty name, empty description, and empty parameters are omitted from serialized output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->