### PR TITLE
support guardrail in streaming

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandler.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 
 import lombok.extern.log4j.Log4j2;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -156,7 +157,8 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
         return error instanceof ValidationException || error instanceof InvalidRequestException || error instanceof AuthenticationException;
     }
 
-    private ConverseStreamRequest buildConverseStreamRequest(String payload, Map<String, String> parameters) {
+    @VisibleForTesting
+    ConverseStreamRequest buildConverseStreamRequest(String payload, Map<String, String> parameters) {
         try {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode payloadJson = mapper.readTree(payload);
@@ -510,7 +512,8 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
         return Document.fromString(node.toString());
     }
 
-    private GuardrailStreamConfiguration parseGuardrailConfig(JsonNode guardrailConfig) {
+    @VisibleForTesting
+    GuardrailStreamConfiguration parseGuardrailConfig(JsonNode guardrailConfig) {
         GuardrailStreamConfiguration.Builder builder = GuardrailStreamConfiguration.builder();
 
         if (guardrailConfig.has("guardrailIdentifier")) {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandlerTest.java
@@ -1,0 +1,162 @@
+package org.opensearch.ml.engine.algorithms.remote.streaming;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.ml.common.connector.AwsConnector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailStreamConfiguration;
+
+public class BedrockStreamingHandlerTest {
+
+    private BedrockStreamingHandler handler;
+    private SdkAsyncHttpClient mockHttpClient;
+    private AwsConnector mockConnector;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() {
+        mockHttpClient = mock(SdkAsyncHttpClient.class);
+        mockConnector = mock(AwsConnector.class);
+
+        when(mockConnector.getAccessKey()).thenReturn("test-access-key");
+        when(mockConnector.getSecretKey()).thenReturn("test-secret-key");
+        when(mockConnector.getRegion()).thenReturn("us-east-1");
+
+        handler = new BedrockStreamingHandler(mockHttpClient, mockConnector);
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void testBuildConverseStreamRequest_withGuardrailConfig() throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+        Map<String, Object> guardrailConfig = new HashMap<>();
+        guardrailConfig.put("guardrailIdentifier", "test-guardrail-id");
+        guardrailConfig.put("guardrailVersion", "1");
+        guardrailConfig.put("trace", "enabled");
+        payload.put("guardrailConfig", guardrailConfig);
+
+        String payloadJson = objectMapper.writeValueAsString(payload);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("model", "anthropic.claude-v2");
+
+        ConverseStreamRequest request = handler.buildConverseStreamRequest(payloadJson, parameters);
+
+        assertNotNull(request);
+        assertNotNull(request.guardrailConfig());
+        assertEquals("test-guardrail-id", request.guardrailConfig().guardrailIdentifier());
+        assertEquals("1", request.guardrailConfig().guardrailVersion());
+        assertEquals("enabled", request.guardrailConfig().traceAsString());
+        assertEquals("async", request.guardrailConfig().streamProcessingModeAsString());
+    }
+
+    @Test
+    public void testBuildConverseStreamRequest_withPartialGuardrailConfig() throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+        Map<String, Object> guardrailConfig = new HashMap<>();
+        guardrailConfig.put("guardrailIdentifier", "test-guardrail-id");
+        payload.put("guardrailConfig", guardrailConfig);
+
+        String payloadJson = objectMapper.writeValueAsString(payload);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("model", "anthropic.claude-v2");
+
+        ConverseStreamRequest request = handler.buildConverseStreamRequest(payloadJson, parameters);
+
+        assertNotNull(request);
+        assertNotNull(request.guardrailConfig());
+        assertEquals("test-guardrail-id", request.guardrailConfig().guardrailIdentifier());
+        assertNull(request.guardrailConfig().guardrailVersion());
+        assertEquals("async", request.guardrailConfig().streamProcessingModeAsString());
+    }
+
+    @Test
+    public void testBuildConverseStreamRequest_withoutGuardrailConfig() throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+
+        String payloadJson = objectMapper.writeValueAsString(payload);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("model", "anthropic.claude-v2");
+
+        ConverseStreamRequest request = handler.buildConverseStreamRequest(payloadJson, parameters);
+
+        assertNotNull(request);
+        assertNull(request.guardrailConfig());
+    }
+
+    @Test
+    public void testBuildConverseStreamRequest_withEmptyGuardrailConfig() throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+        Map<String, Object> guardrailConfig = new HashMap<>();
+        payload.put("guardrailConfig", guardrailConfig);
+
+        String payloadJson = objectMapper.writeValueAsString(payload);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("model", "anthropic.claude-v2");
+
+        ConverseStreamRequest request = handler.buildConverseStreamRequest(payloadJson, parameters);
+
+        assertNotNull(request);
+        assertNotNull(request.guardrailConfig());
+        assertEquals("async", request.guardrailConfig().streamProcessingModeAsString());
+    }
+
+    @Test
+    public void testParseGuardrailConfig_withAllFields() throws Exception {
+        Map<String, Object> guardrailConfig = new HashMap<>();
+        guardrailConfig.put("guardrailIdentifier", "my-guardrail");
+        guardrailConfig.put("guardrailVersion", "2");
+        guardrailConfig.put("trace", "disabled");
+
+        JsonNode guardrailNode = objectMapper.valueToTree(guardrailConfig);
+        GuardrailStreamConfiguration result = handler.parseGuardrailConfig(guardrailNode);
+
+        assertNotNull(result);
+        assertEquals("my-guardrail", result.guardrailIdentifier());
+        assertEquals("2", result.guardrailVersion());
+        assertEquals("disabled", result.traceAsString());
+        assertEquals("async", result.streamProcessingModeAsString());
+    }
+
+    @Test
+    public void testParseGuardrailConfig_withOnlyIdentifier() throws Exception {
+        Map<String, Object> guardrailConfig = new HashMap<>();
+        guardrailConfig.put("guardrailIdentifier", "simple-guardrail");
+
+        JsonNode guardrailNode = objectMapper.valueToTree(guardrailConfig);
+        GuardrailStreamConfiguration result = handler.parseGuardrailConfig(guardrailNode);
+
+        assertNotNull(result);
+        assertEquals("simple-guardrail", result.guardrailIdentifier());
+        assertNull(result.guardrailVersion());
+        assertNull(result.trace());
+        assertEquals("async", result.streamProcessingModeAsString());
+    }
+
+    @Test
+    public void testParseGuardrailConfig_withEmptyConfig() throws Exception {
+        Map<String, Object> guardrailConfig = new HashMap<>();
+
+        JsonNode guardrailNode = objectMapper.valueToTree(guardrailConfig);
+        GuardrailStreamConfiguration result = handler.parseGuardrailConfig(guardrailNode);
+
+        assertNotNull(result);
+        assertNull(result.guardrailIdentifier());
+        assertNull(result.guardrailVersion());
+        assertNull(result.trace());
+        assertEquals("async", result.streamProcessingModeAsString());
+    }
+}


### PR DESCRIPTION
### Description
At the moment, guardrail settings are not applied during predict stream / execute stream. This PR supports guardrail config in streaming.

### Related Issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Register model/connector with guardrail:
```
POST {{endpoint}}/_plugins/_ml/models/_register
{
    "name": "test model",
    "function_name": "remote",
    "description": "test description",
    "connector": {
        "name": "Amazon Bedrock Claude Sonnet 4.5 Connector",
        "description": "Connector for Claude 4.5 via Bedrock Converse API",
        "version": "1",
        "protocol": "aws_sigv4",
        "parameters": {
            "region": "us-east-1",
            "service_name": "bedrock",
            "model": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
            "max_tokens": "4096",
            "temperature": "0.7"
        },
        "credential": {
            "access_key": "{{aws-access-key-id}}",
            "secret_key": "{{aws-secret-access-key}}",
            "session_token": "{{aws-session-token}}"
        },
        "actions": [
            {
                "action_type": "predict",
                "method": "POST",
                "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
                "request_body": "{\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.input}\"}]}],\"inferenceConfig\":{\"maxTokens\":${parameters.max_tokens},\"temperature\":${parameters.temperature}} , \"guardrailConfig\": {\"guardrailIdentifier\": \"aj5r64g28x9a\",\"guardrailVersion\": \"1\",\"trace\": \"enabled\"}}"
            }
        ]
    }
}
```

Predict stream:
```
POST {{endpoint}}/_plugins/_ml/models/{{model_id}}/_predict/stream
{
  "parameters": {
    "input": "block this",
    "_llm_interface": "bedrock/converse/claude"
  }
}

data: {"inference_results":[{"output":[{"name":"response","dataAsMap":{"content":"Sorry, the model cannot answer this question.","is_last":false}}]}]}

data: {"inference_results":[{"output":[{"name":"response","dataAsMap":{"content":"","is_last":true}}]}]}
```