### PR TITLE
Fix: Restore Thread Context in MLAgentExecutor properly to fix Memory Access

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
@@ -263,7 +263,7 @@ public class MLAgentExecutor implements Executable, SettingsChangeListener {
                                                 ? requestParameters.get(MEMORY_CONFIGURATION_FIELD)
                                                 : null;
                                             if (usesRemoteMemory || !Strings.isNullOrEmpty(memoryConfig)) {
-                                                wrappedListener
+                                                listener
                                                     .onFailure(
                                                         new OpenSearchStatusException(
                                                             ML_COMMONS_REMOTE_AGENTIC_MEMORY_DISABLED_MESSAGE,


### PR DESCRIPTION
### Description

After #4564, Get Memory for Admin failed due to missing thread context (user/tenant info). The commit inadvertently change the code this way:

Before the commit we restored the context after performing `sdkClient.getDataObjectAsync()` and hence all the functions inside `sdkClient.getDataObjectAsync().whenComplete()` had access to thread context
```java
try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
    sdkClient
        .getDataObjectAsync(getDataObjectRequest, client.threadPool().executor("opensearch_ml_general"))
        .whenComplete((response, throwable) -> {
            context.restore();  // ← Restore context BEFORE doing anything else
            log.debug("Completed Get Agent Request, Agent id:{}", agentId);
            // ... rest of the code uses listener directly
            listener.onFailure(...);
        });
}
```

After the commit we used a Wrapped Listener which does restore after the whole try block is done. This way the code inside `sdkClient.getDataObjectAsync().whenComplete()` does not have the thread context

``` java
try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
    ActionListener<Output> wrappedListener = ActionListener.runBefore(listener, context::restore);
    sdkClient
        .getDataObjectAsync(getDataObjectRequest, client.threadPool().executor("opensearch_ml_general"))
        .whenComplete((response, throwable) -> {
            // ❌ NO context.restore() here anymore!
            log.debug("Completed Get Agent Request, Agent id:{}", agentId);
            // ... code uses wrappedListener
            wrappedListener.onFailure(...);
        });
}
// Context restored after this
```

This broke the Memory Factory related code inside the `whenComplete()` which uses the thread context data like user information to index into the relevant indices.

### Fix:

The below fix restores the context in the `whenComplete` similar to the implementation before the breaking change

I have verified the change in my local security enabled cluster and found that this change fixes the memory access.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
