### PR TITLE
add: doPrivileged

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandler.java
@@ -483,12 +483,15 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                 .create(AwsSessionCredentials.create(connector.getAccessKey(), connector.getSecretKey(), connector.getSessionToken()))
             : StaticCredentialsProvider.create(AwsBasicCredentials.create(connector.getAccessKey(), connector.getSecretKey()));
 
-        return AccessController.doPrivileged((PrivilegedAction<BedrockRuntimeAsyncClient>) () -> BedrockRuntimeAsyncClient
-            .builder()
-            .region(Region.of(connector.getRegion()))
-            .credentialsProvider(awsCredentialsProvider)
-            .httpClient(httpClient)
-            .build());
+        return AccessController
+            .doPrivileged(
+                (PrivilegedAction<BedrockRuntimeAsyncClient>) () -> BedrockRuntimeAsyncClient
+                    .builder()
+                    .region(Region.of(connector.getRegion()))
+                    .credentialsProvider(awsCredentialsProvider)
+                    .httpClient(httpClient)
+                    .build()
+            );
     }
 
     private List<SystemContentBlock> parseSystemMessages(JsonNode systemArray) {


### PR DESCRIPTION
### Description
Fixed SecurityException when executing Bedrock streaming requests by wrapping the BedrockRuntimeAsyncClient creation with `AccessController.doPrivileged()`, allowing the AWS SDK to read credentials from ~/.aws/credentials despite OpenSearch's security manager restrictions.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
