### PR TITLE
Adapt summarization manager for unified interface

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/contextmanager/SummarizationManager.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/contextmanager/SummarizationManager.java
@@ -247,9 +247,10 @@ public class SummarizationManager implements ContextManager {
     ) {
         try {
             // Create summarized interaction
-            String summarizedInteraction = "{\"role\":\"assistant\",\"content\":\"Summarized previous interactions: "
-                + processTextDoc(summary)
-                + "\"}";
+            String summarizedInteraction =
+                "{\"role\":\"assistant\",\"content\":[{\"type\": \"text\", \"text\": \"Summarized previous interactions: "
+                    + processTextDoc(summary)
+                    + "\"}]}";
 
             // Update interactions: summary + remaining messages
             List<String> updatedInteractions = new ArrayList<>();


### PR DESCRIPTION
### Description

The summarization manager now will create the summarized interaction in the same unified interface format:

local testings for bedrock anthropic.claude-3-sonnet-20240229-v1:0 and openai model gpt-5 are working

```
{
  "role": "assistant",
  "content": [
    {
      "type": "text",
      "text": "Summarized previous interactions: Here is a concise summary of the provided interactions:\n\nThe interactions show the output of running the ListIndexTool, which lists details about the indices in an OpenSearch cluster. The output includes columns for the index name, health status, number of primary and replica shards, document counts, and storage sizes. It displays information for 10 indices, with most being green (healthy) status. Some indices like .plugins-ml-* appear to be related to machine learning plugins, while others like opensearch-release are likely system indices. The output provides an overview of the indices and their sizing/allocation in the cluster."
    }
  ]
}
```
same format as this example listed in https://github.com/opensearch-project/ml-commons/pull/4596 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
