### PR TITLE
Replace usages of java.security.AccessController with org.opensearch.secure_sm.AccessController

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/MLCommonsClassLoader.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLCommonsClassLoader.java
@@ -7,9 +7,6 @@ package org.opensearch.ml.common;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -26,6 +23,7 @@ import org.opensearch.ml.common.dataset.MLInputDataType;
 import org.opensearch.ml.common.exception.MLException;
 import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.output.MLOutputType;
+import org.opensearch.secure_sm.AccessController;
 import org.reflections.Reflections;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -43,14 +41,7 @@ public class MLCommonsClassLoader {
     private static Map<String, Class<?>> connectorClassMap = new HashMap<>();
 
     static {
-        try {
-            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                loadClassMapping();
-                return null;
-            });
-        } catch (PrivilegedActionException e) {
-            throw new RuntimeException("Can't load class mapping in ML commons", e);
-        }
+        AccessController.doPrivileged(MLCommonsClassLoader::loadClassMapping);
     }
 
     public static void loadClassMapping() {

--- a/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
@@ -9,9 +9,6 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.ml.common.utils.StringUtils.gson;
 
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +32,7 @@ import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.MLCommonsClassLoader;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
+import org.opensearch.secure_sm.AccessController;
 
 /**
  * Connector defines how to connect to a remote service.
@@ -129,15 +127,9 @@ public interface Connector extends ToXContentObject, Writeable {
         }
     }
 
-    @SuppressWarnings("removal")
     static Connector createConnector(XContentParser parser) throws IOException {
         Map<String, Object> connectorMap = parser.map();
-        String jsonStr;
-        try {
-            jsonStr = AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> gson.toJson(connectorMap));
-        } catch (PrivilegedActionException e) {
-            throw new IllegalArgumentException("wrong connector");
-        }
+        String jsonStr = AccessController.doPrivileged(() -> gson.toJson(connectorMap));
         String connectorProtocol = (String) connectorMap.get("protocol");
 
         return createConnector(jsonStr, connectorProtocol);

--- a/common/src/main/java/org/opensearch/ml/common/model/LocalRegexGuardrail.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/LocalRegexGuardrail.java
@@ -10,8 +10,6 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.ml.common.utils.StringUtils.gson;
 
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -38,6 +36,7 @@ import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.client.SearchDataObjectRequest;
 import org.opensearch.remote.metadata.common.SdkClientUtils;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.transport.client.Client;
 
 import lombok.Builder;
@@ -225,7 +224,7 @@ public class LocalRegexGuardrail extends Guardrail {
         Map<String, Object> queryBodyMap = Map.of("query", Map.of("percolate", Map.of("field", "query", "document", documentMap)));
         CountDownLatch latch = new CountDownLatch(1);
         try {
-            queryBody = AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> gson.toJson(queryBodyMap));
+            queryBody = AccessController.doPrivileged(() -> gson.toJson(queryBodyMap));
             SearchDataObjectRequest searchDataObjectRequest = buildSearchDataObjectRequest(indexName, queryBody);
             var responseListener = new LatchedActionListener<>(ActionListener.<SearchResponse>wrap(r -> {
                 if (r == null || r.getHits() == null || r.getHits().getTotalHits() == null || r.getHits().getTotalHits().value() == 0) {

--- a/common/src/main/java/org/opensearch/ml/common/model/ModelGuardrail.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/ModelGuardrail.java
@@ -10,8 +10,6 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.ml.common.utils.StringUtils.gson;
 
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -38,6 +36,7 @@ import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.transport.client.Client;
 
 import lombok.Builder;
@@ -107,8 +106,7 @@ public class ModelGuardrail extends Guardrail {
         ActionListener<MLTaskResponse> internalListener = ActionListener.wrap(predictionResponse -> {
             ModelTensorOutput output = (ModelTensorOutput) predictionResponse.getOutput();
             ModelTensor tensor = output.getMlModelOutputs().get(0).getMlModelTensors().get(0);
-            String guardrailResponse = AccessController
-                .doPrivileged((PrivilegedExceptionAction<String>) () -> gson.toJson(tensor.getDataAsMap().get("response")));
+            String guardrailResponse = AccessController.doPrivileged(() -> gson.toJson(tensor.getDataAsMap().get("response")));
             log.info("Guardrail response: {}", guardrailResponse);
             if (!validateAcceptRegex(guardrailResponse)) {
                 isAccepted.set(false);

--- a/common/src/main/java/org/opensearch/ml/common/output/model/ModelTensor.java
+++ b/common/src/main/java/org/opensearch/ml/common/output/model/ModelTensor.java
@@ -11,9 +11,6 @@ import static org.opensearch.ml.common.utils.StringUtils.gson;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +23,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.secure_sm.AccessController;
 
 import lombok.Builder;
 import lombok.Data;
@@ -278,14 +276,7 @@ public class ModelTensor implements Writeable, ToXContentObject {
         out.writeOptionalString(result);
         if (dataAsMap != null) {
             out.writeBoolean(true);
-            try {
-                AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                    out.writeString(gson.toJson(dataAsMap));
-                    return null;
-                });
-            } catch (PrivilegedActionException e) {
-                throw new RuntimeException(e);
-            }
+            AccessController.doPrivilegedChecked(() -> { out.writeString(gson.toJson(dataAsMap)); });
         } else {
             out.writeBoolean(false);
         }

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -12,11 +12,8 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -38,6 +35,7 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.secure_sm.AccessController;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -248,79 +246,56 @@ public class StringUtils {
         filteredKeys.retainAll(allowedList);
         for (String key : filteredKeys) {
             Object value = parameterObjs.get(key);
-            try {
-                AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                    if (value instanceof String) {
-                        parameters.put(key, (String) value);
-                    } else {
-                        parameters.put(key, gson.toJson(value));
-                    }
-                    return null;
-                });
-            } catch (PrivilegedActionException e) {
-                throw new RuntimeException(e);
-            }
+            AccessController.doPrivileged(() -> {
+                if (value instanceof String) {
+                    parameters.put(key, (String) value);
+                } else {
+                    parameters.put(key, gson.toJson(value));
+                }
+            });
         }
         return parameters;
     }
 
-    @SuppressWarnings("removal")
     public static Map<String, String> getParameterMap(Map<String, ?> parameterObjs) {
         Map<String, String> parameters = new HashMap<>();
         if (parameterObjs == null)
             return parameters;
         for (String key : parameterObjs.keySet()) {
             Object value = parameterObjs.get(key);
-            try {
-                AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                    if (value instanceof String) {
-                        parameters.put(key, (String) value);
-                    } else {
-                        parameters.put(key, gson.toJson(value));
-                    }
-                    return null;
-                });
-            } catch (PrivilegedActionException e) {
-                throw new RuntimeException(e);
-            }
+            AccessController.doPrivileged(() -> {
+                if (value instanceof String) {
+                    parameters.put(key, (String) value);
+                } else {
+                    parameters.put(key, gson.toJson(value));
+                }
+            });
         }
         return parameters;
     }
 
-    @SuppressWarnings("removal")
     public static String toJson(Object value) {
-        try {
-            return AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> {
-                if (value instanceof String) {
-                    return (String) value;
-                } else {
-                    return gson.toJson(value);
-                }
-            });
-        } catch (PrivilegedActionException e) {
-            throw new RuntimeException(e);
-        }
+        return AccessController.doPrivileged(() -> {
+            if (value instanceof String) {
+                return (String) value;
+            } else {
+                return gson.toJson(value);
+            }
+        });
     }
 
-    @SuppressWarnings("removal")
     public static Map<String, String> convertScriptStringToJsonString(Map<String, Object> processedInput) {
         Map<String, String> parameterStringMap = new HashMap<>();
-        try {
-            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                Map<String, Object> parametersMap = (Map<String, Object>) processedInput.getOrDefault("parameters", Map.of());
-                for (String key : parametersMap.keySet()) {
-                    if (parametersMap.get(key) instanceof String) {
-                        parameterStringMap.put(key, (String) parametersMap.get(key));
-                    } else {
-                        parameterStringMap.put(key, gson.toJson(parametersMap.get(key)));
-                    }
+        AccessController.doPrivileged(() -> {
+            Map<String, Object> parametersMap = (Map<String, Object>) processedInput.getOrDefault("parameters", Map.of());
+            for (String key : parametersMap.keySet()) {
+                if (parametersMap.get(key) instanceof String) {
+                    parameterStringMap.put(key, (String) parametersMap.get(key));
+                } else {
+                    parameterStringMap.put(key, gson.toJson(parametersMap.get(key)));
                 }
-                return null;
-            });
-        } catch (PrivilegedActionException e) {
-            log.error("Error processing parameters", e);
-            throw new RuntimeException(e);
-        }
+            }
+        });
         return parameterStringMap;
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/MLEngineClassLoader.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/MLEngineClassLoader.java
@@ -6,9 +6,6 @@
 package org.opensearch.ml.engine;
 
 import java.lang.reflect.Constructor;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -23,6 +20,7 @@ import org.opensearch.ml.engine.annotation.Function;
 import org.opensearch.ml.engine.annotation.Ingester;
 import org.opensearch.ml.engine.annotation.Processor;
 import org.opensearch.ml.engine.processor.MLProcessorType;
+import org.opensearch.secure_sm.AccessController;
 import org.reflections.Reflections;
 
 @SuppressWarnings("removal")
@@ -43,16 +41,11 @@ public class MLEngineClassLoader {
     private static Map<Enum<?>, Object> mlObjects = new HashMap<>();
 
     static {
-        try {
-            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-                loadClassMapping();
-                loadIngestClassMapping();
-                loadMLProcessorClassMapping();
-                return null;
-            });
-        } catch (PrivilegedActionException e) {
-            throw new RuntimeException("Can't load class mapping in ML engine", e);
-        }
+        AccessController.doPrivileged(() -> {
+            loadClassMapping();
+            loadIngestClassMapping();
+            loadMLProcessorClassMapping();
+        });
     }
 
     /**

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
@@ -14,9 +14,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +31,7 @@ import org.opensearch.ml.common.model.MLModelFormat;
 import org.opensearch.ml.common.model.QuestionAnsweringModelConfig;
 import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
+import org.opensearch.secure_sm.AccessController;
 
 import com.google.gson.stream.JsonReader;
 
@@ -58,7 +56,6 @@ public class ModelHelper {
         this.mlEngine = mlEngine;
     }
 
-    @SuppressWarnings("removal")
     public void downloadPrebuiltModelConfig(
         String taskId,
         MLRegisterModelInput registerModelInput,
@@ -74,7 +71,7 @@ public class ModelHelper {
         String modelGroupId = registerModelInput.getModelGroupId();
         MLDeploySetting mlDeploySetting = registerModelInput.getDeploySetting();
         try {
-            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+            AccessController.doPrivilegedChecked(() -> {
 
                 Path registerModelPath = mlEngine.getRegisterModelPath(taskId, modelName, version);
                 String configCacheFilePath = registerModelPath.resolve("config.json").toString();
@@ -223,12 +220,11 @@ public class ModelHelper {
         return false;
     }
 
-    @SuppressWarnings("removal")
-    public List downloadPrebuiltModelMetaList(String taskId, MLRegisterModelInput registerModelInput) throws PrivilegedActionException {
+    public List downloadPrebuiltModelMetaList(String taskId, MLRegisterModelInput registerModelInput) throws IOException {
         String modelName = registerModelInput.getModelName();
         String version = registerModelInput.getVersion();
         try {
-            return AccessController.doPrivileged((PrivilegedExceptionAction<List>) () -> {
+            return AccessController.doPrivilegedChecked(() -> {
 
                 Path registerModelPath = mlEngine.getRegisterModelPath(taskId, modelName, version);
                 String cacheFilePath = registerModelPath.resolve("model_meta_list.json").toString();
@@ -257,7 +253,6 @@ public class ModelHelper {
      * @param modelContentHash model content hash value
      * @param listener action listener
      */
-    @SuppressWarnings("removal")
     public void downloadAndSplit(
         MLModelFormat modelFormat,
         String taskId,
@@ -269,7 +264,7 @@ public class ModelHelper {
         ActionListener<Map<String, Object>> listener
     ) {
         try {
-            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+            AccessController.doPrivilegedChecked(() -> {
                 Path registerModelPath = mlEngine.getRegisterModelPath(taskId, modelName, version);
                 String modelPath = registerModelPath + ".zip";
                 Path modelPartsPath = registerModelPath.resolve("chunks");

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -33,9 +33,6 @@ import static org.opensearch.ml.engine.memory.ConversationIndexMemory.LAST_N_INT
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -88,6 +85,7 @@ import org.opensearch.ml.engine.tools.McpStreamableHttpTool;
 import org.opensearch.remote.metadata.client.GetDataObjectRequest;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.common.SdkClientUtils;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.transport.client.Client;
 
 import com.google.gson.reflect.TypeToken;
@@ -630,21 +628,19 @@ public class AgentUtils {
         return null;
     }
 
-    @SuppressWarnings("removal")
-    public static String outputToOutputString(Object output) throws PrivilegedActionException {
+    public static String outputToOutputString(Object output) {
         String outputString;
         if (output instanceof ModelTensorOutput) {
             ModelTensor outputModel = ((ModelTensorOutput) output).getMlModelOutputs().get(0).getMlModelTensors().get(0);
             if (outputModel.getDataAsMap() != null) {
-                outputString = AccessController
-                    .doPrivileged((PrivilegedExceptionAction<String>) () -> gson.toJson(outputModel.getDataAsMap()));
+                outputString = AccessController.doPrivileged(() -> gson.toJson(outputModel.getDataAsMap()));
             } else {
                 outputString = outputModel.getResult();
             }
         } else if (output instanceof String) {
             outputString = (String) output;
         } else {
-            outputString = AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> gson.toJson(output));
+            outputString = AccessController.doPrivileged(() -> gson.toJson(output));
         }
         return outputString;
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -36,7 +36,6 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.substitute;
 import static org.opensearch.ml.engine.algorithms.agent.PromptTemplate.CHAT_HISTORY_PREFIX;
 import static org.opensearch.ml.engine.tools.ReadFromScratchPadTool.SCRATCHPAD_NOTES_KEY;
 
-import java.security.PrivilegedActionException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -546,7 +545,7 @@ public class MLChatAgentRunner implements MLAgentRunner {
         AtomicReference<String> lastActionInput,
         AtomicReference<String> lastToolSelectionResponse,
         Object output
-    ) throws PrivilegedActionException {
+    ) {
         String toolResponse = tmpParameters.get(TOOL_RESPONSE);
         StringSubstitutor toolResponseSubstitutor = new StringSubstitutor(
             Map
@@ -572,7 +571,7 @@ public class MLChatAgentRunner implements MLAgentRunner {
         AtomicReference<String> lastAction,
         Map<String, Object> additionalInfo,
         Object output
-    ) throws PrivilegedActionException {
+    ) {
         MLToolSpec toolSpec = toolSpecMap.get(lastAction.get());
         if (toolSpec != null && toolSpec.isIncludeOutputInAgentResponse()) {
             String outputString = outputToOutputString(output);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLConversationalFlowAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLConversationalFlowAgentRunner.java
@@ -20,7 +20,6 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.getMessageHis
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.getMlToolSpecs;
 import static org.opensearch.ml.engine.algorithms.agent.MLAgentExecutor.QUESTION;
 
-import java.security.PrivilegedActionException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -240,7 +239,6 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
         }
     }
 
-    @SuppressWarnings("removal")
     private void processOutput(
         Map<String, String> params,
         ActionListener<Object> listener,
@@ -257,7 +255,7 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
         Object output,
         String tenantId,
         StepListener<Object> nextStepListener
-    ) throws PrivilegedActionException {
+    ) {
         String toolName = getToolName(previousToolSpec);
         String outputKey = toolName + ".output";
         Map<String, String> toolParameters = ToolUtils.buildToolParameters(params, previousToolSpec, tenantId);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/rcf/RCFModelSerDeSer.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/rcf/RCFModelSerDeSer.java
@@ -7,10 +7,8 @@ package org.opensearch.ml.engine.algorithms.rcf;
 
 import static org.opensearch.ml.engine.utils.ModelSerDeSer.decodeBase64;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 import org.opensearch.ml.common.MLModel;
+import org.opensearch.secure_sm.AccessController;
 
 import com.amazon.randomcutforest.parkservices.state.ThresholdedRandomCutForestState;
 import com.amazon.randomcutforest.state.RandomCutForestState;
@@ -22,15 +20,12 @@ import io.protostuff.runtime.RuntimeSchema;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
-@SuppressWarnings("removal")
 public class RCFModelSerDeSer {
     private static final int SERIALIZATION_BUFFER_BYTES = 512;
     private static final Schema<RandomCutForestState> rcfSchema = AccessController
-        .doPrivileged((PrivilegedAction<Schema<RandomCutForestState>>) () -> RuntimeSchema.getSchema(RandomCutForestState.class));
+        .doPrivileged(() -> RuntimeSchema.getSchema(RandomCutForestState.class));
     private static final Schema<ThresholdedRandomCutForestState> trcfSchema = AccessController
-        .doPrivileged(
-            (PrivilegedAction<Schema<ThresholdedRandomCutForestState>>) () -> RuntimeSchema.getSchema(ThresholdedRandomCutForestState.class)
-        );
+        .doPrivileged(() -> RuntimeSchema.getSchema(ThresholdedRandomCutForestState.class));
 
     public static byte[] serializeRCF(RandomCutForestState model) {
         return serialize(model, rcfSchema);
@@ -56,20 +51,15 @@ public class RCFModelSerDeSer {
         return deserialize(bytes, trcfSchema);
     }
 
-    @SuppressWarnings("removal")
     private static <T> byte[] serialize(T model, Schema<T> schema) {
         LinkedBuffer buffer = LinkedBuffer.allocate(SERIALIZATION_BUFFER_BYTES);
-        byte[] bytes = AccessController.doPrivileged((PrivilegedAction<byte[]>) () -> ProtostuffIOUtil.toByteArray(model, schema, buffer));
+        byte[] bytes = AccessController.doPrivileged(() -> ProtostuffIOUtil.toByteArray(model, schema, buffer));
         return bytes;
     }
 
-    @SuppressWarnings("removal")
     private static <T> T deserialize(byte[] bytes, Schema<T> schema) {
         T model = schema.newMessage();
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            ProtostuffIOUtil.mergeFrom(bytes, model, schema);
-            return null;
-        });
+        AccessController.doPrivileged(() -> { ProtostuffIOUtil.mergeFrom(bytes, model, schema); });
         return model;
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -12,12 +12,9 @@ import static org.opensearch.ml.engine.algorithms.agent.MLChatAgentRunner.LLM_IN
 import static software.amazon.awssdk.http.SdkHttpMethod.GET;
 import static software.amazon.awssdk.http.SdkHttpMethod.POST;
 
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -38,6 +35,7 @@ import org.opensearch.ml.engine.algorithms.remote.streaming.StreamingHandler;
 import org.opensearch.ml.engine.algorithms.remote.streaming.StreamingHandlerFactory;
 import org.opensearch.ml.engine.annotation.ConnectorExecutor;
 import org.opensearch.script.ScriptService;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.client.Client;
 
@@ -92,7 +90,6 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
         return log;
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void invokeRemoteService(
         String action,
@@ -131,8 +128,7 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
                     )
                 )
                 .build();
-            AccessController
-                .doPrivileged((PrivilegedExceptionAction<CompletableFuture<Void>>) () -> getHttpClient().execute(executeRequest));
+            AccessController.doPrivileged(() -> getHttpClient().execute(executeRequest));
         } catch (RuntimeException exception) {
             log.error("Failed to execute {} in aws connector: {}", action, exception.getMessage(), exception);
             actionListener.onFailure(exception);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
@@ -11,12 +11,9 @@ import static org.opensearch.ml.engine.algorithms.agent.MLChatAgentRunner.LLM_IN
 import static software.amazon.awssdk.http.SdkHttpMethod.GET;
 import static software.amazon.awssdk.http.SdkHttpMethod.POST;
 
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -37,6 +34,7 @@ import org.opensearch.ml.engine.algorithms.remote.streaming.StreamingHandler;
 import org.opensearch.ml.engine.algorithms.remote.streaming.StreamingHandlerFactory;
 import org.opensearch.ml.engine.annotation.ConnectorExecutor;
 import org.opensearch.script.ScriptService;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.client.Client;
 
@@ -130,8 +128,7 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
                     )
                 )
                 .build();
-            AccessController
-                .doPrivileged((PrivilegedExceptionAction<CompletableFuture<Void>>) () -> getHttpClient().execute(executeRequest));
+            AccessController.doPrivileged(() -> getHttpClient().execute(executeRequest));
         } catch (RuntimeException e) {
             log.error("Fail to execute http connector", e);
             actionListener.onFailure(e);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/analysis/DJLUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/analysis/DJLUtils.java
@@ -11,13 +11,11 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.opensearch.ml.engine.MLEngine;
+import org.opensearch.secure_sm.AccessController;
 
 import com.google.gson.reflect.TypeToken;
 
@@ -33,8 +31,8 @@ public class DJLUtils {
     @Setter
     private static MLEngine mlEngine;
 
-    private static <T> T withDJLContext(Callable<T> action) throws PrivilegedActionException {
-        return AccessController.doPrivileged((PrivilegedExceptionAction<T>) () -> {
+    private static <T> T withDJLContext(Callable<T> action) throws Exception {
+        return AccessController.doPrivilegedChecked(() -> {
             ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
             try {
                 System.setProperty("java.library.path", mlEngine.getMlCachePath().toAbsolutePath().toString());
@@ -57,7 +55,7 @@ public class DJLUtils {
     public static HuggingFaceTokenizer buildHuggingFaceTokenizer(Path resourcePath) {
         try {
             return withDJLContext(() -> { return HuggingFaceTokenizer.newInstance(resourcePath); });
-        } catch (PrivilegedActionException e) {
+        } catch (Exception e) {
             throw new RuntimeException("Failed to initialize Hugging Face tokenizer. " + e);
         }
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/FileUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/FileUtils.java
@@ -14,8 +14,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -23,6 +21,7 @@ import java.util.Queue;
 import java.util.Set;
 
 import org.opensearch.ml.common.exception.MLException;
+import org.opensearch.secure_sm.AccessController;
 
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
@@ -153,13 +152,9 @@ public class FileUtils {
         deleteFileQuietly(new File(path.toUri()));
     }
 
-    @SuppressWarnings("removal")
     public static void deleteFileQuietly(File file) {
         if (file.exists()) {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                org.apache.commons.io.FileUtils.deleteQuietly(file);
-                return null;
-            });
+            AccessController.doPrivileged(() -> { org.apache.commons.io.FileUtils.deleteQuietly(file); });
         }
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/S3Utils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/S3Utils.java
@@ -5,9 +5,7 @@
 
 package org.opensearch.ml.engine.utils;
 
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
+import org.opensearch.secure_sm.AccessController;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -31,29 +29,29 @@ public class S3Utils {
 
         try {
             S3Client s3 = AccessController
-                .doPrivileged(
-                    (PrivilegedExceptionAction<S3Client>) () -> S3Client
+                .doPrivilegedChecked(
+                    () -> S3Client
                         .builder()
                         .region(Region.of(region))  // Specify the region here
                         .credentialsProvider(StaticCredentialsProvider.create(credentials))
                         .build()
                 );
             return s3;
-        } catch (PrivilegedActionException e) {
+        } catch (Exception e) {
             throw new RuntimeException("Can't load credentials", e);
         }
     }
 
     public static void putObject(S3Client s3Client, String bucketName, String key, String content) {
         try {
-            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+            AccessController.doPrivilegedChecked(() -> {
                 PutObjectRequest request = PutObjectRequest.builder().bucket(bucketName).key(key).build();
 
                 s3Client.putObject(request, RequestBody.fromString(content));
                 log.debug("Successfully uploaded file to S3: s3://{}/{}", bucketName, key);
                 return null; // Void return type for doPrivileged
             });
-        } catch (PrivilegedActionException e) {
+        } catch (Exception e) {
             throw new RuntimeException("Failed to upload file to S3: s3://" + bucketName + "/" + key, e);
         }
     }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.verify;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.security.PrivilegedActionException;
 import java.util.List;
 import java.util.Map;
 
@@ -71,7 +70,6 @@ public class ModelHelperTest {
             .downloadAndSplit(modelFormat, modelId, "model_name", "1", "http://testurl", null, FunctionName.TEXT_EMBEDDING, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals(PrivilegedActionException.class, argumentCaptor.getValue().getClass());
     }
 
     @Test
@@ -177,7 +175,6 @@ public class ModelHelperTest {
         modelHelper.downloadPrebuiltModelConfig(taskId, registerModelInput, registerModelListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(registerModelListener).onFailure(argumentCaptor.capture());
-        assertEquals(PrivilegedActionException.class, argumentCaptor.getValue().getClass());
     }
 
     @Test
@@ -202,7 +199,7 @@ public class ModelHelperTest {
     }
 
     @Test
-    public void testDownloadPrebuiltModelMetaList() throws PrivilegedActionException {
+    public void testDownloadPrebuiltModelMetaList() throws IOException {
         String taskId = "test_task_id";
         MLRegisterModelInput registerModelInput = MLRegisterModelInput
             .builder()
@@ -218,7 +215,7 @@ public class ModelHelperTest {
     }
 
     @Test
-    public void testIsModelAllowed_true() throws PrivilegedActionException {
+    public void testIsModelAllowed_true() throws IOException {
         String taskId = "test_task_id";
         MLRegisterModelInput registerModelInput = MLRegisterModelInput
             .builder()
@@ -234,7 +231,7 @@ public class ModelHelperTest {
     }
 
     @Test
-    public void testIsModelAllowed_WrongModelName() throws PrivilegedActionException {
+    public void testIsModelAllowed_WrongModelName() throws IOException {
         String taskId = "test_task_id";
         MLRegisterModelInput registerModelInput = MLRegisterModelInput
             .builder()
@@ -250,7 +247,7 @@ public class ModelHelperTest {
     }
 
     @Test
-    public void testIsModelAllowed_WrongModelVersion() throws PrivilegedActionException {
+    public void testIsModelAllowed_WrongModelVersion() throws IOException {
         String taskId = "test_task_id";
         MLRegisterModelInput registerModelInput = MLRegisterModelInput
             .builder()

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/analysis/DJLUtilsTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/analysis/DJLUtilsTests.java
@@ -23,13 +23,7 @@ public class DJLUtilsTests extends HFModelAnalyzerTestCase {
             RuntimeException.class,
             () -> DJLUtils.buildHuggingFaceTokenizer(mlEngine.getAnalysisRootPath().resolve("test2").resolve("tokenizer.json"))
         );
-        assertTrue(
-            exception
-                .getMessage()
-                .contains(
-                    "Failed to initialize Hugging Face tokenizer. java.security.PrivilegedActionException: java.nio.file.NoSuchFileException:"
-                )
-        );
+        assertTrue(exception.getMessage().contains("Failed to initialize Hugging Face tokenizer. java.nio.file.NoSuchFileException:"));
     }
 
     @Test

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -57,8 +57,8 @@ import static org.opensearch.ml.utils.MLNodeUtils.checkOpenCircuitBreaker;
 import static org.opensearch.ml.utils.MLNodeUtils.createXContentParserFromRegistry;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
-import java.security.PrivilegedActionException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
@@ -768,7 +768,7 @@ public class MLModelManager {
         }
     }
 
-    private void uploadModel(MLRegisterModelInput registerModelInput, MLTask mlTask, String modelVersion) throws PrivilegedActionException {
+    private void uploadModel(MLRegisterModelInput registerModelInput, MLTask mlTask, String modelVersion) throws IOException {
         if (registerModelInput.getUrl() != null) {
             registerModelFromUrl(registerModelInput, mlTask, modelVersion);
         } else if (registerModelInput.getFunctionName() == FunctionName.REMOTE || registerModelInput.getConnectorId() != null) {
@@ -945,8 +945,7 @@ public class MLModelManager {
             );
     }
 
-    private void registerPrebuiltModel(MLRegisterModelInput registerModelInput, MLTask mlTask, String modelVersion)
-        throws PrivilegedActionException {
+    private void registerPrebuiltModel(MLRegisterModelInput registerModelInput, MLTask mlTask, String modelVersion) throws IOException {
         String taskId = mlTask.getTaskId();
         List modelMetaList = modelHelper.downloadPrebuiltModelMetaList(taskId, registerModelInput);
         if (!modelHelper.isModelAllowed(registerModelInput, modelMetaList)) {

--- a/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/model/MLModelManagerTests.java
@@ -55,7 +55,6 @@ import java.net.InetAddress;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.security.PrivilegedActionException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -434,7 +433,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         verify(modelHelper).downloadAndSplit(eq(modelFormat), eq(modelId), eq(modelName), eq(version), eq(url), any(), any(), any());
     }
 
-    public void testRegisterMLModel_RegisterPreBuildModel() throws PrivilegedActionException, IOException {
+    public void testRegisterMLModel_RegisterPreBuildModel() throws IOException {
         doNothing().when(mlTaskManager).checkLimitAndAddRunningTask(any(), any());
         when(mlCircuitBreakerService.checkOpenCB()).thenReturn(null);
         when(threadPool.executor(REGISTER_THREAD_POOL)).thenReturn(taskExecutorService);
@@ -481,7 +480,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
             );
     }
 
-    public void testRegisterMLRemoteModel() throws PrivilegedActionException, IOException {
+    public void testRegisterMLRemoteModel() throws IOException {
         ActionListener<MLRegisterModelResponse> listener = mock(ActionListener.class);
         doNothing().when(mlTaskManager).checkLimitAndAddRunningTask(any(), any());
         when(mlCircuitBreakerService.checkOpenCB()).thenReturn(null);
@@ -512,7 +511,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
     }
 
     @Test
-    public void testRegisterMLRemoteModelModelGroupNotFoundException() throws PrivilegedActionException, IOException {
+    public void testRegisterMLRemoteModelModelGroupNotFoundException() throws IOException {
         // Create listener and capture the failure
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
         ActionListener<MLRegisterModelResponse> listener = mock(ActionListener.class);
@@ -585,7 +584,7 @@ public class MLModelManagerTests extends OpenSearchTestCase {
         verify(mlTaskManager).updateMLTask(anyString(), any(), anyMap(), anyLong(), anyBoolean());
     }
 
-    public void testIndexRemoteModel() throws PrivilegedActionException, IOException {
+    public void testIndexRemoteModel() throws IOException {
         ActionListener<MLRegisterModelResponse> listener = mock(ActionListener.class);
         doNothing().when(mlTaskManager).checkLimitAndAddRunningTask(any(), any());
         when(mlCircuitBreakerService.checkOpenCB()).thenReturn(null);


### PR DESCRIPTION
### Description

This PR replaces all usages of java.security.AccessController with its replacement org.opensearch.secure_sm.AccessController

### Related Issues

Related to https://github.com/opensearch-project/OpenSearch/issues/18339

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
