### PR TITLE
(feature branch) Remote agent connector

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/agent/ConnectorSpec.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/ConnectorSpec.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agent;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.utils.StringUtils.getParameterMap;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Specification for agent proxy connector configuration.
+ * Represents a single proxy endpoint with optional routing rules.
+ */
+@Data
+@EqualsAndHashCode
+public class ConnectorSpec implements ToXContentObject {
+    public static final String PROXY_URL_FIELD = "proxy_url";
+    public static final String ROUTING_RULES_FIELD = "routing_rules";
+    public static final String AUTH_TYPE_FIELD = "auth_type";
+    public static final String CREDENTIAL_FIELD = "credential";
+    public static final String CONNECTION_TIMEOUT_FIELD = "connection_timeout";
+    public static final String READ_TIMEOUT_FIELD = "read_timeout";
+
+    // Default timeouts
+    public static final int DEFAULT_CONNECTION_TIMEOUT = 10; // seconds
+    public static final int DEFAULT_READ_TIMEOUT = 300; // seconds
+
+    private final String proxyUrl;
+    private final List<RoutingRule> routingRules;
+    private final String authType;
+    private Map<String, String> credential;
+    private final Integer connectionTimeout;
+    private final Integer readTimeout;
+
+    @Builder(toBuilder = true)
+    public ConnectorSpec(
+        String proxyUrl,
+        List<RoutingRule> routingRules,
+        String authType,
+        Map<String, String> credential,
+        Integer connectionTimeout,
+        Integer readTimeout
+    ) {
+        if (proxyUrl == null || proxyUrl.trim().isEmpty()) {
+            throw new IllegalArgumentException("proxy_url is required for connector");
+        }
+
+        this.proxyUrl = proxyUrl;
+        this.routingRules = routingRules;
+        this.authType = authType;
+        this.credential = credential;
+        this.connectionTimeout = connectionTimeout != null ? connectionTimeout : DEFAULT_CONNECTION_TIMEOUT;
+        this.readTimeout = readTimeout != null ? readTimeout : DEFAULT_READ_TIMEOUT;
+
+        // Validate routing rules if present
+        if (routingRules != null && !routingRules.isEmpty()) {
+            for (RoutingRule rule : routingRules) {
+                rule.validate();
+            }
+        }
+    }
+
+    public ConnectorSpec(StreamInput input) throws IOException {
+        proxyUrl = input.readString();
+
+        // Read routing rules
+        if (input.readBoolean()) {
+            int rulesCount = input.readInt();
+            routingRules = new ArrayList<>(rulesCount);
+            for (int i = 0; i < rulesCount; i++) {
+                routingRules.add(new RoutingRule(input));
+            }
+        } else {
+            routingRules = null;
+        }
+
+        authType = input.readOptionalString();
+
+        // Read credential
+        if (input.readBoolean()) {
+            credential = input.readMap(StreamInput::readString, StreamInput::readOptionalString);
+        } else {
+            credential = null;
+        }
+
+        connectionTimeout = input.readOptionalInt();
+        readTimeout = input.readOptionalInt();
+    }
+
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(proxyUrl);
+
+        // Write routing rules
+        if (routingRules != null && !routingRules.isEmpty()) {
+            out.writeBoolean(true);
+            out.writeInt(routingRules.size());
+            for (RoutingRule rule : routingRules) {
+                rule.writeTo(out);
+            }
+        } else {
+            out.writeBoolean(false);
+        }
+
+        out.writeOptionalString(authType);
+
+        // Write credential
+        if (credential != null && !credential.isEmpty()) {
+            out.writeBoolean(true);
+            out.writeMap(credential, StreamOutput::writeString, StreamOutput::writeOptionalString);
+        } else {
+            out.writeBoolean(false);
+        }
+
+        out.writeOptionalInt(connectionTimeout);
+        out.writeOptionalInt(readTimeout);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(PROXY_URL_FIELD, proxyUrl);
+
+        if (routingRules != null && !routingRules.isEmpty()) {
+            builder.startArray(ROUTING_RULES_FIELD);
+            for (RoutingRule rule : routingRules) {
+                rule.toXContent(builder, params);
+            }
+            builder.endArray();
+        }
+
+        if (authType != null) {
+            builder.field(AUTH_TYPE_FIELD, authType);
+        }
+
+        if (credential != null && !credential.isEmpty()) {
+            builder.field(CREDENTIAL_FIELD, credential);
+        }
+
+        if (connectionTimeout != null) {
+            builder.field(CONNECTION_TIMEOUT_FIELD, connectionTimeout);
+        }
+
+        if (readTimeout != null) {
+            builder.field(READ_TIMEOUT_FIELD, readTimeout);
+        }
+
+        builder.endObject();
+        return builder;
+    }
+
+    /**
+     * Remove credentials from this connector spec.
+     * Should be called before returning to user-facing APIs.
+     */
+    public void removeCredential() {
+        this.credential = null;
+    }
+
+    /**
+     * Check if this connector has routing rules (not a catch-all).
+     */
+    public boolean hasRoutingRules() {
+        return routingRules != null && !routingRules.isEmpty();
+    }
+
+    public static ConnectorSpec parse(XContentParser parser) throws IOException {
+        String proxyUrl = null;
+        List<RoutingRule> routingRules = null;
+        String authType = null;
+        Map<String, String> credential = null;
+        Integer connectionTimeout = null;
+        Integer readTimeout = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case PROXY_URL_FIELD:
+                    proxyUrl = parser.text();
+                    break;
+                case ROUTING_RULES_FIELD:
+                    routingRules = parseRoutingRules(parser);
+                    break;
+                case AUTH_TYPE_FIELD:
+                    authType = parser.text();
+                    break;
+                case CREDENTIAL_FIELD:
+                    credential = getParameterMap(parser.map());
+                    break;
+                case CONNECTION_TIMEOUT_FIELD:
+                    connectionTimeout = parser.intValue();
+                    break;
+                case READ_TIMEOUT_FIELD:
+                    readTimeout = parser.intValue();
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+
+        return new ConnectorSpec(proxyUrl, routingRules, authType, credential, connectionTimeout, readTimeout);
+    }
+
+    private static List<RoutingRule> parseRoutingRules(XContentParser parser) throws IOException {
+        List<RoutingRule> rules = new ArrayList<>();
+        ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+
+        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+            rules.add(RoutingRule.parse(parser));
+        }
+
+        return rules;
+    }
+
+    public static ConnectorSpec fromStream(StreamInput in) throws IOException {
+        return new ConnectorSpec(in);
+    }
+
+    /**
+     * Represents a single routing rule for context-based routing.
+     */
+    @Data
+    @EqualsAndHashCode
+    public static class RoutingRule implements ToXContentObject {
+        public static final String CONTEXT_DESCRIPTION_FIELD = "context_description";
+        public static final String VALUE_PATTERN_FIELD = "value_pattern";
+
+        private final String contextDescription;
+        private final String valuePattern;
+        private transient Pattern compiledPattern;
+
+        @Builder
+        public RoutingRule(String contextDescription, String valuePattern) {
+            this.contextDescription = contextDescription;
+            this.valuePattern = valuePattern;
+            validate();
+            compilePattern();
+        }
+
+        public RoutingRule(StreamInput input) throws IOException {
+            contextDescription = input.readString();
+            valuePattern = input.readString();
+            compilePattern();
+        }
+
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(contextDescription);
+            out.writeString(valuePattern);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(CONTEXT_DESCRIPTION_FIELD, contextDescription);
+            builder.field(VALUE_PATTERN_FIELD, valuePattern);
+            builder.endObject();
+            return builder;
+        }
+
+        public void validate() {
+            if (contextDescription == null || contextDescription.trim().isEmpty()) {
+                throw new IllegalArgumentException("context_description is required in routing rule");
+            }
+            if (valuePattern == null || valuePattern.trim().isEmpty()) {
+                throw new IllegalArgumentException("value_pattern is required in routing rule");
+            }
+
+            // Validate regex pattern
+            try {
+                Pattern.compile(valuePattern);
+            } catch (PatternSyntaxException e) {
+                throw new IllegalArgumentException("Invalid regex pattern in value_pattern: " + valuePattern, e);
+            }
+        }
+
+        private void compilePattern() {
+            try {
+                this.compiledPattern = Pattern.compile(valuePattern);
+            } catch (PatternSyntaxException e) {
+                throw new IllegalArgumentException("Invalid regex pattern: " + valuePattern, e);
+            }
+        }
+
+        /**
+         * Check if the given value matches this rule's pattern.
+         */
+        public boolean matches(String value) {
+            if (compiledPattern == null) {
+                compilePattern();
+            }
+            return compiledPattern.matcher(value).find();
+        }
+
+        public static RoutingRule parse(XContentParser parser) throws IOException {
+            String contextDescription = null;
+            String valuePattern = null;
+
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+            while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                String fieldName = parser.currentName();
+                parser.nextToken();
+
+                switch (fieldName) {
+                    case CONTEXT_DESCRIPTION_FIELD:
+                        contextDescription = parser.text();
+                        break;
+                    case VALUE_PATTERN_FIELD:
+                        valuePattern = parser.text();
+                        break;
+                    default:
+                        parser.skipChildren();
+                        break;
+                }
+            }
+
+            return new RoutingRule(contextDescription, valuePattern);
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/agent/MLAgent.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/MLAgent.java
@@ -45,6 +45,7 @@ public class MLAgent implements ToXContentObject, Writeable {
     public static final String DESCRIPTION_FIELD = "description";
     public static final String LLM_FIELD = "llm";
     public static final String MODEL_FIELD = "model";
+    public static final String CONNECTORS_FIELD = "connectors";
     public static final String TOOLS_FIELD = "tools";
     public static final String PARAMETERS_FIELD = "parameters";
     public static final String MEMORY_FIELD = "memory";
@@ -69,6 +70,7 @@ public class MLAgent implements ToXContentObject, Writeable {
     private String description;
     private LLMSpec llm;
     private MLAgentModelSpec model;
+    private List<ConnectorSpec> connectors;
     private List<MLToolSpec> tools;
     private Map<String, String> parameters;
     private MLMemorySpec memory;
@@ -88,6 +90,7 @@ public class MLAgent implements ToXContentObject, Writeable {
         String description,
         LLMSpec llm,
         MLAgentModelSpec model,
+        List<ConnectorSpec> connectors,
         List<MLToolSpec> tools,
         Map<String, String> parameters,
         MLMemorySpec memory,
@@ -104,6 +107,7 @@ public class MLAgent implements ToXContentObject, Writeable {
         this.description = description;
         this.llm = llm;
         this.model = model;
+        this.connectors = connectors;
         this.tools = tools;
         this.parameters = parameters;
         this.memory = memory;
@@ -141,6 +145,7 @@ public class MLAgent implements ToXContentObject, Writeable {
             description,
             llm,
             null,
+            null,
             tools,
             parameters,
             memory,
@@ -165,8 +170,11 @@ public class MLAgent implements ToXContentObject, Writeable {
         }
         validateMLAgentType(type);
         if ((type.equalsIgnoreCase(MLAgentType.CONVERSATIONAL.toString())
-            || type.equalsIgnoreCase(MLAgentType.PLAN_EXECUTE_AND_REFLECT.toString())) && llm == null && model == null) {
-            throw new IllegalArgumentException("We need model information for the conversational agent type");
+            || type.equalsIgnoreCase(MLAgentType.PLAN_EXECUTE_AND_REFLECT.toString()))
+            && llm == null
+            && model == null
+            && (connectors == null || connectors.isEmpty())) {
+            throw new IllegalArgumentException("We need model information (llm, model, or connectors) for the conversational agent type");
         }
         Set<String> toolNames = new HashSet<>();
         if (tools != null) {
@@ -217,6 +225,13 @@ public class MLAgent implements ToXContentObject, Writeable {
             model = new MLAgentModelSpec(input);
         }
         if (input.readBoolean()) {
+            connectors = new ArrayList<>();
+            int connectorsSize = input.readInt();
+            for (int i = 0; i < connectorsSize; i++) {
+                connectors.add(new ConnectorSpec(input));
+            }
+        }
+        if (input.readBoolean()) {
             tools = new ArrayList<>();
             int size = input.readInt();
             for (int i = 0; i < size; i++) {
@@ -263,6 +278,15 @@ public class MLAgent implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
+        if (connectors != null && !connectors.isEmpty()) {
+            out.writeBoolean(true);
+            out.writeInt(connectors.size());
+            for (ConnectorSpec connector : connectors) {
+                connector.writeTo(out);
+            }
+        } else {
+            out.writeBoolean(false);
+        }
         if (tools != null && !tools.isEmpty()) {
             out.writeBoolean(true);
             out.writeInt(tools.size());
@@ -306,12 +330,17 @@ public class MLAgent implements ToXContentObject, Writeable {
     }
 
     /**
-     * Remove credentials from the agent's model spec.
+     * Remove credentials from the agent's model spec and connectors.
      * Should be called before returning to user-facing APIs.
      */
     public void removeCredential() {
         if (this.model != null) {
             this.model.removeCredential();
+        }
+        if (this.connectors != null) {
+            for (ConnectorSpec connector : this.connectors) {
+                connector.removeCredential();
+            }
         }
     }
 
@@ -332,6 +361,9 @@ public class MLAgent implements ToXContentObject, Writeable {
         }
         if (model != null) {
             builder.field(MODEL_FIELD, model);
+        }
+        if (connectors != null && connectors.size() > 0) {
+            builder.field(CONNECTORS_FIELD, connectors);
         }
         if (tools != null && tools.size() > 0) {
             builder.field(TOOLS_FIELD, tools);
@@ -382,6 +414,7 @@ public class MLAgent implements ToXContentObject, Writeable {
         String description = null;
         LLMSpec llm = null;
         MLAgentModelSpec model = null;
+        List<ConnectorSpec> connectors = null;
         List<MLToolSpec> tools = null;
         Map<String, String> parameters = null;
         MLMemorySpec memory = null;
@@ -413,6 +446,13 @@ public class MLAgent implements ToXContentObject, Writeable {
                     break;
                 case MODEL_FIELD:
                     model = MLAgentModelSpec.parse(parser);
+                    break;
+                case CONNECTORS_FIELD:
+                    connectors = new ArrayList<>();
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        connectors.add(ConnectorSpec.parse(parser));
+                    }
                     break;
                 case TOOLS_FIELD:
                     tools = new ArrayList<>();
@@ -462,6 +502,7 @@ public class MLAgent implements ToXContentObject, Writeable {
             .description(description)
             .llm(llm)
             .model(model)
+            .connectors(connectors)
             .tools(tools)
             .parameters(parameters)
             .memory(memory)

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AgentProxyConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AgentProxyConnectorExecutor.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.remote;
+
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_FIELD_CONTEXT;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_FIELD_FORWARDED_PROPS;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_FIELD_MESSAGES;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_FIELD_RUN_ID;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_FIELD_STATE;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_FIELD_THREAD_ID;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_FIELD_TOOLS;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_CONTEXT;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_FORWARDED_PROPS;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_MESSAGES;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_RUN_ID;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_STATE;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_THREAD_ID;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_TOOLS;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opensearch.ml.common.agent.ConnectorSpec;
+import org.opensearch.ml.common.connector.ConnectorClientConfig;
+import org.opensearch.ml.common.exception.MLException;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.transport.MLTaskResponse;
+import org.opensearch.ml.engine.algorithms.remote.streaming.AgentProxyStreamingHandler;
+import org.opensearch.ml.engine.algorithms.remote.streaming.StreamPredictActionListener;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Executor for Agent Proxy requests.
+ * Builds AGUI JSON payload from AgentMLInput and forwards to external proxy via SSE streaming.
+ */
+@Log4j2
+public class AgentProxyConnectorExecutor {
+
+    private final ConnectorSpec connectorSpec;
+    private final ConnectorClientConfig clientConfig;
+
+    public AgentProxyConnectorExecutor(ConnectorSpec connectorSpec) {
+        this.connectorSpec = connectorSpec;
+
+        // Build client config from connector spec timeouts
+        this.clientConfig = ConnectorClientConfig
+            .builder()
+            .connectionTimeout(connectorSpec.getConnectionTimeout())
+            .readTimeout(connectorSpec.getReadTimeout())
+            .build();
+    }
+
+    /**
+     * Execute agent proxy request with streaming.
+     *
+     * @param action Action name (not used for proxy)
+     * @param mlInput ML input containing AGUI parameters
+     * @param parameters Additional parameters
+     * @param executionContext Execution context
+     * @param actionListener Streaming action listener
+     */
+    public void executeStream(
+        String action,
+        MLInput mlInput,
+        Map<String, String> parameters,
+        ExecutionContext executionContext,
+        StreamPredictActionListener<MLTaskResponse, ?> actionListener
+    ) {
+        try {
+            log.info("Executing agent proxy request to: {}", connectorSpec.getProxyUrl());
+
+            // Build AGUI JSON payload from parameters
+            String aguiPayload = buildAGUIPayload(parameters);
+            log.debug("Built AGUI payload for proxy: {}", aguiPayload);
+
+            // Build authentication headers
+            Map<String, String> headers = buildHeaders();
+
+            // Create streaming handler
+            AgentProxyStreamingHandler streamingHandler = new AgentProxyStreamingHandler(
+                connectorSpec.getProxyUrl(),
+                headers,
+                clientConfig
+            );
+
+            // Start streaming
+            streamingHandler.startStream(action, parameters, aguiPayload, actionListener);
+
+        } catch (Exception e) {
+            log.error("Failed to execute agent proxy request", e);
+            actionListener.onFailure(new MLException("Failed to execute agent proxy request", e));
+        }
+    }
+
+    /**
+     * Build AGUI JSON payload from parameters.
+     * Reconstructs the original AGUI format from stored parameters.
+     *
+     * @param parameters Parameters containing AGUI fields
+     * @return AGUI JSON string
+     */
+    private String buildAGUIPayload(Map<String, String> parameters) {
+        JsonObject aguiJson = new JsonObject();
+
+        // Add required fields
+        String threadId = parameters.get(AGUI_PARAM_THREAD_ID);
+        String runId = parameters.get(AGUI_PARAM_RUN_ID);
+
+        if (threadId == null || runId == null) {
+            throw new IllegalArgumentException("Missing required AGUI fields: threadId or runId");
+        }
+
+        aguiJson.addProperty(AGUI_FIELD_THREAD_ID, threadId);
+        aguiJson.addProperty(AGUI_FIELD_RUN_ID, runId);
+
+        // Add state (default to empty object if not present)
+        String stateJson = parameters.get(AGUI_PARAM_STATE);
+        if (stateJson != null && !stateJson.isEmpty()) {
+            aguiJson.add(AGUI_FIELD_STATE, JsonParser.parseString(stateJson));
+        } else {
+            aguiJson.add(AGUI_FIELD_STATE, new JsonObject());
+        }
+
+        // Add messages array
+        String messagesJson = parameters.get(AGUI_PARAM_MESSAGES);
+        if (messagesJson != null && !messagesJson.isEmpty()) {
+            aguiJson.add(AGUI_FIELD_MESSAGES, JsonParser.parseString(messagesJson));
+        } else {
+            throw new IllegalArgumentException("Missing required AGUI field: messages");
+        }
+
+        // Add tools array (default to empty array if not present)
+        String toolsJson = parameters.get(AGUI_PARAM_TOOLS);
+        if (toolsJson != null && !toolsJson.isEmpty()) {
+            aguiJson.add(AGUI_FIELD_TOOLS, JsonParser.parseString(toolsJson));
+        } else {
+            aguiJson.add(AGUI_FIELD_TOOLS, JsonParser.parseString("[]"));
+        }
+
+        // Add context array (default to empty array if not present)
+        String contextJson = parameters.get(AGUI_PARAM_CONTEXT);
+        if (contextJson != null && !contextJson.isEmpty()) {
+            aguiJson.add(AGUI_FIELD_CONTEXT, JsonParser.parseString(contextJson));
+        } else {
+            aguiJson.add(AGUI_FIELD_CONTEXT, JsonParser.parseString("[]"));
+        }
+
+        // Add forwarded props (default to empty object if not present)
+        String forwardedPropsJson = parameters.get(AGUI_PARAM_FORWARDED_PROPS);
+        if (forwardedPropsJson != null && !forwardedPropsJson.isEmpty()) {
+            aguiJson.add(AGUI_FIELD_FORWARDED_PROPS, JsonParser.parseString(forwardedPropsJson));
+        } else {
+            aguiJson.add(AGUI_FIELD_FORWARDED_PROPS, new JsonObject());
+        }
+
+        return aguiJson.toString();
+    }
+
+    /**
+     * Build HTTP headers including authentication.
+     *
+     * @return Map of header name to value
+     */
+    private Map<String, String> buildHeaders() {
+        Map<String, String> headers = new HashMap<>();
+
+        // Add Content-Type
+        headers.put("Content-Type", "application/json");
+
+        // Add authentication headers based on auth type
+        if (connectorSpec.getAuthType() != null && connectorSpec.getCredential() != null) {
+            String authType = connectorSpec.getAuthType().toLowerCase();
+            Map<String, String> credential = connectorSpec.getCredential();
+
+            switch (authType) {
+                case "bearer_token":
+                    // Authorization: Bearer <token>
+                    String token = credential.get("api_key");
+                    if (token != null) {
+                        headers.put("Authorization", "Bearer " + token);
+                        log.debug("Added bearer token authentication");
+                    }
+                    break;
+
+                case "api_key":
+                    // X-API-Key: <key>
+                    String apiKey = credential.get("api_key");
+                    if (apiKey != null) {
+                        headers.put("X-API-Key", apiKey);
+                        log.debug("Added API key authentication");
+                    }
+                    break;
+
+                case "basic_auth":
+                    // Authorization: Basic <base64(username:password)>
+                    String username = credential.get("username");
+                    String password = credential.get("password");
+                    if (username != null && password != null) {
+                        String auth = username + ":" + password;
+                        String encodedAuth = java.util.Base64.getEncoder().encodeToString(auth.getBytes());
+                        headers.put("Authorization", "Basic " + encodedAuth);
+                        log.debug("Added basic authentication");
+                    }
+                    break;
+
+                default:
+                    log.warn("Unsupported auth type for agent proxy: {}", authType);
+                    break;
+            }
+        }
+
+        return headers;
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AgentProxyRouter.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AgentProxyRouter.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.remote;
+
+import java.util.List;
+
+import org.opensearch.ml.common.agent.ConnectorSpec;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Router for selecting the appropriate agent proxy connector based on AGUI context.
+ * Evaluates routing rules against context fields to determine which external agent should handle the request.
+ */
+@Log4j2
+public class AgentProxyRouter {
+
+    /**
+     * Selects the appropriate connector based on AGUI context and routing rules.
+     *
+     * @param contextArray AGUI context array from the request
+     * @param connectors List of connector specs with optional routing rules
+     * @return The selected ConnectorSpec
+     * @throws IllegalArgumentException if no connector matches and no default is configured
+     */
+    public static ConnectorSpec selectConnector(JsonArray contextArray, List<ConnectorSpec> connectors) {
+        if (connectors == null || connectors.isEmpty()) {
+            throw new IllegalArgumentException("No connectors configured for agent proxy");
+        }
+
+        // Iterate through connectors in order
+        for (ConnectorSpec connector : connectors) {
+            if (connector.hasRoutingRules()) {
+                // Connector has routing rules - check if any rule matches
+                if (matchesRules(contextArray, connector.getRoutingRules())) {
+                    log.debug("Connector matched via routing rules: {}", connector.getProxyUrl());
+                    return connector;
+                }
+            } else {
+                // Connector without routing rules is a catch-all/default
+                log.debug("Using default connector (no routing rules): {}", connector.getProxyUrl());
+                return connector;
+            }
+        }
+
+        // No connector matched (all had rules, none matched, and no default)
+        throw new IllegalArgumentException(
+            "No connector matched context and no default connector configured. "
+                + "Add a connector without routing_rules to serve as default."
+        );
+    }
+
+    /**
+     * Check if any routing rule matches the given context array.
+     *
+     * @param contextArray AGUI context array
+     * @param routingRules List of routing rules to evaluate
+     * @return true if at least one rule matches
+     */
+    private static boolean matchesRules(JsonArray contextArray, List<ConnectorSpec.RoutingRule> routingRules) {
+        if (contextArray == null || contextArray.size() == 0) {
+            return false;
+        }
+
+        if (routingRules == null || routingRules.isEmpty()) {
+            return false;
+        }
+
+        // Check each routing rule
+        for (ConnectorSpec.RoutingRule rule : routingRules) {
+            if (matchesRule(contextArray, rule)) {
+                log
+                    .debug(
+                        "Routing rule matched: context_description={}, value_pattern={}",
+                        rule.getContextDescription(),
+                        rule.getValuePattern()
+                    );
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a single routing rule matches any item in the context array.
+     *
+     * @param contextArray AGUI context array
+     * @param rule Routing rule to evaluate
+     * @return true if the rule matches
+     */
+    private static boolean matchesRule(JsonArray contextArray, ConnectorSpec.RoutingRule rule) {
+        String targetDescription = rule.getContextDescription();
+
+        // Iterate through context items to find matching description
+        for (JsonElement contextElement : contextArray) {
+            if (!contextElement.isJsonObject()) {
+                continue;
+            }
+
+            JsonObject contextItem = contextElement.getAsJsonObject();
+
+            // Get description and value fields
+            String description = getStringField(contextItem, "description");
+            String value = getStringField(contextItem, "value");
+
+            if (description == null || value == null) {
+                continue;
+            }
+
+            // Check if description matches
+            if (description.equals(targetDescription)) {
+                // Check if value matches the pattern
+                if (rule.matches(value)) {
+                    log.debug("Context matched: description={}, value={}", description, value);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Helper method to safely extract string field from JsonObject.
+     */
+    private static String getStringField(JsonObject obj, String fieldName) {
+        if (obj == null || !obj.has(fieldName)) {
+            return null;
+        }
+
+        JsonElement element = obj.get(fieldName);
+        if (element == null || element.isJsonNull()) {
+            return null;
+        }
+
+        return element.getAsString();
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/AgentProxyStreamingHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/AgentProxyStreamingHandler.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.remote.streaming;
+
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.opensearch.ml.common.agui.RunErrorEvent;
+import org.opensearch.ml.common.connector.ConnectorClientConfig;
+import org.opensearch.ml.common.exception.MLException;
+import org.opensearch.ml.common.transport.MLTaskResponse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.log4j.Log4j2;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.sse.EventSource;
+import okhttp3.sse.EventSourceListener;
+import okhttp3.sse.EventSources;
+
+/**
+ * Streaming handler for Agent Proxy.
+ * Consumes SSE stream from external proxy and forwards validated AGUI events to client.
+ */
+@Log4j2
+public class AgentProxyStreamingHandler extends BaseStreamingHandler {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final String proxyUrl;
+    private final Map<String, String> headers;
+    private OkHttpClient okHttpClient;
+
+    public AgentProxyStreamingHandler(String proxyUrl, Map<String, String> headers, ConnectorClientConfig clientConfig) {
+        this.proxyUrl = proxyUrl;
+        this.headers = headers;
+
+        Duration connectionTimeout = Duration.ofSeconds(clientConfig.getConnectionTimeout());
+        Duration readTimeout = Duration.ofSeconds(clientConfig.getReadTimeout());
+
+        try {
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                this.okHttpClient = new OkHttpClient.Builder()
+                    .connectTimeout(connectionTimeout)
+                    .readTimeout(readTimeout)
+                    .retryOnConnectionFailure(true)
+                    .build();
+                return null;
+            });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to build OkHttpClient for Agent Proxy", e);
+        }
+    }
+
+    @Override
+    public void startStream(
+        String action,
+        Map<String, String> parameters,
+        String payload,
+        StreamPredictActionListener<MLTaskResponse, ?> actionListener
+    ) {
+        try {
+            log.info("Starting Agent Proxy SSE connection to: {}", proxyUrl);
+
+            EventSourceListener listener = new AgentProxyEventSourceListener(actionListener);
+            Request.Builder requestBuilder = new Request.Builder()
+                .url(proxyUrl)
+                .post(okhttp3.RequestBody.create(payload, okhttp3.MediaType.parse("application/json")));
+
+            // Add headers (auth, content-type, etc.)
+            if (headers != null) {
+                headers.forEach((key, value) -> {
+                    if (value != null) {
+                        requestBuilder.addHeader(key, value);
+                    }
+                });
+            }
+
+            // Set SSE accept header
+            requestBuilder.addHeader("Accept", "text/event-stream");
+
+            Request request = requestBuilder.build();
+
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                EventSources.createFactory(okHttpClient).newEventSource(request, listener);
+                return null;
+            });
+
+        } catch (Exception e) {
+            log.error("Failed to start Agent Proxy streaming", e);
+            handleError(e, actionListener);
+        }
+    }
+
+    @Override
+    public void handleError(Throwable error, StreamPredictActionListener<MLTaskResponse, ?> listener) {
+        log.error("Agent Proxy streaming error", error);
+
+        sendAGUIEvent(new RunErrorEvent("Agent Proxy error: " + error.getMessage(), "PROXY_ERROR"), false, listener);
+        listener.onFailure(new MLException("Agent Proxy streaming failed", error));
+    }
+
+    /**
+     * EventSourceListener for Agent Proxy SSE events.
+     */
+    public final class AgentProxyEventSourceListener extends EventSourceListener {
+        private StreamPredictActionListener<MLTaskResponse, ?> streamActionListener;
+        private AtomicBoolean isStreamClosed;
+
+        public AgentProxyEventSourceListener(StreamPredictActionListener<MLTaskResponse, ?> streamActionListener) {
+            this.streamActionListener = streamActionListener;
+            this.isStreamClosed = new AtomicBoolean(false);
+        }
+
+        @Override
+        public void onOpen(EventSource eventSource, Response response) {
+            log.debug("Agent Proxy SSE connection opened");
+        }
+
+        @Override
+        public void onEvent(EventSource eventSource, String id, String type, String data) {
+            if (isStreamClosed.get()) {
+                log.debug("Stream already closed, ignoring event");
+                return;
+            }
+
+            if (data == null || data.trim().isEmpty()) {
+                log.debug("Empty event data, skipping");
+                return;
+            }
+
+            // Handle [DONE] signal (OpenAI-style)
+            if ("[DONE]".equals(data.trim())) {
+                log.debug("Received [DONE] signal");
+                sendCompletionResponse(isStreamClosed, streamActionListener);
+                return;
+            }
+
+            String eventType = getEventType(data);
+
+            // Skip RUN_STARTED from remote agent (REST layer sends its own)
+            if ("RUN_STARTED".equals(eventType)) {
+                return;
+            }
+
+            // Check if this is the final event
+            boolean isLast = "RUN_FINISHED".equals(eventType) || "RUN_ERROR".equals(eventType);
+
+            // Forward raw JSON to client
+            sendContentResponse(data, isLast, streamActionListener);
+
+            if (isLast) {
+                isStreamClosed.set(true);
+                log.debug("Received final event: {}", eventType);
+            }
+        }
+
+        @Override
+        public void onClosed(EventSource eventSource) {
+            log.debug("Agent Proxy SSE connection closed");
+            sendCompletionResponse(isStreamClosed, streamActionListener);
+        }
+
+        @Override
+        public void onFailure(EventSource eventSource, Throwable t, Response response) {
+            if (isStreamClosed.get()) {
+                log.debug("Stream already closed, ignoring failure");
+                return;
+            }
+
+            String errorMessage = "Agent Proxy connection failed";
+            if (response != null) {
+                errorMessage += " (HTTP " + response.code() + ")";
+            }
+            if (t != null) {
+                errorMessage += ": " + t.getMessage();
+            }
+
+            log.error(errorMessage, t);
+            sendErrorEvent(errorMessage, true);
+            isStreamClosed.set(true);
+        }
+
+        /**
+         * Send error event to client.
+         */
+        private void sendErrorEvent(String message, boolean isLast) {
+            sendAGUIEvent(new RunErrorEvent(message, "PROXY_ERROR"), isLast, streamActionListener);
+        }
+    }
+
+    /**
+     * Extract the "type" field from a JSON string using Jackson.
+     */
+    private static String getEventType(String json) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            JsonNode node = mapper.readTree(json);
+            JsonNode typeNode = node.get("type");
+            return (typeNode != null && !typeNode.isNull()) ? typeNode.asText() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
@@ -192,6 +192,24 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
                     BytesReference completeContent = combineChunks(chunks);
                     MLExecuteTaskRequest mlExecuteTaskRequest = getRequest(agentId, request, completeContent);
                     boolean isAGUI = isAGUIAgent(mlExecuteTaskRequest);
+                    boolean isProxy = agent.getConnectors() != null && !agent.getConnectors().isEmpty();
+
+                    // Inject serialized connectors into parameters so MLExecuteTaskRunner
+                    // can route to the proxy path without re-fetching the agent.
+                    if (isProxy && mlExecuteTaskRequest.getInput() instanceof AgentMLInput agentInput) {
+                        RemoteInferenceInputDataSet inputDataSet = (RemoteInferenceInputDataSet) agentInput.getInputDataset();
+                        try {
+                            XContentBuilder xb = XContentFactory.jsonBuilder();
+                            xb.startArray();
+                            for (org.opensearch.ml.common.agent.ConnectorSpec c : agent.getConnectors()) {
+                                c.toXContent(xb, ToXContent.EMPTY_PARAMS);
+                            }
+                            xb.endArray();
+                            inputDataSet.getParameters().put("_agent_proxy_connectors", xb.toString());
+                        } catch (IOException ex) {
+                            log.error("Failed to serialize connectors", ex);
+                        }
+                    }
 
                     // Send RUN_STARTED event immediately for AG-UI agents (ReAct cycle begins)
                     if (isAGUI) {

--- a/plugin/src/main/java/org/opensearch/ml/task/MLExecuteTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLExecuteTaskRunner.java
@@ -6,12 +6,15 @@
 package org.opensearch.ml.task;
 
 import static org.opensearch.ml.common.agent.MLAgent.CONTEXT_MANAGEMENT_NAME_FIELD;
+import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_CONTEXT;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_ENABLE_INHOUSE_PYTHON_MODEL;
 import static org.opensearch.ml.engine.algorithms.agent.MLAgentExecutor.CONTEXT_MANAGEMENT_PROCESSED;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.EXECUTE_THREAD_POOL;
 import static org.opensearch.ml.plugin.MachineLearningPlugin.STREAM_EXECUTE_THREAD_POOL;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import org.opensearch.action.ActionListenerResponseHandler;
 import org.opensearch.action.get.GetRequest;
@@ -21,6 +24,7 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
 import org.opensearch.ml.action.contextmanagement.ContextManagementTemplateService;
@@ -29,6 +33,7 @@ import org.opensearch.ml.breaker.MLCircuitBreakerService;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
 import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.agent.ConnectorSpec;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.contextmanager.ContextManagementTemplate;
 import org.opensearch.ml.common.contextmanager.ContextManager;
@@ -43,6 +48,10 @@ import org.opensearch.ml.common.transport.execute.MLExecuteTaskAction;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskRequest;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskResponse;
 import org.opensearch.ml.engine.MLEngine;
+import org.opensearch.ml.engine.algorithms.remote.AgentProxyConnectorExecutor;
+import org.opensearch.ml.engine.algorithms.remote.AgentProxyRouter;
+import org.opensearch.ml.engine.algorithms.remote.ExecutionContext;
+import org.opensearch.ml.engine.algorithms.remote.streaming.StreamPredictActionListener;
 import org.opensearch.ml.engine.indices.MLInputDatasetHandler;
 import org.opensearch.ml.stats.ActionName;
 import org.opensearch.ml.stats.MLActionLevelStat;
@@ -55,6 +64,9 @@ import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.client.Client;
 import org.opensearch.transport.stream.StreamTransportResponse;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -184,6 +196,16 @@ public class MLExecuteTaskRunner extends MLTaskRunner<MLExecuteTaskRequest, MLEx
                 // Handle agent execution with context management
                 if (FunctionName.AGENT.equals(functionName) && input instanceof AgentMLInput) {
                     AgentMLInput agentInput = (AgentMLInput) input;
+
+                    // Check if the REST layer flagged this as a proxy agent
+                    if (agentInput.getInputDataset() instanceof RemoteInferenceInputDataSet dataset
+                        && dataset.getParameters() != null
+                        && dataset.getParameters().containsKey("_agent_proxy_connectors")) {
+                        executeAgentProxy(agentInput, dataset.getParameters(), request, channel, listener);
+                        return;
+                    }
+
+                    // Non-proxy agents: check context management
                     getEffectiveContextManagementNameAsync(agentInput, ActionListener.wrap(contextManagementName -> {
                         if (contextManagementName != null && !contextManagementName.trim().isEmpty()) {
                             // Execute agent with context management
@@ -226,6 +248,70 @@ public class MLExecuteTaskRunner extends MLTaskRunner<MLExecuteTaskRequest, MLEx
                 mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).decrement();
             }
         });
+    }
+
+    /**
+     * Execute agent proxy request.
+     * Parses connectors from serialized parameter (injected by REST layer) and
+     * routes to external proxy based on AGUI context.
+     */
+    private void executeAgentProxy(
+        AgentMLInput agentInput,
+        Map<String, String> parameters,
+        MLExecuteTaskRequest request,
+        TransportChannel channel,
+        ActionListener<MLExecuteTaskResponse> listener
+    ) {
+        try {
+            // Parse connectors from the serialized parameter injected by the REST layer
+            String connectorsJson = parameters.get("_agent_proxy_connectors");
+            List<ConnectorSpec> connectors = parseConnectors(connectorsJson);
+
+            // Parse context array for routing
+            String contextJson = parameters.get(AGUI_PARAM_CONTEXT);
+            JsonArray contextArray = null;
+            if (contextJson != null && !contextJson.isEmpty()) {
+                contextArray = JsonParser.parseString(contextJson).getAsJsonArray();
+            }
+
+            // Select connector based on routing rules
+            ConnectorSpec selectedConnector = AgentProxyRouter.selectConnector(contextArray, connectors);
+            log.info("Selected connector for agent proxy: {}", selectedConnector.getProxyUrl());
+
+            // Create executor for selected connector
+            AgentProxyConnectorExecutor executor = new AgentProxyConnectorExecutor(selectedConnector);
+
+            // Create streaming listener for agent proxy
+            StreamPredictActionListener<org.opensearch.ml.common.transport.MLTaskResponse, MLExecuteTaskRequest> streamListener =
+                new StreamPredictActionListener<>(channel);
+
+            // Execute proxy request
+            org.opensearch.ml.common.input.MLInput mlInput = org.opensearch.ml.common.input.MLInput
+                .builder()
+                .algorithm(request.getFunctionName())
+                .inputDataset(agentInput.getInputDataset())
+                .build();
+            executor.executeStream("predict", mlInput, parameters, new ExecutionContext(0), streamListener);
+
+        } catch (Exception e) {
+            log.error("Failed to execute agent proxy", e);
+            listener.onFailure(e);
+        }
+    }
+
+    private List<ConnectorSpec> parseConnectors(String connectorsJson) {
+        List<ConnectorSpec> connectors = new java.util.ArrayList<>();
+        try {
+            XContentParser parser = JsonXContent.jsonXContent
+                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, connectorsJson);
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser);
+            while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                connectors.add(ConnectorSpec.parse(parser));
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to parse agent proxy connectors", e);
+        }
+        return connectors;
     }
 
     /**


### PR DESCRIPTION
# Agent Proxy

Route AG-UI streaming requests to external agent endpoints.

## Overview

Agent Proxy allows an OpenSearch agent to act as a pass-through to an external AG-UI compatible endpoint. The proxy receives an AG-UI request on the OpenSearch streaming endpoint, forwards it to the configured `proxy_url`, and streams the SSE response back to the client.

```
Client --> OpenSearch Agent (proxy) --> External Agent Endpoint
       <-- SSE events <-------------- SSE events
```

## Cluster settings

Both settings must be enabled:

```json
PUT /_cluster/settings
{
  "persistent": {
    "plugins.ml_commons.stream_enabled": true,
    "plugins.ml_commons.ag_ui_enabled": true
  }
}
```

## Registration

Register an agent with a `connectors` array:

```json
POST /_plugins/_ml/agents/_register
{
  "name": "my-proxy-agent",
  "type": "conversational",
  "connectors": [
    {
      "proxy_url": "https://my-agent.example.com/run"
    }
  ]
}
```

### Connector fields

| Field | Required | Default | Description |
|---|---|---|---|
| `proxy_url` | Yes | - | External endpoint URL (must return SSE) |
| `auth_type` | No | - | `bearer_token`, `api_key`, or `basic_auth` |
| `credential` | No | - | Auth credentials (see below) |
| `connection_timeout` | No | 10 | Connection timeout in seconds |
| `read_timeout` | No | 300 | Read timeout in seconds |
| `routing_rules` | No | - | Context-based routing rules (see below) |

### Authentication

```json
{
  "proxy_url": "https://my-agent.example.com/run",
  "auth_type": "bearer_token",
  "credential": { "api_key": "sk-..." }
}
```

| Auth type | Header sent | Credential fields |
|---|---|---|
| `bearer_token` | `Authorization: Bearer <api_key>` | `api_key` |
| `api_key` | `X-API-Key: <api_key>` | `api_key` |
| `basic_auth` | `Authorization: Basic base64(user:pass)` | `username`, `password` |

## Execution

Send an AG-UI request to the streaming endpoint:

```json
POST /_plugins/_ml/agents/<agent_id>/_execute/stream
{
  "threadId": "thread-1",
  "runId": "run-1",
  "messages": [
    { "role": "user", "content": "Hello" }
  ],
  "tools": [],
  "context": [],
  "state": {},
  "forwardedProps": {}
}
```

The response is an SSE stream of AG-UI events:

```
data: {"type":"RUN_STARTED","threadId":"thread-1","runId":"run-1",...}

data: {"type":"TEXT_MESSAGE_START","messageId":"msg-1","role":"assistant",...}

data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"msg-1","delta":"Hello ",...}

data: {"type":"TEXT_MESSAGE_END","messageId":"msg-1",...}

data: {"type":"RUN_FINISHED","threadId":"thread-1","runId":"run-1",...}
```

## Context-based routing

Multiple connectors with routing rules route requests to different endpoints based on the AG-UI `context` array. This is designed for OpenSearch Dashboards, where different pages route to specialized agents.

### Example: Dashboards with specialized agents

Register a single proxy agent with three backends — search relevance, anomaly detection, and a default catch-all:

```json
POST /_plugins/_ml/agents/_register
{
  "name": "dashboards-assistant",
  "type": "conversational",
  "connectors": [
    {
      "proxy_url": "https://search-relevance-agent.example.com/run",
      "routing_rules": [
        {
          "context_description": "opensearch_page",
          "value_pattern": "search.relevance.*"
        }
      ]
    },
    {
      "proxy_url": "https://anomaly-detection-agent.example.com/run",
      "routing_rules": [
        {
          "context_description": "opensearch_page",
          "value_pattern": "anomaly.detection.*"
        }
      ]
    },
    {
      "proxy_url": "https://default-agent.example.com/run"
    }
  ]
}
```

Dashboards sends the current page in the `context` array:

```json
{
  "threadId": "thread-1",
  "runId": "run-1",
  "messages": [{ "role": "user", "content": "Why are my search results not relevant?" }],
  "context": [
    { "description": "opensearch_page", "value": "search.relevance.workbench" }
  ],
  "tools": [],
  "state": {},
  "forwardedProps": {}
}
```

This routes to `search-relevance-agent` because `"search.relevance.workbench"` matches `"search.relevance.*"`. A request from the anomaly detection page would route to `anomaly-detection-agent`, and any other page falls through to `default-agent`.

### Routing logic

1. Connectors are evaluated in order
2. A connector with `routing_rules` is selected if any rule matches: the rule's `context_description` matches a context item's `description`, and `value_pattern` regex matches its `value`
3. A connector without `routing_rules` acts as the default catch-all
4. If no connector matches, the request fails

## Request flow

```
1. RestMLExecuteStreamAction
   - Fetches agent, detects connectors
   - Serializes connectors into request parameters
   - Sends RUN_STARTED event to client

2. MLExecuteTaskRunner
   - Detects _agent_proxy_connectors parameter
   - Routes to executeAgentProxy()

3. AgentProxyRouter
   - Selects connector based on context + routing rules

4. AgentProxyConnectorExecutor
   - Reconstructs AG-UI payload from parameters
   - Creates AgentProxyStreamingHandler

5. AgentProxyStreamingHandler
   - OkHttp POST to proxy_url with AG-UI payload
   - Consumes SSE response via EventSource
   - Forwards raw JSON events to client (no deserialization)
   - Skips RUN_STARTED from remote (REST layer sends its own)
   - Detects RUN_FINISHED/RUN_ERROR as final events
```

## Key files

| File | Description |
|---|---|
| `ConnectorSpec.java` | Proxy connector config model |
| `AgentProxyRouter.java` | Context-based connector selection |
| `AgentProxyConnectorExecutor.java` | Builds AG-UI payload, initiates streaming |
| `AgentProxyStreamingHandler.java` | OkHttp SSE consumer, raw event forwarding |
| `MLExecuteTaskRunner.java` | Proxy detection and routing (modified) |
| `RestMLExecuteStreamAction.java` | Connector serialization, RUN_STARTED (modified) |
| `MLAgent.java` | Added `connectors` field (modified) |
