### PR TITLE
[WIP] [Feature] Agent Token Usage Tracking

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/agent/TokenUsage.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/TokenUsage.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Getter;
+
+/**
+ * Represents token usage information from LLM API calls.
+ * Supports multiple providers (OpenAI, Anthropic Claude, Bedrock, Gemini) including
+ * cache tokens and reasoning tokens.
+ */
+@Getter
+public class TokenUsage {
+
+    // Field name constants
+    public static final String INPUT_TOKENS = "input_tokens";
+    public static final String OUTPUT_TOKENS = "output_tokens";
+    public static final String TOTAL_TOKENS = "total_tokens";
+    public static final String CACHE_READ_INPUT_TOKENS = "cache_read_input_tokens";
+    public static final String CACHE_CREATION_INPUT_TOKENS = "cache_creation_input_tokens";
+    public static final String REASONING_TOKENS = "reasoning_tokens";
+
+    // Core token counts (all providers)
+    private final Long inputTokens;           // prompt tokens
+    private final Long outputTokens;          // completion/candidate tokens
+    private final Long totalTokens;           // sum (computed if not provided)
+
+    // Cache tokens (Anthropic, OpenAI, Gemini)
+    private final Long cacheReadInputTokens;     // tokens served from cache
+    private final Long cacheCreationInputTokens; // tokens used to create cache
+
+    // Extended tokens
+    private final Long reasoningTokens;          // thinking tokens (OpenAI o1, Gemini)
+
+    // Provider-specific additional fields
+    private final Map<String, Long> additionalUsage;
+
+    /**
+     * Constructor for builder pattern
+     */
+    @lombok.Builder
+    public TokenUsage(
+        Long inputTokens,
+        Long outputTokens,
+        Long totalTokens,
+        Long cacheReadInputTokens,
+        Long cacheCreationInputTokens,
+        Long reasoningTokens,
+        Map<String, Long> additionalUsage
+    ) {
+        this.inputTokens = inputTokens;
+        this.outputTokens = outputTokens;
+        this.totalTokens = totalTokens;
+        this.cacheReadInputTokens = cacheReadInputTokens;
+        this.cacheCreationInputTokens = cacheCreationInputTokens;
+        this.reasoningTokens = reasoningTokens;
+        this.additionalUsage = additionalUsage != null ? additionalUsage : new HashMap<>();
+    }
+
+    /**
+     * Adds tokens from another TokenUsage instance to this one.
+     * Used for aggregating usage across multiple API calls.
+     *
+     * @param other The TokenUsage to add
+     * @return A new TokenUsage with aggregated values
+     */
+    public TokenUsage addTokens(TokenUsage other) {
+        if (other == null) {
+            return this;
+        }
+
+        Map<String, Long> mergedAdditional = new HashMap<>(this.additionalUsage);
+        if (other.additionalUsage != null) {
+            other.additionalUsage.forEach((key, value) -> mergedAdditional.merge(key, value, Long::sum));
+        }
+
+        return TokenUsage
+            .builder()
+            .inputTokens(addNullable(this.inputTokens, other.inputTokens))
+            .outputTokens(addNullable(this.outputTokens, other.outputTokens))
+            .totalTokens(addNullable(this.totalTokens, other.totalTokens))
+            .cacheReadInputTokens(addNullable(this.cacheReadInputTokens, other.cacheReadInputTokens))
+            .cacheCreationInputTokens(addNullable(this.cacheCreationInputTokens, other.cacheCreationInputTokens))
+            .reasoningTokens(addNullable(this.reasoningTokens, other.reasoningTokens))
+            .additionalUsage(mergedAdditional)
+            .build();
+    }
+
+    /**
+     * Converts TokenUsage to a Map suitable for JSON serialization in agent responses
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        if (inputTokens != null) {
+            map.put(INPUT_TOKENS, inputTokens);
+        }
+        if (outputTokens != null) {
+            map.put(OUTPUT_TOKENS, outputTokens);
+        }
+        if (totalTokens != null) {
+            map.put(TOTAL_TOKENS, totalTokens);
+        }
+        if (cacheReadInputTokens != null) {
+            map.put(CACHE_READ_INPUT_TOKENS, cacheReadInputTokens);
+        }
+        if (cacheCreationInputTokens != null) {
+            map.put(CACHE_CREATION_INPUT_TOKENS, cacheCreationInputTokens);
+        }
+        if (reasoningTokens != null) {
+            map.put(REASONING_TOKENS, reasoningTokens);
+        }
+        if (additionalUsage != null && !additionalUsage.isEmpty()) {
+            map.putAll(additionalUsage);
+        }
+        return map;
+    }
+
+    /**
+     * Computes total tokens if not provided by summing input and output tokens
+     */
+    public Long getEffectiveTotalTokens() {
+        if (totalTokens != null) {
+            return totalTokens;
+        }
+        if (inputTokens != null && outputTokens != null) {
+            return inputTokens + outputTokens;
+        }
+        return null;
+    }
+
+    private static Long addNullable(Long a, Long b) {
+        return a == null ? b : b == null ? a : Long.valueOf(a + b);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/agent/TokenUsageTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/TokenUsageTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agent;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class TokenUsageTest {
+
+    @Test
+    public void testBuilder() {
+        TokenUsage usage = TokenUsage
+            .builder()
+            .inputTokens(100L)
+            .outputTokens(50L)
+            .totalTokens(150L)
+            .cacheReadInputTokens(20L)
+            .cacheCreationInputTokens(10L)
+            .reasoningTokens(5L)
+            .build();
+
+        assertEquals(Long.valueOf(100L), usage.getInputTokens());
+        assertEquals(Long.valueOf(50L), usage.getOutputTokens());
+        assertEquals(Long.valueOf(150L), usage.getTotalTokens());
+        assertEquals(Long.valueOf(20L), usage.getCacheReadInputTokens());
+        assertEquals(Long.valueOf(10L), usage.getCacheCreationInputTokens());
+        assertEquals(Long.valueOf(5L), usage.getReasoningTokens());
+    }
+
+    @Test
+    public void testBuilderWithNullValues() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).build();
+
+        assertEquals(Long.valueOf(100L), usage.getInputTokens());
+        assertEquals(Long.valueOf(50L), usage.getOutputTokens());
+        assertNull(usage.getTotalTokens());
+        assertNull(usage.getCacheReadInputTokens());
+        assertNull(usage.getCacheCreationInputTokens());
+        assertNull(usage.getReasoningTokens());
+    }
+
+    @Test
+    public void testAddTokens() {
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(200L).outputTokens(75L).totalTokens(275L).build();
+
+        TokenUsage combined = usage1.addTokens(usage2);
+
+        assertEquals(Long.valueOf(300L), combined.getInputTokens());
+        assertEquals(Long.valueOf(125L), combined.getOutputTokens());
+        assertEquals(Long.valueOf(425L), combined.getTotalTokens());
+    }
+
+    @Test
+    public void testAddTokensWithNulls() {
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).build();
+
+        TokenUsage usage2 = TokenUsage.builder().outputTokens(50L).build();
+
+        TokenUsage combined = usage1.addTokens(usage2);
+
+        assertEquals(Long.valueOf(100L), combined.getInputTokens());
+        assertEquals(Long.valueOf(50L), combined.getOutputTokens());
+        assertNull(combined.getTotalTokens());
+    }
+
+    @Test
+    public void testAddTokensWithNull() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).build();
+
+        TokenUsage result = usage.addTokens(null);
+
+        assertSame(usage, result);
+    }
+
+    @Test
+    public void testAddTokensWithAdditionalUsage() {
+        Map<String, Long> additional1 = new HashMap<>();
+        additional1.put("audio_tokens", 10L);
+
+        Map<String, Long> additional2 = new HashMap<>();
+        additional2.put("audio_tokens", 5L);
+        additional2.put("video_tokens", 20L);
+
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).additionalUsage(additional1).build();
+
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(50L).additionalUsage(additional2).build();
+
+        TokenUsage combined = usage1.addTokens(usage2);
+
+        assertEquals(Long.valueOf(150L), combined.getInputTokens());
+        assertEquals(Long.valueOf(15L), combined.getAdditionalUsage().get("audio_tokens"));
+        assertEquals(Long.valueOf(20L), combined.getAdditionalUsage().get("video_tokens"));
+    }
+
+    @Test
+    public void testGetEffectiveTotalTokens() {
+        // Test when totalTokens is provided
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+        assertEquals(Long.valueOf(150L), usage1.getEffectiveTotalTokens());
+
+        // Test when totalTokens is computed
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).build();
+        assertEquals(Long.valueOf(150L), usage2.getEffectiveTotalTokens());
+
+        // Test when input or output is missing
+        TokenUsage usage3 = TokenUsage.builder().inputTokens(100L).build();
+        assertNull(usage3.getEffectiveTotalTokens());
+    }
+
+    @Test
+    public void testToMap() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).cacheReadInputTokens(20L).build();
+
+        Map<String, Object> map = usage.toMap();
+
+        assertEquals(100L, map.get("input_tokens"));
+        assertEquals(50L, map.get("output_tokens"));
+        assertEquals(150L, map.get("total_tokens"));
+        assertEquals(20L, map.get("cache_read_input_tokens"));
+        assertFalse(map.containsKey("cache_creation_input_tokens"));
+        assertFalse(map.containsKey("reasoning_tokens"));
+    }
+
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentTokenTracker.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentTokenTracker.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.agent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.ml.common.agent.TokenUsage;
+
+/**
+ * Tracks token usage across multiple LLM calls during agent execution.
+ * Maintains both per-turn usage (each individual LLM call) and per-model
+ * aggregated usage (total across all calls to each model).
+ */
+public class AgentTokenTracker {
+
+    // Field name constants
+    public static final String TOKEN_USAGE = "token_usage";
+    public static final String PER_MODEL_USAGE = "per_model_usage";
+    public static final String PER_TURN_USAGE = "per_turn_usage";
+    public static final String MODEL_NAME = "model_name";
+    public static final String MODEL_URL = "model_url";
+    public static final String MODEL_ID = "model_id";
+    public static final String CALL_COUNT = "call_count";
+    public static final String TURN = "turn";
+
+    // Track each individual LLM call
+    private final List<Map<String, Object>> perTurnUsage;
+
+    // Aggregated by model ID
+    private final Map<String, ModelUsageAggregation> perModelUsage;
+
+    // Model metadata: modelId -> {modelUrl, modelName}
+    private final Map<String, ModelMetadata> modelMetadataMap;
+
+    // Current turn counter
+    private int turnCounter;
+
+    public AgentTokenTracker() {
+        this.perTurnUsage = new ArrayList<>();
+        this.perModelUsage = new HashMap<>();
+        this.modelMetadataMap = new HashMap<>();
+        this.turnCounter = 0;
+    }
+
+    /**
+     * Sets model metadata for enriching token usage data.
+     * Should be called when model details are resolved.
+     *
+     * @param modelId The model ID
+     * @param modelUrl The resolved model URL
+     * @param modelName The model name (can be same as modelId or modelUrl)
+     */
+    public void setModelMetadata(String modelId, String modelUrl, String modelName) {
+        if (modelId != null) {
+            modelMetadataMap.put(modelId, new ModelMetadata(modelUrl, modelName));
+        }
+    }
+
+    /**
+     * Records token usage for a single LLM call
+     *
+     * @param modelId The model ID
+     * @param usage The token usage from the LLM response
+     */
+    public void recordTurn(String modelId, TokenUsage usage) {
+        if (modelId == null || usage == null) {
+            return;
+        }
+
+        turnCounter++;
+
+        // Get model metadata (or use defaults if not set)
+        ModelMetadata modelMetadata = modelMetadataMap.getOrDefault(modelId, new ModelMetadata(modelId, modelId));
+
+        // Add to per-turn list
+        Map<String, Object> turnData = new HashMap<>();
+        turnData.put(TURN, turnCounter);
+        turnData.put(MODEL_NAME, modelMetadata.getModelName());
+        turnData.put(MODEL_URL, modelMetadata.getModelUrl());
+        turnData.put(MODEL_ID, modelId);
+        turnData.putAll(usage.toMap());
+        perTurnUsage.add(turnData);
+
+        // Update per-model aggregation (keyed by model ID)
+        perModelUsage.computeIfAbsent(modelId, k -> new ModelUsageAggregation(modelMetadata)).addUsage(usage);
+    }
+
+    /**
+     * Returns the complete token usage data structure for inclusion in agent response
+     *
+     * @return Map with "per_model_usage" and "per_turn_usage" keys
+     */
+    public Map<String, Object> toOutputMap() {
+        Map<String, Object> output = new HashMap<>();
+
+        // Build per_model_usage list
+        List<Map<String, Object>> perModelList = new ArrayList<>();
+        for (Map.Entry<String, ModelUsageAggregation> entry : perModelUsage.entrySet()) {
+            Map<String, Object> modelData = new HashMap<>();
+            ModelMetadata modelMetadata = entry.getValue().getMetadata();
+            modelData.put(MODEL_NAME, modelMetadata.getModelName());
+            modelData.put(MODEL_URL, modelMetadata.getModelUrl());
+            modelData.put(MODEL_ID, entry.getKey());
+            modelData.putAll(entry.getValue().getAggregatedUsage().toMap());
+            modelData.put(CALL_COUNT, entry.getValue().getCallCount());
+            perModelList.add(modelData);
+        }
+
+        output.put(PER_MODEL_USAGE, perModelList);
+        output.put(PER_TURN_USAGE, perTurnUsage);
+
+        return output;
+    }
+
+    /**
+     * Merges pre-aggregated token usage data from a sub-agent response.
+     * The sub-agent (e.g., Chat/ReAct executor) has already tracked its own tokens
+     * and returns them as aggregated per_turn_usage and per_model_usage.
+     *
+     * @param tokenUsageMap the token_usage dataAsMap from the sub-agent response tensor
+     */
+    @SuppressWarnings("unchecked")
+    public void mergeSubAgentUsage(Map<String, Object> tokenUsageMap) {
+        if (tokenUsageMap == null) {
+            return;
+        }
+
+        // Merge per-turn usage: re-number turns sequentially
+        Object perTurnObj = tokenUsageMap.get(PER_TURN_USAGE);
+        if (perTurnObj instanceof List) {
+            List<Map<String, Object>> subTurns = (List<Map<String, Object>>) perTurnObj;
+            for (Map<String, Object> subTurn : subTurns) {
+                turnCounter++;
+                Map<String, Object> mergedTurn = new HashMap<>(subTurn);
+                mergedTurn.put(TURN, turnCounter);
+                perTurnUsage.add(mergedTurn);
+            }
+        }
+
+        // Merge per-model usage: aggregate into existing model data
+        Object perModelObj = tokenUsageMap.get(PER_MODEL_USAGE);
+        if (perModelObj instanceof List) {
+            List<Map<String, Object>> subModels = (List<Map<String, Object>>) perModelObj;
+            for (Map<String, Object> subModel : subModels) {
+                String modelId = (String) subModel.get(MODEL_ID);
+                if (modelId == null) {
+                    continue;
+                }
+
+                String modelUrl = (String) subModel.getOrDefault(MODEL_URL, modelId);
+                String modelName = (String) subModel.getOrDefault(MODEL_NAME, modelId);
+
+                TokenUsage subUsage = TokenUsage
+                    .builder()
+                    .inputTokens(getLongFromMap(subModel, TokenUsage.INPUT_TOKENS))
+                    .outputTokens(getLongFromMap(subModel, TokenUsage.OUTPUT_TOKENS))
+                    .totalTokens(getLongFromMap(subModel, TokenUsage.TOTAL_TOKENS))
+                    .cacheReadInputTokens(getLongFromMap(subModel, TokenUsage.CACHE_READ_INPUT_TOKENS))
+                    .cacheCreationInputTokens(getLongFromMap(subModel, TokenUsage.CACHE_CREATION_INPUT_TOKENS))
+                    .reasoningTokens(getLongFromMap(subModel, TokenUsage.REASONING_TOKENS))
+                    .build();
+
+                int subCallCount = subModel.containsKey(CALL_COUNT) ? ((Number) subModel.get(CALL_COUNT)).intValue() : 1;
+
+                if (!modelMetadataMap.containsKey(modelId)) {
+                    modelMetadataMap.put(modelId, new ModelMetadata(modelUrl, modelName));
+                }
+
+                ModelMetadata modelMetadata = modelMetadataMap.getOrDefault(modelId, new ModelMetadata(modelUrl, modelName));
+                perModelUsage
+                    .computeIfAbsent(modelId, k -> new ModelUsageAggregation(modelMetadata))
+                    .mergeAggregated(subUsage, subCallCount);
+            }
+        }
+    }
+
+    private static Long getLongFromMap(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        return null;
+    }
+
+    /**
+     * Checks if any token usage has been recorded
+     *
+     * @return true if at least one turn has been recorded
+     */
+    public boolean hasUsage() {
+        return !perTurnUsage.isEmpty();
+    }
+
+    /**
+     * Internal class to track aggregated usage for a specific model
+     */
+    private static class ModelUsageAggregation {
+        private TokenUsage aggregatedUsage;
+        private int callCount;
+        private ModelMetadata modelMetadata;
+
+        public ModelUsageAggregation(ModelMetadata modelMetadata) {
+            this.aggregatedUsage = TokenUsage.builder().build();
+            this.callCount = 0;
+            this.modelMetadata = modelMetadata;
+        }
+
+        public void addUsage(TokenUsage usage) {
+            this.aggregatedUsage = this.aggregatedUsage.addTokens(usage);
+            this.callCount++;
+        }
+
+        public void mergeAggregated(TokenUsage aggregatedUsage, int callCount) {
+            this.aggregatedUsage = this.aggregatedUsage.addTokens(aggregatedUsage);
+            this.callCount += callCount;
+        }
+
+        public TokenUsage getAggregatedUsage() {
+            return aggregatedUsage;
+        }
+
+        public int getCallCount() {
+            return callCount;
+        }
+
+        public ModelMetadata getMetadata() {
+            return modelMetadata;
+        }
+    }
+
+    /**
+     * Internal class to store model metadata
+     */
+    private static class ModelMetadata {
+        private final String modelUrl;
+        private final String modelName;
+
+        public ModelMetadata(String modelUrl, String modelName) {
+            this.modelUrl = modelUrl != null ? modelUrl : "";
+            this.modelName = modelName != null ? modelName : "";
+        }
+
+        public String getModelUrl() {
+            return modelUrl;
+        }
+
+        public String getModelName() {
+            return modelName;
+        }
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -10,6 +10,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.ml.common.CommonValue.MCP_CONNECTORS_FIELD;
 import static org.opensearch.ml.common.CommonValue.MCP_CONNECTOR_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.common.agent.MLMemorySpec.MEMORY_CONTAINER_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREDENTIAL_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.ENDPOINT_FIELD;
@@ -80,6 +81,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.ml.common.MLAgentType;
+import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLMemorySpec;
 import org.opensearch.ml.common.agent.MLToolSpec;
@@ -89,6 +91,7 @@ import org.opensearch.ml.common.connector.McpConnector;
 import org.opensearch.ml.common.connector.McpStreamableHttpConnector;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.engine.MLEngineClassLoader;
@@ -140,6 +143,7 @@ public class AgentUtils {
     public static final String TOOL_CALLS_TOOL_NAME = "tool_calls.tool_name";
     public static final String TOOL_CALLS_TOOL_INPUT = "tool_calls.tool_input";
     public static final String TOOL_CALL_ID_PATH = "tool_calls.id_path";
+    public static final String TOKEN_USAGE_PATH = "token_usage_path";
     private static final String NAME = "name";
     private static final String DESCRIPTION = "description";
     private static final Pattern ADDITIONAL_PROPERTIES_PATTERN = Pattern
@@ -1277,6 +1281,236 @@ public class AgentUtils {
             return agentType == MLAgentType.AG_UI;
         } catch (IllegalArgumentException e) {
             return false;
+        }
+    }
+
+    public static void getModel(
+        String modelId,
+        String tenantId,
+        SdkClient sdkClient,
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        ActionListener<MLModel> listener
+    ) {
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
+            .index(ML_MODEL_INDEX)
+            .id(modelId)
+            .tenantId(tenantId)
+            .build();
+
+        try (ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().stashContext()) {
+            sdkClient.getDataObjectAsync(getDataObjectRequest).whenComplete((r, throwable) -> {
+                log.debug("Completed Get Model Request, id:{}", modelId);
+                ctx.restore();
+                if (throwable != null) {
+                    Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable);
+                    if (ExceptionsHelper.unwrap(cause, IndexNotFoundException.class) != null) {
+                        log.error("Failed to get model index", cause);
+                        listener.onFailure(new OpenSearchStatusException("Failed to find model", RestStatus.NOT_FOUND));
+                    } else {
+                        log.error("Failed to get ML model {}", modelId, cause);
+                        listener.onFailure(cause);
+                    }
+                } else {
+                    try {
+                        GetResponse gr = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                        if (gr != null && gr.isExists()) {
+                            try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, gr.getSourceAsBytesRef())) {
+                                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                                MLModel mlModel = MLModel.parse(parser, null);
+                                listener.onResponse(mlModel);
+                            } catch (Exception e) {
+                                log.error("Failed to parse model:{}", modelId);
+                                listener.onFailure(e);
+                            }
+                        } else {
+                            listener.onFailure(new OpenSearchStatusException("Failed to find model:" + modelId, RestStatus.NOT_FOUND));
+                        }
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Extracts a Long value from a map, handling both Number and String types
+     *
+     * @param map the map to extract from
+     * @param fieldName the field name
+     * @return Long value or null if extraction fails
+     */
+    public static Long getLongValue(Map<String, Object> map, String fieldName) {
+        Object value = map.get(fieldName);
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Long.parseLong((String) value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the model endpoint URL from an MLModel.
+     * If the model has an inline connector, uses it directly.
+     * If the model has a connector ID, fetches the connector first.
+     * Then resolves the endpoint URL using connector parameters.
+     *
+     * @param mlModel the MLModel to resolve URL from
+     * @param tenantId the tenant ID
+     * @param sdkClient the SDK client for async operations
+     * @param client the OpenSearch client for thread context
+     * @param listener the action listener to handle the resolved URL
+     */
+    public static void resolveModelUrl(
+        MLModel mlModel,
+        String tenantId,
+        SdkClient sdkClient,
+        Client client,
+        ActionListener<String> listener
+    ) {
+        // Check if model has inline connector
+        if (mlModel.getConnector() != null) {
+            try {
+                String url = extractUrlFromConnector(mlModel.getConnector());
+                listener.onResponse(url);
+            } catch (Exception e) {
+                log.debug("Failed to resolve URL from inline connector", e);
+                listener.onFailure(e);
+            }
+            return;
+        }
+
+        // Check if model has connector ID
+        if (mlModel.getConnectorId() != null) {
+            getConnector(mlModel.getConnectorId(), tenantId, sdkClient, client, ActionListener.wrap(connector -> {
+                try {
+                    String url = extractUrlFromConnector(connector);
+                    listener.onResponse(url);
+                } catch (Exception e) {
+                    log.debug("Failed to resolve URL from connector ID", e);
+                    listener.onFailure(e);
+                }
+            }, listener::onFailure));
+            return;
+        }
+
+        // No connector available
+        listener.onFailure(new IllegalStateException("Model has neither connector nor connector ID"));
+    }
+
+    /**
+     * Extracts the endpoint URL from a connector using its parameters.
+     *
+     * @param connector the connector to extract URL from
+     * @return the resolved endpoint URL
+     */
+    private static String extractUrlFromConnector(Connector connector) {
+        if (connector == null) {
+            throw new IllegalArgumentException("Connector cannot be null");
+        }
+
+        Map<String, String> parameters = connector.getParameters();
+        if (parameters == null) {
+            parameters = Map.of();
+        }
+
+        // Get the predict endpoint URL
+        String endpoint = connector.getActionEndpoint("predict", parameters);
+        if (endpoint == null || endpoint.isEmpty()) {
+            throw new IllegalStateException("Connector has no predict endpoint");
+        }
+
+        return endpoint;
+    }
+
+    /**
+     * Resolves model metadata (name and URL) for token tracking.
+     * Combines getModel + resolveModelUrl into a single call that never fails —
+     * always returns best-effort data with fallbacks.
+     *
+     * @param modelId the model ID
+     * @param tenantId the tenant ID
+     * @param sdkClient the SDK client (may be null)
+     * @param client the OpenSearch client
+     * @param xContentRegistry the content registry for parsing
+     * @param listener receives String[]{url, name} — never called with onFailure
+     */
+    public static void getModelMetadata(
+        String modelId,
+        String tenantId,
+        SdkClient sdkClient,
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        ActionListener<String[]> listener
+    ) {
+        // Primarily for test compatibility — sdkClient may be null in unit tests.
+        // TODO: Update tests to mock this
+        if (sdkClient == null) {
+            listener.onResponse(new String[] { modelId, modelId });
+            return;
+        }
+
+        getModel(modelId, tenantId, sdkClient, client, xContentRegistry, ActionListener.wrap(mlModel -> {
+            String modelName = mlModel.getName();
+            resolveModelUrl(
+                mlModel,
+                tenantId,
+                sdkClient,
+                client,
+                ActionListener.wrap(url -> { listener.onResponse(new String[] { url, modelName }); }, e -> {
+                    log.debug("Failed to resolve model URL, using model ID as fallback", e);
+                    listener.onResponse(new String[] { modelId, modelName });
+                })
+            );
+        }, e -> {
+            log.debug("Failed to fetch model for URL resolution, using model ID as fallback", e);
+            listener.onResponse(new String[] { modelId, modelId });
+        }));
+    }
+
+    /**
+     * Adds a token usage tensor to the response and logs per-model usage.
+     * Shared utility used by both MLChatAgentRunner and MLPlanExecuteAndReflectAgentRunner.
+     *
+     * @param modelTensors the response tensor list to add to
+     * @param tokenTracker the token tracker (may be null)
+     * @param tenantId the tenant ID for logging (may be null)
+     */
+    @SuppressWarnings("unchecked")
+    public static void addTokenUsageTensor(List<ModelTensors> modelTensors, AgentTokenTracker tokenTracker, String tenantId) {
+        if (tokenTracker == null || !tokenTracker.hasUsage()) {
+            return;
+        }
+
+        Map<String, Object> tokenUsageMap = tokenTracker.toOutputMap();
+        modelTensors
+            .add(
+                ModelTensors
+                    .builder()
+                    .mlModelTensors(List.of(ModelTensor.builder().name(AgentTokenTracker.TOKEN_USAGE).dataAsMap(tokenUsageMap).build()))
+                    .build()
+            );
+
+        // Log structured token usage for each model
+        Object perModelObj = tokenUsageMap.get(AgentTokenTracker.PER_MODEL_USAGE);
+        if (perModelObj instanceof List) {
+            List<Map<String, Object>> perModelUsage = (List<Map<String, Object>>) perModelObj;
+            long eventTime = System.currentTimeMillis();
+            for (Map<String, Object> modelUsage : perModelUsage) {
+                Map<String, Object> logEntry = new java.util.LinkedHashMap<>();
+                logEntry.put("tenantId", tenantId);
+                logEntry.put("model_usage", modelUsage);
+                logEntry.put("eventTime", eventTime);
+                log.info("{}", StringUtils.toJson(logEntry));
+            }
         }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -75,6 +75,7 @@ import org.opensearch.ml.common.MLMemoryType;
 import org.opensearch.ml.common.agent.LLMSpec;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.contextmanager.ContextManagerContext;
 import org.opensearch.ml.common.conversation.Interaction;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
@@ -390,297 +391,374 @@ public class MLChatAgentRunner implements MLAgentRunner {
         FunctionCalling functionCalling,
         Map<String, Tool> backendTools
     ) {
-        Map<String, String> tmpParameters = constructLLMParams(llm, parameters);
-        String prompt = constructLLMPrompt(tools, tmpParameters);
-        tmpParameters.put(PROMPT, prompt);
-        final String finalPrompt = prompt;
+        String llmModelId = llm.getModelId();
 
-        String question = tmpParameters.get(MLAgentExecutor.QUESTION);
-        String parentInteractionId = tmpParameters.get(MLAgentExecutor.PARENT_INTERACTION_ID);
-        boolean verbose = Boolean.parseBoolean(tmpParameters.getOrDefault(VERBOSE, "false"));
-        boolean traceDisabled = tmpParameters.containsKey(DISABLE_TRACE) && Boolean.parseBoolean(tmpParameters.get(DISABLE_TRACE));
+        AgentUtils.getModelMetadata(llmModelId, tenantId, sdkClient, client, xContentRegistry, ActionListener.wrap(metadata -> {
+            final String modelUrl = metadata[0];
+            final String modelName = metadata[1];
+            Map<String, String> tmpParameters = constructLLMParams(llm, parameters);
+            String prompt = constructLLMPrompt(tools, tmpParameters);
+            tmpParameters.put(PROMPT, prompt);
+            final String finalPrompt = prompt;
 
-        // Trace number
-        AtomicInteger traceNumber = new AtomicInteger(0);
+            String question = tmpParameters.get(MLAgentExecutor.QUESTION);
+            String parentInteractionId = tmpParameters.get(MLAgentExecutor.PARENT_INTERACTION_ID);
+            boolean verbose = Boolean.parseBoolean(tmpParameters.getOrDefault(VERBOSE, "false"));
+            boolean traceDisabled = tmpParameters.containsKey(DISABLE_TRACE) && Boolean.parseBoolean(tmpParameters.get(DISABLE_TRACE));
 
-        AtomicReference<StepListener<MLTaskResponse>> lastLlmListener = new AtomicReference<>();
-        AtomicReference<String> lastThought = new AtomicReference<>();
-        AtomicReference<String> lastAction = new AtomicReference<>();
-        AtomicReference<String> lastActionInput = new AtomicReference<>();
-        AtomicReference<String> lastToolSelectionResponse = new AtomicReference<>();
-        AtomicReference<String> lastToolCallId = new AtomicReference<>();
-        Map<String, Object> additionalInfo = new ConcurrentHashMap<>();
-        Map<String, String> lastToolParams = new ConcurrentHashMap<>();
+            // Trace number
+            AtomicInteger traceNumber = new AtomicInteger(0);
 
-        StepListener firstListener = new StepListener<MLTaskResponse>();
-        lastLlmListener.set(firstListener);
-        StepListener<?> lastStepListener = firstListener;
+            // Token usage tracker
+            AgentTokenTracker tokenTracker = new AgentTokenTracker();
+            // Set model metadata for token tracking
+            tokenTracker.setModelMetadata(llm.getModelId(), modelUrl, modelName);
 
-        StringBuilder scratchpadBuilder = new StringBuilder();
-        final List<String> interactions = new CopyOnWriteArrayList<>();
+            AtomicReference<StepListener<MLTaskResponse>> lastLlmListener = new AtomicReference<>();
+            AtomicReference<String> lastThought = new AtomicReference<>();
+            AtomicReference<String> lastAction = new AtomicReference<>();
+            AtomicReference<String> lastActionInput = new AtomicReference<>();
+            AtomicReference<String> lastToolSelectionResponse = new AtomicReference<>();
+            AtomicReference<String> lastToolCallId = new AtomicReference<>();
+            Map<String, Object> additionalInfo = new ConcurrentHashMap<>();
+            Map<String, String> lastToolParams = new ConcurrentHashMap<>();
 
-        StringSubstitutor tmpSubstitutor = new StringSubstitutor(Map.of(SCRATCHPAD, scratchpadBuilder.toString()), "${parameters.", "}");
-        AtomicReference<String> newPrompt = new AtomicReference<>(tmpSubstitutor.replace(prompt));
-        tmpParameters.put(PROMPT, newPrompt.get());
-        List<ModelTensors> traceTensors = createModelTensors(sessionId, parentInteractionId);
-        int maxIterations = Integer.parseInt(tmpParameters.getOrDefault(MAX_ITERATION, DEFAULT_MAX_ITERATIONS));
-        for (int i = 0; i < maxIterations; i++) {
-            int finalI = i;
-            StepListener<?> nextStepListener = (i == maxIterations - 1) ? null : new StepListener<>();
+            StepListener firstListener = new StepListener<MLTaskResponse>();
+            lastLlmListener.set(firstListener);
+            StepListener<?> lastStepListener = firstListener;
 
-            lastStepListener.whenComplete(output -> {
-                StringBuilder sessionMsgAnswerBuilder = new StringBuilder();
-                if (finalI % 2 == 0) {
-                    MLTaskResponse llmResponse = (MLTaskResponse) output;
-                    ModelTensorOutput tmpModelTensorOutput = (ModelTensorOutput) llmResponse.getOutput();
+            StringBuilder scratchpadBuilder = new StringBuilder();
+            final List<String> interactions = new CopyOnWriteArrayList<>();
 
-                    List<String> llmResponsePatterns = gson.fromJson(tmpParameters.get("llm_response_pattern"), List.class);
-                    Map<String, String> modelOutput = parseLLMOutput(
-                        parameters,
-                        tmpModelTensorOutput,
-                        llmResponsePatterns,
-                        tools.keySet(),
-                        interactions,
-                        functionCalling
-                    );
+            StringSubstitutor tmpSubstitutor = new StringSubstitutor(
+                Map.of(SCRATCHPAD, scratchpadBuilder.toString()),
+                "${parameters.",
+                "}"
+            );
+            AtomicReference<String> newPrompt = new AtomicReference<>(tmpSubstitutor.replace(prompt));
+            tmpParameters.put(PROMPT, newPrompt.get());
+            List<ModelTensors> traceTensors = createModelTensors(sessionId, parentInteractionId);
+            int maxIterations = Integer.parseInt(tmpParameters.getOrDefault(MAX_ITERATION, DEFAULT_MAX_ITERATIONS));
+            for (int i = 0; i < maxIterations; i++) {
+                int finalI = i;
+                StepListener<?> nextStepListener = (i == maxIterations - 1) ? null : new StepListener<>();
 
-                    streamingWrapper.fixInteractionRole(interactions);
-                    String thought = String.valueOf(modelOutput.get(THOUGHT));
-                    String toolCallId = String.valueOf(modelOutput.get("tool_call_id"));
-                    String action = String.valueOf(modelOutput.get(ACTION));
-                    String actionInput = String.valueOf(modelOutput.get(ACTION_INPUT));
-                    String thoughtResponse = modelOutput.get(THOUGHT_RESPONSE);
-                    String finalAnswer = modelOutput.get(FINAL_ANSWER);
+                lastStepListener.whenComplete(output -> {
+                    StringBuilder sessionMsgAnswerBuilder = new StringBuilder();
+                    if (finalI % 2 == 0) {
+                        MLTaskResponse llmResponse = (MLTaskResponse) output;
+                        ModelTensorOutput tmpModelTensorOutput = (ModelTensorOutput) llmResponse.getOutput();
 
-                    if (finalAnswer != null) {
-                        finalAnswer = finalAnswer.trim();
-                        sendFinalAnswer(
-                            sessionId,
-                            listener,
-                            question,
-                            parentInteractionId,
-                            verbose,
-                            traceDisabled,
-                            traceTensors,
-                            memory,
-                            traceNumber,
-                            additionalInfo,
-                            finalAnswer
-                        );
-                        cleanUpResource(tools);
-                        return;
-                    }
+                        // Extract token usage
+                        if (functionCalling != null) {
+                            try {
+                                Map<String, ?> dataAsMap = tmpModelTensorOutput
+                                    .getMlModelOutputs()
+                                    .get(0)
+                                    .getMlModelTensors()
+                                    .get(0)
+                                    .getDataAsMap();
 
-                    sessionMsgAnswerBuilder.append(thought);
-                    lastThought.set(thought);
-                    lastAction.set(action);
-                    lastActionInput.set(actionInput);
-                    lastToolSelectionResponse.set(thoughtResponse);
-                    lastToolCallId.set(toolCallId);
+                                // Use FunctionCalling interface to extract tokens (each impl knows its format)
+                                TokenUsage usage = functionCalling.extractTokenUsage(dataAsMap);
 
-                    traceTensors
-                        .add(
-                            ModelTensors
-                                .builder()
-                                .mlModelTensors(List.of(ModelTensor.builder().name("response").result(thoughtResponse).build()))
-                                .build()
-                        );
-
-                    saveTraceData(
-                        memory,
-                        memory != null ? memory.getType() : null,
-                        question,
-                        thoughtResponse,
-                        sessionId,
-                        traceDisabled,
-                        parentInteractionId,
-                        traceNumber,
-                        "LLM"
-                    );
-
-                    if (nextStepListener == null) {
-                        handleMaxIterationsReached(
-                            sessionId,
-                            listener,
-                            question,
-                            parentInteractionId,
-                            verbose,
-                            traceDisabled,
-                            traceTensors,
-                            memory,
-                            traceNumber,
-                            additionalInfo,
-                            lastThought,
-                            maxIterations,
-                            tools,
-                            llm,
-                            tenantId,
-                            tmpParameters
-                        );
-                        return;
-                    }
-
-                    if (tools.containsKey(action)) {
-                        // Check if this is a backend tool - if it is, execute it normally in the ReAct loop
-                        // If it's NOT a backend tool, it must be a frontend tool, so break out of the loop
-                        boolean isBackendTool = backendTools != null && backendTools.containsKey(action);
-
-                        log.info("AG-UI: Tool execution request - action: {}, isBackendTool: {}", action, isBackendTool);
-
-                        if (!isBackendTool) {
-                            // For frontend tool use, we close the response stream and wait for frontend tool result
-                            if (streamingWrapper != null) {
-                                streamingWrapper.sendRunFinishedAndCloseStream(sessionId, parentInteractionId);
-                            }
-                        } else {
-                            // Handle backend tool normally
-                            Map<String, String> toolParams = constructToolParams(
-                                tools,
-                                toolSpecMap,
-                                question,
-                                lastActionInput,
-                                action,
-                                actionInput
-                            );
-                            toolParams.put(TENANT_ID_FIELD, tenantId);
-                            lastToolParams.clear();
-                            toolParams.forEach((key, value) -> {
-                                // For the case like tenant id is null
-                                if (key != null && value != null) {
-                                    lastToolParams.put(key, value);
+                                if (usage != null) {
+                                    tokenTracker.recordTurn(llm.getModelId(), usage);
                                 }
-                            });
-                            runTool(
-                                tools,
-                                toolSpecMap,
-                                tmpParameters,
-                                (ActionListener<Object>) nextStepListener,
-                                action,
-                                actionInput,
-                                toolParams,
-                                interactions,
-                                toolCallId,
-                                functionCalling,
-                                hookRegistry
-                            );
+                            } catch (Exception e) {
+                                log.debug("Failed to extract token usage", e);
+                            }
                         }
 
-                    } else {
-                        String res = String.format(Locale.ROOT, "Failed to run the tool %s which is unsupported.", action);
-                        StringSubstitutor substitutor = new StringSubstitutor(
-                            Map.of(SCRATCHPAD, scratchpadBuilder.toString()),
-                            "${parameters.",
-                            "}"
+                        // Check if this is a streaming completion marker (text already streamed to client).
+                        // The streaming handler sets streaming_complete=true (NOT is_last=true) to avoid
+                        // prematurely closing the HTTP response — StreamingWrapper sends the real is_last=true.
+                        Map<String, ?> firstTensorData = tmpModelTensorOutput
+                            .getMlModelOutputs()
+                            .get(0)
+                            .getMlModelTensors()
+                            .get(0)
+                            .getDataAsMap();
+                        if (firstTensorData != null
+                            && Boolean.TRUE.equals(firstTensorData.get("streaming_complete"))
+                            && "".equals(firstTensorData.get("content"))) {
+                            sendFinalAnswer(
+                                sessionId,
+                                listener,
+                                question,
+                                parentInteractionId,
+                                verbose,
+                                traceDisabled,
+                                traceTensors,
+                                memory,
+                                traceNumber,
+                                additionalInfo,
+                                "(streamed)", // text was already streamed to client
+                                tokenTracker,
+                                tenantId
+                            );
+                            cleanUpResource(tools);
+                            return;
+                        }
+
+                        List<String> llmResponsePatterns = gson.fromJson(tmpParameters.get("llm_response_pattern"), List.class);
+                        Map<String, String> modelOutput = parseLLMOutput(
+                            parameters,
+                            tmpModelTensorOutput,
+                            llmResponsePatterns,
+                            tools.keySet(),
+                            interactions,
+                            functionCalling
                         );
+
+                        streamingWrapper.fixInteractionRole(interactions);
+                        String thought = String.valueOf(modelOutput.get(THOUGHT));
+                        String toolCallId = String.valueOf(modelOutput.get("tool_call_id"));
+                        String action = String.valueOf(modelOutput.get(ACTION));
+                        String actionInput = String.valueOf(modelOutput.get(ACTION_INPUT));
+                        String thoughtResponse = modelOutput.get(THOUGHT_RESPONSE);
+                        String finalAnswer = modelOutput.get(FINAL_ANSWER);
+
+                        if (finalAnswer != null) {
+                            finalAnswer = finalAnswer.trim();
+                            sendFinalAnswer(
+                                sessionId,
+                                listener,
+                                question,
+                                parentInteractionId,
+                                verbose,
+                                traceDisabled,
+                                traceTensors,
+                                memory,
+                                traceNumber,
+                                additionalInfo,
+                                finalAnswer,
+                                tokenTracker,
+                                tenantId
+                            );
+                            cleanUpResource(tools);
+                            return;
+                        }
+
+                        sessionMsgAnswerBuilder.append(thought);
+                        lastThought.set(thought);
+                        lastAction.set(action);
+                        lastActionInput.set(actionInput);
+                        lastToolSelectionResponse.set(thoughtResponse);
+                        lastToolCallId.set(toolCallId);
+
+                        traceTensors
+                            .add(
+                                ModelTensors
+                                    .builder()
+                                    .mlModelTensors(List.of(ModelTensor.builder().name("response").result(thoughtResponse).build()))
+                                    .build()
+                            );
+
+                        saveTraceData(
+                            memory,
+                            memory != null ? memory.getType() : null,
+                            question,
+                            thoughtResponse,
+                            sessionId,
+                            traceDisabled,
+                            parentInteractionId,
+                            traceNumber,
+                            "LLM"
+                        );
+
+                        if (nextStepListener == null) {
+                            handleMaxIterationsReached(
+                                sessionId,
+                                listener,
+                                question,
+                                parentInteractionId,
+                                verbose,
+                                traceDisabled,
+                                traceTensors,
+                                memory,
+                                traceNumber,
+                                additionalInfo,
+                                lastThought,
+                                maxIterations,
+                                tools,
+                                llm,
+                                tenantId,
+                                tmpParameters,
+                                tokenTracker,
+                                functionCalling
+                            );
+                            return;
+                        }
+
+                        if (tools.containsKey(action)) {
+                            // Check if this is a backend tool - if it is, execute it normally in the ReAct loop
+                            // If it's NOT a backend tool, it must be a frontend tool, so break out of the loop
+                            boolean isBackendTool = backendTools != null && backendTools.containsKey(action);
+
+                            log.info("AG-UI: Tool execution request - action: {}, isBackendTool: {}", action, isBackendTool);
+
+                            if (!isBackendTool) {
+                                // For frontend tool use, we close the response stream and wait for frontend tool result
+                                if (streamingWrapper != null) {
+                                    streamingWrapper.sendRunFinishedAndCloseStream(sessionId, parentInteractionId);
+                                }
+                            } else {
+                                // Handle backend tool normally
+                                Map<String, String> toolParams = constructToolParams(
+                                    tools,
+                                    toolSpecMap,
+                                    question,
+                                    lastActionInput,
+                                    action,
+                                    actionInput
+                                );
+                                toolParams.put(TENANT_ID_FIELD, tenantId);
+                                lastToolParams.clear();
+                                toolParams.forEach((key, value) -> {
+                                    // For the case like tenant id is null
+                                    if (key != null && value != null) {
+                                        lastToolParams.put(key, value);
+                                    }
+                                });
+                                runTool(
+                                    tools,
+                                    toolSpecMap,
+                                    tmpParameters,
+                                    (ActionListener<Object>) nextStepListener,
+                                    action,
+                                    actionInput,
+                                    toolParams,
+                                    interactions,
+                                    toolCallId,
+                                    functionCalling,
+                                    hookRegistry
+                                );
+                            }
+
+                        } else {
+                            String res = String.format(Locale.ROOT, "Failed to run the tool %s which is unsupported.", action);
+                            StringSubstitutor substitutor = new StringSubstitutor(
+                                Map.of(SCRATCHPAD, scratchpadBuilder.toString()),
+                                "${parameters.",
+                                "}"
+                            );
+                            newPrompt.set(substitutor.replace(finalPrompt));
+                            tmpParameters.put(PROMPT, newPrompt.get());
+                            ((ActionListener<Object>) nextStepListener).onResponse(res);
+                        }
+                    } else {
+                        // filteredOutput is the POST Tool output
+                        Object filteredOutput = filterToolOutput(lastToolParams, output);
+                        addToolOutputToAddtionalInfo(toolSpecMap, lastAction, additionalInfo, filteredOutput);
+
+                        String toolResponse = constructToolResponse(
+                            tmpParameters,
+                            lastAction,
+                            lastActionInput,
+                            lastToolSelectionResponse,
+                            filteredOutput
+                        );
+                        scratchpadBuilder.append(toolResponse).append("\n\n");
+
+                        // Record tool result for summary
+                        String outputSummary = outputToOutputString(filteredOutput);
+
+                        // Save trace with processed output
+                        saveTraceData(
+                            memory,
+                            "ReAct",
+                            lastActionInput.get(),
+                            outputToOutputString(filteredOutput),
+                            sessionId,
+                            traceDisabled,
+                            parentInteractionId,
+                            traceNumber,
+                            lastAction.get()
+                        );
+
+                        StringSubstitutor substitutor = new StringSubstitutor(Map.of(SCRATCHPAD, scratchpadBuilder), "${parameters.", "}");
                         newPrompt.set(substitutor.replace(finalPrompt));
                         tmpParameters.put(PROMPT, newPrompt.get());
-                        ((ActionListener<Object>) nextStepListener).onResponse(res);
-                    }
-                } else {
-                    // filteredOutput is the POST Tool output
-                    Object filteredOutput = filterToolOutput(lastToolParams, output);
-                    addToolOutputToAddtionalInfo(toolSpecMap, lastAction, additionalInfo, filteredOutput);
-
-                    String toolResponse = constructToolResponse(
-                        tmpParameters,
-                        lastAction,
-                        lastActionInput,
-                        lastToolSelectionResponse,
-                        filteredOutput
-                    );
-                    scratchpadBuilder.append(toolResponse).append("\n\n");
-
-                    // Record tool result for summary
-                    String outputSummary = outputToOutputString(filteredOutput);
-
-                    // Save trace with processed output
-                    saveTraceData(
-                        memory,
-                        "ReAct",
-                        lastActionInput.get(),
-                        outputToOutputString(filteredOutput),
-                        sessionId,
-                        traceDisabled,
-                        parentInteractionId,
-                        traceNumber,
-                        lastAction.get()
-                    );
-
-                    StringSubstitutor substitutor = new StringSubstitutor(Map.of(SCRATCHPAD, scratchpadBuilder), "${parameters.", "}");
-                    newPrompt.set(substitutor.replace(finalPrompt));
-                    tmpParameters.put(PROMPT, newPrompt.get());
-                    if (!interactions.isEmpty()) {
-                        String interactionsStr = String.join(", ", interactions);
-                        // Set the interactions parameter - this will be processed by context management
-                        tmpParameters.put(INTERACTIONS, ", " + interactionsStr);
-                    }
-
-                    sessionMsgAnswerBuilder.append(outputToOutputString(filteredOutput));
-
-                    String toolOutputString = outputToOutputString(filteredOutput);
-
-                    if (streamingWrapper != null) {
-                        if (isAGUIAgent(parameters)) {
-                            streamingWrapper.sendBackendToolResult(lastToolCallId.get(), toolOutputString, sessionId, parentInteractionId);
-                        } else {
-                            streamingWrapper.sendToolResponse(toolOutputString, sessionId, parentInteractionId);
+                        if (!interactions.isEmpty()) {
+                            String interactionsStr = String.join(", ", interactions);
+                            // Set the interactions parameter - this will be processed by context management
+                            tmpParameters.put(INTERACTIONS, ", " + interactionsStr);
                         }
-                    }
 
-                    traceTensors
-                        .add(
-                            ModelTensors
-                                .builder()
-                                .mlModelTensors(
-                                    Collections
-                                        .singletonList(
-                                            ModelTensor.builder().name("response").result(sessionMsgAnswerBuilder.toString()).build()
-                                        )
-                                )
-                                .build()
-                        );
+                        sessionMsgAnswerBuilder.append(outputToOutputString(filteredOutput));
 
-                    if (finalI == maxIterations - 1) {
-                        handleMaxIterationsReached(
-                            sessionId,
-                            listener,
-                            question,
-                            parentInteractionId,
-                            verbose,
-                            traceDisabled,
-                            traceTensors,
-                            memory,
-                            traceNumber,
-                            additionalInfo,
-                            lastThought,
-                            maxIterations,
-                            tools,
-                            llm,
-                            tenantId,
-                            tmpParameters
-                        );
-                        return;
+                        String toolOutputString = outputToOutputString(filteredOutput);
+
+                        if (streamingWrapper != null) {
+                            if (isAGUIAgent(parameters)) {
+                                streamingWrapper
+                                    .sendBackendToolResult(lastToolCallId.get(), toolOutputString, sessionId, parentInteractionId);
+                            } else {
+                                streamingWrapper.sendToolResponse(toolOutputString, sessionId, parentInteractionId);
+                            }
+                        }
+
+                        traceTensors
+                            .add(
+                                ModelTensors
+                                    .builder()
+                                    .mlModelTensors(
+                                        Collections
+                                            .singletonList(
+                                                ModelTensor.builder().name("response").result(sessionMsgAnswerBuilder.toString()).build()
+                                            )
+                                    )
+                                    .build()
+                            );
+
+                        if (finalI == maxIterations - 1) {
+                            handleMaxIterationsReached(
+                                sessionId,
+                                listener,
+                                question,
+                                parentInteractionId,
+                                verbose,
+                                traceDisabled,
+                                traceTensors,
+                                memory,
+                                traceNumber,
+                                additionalInfo,
+                                lastThought,
+                                maxIterations,
+                                tools,
+                                llm,
+                                tenantId,
+                                tmpParameters,
+                                tokenTracker,
+                                functionCalling
+                            );
+                            return;
+                        }
+                        // Emit PRE_LLM hook event
+                        processPreLLMHook(tmpParameters, interactions, toolSpecMap, memory, hookRegistry);
+                        ActionRequest request = streamingWrapper.createPredictionRequest(llm, tmpParameters, tenantId);
+                        streamingWrapper.executeRequest(request, (ActionListener<MLTaskResponse>) nextStepListener);
                     }
-                    // Emit PRE_LLM hook event
-                    processPreLLMHook(tmpParameters, interactions, toolSpecMap, memory, hookRegistry);
-                    ActionRequest request = streamingWrapper.createPredictionRequest(llm, tmpParameters, tenantId);
-                    streamingWrapper.executeRequest(request, (ActionListener<MLTaskResponse>) nextStepListener);
+                }, e -> {
+                    log.error("Failed to run chat agent", e);
+                    listener.onFailure(e);
+                });
+                if (nextStepListener != null) {
+                    lastStepListener = nextStepListener;
                 }
-            }, e -> {
-                log.error("Failed to run chat agent", e);
-                listener.onFailure(e);
-            });
-            if (nextStepListener != null) {
-                lastStepListener = nextStepListener;
             }
-        }
 
-        // Emit PRE_LLM hook event for initial LLM call
-        tmpParameters.put("_llm_model_id", llm.getModelId());
-        processPreLLMHook(tmpParameters, interactions, toolSpecMap, memory, hookRegistry);
-        ActionRequest request = streamingWrapper.createPredictionRequest(llm, tmpParameters, tenantId);
-        streamingWrapper.executeRequest(request, firstListener);
+            // Emit PRE_LLM hook event for initial LLM call
+            tmpParameters.put("_llm_model_id", llm.getModelId());
+            processPreLLMHook(tmpParameters, interactions, toolSpecMap, memory, hookRegistry);
+            ActionRequest request = streamingWrapper.createPredictionRequest(llm, tmpParameters, tenantId);
+            streamingWrapper.executeRequest(request, firstListener);
 
+        }, e -> {
+            log.error("Failed to resolve model metadata", e);
+            listener.onFailure(e);
+        }));
     }
 
     private static List<ModelTensors> createFinalAnswerTensors(List<ModelTensors> sessionId, List<ModelTensor> lastThought) {
@@ -892,11 +970,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
         Memory memory,
         AtomicInteger traceNumber,
         Map<String, Object> additionalInfo,
-        String finalAnswer
+        String finalAnswer,
+        AgentTokenTracker tokenTracker,
+        String tenantId
     ) {
-        // Send completion chunk for streaming
-        streamingWrapper.sendCompletionChunk(sessionId, parentInteractionId);
-
         if (memory != null) {
             String copyOfFinalAnswer = finalAnswer;
             ActionListener saveTraceListener = ActionListener.wrap(r -> {
@@ -905,22 +982,35 @@ public class MLChatAgentRunner implements MLAgentRunner {
                         parentInteractionId,
                         Map.of(AI_RESPONSE_FIELD, copyOfFinalAnswer, ADDITIONAL_INFO_FIELD, additionalInfo),
                         ActionListener.wrap(res -> {
-                            returnFinalResponse(
-                                sessionId,
-                                listener,
-                                parentInteractionId,
-                                verbose,
-                                cotModelTensors,
-                                additionalInfo,
-                                copyOfFinalAnswer
-                            );
+                            streamingWrapper
+                                .sendFinalResponse(
+                                    sessionId,
+                                    listener,
+                                    parentInteractionId,
+                                    verbose,
+                                    cotModelTensors,
+                                    additionalInfo,
+                                    copyOfFinalAnswer,
+                                    tokenTracker,
+                                    tenantId
+                                );
                         }, e -> { listener.onFailure(e); })
                     );
             }, e -> { listener.onFailure(e); });
             saveMessage(memory, question, finalAnswer, sessionId, parentInteractionId, traceNumber, true, traceDisabled, saveTraceListener);
         } else {
             streamingWrapper
-                .sendFinalResponse(sessionId, listener, parentInteractionId, verbose, cotModelTensors, additionalInfo, finalAnswer);
+                .sendFinalResponse(
+                    sessionId,
+                    listener,
+                    parentInteractionId,
+                    verbose,
+                    cotModelTensors,
+                    additionalInfo,
+                    finalAnswer,
+                    tokenTracker,
+                    tenantId
+                );
         }
     }
 
@@ -1029,7 +1119,9 @@ public class MLChatAgentRunner implements MLAgentRunner {
         boolean verbose,
         List<ModelTensors> cotModelTensors, // AtomicBoolean getFinalAnswer,
         Map<String, Object> additionalInfo,
-        String finalAnswer2
+        String finalAnswer2,
+        AgentTokenTracker tokenTracker,
+        String tenantId
     ) {
         cotModelTensors
             .add(
@@ -1047,11 +1139,12 @@ public class MLChatAgentRunner implements MLAgentRunner {
                         .build()
                 )
         );
-        if (verbose) {
-            listener.onResponse(ModelTensorOutput.builder().mlModelOutputs(cotModelTensors).build());
-        } else {
-            listener.onResponse(ModelTensorOutput.builder().mlModelOutputs(finalModelTensors).build());
-        }
+
+        List<ModelTensors> responseTensors = verbose ? cotModelTensors : finalModelTensors;
+
+        AgentUtils.addTokenUsageTensor(responseTensors, tokenTracker, tenantId);
+
+        listener.onResponse(ModelTensorOutput.builder().mlModelOutputs(responseTensors).build());
     }
 
     private void handleMaxIterationsReached(
@@ -1070,7 +1163,9 @@ public class MLChatAgentRunner implements MLAgentRunner {
         Map<String, Tool> tools,
         LLMSpec llmSpec,
         String tenantId,
-        Map<String, String> parameters
+        Map<String, String> parameters,
+        AgentTokenTracker tokenTracker,
+        FunctionCalling functionCalling
     ) {
         ActionListener<String> responseListener = ActionListener.wrap(response -> {
             sendTraditionalMaxIterationsResponse(
@@ -1085,7 +1180,9 @@ public class MLChatAgentRunner implements MLAgentRunner {
                 traceNumber,
                 additionalInfo,
                 response,
-                tools
+                tools,
+                tokenTracker,
+                tenantId
             );
         }, listener::onFailure);
 
@@ -1095,6 +1192,8 @@ public class MLChatAgentRunner implements MLAgentRunner {
             tenantId,
             question,
             parameters,
+            tokenTracker,
+            functionCalling,
             ActionListener
                 .wrap(
                     summary -> responseListener
@@ -1125,7 +1224,9 @@ public class MLChatAgentRunner implements MLAgentRunner {
         AtomicInteger traceNumber,
         Map<String, Object> additionalInfo,
         String response,
-        Map<String, Tool> tools
+        Map<String, Tool> tools,
+        AgentTokenTracker tokenTracker,
+        String tenantId
     ) {
         sendFinalAnswer(
             sessionId,
@@ -1138,7 +1239,9 @@ public class MLChatAgentRunner implements MLAgentRunner {
             memory,
             traceNumber,
             additionalInfo,
-            response
+            response,
+            tokenTracker,
+            tenantId
         );
         cleanUpResource(tools);
     }
@@ -1149,6 +1252,8 @@ public class MLChatAgentRunner implements MLAgentRunner {
         String tenantId,
         String question,
         Map<String, String> parameter,
+        AgentTokenTracker tokenTracker,
+        FunctionCalling functionCalling,
         ActionListener<String> listener
     ) {
         if (stepsSummary == null || stepsSummary.isEmpty()) {
@@ -1196,6 +1301,27 @@ public class MLChatAgentRunner implements MLAgentRunner {
                 tenantId
             );
             client.execute(MLPredictionTaskAction.INSTANCE, request, ActionListener.wrap(response -> {
+                // Extract token usage from summary generation LLM call
+                if (tokenTracker != null && functionCalling != null && response != null) {
+                    try {
+                        ModelTensorOutput tmpOutput = (ModelTensorOutput) response.getOutput();
+                        if (tmpOutput != null && tmpOutput.getMlModelOutputs() != null && !tmpOutput.getMlModelOutputs().isEmpty()) {
+                            Map<String, ?> dataAsMap = tmpOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap();
+
+                            if (dataAsMap != null) {
+                                // Extract token usage using FunctionCalling
+                                TokenUsage usage = functionCalling.extractTokenUsage(dataAsMap);
+
+                                if (usage != null) {
+                                    tokenTracker.recordTurn(llmSpec.getModelId(), usage);
+                                }
+                            }
+                        }
+                    } catch (Exception e) {
+                        log.debug("Failed to extract token usage from summary generation", e);
+                    }
+                }
+
                 String summary = extractSummaryFromResponse(response, summaryParams);
                 if (summary == null || summary.trim().isEmpty()) {
                     listener.onFailure(new RuntimeException("Empty or invalid LLM summary response"));

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLPlanExecuteAndReflectAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLPlanExecuteAndReflectAgentRunner.java
@@ -61,6 +61,7 @@ import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.agent.LLMSpec;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.contextmanager.ContextManagerContext;
 import org.opensearch.ml.common.conversation.Interaction;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
@@ -81,6 +82,8 @@ import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.engine.agents.AgentContextUtil;
 import org.opensearch.ml.engine.encryptor.Encryptor;
+import org.opensearch.ml.engine.function_calling.FunctionCalling;
+import org.opensearch.ml.engine.function_calling.FunctionCallingFactory;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.client.Client;
@@ -297,70 +300,99 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         // planner prompt for the first call
         usePlannerPromptTemplate(allParams);
 
-        if (mlAgent.getMemory() == null || memoryFactoryMap == null || memoryFactoryMap.isEmpty()) {
-            List<String> completedSteps = new ArrayList<>();
-            setToolsAndRunAgent(mlAgent, allParams, completedSteps, null, null, listener);
-            return;
-        }
+        // Resolve model metadata first, then proceed with memory setup and agent execution.
+        // Everything goes inside the callback to ensure metadata is available before recordTurn.
+        AgentTokenTracker tokenTracker = new AgentTokenTracker();
+        String llmModelId = mlAgent.getLlm().getModelId();
+        String tenantId = allParams.get(TENANT_ID_FIELD);
 
-        String memoryId = allParams.get(MEMORY_ID_FIELD);
-        String memoryType = MLMemoryType.from(mlAgent.getMemory().getType()).name();
-        String appType = mlAgent.getAppType();
-        int messageHistoryLimit = Integer.parseInt(allParams.getOrDefault(PLANNER_MESSAGE_HISTORY_LIMIT, DEFAULT_MESSAGE_HISTORY_LIMIT));
+        // Create FunctionCalling for token usage extraction only.
+        // Do NOT call configure() — that adds tool_configs, tool_template, etc. to allParams
+        // which would break the planner LLM request (PER planner doesn't use native function calling).
+        String llmInterface = allParams.get(MLChatAgentRunner.LLM_INTERFACE);
+        FunctionCalling functionCalling = FunctionCallingFactory.create(llmInterface);
 
-        // Check if this is a fresh conversation (memory was just created, not provided by user)
-        boolean isFreshConversation = "true".equals(allParams.getOrDefault("fresh_memory", "false"));
+        AgentUtils.getModelMetadata(llmModelId, tenantId, sdkClient, client, xContentRegistry, ActionListener.wrap(metadata -> {
+            tokenTracker.setModelMetadata(llmModelId, metadata[0], metadata[1]);
 
-        // todo: use chat history instead of completed steps
-        Map<String, Object> memoryParams = createMemoryParams(apiParams.get(USER_PROMPT_FIELD), memoryId, appType, mlAgent, apiParams);
-        log.debug("MLPlanExecuteAndReflectAgentRunner setting up memory, params: {}", sanitizeForLogging(memoryParams));
-        Memory.Factory<Memory<Interaction, ?, ?>> memoryFactory;
-        if (memoryParams != null && memoryParams.containsKey(ENDPOINT_FIELD)) {
-            // Use RemoteAgenticConversationMemory when inline connector metadata is detected
-            memoryFactory = memoryFactoryMap.get(MLMemoryType.REMOTE_AGENTIC_MEMORY.name());
-            log.info("Detected inline connector metadata, using RemoteAgenticConversationMemory");
-        } else {
-            // Use the originally specified memory factory
-            memoryFactory = memoryFactoryMap.get(memoryType);
-        }
-        if (memoryFactory == null) {
-            listener
-                .onFailure(
-                    new IllegalArgumentException(
-                        "Memory factory not found for type: "
-                            + (memoryParams != null && memoryParams.containsKey(ENDPOINT_FIELD)
-                                ? MLMemoryType.REMOTE_AGENTIC_MEMORY.name()
-                                : memoryType)
-                    )
-                );
-            return;
-        }
-        memoryFactory.create(memoryParams, ActionListener.wrap(memory -> {
-            memory.getMessages(messageHistoryLimit, ActionListener.<List<Interaction>>wrap(interactions -> {
+            if (mlAgent.getMemory() == null || memoryFactoryMap == null || memoryFactoryMap.isEmpty()) {
                 List<String> completedSteps = new ArrayList<>();
-                for (Interaction interaction : interactions) {
-                    String question = interaction.getInput();
-                    String response = interaction.getResponse();
+                setToolsAndRunAgent(mlAgent, allParams, completedSteps, null, null, listener, tokenTracker, functionCalling);
+                return;
+            }
 
-                    if (Strings.isNullOrEmpty(response)) {
-                        continue;
+            String memoryId = allParams.get(MEMORY_ID_FIELD);
+            String memoryType = MLMemoryType.from(mlAgent.getMemory().getType()).name();
+            String appType = mlAgent.getAppType();
+            int messageHistoryLimit = Integer
+                .parseInt(allParams.getOrDefault(PLANNER_MESSAGE_HISTORY_LIMIT, DEFAULT_MESSAGE_HISTORY_LIMIT));
+
+            // Check if this is a fresh conversation (memory was just created, not provided by user)
+            boolean isFreshConversation = "true".equals(allParams.getOrDefault("fresh_memory", "false"));
+
+            // todo: use chat history instead of completed steps
+            Map<String, Object> memoryParams = createMemoryParams(apiParams.get(USER_PROMPT_FIELD), memoryId, appType, mlAgent, apiParams);
+            log.debug("MLPlanExecuteAndReflectAgentRunner setting up memory, params: {}", sanitizeForLogging(memoryParams));
+            Memory.Factory<Memory<Interaction, ?, ?>> memoryFactory;
+            if (memoryParams != null && memoryParams.containsKey(ENDPOINT_FIELD)) {
+                // Use RemoteAgenticConversationMemory when inline connector metadata is detected
+                memoryFactory = memoryFactoryMap.get(MLMemoryType.REMOTE_AGENTIC_MEMORY.name());
+                log.info("Detected inline connector metadata, using RemoteAgenticConversationMemory");
+            } else {
+                // Use the originally specified memory factory
+                memoryFactory = memoryFactoryMap.get(memoryType);
+            }
+            if (memoryFactory == null) {
+                listener
+                    .onFailure(
+                        new IllegalArgumentException(
+                            "Memory factory not found for type: "
+                                + (memoryParams != null && memoryParams.containsKey(ENDPOINT_FIELD)
+                                    ? MLMemoryType.REMOTE_AGENTIC_MEMORY.name()
+                                    : memoryType)
+                        )
+                    );
+                return;
+            }
+            memoryFactory.create(memoryParams, ActionListener.wrap(memory -> {
+                memory.getMessages(messageHistoryLimit, ActionListener.<List<Interaction>>wrap(interactions -> {
+                    List<String> completedSteps = new ArrayList<>();
+                    for (Interaction interaction : interactions) {
+                        String question = interaction.getInput();
+                        String response = interaction.getResponse();
+
+                        if (Strings.isNullOrEmpty(response)) {
+                            continue;
+                        }
+
+                        completedSteps.add(question);
+                        completedSteps.add(response);
                     }
 
-                    completedSteps.add(question);
-                    completedSteps.add(response);
-                }
+                    if (!completedSteps.isEmpty()) {
+                        addSteps(completedSteps, allParams, COMPLETED_STEPS_FIELD);
+                        usePlannerWithHistoryPromptTemplate(allParams);
+                    }
 
-                if (!completedSteps.isEmpty()) {
-                    addSteps(completedSteps, allParams, COMPLETED_STEPS_FIELD);
-                    usePlannerWithHistoryPromptTemplate(allParams);
-                }
-
-                setToolsAndRunAgent(mlAgent, allParams, completedSteps, memory, memory.getId(), listener);
-            }, e -> {
-                log.error("Failed to get chat history", e);
-                listener.onFailure(e);
-            }));
-        }, listener::onFailure));
+                    setToolsAndRunAgent(
+                        mlAgent,
+                        allParams,
+                        completedSteps,
+                        memory,
+                        memory.getId(),
+                        listener,
+                        tokenTracker,
+                        functionCalling
+                    );
+                }, e -> {
+                    log.error("Failed to get chat history", e);
+                    listener.onFailure(e);
+                }));
+            }, listener::onFailure));
+        }, e -> {
+            log.error("Failed to resolve model metadata", e);
+            listener.onFailure(e);
+        }));
     }
 
     private void setToolsAndRunAgent(
@@ -369,7 +401,9 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         List<String> completedSteps,
         Memory memory,
         String conversationId,
-        ActionListener<Object> finalListener
+        ActionListener<Object> finalListener,
+        AgentTokenTracker tokenTracker,
+        FunctionCalling functionCalling
     ) {
         List<MLToolSpec> toolSpecs = getMlToolSpecs(mlAgent, allParams);
 
@@ -382,7 +416,18 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
 
             AtomicInteger traceNumber = new AtomicInteger(0);
 
-            executePlanningLoop(mlAgent.getLlm(), allParams, completedSteps, memory, conversationId, 0, traceNumber, finalListener);
+            executePlanningLoop(
+                mlAgent.getLlm(),
+                allParams,
+                completedSteps,
+                memory,
+                conversationId,
+                0,
+                traceNumber,
+                finalListener,
+                functionCalling,
+                tokenTracker
+            );
         };
 
         // Fetch MCP tools and handle both success and failure cases
@@ -403,13 +448,24 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         String conversationId,
         int stepsExecuted,
         AtomicInteger traceNumber,
-        ActionListener<Object> finalListener
+        ActionListener<Object> finalListener,
+        FunctionCalling functionCalling,
+        AgentTokenTracker tokenTracker
     ) {
         int maxSteps = Integer.parseInt(allParams.getOrDefault(MAX_STEPS_EXECUTED_FIELD, DEFAULT_MAX_STEPS_EXECUTED));
         String parentInteractionId = allParams.get(MLAgentExecutor.PARENT_INTERACTION_ID);
 
         if (stepsExecuted >= maxSteps) {
-            handleMaxStepsReached(llm, allParams, completedSteps, memory, parentInteractionId, finalListener);
+            handleMaxStepsReached(
+                llm,
+                allParams,
+                completedSteps,
+                memory,
+                parentInteractionId,
+                finalListener,
+                functionCalling,
+                tokenTracker
+            );
             return;
         }
         MLPredictionTaskRequest request;
@@ -461,6 +517,25 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
 
         planListener.whenComplete(llmOutput -> {
             ModelTensorOutput modelTensorOutput = (ModelTensorOutput) llmOutput.getOutput();
+
+            // Extract token usage from planner LLM response
+            if (functionCalling != null) {
+                try {
+                    Map<String, ?> dataAsMap = modelTensorOutput
+                        .getMlModelOutputs()
+                        .getFirst()
+                        .getMlModelTensors()
+                        .getFirst()
+                        .getDataAsMap();
+                    TokenUsage usage = functionCalling.extractTokenUsage(dataAsMap);
+                    if (usage != null) {
+                        tokenTracker.recordTurn(llm.getModelId(), usage);
+                    }
+                } catch (Exception e) {
+                    log.debug("Failed to extract token usage from planner LLM response", e);
+                }
+            }
+
             Map<String, Object> parseLLMOutput = parseLLMOutput(allParams, modelTensorOutput);
 
             if (parseLLMOutput.get(RESULT_FIELD) != null) {
@@ -472,7 +547,9 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                     allParams.get(EXECUTOR_AGENT_PARENT_INTERACTION_ID_FIELD),
                     finalResult,
                     null,
-                    finalListener
+                    finalListener,
+                    tokenTracker,
+                    allParams.get(TENANT_ID_FIELD)
                 );
             } else {
                 List<String> steps = (List<String>) parseLLMOutput.get(STEPS_FIELD);
@@ -530,6 +607,13 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                                 break;
                             case PARENT_INTERACTION_ID_FIELD:
                                 results.put(PARENT_INTERACTION_ID_FIELD, tensor.getResult());
+                                break;
+                            case AgentTokenTracker.TOKEN_USAGE:
+                                if (tensor.getDataAsMap() != null) {
+                                    @SuppressWarnings("unchecked")
+                                    Map<String, Object> tokenData = (Map<String, Object>) tensor.getDataAsMap();
+                                    tokenTracker.mergeSubAgentUsage(tokenData);
+                                }
                                 break;
                             default:
                                 String stepResult = parseTensorDataMap(tensor);
@@ -617,7 +701,9 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                         conversationId,
                         stepsExecuted + 1,
                         traceNumber,
-                        finalListener
+                        finalListener,
+                        functionCalling,
+                        tokenTracker
                     );
                 }, e -> {
                     log.error("Failed to execute ReAct agent", e);
@@ -757,7 +843,9 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         String reactParentInteractionId,
         String finalResult,
         String input,
-        ActionListener<Object> finalListener
+        ActionListener<Object> finalListener,
+        AgentTokenTracker tokenTracker,
+        String tenantId
     ) {
         if (memory != null) {
             Map<String, Object> updateContent = new HashMap<>();
@@ -783,6 +871,7 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                             )
                             .build()
                     );
+                AgentUtils.addTokenUsageTensor(finalModelTensors, tokenTracker, tenantId);
                 finalListener.onResponse(ModelTensorOutput.builder().mlModelOutputs(finalModelTensors).build());
             }, e -> {
                 log.error("Failed to update interaction with final result", e);
@@ -804,6 +893,7 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                         )
                         .build()
                 );
+            AgentUtils.addTokenUsageTensor(finalModelTensors, tokenTracker, tenantId);
             finalListener.onResponse(ModelTensorOutput.builder().mlModelOutputs(finalModelTensors).build());
         }
     }
@@ -849,7 +939,9 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         List<String> completedSteps,
         Memory memory,
         String parentInteractionId,
-        ActionListener<Object> finalListener
+        ActionListener<Object> finalListener,
+        FunctionCalling functionCalling,
+        AgentTokenTracker tokenTracker
     ) {
         int maxSteps = Integer.parseInt(allParams.getOrDefault(MAX_STEPS_EXECUTED_FIELD, DEFAULT_MAX_STEPS_EXECUTED));
         log.info("[SUMMARY] Max steps reached. Completed steps: {}", completedSteps.size());
@@ -862,11 +954,13 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                 allParams.get(EXECUTOR_AGENT_PARENT_INTERACTION_ID_FIELD),
                 response,
                 null,
-                finalListener
+                finalListener,
+                tokenTracker,
+                allParams.get(TENANT_ID_FIELD)
             );
         }, finalListener::onFailure);
 
-        generateSummary(llm, completedSteps, allParams, ActionListener.wrap(summary -> {
+        generateSummary(llm, completedSteps, allParams, functionCalling, tokenTracker, ActionListener.wrap(summary -> {
             log.info("Summary generated successfully");
             responseListener
                 .onResponse(
@@ -893,6 +987,8 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         LLMSpec llmSpec,
         List<String> completedSteps,
         Map<String, String> allParams,
+        FunctionCalling functionCalling,
+        AgentTokenTracker tokenTracker,
         ActionListener<String> listener
     ) {
         if (completedSteps == null || completedSteps.isEmpty()) {
@@ -927,6 +1023,24 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
             );
 
             client.execute(MLPredictionTaskAction.INSTANCE, request, ActionListener.wrap(response -> {
+                // Extract token usage from summary LLM call
+                if (tokenTracker != null && functionCalling != null) {
+                    try {
+                        ModelTensorOutput tmpOutput = (ModelTensorOutput) response.getOutput();
+                        if (tmpOutput != null && tmpOutput.getMlModelOutputs() != null && !tmpOutput.getMlModelOutputs().isEmpty()) {
+                            Map<String, ?> dataAsMap = tmpOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap();
+                            if (dataAsMap != null) {
+                                TokenUsage usage = functionCalling.extractTokenUsage(dataAsMap);
+                                if (usage != null) {
+                                    tokenTracker.recordTurn(llmSpec.getModelId(), usage);
+                                }
+                            }
+                        }
+                    } catch (Exception e) {
+                        log.debug("Failed to extract token usage from summary generation", e);
+                    }
+                }
+
                 String summary = extractSummaryFromResponse(response, summaryParams);
                 if (summary == null || summary.trim().isEmpty()) {
                     log.error("Extracted summary is empty");

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/StreamingWrapper.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/StreamingWrapper.java
@@ -110,12 +110,78 @@ public class StreamingWrapper {
         boolean verbose,
         List<ModelTensors> cotModelTensors,
         Map<String, Object> additionalInfo,
-        String finalAnswer
+        String finalAnswer,
+        AgentTokenTracker tokenTracker,
+        String tenantId
     ) {
         if (isStreaming) {
+            // Send token usage BEFORE completion chunk in streaming mode
+            if (tokenTracker != null && tokenTracker.hasUsage()) {
+                try {
+                    Map<String, Object> tokenUsageMap = tokenTracker.toOutputMap();
+                    List<ModelTensor> tokenTensors = new ArrayList<>();
+
+                    // Add memory_id and parent_interaction_id
+                    if (sessionId != null) {
+                        tokenTensors.add(ModelTensor.builder().name("memory_id").result(sessionId).build());
+                    }
+                    if (parentInteractionId != null) {
+                        tokenTensors.add(ModelTensor.builder().name("parent_interaction_id").result(parentInteractionId).build());
+                    }
+
+                    // Send as "token_usage" tensor with structured dataAsMap (matches non-streaming format)
+                    tokenTensors.add(ModelTensor.builder().name(AgentTokenTracker.TOKEN_USAGE).dataAsMap(tokenUsageMap).build());
+
+                    ModelTensorOutput tokenOutput = ModelTensorOutput
+                        .builder()
+                        .mlModelOutputs(List.of(ModelTensors.builder().mlModelTensors(tokenTensors).build()))
+                        .build();
+
+                    channel.sendResponseBatch(new MLTaskResponse(tokenOutput));
+
+                    // Log structured token usage for each model (same as non-streaming mode)
+                    Object perModelObj = tokenUsageMap.get(AgentTokenTracker.PER_MODEL_USAGE);
+                    if (perModelObj instanceof List) {
+                        @SuppressWarnings("unchecked")
+                        List<Map<String, Object>> perModelUsage = (List<Map<String, Object>>) perModelObj;
+                        long eventTime = System.currentTimeMillis();
+                        for (Map<String, Object> modelUsage : perModelUsage) {
+                            Map<String, Object> logEntry = new java.util.LinkedHashMap<>();
+                            logEntry.put("tenantId", tenantId);
+                            logEntry.put("tokenDetails", modelUsage);
+                            logEntry.put("eventTime", eventTime);
+
+                            log.info("{}", StringUtils.toJson(logEntry));
+                        }
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to send token usage in streaming response", e);
+                }
+            }
+
+            // Send final completion chunk with is_last=true
+            sendCompletionChunk(sessionId, parentInteractionId);
+
+            // Close the stream — the handler defers stream completion to here
+            try {
+                channel.completeStream();
+            } catch (Exception e) {
+                log.warn("Failed to complete stream: {}", e.getMessage());
+            }
+
             listener.onResponse("Streaming completed");
         } else {
-            returnFinalResponse(sessionId, listener, parentInteractionId, verbose, cotModelTensors, additionalInfo, finalAnswer);
+            returnFinalResponse(
+                sessionId,
+                listener,
+                parentInteractionId,
+                verbose,
+                cotModelTensors,
+                additionalInfo,
+                finalAnswer,
+                tokenTracker,
+                tenantId
+            );
         }
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandler.java
@@ -63,6 +63,7 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDeltaEvent;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockStartEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamMetadataEvent;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamOutput;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
@@ -71,6 +72,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.ImageBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.ImageSource;
 import software.amazon.awssdk.services.bedrockruntime.model.Message;
 import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
 import software.amazon.awssdk.services.bedrockruntime.model.Tool;
 import software.amazon.awssdk.services.bedrockruntime.model.ToolConfiguration;
 import software.amazon.awssdk.services.bedrockruntime.model.ToolInputSchema;
@@ -93,7 +95,9 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
         STREAMING_CONTENT,
         TOOL_CALL_DETECTED,
         ACCUMULATING_TOOL_INPUT,
+        TOOL_READY_AWAITING_METADATA,
         WAITING_FOR_TOOL_RESULT,
+        MESSAGE_STOP_RECEIVED,
         COMPLETED
     }
 
@@ -129,6 +133,9 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
             StringBuilder toolInputAccumulator = new StringBuilder();
             AtomicReference<StreamState> currentState = new AtomicReference<>(StreamState.STREAMING_CONTENT);
 
+            // Store token usage from metadata event (request-scoped)
+            AtomicReference<Map<String, Object>> streamTokenUsage = new AtomicReference<>();
+
             // Build Bedrock client
             BedrockRuntimeAsyncClient bedrockClient = buildBedrockRuntimeAsyncClient();
 
@@ -155,13 +162,27 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                     listener.onFailure(new MLException(REMOTE_SERVICE_ERROR + error.getMessage(), error));
                 }
             }).onComplete(() -> {
-                if (currentState.get() != StreamState.WAITING_FOR_TOOL_RESULT) {
-                    sendCompletionResponse(isStreamClosed, listener);
+                // onComplete() fires after ALL events including metadata
+                if (currentState.get() == StreamState.TOOL_READY_AWAITING_METADATA) {
+                    // Tool response ready, now send it with captured token usage
+                    currentState.set(StreamState.WAITING_FOR_TOOL_RESULT);
+                    log.debug("Sending tool response after metadata capture");
+                    listener.onResponse(createToolUseResponse(toolName, toolInput, toolUseId, streamTokenUsage));
+                } else if (currentState.get() != StreamState.WAITING_FOR_TOOL_RESULT) {
+                    sendCompletionResponseWithUsage(isStreamClosed, listener, streamTokenUsage);
                 } else {
                     log.debug("Tool execution in progress - keeping stream open");
                 }
             }).subscriber(event -> {
                 log.debug("BEDROCK_RAW_EVENT: Type={}, Event={}", event.sdkEventType(), event);
+
+                // Handle metadata events separately (always last event, contains token usage)
+                if (event.sdkEventType() == ConverseStreamOutput.EventType.METADATA) {
+                    handleMetadataEvent(event, streamTokenUsage);
+                    return;
+                }
+
+                // Handle content/tool events via state machine
                 handleStreamEvent(
                     event,
                     listener,
@@ -302,6 +323,9 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                         sendContentResponse(content, false, listener);
                     }
                 } else if (isStreamComplete(event)) {
+                    // messageStop received - set state but don't close yet (metadata coming next)
+                    currentState.set(StreamState.MESSAGE_STOP_RECEIVED);
+
                     if (isAGUIAgent && textMessageStarted) {
                         parameters.put(AGUI_PARAM_TEXT_MESSAGE_STARTED, "false");
                         BaseEvent textMessageEndEvent = new TextMessageEndEvent(messageId);
@@ -311,12 +335,15 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                         String threadId = parameters.get(AGUI_PARAM_THREAD_ID);
                         String runId = parameters.get(AGUI_PARAM_RUN_ID);
                         BaseEvent runFinishedEvent = new RunFinishedEvent(threadId, runId, null);
-                        sendAGUIEvent(runFinishedEvent, true, listener);
-                        log.debug("BedrockStreamingHandler: Added RUN_FINISHED event - ReAct loop completed");
+                        // Send with is_last=false — don't close the stream yet.
+                        // The metadata event (with token usage) arrives AFTER messageStop.
+                        // onComplete() will send the real completion with token usage.
+                        sendAGUIEvent(runFinishedEvent, false, listener);
+                        log.debug("BedrockStreamingHandler: Added RUN_FINISHED event - waiting for metadata before completing");
                     }
 
-                    currentState.set(StreamState.COMPLETED);
-                    sendCompletionResponse(isStreamClosed, listener);
+                    // Don't send completion yet - wait for metadata event then .onComplete() will handle it
+                    log.debug("messageStop received, waiting for metadata event");
                 }
                 break;
 
@@ -366,13 +393,24 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                         log.debug("AG-UI: Sent TOOL_CALL_END event for tool '{}'", toolName.get());
                     }
 
-                    currentState.set(StreamState.WAITING_FOR_TOOL_RESULT);
-                    listener.onResponse(createToolUseResponse(toolName, toolInput, toolUseId));
+                    // Don't send tool response yet - wait for metadata event
+                    currentState.set(StreamState.TOOL_READY_AWAITING_METADATA);
+                    log.debug("Tool input complete, waiting for metadata before sending response");
                 }
+                break;
+
+            case TOOL_READY_AWAITING_METADATA:
+                // Waiting for metadata event, then onComplete() will send tool response
+                log.debug("In TOOL_READY_AWAITING_METADATA state, waiting for metadata");
                 break;
 
             case WAITING_FOR_TOOL_RESULT:
                 log.debug("Waiting for tool result - keeping stream open");
+                break;
+
+            case MESSAGE_STOP_RECEIVED:
+                // Waiting for metadata event, then onComplete() will send completion
+                log.debug("In MESSAGE_STOP_RECEIVED state, waiting for metadata");
                 break;
 
             case COMPLETED:
@@ -427,14 +465,18 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
     private MLTaskResponse createToolUseResponse(
         AtomicReference<String> toolName,
         AtomicReference<Map<String, Object>> toolInput,
-        AtomicReference<String> toolUseId
+        AtomicReference<String> toolUseId,
+        AtomicReference<Map<String, Object>> streamTokenUsage
     ) {
         // Validate inputs
         if (toolName == null || toolInput == null || toolUseId == null) {
             throw new IllegalArgumentException("Tool references cannot be null");
         }
-        Map<String, Object> wrappedResponse = Map
-            .of(
+
+        // Build response structure (use HashMap to conditionally add usage)
+        Map<String, Object> wrappedResponse = new HashMap<>();
+        wrappedResponse
+            .put(
                 "output",
                 Map
                     .of(
@@ -451,10 +493,14 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                                             )
                                     )
                             )
-                    ),
-                "stopReason",
-                "tool_use"
+                    )
             );
+        wrappedResponse.put("stopReason", "tool_use");
+
+        // Include token usage from metadata event (onComplete always fires after metadata)
+        if (streamTokenUsage != null && streamTokenUsage.get() != null) {
+            wrappedResponse.put("usage", streamTokenUsage.get());
+        }
 
         ModelTensor tensor = ModelTensor.builder().name("response").dataAsMap(wrappedResponse).build();
         ModelTensors tensors = ModelTensors.builder().mlModelTensors(List.of(tensor)).build();
@@ -736,5 +782,112 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
         builder.streamProcessingMode("async");
 
         return builder.build();
+    }
+
+    /**
+     * Handles metadata events from Bedrock stream.
+     * Metadata is always the last event and contains token usage.
+     */
+    private void handleMetadataEvent(ConverseStreamOutput event, AtomicReference<Map<String, Object>> streamTokenUsage) {
+        if (event.sdkEventType() != ConverseStreamOutput.EventType.METADATA) {
+            return;
+        }
+
+        try {
+            ConverseStreamMetadataEvent metadataEvent = (ConverseStreamMetadataEvent) event;
+
+            if (metadataEvent.usage() != null) {
+                TokenUsage usage = metadataEvent.usage();
+
+                // Store in request-scoped field in format expected by BedrockConverseFunctionCalling.extractTokenUsage()
+                Map<String, Object> usageMap = new HashMap<>();
+                usageMap.put("inputTokens", usage.inputTokens());
+                usageMap.put("outputTokens", usage.outputTokens());
+                usageMap.put("totalTokens", usage.totalTokens());
+
+                // Include cache tokens if available
+                if (usage.cacheReadInputTokens() != null) {
+                    usageMap.put("cacheReadInputTokens", usage.cacheReadInputTokens());
+                }
+                if (usage.cacheWriteInputTokens() != null) {
+                    usageMap.put("cacheWriteInputTokens", usage.cacheWriteInputTokens());
+                }
+
+                streamTokenUsage.set(Map.copyOf(usageMap));
+
+                log
+                    .debug(
+                        "Captured token usage: input={}, output={}, total={}, cacheRead={}, cacheWrite={}",
+                        usage.inputTokens(),
+                        usage.outputTokens(),
+                        usage.totalTokens(),
+                        usage.cacheReadInputTokens(),
+                        usage.cacheWriteInputTokens()
+                    );
+            }
+
+        } catch (Exception e) {
+            log.warn("[TOKEN_TRACKING] Failed to extract token usage from metadata event", e);
+            // Don't propagate - usage tracking is best-effort
+        }
+    }
+
+    /**
+     * Sends completion response with token usage included.
+     * Called from .onComplete() after all events (including metadata) have been processed.
+     */
+    private void sendCompletionResponseWithUsage(
+        AtomicBoolean isStreamClosed,
+        StreamPredictActionListener<MLTaskResponse, ?> actionListener,
+        AtomicReference<Map<String, Object>> streamTokenUsage
+    ) {
+        if (isStreamClosed.compareAndSet(false, true)) {
+            boolean isAgentStream = actionListener.hasAgentListener();
+
+            Map<String, Object> completionData = new HashMap<>();
+            completionData.put("content", "");
+            // For agent streams: is_last=false — StreamingWrapper.sendCompletionChunk sends the real is_last=true
+            // after token usage and memory save.
+            // For non-agent streams (plain predict): is_last=true — no agent runner upstream to close the stream,
+            // so we must close it here.
+            completionData.put("is_last", !isAgentStream);
+            completionData.put("streaming_complete", true);
+
+            // Include token usage if available
+            if (streamTokenUsage != null && streamTokenUsage.get() != null) {
+                completionData.put("usage", streamTokenUsage.get());
+                // Store on parameters map so agent runner/StreamingWrapper can access final turn usage
+                if (parameters != null) {
+                    Map<String, Object> usage = streamTokenUsage.get();
+                    parameters.put("stream_input_tokens", String.valueOf(usage.getOrDefault("inputTokens", "0")));
+                    parameters.put("stream_output_tokens", String.valueOf(usage.getOrDefault("outputTokens", "0")));
+                    parameters.put("stream_total_tokens", String.valueOf(usage.getOrDefault("totalTokens", "0")));
+                }
+                log.debug("Including token usage in completion response");
+            } else {
+                log.warn("[TOKEN_TRACKING] Metadata event not received, completion sent without token usage");
+            }
+
+            List<ModelTensor> tensors = new ArrayList<>();
+            tensors.add(ModelTensor.builder().name("response").dataAsMap(completionData).build());
+
+            ModelTensorOutput output = ModelTensorOutput
+                .builder()
+                .mlModelOutputs(List.of(ModelTensors.builder().mlModelTensors(tensors).build()))
+                .build();
+
+            MLTaskResponse response = new MLTaskResponse(output);
+
+            if (isAgentStream) {
+                // Agent path: notify agent listener so agent runner's whenComplete fires
+                // (for token tracking + sendFinalAnswer). Don't close stream here —
+                // StreamingWrapper.sendFinalResponse handles closure after async operations.
+                actionListener.onResponse(response);
+            } else {
+                // Non-agent path: no upstream runner to close the stream, so send with
+                // isLastBatch=true which triggers channel.completeStream().
+                actionListener.onStreamResponse(response, true);
+            }
+        }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/StreamPredictActionListener.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/StreamPredictActionListener.java
@@ -96,6 +96,15 @@ public class StreamPredictActionListener<Response extends TransportResponse, Req
         }
     }
 
+    /**
+     * Returns true if an agent listener is present, meaning an agent runner
+     * upstream will handle stream closure. When false, the streaming handler
+     * must close the stream itself.
+     */
+    public boolean hasAgentListener() {
+        return agentListener != null;
+    }
+
     private Response addMetadataToResponse(Response response) {
         if (!(response instanceof MLTaskResponse)) {
             return response;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/BedrockConverseDeepseekR1FunctionCalling.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/BedrockConverseDeepseekR1FunctionCalling.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_RE
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_REASON_TOOL_USE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_EXCLUDE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOKEN_USAGE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_INPUT;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_NAME;
@@ -30,8 +31,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.engine.algorithms.agent.AgentUtils;
 
 import com.jayway.jsonpath.JsonPath;
 
@@ -74,6 +77,9 @@ public class BedrockConverseDeepseekR1FunctionCalling implements FunctionCalling
 
         params.put(LLM_FINISH_REASON_PATH, "_llm_response.stop_reason");
         params.put(LLM_FINISH_REASON_TOOL_USE, "tool_use");
+
+        // Token usage tracking paths
+        params.put(TOKEN_USAGE_PATH, "$.usage");
     }
 
     @Override
@@ -117,5 +123,31 @@ public class BedrockConverseDeepseekR1FunctionCalling implements FunctionCalling
         }
 
         return List.of(toolMessage);
+    }
+
+    @Override
+    public TokenUsage extractTokenUsage(Map<String, ?> llmResponseDataAsMap) {
+        if (llmResponseDataAsMap == null) {
+            return null;
+        }
+
+        try {
+            Object usageObj = llmResponseDataAsMap.get("usage");
+            if (!(usageObj instanceof Map)) {
+                return null;
+            }
+
+            Map<String, Object> usageMap = (Map<String, Object>) usageObj;
+
+            // Bedrock Deepseek R1 uses standard format
+            return TokenUsage
+                .builder()
+                .inputTokens(AgentUtils.getLongValue(usageMap, "prompt_tokens"))
+                .outputTokens(AgentUtils.getLongValue(usageMap, "completion_tokens"))
+                .totalTokens(AgentUtils.getLongValue(usageMap, "total_tokens"))
+                .build();
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/BedrockConverseFunctionCalling.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/BedrockConverseFunctionCalling.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_RE
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_REASON_TOOL_USE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_EXCLUDE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOKEN_USAGE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_INPUT;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_NAME;
@@ -30,8 +31,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.engine.algorithms.agent.AgentUtils;
 
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
@@ -78,6 +81,9 @@ public class BedrockConverseFunctionCalling implements FunctionCalling {
 
         params.put(LLM_FINISH_REASON_PATH, "$.stopReason");
         params.put(LLM_FINISH_REASON_TOOL_USE, "tool_use");
+
+        // Token usage tracking paths
+        params.put(TOKEN_USAGE_PATH, "$.usage");
     }
 
     @Override
@@ -171,6 +177,35 @@ public class BedrockConverseFunctionCalling implements FunctionCalling {
         } catch (Exception e) {
             log.error("Failed to filter out to only first tool call", e);
             return dataAsMap;
+        }
+    }
+
+    @Override
+    public TokenUsage extractTokenUsage(Map<String, ?> llmResponseDataAsMap) {
+        if (llmResponseDataAsMap == null) {
+            return null;
+        }
+
+        try {
+            Object usageObj = llmResponseDataAsMap.get("usage");
+            if (!(usageObj instanceof Map)) {
+                return null;
+            }
+
+            Map<String, Object> usageMap = (Map<String, Object>) usageObj;
+
+            // Bedrock Converse API always normalizes to camelCase format
+            // regardless of the underlying model (Claude, Llama, etc.)
+            return TokenUsage
+                .builder()
+                .inputTokens(AgentUtils.getLongValue(usageMap, "inputTokens"))
+                .outputTokens(AgentUtils.getLongValue(usageMap, "outputTokens"))
+                .totalTokens(AgentUtils.getLongValue(usageMap, "totalTokens"))
+                .cacheReadInputTokens(AgentUtils.getLongValue(usageMap, "cacheReadInputTokens"))
+                .cacheCreationInputTokens(AgentUtils.getLongValue(usageMap, "cacheWriteInputTokens"))
+                .build();
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/FunctionCalling.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/FunctionCalling.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.engine.function_calling;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 
 /**
@@ -47,5 +48,16 @@ public interface FunctionCalling {
      */
     default Map<String, ?> filterToFirstToolCall(Map<String, ?> dataAsMap, Map<String, String> parameters) {
         return dataAsMap;
+    }
+
+    /**
+     * Extracts token usage information from the LLM response.
+     * Each implementation knows its own response format and field names.
+     *
+     * @param llmResponseDataAsMap the full LLM response data map
+     * @return TokenUsage object with token counts, or null if extraction fails or is not supported
+     */
+    default TokenUsage extractTokenUsage(Map<String, ?> llmResponseDataAsMap) {
+        return null; // Default: no token tracking
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/GeminiV1BetaGenerateContentFunctionCalling.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/GeminiV1BetaGenerateContentFunctionCalling.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_RE
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_REASON_TOOL_USE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_EXCLUDE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOKEN_USAGE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_INPUT;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_NAME;
@@ -30,8 +31,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.engine.algorithms.agent.AgentUtils;
 
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
@@ -85,6 +88,9 @@ public class GeminiV1BetaGenerateContentFunctionCalling implements FunctionCalli
         // TODO: Once tool call detection is refactored into FunctionCalling interface (see AgentUtils.java:434),
         // this parameter may need to be removed or repurposed since it's not used for Gemini.
         params.put(LLM_FINISH_REASON_TOOL_USE, "N/A");
+
+        // Token usage tracking paths
+        params.put(TOKEN_USAGE_PATH, "$.usageMetadata");
     }
 
     @Override
@@ -180,6 +186,33 @@ public class GeminiV1BetaGenerateContentFunctionCalling implements FunctionCalli
         } catch (Exception e) {
             log.error("Failed to filter out to only first tool call", e);
             return dataAsMap;
+        }
+    }
+
+    @Override
+    public TokenUsage extractTokenUsage(Map<String, ?> llmResponseDataAsMap) {
+        if (llmResponseDataAsMap == null) {
+            return null;
+        }
+
+        try {
+            Object usageMetadataObj = llmResponseDataAsMap.get("usageMetadata");
+            if (!(usageMetadataObj instanceof Map)) {
+                return null;
+            }
+
+            Map<String, Object> usageMap = (Map<String, Object>) usageMetadataObj;
+
+            return TokenUsage
+                .builder()
+                .inputTokens(AgentUtils.getLongValue(usageMap, "promptTokenCount"))
+                .outputTokens(AgentUtils.getLongValue(usageMap, "candidatesTokenCount"))
+                .totalTokens(AgentUtils.getLongValue(usageMap, "totalTokenCount"))
+                .cacheReadInputTokens(AgentUtils.getLongValue(usageMap, "cachedContentInputTokenCount"))
+                .reasoningTokens(AgentUtils.getLongValue(usageMap, "thoughtsTokenCount"))
+                .build();
+        } catch (Exception e) {
+            return null;
         }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/OpenaiV1ChatCompletionsFunctionCalling.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/OpenaiV1ChatCompletionsFunctionCalling.java
@@ -12,6 +12,7 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_RE
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_REASON_TOOL_USE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_EXCLUDE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOKEN_USAGE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_INPUT;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_NAME;
@@ -29,8 +30,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.engine.algorithms.agent.AgentUtils;
 
 import com.jayway.jsonpath.JsonPath;
 
@@ -73,6 +76,9 @@ public class OpenaiV1ChatCompletionsFunctionCalling implements FunctionCalling {
 
         params.put(LLM_FINISH_REASON_PATH, "$.choices[0].finish_reason");
         params.put(LLM_FINISH_REASON_TOOL_USE, "tool_calls");
+
+        // Token usage tracking paths
+        params.put(TOKEN_USAGE_PATH, "$.usage");
     }
 
     @Override
@@ -116,5 +122,46 @@ public class OpenaiV1ChatCompletionsFunctionCalling implements FunctionCalling {
         }
 
         return messages;
+    }
+
+    @Override
+    public TokenUsage extractTokenUsage(Map<String, ?> llmResponseDataAsMap) {
+        if (llmResponseDataAsMap == null) {
+            return null;
+        }
+
+        try {
+            Object usageObj = llmResponseDataAsMap.get("usage");
+            if (!(usageObj instanceof Map)) {
+                return null;
+            }
+
+            Map<String, Object> usageMap = (Map<String, Object>) usageObj;
+
+            // OpenAI format: prompt_tokens, completion_tokens, total_tokens
+            TokenUsage.TokenUsageBuilder builder = TokenUsage
+                .builder()
+                .inputTokens(AgentUtils.getLongValue(usageMap, "prompt_tokens"))
+                .outputTokens(AgentUtils.getLongValue(usageMap, "completion_tokens"))
+                .totalTokens(AgentUtils.getLongValue(usageMap, "total_tokens"));
+
+            // OpenAI prompt_tokens_details.cached_tokens
+            Object promptDetailsObj = usageMap.get("prompt_tokens_details");
+            if (promptDetailsObj instanceof Map) {
+                Map<String, Object> promptDetails = (Map<String, Object>) promptDetailsObj;
+                builder.cacheReadInputTokens(AgentUtils.getLongValue(promptDetails, "cached_tokens"));
+            }
+
+            // OpenAI completion_tokens_details.reasoning_tokens
+            Object completionDetailsObj = usageMap.get("completion_tokens_details");
+            if (completionDetailsObj instanceof Map) {
+                Map<String, Object> completionDetails = (Map<String, Object>) completionDetailsObj;
+                builder.reasoningTokens(AgentUtils.getLongValue(completionDetails, "reasoning_tokens"));
+            }
+
+            return builder.build();
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentTokenTrackerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentTokenTrackerTest.java
@@ -1,0 +1,566 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.agent;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.ml.common.agent.TokenUsage;
+
+public class AgentTokenTrackerTest {
+
+    private AgentTokenTracker tracker;
+
+    @Before
+    public void setUp() {
+        tracker = new AgentTokenTracker();
+    }
+
+    @Test
+    public void testRecordSingleTurn() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+
+        tracker.setModelMetadata("gpt-4", "https://api.openai.com/v1/chat/completions", "gpt-4");
+        tracker.recordTurn("gpt-4", usage);
+
+        assertTrue(tracker.hasUsage());
+
+        Map<String, Object> output = tracker.toOutputMap();
+        assertNotNull(output);
+
+        List<Map<String, Object>> perTurnUsage = (List<Map<String, Object>>) output.get("per_turn_usage");
+        assertEquals(1, perTurnUsage.size());
+
+        Map<String, Object> turn = perTurnUsage.get(0);
+        assertEquals(1, turn.get("turn"));
+        assertEquals("gpt-4", turn.get("model_name"));
+        assertEquals(100L, turn.get("input_tokens"));
+        assertEquals(50L, turn.get("output_tokens"));
+        assertEquals(150L, turn.get("total_tokens"));
+    }
+
+    @Test
+    public void testRecordMultipleTurns() {
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(200L).outputTokens(75L).totalTokens(275L).build();
+
+        TokenUsage usage3 = TokenUsage.builder().inputTokens(150L).outputTokens(60L).totalTokens(210L).build();
+
+        tracker.setModelMetadata("gpt-4", "https://api.openai.com/v1/chat/completions", "gpt-4");
+        tracker.recordTurn("gpt-4", usage1);
+        tracker.recordTurn("gpt-4", usage2);
+        tracker.recordTurn("gpt-4", usage3);
+
+        Map<String, Object> output = tracker.toOutputMap();
+
+        List<Map<String, Object>> perTurnUsage = (List<Map<String, Object>>) output.get("per_turn_usage");
+        assertEquals(3, perTurnUsage.size());
+
+        // Verify turn numbers
+        assertEquals(1, perTurnUsage.get(0).get("turn"));
+        assertEquals(2, perTurnUsage.get(1).get("turn"));
+        assertEquals(3, perTurnUsage.get(2).get("turn"));
+    }
+
+    @Test
+    public void testPerModelAggregation() {
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(200L).outputTokens(75L).totalTokens(275L).build();
+
+        tracker.recordTurn("gpt-4", usage1);
+        tracker.recordTurn("gpt-4", usage2);
+
+        Map<String, Object> output = tracker.toOutputMap();
+
+        List<Map<String, Object>> perModelUsage = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(1, perModelUsage.size());
+
+        Map<String, Object> modelData = perModelUsage.get(0);
+        assertEquals("gpt-4", modelData.get("model_name"));
+        assertEquals(300L, modelData.get("input_tokens"));
+        assertEquals(125L, modelData.get("output_tokens"));
+        assertEquals(425L, modelData.get("total_tokens"));
+        assertEquals(2, modelData.get("call_count"));
+    }
+
+    @Test
+    public void testMultipleModels() {
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).build();
+
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(200L).outputTokens(75L).build();
+
+        TokenUsage usage3 = TokenUsage.builder().inputTokens(150L).outputTokens(60L).build();
+
+        tracker.setModelMetadata("gpt-4", "https://api.openai.com/v1/chat/completions", "gpt-4");
+        tracker.setModelMetadata("claude-3", "https://api.anthropic.com/v1/messages", "claude-3");
+        tracker.recordTurn("gpt-4", usage1);
+        tracker.recordTurn("claude-3", usage2);
+        tracker.recordTurn("gpt-4", usage3);
+
+        Map<String, Object> output = tracker.toOutputMap();
+
+        List<Map<String, Object>> perModelUsage = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(2, perModelUsage.size());
+
+        // Find each model's data
+        Map<String, Object> gpt4Data = perModelUsage.stream().filter(m -> "gpt-4".equals(m.get("model_id"))).findFirst().orElse(null);
+        Map<String, Object> claudeData = perModelUsage.stream().filter(m -> "claude-3".equals(m.get("model_id"))).findFirst().orElse(null);
+
+        assertNotNull(gpt4Data);
+        assertNotNull(claudeData);
+
+        assertEquals(250L, gpt4Data.get("input_tokens"));
+        assertEquals(110L, gpt4Data.get("output_tokens"));
+        assertEquals(2, gpt4Data.get("call_count"));
+
+        assertEquals(200L, claudeData.get("input_tokens"));
+        assertEquals(75L, claudeData.get("output_tokens"));
+        assertEquals(1, claudeData.get("call_count"));
+    }
+
+    @Test
+    public void testRecordWithCacheTokens() {
+        TokenUsage usage = TokenUsage
+            .builder()
+            .inputTokens(100L)
+            .outputTokens(50L)
+            .totalTokens(150L)
+            .cacheReadInputTokens(20L)
+            .cacheCreationInputTokens(10L)
+            .build();
+
+        tracker.setModelMetadata("claude-3", "https://api.anthropic.com/v1/messages", "claude-3");
+        tracker.recordTurn("claude-3", usage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perTurnUsage = (List<Map<String, Object>>) output.get("per_turn_usage");
+
+        Map<String, Object> turn = perTurnUsage.get(0);
+        assertEquals(20L, turn.get("cache_read_input_tokens"));
+        assertEquals(10L, turn.get("cache_creation_input_tokens"));
+    }
+
+    @Test
+    public void testRecordWithReasoningTokens() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).reasoningTokens(30L).build();
+
+        tracker.setModelMetadata("o1-preview", "https://api.openai.com/v1/chat/completions", "o1-preview");
+        tracker.recordTurn("o1-preview", usage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perTurnUsage = (List<Map<String, Object>>) output.get("per_turn_usage");
+
+        Map<String, Object> turn = perTurnUsage.get(0);
+        assertEquals(30L, turn.get("reasoning_tokens"));
+    }
+
+    @Test
+    public void testRecordWithNullModelName() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).build();
+
+        tracker.recordTurn(null, usage);
+
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testRecordWithNullUsage() {
+        tracker.recordTurn("gpt-4", null);
+
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testHasUsageWhenEmpty() {
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testEmptyOutputMap() {
+        Map<String, Object> output = tracker.toOutputMap();
+
+        assertNotNull(output);
+        assertTrue(((List<?>) output.get("per_turn_usage")).isEmpty());
+        assertTrue(((List<?>) output.get("per_model_usage")).isEmpty());
+    }
+
+    // --- mergeSubAgentUsage tests ---
+
+    @Test
+    public void testMergeSubAgentUsage_basic() {
+        Map<String, Object> subAgentUsage = new HashMap<>();
+        subAgentUsage
+            .put(
+                "per_turn_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "turn",
+                                1,
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                100L,
+                                "output_tokens",
+                                50L,
+                                "total_tokens",
+                                150L
+                            ),
+                        Map
+                            .of(
+                                "turn",
+                                2,
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                200L,
+                                "output_tokens",
+                                75L,
+                                "total_tokens",
+                                275L
+                            )
+                    )
+            );
+        subAgentUsage
+            .put(
+                "per_model_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                300L,
+                                "output_tokens",
+                                125L,
+                                "total_tokens",
+                                425L,
+                                "call_count",
+                                2
+                            )
+                    )
+            );
+
+        tracker.mergeSubAgentUsage(subAgentUsage);
+
+        assertTrue(tracker.hasUsage());
+        Map<String, Object> output = tracker.toOutputMap();
+
+        List<Map<String, Object>> perTurn = (List<Map<String, Object>>) output.get("per_turn_usage");
+        assertEquals(2, perTurn.size());
+        assertEquals(1, perTurn.get(0).get("turn"));
+        assertEquals(2, perTurn.get(1).get("turn"));
+
+        List<Map<String, Object>> perModel = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(1, perModel.size());
+        assertEquals(300L, perModel.get(0).get("input_tokens"));
+        assertEquals(2, perModel.get(0).get("call_count"));
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_afterExistingTurns() {
+        // Record 2 direct planner turns first
+        tracker.setModelMetadata("gpt-4", "https://openai", "gpt-4");
+        tracker.recordTurn("gpt-4", TokenUsage.builder().inputTokens(50L).outputTokens(25L).totalTokens(75L).build());
+        tracker.recordTurn("gpt-4", TokenUsage.builder().inputTokens(60L).outputTokens(30L).totalTokens(90L).build());
+
+        // Merge sub-agent usage with 3 turns
+        Map<String, Object> subAgentUsage = new HashMap<>();
+        subAgentUsage
+            .put(
+                "per_turn_usage",
+                List
+                    .of(
+                        Map.of("turn", 1, "model_id", "claude-3", "input_tokens", 100L, "output_tokens", 50L, "total_tokens", 150L),
+                        Map.of("turn", 2, "model_id", "claude-3", "input_tokens", 200L, "output_tokens", 75L, "total_tokens", 275L),
+                        Map.of("turn", 3, "model_id", "claude-3", "input_tokens", 150L, "output_tokens", 60L, "total_tokens", 210L)
+                    )
+            );
+        subAgentUsage
+            .put(
+                "per_model_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                450L,
+                                "output_tokens",
+                                185L,
+                                "total_tokens",
+                                635L,
+                                "call_count",
+                                3
+                            )
+                    )
+            );
+
+        tracker.mergeSubAgentUsage(subAgentUsage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perTurn = (List<Map<String, Object>>) output.get("per_turn_usage");
+        assertEquals(5, perTurn.size());
+
+        // Planner turns keep 1, 2; sub-agent turns re-numbered to 3, 4, 5
+        assertEquals(1, perTurn.get(0).get("turn"));
+        assertEquals(2, perTurn.get(1).get("turn"));
+        assertEquals(3, perTurn.get(2).get("turn"));
+        assertEquals(4, perTurn.get(3).get("turn"));
+        assertEquals(5, perTurn.get(4).get("turn"));
+
+        // Two separate models in per_model_usage
+        List<Map<String, Object>> perModel = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(2, perModel.size());
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_sameModel() {
+        // Planner uses same model as executor
+        tracker.setModelMetadata("claude-3", "https://bedrock", "claude-3");
+        tracker.recordTurn("claude-3", TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build());
+
+        Map<String, Object> subAgentUsage = new HashMap<>();
+        subAgentUsage
+            .put(
+                "per_turn_usage",
+                List.of(Map.of("turn", 1, "model_id", "claude-3", "input_tokens", 200L, "output_tokens", 75L, "total_tokens", 275L))
+            );
+        subAgentUsage
+            .put(
+                "per_model_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                200L,
+                                "output_tokens",
+                                75L,
+                                "total_tokens",
+                                275L,
+                                "call_count",
+                                1
+                            )
+                    )
+            );
+
+        tracker.mergeSubAgentUsage(subAgentUsage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perModel = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(1, perModel.size());
+
+        // Aggregated: 100+200=300 input, 50+75=125 output, 150+275=425 total, 1+1=2 calls
+        assertEquals(300L, perModel.get(0).get("input_tokens"));
+        assertEquals(125L, perModel.get(0).get("output_tokens"));
+        assertEquals(425L, perModel.get(0).get("total_tokens"));
+        assertEquals(2, perModel.get(0).get("call_count"));
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_nullInput() {
+        tracker.mergeSubAgentUsage(null);
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_emptyMap() {
+        tracker.mergeSubAgentUsage(new HashMap<>());
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_multipleSteps() {
+        // Simulate PER executing 2 steps, each executor returns token usage
+        tracker.setModelMetadata("gpt-4", "https://openai", "gpt-4");
+
+        // Planner call 1
+        tracker.recordTurn("gpt-4", TokenUsage.builder().inputTokens(50L).outputTokens(25L).totalTokens(75L).build());
+
+        // Executor step 1
+        Map<String, Object> step1Usage = new HashMap<>();
+        step1Usage
+            .put(
+                "per_turn_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "turn",
+                                1,
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                100L,
+                                "output_tokens",
+                                50L,
+                                "total_tokens",
+                                150L
+                            )
+                    )
+            );
+        step1Usage
+            .put(
+                "per_model_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                100L,
+                                "output_tokens",
+                                50L,
+                                "total_tokens",
+                                150L,
+                                "call_count",
+                                1
+                            )
+                    )
+            );
+        tracker.mergeSubAgentUsage(step1Usage);
+
+        // Planner reflect call
+        tracker.recordTurn("gpt-4", TokenUsage.builder().inputTokens(80L).outputTokens(30L).totalTokens(110L).build());
+
+        // Executor step 2
+        Map<String, Object> step2Usage = new HashMap<>();
+        step2Usage
+            .put(
+                "per_turn_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "turn",
+                                1,
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                200L,
+                                "output_tokens",
+                                75L,
+                                "total_tokens",
+                                275L
+                            ),
+                        Map
+                            .of(
+                                "turn",
+                                2,
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                150L,
+                                "output_tokens",
+                                60L,
+                                "total_tokens",
+                                210L
+                            )
+                    )
+            );
+        step2Usage
+            .put(
+                "per_model_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                350L,
+                                "output_tokens",
+                                135L,
+                                "total_tokens",
+                                485L,
+                                "call_count",
+                                2
+                            )
+                    )
+            );
+        tracker.mergeSubAgentUsage(step2Usage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+
+        // 1 planner + 1 executor step1 + 1 planner reflect + 2 executor step2 = 5 turns
+        List<Map<String, Object>> perTurn = (List<Map<String, Object>>) output.get("per_turn_usage");
+        assertEquals(5, perTurn.size());
+        for (int i = 0; i < 5; i++) {
+            assertEquals(i + 1, perTurn.get(i).get("turn"));
+        }
+
+        // 2 models: gpt-4 (planner) and claude-3 (executor)
+        List<Map<String, Object>> perModel = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(2, perModel.size());
+
+        Map<String, Object> gpt4 = perModel.stream().filter(m -> "gpt-4".equals(m.get("model_id"))).findFirst().orElse(null);
+        Map<String, Object> claude3 = perModel.stream().filter(m -> "claude-3".equals(m.get("model_id"))).findFirst().orElse(null);
+
+        assertNotNull(gpt4);
+        assertEquals(130L, gpt4.get("input_tokens")); // 50+80
+        assertEquals(55L, gpt4.get("output_tokens"));  // 25+30
+        assertEquals(2, gpt4.get("call_count"));
+
+        assertNotNull(claude3);
+        assertEquals(450L, claude3.get("input_tokens")); // 100+350
+        assertEquals(185L, claude3.get("output_tokens")); // 50+135
+        assertEquals(3, claude3.get("call_count"));        // 1+2
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.engine.algorithms.agent;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -2056,5 +2057,76 @@ public class AgentUtilsTest extends MLStaticMockBase {
         assertEquals("test-memory-id", result.get("memory_id"));
         // Verify it's a different map (shallow copy)
         assertNotSame(params, result);
+    }
+
+    // ===== getModelMetadata tests =====
+
+    @Test
+    public void testGetModelMetadata_nullSdkClient() {
+        AtomicReference<String[]> result = new AtomicReference<>();
+        AgentUtils.getModelMetadata("model-1", "tenant-1", null, client, null, ActionListener.wrap(result::set, e -> {
+            throw new AssertionError("Should not fail", e);
+        }));
+
+        assertNotNull(result.get());
+        assertEquals("model-1", result.get()[0]); // url falls back to modelId
+        assertEquals("model-1", result.get()[1]); // name falls back to modelId
+    }
+
+    // ===== addTokenUsageTensor tests =====
+
+    @Test
+    public void testAddTokenUsageTensor_nullTracker() {
+        List<ModelTensors> tensors = new ArrayList<>();
+        AgentUtils.addTokenUsageTensor(tensors, null, "tenant-1");
+        assertTrue(tensors.isEmpty());
+    }
+
+    @Test
+    public void testAddTokenUsageTensor_emptyTracker() {
+        List<ModelTensors> tensors = new ArrayList<>();
+        AgentTokenTracker tracker = new AgentTokenTracker();
+        AgentUtils.addTokenUsageTensor(tensors, tracker, "tenant-1");
+        assertTrue(tensors.isEmpty()); // hasUsage() is false
+    }
+
+    @Test
+    public void testAddTokenUsageTensor_withUsage() {
+        List<ModelTensors> tensors = new ArrayList<>();
+        AgentTokenTracker tracker = new AgentTokenTracker();
+        tracker.setModelMetadata("model-1", "https://bedrock.amazonaws.com", "claude-v3");
+        tracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        AgentUtils.addTokenUsageTensor(tensors, tracker, "tenant-1");
+
+        assertEquals(1, tensors.size());
+        ModelTensors modelTensors = tensors.get(0);
+        assertEquals(1, modelTensors.getMlModelTensors().size());
+
+        ModelTensor tensor = modelTensors.getMlModelTensors().get(0);
+        assertEquals(AgentTokenTracker.TOKEN_USAGE, tensor.getName());
+        assertNotNull(tensor.getDataAsMap());
+        assertTrue(tensor.getDataAsMap().containsKey(AgentTokenTracker.PER_MODEL_USAGE));
+        assertTrue(tensor.getDataAsMap().containsKey(AgentTokenTracker.PER_TURN_USAGE));
+    }
+
+    @Test
+    public void testAddTokenUsageTensor_logsPerModelUsage() {
+        List<ModelTensors> tensors = new ArrayList<>();
+        AgentTokenTracker tracker = new AgentTokenTracker();
+        tracker.setModelMetadata("model-1", "https://example.com", "test-model");
+        tracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(200L).outputTokens(100L).totalTokens(300L).build()
+            );
+
+        // Should not throw even with null tenantId
+        AgentUtils.addTokenUsageTensor(tensors, tracker, null);
+        assertEquals(1, tensors.size());
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerTest.java
@@ -169,6 +169,7 @@ public class MLChatAgentRunnerTest {
             return null;
         }).when(conversationIndexMemory).update(any(), any(), any());
 
+        // Pass null for sdkClient in tests - the null check in runReAct will skip model resolution
         mlChatAgentRunner = new MLChatAgentRunner(client, settings, clusterService, xContentRegistry, toolFactories, memoryMap, null, null);
         when(firstToolFactory.create(Mockito.anyMap())).thenReturn(firstTool);
         when(secondToolFactory.create(Mockito.anyMap())).thenReturn(secondTool);
@@ -1495,7 +1496,7 @@ public class MLChatAgentRunnerTest {
         LLMSpec llmSpec = LLMSpec.builder().modelId("MODEL_ID").build();
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
 
-        mlChatAgentRunner.generateLLMSummary(null, llmSpec, "tenant", "question", new HashMap<>(), listener);
+        mlChatAgentRunner.generateLLMSummary(null, llmSpec, "tenant", "question", new HashMap<>(), null, null, listener);
 
         verify(listener).onFailure(any(IllegalArgumentException.class));
     }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLPlanExecuteAndReflectAgentRunnerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLPlanExecuteAndReflectAgentRunnerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -168,6 +169,8 @@ public class MLPlanExecuteAndReflectAgentRunnerTest extends MLStaticMockBase {
             return null;
         }).when(conversationIndexMemory).save(any(), any(), any(), any(), any());
 
+        // Pass null for sdkClient - the null check in setToolsAndRunAgent will skip model resolution
+        // Same pattern as MLChatAgentRunnerTest
         mlPlanExecuteAndReflectAgentRunner = new MLPlanExecuteAndReflectAgentRunner(
             client,
             settings,
@@ -175,7 +178,7 @@ public class MLPlanExecuteAndReflectAgentRunnerTest extends MLStaticMockBase {
             xContentRegistry,
             toolFactories,
             memoryMap,
-            sdkClient,
+            null,
             encryptor,
             null
         );
@@ -854,7 +857,9 @@ public class MLPlanExecuteAndReflectAgentRunnerTest extends MLStaticMockBase {
                 executorParentId,
                 finalResult,
                 input,
-                agentActionListener
+                agentActionListener,
+                null,
+                null
             );
 
         verify(agentActionListener).onResponse(objectCaptor.capture());
@@ -1054,7 +1059,7 @@ public class MLPlanExecuteAndReflectAgentRunnerTest extends MLStaticMockBase {
             assertEquals("test_executor_parent_id", response.get("executor_agent_parent_interaction_id"));
 
             mlTaskUtilsMockedStatic
-                .verify(() -> MLTaskUtils.updateMLTaskDirectly(eq(taskId), any(), eq(taskUpdates), eq(client), eq(sdkClient), any()));
+                .verify(() -> MLTaskUtils.updateMLTaskDirectly(eq(taskId), any(), eq(taskUpdates), eq(client), isNull(), any()));
         }
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/StreamingWrapperTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/StreamingWrapperTest.java
@@ -32,6 +32,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.agent.LLMSpec;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionStreamTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
@@ -187,9 +188,85 @@ public class StreamingWrapperTest {
 
     @Test
     public void testSendFinalResponseStreaming() {
-        streamingWrapper.sendFinalResponse("session1", listener, "parent1", true, null, null, "answer");
+        streamingWrapper.sendFinalResponse("session1", listener, "parent1", true, null, null, "answer", null, "tenant1");
 
         verify(listener).onResponse("Streaming completed");
+    }
+
+    @Test
+    public void testSendFinalResponseStreaming_withTokenUsage() throws Exception {
+        AgentTokenTracker tokenTracker = new AgentTokenTracker();
+        tokenTracker.setModelMetadata("model-1", "https://bedrock.amazonaws.com", "claude-v3");
+        tokenTracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        streamingWrapper.sendFinalResponse("session1", listener, "parent1", true, null, null, "answer", tokenTracker, "tenant1");
+
+        // Verify two batches sent: token usage chunk + completion chunk
+        ArgumentCaptor<MLTaskResponse> responseCaptor = ArgumentCaptor.forClass(MLTaskResponse.class);
+        verify(channel, org.mockito.Mockito.atLeast(2)).sendResponseBatch(responseCaptor.capture());
+
+        // First batch should be the token usage
+        MLTaskResponse tokenResponse = responseCaptor.getAllValues().get(0);
+        ModelTensorOutput tokenOutput = (ModelTensorOutput) tokenResponse.getOutput();
+        List<ModelTensor> tokenTensors = tokenOutput.getMlModelOutputs().get(0).getMlModelTensors();
+
+        // Should contain memory_id, parent_interaction_id, and token_usage tensor with structured data
+        boolean foundTokenUsage = false;
+        for (ModelTensor tensor : tokenTensors) {
+            if (AgentTokenTracker.TOKEN_USAGE.equals(tensor.getName()) && tensor.getDataAsMap() != null) {
+                foundTokenUsage = true;
+                Map<String, ?> dataMap = tensor.getDataAsMap();
+                assertTrue("Token usage should contain per_model_usage", dataMap.containsKey(AgentTokenTracker.PER_MODEL_USAGE));
+            }
+        }
+        assertTrue("Token usage chunk should be sent in streaming mode", foundTokenUsage);
+
+        verify(listener).onResponse("Streaming completed");
+    }
+
+    @Test
+    public void testSendFinalResponseNonStreaming_withTokenUsage() {
+        AgentTokenTracker tokenTracker = new AgentTokenTracker();
+        tokenTracker.setModelMetadata("model-1", "https://bedrock.amazonaws.com", "claude-v3");
+        tokenTracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        nonStreamingWrapper
+            .sendFinalResponse(
+                "session1",
+                listener,
+                "parent1",
+                false,
+                new ArrayList<>(),
+                new HashMap<>(),
+                "answer",
+                tokenTracker,
+                "tenant1"
+            );
+
+        // Non-streaming path calls returnFinalResponse which calls listener.onResponse with ModelTensorOutput
+        ArgumentCaptor<Object> responseCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(listener).onResponse(responseCaptor.capture());
+
+        ModelTensorOutput output = (ModelTensorOutput) responseCaptor.getValue();
+        // Should contain token_usage tensor
+        boolean foundTokenUsage = false;
+        for (ModelTensors modelTensors : output.getMlModelOutputs()) {
+            for (ModelTensor tensor : modelTensors.getMlModelTensors()) {
+                if (AgentTokenTracker.TOKEN_USAGE.equals(tensor.getName())) {
+                    foundTokenUsage = true;
+                    assertNotNull(tensor.getDataAsMap());
+                }
+            }
+        }
+        assertTrue("Token usage tensor should be included in non-streaming response", foundTokenUsage);
     }
 
     @Test

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/BedrockConverseDeepseekR1FunctionCallingTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/BedrockConverseDeepseekR1FunctionCallingTests.java
@@ -53,7 +53,7 @@ public class BedrockConverseDeepseekR1FunctionCallingTests {
     public void configure() {
         Map<String, String> parameters = new HashMap<>();
         functionCalling.configure(parameters);
-        Assert.assertEquals(15, parameters.size());
+        Assert.assertEquals(16, parameters.size()); // Updated for token_usage_path
         Assert.assertEquals(BEDROCK_DEEPSEEK_R1_TOOL_TEMPLATE, parameters.get("tool_template"));
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/BedrockConverseFunctionCallingTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/BedrockConverseFunctionCallingTests.java
@@ -52,7 +52,7 @@ public class BedrockConverseFunctionCallingTests {
     public void configure() {
         Map<String, String> parameters = new HashMap<>();
         functionCalling.configure(parameters);
-        Assert.assertEquals(14, parameters.size());
+        Assert.assertEquals(15, parameters.size()); // Updated for token_usage_path
         Assert.assertEquals(BEDROCK_CONVERSE_TOOL_TEMPLATE, parameters.get("tool_template"));
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/GeminiV1BetaGenerateContentFunctionCallingTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/GeminiV1BetaGenerateContentFunctionCallingTests.java
@@ -51,7 +51,7 @@ public class GeminiV1BetaGenerateContentFunctionCallingTests {
     public void configure() {
         Map<String, String> parameters = new HashMap<>();
         functionCalling.configure(parameters);
-        Assert.assertEquals(15, parameters.size());
+        Assert.assertEquals(16, parameters.size()); // Updated for token_usage_path
         Assert.assertEquals(GEMINI_TOOL_TEMPLATE, parameters.get("tool_template"));
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/OpenaiV1ChatCompletionsFunctionCallingTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/OpenaiV1ChatCompletionsFunctionCallingTests.java
@@ -58,7 +58,7 @@ public class OpenaiV1ChatCompletionsFunctionCallingTests {
     public void configure() {
         Map<String, String> parameters = new HashMap<>();
         functionCalling.configure(parameters);
-        Assert.assertEquals(16, parameters.size());
+        Assert.assertEquals(17, parameters.size()); // Updated for token_usage_path
         Assert.assertEquals(OPENAI_V1_CHAT_COMPLETION_TEMPLATE, parameters.get("tool_template"));
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
@@ -27,6 +27,7 @@ import static org.opensearch.ml.utils.TenantAwareHelper.getTenantID;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -464,17 +465,21 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
         }
 
         // Create ordered tensors
-        List<ModelTensor> orderedTensors = List
-            .of(
-                ModelTensor.builder().name("memory_id").result(memoryId).build(),
-                ModelTensor.builder().name("parent_interaction_id").result(parentInteractionId).build(),
-                ModelTensor.builder().name("response").dataAsMap(new LinkedHashMap<String, Object>() {
-                    {
-                        put("content", finalContent);
-                        put("is_last", finalIsLast);
-                    }
-                }).build()
-            );
+        List<ModelTensor> orderedTensors = new ArrayList<>();
+        orderedTensors.add(ModelTensor.builder().name("memory_id").result(memoryId).build());
+        orderedTensors.add(ModelTensor.builder().name("parent_interaction_id").result(parentInteractionId).build());
+        orderedTensors.add(ModelTensor.builder().name("response").dataAsMap(new LinkedHashMap<String, Object>() {
+            {
+                put("content", finalContent);
+                put("is_last", finalIsLast);
+            }
+        }).build());
+
+        // Pass through token_usage tensor if present (matches non-streaming format)
+        Map<String, ?> tokenUsage = extractTokenUsage(response);
+        if (tokenUsage != null) {
+            orderedTensors.add(ModelTensor.builder().name("token_usage").dataAsMap(tokenUsage).build());
+        }
 
         ModelTensors tensors = ModelTensors.builder().mlModelTensors(orderedTensors).build();
 
@@ -516,6 +521,20 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
             }
         }
         return Map.of();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, ?> extractTokenUsage(MLTaskResponse response) {
+        ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
+        if (output != null && !output.getMlModelOutputs().isEmpty()) {
+            ModelTensors tensors = output.getMlModelOutputs().get(0);
+            for (ModelTensor tensor : tensors.getMlModelTensors()) {
+                if ("token_usage".equals(tensor.getName()) && tensor.getDataAsMap() != null) {
+                    return tensor.getDataAsMap();
+                }
+            }
+        }
+        return null;
     }
 
     private HttpChunk convertToAGUIEvent(String content, boolean isLast) {


### PR DESCRIPTION
TODO: Rebase with changes in #4645

### Description
Adds token usage tracking to the ML Commons agent framework. When an agent executes, every LLM call now records input/output/total tokens (plus cache and reasoning tokens where supported). The usage data is returned in the agent response as a `token_usage` tensor with per-model aggregation and per-turn breakdown.

TODO: Add testing Guide

### Related Issues
Resolves #4662
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
