### PR TITLE
fix jackson annotations version

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -40,7 +40,7 @@ dependencies {
         exclude group: 'net.minidev', module: 'json-smart'
     }
     compileOnly ('net.minidev:json-smart:2.5.2')
-    compileOnly("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+    compileOnly("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
     compileOnly("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     compileOnly group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
     // Multi-tenant SDK Client

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     testImplementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     testImplementation group: 'com.google.code.gson', name: 'gson', version: "${versions.gson}"
     testImplementation group: 'org.json', name: 'json', version: '20231013'
-    testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+    testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
     testImplementation ('com.jayway.jsonpath:json-path:2.9.0') {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     implementation group: 'org.json', name: 'json', version: '20231013'
     implementation group: 'software.amazon.awssdk', name: 'netty-nio-client', version: "${versions.aws}"
     api('io.modelcontextprotocol.sdk:mcp:0.12.1')
-    testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+    testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
     api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.12.0'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation "org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}"
 
     implementation "org.opensearch:common-utils:${common_utils_version}"
-    implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
     implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     implementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
     implementation (group: 'com.google.guava', name: 'guava', version: '32.1.3-jre') {
@@ -664,7 +664,7 @@ configurations.all {
     resolutionStrategy.force "software.amazon.awssdk:regions:${versions.aws}"
     resolutionStrategy.force "software.amazon.awssdk:netty-nio-client:${versions.aws}"
     resolutionStrategy.force "software.amazon.awssdk:s3:${versions.aws}"
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
     resolutionStrategy.force 'com.networknt:json-schema-validator:1.5.7'
     resolutionStrategy.force 'com.fasterxml.jackson:jackson-bom:2.18.3'
     resolutionStrategy.force 'org.yaml:snakeyaml:2.3'


### PR DESCRIPTION
### Description
Build on main branch is failing with the below error:
```
* What went wrong:
Execution failed for task ':opensearch-ml-common:compileJava'.
> Could not resolve all files for configuration ':opensearch-ml-common:compileClasspath'.
   > Could not resolve com.fasterxml.jackson.core:jackson-annotations:2.20.1.
     Required by:
         project ':opensearch-ml-common'
      > Could not resolve com.fasterxml.jackson.core:jackson-annotations:2.20.1.
         > Could not get resource 'https://ci.opensearch.org/ci/dbc/snapshots/maven/com/fasterxml/jackson/core/jackson-annotations/2.20.1/jackson-annotations-2.20.1.pom'.
            > Could not GET 'https://ci.opensearch.org/ci/dbc/snapshots/maven/com/fasterxml/jackson/core/jackson-annotations/2.20.1/jackson-annotations-2.20.1.pom'. Received status code 403 from server: Forbidden
      > Could not resolve com.fasterxml.jackson.core:jackson-annotations:2.20.1.
         > Could not get resource 'https://ci.opensearch.org/ci/dbc/snapshots/lucene/com/fasterxml/jackson/core/jackson-annotations/2.20.1/jackson-annotations-2.20.1.pom'.
            > Could not GET 'https://ci.opensearch.org/ci/dbc/snapshots/lucene/com/fasterxml/jackson/core/jackson-annotations/2.20.1/jackson-annotations-2.20.1.pom'. Received status code 403 from server: Forbidden
> There are 2 more failures with identical causes.
```

This is due to Jackson version upgrade from OpenSearch core to 2.20.1: https://github.com/opensearch-project/OpenSearch/pull/20343, but there is only version 2.20 for jackson-annotations. The OS core PR also introduces `${versions.jackson_annotations}` set to 2.20 so we should use that instead.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Jackson library dependency versions across build configurations to use a dedicated version variable for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->