### PR TITLE
fix: type mismatch in AgenticConversationMemory

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/AgenticConversationMemory.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/AgenticConversationMemory.java
@@ -20,6 +20,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.ml.common.MLMemoryType;
 import org.opensearch.ml.common.conversation.Interaction;
 import org.opensearch.ml.common.memory.Memory;
 import org.opensearch.ml.common.memory.Message;
@@ -56,7 +57,7 @@ import lombok.extern.log4j.Log4j2;
 @Getter
 public class AgenticConversationMemory implements Memory<Message, CreateInteractionResponse, UpdateResponse> {
 
-    public static final String TYPE = "agentic_conversation";
+    public static final String TYPE = MLMemoryType.AGENTIC_MEMORY.name();
     private static final String SESSION_ID_FIELD = "session_id";
     private static final String CREATED_TIME_FIELD = "created_time";
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/AgenticConversationMemoryTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/AgenticConversationMemoryTest.java
@@ -81,7 +81,7 @@ public class AgenticConversationMemoryTest {
 
     @Test
     public void testGetType() {
-        assertEquals("agentic_conversation", agenticMemory.getType());
+        assertEquals("AGENTIC_MEMORY", agenticMemory.getType());
     }
 
     @Test


### PR DESCRIPTION
### Description
#### Summary:

  - Align AgenticConversationMemory.TYPE with MLMemoryType.AGENTIC_MEMORY.name() to match factory registration/lookup.
  - Update the corresponding unit test expectation.
  
####  Problem:
  Agent execution could fail with Memory factory not found for type: AGENTIC_MEMORY because the memory factory map was keyed by "agentic_conversation" while the runtime requested "AGENTIC_MEMORY".

#### Fix:
  Use the enum name for the memory type constant and adjust the test accordingly.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
