### PR TITLE
Fix gemini function calling in tool failure case

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/GeminiV1BetaGenerateContentFunctionCalling.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/GeminiV1BetaGenerateContentFunctionCalling.java
@@ -73,7 +73,7 @@ public class GeminiV1BetaGenerateContentFunctionCalling implements FunctionCalli
         params
             .put(
                 INTERACTION_TEMPLATE_TOOL_RESPONSE,
-                "{\"role\":\"user\",\"parts\":[{\"functionResponse\":{\"name\":\"${_interactions.tool_call_id}\",\"response\":${_interactions.tool_response}}}]}"
+                "{\"role\":\"user\",\"parts\":[{\"functionResponse\":{\"name\":\"${_interactions.tool_call_id}\",\"response\":{\"text\":\"${_interactions.tool_response}\"}}}]}"
             );
 
         params.put(CHAT_HISTORY_QUESTION_TEMPLATE, "{\"role\":\"user\",\"parts\":[{\"text\":\"${_chat_history.message.question}\"}]}");


### PR DESCRIPTION
### Description
Gemini expects a JSON in tool response. While the `supply` method in `GeminiV1BetaGenerateContentFunctionCalling.java` handles it, in error cases the supply method is bypassed by the `runTool` function. This change to the template ensures that we always supply the tool response in JSON format. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
