### PR TITLE
Parallelize CI: split assemble from build to unblock docker job

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -38,6 +38,53 @@ jobs:
       - name: Spotless Check
         run: ./gradlew spotlessCheck
 
+  Assemble-ml-linux:
+    needs: [Get-Require-Approval, Get-CI-Image-Tag, spotless]
+    strategy:
+      matrix:
+        java: [21, 25]
+
+    name: Assemble MLCommons Plugin on linux
+    if: github.repository == 'opensearch-project/ml-commons'
+    environment: ${{ needs.Get-Require-Approval.outputs.is-require-approval }}
+    outputs:
+      plugin-name: ${{ steps.step-assemble.outputs.plugin-name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
+
+    steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Checkout MLCommons
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Assemble
+        id: step-assemble
+        run: |
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c 'whoami && java -version &&
+                               echo "Assembling plugin" && ./gradlew assemble "-Pcrypto.standard=FIPS-140-3" -x spotlessJava &&
+                               echo "Publish to Maven Local" && ./gradlew publishToMavenLocal "-Pcrypto.standard=FIPS-140-3" -x spotlessJava'
+          plugin=`basename $(ls plugin/build/distributions/*.zip)`
+          echo $plugin
+          mv -v plugin/build/distributions/$plugin ./
+          echo "plugin-name=$plugin" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ml-plugin-linux-${{ matrix.java }}
+          path: ${{ steps.step-assemble.outputs.plugin-name }}
+          if-no-files-found: error
+
   Build-ml-linux:
     needs: [Get-Require-Approval, Get-CI-Image-Tag, spotless]
     strategy:
@@ -47,8 +94,6 @@ jobs:
     name: Build and Test MLCommons Plugin on linux
     if: github.repository == 'opensearch-project/ml-commons'
     environment: ${{ needs.Get-Require-Approval.outputs.is-require-approval }}
-    outputs:
-      build-test-linux: ${{ steps.step-build-test-linux.outputs.build-test-linux }}
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
@@ -75,21 +120,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           
       - name: Build and Run Tests
-        id: step-build-test-linux
         run: |
           chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c 'whoami && java -version && 
+          su `id -un 1000` -c 'whoami && java -version &&
                                export OPENAI_KEY=`aws secretsmanager get-secret-value --secret-id github_openai_key --query SecretString --output text` &&
                                export COHERE_KEY=`aws secretsmanager get-secret-value --secret-id github_cohere_key --query SecretString --output text` &&
                                echo "::add-mask::$OPENAI_KEY" &&
                                echo "::add-mask::$COHERE_KEY" &&
                                echo "build and run tests" && ./gradlew build "-Pcrypto.standard=FIPS-140-3" -x spotlessJava &&
-                               echo "Publish to Maven Local" && ./gradlew publishToMavenLocal "-Pcrypto.standard=FIPS-140-3" -x spotlessJava &&
                                echo "Multi Nodes Integration Testing" && ./gradlew integTest -PnumNodes=3 "-Pcrypto.standard=FIPS-140-3" -x spotlessJava'
-          plugin=`basename $(ls plugin/build/distributions/*.zip)`
-          echo $plugin
-          mv -v plugin/build/distributions/$plugin ./
-          echo "build-test-linux=$plugin" >> $GITHUB_OUTPUT
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v3
@@ -97,15 +136,8 @@ jobs:
           flags: ml-commons
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ml-plugin-linux-${{ matrix.java }}
-          path: ${{ steps.step-build-test-linux.outputs.build-test-linux }}
-          if-no-files-found: error
-
-
   Test-ml-linux-docker:
-    needs: [Get-Require-Approval, Build-ml-linux, spotless]
+    needs: [Get-Require-Approval, Assemble-ml-linux, spotless]
     strategy:
       matrix:
         java: [21, 25]
@@ -137,7 +169,7 @@ jobs:
 
       - name: Pull and Run Docker
         run: |
-          plugin=${{ needs.Build-ml-linux.outputs.build-test-linux }}
+          plugin=${{ needs.Assemble-ml-linux.outputs.plugin-name }}
           version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-3`
           plugin_version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-4`
           qualifier=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-1`


### PR DESCRIPTION
### Description
Extracts plugin assembly into a dedicated Assemble-ml-linux job so Test-ml-linux-docker can start as soon as the zip is ready, instead of waiting for the full Build-ml-linux test suite to complete.

### Related Issues
Resolves #4674
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
