### PR TITLE
[Agentic Search] Validate model type as REMOTE for the Query Planner Tool

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.engine.tools;
 
 import static org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest.DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
+import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.TOOL_INPUT_SCHEMA_FIELD;
 import static org.opensearch.ml.common.utils.StringUtils.gson;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.AGENT_LLM_MODEL_ID;
@@ -37,9 +38,13 @@ import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.spi.tools.Parser;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.common.spi.tools.WithModelTool;
+import org.opensearch.ml.common.transport.model.MLModelGetAction;
+import org.opensearch.ml.common.transport.model.MLModelGetRequest;
 import org.opensearch.ml.common.utils.ToolUtils;
 import org.opensearch.ml.engine.processor.ProcessorChain;
 import org.opensearch.ml.engine.tools.parser.ToolParser;
@@ -94,6 +99,10 @@ public class QueryPlanningTool implements WithModelTool {
         .of(CHAT_HISTORY_FIELD, TOOLS_FIELD, INTERACTIONS_FIELD, TOOL_CONFIGS_FIELD);
     public static final String FALLBACK_QUERY_FIELD = "fallback_query";
 
+    // Model validation error messages
+    private static final String LLM_MODEL_NOT_FOUND_ERROR = "LLM model not found. Please provide a valid model ID.";
+    private static final String LLM_MODEL_NOT_REMOTE_ERROR = "Query Planning Tool requires a remote LLM model.";
+
     @Getter
     private final String generationType;
     @Getter
@@ -130,6 +139,8 @@ public class QueryPlanningTool implements WithModelTool {
     @Setter
     private String description = DEFAULT_DESCRIPTION;
     private final Client client;
+    private final String modelId;
+    private volatile boolean validated = false;
 
     @Setter
     @Getter
@@ -140,13 +151,15 @@ public class QueryPlanningTool implements WithModelTool {
         MLModelTool queryGenerationTool,
         Client client,
         String searchTemplates,
-        String fallbackQuery
+        String fallbackQuery,
+        String modelId
     ) {
         this.generationType = generationType;
         this.queryGenerationTool = queryGenerationTool;
         this.client = client;
         this.searchTemplates = searchTemplates;
         this.fallbackQuery = fallbackQuery;
+        this.modelId = modelId;
         this.attributes = new HashMap<>(DEFAULT_ATTRIBUTES);
     }
 
@@ -166,6 +179,25 @@ public class QueryPlanningTool implements WithModelTool {
     public <T> void run(Map<String, String> originalParameters, ActionListener<T> listener) {
         try {
             Map<String, String> parameters = stripAgentContextParameters(ToolUtils.extractInputParameters(originalParameters, attributes));
+            String tenantId = originalParameters.get(TENANT_ID_FIELD);
+
+            // Validate that the model is of REMOTE type (only on first run)
+            if (!validated) {
+                validateModelIsRemote(modelId, tenantId, ActionListener.wrap(valid -> {
+                    validated = true;
+                    runAfterModelValidation(parameters, listener);
+                }, listener::onFailure));
+            } else {
+                runAfterModelValidation(parameters, listener);
+            }
+        } catch (Exception e) {
+            log.error("Failed to run QueryPlannerTool", e);
+            listener.onFailure(e);
+        }
+    }
+
+    private <T> void runAfterModelValidation(Map<String, String> parameters, ActionListener<T> listener) {
+        try {
             if (!validate(parameters)) {
                 listener
                     .onFailure(
@@ -235,6 +267,41 @@ public class QueryPlanningTool implements WithModelTool {
             log.error("Failed to run QueryPlannerTool", e);
             listener.onFailure(e);
         }
+    }
+
+    /**
+     * Validates that the model exists and is of REMOTE type.
+     * QueryPlanningTool requires an LLM model which must be of REMOTE type.
+     *
+     * @param modelId  The model ID to validate
+     * @param tenantId The tenant ID for multi-tenancy support
+     * @param listener Action listener that receives true on success, or error on failure
+     */
+    private void validateModelIsRemote(String modelId, String tenantId, ActionListener<Boolean> listener) {
+        if (modelId == null || modelId.isEmpty()) {
+            listener.onFailure(new IllegalArgumentException(LLM_MODEL_NOT_FOUND_ERROR));
+            return;
+        }
+
+        MLModelGetRequest getRequest = new MLModelGetRequest(modelId, false, false, tenantId);
+        client.execute(MLModelGetAction.INSTANCE, getRequest, ActionListener.wrap(response -> {
+            MLModel model = response.getMlModel();
+            if (model == null) {
+                listener.onFailure(new IllegalArgumentException(LLM_MODEL_NOT_FOUND_ERROR));
+                return;
+            }
+
+            FunctionName algorithm = model.getAlgorithm();
+            if (algorithm != FunctionName.REMOTE) {
+                listener.onFailure(new IllegalArgumentException(LLM_MODEL_NOT_REMOTE_ERROR));
+                return;
+            }
+
+            listener.onResponse(true);
+        }, e -> {
+            log.error("Failed to get LLM model: {}", modelId, e);
+            listener.onFailure(new IllegalArgumentException(LLM_MODEL_NOT_FOUND_ERROR, e));
+        }));
     }
 
     @SuppressWarnings("unchecked")
@@ -464,6 +531,8 @@ public class QueryPlanningTool implements WithModelTool {
                 params.put(MODEL_ID_FIELD, params.get(AGENT_LLM_MODEL_ID));
             }
 
+            String modelId = (String) params.get(MODEL_ID_FIELD);
+
             MLModelTool queryGenerationTool = MLModelTool.Factory.getInstance().create(params);
 
             String type = (String) params.get(GENERATION_TYPE_FIELD);
@@ -495,7 +564,14 @@ public class QueryPlanningTool implements WithModelTool {
 
             String fallbackQuery = params.containsKey(FALLBACK_QUERY_FIELD) ? (String) params.get(FALLBACK_QUERY_FIELD) : null;
 
-            QueryPlanningTool queryPlanningTool = new QueryPlanningTool(type, queryGenerationTool, client, searchTemplates, fallbackQuery);
+            QueryPlanningTool queryPlanningTool = new QueryPlanningTool(
+                type,
+                queryGenerationTool,
+                client,
+                searchTemplates,
+                fallbackQuery,
+                modelId
+            );
 
             // Create parser with default extract_json processor + any custom processors
             queryPlanningTool.setOutputParser(createParserWithDefaultExtractJson(params));

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -65,8 +66,12 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.spi.tools.Parser;
 import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.ml.common.transport.model.MLModelGetRequest;
+import org.opensearch.ml.common.transport.model.MLModelGetResponse;
 import org.opensearch.ml.engine.tools.parser.ToolParser;
 import org.opensearch.script.StoredScriptSource;
 import org.opensearch.transport.client.AdminClient;
@@ -128,7 +133,8 @@ public class QueryPlanningToolTests {
         when(adminClient.indices()).thenReturn(indicesAdminClient);
         when(adminClient.cluster()).thenReturn(clusterAdminClient);
 
-        // Mock the MLFeatureEnabledSetting to return true for agentic search
+        // Mock the model validation to return a valid REMOTE model by default
+        mockRemoteModelValidation();
 
         // Initialize the factory with mocked dependencies
         factory = QueryPlanningTool.Factory.getInstance();
@@ -138,6 +144,24 @@ public class QueryPlanningToolTests {
         validParams.put(QUERY_PLANNER_SYSTEM_PROMPT_FIELD, DEFAULT_QUERY_PLANNING_SYSTEM_PROMPT);
         emptyParams = Collections.emptyMap();
 
+    }
+
+    /**
+     * Mocks the model validation to return a valid REMOTE model.
+     * This is needed because QueryPlanningTool.run() validates the model is REMOTE type.
+     */
+    public void mockRemoteModelValidation() {
+        MLModel mockModel = mock(MLModel.class);
+        when(mockModel.getAlgorithm()).thenReturn(FunctionName.REMOTE);
+
+        MLModelGetResponse mockResponse = mock(MLModelGetResponse.class);
+        when(mockResponse.getMlModel()).thenReturn(mockModel);
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelGetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(client).execute(any(), any(MLModelGetRequest.class), any());
     }
 
     @SneakyThrows
@@ -231,7 +255,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
 
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
@@ -283,7 +307,14 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(USER_SEARCH_TEMPLATES_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(
+            USER_SEARCH_TEMPLATES_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            null,
+            "test_model_id"
+        );
 
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
@@ -318,7 +349,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
 
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
@@ -361,7 +392,14 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(USER_SEARCH_TEMPLATES_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(
+            USER_SEARCH_TEMPLATES_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            null,
+            "test_model_id"
+        );
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         // test try to update the prompt
@@ -401,7 +439,8 @@ public class QueryPlanningToolTests {
             queryGenerationTool,
             client,
             searchTemplates,
-            null
+            null,
+            "test_model_id"
         );
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
@@ -431,7 +470,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("question", "help me find some books related to wind");
@@ -456,7 +495,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("question", "help me find some books related to wind");
@@ -482,7 +521,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("question", "help me find some books related to wind");
@@ -526,6 +565,40 @@ public class QueryPlanningToolTests {
 
     @SneakyThrows
     @Test
+    public void testRunWithNoPrompt() {
+        // Mock the async calls
+        mockSampleDoc();
+        mockGetIndexMapping();
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("question", "some query");
+        parameters.put(INDEX_NAME_FIELD, "testIndex");
+        ActionListener<String> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<String> modelListener = invocation.getArgument(1);
+            modelListener.onResponse("{\"query\":{\"match\":{\"title\":\"test\"}}}");
+            return null;
+        }).when(queryGenerationTool).run(any(), any());
+
+        tool.run(parameters, listener);
+
+        // Manually trigger the getIndex response to prevent hanging
+        actionListenerCaptor.getValue().onResponse(getIndexResponse);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(queryGenerationTool).run(captor.capture(), any());
+        Map<String, String> capturedParams = captor.getValue();
+        // With no custom fallback query configured, the escaped default query is substituted into the placeholder
+        String escapedDefaultQuery = gson.toJson(DEFAULT_QUERY);
+        escapedDefaultQuery = escapedDefaultQuery.substring(1, escapedDefaultQuery.length() - 1);
+        String expectedSystemPrompt = DEFAULT_QUERY_PLANNING_SYSTEM_PROMPT
+            .replace(QueryPlanningPromptTemplate.FALLBACK_QUERY_PROMPT_PLACEHOLDER, escapedDefaultQuery);
+        assertEquals(expectedSystemPrompt, capturedParams.get("system_prompt"));
+    }
+
+    @SneakyThrows
+    @Test
     public void testStripAgentContextParameters() throws ExecutionException, InterruptedException {
         mockSampleDoc();
         mockGetIndexMapping();
@@ -538,7 +611,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(paramsCaptor.capture(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
 
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
@@ -580,7 +653,7 @@ public class QueryPlanningToolTests {
     public void testRunWithInvalidParameters() {
         mockSampleDoc();
         mockGetIndexMapping();
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         ActionListener<String> listener = mock(ActionListener.class);
 
         tool.run(Collections.emptyMap(), listener);
@@ -599,7 +672,7 @@ public class QueryPlanningToolTests {
         // Mock the async calls
         mockSampleDoc();
         mockGetIndexMapping();
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         Map<String, String> parameters = new HashMap<>();
         parameters.put("question", "some query");
         parameters.put(INDEX_NAME_FIELD, "testIndex");
@@ -623,7 +696,7 @@ public class QueryPlanningToolTests {
 
     @Test
     public void testSetName() {
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         tool.setName("NewName");
         assertEquals("NewName", tool.getName());
     }
@@ -660,7 +733,7 @@ public class QueryPlanningToolTests {
         // Mock the async calls
         mockSampleDoc();
         mockGetIndexMapping();
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         Map<String, String> parameters = new HashMap<>();
         parameters.put("question", "test query");
         parameters.put(INDEX_NAME_FIELD, "testIndex");
@@ -707,7 +780,7 @@ public class QueryPlanningToolTests {
         // Mock the async calls
         mockSampleDoc();
         mockGetIndexMapping();
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         Map<String, String> parameters = new HashMap<>();
         parameters.put("question", "test query");
         parameters.put(INDEX_NAME_FIELD, "testIndex");
@@ -756,7 +829,7 @@ public class QueryPlanningToolTests {
         // Mock the async calls
         mockSampleDoc();
         mockGetIndexMapping();
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         Map<String, String> parameters = new HashMap<>();
         parameters.put("question", "test query");
         parameters.put(INDEX_NAME_FIELD, "testIndex");
@@ -893,7 +966,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(indicesAdminClient).getIndex(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool, client, null, null, "test_model_id");
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
 
@@ -980,7 +1053,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(paramsCaptor.capture(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
 
@@ -1017,7 +1090,7 @@ public class QueryPlanningToolTests {
         // Success for index mapping
         mockGetIndexMapping();
 
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
 
         // Case 1: onResponse throws inside try (null SearchResponse)
         doAnswer(invocation -> {
@@ -1073,7 +1146,7 @@ public class QueryPlanningToolTests {
     @SneakyThrows
     @Test
     public void testGetIndexMapping_ErrorPaths() throws ExecutionException, InterruptedException {
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
 
         // Common model stub to avoid NPE later if it gets that far
         doAnswer(invocation -> {
@@ -1219,7 +1292,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(paramsCaptor.capture(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
 
         // Run 1: no hits
         final CompletableFuture<String> future1 = new CompletableFuture<>();
@@ -1280,7 +1353,14 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(USER_SEARCH_TEMPLATES_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(
+            USER_SEARCH_TEMPLATES_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            null,
+            "test_model_id"
+        );
 
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
@@ -1338,7 +1418,14 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(USER_SEARCH_TEMPLATES_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(
+            USER_SEARCH_TEMPLATES_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            null,
+            "test_model_id"
+        );
 
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
@@ -1449,7 +1536,7 @@ public class QueryPlanningToolTests {
         }).when(queryGenerationTool).run(any(), any());
 
         // Create tool using constructor with the mocked queryGenerationTool
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
 
         // Create extract_json processor config (same as in factory)
         Map<String, Object> extractJsonConfig = new HashMap<>();
@@ -1538,7 +1625,7 @@ public class QueryPlanningToolTests {
             return null;
         }).when(queryGenerationTool).run(any(), any());
 
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
 
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
@@ -1563,7 +1650,7 @@ public class QueryPlanningToolTests {
         GetIndexResponse response = mock(GetIndexResponse.class);
         when(response.mappings()).thenReturn(null);
 
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
 
         CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
@@ -1606,7 +1693,14 @@ public class QueryPlanningToolTests {
 
         String customFallbackQuery =
             "{\"size\":10,\"query\":{\"multi_match\":{\"query\":\"${parameters.question}\",\"fields\":[\"title\",\"description\"]}}}";
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, customFallbackQuery);
+        QueryPlanningTool tool = new QueryPlanningTool(
+            LLM_GENERATED_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            customFallbackQuery,
+            "test_model_id"
+        );
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("question", "help me find some books related to wind");
@@ -1635,7 +1729,14 @@ public class QueryPlanningToolTests {
 
         String customFallbackQuery =
             "{\"size\":10,\"query\":{\"multi_match\":{\"query\":\"${parameters.question}\",\"fields\":[\"title\",\"description\"]}}}";
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, customFallbackQuery);
+        QueryPlanningTool tool = new QueryPlanningTool(
+            LLM_GENERATED_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            customFallbackQuery,
+            "test_model_id"
+        );
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("question", "help me find some books related to wind");
@@ -1663,7 +1764,14 @@ public class QueryPlanningToolTests {
         }).when(queryGenerationTool).run(any(), any());
 
         String customFallbackQuery = "{\"size\":5,\"query\":{\"match\":{\"title\":\"${parameters.question}\"}}}";
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, customFallbackQuery);
+        QueryPlanningTool tool = new QueryPlanningTool(
+            LLM_GENERATED_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            customFallbackQuery,
+            "test_model_id"
+        );
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("question", "help me find some books related to wind");
@@ -1692,7 +1800,14 @@ public class QueryPlanningToolTests {
 
         // Fallback with no parameter placeholders
         String customFallbackQuery = "{\"size\":20,\"query\":{\"match_all\":{}},\"sort\":[{\"timestamp\":{\"order\":\"desc\"}}]}";
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, customFallbackQuery);
+        QueryPlanningTool tool = new QueryPlanningTool(
+            LLM_GENERATED_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            customFallbackQuery,
+            "test_model_id"
+        );
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("question", "help me find some books related to wind");
@@ -1718,7 +1833,7 @@ public class QueryPlanningToolTests {
         }).when(queryGenerationTool).run(any(), any());
 
         // null fallback — should behave exactly like before
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("question", "help me find some books related to wind");
@@ -1744,7 +1859,7 @@ public class QueryPlanningToolTests {
         }).when(queryGenerationTool).run(any(), any());
 
         // null fallback — should behave exactly like before
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("question", "help me find some books related to wind");
@@ -1772,7 +1887,14 @@ public class QueryPlanningToolTests {
 
         String customFallbackQuery =
             "{\"query\":{\"neural\":{\"embedding\":{\"query_text\":\"${parameters.question}\",\"model_id\":\"${parameters.embedding_model_id}\",\"k\":10}}}}";
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, customFallbackQuery);
+        QueryPlanningTool tool = new QueryPlanningTool(
+            LLM_GENERATED_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            customFallbackQuery,
+            "test_model_id"
+        );
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
         validParams.put("question", "help me find some books related to wind");
@@ -1803,7 +1925,14 @@ public class QueryPlanningToolTests {
 
         String customFallbackQuery =
             "{\"size\":10,\"query\":{\"multi_match\":{\"query\":\"${parameters.question}\",\"fields\":[\"title\",\"description\"]}}}";
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, customFallbackQuery);
+        QueryPlanningTool tool = new QueryPlanningTool(
+            LLM_GENERATED_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            customFallbackQuery,
+            "test_model_id"
+        );
         tool.setOutputParser(null);
         final CompletableFuture<String> future = new CompletableFuture<>();
         ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
@@ -1861,14 +1990,155 @@ public class QueryPlanningToolTests {
     @Test
     public void testGetFallbackQuery_ReturnsConfiguredValue() {
         String customFallbackQuery = "{\"query\":{\"match\":{\"title\":\"test\"}}}";
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, customFallbackQuery);
+        QueryPlanningTool tool = new QueryPlanningTool(
+            LLM_GENERATED_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            customFallbackQuery,
+            "test_model_id"
+        );
         assertEquals(customFallbackQuery, tool.getFallbackQuery());
     }
 
     @Test
     public void testGetFallbackQuery_ReturnsNullWhenNotConfigured() {
-        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null);
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "test_model_id");
         assertNull(tool.getFallbackQuery());
+    }
+
+    @SneakyThrows
+    @Test
+    public void testRun_RemoteModel_ValidationSucceeds() throws ExecutionException, InterruptedException {
+        mockSampleDoc();
+        mockGetIndexMapping();
+
+        // Mock a REMOTE model - validation should succeed
+        MLModel mockModel = mock(MLModel.class);
+        when(mockModel.getAlgorithm()).thenReturn(FunctionName.REMOTE);
+
+        MLModelGetResponse mockResponse = mock(MLModelGetResponse.class);
+        when(mockResponse.getMlModel()).thenReturn(mockModel);
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelGetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(client).execute(any(), any(MLModelGetRequest.class), any());
+
+        QueryPlanningTool tool = new QueryPlanningTool(
+            LLM_GENERATED_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            null,
+            "remote_model_id"
+        );
+
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(1);
+            listener.onResponse("{\"query\":{\"match_all\":{}}}");
+            return null;
+        }).when(queryGenerationTool).run(any(), any());
+
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
+
+        Map<String, String> params = new HashMap<>();
+        params.put(QUESTION_FIELD, "test question");
+        params.put(INDEX_NAME_FIELD, "testIndex");
+
+        tool.run(params, listener);
+
+        // Manually trigger the getIndex response
+        actionListenerCaptor.getValue().onResponse(getIndexResponse);
+
+        // Should succeed - no exception thrown
+        String result = future.get();
+        assertNotNull(result);
+    }
+
+    @SneakyThrows
+    @Test
+    public void testRun_NonRemoteModel_ValidationFails() throws ExecutionException, InterruptedException {
+        // Mock a non-REMOTE model (e.g., TEXT_EMBEDDING) - validation should fail
+        MLModel mockModel = mock(MLModel.class);
+        when(mockModel.getAlgorithm()).thenReturn(FunctionName.TEXT_EMBEDDING);
+
+        MLModelGetResponse mockResponse = mock(MLModelGetResponse.class);
+        when(mockResponse.getMlModel()).thenReturn(mockModel);
+
+        doAnswer(invocation -> {
+            ActionListener<MLModelGetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(client).execute(any(), any(MLModelGetRequest.class), any());
+
+        QueryPlanningTool tool = new QueryPlanningTool(
+            LLM_GENERATED_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            null,
+            null,
+            "non_remote_model_id"
+        );
+
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
+
+        Map<String, String> params = new HashMap<>();
+        params.put(QUESTION_FIELD, "test question");
+        params.put(INDEX_NAME_FIELD, "testIndex");
+
+        tool.run(params, listener);
+
+        // Should fail with validation error
+        ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get());
+        assertTrue(exception.getCause() instanceof IllegalArgumentException);
+        assertTrue(exception.getCause().getMessage().contains("requires a remote LLM model"));
+    }
+
+    @SneakyThrows
+    @Test
+    public void testRun_NullModelId_ValidationFails() throws ExecutionException, InterruptedException {
+        // No model id provided - validation should fail before any model lookup is attempted
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, null);
+
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
+
+        Map<String, String> params = new HashMap<>();
+        params.put(QUESTION_FIELD, "test question");
+        params.put(INDEX_NAME_FIELD, "testIndex");
+
+        tool.run(params, listener);
+
+        ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get());
+        assertTrue(exception.getCause() instanceof IllegalArgumentException);
+        assertTrue(exception.getCause().getMessage().contains("LLM model not found"));
+        // The model lookup must never be invoked when the model id is missing
+        verify(client, never()).execute(any(), any(MLModelGetRequest.class), any());
+    }
+
+    @SneakyThrows
+    @Test
+    public void testRun_EmptyModelId_ValidationFails() throws ExecutionException, InterruptedException {
+        // Empty model id provided - validation should fail before any model lookup is attempted
+        QueryPlanningTool tool = new QueryPlanningTool(LLM_GENERATED_TYPE_FIELD, queryGenerationTool, client, null, null, "");
+
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
+
+        Map<String, String> params = new HashMap<>();
+        params.put(QUESTION_FIELD, "test question");
+        params.put(INDEX_NAME_FIELD, "testIndex");
+
+        tool.run(params, listener);
+
+        ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get());
+        assertTrue(exception.getCause() instanceof IllegalArgumentException);
+        assertTrue(exception.getCause().getMessage().contains("LLM model not found"));
+        verify(client, never()).execute(any(), any(MLModelGetRequest.class), any());
     }
 
 }


### PR DESCRIPTION
### Description
This PR validates the model type used in Query Planner Tool as REMOTE (ideally should validate as LLM but there is no way to determine it for now)



### Related Issues
Resolves #4540
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
