### PR TITLE
make credential optional in mcp connectors

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/McpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/McpConnector.java
@@ -212,6 +212,8 @@ public class McpConnector implements Connector {
                 decrypted.put(key, function.apply(credential.get(key), tenantId));
             }
             this.decryptedCredential = decrypted;
+        } else {
+            this.decryptedCredential = new HashMap<>();
         }
         this.decryptedHeaders = createDecryptedHeaders(headers);
     }

--- a/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/McpStreamableHttpConnector.java
@@ -211,6 +211,8 @@ public class McpStreamableHttpConnector implements Connector {
                 decrypted.put(key, function.apply(credential.get(key), tenantId));
             }
             this.decryptedCredential = decrypted;
+        } else {
+            this.decryptedCredential = new HashMap<>();
         }
         this.decryptedHeaders = createDecryptedHeaders(headers);
     }


### PR DESCRIPTION
### Description
At the moment, MCP connector requires a credentials field. However, credentials is not always needed for remote MCP servers. This PR will make it optional.

(Previously reviewed on feature branch in https://github.com/opensearch-project/ml-commons/pull/4395)

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-safety for credential handling in encryption and decryption: operations safely no-op when credentials are absent.
  * When credentials are missing, decrypted credential data is now treated as empty while header updates still proceed, reducing runtime errors and improving connector reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->