### PR TITLE
ci: quote FIPS crypto standard parameter in workflow files

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -83,9 +83,9 @@ jobs:
                                export COHERE_KEY=`aws secretsmanager get-secret-value --secret-id github_cohere_key --query SecretString --output text` &&
                                echo "::add-mask::$OPENAI_KEY" &&
                                echo "::add-mask::$COHERE_KEY" &&
-                               echo "build and run tests" && ./gradlew build -Pcrypto.standard=FIPS-140-3 -x spotlessJava &&
-                               echo "Publish to Maven Local" && ./gradlew publishToMavenLocal -Pcrypto.standard=FIPS-140-3 -x spotlessJava &&
-                               echo "Multi Nodes Integration Testing" && ./gradlew integTest -PnumNodes=3 -Pcrypto.standard=FIPS-140-3 -x spotlessJava'
+                               echo "build and run tests" && ./gradlew build "-Pcrypto.standard=FIPS-140-3" -x spotlessJava &&
+                               echo "Publish to Maven Local" && ./gradlew publishToMavenLocal "-Pcrypto.standard=FIPS-140-3" -x spotlessJava &&
+                               echo "Multi Nodes Integration Testing" && ./gradlew integTest -PnumNodes=3 "-Pcrypto.standard=FIPS-140-3" -x spotlessJava'
           plugin=`basename $(ls plugin/build/distributions/*.zip)`
           echo $plugin
           mv -v plugin/build/distributions/$plugin ./
@@ -189,10 +189,10 @@ jobs:
           if [ $security -gt 0 ]
           then
             echo "Security plugin is available"
-            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=${{ steps.genpass.outputs.password }} -Pcrypto.standard=FIPS-140-3 -x spotlessJava
+            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=${{ steps.genpass.outputs.password }} "-Pcrypto.standard=FIPS-140-3" -x spotlessJava
           else
             echo "Security plugin is NOT available"
-            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Pcrypto.standard=FIPS-140-3 -x spotlessJava
+            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" "-Pcrypto.standard=FIPS-140-3" -x spotlessJava
           fi
 
       - name: Upload Coverage Report
@@ -235,10 +235,10 @@ jobs:
           export COHERE_KEY=$(aws secretsmanager get-secret-value --secret-id github_cohere_key --query SecretString --output text)
           echo "::add-mask::$OPENAI_KEY"
           echo "::add-mask::$COHERE_KEY"
-          ./gradlew.bat build -Pcrypto.standard=FIPS-140-3 -x spotlessJava
+          ./gradlew.bat build "-Pcrypto.standard=FIPS-140-3" -x spotlessJava
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Pcrypto.standard=FIPS-140-3 -x spotlessJava
+          ./gradlew publishToMavenLocal "-Pcrypto.standard=FIPS-140-3" -x spotlessJava
 #      - name: Multi Nodes Integration Testing
 #        shell: bash
 #        run: |

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -44,4 +44,4 @@ jobs:
 
       - name: publish snapshots to maven
         run: |
-          ./gradlew publishPluginZipPublicationToSnapshotsRepository publishShadowPublicationToSnapshotsRepository -Pcrypto.standard=FIPS-140-3
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository publishShadowPublicationToSnapshotsRepository "-Pcrypto.standard=FIPS-140-3"


### PR DESCRIPTION
### Description

Quote the `-Pcrypto.standard=FIPS-140-3` Gradle parameter in CI and maven-publish workflow files, consistent with other OpenSearch plugin repositories (e.g. [flow-framework PR #1322](https://github.com/opensearch-project/flow-framework/pull/1322)).

**Change**: `-Pcrypto.standard=FIPS-140-3` → `"-Pcrypto.standard=FIPS-140-3"` in `.github/workflows/CI-workflow.yml` and `.github/workflows/maven-publish.yml`

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.