### PR TITLE
Optimize inline connector async httpclient instance creation

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/httpclient/MLValidatableAsyncHttpClient.java
+++ b/common/src/main/java/org/opensearch/ml/common/httpclient/MLValidatableAsyncHttpClient.java
@@ -21,7 +21,7 @@ public class MLValidatableAsyncHttpClient implements SdkAsyncHttpClient {
     private final SdkAsyncHttpClient delegate;
     private final boolean connectorPrivateIpEnabled;
 
-    protected MLValidatableAsyncHttpClient(SdkAsyncHttpClient client, boolean connectorPrivateIpEnabled) {
+    public MLValidatableAsyncHttpClient(SdkAsyncHttpClient client, boolean connectorPrivateIpEnabled) {
         this.delegate = client;
         this.connectorPrivateIpEnabled = connectorPrivateIpEnabled;
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -237,7 +237,7 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
 
     public void setAsyncHttpClient(SdkAsyncHttpClient client) {
         if (this.httpClientRef.get() == null) {
-            this.httpClientRef.set(client);
+            this.httpClientRef.compareAndSet(null, client);
         }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -236,8 +236,6 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
     }
 
     public void setAsyncHttpClient(SdkAsyncHttpClient client) {
-        if (this.httpClientRef.get() == null) {
-            this.httpClientRef.compareAndSet(null, client);
-        }
+        this.httpClientRef.compareAndSet(null, client);
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -201,7 +201,7 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
     }
 
     @VisibleForTesting
-    protected SdkAsyncHttpClient getHttpClient() {
+    public SdkAsyncHttpClient getHttpClient() {
         if (httpClientRef.get() == null) {
             Duration connectionTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getConnectionTimeout());
             Duration readTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getReadTimeout());
@@ -233,5 +233,11 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
                 );
         }
         return httpClientRef.get();
+    }
+
+    public void setAsyncHttpClient(SdkAsyncHttpClient client) {
+        if (this.httpClientRef.get() == null) {
+            this.httpClientRef.set(client);
+        }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
@@ -226,8 +226,6 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
     }
 
     public void setAsyncHttpClient(SdkAsyncHttpClient client) {
-        if (this.httpClientRef.get() == null) {
-            this.httpClientRef.compareAndSet(null, client);
-        }
+        this.httpClientRef.compareAndSet(null, client);
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
@@ -224,4 +224,10 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
         }
         return httpClientRef.get();
     }
+
+    public void setAsyncHttpClient(SdkAsyncHttpClient client) {
+        if (this.httpClientRef.get() == null) {
+            this.httpClientRef.compareAndSet(null, client);
+        }
+    }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
@@ -191,7 +191,7 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
     }
 
     @VisibleForTesting
-    protected SdkAsyncHttpClient getHttpClient() {
+    public SdkAsyncHttpClient getHttpClient() {
         if (httpClientRef.get() == null) {
             Duration connectionTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getConnectionTimeout());
             Duration readTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getReadTimeout());

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -61,6 +61,7 @@ import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.client.Client;
 
 import lombok.Builder;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 
 public interface RemoteConnectorExecutor {
 
@@ -194,6 +195,12 @@ public interface RemoteConnectorExecutor {
     default void setUserRateLimiterMap(Map<String, TokenBucket> userRateLimiterMap) {}
 
     default void setMlGuard(MLGuard mlGuard) {}
+
+    default void setAsyncHttpClient(SdkAsyncHttpClient client) {}
+
+    default SdkAsyncHttpClient getHttpClient() {
+        return null;
+    }
 
     default void preparePayloadAndInvoke(
         String action,

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemory.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemory.java
@@ -41,6 +41,7 @@ import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.conversation.Interaction;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.httpclient.MLHttpClientFactory;
 import org.opensearch.ml.common.httpclient.MLValidatableAsyncHttpClient;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.memory.Memory;
@@ -1161,14 +1162,7 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
                         Duration readTimeout = Duration.ofSeconds(10);
                         int maxConnections = 100;
 
-                        SdkAsyncHttpClient delegate = NettyNioAsyncHttpClient
-                            .builder()
-                            .connectionTimeout(connectionTimeout)
-                            .readTimeout(readTimeout)
-                            .maxConcurrency(maxConnections)
-                            .build();
-
-                        defaultHttpClient = new MLValidatableAsyncHttpClient(delegate, false);
+                        defaultHttpClient = MLHttpClientFactory.getAsyncHttpClient(connectionTimeout, readTimeout, maxConnections, false);
                     } catch (Exception e) {
                         log.error("Failed to create default HTTP client for RemoteAgenticConversationMemory", e);
                         throw new RuntimeException("Failed to create default HTTP client", e);
@@ -1304,7 +1298,6 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
             executor.setXContentRegistry(xContentRegistry);
             executor.setConnectorPrivateIpEnabled(mlFeatureEnabledSetting.isConnectorPrivateIpEnabled());
 
-            // Set the default HTTP client with 64 threads
             executor.setAsyncHttpClient(getOrCreateDefaultHttpClient());
 
             // Prepare parameters for the action

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemory.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemory.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.engine.memory.ConversationIndexMemory.MEMORY_ID;
 import static org.opensearch.ml.engine.memory.ConversationIndexMemory.MEMORY_NAME;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,6 +41,7 @@ import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.conversation.Interaction;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.httpclient.MLValidatableAsyncHttpClient;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.memory.Memory;
 import org.opensearch.ml.common.memory.Message;
@@ -64,6 +66,8 @@ import com.google.gson.Gson;
 
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 
 /**
  * Remote agentic memory implementation backed by connector-defined REST APIs.
@@ -77,6 +81,9 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
     private static final String CREATED_TIME_FIELD = "created_time";
     private static final String MESSAGE_ID_FIELD = "message_id";
     private static final Gson GSON = new Gson();
+
+    // Default HTTP client with 64 threads for all remote agentic memory instances
+    private static volatile SdkAsyncHttpClient defaultHttpClient = null;
 
     private final String conversationId;
     private final String memoryContainerId;
@@ -120,6 +127,9 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
         this.executor.setClient(client);
         this.executor.setXContentRegistry(xContentRegistry);
         this.executor.setConnectorPrivateIpEnabled(mlFeatureEnabledSetting.isConnectorPrivateIpEnabled());
+
+        // Set the default HTTP client with 64 threads
+        this.executor.setAsyncHttpClient(getOrCreateDefaultHttpClient());
 
         // Log creation for debugging/monitoring
         log
@@ -288,7 +298,6 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
             if (workingMemory == null || workingMemory.getStructuredDataBlob() == null) {
                 structuredData = new HashMap<>();
             } else {
-                // Create a mutable copy
                 structuredData = new HashMap<>(workingMemory.getStructuredDataBlob());
             }
 
@@ -1137,6 +1146,40 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
     }
 
     /**
+     * Get or create the default HTTP client.
+     * This is shared across all RemoteAgenticConversationMemory instances.
+     */
+    private static SdkAsyncHttpClient getOrCreateDefaultHttpClient() {
+        if (defaultHttpClient == null) {
+            synchronized (RemoteAgenticConversationMemory.class) {
+                if (defaultHttpClient == null) {
+                    try {
+                        log.info("Creating default HTTP client for RemoteAgenticConversationMemory");
+
+                        // Use default configuration values
+                        Duration connectionTimeout = Duration.ofSeconds(1);
+                        Duration readTimeout = Duration.ofSeconds(10);
+                        int maxConnections = 100;
+
+                        SdkAsyncHttpClient delegate = NettyNioAsyncHttpClient
+                            .builder()
+                            .connectionTimeout(connectionTimeout)
+                            .readTimeout(readTimeout)
+                            .maxConcurrency(maxConnections)
+                            .build();
+
+                        defaultHttpClient = new MLValidatableAsyncHttpClient(delegate, false);
+                    } catch (Exception e) {
+                        log.error("Failed to create default HTTP client for RemoteAgenticConversationMemory", e);
+                        throw new RuntimeException("Failed to create default HTTP client", e);
+                    }
+                }
+            }
+        }
+        return defaultHttpClient;
+    }
+
+    /**
      * Factory for creating RemoteAgenticConversationMemory instances
      */
     public static class Factory implements Memory.Factory<RemoteAgenticConversationMemory> {
@@ -1260,6 +1303,9 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
             executor.setClient(client);
             executor.setXContentRegistry(xContentRegistry);
             executor.setConnectorPrivateIpEnabled(mlFeatureEnabledSetting.isConnectorPrivateIpEnabled());
+
+            // Set the default HTTP client with 64 threads
+            executor.setAsyncHttpClient(getOrCreateDefaultHttpClient());
 
             // Prepare parameters for the action
             Map<String, String> inputParams = new HashMap<>();

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemory.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemory.java
@@ -82,7 +82,7 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
     private static final String MESSAGE_ID_FIELD = "message_id";
     private static final Gson GSON = new Gson();
 
-    private static volatile SdkAsyncHttpClient defaultHttpClient = null;
+    private static volatile SdkAsyncHttpClient DEFAULT_HTTP_CLIENT = null;
     // The connector is an inline connector so we use default connector client configs.
     private static final ConnectorClientConfig DEFAULT_CONNECTOR_CLIENT_CONFIG = new ConnectorClientConfig();
     // The connector will be used to handle all the memory operations during agent running and one agent consumes one connection at any
@@ -1152,9 +1152,9 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
      * This is shared across all RemoteAgenticConversationMemory instances.
      */
     private static SdkAsyncHttpClient getOrCreateDefaultHttpClient() {
-        if (defaultHttpClient == null) {
+        if (DEFAULT_HTTP_CLIENT == null) {
             synchronized (RemoteAgenticConversationMemory.class) {
-                if (defaultHttpClient == null) {
+                if (DEFAULT_HTTP_CLIENT == null) {
                     try {
                         log
                             .info(
@@ -1163,7 +1163,7 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
                                 DEFAULT_CONNECTOR_CLIENT_CONFIG.getReadTimeout(),
                                 MAX_CONNECTIONS
                             );
-                        defaultHttpClient = MLHttpClientFactory
+                        DEFAULT_HTTP_CLIENT = MLHttpClientFactory
                             .getAsyncHttpClient(
                                 Duration.ofMillis(DEFAULT_CONNECTOR_CLIENT_CONFIG.getConnectionTimeout()),
                                 Duration.ofSeconds(DEFAULT_CONNECTOR_CLIENT_CONFIG.getReadTimeout()),
@@ -1178,7 +1178,7 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
                 }
             }
         }
-        return defaultHttpClient;
+        return DEFAULT_HTTP_CLIENT;
     }
 
     /**

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemory.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemory.java
@@ -38,11 +38,11 @@ import org.opensearch.ml.common.MLMemoryType;
 import org.opensearch.ml.common.connector.AwsConnector;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
+import org.opensearch.ml.common.connector.ConnectorClientConfig;
 import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.conversation.Interaction;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.httpclient.MLHttpClientFactory;
-import org.opensearch.ml.common.httpclient.MLValidatableAsyncHttpClient;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.memory.Memory;
 import org.opensearch.ml.common.memory.Message;
@@ -68,7 +68,6 @@ import com.google.gson.Gson;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
-import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 
 /**
  * Remote agentic memory implementation backed by connector-defined REST APIs.
@@ -83,8 +82,12 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
     private static final String MESSAGE_ID_FIELD = "message_id";
     private static final Gson GSON = new Gson();
 
-    // Default HTTP client with 64 threads for all remote agentic memory instances
     private static volatile SdkAsyncHttpClient defaultHttpClient = null;
+    // The connector is an inline connector so we use default connector client configs.
+    private static final ConnectorClientConfig DEFAULT_CONNECTOR_CLIENT_CONFIG = new ConnectorClientConfig();
+    // The connector will be used to handle all the memory operations during agent running and one agent consumes one connection at any
+    // given time, let's say we support 200 concurrent agents running we need at least 200 connections.
+    private static final int MAX_CONNECTIONS = 200;
 
     private final String conversationId;
     private final String memoryContainerId;
@@ -128,8 +131,6 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
         this.executor.setClient(client);
         this.executor.setXContentRegistry(xContentRegistry);
         this.executor.setConnectorPrivateIpEnabled(mlFeatureEnabledSetting.isConnectorPrivateIpEnabled());
-
-        // Set the default HTTP client with 64 threads
         this.executor.setAsyncHttpClient(getOrCreateDefaultHttpClient());
 
         // Log creation for debugging/monitoring
@@ -1155,14 +1156,21 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
             synchronized (RemoteAgenticConversationMemory.class) {
                 if (defaultHttpClient == null) {
                     try {
-                        log.info("Creating default HTTP client for RemoteAgenticConversationMemory");
-
-                        // Use default configuration values
-                        Duration connectionTimeout = Duration.ofSeconds(1);
-                        Duration readTimeout = Duration.ofSeconds(10);
-                        int maxConnections = 100;
-
-                        defaultHttpClient = MLHttpClientFactory.getAsyncHttpClient(connectionTimeout, readTimeout, maxConnections, false);
+                        log
+                            .info(
+                                "Creating default HTTP client for RemoteAgenticConversationMemory with configurations connection timeout: {}ms, read timeout: {}s, max connections: {}, the private ip enabled and skip ssl verification both uses default value: false",
+                                DEFAULT_CONNECTOR_CLIENT_CONFIG.getConnectionTimeout(),
+                                DEFAULT_CONNECTOR_CLIENT_CONFIG.getReadTimeout(),
+                                MAX_CONNECTIONS
+                            );
+                        defaultHttpClient = MLHttpClientFactory
+                            .getAsyncHttpClient(
+                                Duration.ofMillis(DEFAULT_CONNECTOR_CLIENT_CONFIG.getConnectionTimeout()),
+                                Duration.ofSeconds(DEFAULT_CONNECTOR_CLIENT_CONFIG.getReadTimeout()),
+                                MAX_CONNECTIONS,
+                                false,
+                                false
+                            );
                     } catch (Exception e) {
                         log.error("Failed to create default HTTP client for RemoteAgenticConversationMemory", e);
                         throw new RuntimeException("Failed to create default HTTP client", e);
@@ -1297,7 +1305,6 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
             executor.setClient(client);
             executor.setXContentRegistry(xContentRegistry);
             executor.setConnectorPrivateIpEnabled(mlFeatureEnabledSetting.isConnectorPrivateIpEnabled());
-
             executor.setAsyncHttpClient(getOrCreateDefaultHttpClient());
 
             // Prepare parameters for the action

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemoryTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemoryTest.java
@@ -44,6 +44,8 @@ import org.opensearch.ml.memory.action.conversation.CreateInteractionResponse;
 import org.opensearch.script.ScriptService;
 import org.opensearch.transport.client.Client;
 
+import com.google.common.collect.ImmutableMap;
+
 public class RemoteAgenticConversationMemoryTest {
 
     @Rule
@@ -403,5 +405,132 @@ public class RemoteAgenticConversationMemoryTest {
             .parameters(Map.of("endpoint", "http://localhost:9200"))
             .actions(List.of())
             .build();
+    }
+
+    // Tests for defaultHttpClient
+    @Test
+    public void testDefaultHttpClientInitialization() {
+        // Create first instance - this should initialize the defaultHttpClient
+        RemoteAgenticConversationMemory memory1 = createTestMemory();
+        assertNotNull("Memory instance should be created", memory1);
+        assertNotNull("Executor should be initialized", memory1.getExecutor());
+        assertNotNull("Async HTTP client should be set", memory1.getExecutor().getHttpClient());
+    }
+
+    @Test
+    public void testDefaultHttpClientReuse() {
+        // Create multiple instances and verify they share the same HTTP client
+        RemoteAgenticConversationMemory memory1 = createTestMemory();
+        RemoteAgenticConversationMemory memory2 = createTestMemory();
+
+        assertNotNull("First memory instance should be created", memory1);
+        assertNotNull("Second memory instance should be created", memory2);
+
+        // Both should have executors with HTTP clients set
+        assertNotNull("First executor should be initialized", memory1.getExecutor());
+        assertNotNull("Second executor should be initialized", memory2.getExecutor());
+        assertNotNull("First async HTTP client should be set", memory1.getExecutor().getHttpClient());
+        assertNotNull("Second async HTTP client should be set", memory2.getExecutor().getHttpClient());
+    }
+
+    @Test
+    public void testDefaultHttpClientThreadSafety() throws InterruptedException {
+        // Test concurrent initialization to verify double-checked locking works
+        final int threadCount = 10;
+        Thread[] threads = new Thread[threadCount];
+        final RemoteAgenticConversationMemory[] memories = new RemoteAgenticConversationMemory[threadCount];
+
+        // Create multiple threads that create memory instances concurrently
+        for (int i = 0; i < threadCount; i++) {
+            final int index = i;
+            threads[i] = new Thread(() -> { memories[index] = createTestMemory(); });
+        }
+
+        // Start all threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // Wait for all threads to complete
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // Verify all instances were created successfully
+        for (int i = 0; i < threadCount; i++) {
+            assertNotNull("Memory instance " + i + " should be created", memories[i]);
+            assertNotNull("Executor " + i + " should be initialized", memories[i].getExecutor());
+            assertNotNull("Async HTTP client " + i + " should be set", memories[i].getExecutor().getHttpClient());
+        }
+    }
+
+    @Test
+    public void testFactoryUsesDefaultHttpClient() {
+        RemoteAgenticConversationMemory.Factory factory = new RemoteAgenticConversationMemory.Factory();
+        factory.init(scriptService, clusterService, client, xContentRegistry, mlFeatureEnabledSetting);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("memory_id", "test_memory_id");
+        params.put("memory_name", "Test Memory");
+        params.put("memory_container_id", "test_container_id");
+        params.put("endpoint", "https://example.com");
+        params.put("credential", ImmutableMap.of("username", "test_user", "password", "test_password"));
+
+        ActionListener<RemoteAgenticConversationMemory> listener = ActionListener.wrap(memory -> {
+            assertNotNull("Memory should be created", memory);
+            assertNotNull("Executor should be initialized", memory.getExecutor());
+            assertNotNull("Async HTTP client should be set", memory.getExecutor().getHttpClient());
+        }, e -> { throw new RuntimeException("Factory create should succeed", e); });
+
+        factory.create(params, listener);
+    }
+
+    @Test
+    public void testMultipleMemoryInstancesShareHttpClient() {
+        // Create multiple memory instances
+        RemoteAgenticConversationMemory memory1 = new RemoteAgenticConversationMemory(
+            "conversation_1",
+            "container_1",
+            "user_1",
+            createMockConnector(),
+            scriptService,
+            clusterService,
+            client,
+            xContentRegistry,
+            mlFeatureEnabledSetting
+        );
+
+        RemoteAgenticConversationMemory memory2 = new RemoteAgenticConversationMemory(
+            "conversation_2",
+            "container_2",
+            "user_2",
+            createMockConnector(),
+            scriptService,
+            clusterService,
+            client,
+            xContentRegistry,
+            mlFeatureEnabledSetting
+        );
+
+        RemoteAgenticConversationMemory memory3 = new RemoteAgenticConversationMemory(
+            "conversation_3",
+            "container_3",
+            "user_3",
+            createMockConnector(),
+            scriptService,
+            clusterService,
+            client,
+            xContentRegistry,
+            mlFeatureEnabledSetting
+        );
+
+        // All should have executors with HTTP clients
+        assertNotNull("Memory 1 executor should be initialized", memory1.getExecutor());
+        assertNotNull("Memory 2 executor should be initialized", memory2.getExecutor());
+        assertNotNull("Memory 3 executor should be initialized", memory3.getExecutor());
+
+        assertNotNull("Memory 1 HTTP client should be set", memory1.getExecutor().getHttpClient());
+        assertNotNull("Memory 2 HTTP client should be set", memory2.getExecutor().getHttpClient());
+        assertNotNull("Memory 3 HTTP client should be set", memory3.getExecutor().getHttpClient());
     }
 }


### PR DESCRIPTION
### Description
In remote model inference we setup a connectorExecutor for each connector, in each connectorExecutor it has one [SdkAsyncHttpClient](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java#L204-L224). While in RemoteAgenticConversationMemory.java, we have a lot of inline connectors and they're created based on requests, which means multiple connectorExecutors will be created for each request, and each of them corresponding to a SdkAsyncHttpClient, creating a new SdkAsyncHttpClient is heavy because it needs to create underlying new connections instead of reusing the created connections because each instance has its own connection pool. This is a performance degrade and we can use a global SdkAsyncHttpClient for all the connectors in RemoteAgenticConversationMemory.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
