### PR TITLE
Use dedicated thread pool in response handler to fix connection cannot get error when executing PER agent

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -127,17 +127,9 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
             }
             ThreadContext.StoredContext storedContext = client.threadPool().getThreadContext().newStoredContext(true);
 
-            // Wrap listener to offload response processing from Netty I/O thread to ML thread pool
-            // This prevents blocking I/O threads during long-running cases like PER agent.
             // TODO: We should have an idea to identify the source of the request(predict/agent execution),
             // but currently it's not easy, so reusing the predict thread pool won't harm anything.
-            ThreadedActionListener<Tuple<Integer, ModelTensors>> threadedListener = new ThreadedActionListener<>(
-                log,
-                client.threadPool(),
-                "opensearch_ml_predict_remote",
-                actionListener,
-                false
-            );
+            ThreadedActionListener<Tuple<Integer, ModelTensors>> threadedListener = createThreadedListener(log, actionListener);
 
             AsyncExecuteRequest executeRequest = AsyncExecuteRequest
                 .builder()

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
@@ -126,17 +126,9 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
             }
             ThreadContext.StoredContext storedContext = client.threadPool().getThreadContext().newStoredContext(true);
 
-            // Wrap listener to offload response processing from Netty I/O thread to ML thread pool
-            // This prevents blocking I/O threads during long-running cases like PER agent.
             // TODO: We should have an idea to identify the source of the request(predict/agent execution),
             // but currently it's not easy, so reusing the predict thread pool won't harm anything.
-            ThreadedActionListener<Tuple<Integer, ModelTensors>> threadedListener = new ThreadedActionListener<>(
-                log,
-                client.threadPool(),
-                "opensearch_ml_predict_remote",
-                actionListener,
-                false
-            );
+            ThreadedActionListener<Tuple<Integer, ModelTensors>> threadedListener = createThreadedListener(log, actionListener);
 
             AsyncExecuteRequest executeRequest = AsyncExecuteRequest
                 .builder()


### PR DESCRIPTION
### Description
When executing complex PER agent concurrently, below error shows up occasionally:
```
[2026-01-30T13:09:11,806][ERROR][o.o.m.e.a.a.MLChatAgentRunner] [node-1] Failed to run chat agent
org.opensearch.OpenSearchStatusException: Error communicating with remote model: Acquire operation took longer than the configured maximum time. This indicates that a request cannot get a connection from the pool within the specified maximum time. This can be due to high request rate.
Consider taking any of the following actions to mitigate the issue: increase max connections, increase acquire timeout, or slowing the request rate.
Increasing the max connections can increase client throughput (unless the network interface is already fully utilized), but can eventually start to hit operation system limitations on the number of file descriptors used by the process. If you already are fully utilizing your network interface or cannot further increase your connection count, increasing the acquire timeout gives extra time for requests to acquire a connection before timing out. If the connections doesn't free up, the subsequent requests will still timeout.
If the above mechanisms are not able to fix the issue, try smoothing out your requests so that large traffic bursts cannot overload the client, being more efficient with the number of times you need to call AWS, or by increasing the number of hosts sending requests.
	at org.opensearch.ml.engine.algorithms.remote.MLSdkAsyncHttpResponseHandler.onError(MLSdkAsyncHttpResponseHandler.java:148) ~[?:?]
	at software.amazon.awssdk.http.nio.netty.internal.NettyRequestExecutor.handleFailure(NettyRequestExecutor.java:308) ~[?:?]
	at software.amazon.awssdk.http.nio.netty.internal.NettyRequestExecutor.makeRequestListener(NettyRequestExecutor.java:188) ~[?:?]
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:604) ~[?:?]
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:571) ~[?:?]
	at io.netty.util.concurrent.DefaultPromise.access$200(DefaultPromise.java:37) ~[?:?]
	at io.netty.util.concurrent.DefaultPromise$1.run(DefaultPromise.java:517) ~[?:?]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148) ~[?:?]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141) ~[?:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:535) ~[?:?]
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:201) ~[?:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1193) ~[?:?]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```
Increasing the [connection pool](https://github.com/opensearch-project/ml-commons/blob/main/common/src/main/java/org/opensearch/ml/common/connector/ConnectorClientConfig.java#L40) doesn't help, e.g. currently 4 complex PER agent execution can reproduce this issue with the default 30 connection pool.
We know that PER agent invokes chat agent and chat agent execute LLM requests in sequential order, so at any time point 4 PER execution has at most 4 concurrent requests to LLM and 30 connection is obviously enough, the default connection acquire operation timeout is 10s which is also a reasonable number, but, it failed to get a connection.

By adding more logs I can see that even it's a fresh [async httpclient](https://github.com/opensearch-project/ml-commons/blob/main/common/src/main/java/org/opensearch/ml/common/httpclient/MLHttpClientFactory.java#L33) when first request it handles, it throws this error.

The actual root cause is the because of the execution flow of the PER/ReAct agent, before this we need to understand how the AsyncHttpClient works underlying:
![async_httpclient](https://github.com/user-attachments/assets/55b55d50-1c43-4023-82b3-13d4063cabf9)
Since in our code we didn't specify dedicated EventLoopGroup, so by default it's using a global one with few I/O threads.
When a PER/ReAct agent execute request comes and when it needs to call LLM, the request is dispatched to the AsyncHttpClient EventLoopGroup threads, after it's completed the response is still using the same thread to process next step(PER/ReAct agent next step), which means the I/O threads is busy with the `for loop` code in ReAct agent and when multiple requests comes these threads are exhausted with the agent code, they don't have a chance to handle the `get connection` requests for when calling LLM.

The change is to dispatch the response handling to a dedicated thread pool instead of using the AsyncHttpClient I/O threads, currently we don't have a good approach to differentiate the predict is a `simple model predict` or `simple agent model predict` or `PER/ReAct agent model predict`, so we simply use the predict remote model thread pool, which shouldn't do harm to elsewhere.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
