### PR TITLE
Fix tool name matching to prefer exact match over prefix collision

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -502,12 +502,21 @@ public class AgentUtils {
     }
 
     public static String getMatchedTool(Collection<String> tools, String action) {
+        String bestMatch = null;
+        String actionLower = action.toLowerCase(Locale.ROOT);
         for (String tool : tools) {
-            if (action.toLowerCase(Locale.ROOT).contains(tool.toLowerCase(Locale.ROOT))) {
+            // Exact match takes priority
+            if (action.equalsIgnoreCase(tool)) {
                 return tool;
             }
+            // Track longest substring match to avoid prefix collisions (e.g., "get_order" vs "get_order_simple")
+            if (actionLower.contains(tool.toLowerCase(Locale.ROOT))) {
+                if (bestMatch == null || tool.length() > bestMatch.length()) {
+                    bestMatch = tool;
+                }
+            }
         }
-        return null;
+        return bestMatch;
     }
 
     public static void extractParams(Map<String, String> modelOutput, Map<String, ?> dataAsMap, String paramName) {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -2000,4 +2000,12 @@ public class AgentUtilsTest extends MLStaticMockBase {
         doNothing().when(mockConnector).decrypt(anyString(), any(), anyString());
         connectorStatic.when(() -> Connector.createConnector(any(XContentParser.class))).thenReturn(mockConnector);
     }
+
+    @Test
+    public void testGetMatchedTool_PrefersExactMatchOverPrefix() {
+        // When two tools share a prefix, exact match should win regardless of order
+        List<String> tools = List.of("get_order_history", "get_order_history_simple");
+        assertEquals("get_order_history_simple", AgentUtils.getMatchedTool(tools, "get_order_history_simple"));
+        assertEquals("get_order_history", AgentUtils.getMatchedTool(tools, "get_order_history"));
+    }
 }


### PR DESCRIPTION
### Description
**Issue:**
When an agent has multiple MCP tools with similar names (e.g., `get_order_history` and `get_order_history_simple`), the `getMatchedTool()` function could incorrectly match the shorter tool name due to substring matching.
For example, when the LLM calls `get_order_history_simple`, the function would check if `"get_order_history_simple".contains("get_order_history")` — which is true — and return `get_order_history` instead of the correct tool, causing validation errors on the MCP server.

**Fix:**
Updated getMatchedTool() to:
- Prioritize exact match (case-insensitive) — returns immediately if found
- Fall back to substring matching with longest-match preference to

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool matching logic to prioritize exact matches over partial matches with case-insensitive comparison for more accurate results.

* **Tests**
  * Added test coverage to verify exact match precedence in tool selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->