### PR TITLE
Fix stream threadpool

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
@@ -76,7 +76,6 @@ import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.StreamingRestChannel;
-import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.StreamTransportResponseHandler;
 import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.TransportException;
@@ -236,7 +235,7 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
 
                         @Override
                         public String executor() {
-                            return ThreadPool.Names.SAME;
+                            return STREAM_EXECUTE_THREAD_POOL;
                         }
 
                         @Override


### PR DESCRIPTION
### Description
Current implementation uses `ThreadPool.Names.SAME`, which causes the initial stream response to go to `transport_worker` thread pool and the subsequent responses go to `STREAM_EXECUTE_THREAD_POOL`, blocking the transport thread. With this change, the initial and subsequent stream responses will all go to `STREAM_EXECUTE_THREAD_POOL`.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
