### PR TITLE
Add validation for ToolsOutputTruncateManager not using token_exceed

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/contextmanager/ToolsOutputTruncateManager.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/contextmanager/ToolsOutputTruncateManager.java
@@ -52,16 +52,26 @@ public class ToolsOutputTruncateManager implements ContextManager {
         @SuppressWarnings("unchecked")
         Map<String, Object> activationConfig = (Map<String, Object>) config.get("activation");
 
-        // Validate: tokens_exceed doesn't make sense for POST_TOOL hook
-        // tokens_exceed measures the entire context window (prompts + history + tool interactions)
-        // and is meant for PRE_LLM hooks to prevent context overflow before LLM invocation.
-        // POST_TOOL hook should always truncate tool output proactively, not based on total context size.
-        if (activationConfig != null && activationConfig.containsKey("tokens_exceed")) {
-            throw new IllegalArgumentException(
-                "ToolsOutputTruncateManager does not support 'tokens_exceed' activation rule. "
-                    + "The 'tokens_exceed' rule measures the entire context window and is designed for PRE_LLM hooks. "
-                    + "For POST_TOOL hooks, either use no activation rules (always truncate) or remove the 'activation' config entirely."
-            );
+        // Validate: context-level activation rules don't make sense for POST_TOOL hook
+        // - tokens_exceed: measures entire context window (prompts + history + tool interactions)
+        // - message_count_exceed: measures chat history size
+        // Both are designed for PRE_LLM hooks where the full context is available.
+        // POST_TOOL hook should truncate tool output proactively, not based on accumulated context.
+        if (activationConfig != null) {
+            if (activationConfig.containsKey("tokens_exceed")) {
+                throw new IllegalArgumentException(
+                    "ToolsOutputTruncateManager does not support 'tokens_exceed' activation rule. "
+                        + "The 'tokens_exceed' rule measures the entire context window and is designed for PRE_LLM hooks. "
+                        + "For POST_TOOL hooks, either use no activation rules (always truncate) or remove the 'activation' config entirely."
+                );
+            }
+            if (activationConfig.containsKey("message_count_exceed")) {
+                throw new IllegalArgumentException(
+                    "ToolsOutputTruncateManager does not support 'message_count_exceed' activation rule. "
+                        + "The 'message_count_exceed' rule measures chat history size and is designed for PRE_LLM hooks. "
+                        + "For POST_TOOL hooks, either use no activation rules (always truncate) or remove the 'activation' config entirely."
+                );
+            }
         }
 
         this.activationRules = ActivationRuleFactory.createRules(activationConfig);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/contextmanager/ToolsOutputTruncateManagerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/contextmanager/ToolsOutputTruncateManagerTest.java
@@ -68,6 +68,21 @@ public class ToolsOutputTruncateManagerTest {
     }
 
     @Test
+    public void testInitializeWithMessageCountExceedThrowsException() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("max_output_length", 10000);
+
+        Map<String, Object> activation = new HashMap<>();
+        activation.put("message_count_exceed", 10);
+        config.put("activation", activation);
+
+        // Should throw IllegalArgumentException when message_count_exceed is used
+        IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class, () -> manager.initialize(config));
+
+        Assert.assertTrue(exception.getMessage().contains("does not support 'message_count_exceed' activation rule"));
+    }
+
+    @Test
     public void testInitializeWithOtherActivationRulesSucceeds() {
         Map<String, Object> config = new HashMap<>();
         config.put("max_output_length", 10000);


### PR DESCRIPTION
### Description

We allow all activation rules to configure on different hooks, but there are bad configurations, 

For example:

- using token_exceed on POST_TOOL hook, 

The ToolsOutputTruncateManager is designed for POST_TOOL hooks to proactively truncate individual tool outputs before they accumulate in the context window. However, users could mistakenly configure it with a  tokens_exceed activation rule, which doesn't work as intended because:

  1. Semantic mismatch: tokens_exceed measures the entire context window (system prompt + user prompt + chat history + tool interactions), which is designed for PRE_LLM hooks to prevent context overflow before LLM
  invocation.
  2. Missing data in POST_TOOL context: When POST_TOOL hooks fire, the context only contains:
    - Current tool output (in _current_tool_output parameter)
    - System and user prompts
    - NOT the accumulated tool interactions (those are added AFTER the hook completes)
  4. Wrong activation timing: By the time tokens_exceed would trigger in a POST_TOOL hook, multiple large tool outputs may have already accumulated, defeating the purpose of proactive truncation.

- using message_count_exceed rule on POST_TOOL hook, also doesn't make sense. 

We shouldn't truncate a toolOutput when the message array is long. 

### Solution: 

 Add validation in ToolsOutputTruncateManager.initialize() to reject context-level activation rules (tokens_exceed and message_count_exceed) with clear error messages explaining:
  - Why they're not supported for POST_TOOL hooks
  - The correct usage pattern (no activation rules for always-on truncation)
  - The semantic difference between POST_TOOL and PRE_LLM hooks


### Related Issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
