### PR TITLE
Agent Token Usage Tracking

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/agent/TokenUsage.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/TokenUsage.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Getter;
+
+/**
+ * Represents token usage information from LLM API calls.
+ * Supports multiple providers (OpenAI, Anthropic Claude, Bedrock, Gemini) including
+ * cache tokens and reasoning tokens.
+ */
+@Getter
+public class TokenUsage {
+
+    // Field name constants
+    public static final String INPUT_TOKENS = "input_tokens";
+    public static final String OUTPUT_TOKENS = "output_tokens";
+    public static final String TOTAL_TOKENS = "total_tokens";
+    public static final String CACHE_READ_INPUT_TOKENS = "cache_read_input_tokens";
+    public static final String CACHE_CREATION_INPUT_TOKENS = "cache_creation_input_tokens";
+    public static final String REASONING_TOKENS = "reasoning_tokens";
+
+    // Core token counts (all providers)
+    private final Long inputTokens;           // prompt tokens
+    private final Long outputTokens;          // completion/candidate tokens
+    private final Long totalTokens;           // sum (computed if not provided)
+
+    // Cache tokens (Anthropic, OpenAI, Gemini)
+    private final Long cacheReadInputTokens;     // tokens served from cache
+    private final Long cacheCreationInputTokens; // tokens used to create cache
+
+    // Extended tokens
+    private final Long reasoningTokens;          // thinking tokens (OpenAI o1, Gemini)
+
+    // Provider-specific additional fields
+    private final Map<String, Long> additionalUsage;
+
+    /**
+     * Constructor for builder pattern
+     */
+    @lombok.Builder
+    public TokenUsage(
+        Long inputTokens,
+        Long outputTokens,
+        Long totalTokens,
+        Long cacheReadInputTokens,
+        Long cacheCreationInputTokens,
+        Long reasoningTokens,
+        Map<String, Long> additionalUsage
+    ) {
+        this.inputTokens = inputTokens;
+        this.outputTokens = outputTokens;
+        this.totalTokens = totalTokens;
+        this.cacheReadInputTokens = cacheReadInputTokens;
+        this.cacheCreationInputTokens = cacheCreationInputTokens;
+        this.reasoningTokens = reasoningTokens;
+        this.additionalUsage = additionalUsage != null ? additionalUsage : new HashMap<>();
+    }
+
+    /**
+     * Adds tokens from another TokenUsage instance to this one.
+     * Used for aggregating usage across multiple API calls.
+     *
+     * @param other The TokenUsage to add
+     * @return A new TokenUsage with aggregated values
+     */
+    public TokenUsage addTokens(TokenUsage other) {
+        if (other == null) {
+            return this;
+        }
+
+        Map<String, Long> mergedAdditional = new HashMap<>(this.additionalUsage);
+        if (other.additionalUsage != null) {
+            other.additionalUsage.forEach((key, value) -> mergedAdditional.merge(key, value, Long::sum));
+        }
+
+        return TokenUsage
+            .builder()
+            .inputTokens(addNullable(this.inputTokens, other.inputTokens))
+            .outputTokens(addNullable(this.outputTokens, other.outputTokens))
+            .totalTokens(addNullable(this.totalTokens, other.totalTokens))
+            .cacheReadInputTokens(addNullable(this.cacheReadInputTokens, other.cacheReadInputTokens))
+            .cacheCreationInputTokens(addNullable(this.cacheCreationInputTokens, other.cacheCreationInputTokens))
+            .reasoningTokens(addNullable(this.reasoningTokens, other.reasoningTokens))
+            .additionalUsage(mergedAdditional)
+            .build();
+    }
+
+    /**
+     * Converts TokenUsage to a Map suitable for JSON serialization in agent responses
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        if (inputTokens != null) {
+            map.put(INPUT_TOKENS, inputTokens);
+        }
+        if (outputTokens != null) {
+            map.put(OUTPUT_TOKENS, outputTokens);
+        }
+        if (totalTokens != null) {
+            map.put(TOTAL_TOKENS, totalTokens);
+        }
+        if (cacheReadInputTokens != null) {
+            map.put(CACHE_READ_INPUT_TOKENS, cacheReadInputTokens);
+        }
+        if (cacheCreationInputTokens != null) {
+            map.put(CACHE_CREATION_INPUT_TOKENS, cacheCreationInputTokens);
+        }
+        if (reasoningTokens != null) {
+            map.put(REASONING_TOKENS, reasoningTokens);
+        }
+        if (additionalUsage != null && !additionalUsage.isEmpty()) {
+            map.putAll(additionalUsage);
+        }
+        return map;
+    }
+
+    /**
+     * Computes total tokens if not provided by summing input and output tokens
+     */
+    public Long getEffectiveTotalTokens() {
+        if (totalTokens != null) {
+            return totalTokens;
+        }
+        if (inputTokens != null && outputTokens != null) {
+            return inputTokens + outputTokens;
+        }
+        return null;
+    }
+
+    private static Long addNullable(Long a, Long b) {
+        return a == null ? b : b == null ? a : Long.valueOf(a + b);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/agui/CustomEvent.java
+++ b/common/src/main/java/org/opensearch/ml/common/agui/CustomEvent.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agui;
+
+import java.io.IOException;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class CustomEvent extends BaseEvent {
+
+    public static final String TYPE = "Custom";
+
+    private String name;
+    private Object value;
+
+    public CustomEvent(String name, Object value) {
+        super(TYPE, System.currentTimeMillis(), null);
+        this.name = name;
+        this.value = value;
+    }
+
+    public CustomEvent(StreamInput input) throws IOException {
+        super(input);
+        this.name = input.readString();
+        if (input.readBoolean()) {
+            this.value = input.readGenericValue();
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(name);
+        if (value != null) {
+            out.writeBoolean(true);
+            out.writeGenericValue(value);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    @Override
+    protected void addEventSpecificFields(XContentBuilder builder, Params params) throws IOException {
+        builder.field("name", name);
+        if (value != null) {
+            builder.field("value", value);
+        }
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/agent/TokenUsageTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/TokenUsageTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agent;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class TokenUsageTest {
+
+    @Test
+    public void testBuilder() {
+        TokenUsage usage = TokenUsage
+            .builder()
+            .inputTokens(100L)
+            .outputTokens(50L)
+            .totalTokens(150L)
+            .cacheReadInputTokens(20L)
+            .cacheCreationInputTokens(10L)
+            .reasoningTokens(5L)
+            .build();
+
+        assertEquals(Long.valueOf(100L), usage.getInputTokens());
+        assertEquals(Long.valueOf(50L), usage.getOutputTokens());
+        assertEquals(Long.valueOf(150L), usage.getTotalTokens());
+        assertEquals(Long.valueOf(20L), usage.getCacheReadInputTokens());
+        assertEquals(Long.valueOf(10L), usage.getCacheCreationInputTokens());
+        assertEquals(Long.valueOf(5L), usage.getReasoningTokens());
+    }
+
+    @Test
+    public void testBuilderWithNullValues() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).build();
+
+        assertEquals(Long.valueOf(100L), usage.getInputTokens());
+        assertEquals(Long.valueOf(50L), usage.getOutputTokens());
+        assertNull(usage.getTotalTokens());
+        assertNull(usage.getCacheReadInputTokens());
+        assertNull(usage.getCacheCreationInputTokens());
+        assertNull(usage.getReasoningTokens());
+    }
+
+    @Test
+    public void testAddTokens() {
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(200L).outputTokens(75L).totalTokens(275L).build();
+
+        TokenUsage combined = usage1.addTokens(usage2);
+
+        assertEquals(Long.valueOf(300L), combined.getInputTokens());
+        assertEquals(Long.valueOf(125L), combined.getOutputTokens());
+        assertEquals(Long.valueOf(425L), combined.getTotalTokens());
+    }
+
+    @Test
+    public void testAddTokensWithNulls() {
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).build();
+
+        TokenUsage usage2 = TokenUsage.builder().outputTokens(50L).build();
+
+        TokenUsage combined = usage1.addTokens(usage2);
+
+        assertEquals(Long.valueOf(100L), combined.getInputTokens());
+        assertEquals(Long.valueOf(50L), combined.getOutputTokens());
+        assertNull(combined.getTotalTokens());
+    }
+
+    @Test
+    public void testAddTokensWithNull() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).build();
+
+        TokenUsage result = usage.addTokens(null);
+
+        assertSame(usage, result);
+    }
+
+    @Test
+    public void testAddTokensWithAdditionalUsage() {
+        Map<String, Long> additional1 = new HashMap<>();
+        additional1.put("audio_tokens", 10L);
+
+        Map<String, Long> additional2 = new HashMap<>();
+        additional2.put("audio_tokens", 5L);
+        additional2.put("video_tokens", 20L);
+
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).additionalUsage(additional1).build();
+
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(50L).additionalUsage(additional2).build();
+
+        TokenUsage combined = usage1.addTokens(usage2);
+
+        assertEquals(Long.valueOf(150L), combined.getInputTokens());
+        assertEquals(Long.valueOf(15L), combined.getAdditionalUsage().get("audio_tokens"));
+        assertEquals(Long.valueOf(20L), combined.getAdditionalUsage().get("video_tokens"));
+    }
+
+    @Test
+    public void testGetEffectiveTotalTokens() {
+        // Test when totalTokens is provided
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+        assertEquals(Long.valueOf(150L), usage1.getEffectiveTotalTokens());
+
+        // Test when totalTokens is computed
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).build();
+        assertEquals(Long.valueOf(150L), usage2.getEffectiveTotalTokens());
+
+        // Test when input or output is missing
+        TokenUsage usage3 = TokenUsage.builder().inputTokens(100L).build();
+        assertNull(usage3.getEffectiveTotalTokens());
+    }
+
+    @Test
+    public void testToMap() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).cacheReadInputTokens(20L).build();
+
+        Map<String, Object> map = usage.toMap();
+
+        assertEquals(100L, map.get("input_tokens"));
+        assertEquals(50L, map.get("output_tokens"));
+        assertEquals(150L, map.get("total_tokens"));
+        assertEquals(20L, map.get("cache_read_input_tokens"));
+        assertFalse(map.containsKey("cache_creation_input_tokens"));
+        assertFalse(map.containsKey("reasoning_tokens"));
+    }
+
+    @Test
+    public void testToMap_allFieldsPopulated() {
+        Map<String, Long> additional = new HashMap<>();
+        additional.put("audio_tokens", 10L);
+
+        TokenUsage usage = TokenUsage
+            .builder()
+            .inputTokens(100L)
+            .outputTokens(50L)
+            .totalTokens(150L)
+            .cacheReadInputTokens(20L)
+            .cacheCreationInputTokens(15L)
+            .reasoningTokens(30L)
+            .additionalUsage(additional)
+            .build();
+
+        Map<String, Object> map = usage.toMap();
+
+        assertEquals(100L, map.get("input_tokens"));
+        assertEquals(50L, map.get("output_tokens"));
+        assertEquals(150L, map.get("total_tokens"));
+        assertEquals(20L, map.get("cache_read_input_tokens"));
+        assertEquals(15L, map.get("cache_creation_input_tokens"));
+        assertEquals(30L, map.get("reasoning_tokens"));
+        assertEquals(10L, map.get("audio_tokens"));
+    }
+
+    @Test
+    public void testToMap_emptyUsage() {
+        TokenUsage usage = TokenUsage.builder().build();
+
+        Map<String, Object> map = usage.toMap();
+
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void testAddTokens_withCacheAndReasoningTokens() {
+        TokenUsage usage1 = TokenUsage
+            .builder()
+            .inputTokens(100L)
+            .outputTokens(50L)
+            .cacheReadInputTokens(10L)
+            .cacheCreationInputTokens(5L)
+            .reasoningTokens(20L)
+            .build();
+
+        TokenUsage usage2 = TokenUsage
+            .builder()
+            .inputTokens(200L)
+            .outputTokens(75L)
+            .cacheReadInputTokens(15L)
+            .cacheCreationInputTokens(8L)
+            .reasoningTokens(30L)
+            .build();
+
+        TokenUsage combined = usage1.addTokens(usage2);
+
+        assertEquals(Long.valueOf(300L), combined.getInputTokens());
+        assertEquals(Long.valueOf(125L), combined.getOutputTokens());
+        assertEquals(Long.valueOf(25L), combined.getCacheReadInputTokens());
+        assertEquals(Long.valueOf(13L), combined.getCacheCreationInputTokens());
+        assertEquals(Long.valueOf(50L), combined.getReasoningTokens());
+    }
+
+    @Test
+    public void testAddTokens_oneSideNull() {
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).cacheReadInputTokens(10L).reasoningTokens(20L).build();
+
+        TokenUsage usage2 = TokenUsage.builder().outputTokens(50L).build();
+
+        TokenUsage combined = usage1.addTokens(usage2);
+
+        assertEquals(Long.valueOf(100L), combined.getInputTokens());
+        assertEquals(Long.valueOf(50L), combined.getOutputTokens());
+        assertEquals(Long.valueOf(10L), combined.getCacheReadInputTokens());
+        assertNull(combined.getCacheCreationInputTokens());
+        assertEquals(Long.valueOf(20L), combined.getReasoningTokens());
+    }
+
+    @Test
+    public void testAddTokens_additionalUsageOnlyOnOneSide() {
+        Map<String, Long> additional = new HashMap<>();
+        additional.put("audio_tokens", 10L);
+
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).additionalUsage(additional).build();
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(50L).build();
+
+        TokenUsage combined = usage1.addTokens(usage2);
+
+        assertEquals(Long.valueOf(150L), combined.getInputTokens());
+        assertEquals(Long.valueOf(10L), combined.getAdditionalUsage().get("audio_tokens"));
+    }
+
+    @Test
+    public void testGetEffectiveTotalTokens_onlyOutputTokens() {
+        TokenUsage usage = TokenUsage.builder().outputTokens(50L).build();
+        assertNull(usage.getEffectiveTotalTokens());
+    }
+
+    @Test
+    public void testAdditionalUsage_defaultsToEmptyMap() {
+        TokenUsage usage = TokenUsage.builder().build();
+        assertNotNull(usage.getAdditionalUsage());
+        assertTrue(usage.getAdditionalUsage().isEmpty());
+    }
+
+}

--- a/common/src/test/java/org/opensearch/ml/common/agui/AGUIEventTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agui/AGUIEventTest.java
@@ -360,6 +360,67 @@ public class AGUIEventTest {
     }
 
     @Test
+    public void testCustomEvent_Constructor() {
+        Map<String, Object> value = new HashMap<>();
+        value.put("input_tokens", 100);
+        value.put("output_tokens", 50);
+
+        CustomEvent event = new CustomEvent("token_usage", value);
+
+        assertEquals(CustomEvent.TYPE, event.getType());
+        assertEquals("token_usage", event.getName());
+        assertNotNull(event.getValue());
+        assertNotNull(event.getTimestamp());
+    }
+
+    @Test
+    public void testCustomEvent_NullValue() {
+        CustomEvent event = new CustomEvent("token_usage", null);
+
+        assertEquals(CustomEvent.TYPE, event.getType());
+        assertEquals("token_usage", event.getName());
+        assertEquals(null, event.getValue());
+    }
+
+    @Test
+    public void testCustomEvent_ToJsonString() {
+        Map<String, Object> value = new HashMap<>();
+        value.put("input_tokens", 100);
+        value.put("output_tokens", 50);
+
+        CustomEvent event = new CustomEvent("token_usage", value);
+        String json = event.toJsonString();
+
+        assertNotNull(json);
+        assertTrue(json.contains("Custom"));
+        assertTrue(json.contains("token_usage"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCustomEvent_Serialization() throws IOException {
+        Map<String, Object> value = new HashMap<>();
+        value.put("input_tokens", 100);
+        value.put("output_tokens", 50);
+
+        CustomEvent original = new CustomEvent("token_usage", value);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        CustomEvent deserialized = new CustomEvent(input);
+
+        assertEquals(original.getType(), deserialized.getType());
+        assertEquals(original.getName(), deserialized.getName());
+        assertNotNull(deserialized.getValue());
+        assertEquals(
+            ((Map<String, Object>) original.getValue()).get("input_tokens"),
+            ((Map<String, Object>) deserialized.getValue()).get("input_tokens")
+        );
+    }
+
+    @Test
     public void testMessagesSnapshotEvent_Constructor() {
         List<Object> messages = new ArrayList<>();
         Map<String, String> message1 = new HashMap<>();

--- a/common/src/test/java/org/opensearch/ml/common/agui/CustomEventTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agui/CustomEventTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agui;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+public class CustomEventTest {
+
+    @Test
+    public void testConstructor_setsTypeAndFields() {
+        Map<String, Object> value = new HashMap<>();
+        value.put("inputTokens", 100);
+        value.put("outputTokens", 50);
+        value.put("totalTokens", 150);
+
+        CustomEvent event = new CustomEvent("token_usage", value);
+
+        assertEquals(CustomEvent.TYPE, event.getType());
+        assertEquals("Custom", event.getType());
+        assertEquals("token_usage", event.getName());
+        assertNotNull(event.getValue());
+        assertNotNull(event.getTimestamp());
+    }
+
+    @Test
+    public void testConstructor_nullValue() {
+        CustomEvent event = new CustomEvent("token_usage", null);
+
+        assertEquals(CustomEvent.TYPE, event.getType());
+        assertEquals("token_usage", event.getName());
+        assertNull(event.getValue());
+        assertNotNull(event.getTimestamp());
+    }
+
+    @Test
+    public void testConstructor_timestampIsRecent() {
+        long before = System.currentTimeMillis();
+        CustomEvent event = new CustomEvent("token_usage", null);
+        long after = System.currentTimeMillis();
+
+        assertTrue(event.getTimestamp() >= before);
+        assertTrue(event.getTimestamp() <= after);
+    }
+
+    @Test
+    public void testToJsonString_containsRequiredFields() {
+        Map<String, Object> value = new HashMap<>();
+        value.put("inputTokens", 100);
+        value.put("outputTokens", 50);
+
+        CustomEvent event = new CustomEvent("token_usage", value);
+        String json = event.toJsonString();
+
+        assertNotNull(json);
+        assertTrue(json.contains("\"type\""));
+        assertTrue(json.contains("Custom"));
+        assertTrue(json.contains("\"name\""));
+        assertTrue(json.contains("token_usage"));
+        assertTrue(json.contains("\"value\""));
+        assertTrue(json.contains("inputTokens"));
+        assertTrue(json.contains("100"));
+    }
+
+    @Test
+    public void testToJsonString_nullValueOmitted() {
+        CustomEvent event = new CustomEvent("token_usage", null);
+        String json = event.toJsonString();
+
+        assertNotNull(json);
+        assertTrue(json.contains("Custom"));
+        assertTrue(json.contains("token_usage"));
+        // value field should not appear when null
+        assertTrue(!json.contains("\"value\""));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSerialization_roundTrip() throws IOException {
+        Map<String, Object> value = new HashMap<>();
+        value.put("inputTokens", 100);
+        value.put("outputTokens", 50);
+        value.put("totalTokens", 150);
+
+        CustomEvent original = new CustomEvent("token_usage", value);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        CustomEvent deserialized = new CustomEvent(input);
+
+        assertEquals(original.getType(), deserialized.getType());
+        assertEquals(original.getName(), deserialized.getName());
+        assertEquals(original.getTimestamp(), deserialized.getTimestamp());
+        assertNotNull(deserialized.getValue());
+
+        Map<String, Object> deserializedValue = (Map<String, Object>) deserialized.getValue();
+        assertEquals(((Map<String, Object>) original.getValue()).get("inputTokens"), deserializedValue.get("inputTokens"));
+        assertEquals(((Map<String, Object>) original.getValue()).get("outputTokens"), deserializedValue.get("outputTokens"));
+        assertEquals(((Map<String, Object>) original.getValue()).get("totalTokens"), deserializedValue.get("totalTokens"));
+    }
+
+    @Test
+    public void testSerialization_nullValueRoundTrip() throws IOException {
+        CustomEvent original = new CustomEvent("token_usage", null);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        CustomEvent deserialized = new CustomEvent(input);
+
+        assertEquals(original.getType(), deserialized.getType());
+        assertEquals(original.getName(), deserialized.getName());
+        assertNull(deserialized.getValue());
+    }
+
+    @Test
+    public void testSerialization_customNameRoundTrip() throws IOException {
+        CustomEvent original = new CustomEvent("my_custom_event", Map.of("key", "val"));
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput streamInput = output.bytes().streamInput();
+        CustomEvent deserialized = new CustomEvent(streamInput);
+
+        assertEquals("my_custom_event", deserialized.getName());
+        assertEquals(CustomEvent.TYPE, deserialized.getType());
+    }
+
+    @Test
+    public void testNoArgsConstructor() {
+        CustomEvent event = new CustomEvent();
+
+        assertNull(event.getName());
+        assertNull(event.getValue());
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentTokenTracker.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentTokenTracker.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.agent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.ml.common.agent.TokenUsage;
+
+/**
+ * Tracks token usage across multiple LLM calls during agent execution.
+ * Maintains both per-turn usage (each individual LLM call) and per-model
+ * aggregated usage (total across all calls to each model).
+ */
+public class AgentTokenTracker {
+
+    // Field name constants
+    public static final String TOKEN_USAGE = "token_usage";
+    public static final String PER_MODEL_USAGE = "per_model_usage";
+    public static final String PER_TURN_USAGE = "per_turn_usage";
+    public static final String MODEL_NAME = "model_name";
+    public static final String MODEL_URL = "model_url";
+    public static final String MODEL_ID = "model_id";
+    public static final String CALL_COUNT = "call_count";
+    public static final String TURN = "turn";
+    public static final String IS_SUB_AGENT_FIELD = "_is_sub_agent";
+
+    // Track each individual LLM call
+    private final List<Map<String, Object>> perTurnUsage;
+
+    // Aggregated by model ID
+    private final Map<String, ModelUsageAggregation> perModelUsage;
+
+    // Model metadata: modelId -> {modelUrl, modelName}
+    private final Map<String, ModelMetadata> modelMetadataMap;
+
+    // Current turn counter
+    private int turnCounter;
+
+    // Whether this tracker belongs to a sub-agent (e.g., ReAct executor inside PER).
+    // When true, token usage logging is suppressed to avoid double-logging —
+    // the parent agent logs the merged totals instead.
+    private boolean subAgent;
+
+    public AgentTokenTracker() {
+        this.perTurnUsage = new ArrayList<>();
+        this.perModelUsage = new HashMap<>();
+        this.modelMetadataMap = new HashMap<>();
+        this.turnCounter = 0;
+        this.subAgent = false;
+    }
+
+    public boolean isSubAgent() {
+        return subAgent;
+    }
+
+    public void setSubAgent(boolean subAgent) {
+        this.subAgent = subAgent;
+    }
+
+    /**
+     * Sets model metadata for enriching token usage data.
+     * Should be called when model details are resolved.
+     *
+     * @param modelId The model ID
+     * @param modelUrl The resolved model URL
+     * @param modelName The model name (can be same as modelId or modelUrl)
+     */
+    public void setModelMetadata(String modelId, String modelUrl, String modelName) {
+        if (modelId != null) {
+            modelMetadataMap.put(modelId, new ModelMetadata(modelUrl, modelName));
+        }
+    }
+
+    /**
+     * Records token usage for a single LLM call
+     *
+     * @param modelId The model ID
+     * @param usage The token usage from the LLM response
+     */
+    public void recordTurn(String modelId, TokenUsage usage) {
+        if (modelId == null || usage == null) {
+            return;
+        }
+
+        turnCounter++;
+
+        // Get model metadata (or use defaults if not set)
+        ModelMetadata modelMetadata = modelMetadataMap.getOrDefault(modelId, new ModelMetadata(modelId, modelId));
+
+        // Add to per-turn list
+        Map<String, Object> turnData = new HashMap<>();
+        turnData.put(TURN, turnCounter);
+        turnData.put(MODEL_NAME, modelMetadata.getModelName());
+        turnData.put(MODEL_URL, modelMetadata.getModelUrl());
+        turnData.put(MODEL_ID, modelId);
+        turnData.putAll(usage.toMap());
+        perTurnUsage.add(turnData);
+
+        // Update per-model aggregation (keyed by model ID)
+        perModelUsage.computeIfAbsent(modelId, k -> new ModelUsageAggregation(modelMetadata)).addUsage(usage);
+    }
+
+    /**
+     * Returns the complete token usage data structure for inclusion in agent response
+     *
+     * @return Map with "per_model_usage" and "per_turn_usage" keys
+     */
+    public Map<String, Object> toOutputMap() {
+        Map<String, Object> output = new HashMap<>();
+
+        // Build per_model_usage list
+        List<Map<String, Object>> perModelList = new ArrayList<>();
+        for (Map.Entry<String, ModelUsageAggregation> entry : perModelUsage.entrySet()) {
+            Map<String, Object> modelData = new HashMap<>();
+            ModelMetadata modelMetadata = entry.getValue().getMetadata();
+            modelData.put(MODEL_NAME, modelMetadata.getModelName());
+            modelData.put(MODEL_URL, modelMetadata.getModelUrl());
+            modelData.put(MODEL_ID, entry.getKey());
+            modelData.putAll(entry.getValue().getAggregatedUsage().toMap());
+            modelData.put(CALL_COUNT, entry.getValue().getCallCount());
+            perModelList.add(modelData);
+        }
+
+        output.put(PER_MODEL_USAGE, perModelList);
+        output.put(PER_TURN_USAGE, perTurnUsage);
+
+        return output;
+    }
+
+    /**
+     * Merges pre-aggregated token usage data from a sub-agent response.
+     * The sub-agent (e.g., Chat/ReAct executor) has already tracked its own tokens
+     * and returns them as aggregated per_turn_usage and per_model_usage.
+     *
+     * @param tokenUsageMap the token_usage dataAsMap from the sub-agent response tensor
+     */
+    @SuppressWarnings("unchecked")
+    public void mergeSubAgentUsage(Map<String, Object> tokenUsageMap) {
+        if (tokenUsageMap == null) {
+            return;
+        }
+
+        // Merge per-turn usage: re-number turns sequentially
+        Object perTurnObj = tokenUsageMap.get(PER_TURN_USAGE);
+        if (perTurnObj instanceof List) {
+            List<Map<String, Object>> subTurns = (List<Map<String, Object>>) perTurnObj;
+            for (Map<String, Object> subTurn : subTurns) {
+                turnCounter++;
+                Map<String, Object> mergedTurn = new HashMap<>(subTurn);
+                mergedTurn.put(TURN, turnCounter);
+                perTurnUsage.add(mergedTurn);
+            }
+        }
+
+        // Merge per-model usage: aggregate into existing model data
+        Object perModelObj = tokenUsageMap.get(PER_MODEL_USAGE);
+        if (perModelObj instanceof List) {
+            List<Map<String, Object>> subModels = (List<Map<String, Object>>) perModelObj;
+            for (Map<String, Object> subModel : subModels) {
+                String modelId = (String) subModel.get(MODEL_ID);
+                if (modelId == null) {
+                    continue;
+                }
+
+                String modelUrl = (String) subModel.getOrDefault(MODEL_URL, modelId);
+                String modelName = (String) subModel.getOrDefault(MODEL_NAME, modelId);
+
+                TokenUsage subUsage = TokenUsage
+                    .builder()
+                    .inputTokens(getLongFromMap(subModel, TokenUsage.INPUT_TOKENS))
+                    .outputTokens(getLongFromMap(subModel, TokenUsage.OUTPUT_TOKENS))
+                    .totalTokens(getLongFromMap(subModel, TokenUsage.TOTAL_TOKENS))
+                    .cacheReadInputTokens(getLongFromMap(subModel, TokenUsage.CACHE_READ_INPUT_TOKENS))
+                    .cacheCreationInputTokens(getLongFromMap(subModel, TokenUsage.CACHE_CREATION_INPUT_TOKENS))
+                    .reasoningTokens(getLongFromMap(subModel, TokenUsage.REASONING_TOKENS))
+                    .build();
+
+                int subCallCount = subModel.containsKey(CALL_COUNT) ? ((Number) subModel.get(CALL_COUNT)).intValue() : 1;
+
+                if (!modelMetadataMap.containsKey(modelId)) {
+                    modelMetadataMap.put(modelId, new ModelMetadata(modelUrl, modelName));
+                }
+
+                ModelMetadata modelMetadata = modelMetadataMap.getOrDefault(modelId, new ModelMetadata(modelUrl, modelName));
+                perModelUsage
+                    .computeIfAbsent(modelId, k -> new ModelUsageAggregation(modelMetadata))
+                    .mergeAggregated(subUsage, subCallCount);
+            }
+        }
+    }
+
+    private static Long getLongFromMap(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        return null;
+    }
+
+    /**
+     * Checks if any token usage has been recorded
+     *
+     * @return true if at least one turn has been recorded
+     */
+    public boolean hasUsage() {
+        return !perTurnUsage.isEmpty();
+    }
+
+    /**
+     * Internal class to track aggregated usage for a specific model
+     */
+    private static class ModelUsageAggregation {
+        private TokenUsage aggregatedUsage;
+        private int callCount;
+        private ModelMetadata modelMetadata;
+
+        public ModelUsageAggregation(ModelMetadata modelMetadata) {
+            this.aggregatedUsage = TokenUsage.builder().build();
+            this.callCount = 0;
+            this.modelMetadata = modelMetadata;
+        }
+
+        public void addUsage(TokenUsage usage) {
+            this.aggregatedUsage = this.aggregatedUsage.addTokens(usage);
+            this.callCount++;
+        }
+
+        public void mergeAggregated(TokenUsage aggregatedUsage, int callCount) {
+            this.aggregatedUsage = this.aggregatedUsage.addTokens(aggregatedUsage);
+            this.callCount += callCount;
+        }
+
+        public TokenUsage getAggregatedUsage() {
+            return aggregatedUsage;
+        }
+
+        public int getCallCount() {
+            return callCount;
+        }
+
+        public ModelMetadata getMetadata() {
+            return modelMetadata;
+        }
+    }
+
+    /**
+     * Internal class to store model metadata
+     */
+    private static class ModelMetadata {
+        private final String modelUrl;
+        private final String modelName;
+
+        public ModelMetadata(String modelUrl, String modelName) {
+            this.modelUrl = modelUrl != null ? modelUrl : "";
+            this.modelName = modelName != null ? modelName : "";
+        }
+
+        public String getModelUrl() {
+            return modelUrl;
+        }
+
+        public String getModelName() {
+            return modelName;
+        }
+    }
+}

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -10,6 +10,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.ml.common.CommonValue.MCP_CONNECTORS_FIELD;
 import static org.opensearch.ml.common.CommonValue.MCP_CONNECTOR_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.common.agent.MLMemorySpec.MEMORY_CONTAINER_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREDENTIAL_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.ENDPOINT_FIELD;
@@ -81,6 +82,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.ml.common.MLAgentType;
+import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLMemorySpec;
 import org.opensearch.ml.common.agent.MLToolSpec;
@@ -93,6 +95,7 @@ import org.opensearch.ml.common.input.execute.agent.ContentType;
 import org.opensearch.ml.common.input.execute.agent.Message;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.engine.MLEngineClassLoader;
@@ -129,6 +132,7 @@ public class AgentUtils {
     public static final String PROMPT_CHAT_HISTORY_PREFIX = "prompt.chat_history_prefix";
     public static final String DISABLE_TRACE = "disable_trace";
     public static final String VERBOSE = "verbose";
+    public static final String INCLUDE_TOKEN_USAGE = "include_token_usage";
     public static final String LLM_GEN_INPUT = "llm_generated_input";
 
     public static final String LLM_RESPONSE_EXCLUDE_PATH = "llm_response_exclude_path";
@@ -145,6 +149,7 @@ public class AgentUtils {
     public static final String TOOL_CALLS_TOOL_NAME = "tool_calls.tool_name";
     public static final String TOOL_CALLS_TOOL_INPUT = "tool_calls.tool_input";
     public static final String TOOL_CALL_ID_PATH = "tool_calls.id_path";
+    public static final String TOKEN_USAGE_PATH = "token_usage_path";
     private static final String NAME = "name";
     private static final String DESCRIPTION = "description";
     private static final Pattern ADDITIONAL_PROPERTIES_PATTERN = Pattern
@@ -1435,5 +1440,267 @@ public class AgentUtils {
             return String.valueOf(((OpenSearchException) e).status().getStatus());
         }
         return "unknown";
+    }
+
+    public static void getModel(
+        String modelId,
+        String tenantId,
+        SdkClient sdkClient,
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        ActionListener<MLModel> listener
+    ) {
+        GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest
+            .builder()
+            .index(ML_MODEL_INDEX)
+            .id(modelId)
+            .tenantId(tenantId)
+            .build();
+
+        try (ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().stashContext()) {
+            sdkClient.getDataObjectAsync(getDataObjectRequest).whenComplete((r, throwable) -> {
+                log.debug("Completed Get Model Request, id:{}", modelId);
+                ctx.restore();
+                if (throwable != null) {
+                    Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable);
+                    if (ExceptionsHelper.unwrap(cause, IndexNotFoundException.class) != null) {
+                        log.error("Failed to get model index", cause);
+                        listener.onFailure(new OpenSearchStatusException("Failed to find model", RestStatus.NOT_FOUND));
+                    } else {
+                        log.error("Failed to get ML model {}", modelId, cause);
+                        listener.onFailure(cause);
+                    }
+                } else {
+                    try {
+                        GetResponse gr = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                        if (gr != null && gr.isExists()) {
+                            try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, gr.getSourceAsBytesRef())) {
+                                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                                MLModel mlModel = MLModel.parse(parser, null);
+                                listener.onResponse(mlModel);
+                            } catch (Exception e) {
+                                log.error("Failed to parse model:{}", modelId);
+                                listener.onFailure(e);
+                            }
+                        } else {
+                            listener.onFailure(new OpenSearchStatusException("Failed to find model:" + modelId, RestStatus.NOT_FOUND));
+                        }
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Extracts a Long value from a map, handling both Number and String types
+     *
+     * @param map the map to extract from
+     * @param fieldName the field name
+     * @return Long value or null if extraction fails
+     */
+    public static Long getLongValue(Map<String, Object> map, String fieldName) {
+        Object value = map.get(fieldName);
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Long.parseLong((String) value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the model endpoint URL from an MLModel.
+     * If the model has an inline connector, uses it directly.
+     * If the model has a connector ID, fetches the connector first.
+     * Then resolves the endpoint URL using connector parameters.
+     *
+     * @param mlModel the MLModel to resolve URL from
+     * @param tenantId the tenant ID
+     * @param sdkClient the SDK client for async operations
+     * @param client the OpenSearch client for thread context
+     * @param listener the action listener to handle the resolved URL
+     */
+    public static void resolveModelUrl(
+        MLModel mlModel,
+        String tenantId,
+        SdkClient sdkClient,
+        Client client,
+        ActionListener<String> listener
+    ) {
+        // Check if model has inline connector
+        if (mlModel.getConnector() != null) {
+            try {
+                String url = extractUrlFromConnector(mlModel.getConnector());
+                listener.onResponse(url);
+            } catch (Exception e) {
+                log.debug("Failed to resolve URL from inline connector", e);
+                listener.onFailure(e);
+            }
+            return;
+        }
+
+        // Check if model has connector ID
+        if (mlModel.getConnectorId() != null) {
+            getConnector(mlModel.getConnectorId(), tenantId, sdkClient, client, ActionListener.wrap(connector -> {
+                try {
+                    String url = extractUrlFromConnector(connector);
+                    listener.onResponse(url);
+                } catch (Exception e) {
+                    log.debug("Failed to resolve URL from connector ID", e);
+                    listener.onFailure(e);
+                }
+            }, listener::onFailure));
+            return;
+        }
+
+        // No connector available
+        listener.onFailure(new IllegalStateException("Model has neither connector nor connector ID"));
+    }
+
+    /**
+     * Extracts the endpoint URL from a connector using its parameters.
+     *
+     * @param connector the connector to extract URL from
+     * @return the resolved endpoint URL
+     */
+    private static String extractUrlFromConnector(Connector connector) {
+        if (connector == null) {
+            throw new IllegalArgumentException("Connector cannot be null");
+        }
+
+        Map<String, String> parameters = connector.getParameters();
+        if (parameters == null) {
+            parameters = Map.of();
+        }
+
+        // Get the predict endpoint URL
+        String endpoint = connector.getActionEndpoint("predict", parameters);
+        if (endpoint == null || endpoint.isEmpty()) {
+            throw new IllegalStateException("Connector has no predict endpoint");
+        }
+
+        return endpoint;
+    }
+
+    /**
+     * Resolves model metadata (name and URL) for token tracking.
+     * Combines getModel + resolveModelUrl into a single call that never fails —
+     * always returns best-effort data with fallbacks.
+     *
+     * @param modelId the model ID
+     * @param tenantId the tenant ID
+     * @param sdkClient the SDK client (may be null)
+     * @param client the OpenSearch client
+     * @param xContentRegistry the content registry for parsing
+     * @param listener receives String[]{url, name} — never called with onFailure
+     */
+    public static void getModelMetadata(
+        String modelId,
+        String tenantId,
+        SdkClient sdkClient,
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        ActionListener<String[]> listener
+    ) {
+        // Primarily for test compatibility — sdkClient may be null in unit tests.
+        // TODO: Update tests to mock this
+        if (sdkClient == null) {
+            listener.onResponse(new String[] { modelId, modelId });
+            return;
+        }
+
+        getModel(modelId, tenantId, sdkClient, client, xContentRegistry, ActionListener.wrap(mlModel -> {
+            String modelName = mlModel.getName();
+            resolveModelUrl(
+                mlModel,
+                tenantId,
+                sdkClient,
+                client,
+                ActionListener.wrap(url -> { listener.onResponse(new String[] { url, modelName }); }, e -> {
+                    log.debug("Failed to resolve model URL, using model ID as fallback", e);
+                    listener.onResponse(new String[] { modelId, modelName });
+                })
+            );
+        }, e -> {
+            log.debug("Failed to fetch model for URL resolution, using model ID as fallback", e);
+            listener.onResponse(new String[] { modelId, modelId });
+        }));
+    }
+
+    /**
+     * Adds a token usage tensor to the response and logs per-model usage.
+     * Shared utility used by both MLChatAgentRunner and MLPlanExecuteAndReflectAgentRunner.
+     *
+     * @param modelTensors the response tensor list to add to
+     * @param tokenTracker the token tracker (may be null)
+     * @param tenantId the tenant ID for logging (may be null)
+     * @param includeTokenUsage whether to include the token usage tensor in the response;
+     *                          sub-agents always include the tensor regardless of this flag
+     *                          so the parent agent can merge their usage
+     */
+    public static void addTokenUsageTensor(
+        List<ModelTensors> modelTensors,
+        AgentTokenTracker tokenTracker,
+        String tenantId,
+        boolean includeTokenUsage
+    ) {
+        if (tokenTracker == null || !tokenTracker.hasUsage()) {
+            return;
+        }
+
+        Map<String, Object> tokenUsageMap = tokenTracker.toOutputMap();
+
+        // Sub-agents always include the tensor so the parent can merge their usage
+        if (includeTokenUsage || tokenTracker.isSubAgent()) {
+            modelTensors
+                .add(
+                    ModelTensors
+                        .builder()
+                        .mlModelTensors(List.of(ModelTensor.builder().name(AgentTokenTracker.TOKEN_USAGE).dataAsMap(tokenUsageMap).build()))
+                        .build()
+                );
+        }
+
+        logTokenUsageDetails(tokenTracker, tokenUsageMap, tenantId);
+    }
+
+    /**
+     * Logs structured per-model token usage for analytics/monitoring.
+     * Skips logging for sub-agents since the parent agent logs the merged totals.
+     *
+     * @param tokenTracker the token tracker
+     * @param tokenUsageMap the pre-computed output map from the tracker
+     * @param tenantId the tenant ID for logging (may be null)
+     */
+    @SuppressWarnings("unchecked")
+    public static void logTokenUsageDetails(AgentTokenTracker tokenTracker, Map<String, Object> tokenUsageMap, String tenantId) {
+        if (tokenTracker == null || tokenUsageMap == null) {
+            return;
+        }
+
+        // Skip logging for sub-agents — the parent agent logs the merged totals
+        if (tokenTracker.isSubAgent()) {
+            return;
+        }
+
+        Object perModelObj = tokenUsageMap.get(AgentTokenTracker.PER_MODEL_USAGE);
+        if (perModelObj instanceof List) {
+            List<Map<String, Object>> perModelUsage = (List<Map<String, Object>>) perModelObj;
+            long eventTime = System.currentTimeMillis();
+            for (Map<String, Object> modelUsage : perModelUsage) {
+                Map<String, Object> logEntry = new java.util.LinkedHashMap<>();
+                logEntry.put("tenantId", tenantId);
+                logEntry.put("model_usage", modelUsage);
+                logEntry.put("eventTime", eventTime);
+                log.info("{}", StringUtils.toJson(logEntry));
+            }
+        }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -77,6 +77,7 @@ import org.opensearch.ml.common.MLMemoryType;
 import org.opensearch.ml.common.agent.LLMSpec;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.contextmanager.ContextManagerContext;
 import org.opensearch.ml.common.conversation.Interaction;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
@@ -401,7 +402,7 @@ public class MLChatAgentRunner implements MLAgentRunner {
         processUnifiedTools(mlAgent, params, listener, memory, functionCalling, frontendTools);
     }
 
-    private void runReAct(
+    private void resolveModelMetadataAndRunReAct(
         MLAgent mlAgent,
         Map<String, Tool> tools,
         Map<String, MLToolSpec> toolSpecMap,
@@ -416,9 +417,72 @@ public class MLChatAgentRunner implements MLAgentRunner {
         log.info("Starting chat agent execution. agentId={}, tenantId={}", agentId, tenantId);
 
         LLMSpec llm = mlAgent.getLlm();
+        String llmModelId = llm.getModelId();
         String sessionId = memory != null ? memory.getId() : null;
         boolean usesUnifiedInterface = Boolean.parseBoolean(parameters.getOrDefault(MLAgentExecutor.USES_UNIFIED_INTERFACE, "false"));
         ModelProvider modelProvider = usesUnifiedInterface ? ModelProviderFactory.getProvider(mlAgent.getModel().getModelProvider()) : null;
+
+        // Token tracking: create tracker and resolve model metadata before starting ReAct loop.
+        AgentTokenTracker tokenTracker = new AgentTokenTracker();
+        if (Boolean.parseBoolean(parameters.getOrDefault(AgentTokenTracker.IS_SUB_AGENT_FIELD, "false"))) {
+            tokenTracker.setSubAgent(true);
+        }
+
+        // getModelMetadata always calls onResponse (falls back to modelId on failure),
+        // but we handle onFailure defensively in case the contract changes.
+        AgentUtils.getModelMetadata(llmModelId, tenantId, sdkClient, client, xContentRegistry, ActionListener.wrap(metadata -> {
+            tokenTracker.setModelMetadata(llmModelId, metadata[0], metadata[1]);
+            runReAct(
+                mlAgent,
+                tools,
+                toolSpecMap,
+                parameters,
+                memory,
+                listener,
+                functionCalling,
+                backendTools,
+                tokenTracker,
+                tenantId,
+                usesUnifiedInterface,
+                modelProvider
+            );
+        }, e -> {
+            log.debug("Failed to resolve model metadata for token tracking, proceeding with model ID as fallback", e);
+            tokenTracker.setModelMetadata(llmModelId, llmModelId, llmModelId);
+            runReAct(
+                mlAgent,
+                tools,
+                toolSpecMap,
+                parameters,
+                memory,
+                listener,
+                functionCalling,
+                backendTools,
+                tokenTracker,
+                tenantId,
+                usesUnifiedInterface,
+                modelProvider
+            );
+        }));
+    }
+
+    private void runReAct(
+        MLAgent mlAgent,
+        Map<String, Tool> tools,
+        Map<String, MLToolSpec> toolSpecMap,
+        Map<String, String> parameters,
+        Memory memory,
+        ActionListener<Object> listener,
+        FunctionCalling functionCalling,
+        Map<String, Tool> backendTools,
+        AgentTokenTracker tokenTracker,
+        String tenantId,
+        boolean usesUnifiedInterface,
+        ModelProvider modelProvider
+    ) {
+        String agentId = parameters.get(AGENT_ID_FIELD);
+        LLMSpec llm = mlAgent.getLlm();
+        String sessionId = memory != null ? memory.getId() : null;
 
         Map<String, String> tmpParameters = constructLLMParams(llm, parameters);
         String prompt = constructLLMPrompt(tools, tmpParameters);
@@ -428,6 +492,7 @@ public class MLChatAgentRunner implements MLAgentRunner {
         String question = tmpParameters.get(MLAgentExecutor.QUESTION);
         String parentInteractionId = tmpParameters.get(MLAgentExecutor.PARENT_INTERACTION_ID);
         boolean verbose = Boolean.parseBoolean(tmpParameters.getOrDefault(VERBOSE, "false"));
+        boolean includeTokenUsage = Boolean.parseBoolean(tmpParameters.getOrDefault(AgentUtils.INCLUDE_TOKEN_USAGE, "false"));
         boolean traceDisabled = usesUnifiedInterface
             || (tmpParameters.containsKey(DISABLE_TRACE) && Boolean.parseBoolean(tmpParameters.get(DISABLE_TRACE)));
 
@@ -475,6 +540,24 @@ public class MLChatAgentRunner implements MLAgentRunner {
                         functionCalling
                     );
 
+                    // Extract per-turn token usage from LLM response
+                    if (functionCalling != null) {
+                        try {
+                            Map<String, ?> dataAsMap = tmpModelTensorOutput
+                                .getMlModelOutputs()
+                                .getFirst()
+                                .getMlModelTensors()
+                                .getFirst()
+                                .getDataAsMap();
+                            TokenUsage usage = functionCalling.extractTokenUsage(dataAsMap);
+                            if (usage != null) {
+                                tokenTracker.recordTurn(llm.getModelId(), usage);
+                            }
+                        } catch (Exception e) {
+                            log.debug("Failed to extract token usage from LLM response", e);
+                        }
+                    }
+
                     streamingWrapper.fixInteractionRole(interactions);
                     String thought = String.valueOf(modelOutput.get(THOUGHT));
                     String toolCallId = String.valueOf(modelOutput.get("tool_call_id"));
@@ -499,7 +582,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
                             finalAnswer,
                             usesUnifiedInterface,
                             new ArrayList<>(interactions),
-                            modelProvider
+                            modelProvider,
+                            tokenTracker,
+                            tenantId,
+                            includeTokenUsage
                         );
                         cleanUpResource(tools);
                         return;
@@ -552,7 +638,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
                             tmpParameters,
                             usesUnifiedInterface,
                             new ArrayList<>(interactions),
-                            modelProvider
+                            modelProvider,
+                            tokenTracker,
+                            functionCalling,
+                            includeTokenUsage
                         );
                         return;
                     }
@@ -697,7 +786,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
                             tmpParameters,
                             usesUnifiedInterface,
                             new ArrayList<>(interactions),
-                            modelProvider
+                            modelProvider,
+                            tokenTracker,
+                            functionCalling,
+                            includeTokenUsage
                         );
                         return;
                     }
@@ -951,10 +1043,18 @@ public class MLChatAgentRunner implements MLAgentRunner {
         String finalAnswer,
         boolean usesUnifiedInterface,
         List<String> toolInteractions,
-        ModelProvider modelProvider
+        ModelProvider modelProvider,
+        AgentTokenTracker tokenTracker,
+        String tenantId,
+        boolean includeTokenUsage
     ) {
-        // Send completion chunk for streaming
-        streamingWrapper.sendCompletionChunk(sessionId, parentInteractionId);
+        // Token tracking: send streaming batch or add to response tensors
+        if (streamingWrapper.isStreaming()) {
+            if (includeTokenUsage) {
+                streamingWrapper.sendTokenUsageBatch(sessionId, parentInteractionId, tokenTracker, tenantId);
+            }
+            streamingWrapper.sendCompletionChunk(sessionId, parentInteractionId);
+        }
 
         if (memory != null) {
             String copyOfFinalAnswer = finalAnswer;
@@ -974,7 +1074,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
                             verbose,
                             cotModelTensors,
                             additionalInfo,
-                            copyOfFinalAnswer
+                            copyOfFinalAnswer,
+                            tokenTracker,
+                            tenantId,
+                            includeTokenUsage
                         );
                     }, e -> {
                         log.error("Failed to save assistant response as structured message", e);
@@ -983,39 +1086,84 @@ public class MLChatAgentRunner implements MLAgentRunner {
                 );
             } else {
                 // For legacy interface, use traditional saveMessage
-                ActionListener saveTraceListener = ActionListener.wrap(r -> {
-                    memory
-                        .update(
-                            parentInteractionId,
-                            Map.of(AI_RESPONSE_FIELD, copyOfFinalAnswer, ADDITIONAL_INFO_FIELD, additionalInfo),
-                            ActionListener.wrap(res -> {
-                                returnFinalResponse(
-                                    sessionId,
-                                    listener,
-                                    parentInteractionId,
-                                    verbose,
-                                    cotModelTensors,
-                                    additionalInfo,
-                                    copyOfFinalAnswer
-                                );
-                            }, e -> { listener.onFailure(e); })
+                if (parentInteractionId == null) {
+                    // No parent interaction (e.g. AG-UI agents skip interaction creation).
+                    // Save the question + answer as a structured message pair instead.
+                    ContentBlock userContent = new ContentBlock();
+                    userContent.setType(ContentType.TEXT);
+                    userContent.setText(question);
+                    Message userMessage = new Message("user", List.of(userContent));
+
+                    ContentBlock assistantContent = new ContentBlock();
+                    assistantContent.setType(ContentType.TEXT);
+                    assistantContent.setText(copyOfFinalAnswer);
+                    Message assistantMessage = new Message("assistant", List.of(assistantContent));
+
+                    memory.saveStructuredMessages(List.of(userMessage, assistantMessage), ActionListener.wrap(v -> {
+                        returnFinalResponse(
+                            sessionId,
+                            listener,
+                            null,
+                            verbose,
+                            cotModelTensors,
+                            additionalInfo,
+                            copyOfFinalAnswer,
+                            tokenTracker,
+                            tenantId,
+                            includeTokenUsage
                         );
-                }, e -> { listener.onFailure(e); });
-                saveMessage(
-                    memory,
-                    question,
-                    finalAnswer,
-                    sessionId,
-                    parentInteractionId,
-                    traceNumber,
-                    true,
-                    traceDisabled,
-                    saveTraceListener
-                );
+                    }, e -> {
+                        log.error("Failed to save structured messages for AG-UI agent", e);
+                        listener.onFailure(e);
+                    }));
+                } else {
+                    ActionListener saveTraceListener = ActionListener.wrap(r -> {
+                        memory
+                            .update(
+                                parentInteractionId,
+                                Map.of(AI_RESPONSE_FIELD, copyOfFinalAnswer, ADDITIONAL_INFO_FIELD, additionalInfo),
+                                ActionListener.wrap(res -> {
+                                    returnFinalResponse(
+                                        sessionId,
+                                        listener,
+                                        parentInteractionId,
+                                        verbose,
+                                        cotModelTensors,
+                                        additionalInfo,
+                                        copyOfFinalAnswer,
+                                        tokenTracker,
+                                        tenantId,
+                                        includeTokenUsage
+                                    );
+                                }, e -> { listener.onFailure(e); })
+                            );
+                    }, e -> { listener.onFailure(e); });
+                    saveMessage(
+                        memory,
+                        question,
+                        finalAnswer,
+                        sessionId,
+                        parentInteractionId,
+                        traceNumber,
+                        true,
+                        traceDisabled,
+                        saveTraceListener
+                    );
+                }
             }
         } else {
-            streamingWrapper
-                .sendFinalResponse(sessionId, listener, parentInteractionId, verbose, cotModelTensors, additionalInfo, finalAnswer);
+            returnFinalResponse(
+                sessionId,
+                listener,
+                parentInteractionId,
+                verbose,
+                cotModelTensors,
+                additionalInfo,
+                finalAnswer,
+                tokenTracker,
+                tenantId,
+                includeTokenUsage
+            );
         }
     }
 
@@ -1176,7 +1324,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
         boolean verbose,
         List<ModelTensors> cotModelTensors, // AtomicBoolean getFinalAnswer,
         Map<String, Object> additionalInfo,
-        String finalAnswer2
+        String finalAnswer2,
+        AgentTokenTracker tokenTracker,
+        String tenantId,
+        boolean includeTokenUsage
     ) {
         cotModelTensors
             .add(
@@ -1195,8 +1346,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
                 )
         );
         if (verbose) {
+            AgentUtils.addTokenUsageTensor(cotModelTensors, tokenTracker, tenantId, includeTokenUsage);
             listener.onResponse(ModelTensorOutput.builder().mlModelOutputs(cotModelTensors).build());
         } else {
+            AgentUtils.addTokenUsageTensor(finalModelTensors, tokenTracker, tenantId, includeTokenUsage);
             listener.onResponse(ModelTensorOutput.builder().mlModelOutputs(finalModelTensors).build());
         }
     }
@@ -1220,7 +1373,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
         Map<String, String> parameters,
         boolean usesUnifiedInterface,
         List<String> toolInteractions,
-        ModelProvider modelProvider
+        ModelProvider modelProvider,
+        AgentTokenTracker tokenTracker,
+        FunctionCalling functionCalling,
+        boolean includeTokenUsage
     ) {
         ActionListener<String> responseListener = ActionListener.wrap(response -> {
             sendTraditionalMaxIterationsResponse(
@@ -1238,7 +1394,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
                 tools,
                 usesUnifiedInterface,
                 toolInteractions,
-                modelProvider
+                modelProvider,
+                tokenTracker,
+                tenantId,
+                includeTokenUsage
             );
         }, listener::onFailure);
 
@@ -1262,7 +1421,9 @@ public class MLChatAgentRunner implements MLAgentRunner {
                                 : String.format(MAX_ITERATIONS_MESSAGE, maxIterations);
                         responseListener.onResponse(fallbackResponse);
                     }
-                )
+                ),
+            tokenTracker,
+            functionCalling
         );
     }
 
@@ -1281,7 +1442,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
         Map<String, Tool> tools,
         boolean usesUnifiedInterface,
         List<String> toolInteractions,
-        ModelProvider modelProvider
+        ModelProvider modelProvider,
+        AgentTokenTracker tokenTracker,
+        String tenantId,
+        boolean includeTokenUsage
     ) {
         sendFinalAnswer(
             sessionId,
@@ -1297,7 +1461,10 @@ public class MLChatAgentRunner implements MLAgentRunner {
             response,
             usesUnifiedInterface,
             toolInteractions,
-            modelProvider
+            modelProvider,
+            tokenTracker,
+            tenantId,
+            includeTokenUsage
         );
         cleanUpResource(tools);
     }
@@ -1308,7 +1475,9 @@ public class MLChatAgentRunner implements MLAgentRunner {
         String tenantId,
         String question,
         Map<String, String> parameter,
-        ActionListener<String> listener
+        ActionListener<String> listener,
+        AgentTokenTracker tokenTracker,
+        FunctionCalling functionCalling
     ) {
         if (stepsSummary == null || stepsSummary.isEmpty()) {
             listener.onFailure(new IllegalArgumentException("Steps summary cannot be null or empty"));
@@ -1355,6 +1524,19 @@ public class MLChatAgentRunner implements MLAgentRunner {
                 tenantId
             );
             client.execute(MLPredictionTaskAction.INSTANCE, request, ActionListener.wrap(response -> {
+                // Extract token usage from summary LLM response
+                if (tokenTracker != null && functionCalling != null) {
+                    try {
+                        ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
+                        Map<String, ?> dataAsMap = output.getMlModelOutputs().getFirst().getMlModelTensors().getFirst().getDataAsMap();
+                        TokenUsage usage = functionCalling.extractTokenUsage(dataAsMap);
+                        if (usage != null) {
+                            tokenTracker.recordTurn(llmSpec.getModelId(), usage);
+                        }
+                    } catch (Exception e) {
+                        log.debug("Failed to extract token usage from summary LLM response", e);
+                    }
+                }
                 String summary = extractSummaryFromResponse(response, summaryParams);
                 if (summary == null || summary.trim().isEmpty()) {
                     listener.onFailure(new RuntimeException("Empty or invalid LLM summary response"));
@@ -1535,9 +1717,9 @@ public class MLChatAgentRunner implements MLAgentRunner {
                 );
         }
 
-        // Call runReAct with unified tools - both frontend and backend tools will be visible to LLM
+        // Call resolveModelMetadataAndRunReAct with unified tools - both frontend and backend tools will be visible to LLM
         // Pass mlAgent and backendToolsMap so runReAct can distinguish between frontend and backend tools
-        runReAct(mlAgent, unifiedToolsMap, toolSpecMap, params, memory, listener, functionCalling, backendToolsMap);
+        resolveModelMetadataAndRunReAct(mlAgent, unifiedToolsMap, toolSpecMap, params, memory, listener, functionCalling, backendToolsMap);
     }
 
     /**

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLPlanExecuteAndReflectAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLPlanExecuteAndReflectAgentRunner.java
@@ -63,6 +63,7 @@ import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.agent.LLMSpec;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.contextmanager.ContextManagerContext;
 import org.opensearch.ml.common.conversation.Interaction;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
@@ -83,6 +84,8 @@ import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.engine.agents.AgentContextUtil;
 import org.opensearch.ml.engine.encryptor.Encryptor;
+import org.opensearch.ml.engine.function_calling.FunctionCalling;
+import org.opensearch.ml.engine.function_calling.FunctionCallingFactory;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.client.Client;
@@ -299,9 +302,40 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         // planner prompt for the first call
         usePlannerPromptTemplate(allParams);
 
+        // Token tracking: resolve model metadata, then proceed with memory setup and execution.
+        String llmModelId = mlAgent.getLlm().getModelId();
+        String tenantId = allParams.get(TENANT_ID_FIELD);
+        AgentTokenTracker tokenTracker = new AgentTokenTracker();
+
+        // Create FunctionCalling for token usage extraction only.
+        // Do NOT call configure() — that adds tool_configs, tool_template, etc. to allParams
+        // which would break the planner LLM request (PER planner doesn't use native function calling).
+        String llmInterface = allParams.get(MLChatAgentRunner.LLM_INTERFACE);
+        FunctionCalling functionCalling = FunctionCallingFactory.create(llmInterface);
+
+        // getModelMetadata always calls onResponse (falls back to modelId on failure),
+        // but we handle onFailure defensively in case the contract changes.
+        AgentUtils.getModelMetadata(llmModelId, tenantId, sdkClient, client, xContentRegistry, ActionListener.wrap(metadata -> {
+            tokenTracker.setModelMetadata(llmModelId, metadata[0], metadata[1]);
+            setupMemoryAndRun(mlAgent, apiParams, allParams, listener, tokenTracker, functionCalling);
+        }, e -> {
+            log.debug("Failed to resolve model metadata for token tracking, proceeding with model ID as fallback", e);
+            tokenTracker.setModelMetadata(llmModelId, llmModelId, llmModelId);
+            setupMemoryAndRun(mlAgent, apiParams, allParams, listener, tokenTracker, functionCalling);
+        }));
+    }
+
+    private void setupMemoryAndRun(
+        MLAgent mlAgent,
+        Map<String, String> apiParams,
+        Map<String, String> allParams,
+        ActionListener<Object> listener,
+        AgentTokenTracker tokenTracker,
+        FunctionCalling functionCalling
+    ) {
         if (mlAgent.getMemory() == null || memoryFactoryMap == null || memoryFactoryMap.isEmpty()) {
             List<String> completedSteps = new ArrayList<>();
-            setToolsAndRunAgent(mlAgent, allParams, completedSteps, null, null, listener);
+            setToolsAndRunAgent(mlAgent, allParams, completedSteps, null, null, listener, tokenTracker, functionCalling);
             return;
         }
 
@@ -357,7 +391,7 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                     usePlannerWithHistoryPromptTemplate(allParams);
                 }
 
-                setToolsAndRunAgent(mlAgent, allParams, completedSteps, memory, memory.getId(), listener);
+                setToolsAndRunAgent(mlAgent, allParams, completedSteps, memory, memory.getId(), listener, tokenTracker, functionCalling);
             }, e -> {
                 log.error("Failed to get chat history. agentId={}, tenantId={}", allParams.get(AGENT_ID_FIELD), mlAgent.getTenantId(), e);
                 listener.onFailure(e);
@@ -371,7 +405,9 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         List<String> completedSteps,
         Memory memory,
         String conversationId,
-        ActionListener<Object> finalListener
+        ActionListener<Object> finalListener,
+        AgentTokenTracker tokenTracker,
+        FunctionCalling functionCalling
     ) {
         List<MLToolSpec> toolSpecs = getMlToolSpecs(mlAgent, allParams);
 
@@ -384,7 +420,18 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
 
             AtomicInteger traceNumber = new AtomicInteger(0);
 
-            executePlanningLoop(mlAgent.getLlm(), allParams, completedSteps, memory, conversationId, 0, traceNumber, finalListener);
+            executePlanningLoop(
+                mlAgent.getLlm(),
+                allParams,
+                completedSteps,
+                memory,
+                conversationId,
+                0,
+                traceNumber,
+                finalListener,
+                functionCalling,
+                tokenTracker
+            );
         };
 
         // Fetch MCP tools and handle both success and failure cases
@@ -405,13 +452,24 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         String conversationId,
         int stepsExecuted,
         AtomicInteger traceNumber,
-        ActionListener<Object> finalListener
+        ActionListener<Object> finalListener,
+        FunctionCalling functionCalling,
+        AgentTokenTracker tokenTracker
     ) {
         int maxSteps = Integer.parseInt(allParams.getOrDefault(MAX_STEPS_EXECUTED_FIELD, DEFAULT_MAX_STEPS_EXECUTED));
         String parentInteractionId = allParams.get(MLAgentExecutor.PARENT_INTERACTION_ID);
 
         if (stepsExecuted >= maxSteps) {
-            handleMaxStepsReached(llm, allParams, completedSteps, memory, parentInteractionId, finalListener);
+            handleMaxStepsReached(
+                llm,
+                allParams,
+                completedSteps,
+                memory,
+                parentInteractionId,
+                finalListener,
+                functionCalling,
+                tokenTracker
+            );
             return;
         }
         MLPredictionTaskRequest request;
@@ -463,10 +521,30 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
 
         planListener.whenComplete(llmOutput -> {
             ModelTensorOutput modelTensorOutput = (ModelTensorOutput) llmOutput.getOutput();
+
+            // Extract token usage from planner LLM response
+            if (functionCalling != null) {
+                try {
+                    Map<String, ?> dataAsMap = modelTensorOutput
+                        .getMlModelOutputs()
+                        .getFirst()
+                        .getMlModelTensors()
+                        .getFirst()
+                        .getDataAsMap();
+                    TokenUsage usage = functionCalling.extractTokenUsage(dataAsMap);
+                    if (usage != null) {
+                        tokenTracker.recordTurn(llm.getModelId(), usage);
+                    }
+                } catch (Exception e) {
+                    log.debug("Failed to extract token usage from planner LLM response", e);
+                }
+            }
+
             Map<String, Object> parseLLMOutput = parseLLMOutput(allParams, modelTensorOutput);
 
             if (parseLLMOutput.get(RESULT_FIELD) != null) {
                 String finalResult = (String) parseLLMOutput.get(RESULT_FIELD);
+                boolean includeTokenUsage = Boolean.parseBoolean(allParams.getOrDefault(AgentUtils.INCLUDE_TOKEN_USAGE, "false"));
                 saveAndReturnFinalResult(
                     memory,
                     parentInteractionId,
@@ -474,7 +552,10 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                     allParams.get(EXECUTOR_AGENT_PARENT_INTERACTION_ID_FIELD),
                     finalResult,
                     null,
-                    finalListener
+                    finalListener,
+                    tokenTracker,
+                    allParams.get(TENANT_ID_FIELD),
+                    includeTokenUsage
                 );
             } else {
                 List<String> steps = (List<String>) parseLLMOutput.get(STEPS_FIELD);
@@ -504,6 +585,8 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                 if (allParams.containsKey(MEMORY_CONFIGURATION_FIELD)) {
                     reactParams.put(MEMORY_CONFIGURATION_FIELD, allParams.get(MEMORY_CONFIGURATION_FIELD));
                 }
+                // Mark sub-agent so its token tracker suppresses logging (parent logs merged totals)
+                reactParams.put(AgentTokenTracker.IS_SUB_AGENT_FIELD, "true");
 
                 AgentMLInput agentInput = AgentMLInput
                     .AgentMLInputBuilder()
@@ -532,6 +615,13 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                                 break;
                             case PARENT_INTERACTION_ID_FIELD:
                                 results.put(PARENT_INTERACTION_ID_FIELD, tensor.getResult());
+                                break;
+                            case AgentTokenTracker.TOKEN_USAGE:
+                                if (tensor.getDataAsMap() != null) {
+                                    @SuppressWarnings("unchecked")
+                                    Map<String, Object> tokenData = (Map<String, Object>) tensor.getDataAsMap();
+                                    tokenTracker.mergeSubAgentUsage(tokenData);
+                                }
                                 break;
                             default:
                                 String stepResult = parseTensorDataMap(tensor);
@@ -619,7 +709,9 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                         conversationId,
                         stepsExecuted + 1,
                         traceNumber,
-                        finalListener
+                        finalListener,
+                        functionCalling,
+                        tokenTracker
                     );
                 }, e -> {
                     String agentId = allParams.getOrDefault("agent_id", "unknown");
@@ -769,7 +861,10 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         String reactParentInteractionId,
         String finalResult,
         String input,
-        ActionListener<Object> finalListener
+        ActionListener<Object> finalListener,
+        AgentTokenTracker tokenTracker,
+        String tenantId,
+        boolean includeTokenUsage
     ) {
         if (memory != null) {
             Map<String, Object> updateContent = new HashMap<>();
@@ -795,6 +890,7 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                             )
                             .build()
                     );
+                AgentUtils.addTokenUsageTensor(finalModelTensors, tokenTracker, tenantId, includeTokenUsage);
                 finalListener.onResponse(ModelTensorOutput.builder().mlModelOutputs(finalModelTensors).build());
             }, e -> {
                 log.error("Failed to update interaction with final result", e);
@@ -816,6 +912,7 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                         )
                         .build()
                 );
+            AgentUtils.addTokenUsageTensor(finalModelTensors, tokenTracker, tenantId, includeTokenUsage);
             finalListener.onResponse(ModelTensorOutput.builder().mlModelOutputs(finalModelTensors).build());
         }
     }
@@ -861,11 +958,14 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         List<String> completedSteps,
         Memory memory,
         String parentInteractionId,
-        ActionListener<Object> finalListener
+        ActionListener<Object> finalListener,
+        FunctionCalling functionCalling,
+        AgentTokenTracker tokenTracker
     ) {
         int maxSteps = Integer.parseInt(allParams.getOrDefault(MAX_STEPS_EXECUTED_FIELD, DEFAULT_MAX_STEPS_EXECUTED));
         log.info("[SUMMARY] Max steps reached. Completed steps: {}", completedSteps.size());
 
+        boolean includeTokenUsage = Boolean.parseBoolean(allParams.getOrDefault(AgentUtils.INCLUDE_TOKEN_USAGE, "false"));
         ActionListener<String> responseListener = ActionListener.wrap(response -> {
             saveAndReturnFinalResult(
                 memory,
@@ -874,11 +974,14 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
                 allParams.get(EXECUTOR_AGENT_PARENT_INTERACTION_ID_FIELD),
                 response,
                 null,
-                finalListener
+                finalListener,
+                tokenTracker,
+                allParams.get(TENANT_ID_FIELD),
+                includeTokenUsage
             );
         }, finalListener::onFailure);
 
-        generateSummary(llm, completedSteps, allParams, ActionListener.wrap(summary -> {
+        generateSummary(llm, completedSteps, allParams, functionCalling, tokenTracker, ActionListener.wrap(summary -> {
             log.info("Summary generated successfully");
             responseListener
                 .onResponse(
@@ -905,6 +1008,8 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
         LLMSpec llmSpec,
         List<String> completedSteps,
         Map<String, String> allParams,
+        FunctionCalling functionCalling,
+        AgentTokenTracker tokenTracker,
         ActionListener<String> listener
     ) {
         if (completedSteps == null || completedSteps.isEmpty()) {
@@ -939,6 +1044,24 @@ public class MLPlanExecuteAndReflectAgentRunner implements MLAgentRunner {
             );
 
             client.execute(MLPredictionTaskAction.INSTANCE, request, ActionListener.wrap(response -> {
+                // Extract token usage from summary LLM call
+                if (tokenTracker != null && functionCalling != null) {
+                    try {
+                        ModelTensorOutput tmpOutput = (ModelTensorOutput) response.getOutput();
+                        if (tmpOutput != null && tmpOutput.getMlModelOutputs() != null && !tmpOutput.getMlModelOutputs().isEmpty()) {
+                            Map<String, ?> dataAsMap = tmpOutput.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap();
+                            if (dataAsMap != null) {
+                                TokenUsage usage = functionCalling.extractTokenUsage(dataAsMap);
+                                if (usage != null) {
+                                    tokenTracker.recordTurn(llmSpec.getModelId(), usage);
+                                }
+                            }
+                        }
+                    } catch (Exception e) {
+                        log.debug("Failed to extract token usage from summary generation", e);
+                    }
+                }
+
                 String summary = extractSummaryFromResponse(response, summaryParams);
                 if (summary == null || summary.trim().isEmpty()) {
                     log.error("Extracted summary is empty");

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/StreamingWrapper.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/StreamingWrapper.java
@@ -8,7 +8,6 @@ package org.opensearch.ml.engine.algorithms.agent;
 import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_RUN_ID;
 import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_THREAD_ID;
 import static org.opensearch.ml.common.utils.StringUtils.gson;
-import static org.opensearch.ml.engine.algorithms.agent.MLChatAgentRunner.returnFinalResponse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +50,10 @@ public class StreamingWrapper {
         this.client = client;
         this.parameters = parameters;
         this.isStreaming = (channel != null);
+    }
+
+    public boolean isStreaming() {
+        return isStreaming;
     }
 
     public void fixInteractionRole(List<String> interactions) {
@@ -105,19 +108,36 @@ public class StreamingWrapper {
         }
     }
 
-    public void sendFinalResponse(
-        String sessionId,
-        ActionListener<Object> listener,
-        String parentInteractionId,
-        boolean verbose,
-        List<ModelTensors> cotModelTensors,
-        Map<String, Object> additionalInfo,
-        String finalAnswer
-    ) {
-        if (isStreaming) {
-            listener.onResponse("Streaming completed");
-        } else {
-            returnFinalResponse(sessionId, listener, parentInteractionId, verbose, cotModelTensors, additionalInfo, finalAnswer);
+    /**
+     * Send token usage as a streaming batch before the completion chunk.
+     * No-op if tokenTracker is null, has no usage, or not streaming.
+     */
+    public void sendTokenUsageBatch(String sessionId, String parentInteractionId, AgentTokenTracker tokenTracker, String tenantId) {
+        if (!isStreaming || tokenTracker == null || !tokenTracker.hasUsage()) {
+            return;
+        }
+        try {
+            Map<String, Object> tokenUsageMap = tokenTracker.toOutputMap();
+            List<ModelTensor> tokenTensors = new ArrayList<>();
+
+            if (sessionId != null) {
+                tokenTensors.add(ModelTensor.builder().name("memory_id").result(sessionId).build());
+            }
+            if (parentInteractionId != null) {
+                tokenTensors.add(ModelTensor.builder().name("parent_interaction_id").result(parentInteractionId).build());
+            }
+
+            tokenTensors.add(ModelTensor.builder().name(AgentTokenTracker.TOKEN_USAGE).dataAsMap(tokenUsageMap).build());
+
+            ModelTensorOutput tokenOutput = ModelTensorOutput
+                .builder()
+                .mlModelOutputs(List.of(ModelTensors.builder().mlModelTensors(tokenTensors).build()))
+                .build();
+
+            channel.sendResponseBatch(new MLTaskResponse(tokenOutput));
+
+        } catch (Exception e) {
+            log.error("Failed to send token usage in streaming response", e);
         }
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandler.java
@@ -7,9 +7,7 @@ package org.opensearch.ml.engine.algorithms.remote.streaming;
 
 import static org.opensearch.ml.common.CommonValue.REMOTE_SERVICE_ERROR;
 import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_MESSAGE_ID;
-import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_RUN_ID;
 import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_TEXT_MESSAGE_STARTED;
-import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_THREAD_ID;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,7 +25,6 @@ import javax.naming.AuthenticationException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.agui.BaseEvent;
-import org.opensearch.ml.common.agui.RunFinishedEvent;
 import org.opensearch.ml.common.agui.TextMessageContentEvent;
 import org.opensearch.ml.common.agui.TextMessageEndEvent;
 import org.opensearch.ml.common.agui.TextMessageStartEvent;
@@ -63,6 +60,7 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDeltaEvent;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockStartEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamMetadataEvent;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamOutput;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
@@ -70,6 +68,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.GuardrailStreamConfi
 import software.amazon.awssdk.services.bedrockruntime.model.ImageBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.ImageSource;
 import software.amazon.awssdk.services.bedrockruntime.model.Message;
+import software.amazon.awssdk.services.bedrockruntime.model.MessageStopEvent;
 import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.Tool;
 import software.amazon.awssdk.services.bedrockruntime.model.ToolConfiguration;
@@ -80,6 +79,33 @@ import software.amazon.awssdk.services.bedrockruntime.model.ToolSpecification;
 import software.amazon.awssdk.services.bedrockruntime.model.ValidationException;
 import software.amazon.awssdk.services.s3.model.InvalidRequestException;
 
+/**
+ * Bedrock ConverseStream handler supporting three streaming paths:
+ *
+ * <p><b>Bedrock event sequence:</b>
+ * <pre>
+ * ContentBlockStart → ContentBlockDelta* → ContentBlockStop → ... → MessageStop → Metadata → onComplete()
+ * </pre>
+ *
+ * <p><b>Streaming paths:</b>
+ * <ul>
+ *   <li><b>Normal predict (no agent):</b> Text chunks streamed to client via SSE.
+ *       Stream closed at onComplete after Metadata (token usage) is captured.
+ *   <li><b>Conversational agent (non-AGUI):</b> Text chunks streamed via SSE. At onComplete,
+ *       agent runner is notified with a Bedrock-format response containing accumulated content
+ *       and token usage. Agent runner handles memory save and stream closure via StreamingWrapper.
+ *   <li><b>AG-UI agent:</b> Structured AG-UI events streamed (TextMessageStart/Content/End,
+ *       ToolCallStart/Args/End, RunFinished). AG-UI events fire in real-time at MessageStop.
+ *       Agent runner is notified at onComplete with accumulated content and token usage.
+ *       Stream closure is handled by StreamingWrapper (same as conv agent).
+ * </ul>
+ *
+ * <p><b>Key design decision:</b> All paths defer finalization to {@code onComplete()} so that
+ * the Metadata event (which carries token usage) is captured before constructing the response.
+ * AG-UI streaming protocol events (TextMessage*, ToolCall*, RunFinished) still fire at
+ * MessageStop time for real-time delivery; only the agent runner notification and stream
+ * closure are deferred.
+ */
 @Log4j2
 public class BedrockStreamingHandler extends BaseStreamingHandler {
 
@@ -87,14 +113,23 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
     private final AwsConnector connector;
     private final Map<String, String> parameters;
     private final boolean isAGUIAgent;
-    private static final String STOP_REASON_TOOL_USE = "StopReason=tool_use";
 
+    /**
+     * States for the Bedrock ConverseStream state machine.
+     *
+     *   STREAMING_CONTENT       — receiving text content deltas
+     *   TOOL_CALL_DETECTED      — ContentBlockStart with toolUse received
+     *   ACCUMULATING_TOOL_INPUT — receiving tool input deltas
+     *   AWAITING_COMPLETION     — MessageStop received, waiting for Metadata + onComplete to finalize
+     *
+     * All paths (AGUI, conv agent, predict) converge to AWAITING_COMPLETION at MessageStop.
+     * Finalization always happens in onComplete() after the Metadata event (token usage) is captured.
+     */
     private enum StreamState {
         STREAMING_CONTENT,
         TOOL_CALL_DETECTED,
         ACCUMULATING_TOOL_INPUT,
-        WAITING_FOR_TOOL_RESULT,
-        COMPLETED
+        AWAITING_COMPLETION
     }
 
     public BedrockStreamingHandler(SdkAsyncHttpClient httpClient, AwsConnector connector) {
@@ -131,6 +166,7 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
             StringBuilder toolInputAccumulator = new StringBuilder();
             StringBuilder accumulatedContent = new StringBuilder();
             AtomicReference<StreamState> currentState = new AtomicReference<>(StreamState.STREAMING_CONTENT);
+            AtomicReference<Map<String, Object>> tokenUsage = new AtomicReference<>();
 
             // Build Bedrock client
             BedrockRuntimeAsyncClient bedrockClient = buildBedrockRuntimeAsyncClient();
@@ -158,13 +194,30 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                     listener.onFailure(new MLException(REMOTE_SERVICE_ERROR + error.getMessage(), error));
                 }
             }).onComplete(() -> {
-                if (currentState.get() != StreamState.WAITING_FOR_TOOL_RESULT) {
-                    sendCompletionResponse(isStreamClosed, listener);
+                if (currentState.get() == StreamState.AWAITING_COMPLETION) {
+                    // All paths converge here: Metadata (token usage) has been captured.
+                    // Notify agent runner with response, or close stream for predict.
+                    onStreamComplete(listener, isStreamClosed, toolName, toolInput, toolUseId, accumulatedContent, tokenUsage);
                 } else {
-                    log.debug("Tool execution in progress - keeping stream open");
+                    // Safety net: unexpected early completion (e.g., error during streaming)
+                    log
+                        .warn(
+                            "Stream completed in unexpected state [{}]. Token usage {}: {}",
+                            currentState.get(),
+                            tokenUsage.get() != null ? "was captured" : "was not captured",
+                            tokenUsage.get()
+                        );
+                    sendCompletionResponse(isStreamClosed, listener);
                 }
             }).subscriber(event -> {
                 log.debug("BEDROCK_RAW_EVENT: Type={}, Event={}", event.sdkEventType(), event);
+                // Capture Metadata event (token usage) before state machine processing.
+                // Metadata arrives after MessageStop, before onComplete — all paths capture it
+                // and all paths (AGUI, conv agent, predict) use it in onStreamComplete.
+                if (isMetadataEvent(event)) {
+                    captureTokenUsage(event, tokenUsage);
+                    return;
+                }
                 handleStreamEvent(
                     event,
                     listener,
@@ -292,6 +345,9 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                     }
                 } else if (isContentDelta(event)) {
                     String content = getTextContent(event);
+                    // Accumulate content for all paths — needed for createFinalAnswerResponse (conv agent)
+                    // and createToolUseResponse (text blocks before tool calls)
+                    accumulatedContent.append(content);
 
                     // Log time to first token
                     if (!firstTokenReceived.get() && content != null && !content.isEmpty()) {
@@ -309,7 +365,6 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                     }
 
                     if (isAGUIAgent) {
-                        accumulatedContent.append(content);
 
                         if (!textMessageStarted) {
                             messageId = "msg_" + System.nanoTime();
@@ -327,7 +382,8 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                     } else {
                         sendContentResponse(content, false, listener);
                     }
-                } else if (isStreamComplete(event)) {
+                } else if (isEndTurnStop(event)) {
+                    // AG-UI: send terminal streaming protocol events immediately
                     if (isAGUIAgent) {
                         if (textMessageStarted) {
                             parameters.put(AGUI_PARAM_TEXT_MESSAGE_STARTED, "false");
@@ -335,18 +391,13 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                             sendAGUIEvent(textMessageEndEvent, false, listener);
                             log.debug("AG-UI: Sent TEXT_MESSAGE_END for messageId: {}", messageId);
                         }
-
-                        String threadId = parameters.get(AGUI_PARAM_THREAD_ID);
-                        String runId = parameters.get(AGUI_PARAM_RUN_ID);
-                        BaseEvent runFinishedEvent = new RunFinishedEvent(threadId, runId, null);
-                        sendAGUIEvent(runFinishedEvent, false, listener);
-                        log.debug("BedrockStreamingHandler: Added RUN_FINISHED event - ReAct loop completed");
-
-                        listener.onResponse(createFinalAnswerResponse(accumulatedContent.toString()));
+                        // RUN_FINISHED is emitted by RestMLExecuteStreamAction after token_usage,
+                        // once the final response chunk (is_last=true) arrives from the agent runner.
                     }
 
-                    currentState.set(StreamState.COMPLETED);
-                    sendCompletionResponse(isStreamClosed, listener);
+                    // All paths: defer finalization to onComplete() so Metadata (token usage) is captured.
+                    // onStreamComplete() will notify the agent runner or close the stream.
+                    currentState.set(StreamState.AWAITING_COMPLETION);
                 }
                 break;
 
@@ -384,28 +435,28 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
                     // Since we do not support parallel tool execution yet, drop tool args after the first
                     firstToolSent.set(true);
                     log.info("First tool complete, will drop events for subsequent tools");
-                } else if (isToolInputComplete(event)) {
+                } else if (isToolUseStop(event)) {
                     // Ensure toolInput is set even if it's empty
                     if (toolInput.get() == null) {
                         toolInput.set(Map.of());
                     }
 
+                    // AG-UI: send ToolCallEnd streaming protocol event immediately
                     if (isAGUIAgent) {
                         BaseEvent toolCallEndEvent = new ToolCallEndEvent(toolUseId.get());
                         sendAGUIEvent(toolCallEndEvent, false, listener);
                         log.debug("AG-UI: Sent TOOL_CALL_END event for tool '{}'", toolName.get());
                     }
 
-                    currentState.set(StreamState.WAITING_FOR_TOOL_RESULT);
-                    listener.onResponse(createToolUseResponse(toolName, toolInput, toolUseId, accumulatedContent));
+                    // All paths: defer finalization to onComplete() so Metadata (token usage) is captured.
+                    // onStreamComplete() will send createToolUseResponse with token usage included.
+                    currentState.set(StreamState.AWAITING_COMPLETION);
                 }
                 break;
 
-            case WAITING_FOR_TOOL_RESULT:
-                log.debug("Waiting for tool result - keeping stream open");
-                break;
-
-            case COMPLETED:
+            case AWAITING_COMPLETION:
+                // MessageStop received, waiting for Metadata event and onComplete to finalize.
+                // Metadata capture is handled in the subscriber before this switch statement.
                 break;
         }
     }
@@ -442,32 +493,98 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
             && ((ContentBlockDeltaEvent) event).delta().toolUse() != null;
     }
 
-    private boolean isStreamComplete(ConverseStreamOutput event) {
-        return event.sdkEventType() == ConverseStreamOutput.EventType.MESSAGE_STOP && !event.toString().contains(STOP_REASON_TOOL_USE);
+    /**
+     * Checks if the event is a MessageStop with a non-tool_use stop reason (e.g., end_turn, max_tokens).
+     * Note: this is NOT stream completion — the Metadata event and onComplete() still follow.
+     */
+    private boolean isEndTurnStop(ConverseStreamOutput event) {
+        if (!(event instanceof MessageStopEvent)) {
+            return false;
+        }
+        return !"tool_use".equals(((MessageStopEvent) event).stopReasonAsString());
     }
 
-    private boolean isToolInputComplete(ConverseStreamOutput event) {
-        return event.sdkEventType() == ConverseStreamOutput.EventType.MESSAGE_STOP && event.toString().contains(STOP_REASON_TOOL_USE);
+    /**
+     * Checks if the event is a MessageStop with tool_use stop reason,
+     * indicating the LLM wants to call a tool.
+     */
+    private boolean isToolUseStop(ConverseStreamOutput event) {
+        if (!(event instanceof MessageStopEvent)) {
+            return false;
+        }
+        return "tool_use".equals(((MessageStopEvent) event).stopReasonAsString());
     }
 
     private boolean isCurrentToolInputComplete(ConverseStreamOutput event) {
         return event.sdkEventType() == ConverseStreamOutput.EventType.CONTENT_BLOCK_STOP;
     }
 
+    private boolean isMetadataEvent(ConverseStreamOutput event) {
+        return event instanceof ConverseStreamMetadataEvent;
+    }
+
     /**
-     * Create a Bedrock-formatted final answer response that parseLLMOutput can extract
-     * the final answer from. Uses the same format as a Bedrock Converse API response
-     * with stopReason="end_turn".
+     * Extracts token usage from the Bedrock Metadata event and stores it for inclusion
+     * in the response constructed at onComplete time.
+     */
+    private void captureTokenUsage(ConverseStreamOutput event, AtomicReference<Map<String, Object>> tokenUsage) {
+        ConverseStreamMetadataEvent metadataEvent = (ConverseStreamMetadataEvent) event;
+        if (metadataEvent.usage() != null) {
+            Map<String, Object> usage = new HashMap<>();
+            usage.put("inputTokens", metadataEvent.usage().inputTokens());
+            usage.put("outputTokens", metadataEvent.usage().outputTokens());
+            usage.put("totalTokens", metadataEvent.usage().totalTokens());
+            tokenUsage.set(usage);
+            log.debug("Captured token usage from metadata: {}", usage);
+        }
+    }
+
+    /**
+     * Finalization — called from onComplete() after all Bedrock events (including Metadata)
+     * have been received. Constructs the appropriate response with token usage and notifies upstream.
+     * All paths (AGUI, conv agent, predict) converge here.
+     *
+     * Three outcomes:
+     * - Tool call (agent): send Bedrock-format tool use response with token usage to agent runner
+     * - End turn (agent): send Bedrock-format final answer with token usage to agent runner
+     * - End turn (predict, no agent): close stream directly
+     */
+    private void onStreamComplete(
+        StreamPredictActionListener<MLTaskResponse, ?> listener,
+        AtomicBoolean isStreamClosed,
+        AtomicReference<String> toolName,
+        AtomicReference<Map<String, Object>> toolInput,
+        AtomicReference<String> toolUseId,
+        StringBuilder accumulatedContent,
+        AtomicReference<Map<String, Object>> tokenUsage
+    ) {
+        if (toolName.get() != null) {
+            // Tool use: construct response with accumulated text + tool call + token usage
+            listener.onResponse(createToolUseResponse(toolName, toolInput, toolUseId, accumulatedContent, tokenUsage.get()));
+        } else if (listener.hasAgentListener()) {
+            // Conv agent end_turn: construct final answer with accumulated content + token usage
+            listener.onResponse(createFinalAnswerResponse(accumulatedContent.toString(), tokenUsage.get()));
+        } else {
+            // Predict (no agent): close stream directly
+            sendCompletionResponse(isStreamClosed, listener);
+        }
+    }
+
+    /**
+     * Create a Bedrock-formatted final answer response with optional token usage.
+     * Token usage is captured from the Bedrock Metadata event at onComplete time.
+     * The agent runner extracts token usage via functionCalling.extractTokenUsage().
+     *
+     * Response format matches Bedrock Converse API: stopReason="end_turn", output.message.content[].text
      */
     @VisibleForTesting
-    MLTaskResponse createFinalAnswerResponse(String text) {
-        Map<String, Object> wrappedResponse = Map
-            .of(
-                "output",
-                Map.of("message", Map.of("content", List.of(Map.of("text", text != null ? text : "")))),
-                "stopReason",
-                "end_turn"
-            );
+    MLTaskResponse createFinalAnswerResponse(String text, Map<String, Object> tokenUsage) {
+        Map<String, Object> wrappedResponse = new HashMap<>();
+        wrappedResponse.put("output", Map.of("message", Map.of("content", List.of(Map.of("text", text != null ? text : "")))));
+        wrappedResponse.put("stopReason", "end_turn");
+        if (tokenUsage != null) {
+            wrappedResponse.put("usage", tokenUsage);
+        }
 
         ModelTensor tensor = ModelTensor.builder().name("response").dataAsMap(wrappedResponse).build();
         ModelTensors tensors = ModelTensors.builder().mlModelTensors(List.of(tensor)).build();
@@ -475,11 +592,19 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
         return new MLTaskResponse(output);
     }
 
+    /**
+     * Create a tool use response with optional token usage.
+     * Token usage is captured from the Bedrock Metadata event at onComplete time.
+     *
+     * Response format matches Bedrock Converse API: stopReason="tool_use",
+     * output.message.content[] with text blocks (if any) + toolUse block.
+     */
     private MLTaskResponse createToolUseResponse(
         AtomicReference<String> toolName,
         AtomicReference<Map<String, Object>> toolInput,
         AtomicReference<String> toolUseId,
-        StringBuilder accumulatedContent
+        StringBuilder accumulatedContent,
+        Map<String, Object> tokenUsage
     ) {
         // Validate inputs
         if (toolName == null || toolInput == null || toolUseId == null) {
@@ -494,8 +619,12 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
         }
         contentBlocks.add(Map.of("toolUse", Map.of("name", toolName.get(), "input", toolInput.get(), "toolUseId", toolUseId.get())));
 
-        Map<String, Object> wrappedResponse = Map
-            .of("output", Map.of("message", Map.of("content", contentBlocks)), "stopReason", "tool_use");
+        Map<String, Object> wrappedResponse = new HashMap<>();
+        wrappedResponse.put("output", Map.of("message", Map.of("content", contentBlocks)));
+        wrappedResponse.put("stopReason", "tool_use");
+        if (tokenUsage != null) {
+            wrappedResponse.put("usage", tokenUsage);
+        }
 
         ModelTensor tensor = ModelTensor.builder().name("response").dataAsMap(wrappedResponse).build();
         ModelTensors tensors = ModelTensors.builder().mlModelTensors(List.of(tensor)).build();

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/StreamPredictActionListener.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/StreamPredictActionListener.java
@@ -96,6 +96,15 @@ public class StreamPredictActionListener<Response extends TransportResponse, Req
         }
     }
 
+    /**
+     * Returns true if an agent listener is present, meaning an agent runner
+     * upstream will handle stream closure. When false, the streaming handler
+     * must close the stream itself.
+     */
+    public boolean hasAgentListener() {
+        return agentListener != null;
+    }
+
     private Response addMetadataToResponse(Response response) {
         if (!(response instanceof MLTaskResponse)) {
             return response;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/BedrockConverseDeepseekR1FunctionCalling.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/BedrockConverseDeepseekR1FunctionCalling.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_RE
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_REASON_TOOL_USE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_EXCLUDE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOKEN_USAGE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_INPUT;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_NAME;
@@ -30,8 +31,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.engine.algorithms.agent.AgentUtils;
 
 import com.jayway.jsonpath.JsonPath;
 
@@ -74,6 +77,9 @@ public class BedrockConverseDeepseekR1FunctionCalling implements FunctionCalling
 
         params.put(LLM_FINISH_REASON_PATH, "_llm_response.stop_reason");
         params.put(LLM_FINISH_REASON_TOOL_USE, "tool_use");
+
+        // Token usage tracking paths
+        params.put(TOKEN_USAGE_PATH, "$.usage");
     }
 
     @Override
@@ -117,5 +123,31 @@ public class BedrockConverseDeepseekR1FunctionCalling implements FunctionCalling
         }
 
         return List.of(toolMessage);
+    }
+
+    @Override
+    public TokenUsage extractTokenUsage(Map<String, ?> llmResponseDataAsMap) {
+        if (llmResponseDataAsMap == null) {
+            return null;
+        }
+
+        try {
+            Object usageObj = llmResponseDataAsMap.get("usage");
+            if (!(usageObj instanceof Map)) {
+                return null;
+            }
+
+            Map<String, Object> usageMap = (Map<String, Object>) usageObj;
+
+            // Bedrock Deepseek R1 uses standard format
+            return TokenUsage
+                .builder()
+                .inputTokens(AgentUtils.getLongValue(usageMap, "prompt_tokens"))
+                .outputTokens(AgentUtils.getLongValue(usageMap, "completion_tokens"))
+                .totalTokens(AgentUtils.getLongValue(usageMap, "total_tokens"))
+                .build();
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/BedrockConverseFunctionCalling.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/BedrockConverseFunctionCalling.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_RE
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_REASON_TOOL_USE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_EXCLUDE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOKEN_USAGE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_INPUT;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_NAME;
@@ -30,8 +31,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.engine.algorithms.agent.AgentUtils;
 
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
@@ -78,6 +81,9 @@ public class BedrockConverseFunctionCalling implements FunctionCalling {
 
         params.put(LLM_FINISH_REASON_PATH, "$.stopReason");
         params.put(LLM_FINISH_REASON_TOOL_USE, "tool_use");
+
+        // Token usage tracking paths
+        params.put(TOKEN_USAGE_PATH, "$.usage");
     }
 
     @Override
@@ -171,6 +177,35 @@ public class BedrockConverseFunctionCalling implements FunctionCalling {
         } catch (Exception e) {
             log.error("Failed to filter out to only first tool call", e);
             return dataAsMap;
+        }
+    }
+
+    @Override
+    public TokenUsage extractTokenUsage(Map<String, ?> llmResponseDataAsMap) {
+        if (llmResponseDataAsMap == null) {
+            return null;
+        }
+
+        try {
+            Object usageObj = llmResponseDataAsMap.get("usage");
+            if (!(usageObj instanceof Map)) {
+                return null;
+            }
+
+            Map<String, Object> usageMap = (Map<String, Object>) usageObj;
+
+            // Bedrock Converse API always normalizes to camelCase format
+            // regardless of the underlying model (Claude, Llama, etc.)
+            return TokenUsage
+                .builder()
+                .inputTokens(AgentUtils.getLongValue(usageMap, "inputTokens"))
+                .outputTokens(AgentUtils.getLongValue(usageMap, "outputTokens"))
+                .totalTokens(AgentUtils.getLongValue(usageMap, "totalTokens"))
+                .cacheReadInputTokens(AgentUtils.getLongValue(usageMap, "cacheReadInputTokens"))
+                .cacheCreationInputTokens(AgentUtils.getLongValue(usageMap, "cacheWriteInputTokens"))
+                .build();
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/FunctionCalling.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/FunctionCalling.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.engine.function_calling;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 
 /**
@@ -47,5 +48,16 @@ public interface FunctionCalling {
      */
     default Map<String, ?> filterToFirstToolCall(Map<String, ?> dataAsMap, Map<String, String> parameters) {
         return dataAsMap;
+    }
+
+    /**
+     * Extracts token usage information from the LLM response.
+     * Each implementation knows its own response format and field names.
+     *
+     * @param llmResponseDataAsMap the full LLM response data map
+     * @return TokenUsage object with token counts, or null if extraction fails or is not supported
+     */
+    default TokenUsage extractTokenUsage(Map<String, ?> llmResponseDataAsMap) {
+        return null; // Default: no token tracking
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/GeminiV1BetaGenerateContentFunctionCalling.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/GeminiV1BetaGenerateContentFunctionCalling.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_RE
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_REASON_TOOL_USE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_EXCLUDE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOKEN_USAGE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_INPUT;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_NAME;
@@ -30,8 +31,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.engine.algorithms.agent.AgentUtils;
 
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
@@ -85,6 +88,9 @@ public class GeminiV1BetaGenerateContentFunctionCalling implements FunctionCalli
         // TODO: Once tool call detection is refactored into FunctionCalling interface (see AgentUtils.java:434),
         // this parameter may need to be removed or repurposed since it's not used for Gemini.
         params.put(LLM_FINISH_REASON_TOOL_USE, "N/A");
+
+        // Token usage tracking paths
+        params.put(TOKEN_USAGE_PATH, "$.usageMetadata");
     }
 
     @Override
@@ -180,6 +186,33 @@ public class GeminiV1BetaGenerateContentFunctionCalling implements FunctionCalli
         } catch (Exception e) {
             log.error("Failed to filter out to only first tool call", e);
             return dataAsMap;
+        }
+    }
+
+    @Override
+    public TokenUsage extractTokenUsage(Map<String, ?> llmResponseDataAsMap) {
+        if (llmResponseDataAsMap == null) {
+            return null;
+        }
+
+        try {
+            Object usageMetadataObj = llmResponseDataAsMap.get("usageMetadata");
+            if (!(usageMetadataObj instanceof Map)) {
+                return null;
+            }
+
+            Map<String, Object> usageMap = (Map<String, Object>) usageMetadataObj;
+
+            return TokenUsage
+                .builder()
+                .inputTokens(AgentUtils.getLongValue(usageMap, "promptTokenCount"))
+                .outputTokens(AgentUtils.getLongValue(usageMap, "candidatesTokenCount"))
+                .totalTokens(AgentUtils.getLongValue(usageMap, "totalTokenCount"))
+                .cacheReadInputTokens(AgentUtils.getLongValue(usageMap, "cachedContentInputTokenCount"))
+                .reasoningTokens(AgentUtils.getLongValue(usageMap, "thoughtsTokenCount"))
+                .build();
+        } catch (Exception e) {
+            return null;
         }
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/OpenaiV1ChatCompletionsFunctionCalling.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/OpenaiV1ChatCompletionsFunctionCalling.java
@@ -12,6 +12,7 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_RE
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_FINISH_REASON_TOOL_USE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_EXCLUDE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOKEN_USAGE_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_PATH;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_INPUT;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_NAME;
@@ -29,8 +30,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.engine.algorithms.agent.AgentUtils;
 
 import com.jayway.jsonpath.JsonPath;
 
@@ -73,6 +76,9 @@ public class OpenaiV1ChatCompletionsFunctionCalling implements FunctionCalling {
 
         params.put(LLM_FINISH_REASON_PATH, "$.choices[0].finish_reason");
         params.put(LLM_FINISH_REASON_TOOL_USE, "tool_calls");
+
+        // Token usage tracking paths
+        params.put(TOKEN_USAGE_PATH, "$.usage");
     }
 
     @Override
@@ -116,5 +122,46 @@ public class OpenaiV1ChatCompletionsFunctionCalling implements FunctionCalling {
         }
 
         return messages;
+    }
+
+    @Override
+    public TokenUsage extractTokenUsage(Map<String, ?> llmResponseDataAsMap) {
+        if (llmResponseDataAsMap == null) {
+            return null;
+        }
+
+        try {
+            Object usageObj = llmResponseDataAsMap.get("usage");
+            if (!(usageObj instanceof Map)) {
+                return null;
+            }
+
+            Map<String, Object> usageMap = (Map<String, Object>) usageObj;
+
+            // OpenAI format: prompt_tokens, completion_tokens, total_tokens
+            TokenUsage.TokenUsageBuilder builder = TokenUsage
+                .builder()
+                .inputTokens(AgentUtils.getLongValue(usageMap, "prompt_tokens"))
+                .outputTokens(AgentUtils.getLongValue(usageMap, "completion_tokens"))
+                .totalTokens(AgentUtils.getLongValue(usageMap, "total_tokens"));
+
+            // OpenAI prompt_tokens_details.cached_tokens
+            Object promptDetailsObj = usageMap.get("prompt_tokens_details");
+            if (promptDetailsObj instanceof Map) {
+                Map<String, Object> promptDetails = (Map<String, Object>) promptDetailsObj;
+                builder.cacheReadInputTokens(AgentUtils.getLongValue(promptDetails, "cached_tokens"));
+            }
+
+            // OpenAI completion_tokens_details.reasoning_tokens
+            Object completionDetailsObj = usageMap.get("completion_tokens_details");
+            if (completionDetailsObj instanceof Map) {
+                Map<String, Object> completionDetails = (Map<String, Object>) completionDetailsObj;
+                builder.reasoningTokens(AgentUtils.getLongValue(completionDetails, "reasoning_tokens"));
+            }
+
+            return builder.build();
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentTokenTrackerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentTokenTrackerTest.java
@@ -1,0 +1,662 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.agent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.ml.common.agent.TokenUsage;
+
+public class AgentTokenTrackerTest {
+
+    private AgentTokenTracker tracker;
+
+    @Before
+    public void setUp() {
+        tracker = new AgentTokenTracker();
+    }
+
+    @Test
+    public void testRecordSingleTurn() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+
+        tracker.setModelMetadata("gpt-4", "https://api.openai.com/v1/chat/completions", "gpt-4");
+        tracker.recordTurn("gpt-4", usage);
+
+        assertTrue(tracker.hasUsage());
+
+        Map<String, Object> output = tracker.toOutputMap();
+        assertNotNull(output);
+
+        List<Map<String, Object>> perTurnUsage = (List<Map<String, Object>>) output.get("per_turn_usage");
+        assertEquals(1, perTurnUsage.size());
+
+        Map<String, Object> turn = perTurnUsage.get(0);
+        assertEquals(1, turn.get("turn"));
+        assertEquals("gpt-4", turn.get("model_name"));
+        assertEquals(100L, turn.get("input_tokens"));
+        assertEquals(50L, turn.get("output_tokens"));
+        assertEquals(150L, turn.get("total_tokens"));
+    }
+
+    @Test
+    public void testRecordMultipleTurns() {
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(200L).outputTokens(75L).totalTokens(275L).build();
+
+        TokenUsage usage3 = TokenUsage.builder().inputTokens(150L).outputTokens(60L).totalTokens(210L).build();
+
+        tracker.setModelMetadata("gpt-4", "https://api.openai.com/v1/chat/completions", "gpt-4");
+        tracker.recordTurn("gpt-4", usage1);
+        tracker.recordTurn("gpt-4", usage2);
+        tracker.recordTurn("gpt-4", usage3);
+
+        Map<String, Object> output = tracker.toOutputMap();
+
+        List<Map<String, Object>> perTurnUsage = (List<Map<String, Object>>) output.get("per_turn_usage");
+        assertEquals(3, perTurnUsage.size());
+
+        // Verify turn numbers
+        assertEquals(1, perTurnUsage.get(0).get("turn"));
+        assertEquals(2, perTurnUsage.get(1).get("turn"));
+        assertEquals(3, perTurnUsage.get(2).get("turn"));
+    }
+
+    @Test
+    public void testPerModelAggregation() {
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(200L).outputTokens(75L).totalTokens(275L).build();
+
+        tracker.recordTurn("gpt-4", usage1);
+        tracker.recordTurn("gpt-4", usage2);
+
+        Map<String, Object> output = tracker.toOutputMap();
+
+        List<Map<String, Object>> perModelUsage = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(1, perModelUsage.size());
+
+        Map<String, Object> modelData = perModelUsage.get(0);
+        assertEquals("gpt-4", modelData.get("model_name"));
+        assertEquals(300L, modelData.get("input_tokens"));
+        assertEquals(125L, modelData.get("output_tokens"));
+        assertEquals(425L, modelData.get("total_tokens"));
+        assertEquals(2, modelData.get("call_count"));
+    }
+
+    @Test
+    public void testMultipleModels() {
+        TokenUsage usage1 = TokenUsage.builder().inputTokens(100L).outputTokens(50L).build();
+
+        TokenUsage usage2 = TokenUsage.builder().inputTokens(200L).outputTokens(75L).build();
+
+        TokenUsage usage3 = TokenUsage.builder().inputTokens(150L).outputTokens(60L).build();
+
+        tracker.setModelMetadata("gpt-4", "https://api.openai.com/v1/chat/completions", "gpt-4");
+        tracker.setModelMetadata("claude-3", "https://api.anthropic.com/v1/messages", "claude-3");
+        tracker.recordTurn("gpt-4", usage1);
+        tracker.recordTurn("claude-3", usage2);
+        tracker.recordTurn("gpt-4", usage3);
+
+        Map<String, Object> output = tracker.toOutputMap();
+
+        List<Map<String, Object>> perModelUsage = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(2, perModelUsage.size());
+
+        // Find each model's data
+        Map<String, Object> gpt4Data = perModelUsage.stream().filter(m -> "gpt-4".equals(m.get("model_id"))).findFirst().orElse(null);
+        Map<String, Object> claudeData = perModelUsage.stream().filter(m -> "claude-3".equals(m.get("model_id"))).findFirst().orElse(null);
+
+        assertNotNull(gpt4Data);
+        assertNotNull(claudeData);
+
+        assertEquals(250L, gpt4Data.get("input_tokens"));
+        assertEquals(110L, gpt4Data.get("output_tokens"));
+        assertEquals(2, gpt4Data.get("call_count"));
+
+        assertEquals(200L, claudeData.get("input_tokens"));
+        assertEquals(75L, claudeData.get("output_tokens"));
+        assertEquals(1, claudeData.get("call_count"));
+    }
+
+    @Test
+    public void testRecordWithCacheTokens() {
+        TokenUsage usage = TokenUsage
+            .builder()
+            .inputTokens(100L)
+            .outputTokens(50L)
+            .totalTokens(150L)
+            .cacheReadInputTokens(20L)
+            .cacheCreationInputTokens(10L)
+            .build();
+
+        tracker.setModelMetadata("claude-3", "https://api.anthropic.com/v1/messages", "claude-3");
+        tracker.recordTurn("claude-3", usage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perTurnUsage = (List<Map<String, Object>>) output.get("per_turn_usage");
+
+        Map<String, Object> turn = perTurnUsage.get(0);
+        assertEquals(20L, turn.get("cache_read_input_tokens"));
+        assertEquals(10L, turn.get("cache_creation_input_tokens"));
+    }
+
+    @Test
+    public void testRecordWithReasoningTokens() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).reasoningTokens(30L).build();
+
+        tracker.setModelMetadata("o1-preview", "https://api.openai.com/v1/chat/completions", "o1-preview");
+        tracker.recordTurn("o1-preview", usage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perTurnUsage = (List<Map<String, Object>>) output.get("per_turn_usage");
+
+        Map<String, Object> turn = perTurnUsage.get(0);
+        assertEquals(30L, turn.get("reasoning_tokens"));
+    }
+
+    @Test
+    public void testRecordWithNullModelName() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).build();
+
+        tracker.recordTurn(null, usage);
+
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testRecordWithNullUsage() {
+        tracker.recordTurn("gpt-4", null);
+
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testHasUsageWhenEmpty() {
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testEmptyOutputMap() {
+        Map<String, Object> output = tracker.toOutputMap();
+
+        assertNotNull(output);
+        assertTrue(((List<?>) output.get("per_turn_usage")).isEmpty());
+        assertTrue(((List<?>) output.get("per_model_usage")).isEmpty());
+    }
+
+    // --- mergeSubAgentUsage tests ---
+
+    @Test
+    public void testMergeSubAgentUsage_basic() {
+        Map<String, Object> subAgentUsage = new HashMap<>();
+        subAgentUsage
+            .put(
+                "per_turn_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "turn",
+                                1,
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                100L,
+                                "output_tokens",
+                                50L,
+                                "total_tokens",
+                                150L
+                            ),
+                        Map
+                            .of(
+                                "turn",
+                                2,
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                200L,
+                                "output_tokens",
+                                75L,
+                                "total_tokens",
+                                275L
+                            )
+                    )
+            );
+        subAgentUsage
+            .put(
+                "per_model_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                300L,
+                                "output_tokens",
+                                125L,
+                                "total_tokens",
+                                425L,
+                                "call_count",
+                                2
+                            )
+                    )
+            );
+
+        tracker.mergeSubAgentUsage(subAgentUsage);
+
+        assertTrue(tracker.hasUsage());
+        Map<String, Object> output = tracker.toOutputMap();
+
+        List<Map<String, Object>> perTurn = (List<Map<String, Object>>) output.get("per_turn_usage");
+        assertEquals(2, perTurn.size());
+        assertEquals(1, perTurn.get(0).get("turn"));
+        assertEquals(2, perTurn.get(1).get("turn"));
+
+        List<Map<String, Object>> perModel = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(1, perModel.size());
+        assertEquals(300L, perModel.get(0).get("input_tokens"));
+        assertEquals(2, perModel.get(0).get("call_count"));
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_afterExistingTurns() {
+        // Record 2 direct planner turns first
+        tracker.setModelMetadata("gpt-4", "https://openai", "gpt-4");
+        tracker.recordTurn("gpt-4", TokenUsage.builder().inputTokens(50L).outputTokens(25L).totalTokens(75L).build());
+        tracker.recordTurn("gpt-4", TokenUsage.builder().inputTokens(60L).outputTokens(30L).totalTokens(90L).build());
+
+        // Merge sub-agent usage with 3 turns
+        Map<String, Object> subAgentUsage = new HashMap<>();
+        subAgentUsage
+            .put(
+                "per_turn_usage",
+                List
+                    .of(
+                        Map.of("turn", 1, "model_id", "claude-3", "input_tokens", 100L, "output_tokens", 50L, "total_tokens", 150L),
+                        Map.of("turn", 2, "model_id", "claude-3", "input_tokens", 200L, "output_tokens", 75L, "total_tokens", 275L),
+                        Map.of("turn", 3, "model_id", "claude-3", "input_tokens", 150L, "output_tokens", 60L, "total_tokens", 210L)
+                    )
+            );
+        subAgentUsage
+            .put(
+                "per_model_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                450L,
+                                "output_tokens",
+                                185L,
+                                "total_tokens",
+                                635L,
+                                "call_count",
+                                3
+                            )
+                    )
+            );
+
+        tracker.mergeSubAgentUsage(subAgentUsage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perTurn = (List<Map<String, Object>>) output.get("per_turn_usage");
+        assertEquals(5, perTurn.size());
+
+        // Planner turns keep 1, 2; sub-agent turns re-numbered to 3, 4, 5
+        assertEquals(1, perTurn.get(0).get("turn"));
+        assertEquals(2, perTurn.get(1).get("turn"));
+        assertEquals(3, perTurn.get(2).get("turn"));
+        assertEquals(4, perTurn.get(3).get("turn"));
+        assertEquals(5, perTurn.get(4).get("turn"));
+
+        // Two separate models in per_model_usage
+        List<Map<String, Object>> perModel = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(2, perModel.size());
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_sameModel() {
+        // Planner uses same model as executor
+        tracker.setModelMetadata("claude-3", "https://bedrock", "claude-3");
+        tracker.recordTurn("claude-3", TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build());
+
+        Map<String, Object> subAgentUsage = new HashMap<>();
+        subAgentUsage
+            .put(
+                "per_turn_usage",
+                List.of(Map.of("turn", 1, "model_id", "claude-3", "input_tokens", 200L, "output_tokens", 75L, "total_tokens", 275L))
+            );
+        subAgentUsage
+            .put(
+                "per_model_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                200L,
+                                "output_tokens",
+                                75L,
+                                "total_tokens",
+                                275L,
+                                "call_count",
+                                1
+                            )
+                    )
+            );
+
+        tracker.mergeSubAgentUsage(subAgentUsage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perModel = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(1, perModel.size());
+
+        // Aggregated: 100+200=300 input, 50+75=125 output, 150+275=425 total, 1+1=2 calls
+        assertEquals(300L, perModel.get(0).get("input_tokens"));
+        assertEquals(125L, perModel.get(0).get("output_tokens"));
+        assertEquals(425L, perModel.get(0).get("total_tokens"));
+        assertEquals(2, perModel.get(0).get("call_count"));
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_nullInput() {
+        tracker.mergeSubAgentUsage(null);
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_emptyMap() {
+        tracker.mergeSubAgentUsage(new HashMap<>());
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_multipleSteps() {
+        // Simulate PER executing 2 steps, each executor returns token usage
+        tracker.setModelMetadata("gpt-4", "https://openai", "gpt-4");
+
+        // Planner call 1
+        tracker.recordTurn("gpt-4", TokenUsage.builder().inputTokens(50L).outputTokens(25L).totalTokens(75L).build());
+
+        // Executor step 1
+        Map<String, Object> step1Usage = new HashMap<>();
+        step1Usage
+            .put(
+                "per_turn_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "turn",
+                                1,
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                100L,
+                                "output_tokens",
+                                50L,
+                                "total_tokens",
+                                150L
+                            )
+                    )
+            );
+        step1Usage
+            .put(
+                "per_model_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                100L,
+                                "output_tokens",
+                                50L,
+                                "total_tokens",
+                                150L,
+                                "call_count",
+                                1
+                            )
+                    )
+            );
+        tracker.mergeSubAgentUsage(step1Usage);
+
+        // Planner reflect call
+        tracker.recordTurn("gpt-4", TokenUsage.builder().inputTokens(80L).outputTokens(30L).totalTokens(110L).build());
+
+        // Executor step 2
+        Map<String, Object> step2Usage = new HashMap<>();
+        step2Usage
+            .put(
+                "per_turn_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "turn",
+                                1,
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                200L,
+                                "output_tokens",
+                                75L,
+                                "total_tokens",
+                                275L
+                            ),
+                        Map
+                            .of(
+                                "turn",
+                                2,
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                150L,
+                                "output_tokens",
+                                60L,
+                                "total_tokens",
+                                210L
+                            )
+                    )
+            );
+        step2Usage
+            .put(
+                "per_model_usage",
+                List
+                    .of(
+                        Map
+                            .of(
+                                "model_id",
+                                "claude-3",
+                                "model_name",
+                                "claude-3",
+                                "model_url",
+                                "https://bedrock",
+                                "input_tokens",
+                                350L,
+                                "output_tokens",
+                                135L,
+                                "total_tokens",
+                                485L,
+                                "call_count",
+                                2
+                            )
+                    )
+            );
+        tracker.mergeSubAgentUsage(step2Usage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+
+        // 1 planner + 1 executor step1 + 1 planner reflect + 2 executor step2 = 5 turns
+        List<Map<String, Object>> perTurn = (List<Map<String, Object>>) output.get("per_turn_usage");
+        assertEquals(5, perTurn.size());
+        for (int i = 0; i < 5; i++) {
+            assertEquals(i + 1, perTurn.get(i).get("turn"));
+        }
+
+        // 2 models: gpt-4 (planner) and claude-3 (executor)
+        List<Map<String, Object>> perModel = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(2, perModel.size());
+
+        Map<String, Object> gpt4 = perModel.stream().filter(m -> "gpt-4".equals(m.get("model_id"))).findFirst().orElse(null);
+        Map<String, Object> claude3 = perModel.stream().filter(m -> "claude-3".equals(m.get("model_id"))).findFirst().orElse(null);
+
+        assertNotNull(gpt4);
+        assertEquals(130L, gpt4.get("input_tokens")); // 50+80
+        assertEquals(55L, gpt4.get("output_tokens"));  // 25+30
+        assertEquals(2, gpt4.get("call_count"));
+
+        assertNotNull(claude3);
+        assertEquals(450L, claude3.get("input_tokens")); // 100+350
+        assertEquals(185L, claude3.get("output_tokens")); // 50+135
+        assertEquals(3, claude3.get("call_count"));        // 1+2
+    }
+
+    @Test
+    public void testSubAgentFlag_defaultFalse() {
+        assertFalse(tracker.isSubAgent());
+    }
+
+    @Test
+    public void testSubAgentFlag_setTrue() {
+        tracker.setSubAgent(true);
+        assertTrue(tracker.isSubAgent());
+    }
+
+    @Test
+    public void testSetModelMetadata_nullModelId() {
+        tracker.setModelMetadata(null, "https://api.openai.com", "gpt-4");
+        // Should not throw; metadata not stored for null key
+
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+        tracker.recordTurn("some-model", usage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perTurn = (List<Map<String, Object>>) output.get("per_turn_usage");
+        // Should use defaults since no metadata was set for "some-model"
+        assertEquals("some-model", perTurn.get(0).get("model_name"));
+        assertEquals("some-model", perTurn.get(0).get("model_url"));
+    }
+
+    @Test
+    public void testRecordTurn_nullModelId() {
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).build();
+        tracker.recordTurn(null, usage);
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testRecordTurn_nullUsage() {
+        tracker.recordTurn("model-1", null);
+        assertFalse(tracker.hasUsage());
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_nullModelIdInSubModel() {
+        Map<String, Object> subModel = new HashMap<>();
+        subModel.put("model_id", null);
+        subModel.put("input_tokens", 100L);
+
+        Map<String, Object> tokenUsageMap = new HashMap<>();
+        tokenUsageMap.put("per_model_usage", List.of(subModel));
+        tokenUsageMap.put("per_turn_usage", List.of());
+
+        tracker.mergeSubAgentUsage(tokenUsageMap);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perModel = (List<Map<String, Object>>) output.get("per_model_usage");
+        // Null model ID entries should be skipped
+        assertTrue(perModel.isEmpty());
+    }
+
+    @Test
+    public void testMergeSubAgentUsage_subModelWithoutCallCount() {
+        Map<String, Object> subModel = new HashMap<>();
+        subModel.put("model_id", "claude-3");
+        subModel.put("model_url", "https://bedrock.amazonaws.com");
+        subModel.put("model_name", "claude-3");
+        subModel.put("input_tokens", 100L);
+        subModel.put("output_tokens", 50L);
+        // No CALL_COUNT key — should default to 1
+
+        Map<String, Object> tokenUsageMap = new HashMap<>();
+        tokenUsageMap.put("per_model_usage", List.of(subModel));
+        tokenUsageMap.put("per_turn_usage", List.of());
+
+        tracker.mergeSubAgentUsage(tokenUsageMap);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perModel = (List<Map<String, Object>>) output.get("per_model_usage");
+        assertEquals(1, perModel.size());
+        assertEquals(1, perModel.get(0).get("call_count"));
+    }
+
+    @Test
+    public void testSetModelMetadata_nullUrlAndName() {
+        tracker.setModelMetadata("model-1", null, null);
+
+        TokenUsage usage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+        tracker.recordTurn("model-1", usage);
+
+        Map<String, Object> output = tracker.toOutputMap();
+        List<Map<String, Object>> perTurn = (List<Map<String, Object>>) output.get("per_turn_usage");
+        // Should default to empty strings for null url/name
+        assertEquals("", perTurn.get(0).get("model_name"));
+        assertEquals("", perTurn.get(0).get("model_url"));
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.engine.algorithms.agent;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -2254,5 +2255,485 @@ public class AgentUtilsTest extends MLStaticMockBase {
         List<org.opensearch.ml.engine.memory.ConversationIndexMessage> pairs = AgentUtils
             .extractMessagePairs(Collections.emptyList(), "s1", null);
         assertTrue(pairs.isEmpty());
+    }
+
+    // ===== getModelMetadata tests =====
+
+    @Test
+    public void testGetModelMetadata_nullSdkClient() {
+        AtomicReference<String[]> result = new AtomicReference<>();
+        AgentUtils.getModelMetadata("model-1", "tenant-1", null, client, null, ActionListener.wrap(result::set, e -> {
+            throw new AssertionError("Should not fail", e);
+        }));
+
+        assertNotNull(result.get());
+        assertEquals("model-1", result.get()[0]); // url falls back to modelId
+        assertEquals("model-1", result.get()[1]); // name falls back to modelId
+    }
+
+    // ===== addTokenUsageTensor tests =====
+
+    @Test
+    public void testAddTokenUsageTensor_nullTracker() {
+        List<ModelTensors> tensors = new ArrayList<>();
+        AgentUtils.addTokenUsageTensor(tensors, null, "tenant-1", true);
+        assertTrue(tensors.isEmpty());
+    }
+
+    @Test
+    public void testAddTokenUsageTensor_emptyTracker() {
+        List<ModelTensors> tensors = new ArrayList<>();
+        AgentTokenTracker tracker = new AgentTokenTracker();
+        AgentUtils.addTokenUsageTensor(tensors, tracker, "tenant-1", true);
+        assertTrue(tensors.isEmpty()); // hasUsage() is false
+    }
+
+    @Test
+    public void testAddTokenUsageTensor_withUsage() {
+        List<ModelTensors> tensors = new ArrayList<>();
+        AgentTokenTracker tracker = new AgentTokenTracker();
+        tracker.setModelMetadata("model-1", "https://bedrock.amazonaws.com", "claude-v3");
+        tracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        AgentUtils.addTokenUsageTensor(tensors, tracker, "tenant-1", true);
+
+        assertEquals(1, tensors.size());
+        ModelTensors modelTensors = tensors.get(0);
+        assertEquals(1, modelTensors.getMlModelTensors().size());
+
+        ModelTensor tensor = modelTensors.getMlModelTensors().get(0);
+        assertEquals(AgentTokenTracker.TOKEN_USAGE, tensor.getName());
+        assertNotNull(tensor.getDataAsMap());
+        assertTrue(tensor.getDataAsMap().containsKey(AgentTokenTracker.PER_MODEL_USAGE));
+        assertTrue(tensor.getDataAsMap().containsKey(AgentTokenTracker.PER_TURN_USAGE));
+    }
+
+    @Test
+    public void testAddTokenUsageTensor_excludedWhenFlagFalse() {
+        List<ModelTensors> tensors = new ArrayList<>();
+        AgentTokenTracker tracker = new AgentTokenTracker();
+        tracker.setModelMetadata("model-1", "https://bedrock.amazonaws.com", "claude-v3");
+        tracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        AgentUtils.addTokenUsageTensor(tensors, tracker, "tenant-1", false);
+
+        // Tensor should NOT be added when includeTokenUsage is false
+        assertTrue(tensors.isEmpty());
+    }
+
+    @Test
+    public void testAddTokenUsageTensor_subAgentAlwaysIncludesTensor() {
+        List<ModelTensors> tensors = new ArrayList<>();
+        AgentTokenTracker tracker = new AgentTokenTracker();
+        tracker.setSubAgent(true);
+        tracker.setModelMetadata("model-1", "https://example.com", "test-model");
+        tracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        // Even with includeTokenUsage=false, sub-agents must include the tensor for parent merging
+        AgentUtils.addTokenUsageTensor(tensors, tracker, "tenant-1", false);
+
+        assertEquals(1, tensors.size());
+        ModelTensor tensor = tensors.get(0).getMlModelTensors().get(0);
+        assertEquals(AgentTokenTracker.TOKEN_USAGE, tensor.getName());
+    }
+
+    // ===== getLongValue tests =====
+
+    @Test
+    public void testGetLongValue_fromNumber() {
+        Map<String, Object> map = Map.of("tokens", 42L);
+        assertEquals(Long.valueOf(42L), AgentUtils.getLongValue(map, "tokens"));
+    }
+
+    @Test
+    public void testGetLongValue_fromString() {
+        Map<String, Object> map = Map.of("tokens", "100");
+        assertEquals(Long.valueOf(100L), AgentUtils.getLongValue(map, "tokens"));
+    }
+
+    @Test
+    public void testGetLongValue_fromInvalidString() {
+        Map<String, Object> map = Map.of("tokens", "not_a_number");
+        assertNull(AgentUtils.getLongValue(map, "tokens"));
+    }
+
+    @Test
+    public void testGetLongValue_missingKey() {
+        Map<String, Object> map = Map.of("other", 42);
+        assertNull(AgentUtils.getLongValue(map, "tokens"));
+    }
+
+    // ===== resolveModelUrl tests =====
+
+    @Test
+    public void testResolveModelUrl_withInlineConnector() {
+        org.opensearch.ml.common.MLModel mlModel = mock(org.opensearch.ml.common.MLModel.class);
+        Connector connector = mock(Connector.class);
+        when(mlModel.getConnector()).thenReturn(connector);
+        when(connector.getParameters()).thenReturn(Map.of());
+        when(connector.getActionEndpoint("predict", Map.of())).thenReturn("https://bedrock.amazonaws.com/model/claude/converse");
+
+        AtomicReference<String> result = new AtomicReference<>();
+        AgentUtils.resolveModelUrl(mlModel, "tenant-1", null, null, ActionListener.wrap(result::set, e -> {
+            throw new AssertionError("Should not fail", e);
+        }));
+
+        assertEquals("https://bedrock.amazonaws.com/model/claude/converse", result.get());
+    }
+
+    @Test
+    public void testResolveModelUrl_noConnectorOrConnectorId() {
+        org.opensearch.ml.common.MLModel mlModel = mock(org.opensearch.ml.common.MLModel.class);
+        when(mlModel.getConnector()).thenReturn(null);
+        when(mlModel.getConnectorId()).thenReturn(null);
+
+        AtomicReference<Exception> error = new AtomicReference<>();
+        AgentUtils
+            .resolveModelUrl(
+                mlModel,
+                "tenant-1",
+                null,
+                null,
+                ActionListener.wrap(url -> { throw new AssertionError("Should not succeed"); }, error::set)
+            );
+
+        assertNotNull(error.get());
+        assertTrue(error.get() instanceof IllegalStateException);
+    }
+
+    @Test
+    public void testResolveModelUrl_inlineConnectorNullEndpoint() {
+        org.opensearch.ml.common.MLModel mlModel = mock(org.opensearch.ml.common.MLModel.class);
+        Connector connector = mock(Connector.class);
+        when(mlModel.getConnector()).thenReturn(connector);
+        when(connector.getParameters()).thenReturn(null);
+        when(connector.getActionEndpoint("predict", Map.of())).thenReturn(null);
+
+        AtomicReference<Exception> error = new AtomicReference<>();
+        AgentUtils
+            .resolveModelUrl(
+                mlModel,
+                "tenant-1",
+                null,
+                null,
+                ActionListener.wrap(url -> { throw new AssertionError("Should not succeed"); }, error::set)
+            );
+
+        assertNotNull(error.get());
+        assertTrue(error.get() instanceof IllegalStateException);
+    }
+
+    // ===== logTokenUsageDetails tests =====
+
+    @Test
+    public void testLogTokenUsageDetails_nullTracker() {
+        // Should not throw
+        AgentUtils.logTokenUsageDetails(null, Map.of(), "tenant-1");
+    }
+
+    @Test
+    public void testLogTokenUsageDetails_nullMap() {
+        AgentTokenTracker tracker = new AgentTokenTracker();
+        // Should not throw
+        AgentUtils.logTokenUsageDetails(tracker, null, "tenant-1");
+    }
+
+    @Test
+    public void testLogTokenUsageDetails_subAgent_skipsLogging() {
+        AgentTokenTracker tracker = new AgentTokenTracker();
+        tracker.setSubAgent(true);
+        tracker.setModelMetadata("model-1", "https://example.com", "test-model");
+        tracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        // Should not throw; sub-agent logging is silently skipped
+        AgentUtils.logTokenUsageDetails(tracker, tracker.toOutputMap(), "tenant-1");
+    }
+
+    @Test
+    public void testLogTokenUsageDetails_withPerModelUsage() {
+        AgentTokenTracker tracker = new AgentTokenTracker();
+        tracker.setModelMetadata("model-1", "https://example.com", "test-model");
+        tracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        // Should not throw; logs structured per-model usage
+        AgentUtils.logTokenUsageDetails(tracker, tracker.toOutputMap(), "tenant-1");
+    }
+
+    @Test
+    public void testLogTokenUsageDetails_emptyPerModelUsage() {
+        AgentTokenTracker tracker = new AgentTokenTracker();
+        Map<String, Object> emptyMap = new HashMap<>();
+        emptyMap.put(AgentTokenTracker.PER_MODEL_USAGE, "not_a_list");
+
+        // Should not throw; per_model_usage is not a List so logging loop is skipped
+        AgentUtils.logTokenUsageDetails(tracker, emptyMap, null);
+    }
+
+    // ===== getModel tests =====
+
+    @SuppressWarnings("unchecked")
+    private void stubGetModelSuccess(String modelJson) {
+        threadContext = new ThreadContext(Settings.builder().build());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenAnswer(inv -> {
+            String json = "{\"_index\":\""
+                + org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX
+                + "\",\"_id\":\"model-1\",\"found\":true,\"_source\":"
+                + modelJson
+                + "}";
+            XContentParser parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, null, json);
+
+            GetDataObjectResponse resp = mock(GetDataObjectResponse.class);
+            when(resp.parser()).thenReturn(parser);
+
+            CompletionStage<GetDataObjectResponse> stage = mock(CompletionStage.class);
+            when(stage.whenComplete(any())).thenAnswer(cbInv -> {
+                BiConsumer<GetDataObjectResponse, Throwable> cb = cbInv.getArgument(0);
+                cb.accept(resp, null);
+                return stage;
+            });
+
+            return stage;
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubGetModelNotFound() {
+        threadContext = new ThreadContext(Settings.builder().build());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenAnswer(inv -> {
+            String json = "{\"_index\":\"i\",\"_id\":\"model-1\",\"found\":false}";
+            XContentParser parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, null, json);
+
+            GetDataObjectResponse resp = mock(GetDataObjectResponse.class);
+            when(resp.parser()).thenReturn(parser);
+
+            CompletionStage<GetDataObjectResponse> stage = mock(CompletionStage.class);
+            when(stage.whenComplete(any())).thenAnswer(cbInv -> {
+                BiConsumer<GetDataObjectResponse, Throwable> cb = cbInv.getArgument(0);
+                cb.accept(resp, null);
+                return stage;
+            });
+
+            return stage;
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubGetModelException(Throwable error) {
+        threadContext = new ThreadContext(Settings.builder().build());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenAnswer(inv -> {
+            CompletionStage<GetDataObjectResponse> stage = mock(CompletionStage.class);
+            when(stage.whenComplete(any())).thenAnswer(cbInv -> {
+                BiConsumer<GetDataObjectResponse, Throwable> cb = cbInv.getArgument(0);
+                cb.accept(null, error);
+                return stage;
+            });
+
+            return stage;
+        });
+    }
+
+    @Test
+    public void testGetModel_success() {
+        String modelJson = "{\"name\":\"test-model\",\"algorithm\":\"TEXT_EMBEDDING\"}";
+        stubGetModelSuccess(modelJson);
+
+        AtomicReference<org.opensearch.ml.common.MLModel> result = new AtomicReference<>();
+        AtomicReference<Exception> error = new AtomicReference<>();
+        AgentUtils
+            .getModel("model-1", "tenant-1", sdkClient, client, NamedXContentRegistry.EMPTY, ActionListener.wrap(result::set, error::set));
+
+        assertNull(error.get());
+        assertNotNull(result.get());
+        assertEquals("test-model", result.get().getName());
+    }
+
+    @Test
+    public void testGetModel_notFound() {
+        stubGetModelNotFound();
+
+        AtomicReference<Exception> error = new AtomicReference<>();
+        AgentUtils.getModel("model-1", "tenant-1", sdkClient, client, NamedXContentRegistry.EMPTY, ActionListener.wrap(m -> {
+            throw new AssertionError("Should not succeed");
+        }, error::set));
+
+        assertNotNull(error.get());
+        assertTrue(error.get().getMessage().contains("Failed to find model"));
+    }
+
+    @Test
+    public void testGetModel_indexNotFoundException() {
+        stubGetModelException(new org.opensearch.index.IndexNotFoundException("test"));
+
+        AtomicReference<Exception> error = new AtomicReference<>();
+        AgentUtils.getModel("model-1", "tenant-1", sdkClient, client, NamedXContentRegistry.EMPTY, ActionListener.wrap(m -> {
+            throw new AssertionError("Should not succeed");
+        }, error::set));
+
+        assertNotNull(error.get());
+        assertTrue(error.get().getMessage().contains("Failed to find model"));
+    }
+
+    @Test
+    public void testGetModel_genericException() {
+        stubGetModelException(new RuntimeException("Something went wrong"));
+
+        AtomicReference<Exception> error = new AtomicReference<>();
+        AgentUtils.getModel("model-1", "tenant-1", sdkClient, client, NamedXContentRegistry.EMPTY, ActionListener.wrap(m -> {
+            throw new AssertionError("Should not succeed");
+        }, error::set));
+
+        assertNotNull(error.get());
+    }
+
+    @Test
+    public void testGetModel_nullParser() {
+        threadContext = new ThreadContext(Settings.builder().build());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenAnswer(inv -> {
+            GetDataObjectResponse resp = mock(GetDataObjectResponse.class);
+            when(resp.parser()).thenReturn(null);
+
+            CompletionStage<GetDataObjectResponse> stage = mock(CompletionStage.class);
+            when(stage.whenComplete(any())).thenAnswer(cbInv -> {
+                BiConsumer<GetDataObjectResponse, Throwable> cb = cbInv.getArgument(0);
+                cb.accept(resp, null);
+                return stage;
+            });
+
+            return stage;
+        });
+
+        AtomicReference<Exception> error = new AtomicReference<>();
+        AgentUtils.getModel("model-1", "tenant-1", sdkClient, client, NamedXContentRegistry.EMPTY, ActionListener.wrap(m -> {
+            throw new AssertionError("Should not succeed");
+        }, error::set));
+
+        assertNotNull(error.get());
+        assertTrue(error.get().getMessage().contains("Failed to find model"));
+    }
+
+    // ===== resolveModelUrl connector ID path tests =====
+
+    @Test
+    public void testResolveModelUrl_withConnectorId_success() {
+        org.opensearch.ml.common.MLModel mlModel = mock(org.opensearch.ml.common.MLModel.class);
+        when(mlModel.getConnector()).thenReturn(null);
+        when(mlModel.getConnectorId()).thenReturn("connector-1");
+
+        // Stub getConnector to return a connector with a valid endpoint
+        stubGetConnector();
+
+        try (MockedStatic<Connector> connStatic = mockStatic(Connector.class)) {
+            Connector mockConnector = mock(Connector.class);
+            when(mockConnector.getParameters()).thenReturn(Map.of());
+            when(mockConnector.getActionEndpoint("predict", Map.of())).thenReturn("https://bedrock.amazonaws.com/model/test");
+            connStatic.when(() -> Connector.createConnector(any(XContentParser.class))).thenReturn(mockConnector);
+
+            AtomicReference<String> result = new AtomicReference<>();
+            AtomicReference<Exception> error = new AtomicReference<>();
+            AgentUtils.resolveModelUrl(mlModel, "tenant-1", sdkClient, client, ActionListener.wrap(result::set, error::set));
+
+            assertNull(error.get());
+            assertEquals("https://bedrock.amazonaws.com/model/test", result.get());
+        }
+    }
+
+    @Test
+    public void testResolveModelUrl_withConnectorId_connectorFetchFails() {
+        org.opensearch.ml.common.MLModel mlModel = mock(org.opensearch.ml.common.MLModel.class);
+        when(mlModel.getConnector()).thenReturn(null);
+        when(mlModel.getConnectorId()).thenReturn("connector-1");
+
+        // Stub getConnector to fail
+        threadContext = new ThreadContext(Settings.builder().build());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenAnswer(inv -> {
+            CompletionStage<GetDataObjectResponse> stage = mock(CompletionStage.class);
+            when(stage.whenComplete(any())).thenAnswer(cbInv -> {
+                BiConsumer<GetDataObjectResponse, Throwable> cb = cbInv.getArgument(0);
+                cb.accept(null, new RuntimeException("Failed to get connector"));
+                return stage;
+            });
+            return stage;
+        });
+
+        AtomicReference<Exception> error = new AtomicReference<>();
+        AgentUtils.resolveModelUrl(mlModel, "tenant-1", sdkClient, client, ActionListener.wrap(url -> {
+            throw new AssertionError("Should not succeed");
+        }, error::set));
+
+        assertNotNull(error.get());
+    }
+
+    // ===== getModelMetadata with sdkClient tests =====
+
+    @Test
+    public void testGetModelMetadata_success() {
+        String modelJson = "{\"name\":\"test-model\",\"algorithm\":\"TEXT_EMBEDDING\"}";
+        stubGetModelSuccess(modelJson);
+
+        // Need a second stub for the connector fetch from resolveModelUrl
+        // But the model has no connector, so it will fail with IllegalStateException
+        // which triggers the fallback path
+
+        AtomicReference<String[]> result = new AtomicReference<>();
+        AgentUtils
+            .getModelMetadata("model-1", "tenant-1", sdkClient, client, NamedXContentRegistry.EMPTY, ActionListener.wrap(result::set, e -> {
+                throw new AssertionError("Should not fail", e);
+            }));
+
+        assertNotNull(result.get());
+        // URL falls back to modelId because model has no connector
+        assertEquals("model-1", result.get()[0]);
+        // Name comes from the model
+        assertEquals("test-model", result.get()[1]);
+    }
+
+    @Test
+    public void testGetModelMetadata_getModelFails_fallback() {
+        stubGetModelException(new RuntimeException("DB error"));
+
+        AtomicReference<String[]> result = new AtomicReference<>();
+        AgentUtils
+            .getModelMetadata("model-1", "tenant-1", sdkClient, client, NamedXContentRegistry.EMPTY, ActionListener.wrap(result::set, e -> {
+                throw new AssertionError("Should not fail", e);
+            }));
+
+        assertNotNull(result.get());
+        assertEquals("model-1", result.get()[0]); // falls back to modelId
+        assertEquals("model-1", result.get()[1]); // falls back to modelId
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerTest.java
@@ -170,6 +170,12 @@ public class MLChatAgentRunnerTest {
             return null;
         }).when(conversationIndexMemory).update(any(), any(), any());
 
+        doAnswer(invocation -> {
+            ActionListener<Void> listener = invocation.getArgument(1);
+            listener.onResponse(null);
+            return null;
+        }).when(conversationIndexMemory).saveStructuredMessages(any(), any());
+
         mlChatAgentRunner = new MLChatAgentRunner(client, settings, clusterService, xContentRegistry, toolFactories, memoryMap, null, null);
         when(firstToolFactory.create(Mockito.anyMap())).thenReturn(firstTool);
         when(secondToolFactory.create(Mockito.anyMap())).thenReturn(secondTool);
@@ -889,10 +895,10 @@ public class MLChatAgentRunnerTest {
         Map<String, String> params = createAgentParamsWithAction(FIRST_TOOL, "someInput");
 
         doAnswer(invocation -> {
-            ActionListener<CreateInteractionResponse> listener = invocation.getArgument(4);
+            ActionListener<Void> listener = invocation.getArgument(1);
             listener.onFailure(new IllegalArgumentException());
             return null;
-        }).when(conversationIndexMemory).save(any(), any(), any(), any(), conversationIndexMemoryCapture.capture());
+        }).when(conversationIndexMemory).saveStructuredMessages(any(), any());
         // Run the MLChatAgentRunner
         mlChatAgentRunner.run(mlAgent, params, agentActionListener, null);
 
@@ -1496,7 +1502,7 @@ public class MLChatAgentRunnerTest {
         LLMSpec llmSpec = LLMSpec.builder().modelId("MODEL_ID").build();
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
 
-        mlChatAgentRunner.generateLLMSummary(null, llmSpec, "tenant", "question", new HashMap<>(), listener);
+        mlChatAgentRunner.generateLLMSummary(null, llmSpec, "tenant", "question", new HashMap<>(), listener, null, null);
 
         verify(listener).onFailure(any(IllegalArgumentException.class));
     }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLPlanExecuteAndReflectAgentRunnerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLPlanExecuteAndReflectAgentRunnerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -47,6 +48,7 @@ import org.opensearch.ml.common.agent.LLMSpec;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLMemorySpec;
 import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.conversation.Interaction;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.execute.agent.AgentMLInput;
@@ -64,6 +66,8 @@ import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 import org.opensearch.ml.common.utils.MLTaskUtils;
 import org.opensearch.ml.engine.MLStaticMockBase;
 import org.opensearch.ml.engine.encryptor.Encryptor;
+import org.opensearch.ml.engine.function_calling.FunctionCalling;
+import org.opensearch.ml.engine.function_calling.FunctionCallingFactory;
 import org.opensearch.ml.engine.memory.ConversationIndexMemory;
 import org.opensearch.ml.engine.memory.MLMemoryManager;
 import org.opensearch.ml.memory.action.conversation.CreateInteractionResponse;
@@ -168,6 +172,8 @@ public class MLPlanExecuteAndReflectAgentRunnerTest extends MLStaticMockBase {
             return null;
         }).when(conversationIndexMemory).save(any(), any(), any(), any(), any());
 
+        // Pass null for sdkClient - the null check in setToolsAndRunAgent will skip model resolution
+        // Same pattern as MLChatAgentRunnerTest
         mlPlanExecuteAndReflectAgentRunner = new MLPlanExecuteAndReflectAgentRunner(
             client,
             settings,
@@ -175,7 +181,7 @@ public class MLPlanExecuteAndReflectAgentRunnerTest extends MLStaticMockBase {
             xContentRegistry,
             toolFactories,
             memoryMap,
-            sdkClient,
+            null,
             encryptor,
             null
         );
@@ -854,7 +860,10 @@ public class MLPlanExecuteAndReflectAgentRunnerTest extends MLStaticMockBase {
                 executorParentId,
                 finalResult,
                 input,
-                agentActionListener
+                agentActionListener,
+                null,
+                null,
+                false
             );
 
         verify(agentActionListener).onResponse(objectCaptor.capture());
@@ -1054,7 +1063,7 @@ public class MLPlanExecuteAndReflectAgentRunnerTest extends MLStaticMockBase {
             assertEquals("test_executor_parent_id", response.get("executor_agent_parent_interaction_id"));
 
             mlTaskUtilsMockedStatic
-                .verify(() -> MLTaskUtils.updateMLTaskDirectly(eq(taskId), any(), eq(taskUpdates), eq(client), eq(sdkClient), any()));
+                .verify(() -> MLTaskUtils.updateMLTaskDirectly(eq(taskId), any(), eq(taskUpdates), eq(client), isNull(), any()));
         }
     }
 
@@ -1254,5 +1263,130 @@ public class MLPlanExecuteAndReflectAgentRunnerTest extends MLStaticMockBase {
         mlPlanExecuteAndReflectAgentRunner.run(mlAgent, params, agentActionListener);
 
         verify(agentActionListener).onResponse(any());
+    }
+
+    // ===== Token usage tracking tests =====
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testTokenUsageTracking_withLlmInterface() {
+        MLAgent mlAgent = createMLAgentWithTools();
+
+        try (MockedStatic<FunctionCallingFactory> factoryMock = mockStatic(FunctionCallingFactory.class)) {
+            FunctionCalling mockFunctionCalling = mock(FunctionCalling.class);
+            TokenUsage mockUsage = TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build();
+            when(mockFunctionCalling.extractTokenUsage(any())).thenReturn(mockUsage);
+            factoryMock.when(() -> FunctionCallingFactory.create(anyString())).thenReturn(mockFunctionCalling);
+
+            // LLM response with only "response" key so parseLLMOutput works
+            doAnswer(invocation -> {
+                ActionListener<Object> listener = invocation.getArgument(2);
+                ModelTensor modelTensor = ModelTensor
+                    .builder()
+                    .dataAsMap(ImmutableMap.of("response", "{\"steps\":[\"step1\"], \"result\":\"final result\"}"))
+                    .build();
+                ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+                ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+                when(mlTaskResponse.getOutput()).thenReturn(mlModelTensorOutput);
+                listener.onResponse(mlTaskResponse);
+                return null;
+            }).when(client).execute(eq(MLPredictionTaskAction.INSTANCE), any(MLPredictionTaskRequest.class), any());
+
+            doAnswer(invocation -> {
+                ActionListener<Object> listener = invocation.getArgument(1);
+                ModelTensor modelTensor = ModelTensor.builder().dataAsMap(ImmutableMap.of("response", "tool execution result")).build();
+                ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+                ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+                when(mlExecuteTaskResponse.getOutput()).thenReturn(mlModelTensorOutput);
+                listener.onResponse(mlExecuteTaskResponse);
+                return null;
+            }).when(client).execute(eq(MLExecuteTaskAction.INSTANCE), any(MLExecuteTaskRequest.class), any());
+
+            doAnswer(invocation -> {
+                ActionListener<UpdateResponse> listener = invocation.getArgument(2);
+                listener.onResponse(updateResponse);
+                return null;
+            }).when(mlMemoryManager).updateInteraction(any(), any(), any());
+
+            doAnswer(invocation -> {
+                ActionListener<Object> listener = invocation.getArgument(2);
+                listener.onResponse("success");
+                return null;
+            }).when(conversationIndexMemory).update(any(), any(), any());
+
+            Map<String, String> params = new HashMap<>();
+            params.put("question", "test question");
+            params.put(MLAgentExecutor.PARENT_INTERACTION_ID, "test_parent_interaction_id");
+            params.put("_llm_interface", "openai/v1/chat/completions");
+            params.put("include_token_usage", "true");
+            mlPlanExecuteAndReflectAgentRunner.run(mlAgent, params, agentActionListener, transportChannel);
+
+            verify(agentActionListener).onResponse(objectCaptor.capture());
+            Object response = objectCaptor.getValue();
+            assertTrue(response instanceof ModelTensorOutput);
+            ModelTensorOutput modelTensorOutput = (ModelTensorOutput) response;
+
+            // Find the token_usage tensor in the output
+            boolean foundTokenUsage = false;
+            for (ModelTensors tensors : modelTensorOutput.getMlModelOutputs()) {
+                for (ModelTensor tensor : tensors.getMlModelTensors()) {
+                    if (AgentTokenTracker.TOKEN_USAGE.equals(tensor.getName())) {
+                        foundTokenUsage = true;
+                        Map<String, Object> tokenData = (Map<String, Object>) tensor.getDataAsMap();
+                        assertNotNull(tokenData.get(AgentTokenTracker.PER_MODEL_USAGE));
+                        assertNotNull(tokenData.get(AgentTokenTracker.PER_TURN_USAGE));
+                    }
+                }
+            }
+            assertTrue("Token usage tensor should be present in output", foundTokenUsage);
+        }
+    }
+
+    @Test
+    public void testTokenUsageTracking_maxStepsZero_summaryWithTokenUsage() {
+        MLAgent mlAgent = createMLAgentWithTools();
+
+        try (MockedStatic<FunctionCallingFactory> factoryMock = mockStatic(FunctionCallingFactory.class)) {
+            FunctionCalling mockFunctionCalling = mock(FunctionCalling.class);
+            TokenUsage mockUsage = TokenUsage.builder().inputTokens(50L).outputTokens(25L).totalTokens(75L).build();
+            when(mockFunctionCalling.extractTokenUsage(any())).thenReturn(mockUsage);
+            factoryMock.when(() -> FunctionCallingFactory.create(anyString())).thenReturn(mockFunctionCalling);
+
+            // LLM response with only "response" key
+            doAnswer(invocation -> {
+                ActionListener<Object> listener = invocation.getArgument(2);
+                ModelTensor modelTensor = ModelTensor
+                    .builder()
+                    .dataAsMap(ImmutableMap.of("response", "Summary of completed steps"))
+                    .build();
+                ModelTensors modelTensors = ModelTensors.builder().mlModelTensors(Arrays.asList(modelTensor)).build();
+                ModelTensorOutput mlModelTensorOutput = ModelTensorOutput.builder().mlModelOutputs(Arrays.asList(modelTensors)).build();
+                when(mlTaskResponse.getOutput()).thenReturn(mlModelTensorOutput);
+                listener.onResponse(mlTaskResponse);
+                return null;
+            }).when(client).execute(eq(MLPredictionTaskAction.INSTANCE), any(MLPredictionTaskRequest.class), any());
+
+            doAnswer(invocation -> {
+                ActionListener<UpdateResponse> listener = invocation.getArgument(2);
+                listener.onResponse(updateResponse);
+                return null;
+            }).when(mlMemoryManager).updateInteraction(any(), any(), any());
+
+            doAnswer(invocation -> {
+                ActionListener<Object> listener = invocation.getArgument(2);
+                listener.onResponse("success");
+                return null;
+            }).when(conversationIndexMemory).update(any(), any(), any());
+
+            Map<String, String> params = new HashMap<>();
+            params.put("question", "test");
+            params.put("parent_interaction_id", "pid");
+            params.put("max_steps", "0");
+            params.put("_llm_interface", "openai/v1/chat/completions");
+            params.put("include_token_usage", "true");
+            mlPlanExecuteAndReflectAgentRunner.run(mlAgent, params, agentActionListener);
+
+            verify(agentActionListener).onResponse(any());
+        }
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/StreamingWrapperTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/StreamingWrapperTest.java
@@ -186,10 +186,48 @@ public class StreamingWrapperTest {
     }
 
     @Test
-    public void testSendFinalResponseStreaming() {
-        streamingWrapper.sendFinalResponse("session1", listener, "parent1", true, null, null, "answer");
+    public void testSendTokenUsageBatchStreaming() throws Exception {
+        AgentTokenTracker tokenTracker = new AgentTokenTracker();
+        tokenTracker.setModelMetadata("model-1", "https://bedrock.amazonaws.com", "claude-v3");
+        tokenTracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
 
-        verify(listener).onResponse("Streaming completed");
+        streamingWrapper.sendTokenUsageBatch("session1", "parent1", tokenTracker, "tenant1");
+
+        ArgumentCaptor<MLTaskResponse> responseCaptor = ArgumentCaptor.forClass(MLTaskResponse.class);
+        verify(channel).sendResponseBatch(responseCaptor.capture());
+
+        ModelTensorOutput tokenOutput = (ModelTensorOutput) responseCaptor.getValue().getOutput();
+        List<ModelTensor> tokenTensors = tokenOutput.getMlModelOutputs().get(0).getMlModelTensors();
+
+        boolean foundTokenUsage = false;
+        for (ModelTensor tensor : tokenTensors) {
+            if (AgentTokenTracker.TOKEN_USAGE.equals(tensor.getName()) && tensor.getDataAsMap() != null) {
+                foundTokenUsage = true;
+                Map<String, ?> dataMap = tensor.getDataAsMap();
+                assertTrue("Token usage should contain per_model_usage", dataMap.containsKey(AgentTokenTracker.PER_MODEL_USAGE));
+            }
+        }
+        assertTrue("Token usage chunk should be sent in streaming mode", foundTokenUsage);
+    }
+
+    @Test
+    public void testSendTokenUsageBatchNonStreaming_isNoOp() {
+        AgentTokenTracker tokenTracker = new AgentTokenTracker();
+        tokenTracker.setModelMetadata("model-1", "https://bedrock.amazonaws.com", "claude-v3");
+        tokenTracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        nonStreamingWrapper.sendTokenUsageBatch("session1", "parent1", tokenTracker, "tenant1");
+
+        // Non-streaming wrapper should not send anything
+        verify(channel, org.mockito.Mockito.never()).sendResponseBatch(any());
     }
 
     @Test
@@ -260,5 +298,103 @@ public class StreamingWrapperTest {
         assertEquals("test-parent", parentTensor.getResult());
         assertTrue((Boolean) responseTensor.getDataAsMap().get("is_last"));
 
+    }
+
+    @Test
+    public void testIsStreaming() {
+        assertTrue(streamingWrapper.isStreaming());
+        assertFalse(nonStreamingWrapper.isStreaming());
+    }
+
+    @Test
+    public void testSendTokenUsageBatch_nullTracker() {
+        streamingWrapper.sendTokenUsageBatch("session1", "parent1", null, "tenant1");
+        verify(channel, never()).sendResponseBatch(any());
+    }
+
+    @Test
+    public void testSendTokenUsageBatch_emptyTracker() {
+        AgentTokenTracker emptyTracker = new AgentTokenTracker();
+        streamingWrapper.sendTokenUsageBatch("session1", "parent1", emptyTracker, "tenant1");
+        verify(channel, never()).sendResponseBatch(any());
+    }
+
+    @Test
+    public void testSendTokenUsageBatch_nullSessionId() throws Exception {
+        AgentTokenTracker tokenTracker = new AgentTokenTracker();
+        tokenTracker.setModelMetadata("model-1", "https://bedrock.amazonaws.com", "claude-v3");
+        tokenTracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        streamingWrapper.sendTokenUsageBatch(null, "parent1", tokenTracker, "tenant1");
+
+        ArgumentCaptor<MLTaskResponse> responseCaptor = ArgumentCaptor.forClass(MLTaskResponse.class);
+        verify(channel).sendResponseBatch(responseCaptor.capture());
+
+        ModelTensorOutput tokenOutput = (ModelTensorOutput) responseCaptor.getValue().getOutput();
+        List<ModelTensor> tokenTensors = tokenOutput.getMlModelOutputs().get(0).getMlModelTensors();
+
+        // Should not contain memory_id tensor when sessionId is null
+        boolean foundMemoryId = tokenTensors.stream().anyMatch(t -> "memory_id".equals(t.getName()));
+        assertFalse(foundMemoryId);
+    }
+
+    @Test
+    public void testSendTokenUsageBatch_nullParentInteractionId() throws Exception {
+        AgentTokenTracker tokenTracker = new AgentTokenTracker();
+        tokenTracker.setModelMetadata("model-1", "https://bedrock.amazonaws.com", "claude-v3");
+        tokenTracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        streamingWrapper.sendTokenUsageBatch("session1", null, tokenTracker, "tenant1");
+
+        ArgumentCaptor<MLTaskResponse> responseCaptor = ArgumentCaptor.forClass(MLTaskResponse.class);
+        verify(channel).sendResponseBatch(responseCaptor.capture());
+
+        ModelTensorOutput tokenOutput = (ModelTensorOutput) responseCaptor.getValue().getOutput();
+        List<ModelTensor> tokenTensors = tokenOutput.getMlModelOutputs().get(0).getMlModelTensors();
+
+        // Should not contain parent_interaction_id tensor
+        boolean foundParentId = tokenTensors.stream().anyMatch(t -> "parent_interaction_id".equals(t.getName()));
+        assertFalse(foundParentId);
+    }
+
+    @Test
+    public void testSendTokenUsageBatch_withException() throws Exception {
+        AgentTokenTracker tokenTracker = new AgentTokenTracker();
+        tokenTracker.setModelMetadata("model-1", "https://bedrock.amazonaws.com", "claude-v3");
+        tokenTracker
+            .recordTurn(
+                "model-1",
+                org.opensearch.ml.common.agent.TokenUsage.builder().inputTokens(100L).outputTokens(50L).totalTokens(150L).build()
+            );
+
+        doThrow(new RuntimeException("Channel error")).when(channel).sendResponseBatch(any());
+
+        // Should not throw exception, just log error
+        streamingWrapper.sendTokenUsageBatch("session1", "parent1", tokenTracker, "tenant1");
+
+        verify(channel).sendResponseBatch(any());
+    }
+
+    @Test
+    public void testSendCompletionChunk_nullSessionAndParent() throws Exception {
+        streamingWrapper.sendCompletionChunk(null, null);
+
+        ArgumentCaptor<MLTaskResponse> responseCaptor = ArgumentCaptor.forClass(MLTaskResponse.class);
+        verify(channel).sendResponseBatch(responseCaptor.capture());
+
+        ModelTensorOutput output = (ModelTensorOutput) responseCaptor.getValue().getOutput();
+        List<ModelTensor> tensors = output.getMlModelOutputs().get(0).getMlModelTensors();
+
+        // Should only have the response tensor, no memory_id or parent_interaction_id
+        assertEquals(1, tensors.size());
+        assertEquals("response", tensors.get(0).getName());
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/StreamPredictActionListenerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/StreamPredictActionListenerTest.java
@@ -6,8 +6,11 @@
 package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -16,6 +19,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.transport.MLTaskResponse;
@@ -125,5 +129,24 @@ public class StreamPredictActionListenerTest {
 
         verify(mockChannel).sendResponseBatch(any(MLTaskResponse.class));
         verify(mockChannel).completeStream();
+    }
+
+    @Test
+    public void testHasAgentListener_false() {
+        // Default constructor sets agentListener to null
+        assertFalse(listener.hasAgentListener());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testHasAgentListener_true() {
+        ActionListener<MLTaskResponse> agentListener = mock(ActionListener.class);
+        StreamPredictActionListener<MLTaskResponse, TransportRequest> listenerWithAgent = new StreamPredictActionListener<>(
+            mockChannel,
+            agentListener,
+            "memory-id",
+            "interaction-id"
+        );
+        assertTrue(listenerWithAgent.hasAgentListener());
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandlerTest.java
@@ -6,9 +6,12 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -242,7 +245,7 @@ public class BedrockStreamingHandlerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testCreateFinalAnswerResponse_WithText() {
-        MLTaskResponse response = handler.createFinalAnswerResponse("Final answer text");
+        MLTaskResponse response = handler.createFinalAnswerResponse("Final answer text", null);
 
         assertNotNull(response);
         ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
@@ -264,7 +267,7 @@ public class BedrockStreamingHandlerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testCreateFinalAnswerResponse_NullText() {
-        MLTaskResponse response = handler.createFinalAnswerResponse(null);
+        MLTaskResponse response = handler.createFinalAnswerResponse(null, null);
 
         assertNotNull(response);
         ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
@@ -278,7 +281,7 @@ public class BedrockStreamingHandlerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testCreateFinalAnswerResponse_EmptyText() {
-        MLTaskResponse response = handler.createFinalAnswerResponse("");
+        MLTaskResponse response = handler.createFinalAnswerResponse("", null);
 
         assertNotNull(response);
         ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
@@ -287,5 +290,282 @@ public class BedrockStreamingHandlerTest {
         Map<String, Object> message = (Map<String, Object>) outputMap.get("message");
         List<Map<String, Object>> content = (List<Map<String, Object>>) message.get("content");
         assertEquals("", content.get(0).get("text"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateFinalAnswerResponse_WithTokenUsage() {
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("inputTokens", 100);
+        tokenUsage.put("outputTokens", 50);
+        tokenUsage.put("totalTokens", 150);
+
+        MLTaskResponse response = handler.createFinalAnswerResponse("answer", tokenUsage);
+
+        ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
+        Map<String, ?> dataMap = output.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap();
+        assertEquals("end_turn", dataMap.get("stopReason"));
+
+        Map<String, Object> usage = (Map<String, Object>) dataMap.get("usage");
+        assertNotNull(usage);
+        assertEquals(100, usage.get("inputTokens"));
+        assertEquals(50, usage.get("outputTokens"));
+        assertEquals(150, usage.get("totalTokens"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateFinalAnswerResponse_WithTokenUsageAndTextContent() {
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("inputTokens", 500);
+        tokenUsage.put("outputTokens", 200);
+        tokenUsage.put("totalTokens", 700);
+
+        MLTaskResponse response = handler.createFinalAnswerResponse("Here is the answer", tokenUsage);
+
+        ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
+        Map<String, ?> dataMap = output.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap();
+
+        // Verify response structure
+        assertEquals("end_turn", dataMap.get("stopReason"));
+
+        // Verify text content
+        Map<String, Object> outputMap = (Map<String, Object>) dataMap.get("output");
+        Map<String, Object> message = (Map<String, Object>) outputMap.get("message");
+        List<Map<String, Object>> content = (List<Map<String, Object>>) message.get("content");
+        assertEquals("Here is the answer", content.get(0).get("text"));
+
+        // Verify token usage
+        Map<String, Object> usage = (Map<String, Object>) dataMap.get("usage");
+        assertNotNull(usage);
+        assertEquals(500, usage.get("inputTokens"));
+        assertEquals(200, usage.get("outputTokens"));
+        assertEquals(700, usage.get("totalTokens"));
+    }
+
+    // ==================== Tests for buildConverseStreamRequest with messages ====================
+
+    @Test
+    public void testBuildConverseStreamRequest_withBasicTextMessages() throws Exception {
+        String payloadJson = """
+            {
+              "messages": [
+                {"role": "user", "content": [{"text": "Hello"}]},
+                {"role": "assistant", "content": [{"text": "Hi there"}]},
+                {"role": "user", "content": [{"text": "How are you?"  }]}
+              ]
+            }
+            """;
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("model", "anthropic.claude-v2");
+
+        ConverseStreamRequest request = handler.buildConverseStreamRequest(payloadJson, parameters);
+
+        assertNotNull(request);
+        assertEquals(3, request.messages().size());
+        assertEquals("user", request.messages().get(0).role().toString());
+        assertEquals("Hello", request.messages().get(0).content().get(0).text());
+        assertEquals("assistant", request.messages().get(1).role().toString());
+    }
+
+    @Test
+    public void testBuildConverseStreamRequest_withSystemMessages() throws Exception {
+        String payloadJson = """
+            {
+              "system": [{"text": "You are a helpful assistant"}],
+              "messages": [
+                {"role": "user", "content": [{"text": "Hello"}]}
+              ]
+            }
+            """;
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("model", "anthropic.claude-v2");
+
+        ConverseStreamRequest request = handler.buildConverseStreamRequest(payloadJson, parameters);
+
+        assertNotNull(request);
+        assertNotNull(request.system());
+        assertEquals(1, request.system().size());
+        assertEquals("You are a helpful assistant", request.system().get(0).text());
+    }
+
+    @Test
+    public void testBuildConverseStreamRequest_withToolConfig() throws Exception {
+        String payloadJson = """
+            {
+              "messages": [
+                {"role": "user", "content": [{"text": "What is the weather?"}]}
+              ],
+              "toolConfig": {
+                "tools": [
+                  {
+                    "toolSpec": {
+                      "name": "get_weather",
+                      "description": "Gets the weather",
+                      "inputSchema": {
+                        "json": {
+                          "type": "object",
+                          "properties": {
+                            "location": {"type": "string"}
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("model", "anthropic.claude-v2");
+
+        ConverseStreamRequest request = handler.buildConverseStreamRequest(payloadJson, parameters);
+
+        assertNotNull(request);
+        assertNotNull(request.toolConfig());
+        assertEquals(1, request.toolConfig().tools().size());
+        assertEquals("get_weather", request.toolConfig().tools().get(0).toolSpec().name());
+        assertEquals("Gets the weather", request.toolConfig().tools().get(0).toolSpec().description());
+    }
+
+    @Test
+    public void testBuildConverseStreamRequest_withToolResultContent() throws Exception {
+        String payloadJson = """
+            {
+              "messages": [
+                {"role": "user", "content": [{"text": "What is the weather?"}]},
+                {"role": "assistant", "content": [
+                  {"toolUse": {"toolUseId": "tool_1", "name": "get_weather", "input": {"location": "Seattle"}}}
+                ]},
+                {"role": "user", "content": [
+                  {"toolResult": {"toolUseId": "tool_1", "content": [{"text": "72F and sunny"}]}}
+                ]}
+              ]
+            }
+            """;
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("model", "anthropic.claude-v2");
+
+        ConverseStreamRequest request = handler.buildConverseStreamRequest(payloadJson, parameters);
+
+        assertNotNull(request);
+        assertEquals(3, request.messages().size());
+        // Third message should have a tool result content block
+        assertNotNull(request.messages().get(2).content().get(0).toolResult());
+        assertEquals("tool_1", request.messages().get(2).content().get(0).toolResult().toolUseId());
+    }
+
+    // ==================== Tests for createToolUseResponse ====================
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateToolUseResponse_withToolUseOnly() throws Exception {
+        AtomicReference<String> toolName = new AtomicReference<>("get_weather");
+        AtomicReference<Map<String, Object>> toolInput = new AtomicReference<>(Map.of("location", "Seattle"));
+        AtomicReference<String> toolUseId = new AtomicReference<>("tool_123");
+
+        MLTaskResponse response = invokeCreateToolUseResponse(toolName, toolInput, toolUseId, new StringBuilder(), null);
+
+        assertNotNull(response);
+        ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
+        Map<String, ?> dataMap = output.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap();
+        assertEquals("tool_use", dataMap.get("stopReason"));
+        assertNull(dataMap.get("usage"));
+
+        Map<String, Object> outputMap = (Map<String, Object>) dataMap.get("output");
+        Map<String, Object> message = (Map<String, Object>) outputMap.get("message");
+        List<Map<String, Object>> content = (List<Map<String, Object>>) message.get("content");
+        assertEquals(1, content.size());
+        Map<String, Object> toolUseBlock = (Map<String, Object>) content.get(0).get("toolUse");
+        assertEquals("get_weather", toolUseBlock.get("name"));
+        assertEquals("tool_123", toolUseBlock.get("toolUseId"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateToolUseResponse_withTokenUsage() throws Exception {
+        AtomicReference<String> toolName = new AtomicReference<>("search");
+        AtomicReference<Map<String, Object>> toolInput = new AtomicReference<>(Map.of("query", "test"));
+        AtomicReference<String> toolUseId = new AtomicReference<>("tool_456");
+
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("inputTokens", 200);
+        tokenUsage.put("outputTokens", 100);
+        tokenUsage.put("totalTokens", 300);
+
+        MLTaskResponse response = invokeCreateToolUseResponse(toolName, toolInput, toolUseId, new StringBuilder(), tokenUsage);
+
+        ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
+        Map<String, ?> dataMap = output.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap();
+        assertEquals("tool_use", dataMap.get("stopReason"));
+
+        Map<String, Object> usage = (Map<String, Object>) dataMap.get("usage");
+        assertNotNull(usage);
+        assertEquals(200, usage.get("inputTokens"));
+        assertEquals(100, usage.get("outputTokens"));
+        assertEquals(300, usage.get("totalTokens"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateToolUseResponse_withAccumulatedTextContent() throws Exception {
+        AtomicReference<String> toolName = new AtomicReference<>("calculator");
+        AtomicReference<Map<String, Object>> toolInput = new AtomicReference<>(Map.of("expression", "2+2"));
+        AtomicReference<String> toolUseId = new AtomicReference<>("tool_789");
+        StringBuilder accumulatedContent = new StringBuilder("Let me calculate that for you.");
+
+        MLTaskResponse response = invokeCreateToolUseResponse(toolName, toolInput, toolUseId, accumulatedContent, null);
+
+        ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
+        Map<String, ?> dataMap = output.getMlModelOutputs().get(0).getMlModelTensors().get(0).getDataAsMap();
+
+        Map<String, Object> outputMap = (Map<String, Object>) dataMap.get("output");
+        Map<String, Object> message = (Map<String, Object>) outputMap.get("message");
+        List<Map<String, Object>> content = (List<Map<String, Object>>) message.get("content");
+        // Should have text block + toolUse block
+        assertEquals(2, content.size());
+        assertEquals("Let me calculate that for you.", content.get(0).get("text"));
+        assertNotNull(content.get(1).get("toolUse"));
+    }
+
+    @Test(expected = InvocationTargetException.class)
+    public void testCreateToolUseResponse_nullToolName() throws Exception {
+        invokeCreateToolUseResponse(null, new AtomicReference<>(Map.of()), new AtomicReference<>("id"), new StringBuilder(), null);
+    }
+
+    @Test(expected = InvocationTargetException.class)
+    public void testCreateToolUseResponse_nullToolInput() throws Exception {
+        invokeCreateToolUseResponse(new AtomicReference<>("name"), null, new AtomicReference<>("id"), new StringBuilder(), null);
+    }
+
+    @Test(expected = InvocationTargetException.class)
+    public void testCreateToolUseResponse_nullToolUseId() throws Exception {
+        invokeCreateToolUseResponse(new AtomicReference<>("name"), new AtomicReference<>(Map.of()), null, new StringBuilder(), null);
+    }
+
+    // ===== Reflection helper for testing private methods =====
+
+    private MLTaskResponse invokeCreateToolUseResponse(
+        AtomicReference<String> toolName,
+        AtomicReference<Map<String, Object>> toolInput,
+        AtomicReference<String> toolUseId,
+        StringBuilder accumulatedContent,
+        Map<String, Object> tokenUsage
+    ) throws Exception {
+        Method method = BedrockStreamingHandler.class
+            .getDeclaredMethod(
+                "createToolUseResponse",
+                AtomicReference.class,
+                AtomicReference.class,
+                AtomicReference.class,
+                StringBuilder.class,
+                Map.class
+            );
+        method.setAccessible(true);
+        return (MLTaskResponse) method.invoke(handler, toolName, toolInput, toolUseId, accumulatedContent, tokenUsage);
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/BedrockConverseDeepseekR1FunctionCallingTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/BedrockConverseDeepseekR1FunctionCallingTests.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
@@ -53,7 +54,7 @@ public class BedrockConverseDeepseekR1FunctionCallingTests {
     public void configure() {
         Map<String, String> parameters = new HashMap<>();
         functionCalling.configure(parameters);
-        Assert.assertEquals(15, parameters.size());
+        Assert.assertEquals(16, parameters.size()); // Updated for token_usage_path
         Assert.assertEquals(BEDROCK_DEEPSEEK_R1_TOOL_TEMPLATE, parameters.get("tool_template"));
     }
 
@@ -83,5 +84,50 @@ public class BedrockConverseDeepseekR1FunctionCallingTests {
         Map<String, Object> resultMap = StringUtils.fromJson(textJson, "response");
         Assert.assertEquals("test_tool_call_id", resultMap.get("tool_call_id"));
         Assert.assertEquals("test result for bedrock deepseek", resultMap.get("tool_result"));
+    }
+
+    @Test
+    public void extractTokenUsage_allFields() {
+        Map<String, Object> usageMap = new HashMap<>();
+        usageMap.put("prompt_tokens", 100);
+        usageMap.put("completion_tokens", 50);
+        usageMap.put("total_tokens", 150);
+        Map<String, Object> response = new HashMap<>();
+        response.put("usage", usageMap);
+
+        TokenUsage result = functionCalling.extractTokenUsage(response);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Long.valueOf(100), result.getInputTokens());
+        Assert.assertEquals(Long.valueOf(50), result.getOutputTokens());
+        Assert.assertEquals(Long.valueOf(150), result.getTotalTokens());
+    }
+
+    @Test
+    public void extractTokenUsage_nullInput() {
+        Assert.assertNull(functionCalling.extractTokenUsage(null));
+    }
+
+    @Test
+    public void extractTokenUsage_missingUsageKey() {
+        Assert.assertNull(functionCalling.extractTokenUsage(Map.of("other", "data")));
+    }
+
+    @Test
+    public void extractTokenUsage_usageNotMap() {
+        Assert.assertNull(functionCalling.extractTokenUsage(Map.of("usage", "not_a_map")));
+    }
+
+    @Test
+    public void extractTokenUsage_exceptionDuringExtraction() {
+        Map<String, Object> badUsageMap = new HashMap<>() {
+            @Override
+            public Object get(Object key) {
+                throw new RuntimeException("Simulated error");
+            }
+        };
+        Map<String, Object> response = new HashMap<>();
+        response.put("usage", badUsageMap);
+        Assert.assertNull(functionCalling.extractTokenUsage(response));
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/BedrockConverseFunctionCallingTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/BedrockConverseFunctionCallingTests.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.ml.engine.function_calling;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_BEDROCK_CONVERSE_CLAUDE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALL_ID;
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
@@ -52,7 +53,7 @@ public class BedrockConverseFunctionCallingTests {
     public void configure() {
         Map<String, String> parameters = new HashMap<>();
         functionCalling.configure(parameters);
-        Assert.assertEquals(14, parameters.size());
+        Assert.assertEquals(15, parameters.size()); // Updated for token_usage_path
         Assert.assertEquals(BEDROCK_CONVERSE_TOOL_TEMPLATE, parameters.get("tool_template"));
     }
 
@@ -172,5 +173,54 @@ public class BedrockConverseFunctionCallingTests {
         assertEquals(2, resultContent.size());
         assertEquals("Some text", ((Map<?, ?>) resultContent.get(0)).get("text"));
         assertEquals("tool1", ((Map<?, ?>) ((Map<?, ?>) resultContent.get(1)).get("toolUse")).get("name"));
+    }
+
+    @Test
+    public void extractTokenUsage_allFields() {
+        Map<String, Object> usageMap = new HashMap<>();
+        usageMap.put("inputTokens", 100);
+        usageMap.put("outputTokens", 50);
+        usageMap.put("totalTokens", 150);
+        usageMap.put("cacheReadInputTokens", 10);
+        usageMap.put("cacheWriteInputTokens", 5);
+        Map<String, Object> response = new HashMap<>();
+        response.put("usage", usageMap);
+
+        TokenUsage result = functionCalling.extractTokenUsage(response);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Long.valueOf(100), result.getInputTokens());
+        Assert.assertEquals(Long.valueOf(50), result.getOutputTokens());
+        Assert.assertEquals(Long.valueOf(150), result.getTotalTokens());
+        Assert.assertEquals(Long.valueOf(10), result.getCacheReadInputTokens());
+        Assert.assertEquals(Long.valueOf(5), result.getCacheCreationInputTokens());
+    }
+
+    @Test
+    public void extractTokenUsage_nullInput() {
+        Assert.assertNull(functionCalling.extractTokenUsage(null));
+    }
+
+    @Test
+    public void extractTokenUsage_missingUsageKey() {
+        Assert.assertNull(functionCalling.extractTokenUsage(Map.of("other", "data")));
+    }
+
+    @Test
+    public void extractTokenUsage_usageNotMap() {
+        Assert.assertNull(functionCalling.extractTokenUsage(Map.of("usage", "not_a_map")));
+    }
+
+    @Test
+    public void extractTokenUsage_exceptionDuringExtraction() {
+        Map<String, Object> badUsageMap = new HashMap<>() {
+            @Override
+            public Object get(Object key) {
+                throw new RuntimeException("Simulated error");
+            }
+        };
+        Map<String, Object> response = new HashMap<>();
+        response.put("usage", badUsageMap);
+        Assert.assertNull(functionCalling.extractTokenUsage(response));
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/GeminiV1BetaGenerateContentFunctionCallingTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/GeminiV1BetaGenerateContentFunctionCallingTests.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.ml.engine.function_calling;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_GEMINI_V1BETA_GENERATE_CONTENT;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALL_ID;
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
@@ -51,7 +52,7 @@ public class GeminiV1BetaGenerateContentFunctionCallingTests {
     public void configure() {
         Map<String, String> parameters = new HashMap<>();
         functionCalling.configure(parameters);
-        Assert.assertEquals(15, parameters.size());
+        Assert.assertEquals(16, parameters.size()); // Updated for token_usage_path
         Assert.assertEquals(GEMINI_TOOL_TEMPLATE, parameters.get("tool_template"));
     }
 
@@ -178,5 +179,54 @@ public class GeminiV1BetaGenerateContentFunctionCallingTests {
         assertEquals(2, resultParts.size());
         assertEquals("Some text", ((Map<?, ?>) resultParts.get(0)).get("text"));
         assertEquals("tool1", ((Map<?, ?>) ((Map<?, ?>) resultParts.get(1)).get("functionCall")).get("name"));
+    }
+
+    @Test
+    public void extractTokenUsage_allFields() {
+        Map<String, Object> usageMap = new HashMap<>();
+        usageMap.put("promptTokenCount", 100);
+        usageMap.put("candidatesTokenCount", 50);
+        usageMap.put("totalTokenCount", 150);
+        usageMap.put("cachedContentInputTokenCount", 10);
+        usageMap.put("thoughtsTokenCount", 5);
+        Map<String, Object> response = new HashMap<>();
+        response.put("usageMetadata", usageMap);
+
+        TokenUsage result = functionCalling.extractTokenUsage(response);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Long.valueOf(100), result.getInputTokens());
+        Assert.assertEquals(Long.valueOf(50), result.getOutputTokens());
+        Assert.assertEquals(Long.valueOf(150), result.getTotalTokens());
+        Assert.assertEquals(Long.valueOf(10), result.getCacheReadInputTokens());
+        Assert.assertEquals(Long.valueOf(5), result.getReasoningTokens());
+    }
+
+    @Test
+    public void extractTokenUsage_nullInput() {
+        Assert.assertNull(functionCalling.extractTokenUsage(null));
+    }
+
+    @Test
+    public void extractTokenUsage_missingUsageMetadataKey() {
+        Assert.assertNull(functionCalling.extractTokenUsage(Map.of("other", "data")));
+    }
+
+    @Test
+    public void extractTokenUsage_usageMetadataNotMap() {
+        Assert.assertNull(functionCalling.extractTokenUsage(Map.of("usageMetadata", "not_a_map")));
+    }
+
+    @Test
+    public void extractTokenUsage_exceptionDuringExtraction() {
+        Map<String, Object> badUsageMap = new HashMap<>() {
+            @Override
+            public Object get(Object key) {
+                throw new RuntimeException("Simulated error");
+            }
+        };
+        Map<String, Object> response = new HashMap<>();
+        response.put("usageMetadata", badUsageMap);
+        Assert.assertNull(functionCalling.extractTokenUsage(response));
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/OpenaiV1ChatCompletionsFunctionCallingTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/function_calling/OpenaiV1ChatCompletionsFunctionCallingTests.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.ml.engine.function_calling;
 
-import static org.junit.Assert.*;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_OPENAI_V1_CHAT_COMPLETIONS;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALL_ID;
@@ -21,6 +20,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.ml.common.agent.TokenUsage;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
@@ -58,7 +58,7 @@ public class OpenaiV1ChatCompletionsFunctionCallingTests {
     public void configure() {
         Map<String, String> parameters = new HashMap<>();
         functionCalling.configure(parameters);
-        Assert.assertEquals(16, parameters.size());
+        Assert.assertEquals(17, parameters.size()); // Updated for token_usage_path
         Assert.assertEquals(OPENAI_V1_CHAT_COMPLETION_TEMPLATE, parameters.get("tool_template"));
     }
 
@@ -121,5 +121,92 @@ public class OpenaiV1ChatCompletionsFunctionCallingTests {
 
         // Verify tool_call_ids are unique
         Assert.assertNotEquals("tool_call_id values should be unique", message1.getToolCallId(), message2.getToolCallId());
+    }
+
+    @Test
+    public void extractTokenUsage_allFields() {
+        Map<String, Object> usageMap = new HashMap<>();
+        usageMap.put("prompt_tokens", 100);
+        usageMap.put("completion_tokens", 50);
+        usageMap.put("total_tokens", 150);
+        usageMap.put("prompt_tokens_details", Map.of("cached_tokens", 10));
+        usageMap.put("completion_tokens_details", Map.of("reasoning_tokens", 5));
+        Map<String, Object> response = new HashMap<>();
+        response.put("usage", usageMap);
+
+        TokenUsage result = functionCalling.extractTokenUsage(response);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Long.valueOf(100), result.getInputTokens());
+        Assert.assertEquals(Long.valueOf(50), result.getOutputTokens());
+        Assert.assertEquals(Long.valueOf(150), result.getTotalTokens());
+        Assert.assertEquals(Long.valueOf(10), result.getCacheReadInputTokens());
+        Assert.assertEquals(Long.valueOf(5), result.getReasoningTokens());
+    }
+
+    @Test
+    public void extractTokenUsage_basicFieldsOnly() {
+        Map<String, Object> usageMap = new HashMap<>();
+        usageMap.put("prompt_tokens", 200);
+        usageMap.put("completion_tokens", 75);
+        usageMap.put("total_tokens", 275);
+        Map<String, Object> response = new HashMap<>();
+        response.put("usage", usageMap);
+
+        TokenUsage result = functionCalling.extractTokenUsage(response);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Long.valueOf(200), result.getInputTokens());
+        Assert.assertEquals(Long.valueOf(75), result.getOutputTokens());
+        Assert.assertNull(result.getCacheReadInputTokens());
+        Assert.assertNull(result.getReasoningTokens());
+    }
+
+    @Test
+    public void extractTokenUsage_nullInput() {
+        Assert.assertNull(functionCalling.extractTokenUsage(null));
+    }
+
+    @Test
+    public void extractTokenUsage_missingUsageKey() {
+        Assert.assertNull(functionCalling.extractTokenUsage(Map.of("other", "data")));
+    }
+
+    @Test
+    public void extractTokenUsage_usageNotMap() {
+        Assert.assertNull(functionCalling.extractTokenUsage(Map.of("usage", "not_a_map")));
+    }
+
+    @Test
+    public void extractTokenUsage_defaultInterfaceMethod() {
+        // Test the FunctionCalling interface default method returns null
+        FunctionCalling defaultImpl = new FunctionCalling() {
+            @Override
+            public void configure(Map<String, String> params) {}
+
+            @Override
+            public List<Map<String, String>> handle(ModelTensorOutput modelTensorOutput, Map<String, String> parameters) {
+                return List.of();
+            }
+
+            @Override
+            public List<LLMMessage> supply(List<Map<String, Object>> toolResults) {
+                return List.of();
+            }
+        };
+        Assert.assertNull(defaultImpl.extractTokenUsage(Map.of("usage", Map.of("tokens", 100))));
+    }
+
+    @Test
+    public void extractTokenUsage_exceptionDuringExtraction() {
+        Map<String, Object> badUsageMap = new HashMap<>() {
+            @Override
+            public Object get(Object key) {
+                throw new RuntimeException("Simulated error");
+            }
+        };
+        Map<String, Object> response = new HashMap<>();
+        response.put("usage", badUsageMap);
+        Assert.assertNull(functionCalling.extractTokenUsage(response));
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
@@ -27,6 +27,7 @@ import static org.opensearch.ml.utils.TenantAwareHelper.getTenantID;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -58,7 +59,9 @@ import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agui.AGUIInputConverter;
 import org.opensearch.ml.common.agui.BaseEvent;
+import org.opensearch.ml.common.agui.CustomEvent;
 import org.opensearch.ml.common.agui.RunErrorEvent;
+import org.opensearch.ml.common.agui.RunFinishedEvent;
 import org.opensearch.ml.common.agui.RunStartedEvent;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.Input;
@@ -192,12 +195,11 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
                     BytesReference completeContent = combineChunks(chunks);
                     MLExecuteTaskRequest mlExecuteTaskRequest = getRequest(agentId, request, completeContent);
                     boolean isAGUI = isAGUIAgent(mlExecuteTaskRequest);
+                    String threadId = extractThreadId(mlExecuteTaskRequest);
+                    String runId = extractRunId(mlExecuteTaskRequest);
 
                     // Send RUN_STARTED event immediately for AG-UI agents (ReAct cycle begins)
                     if (isAGUI) {
-                        String threadId = extractThreadId(mlExecuteTaskRequest);
-                        String runId = extractRunId(mlExecuteTaskRequest);
-
                         BaseEvent runStartedEvent = new RunStartedEvent(threadId, runId);
                         HttpChunk startChunk = createHttpChunk("data: " + runStartedEvent.toJsonString() + "\n\n", false);
                         channel.sendChunk(startChunk);
@@ -212,7 +214,7 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
                                 MLTaskResponse response = streamResponse.nextResponse();
 
                                 if (response != null) {
-                                    HttpChunk responseChunk = convertToHttpChunk(response, isAGUI);
+                                    HttpChunk responseChunk = convertToHttpChunk(response, isAGUI, threadId, runId);
                                     channel.sendChunk(responseChunk);
 
                                     // Recursively handle the next response
@@ -428,7 +430,7 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
         return "run_" + System.currentTimeMillis();
     }
 
-    private HttpChunk convertToHttpChunk(MLTaskResponse response, boolean isAGUIAgent) throws IOException {
+    private HttpChunk convertToHttpChunk(MLTaskResponse response, boolean isAGUIAgent, String threadId, String runId) throws IOException {
         String memoryId = "";
         String parentInteractionId = "";
         String content = "";
@@ -460,21 +462,44 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
 
         // If this is an AG-UI agent, convert to AG-UI event format
         if (isAGUIAgent) {
-            return convertToAGUIEvent(content, isLast);
+            // Build the combined SSE: [Custom(token_usage)?] + [content events] + [RunFinished if last]
+            Map<String, ?> aguiTokenUsage = extractTokenUsage(response);
+            StringBuilder combinedSse = new StringBuilder();
+
+            if (aguiTokenUsage != null) {
+                BaseEvent tokenUsageEvent = new CustomEvent("token_usage", aguiTokenUsage);
+                combinedSse.append("data: ").append(tokenUsageEvent.toJsonString()).append("\n\n");
+            }
+
+            // Forward any content events (pass false — isLast is controlled by the outer chunk)
+            HttpChunk contentChunk = convertToAGUIEvent(content, false);
+            combinedSse.append(new String(BytesReference.toBytes(contentChunk.content())));
+
+            // RunFinished is the last AG-UI event, emitted only on the final chunk
+            if (isLast) {
+                BaseEvent runFinishedEvent = new RunFinishedEvent(threadId, runId, null);
+                combinedSse.append("data: ").append(runFinishedEvent.toJsonString()).append("\n\n");
+            }
+
+            return createHttpChunk(combinedSse.toString(), isLast);
         }
 
         // Create ordered tensors
-        List<ModelTensor> orderedTensors = List
-            .of(
-                ModelTensor.builder().name("memory_id").result(memoryId).build(),
-                ModelTensor.builder().name("parent_interaction_id").result(parentInteractionId).build(),
-                ModelTensor.builder().name("response").dataAsMap(new LinkedHashMap<String, Object>() {
-                    {
-                        put("content", finalContent);
-                        put("is_last", finalIsLast);
-                    }
-                }).build()
-            );
+        List<ModelTensor> orderedTensors = new ArrayList<>();
+        orderedTensors.add(ModelTensor.builder().name("memory_id").result(memoryId).build());
+        orderedTensors.add(ModelTensor.builder().name("parent_interaction_id").result(parentInteractionId).build());
+        orderedTensors.add(ModelTensor.builder().name("response").dataAsMap(new LinkedHashMap<String, Object>() {
+            {
+                put("content", finalContent);
+                put("is_last", finalIsLast);
+            }
+        }).build());
+
+        // Pass through token_usage tensor if present (matches non-streaming format)
+        Map<String, ?> tokenUsage = extractTokenUsage(response);
+        if (tokenUsage != null) {
+            orderedTensors.add(ModelTensor.builder().name("token_usage").dataAsMap(tokenUsage).build());
+        }
 
         ModelTensors tensors = ModelTensors.builder().mlModelTensors(orderedTensors).build();
 
@@ -516,6 +541,20 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
             }
         }
         return Map.of();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, ?> extractTokenUsage(MLTaskResponse response) {
+        ModelTensorOutput output = (ModelTensorOutput) response.getOutput();
+        if (output != null && !output.getMlModelOutputs().isEmpty()) {
+            ModelTensors tensors = output.getMlModelOutputs().get(0);
+            for (ModelTensor tensor : tensors.getMlModelTensors()) {
+                if ("token_usage".equals(tensor.getName()) && tensor.getDataAsMap() != null) {
+                    return tensor.getDataAsMap();
+                }
+            }
+        }
+        return null;
     }
 
     private HttpChunk convertToAGUIEvent(String content, boolean isLast) {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteStreamActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteStreamActionTests.java
@@ -18,6 +18,7 @@ import static org.opensearch.ml.utils.RestActionUtils.PARAMETER_AGENT_ID;
 import static org.opensearch.ml.utils.TestHelper.getExecuteAgentStreamRestRequest;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,11 @@ import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.Input;
 import org.opensearch.ml.common.input.execute.agent.AgentMLInput;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskRequest;
 import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.rest.RestChannel;
@@ -486,5 +491,269 @@ public class RestMLExecuteStreamActionTests extends OpenSearchTestCase {
         assertEquals("us-west-2", client.threadPool().getThreadContext().getHeader("aws-region"));
         assertEquals("bedrock", client.threadPool().getThreadContext().getHeader("aws-service-name"));
         assertEquals("https://localhost:9200", client.threadPool().getThreadContext().getHeader("opensearch-url"));
+    }
+
+    // ===== extractTokenUsage tests =====
+
+    private MLTaskResponse buildResponseWithTokenUsage() {
+        Map<String, Object> tokenUsageMap = new HashMap<>();
+        tokenUsageMap.put("per_model_usage", List.of(Map.of("model_id", "m1", "input_tokens", 100L)));
+        tokenUsageMap.put("per_turn_usage", List.of(Map.of("turn", 1, "input_tokens", 100L)));
+
+        ModelTensor responseTensor = ModelTensor.builder().name("response").dataAsMap(Map.of("content", "hello", "is_last", false)).build();
+        ModelTensor tokenTensor = ModelTensor.builder().name("token_usage").dataAsMap(tokenUsageMap).build();
+        ModelTensors tensors = ModelTensors.builder().mlModelTensors(List.of(responseTensor, tokenTensor)).build();
+        ModelTensorOutput output = ModelTensorOutput.builder().mlModelOutputs(List.of(tensors)).build();
+        return MLTaskResponse.builder().output(output).build();
+    }
+
+    private MLTaskResponse buildResponseWithoutTokenUsage() {
+        ModelTensor responseTensor = ModelTensor.builder().name("response").dataAsMap(Map.of("content", "hello", "is_last", false)).build();
+        ModelTensors tensors = ModelTensors.builder().mlModelTensors(List.of(responseTensor)).build();
+        ModelTensorOutput output = ModelTensorOutput.builder().mlModelOutputs(List.of(tensors)).build();
+        return MLTaskResponse.builder().output(output).build();
+    }
+
+    @Test
+    public void testExtractTokenUsage_withTokenUsageTensor() throws Exception {
+        MLTaskResponse response = buildResponseWithTokenUsage();
+
+        Map<String, ?> tokenUsage = invokeExtractTokenUsage(response);
+
+        assertNotNull(tokenUsage);
+        assertTrue(tokenUsage.containsKey("per_model_usage"));
+        assertTrue(tokenUsage.containsKey("per_turn_usage"));
+    }
+
+    @Test
+    public void testExtractTokenUsage_withoutTokenUsageTensor() throws Exception {
+        MLTaskResponse response = buildResponseWithoutTokenUsage();
+
+        Map<String, ?> tokenUsage = invokeExtractTokenUsage(response);
+
+        assertNull(tokenUsage);
+    }
+
+    @Test
+    public void testExtractTokenUsage_emptyOutput() throws Exception {
+        ModelTensorOutput output = ModelTensorOutput.builder().mlModelOutputs(List.of()).build();
+        MLTaskResponse response = MLTaskResponse.builder().output(output).build();
+
+        Map<String, ?> tokenUsage = invokeExtractTokenUsage(response);
+
+        assertNull(tokenUsage);
+    }
+
+    // ===== extractThreadId / extractRunId tests =====
+
+    private MLExecuteTaskRequest buildAGUIRequest(Map<String, String> parameters) {
+        AgentMLInput agentInput = new AgentMLInput(
+            "agent-1",
+            null,
+            FunctionName.AGENT,
+            RemoteInferenceInputDataSet.builder().parameters(parameters).build(),
+            false
+        );
+        return new MLExecuteTaskRequest(FunctionName.AGENT, agentInput, false);
+    }
+
+    @Test
+    public void testExtractThreadId_withAGUIParam() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("agui_thread_id", "thread_abc123");
+        params.put("agui_run_id", "run_xyz");
+        MLExecuteTaskRequest request = buildAGUIRequest(params);
+
+        String threadId = invokeExtractThreadId(request);
+
+        assertEquals("thread_abc123", threadId);
+    }
+
+    @Test
+    public void testExtractThreadId_withoutAGUIParam_fallback() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("question", "test");
+        MLExecuteTaskRequest request = buildAGUIRequest(params);
+
+        String threadId = invokeExtractThreadId(request);
+
+        assertTrue(threadId.startsWith("thread_"));
+    }
+
+    @Test
+    public void testExtractRunId_withAGUIParam() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("agui_thread_id", "thread_abc");
+        params.put("agui_run_id", "run_xyz789");
+        MLExecuteTaskRequest request = buildAGUIRequest(params);
+
+        String runId = invokeExtractRunId(request);
+
+        assertEquals("run_xyz789", runId);
+    }
+
+    @Test
+    public void testExtractRunId_withoutAGUIParam_fallback() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("question", "test");
+        MLExecuteTaskRequest request = buildAGUIRequest(params);
+
+        String runId = invokeExtractRunId(request);
+
+        assertTrue(runId.startsWith("run_"));
+    }
+
+    // ===== isAGUIAgent tests =====
+
+    @Test
+    public void testIsAGUIAgent_withThreadId() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("agui_thread_id", "thread_abc");
+        MLExecuteTaskRequest request = buildAGUIRequest(params);
+
+        assertTrue(invokeIsAGUIAgent(request));
+    }
+
+    @Test
+    public void testIsAGUIAgent_withRunId() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("agui_run_id", "run_abc");
+        MLExecuteTaskRequest request = buildAGUIRequest(params);
+
+        assertTrue(invokeIsAGUIAgent(request));
+    }
+
+    @Test
+    public void testIsAGUIAgent_withoutAGUIParams() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("question", "test");
+        MLExecuteTaskRequest request = buildAGUIRequest(params);
+
+        assertFalse(invokeIsAGUIAgent(request));
+    }
+
+    // ===== convertToHttpChunk tests =====
+
+    @Test
+    public void testConvertToHttpChunk_nonAGUI_withContent() throws Exception {
+        ModelTensor responseTensor = ModelTensor
+            .builder()
+            .name("response")
+            .dataAsMap(Map.of("content", "Hello world", "is_last", false))
+            .build();
+        ModelTensor memoryTensor = ModelTensor.builder().name("memory_id").result("session-1").build();
+        ModelTensor parentTensor = ModelTensor.builder().name("parent_interaction_id").result("parent-1").build();
+        ModelTensors tensors = ModelTensors.builder().mlModelTensors(List.of(responseTensor, memoryTensor, parentTensor)).build();
+        ModelTensorOutput output = ModelTensorOutput.builder().mlModelOutputs(List.of(tensors)).build();
+        MLTaskResponse response = MLTaskResponse.builder().output(output).build();
+
+        HttpChunk chunk = invokeConvertToHttpChunk(response, false, null, null);
+
+        assertNotNull(chunk);
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertTrue(content.contains("Hello world"));
+        assertTrue(content.startsWith("data: "));
+    }
+
+    @Test
+    public void testConvertToHttpChunk_nonAGUI_withTokenUsage() throws Exception {
+        MLTaskResponse response = buildResponseWithTokenUsage();
+
+        HttpChunk chunk = invokeConvertToHttpChunk(response, false, null, null);
+
+        assertNotNull(chunk);
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertTrue(content.contains("token_usage"));
+        assertTrue(content.contains("per_model_usage"));
+    }
+
+    @Test
+    public void testConvertToHttpChunk_nonAGUI_lastChunk() throws Exception {
+        ModelTensor responseTensor = ModelTensor.builder().name("response").dataAsMap(Map.of("content", "", "is_last", true)).build();
+        ModelTensors tensors = ModelTensors.builder().mlModelTensors(List.of(responseTensor)).build();
+        ModelTensorOutput output = ModelTensorOutput.builder().mlModelOutputs(List.of(tensors)).build();
+        MLTaskResponse response = MLTaskResponse.builder().output(output).build();
+
+        HttpChunk chunk = invokeConvertToHttpChunk(response, false, null, null);
+
+        assertNotNull(chunk);
+        assertTrue(chunk.isLast());
+    }
+
+    @Test
+    public void testConvertToHttpChunk_AGUI_withTokenUsage() throws Exception {
+        MLTaskResponse response = buildResponseWithTokenUsage();
+
+        HttpChunk chunk = invokeConvertToHttpChunk(response, true, "thread_1", "run_1");
+
+        assertNotNull(chunk);
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        // AG-UI mode should emit token_usage as a CustomEvent
+        assertTrue(content.contains("token_usage"));
+    }
+
+    @Test
+    public void testConvertToHttpChunk_AGUI_lastChunk_emitsRunFinished() throws Exception {
+        ModelTensor responseTensor = ModelTensor.builder().name("response").dataAsMap(Map.of("content", "", "is_last", true)).build();
+        ModelTensors tensors = ModelTensors.builder().mlModelTensors(List.of(responseTensor)).build();
+        ModelTensorOutput output = ModelTensorOutput.builder().mlModelOutputs(List.of(tensors)).build();
+        MLTaskResponse response = MLTaskResponse.builder().output(output).build();
+
+        HttpChunk chunk = invokeConvertToHttpChunk(response, true, "thread_1", "run_1");
+
+        assertNotNull(chunk);
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertTrue(content.contains("RUN_FINISHED"));
+        assertTrue(chunk.isLast());
+    }
+
+    @Test
+    public void testConvertToHttpChunk_errorResponse() throws Exception {
+        ModelTensor responseTensor = ModelTensor.builder().name("response").dataAsMap(Map.of("error", "Something went wrong")).build();
+        ModelTensors tensors = ModelTensors.builder().mlModelTensors(List.of(responseTensor)).build();
+        ModelTensorOutput output = ModelTensorOutput.builder().mlModelOutputs(List.of(tensors)).build();
+        MLTaskResponse response = MLTaskResponse.builder().output(output).build();
+
+        HttpChunk chunk = invokeConvertToHttpChunk(response, false, null, null);
+
+        assertNotNull(chunk);
+        assertTrue(chunk.isLast());
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertTrue(content.contains("Something went wrong"));
+    }
+
+    // ===== Reflection helpers for testing private methods =====
+
+    @SuppressWarnings("unchecked")
+    private Map<String, ?> invokeExtractTokenUsage(MLTaskResponse response) throws Exception {
+        Method method = RestMLExecuteStreamAction.class.getDeclaredMethod("extractTokenUsage", MLTaskResponse.class);
+        method.setAccessible(true);
+        return (Map<String, ?>) method.invoke(restAction, response);
+    }
+
+    private String invokeExtractThreadId(MLExecuteTaskRequest request) throws Exception {
+        Method method = RestMLExecuteStreamAction.class.getDeclaredMethod("extractThreadId", MLExecuteTaskRequest.class);
+        method.setAccessible(true);
+        return (String) method.invoke(restAction, request);
+    }
+
+    private String invokeExtractRunId(MLExecuteTaskRequest request) throws Exception {
+        Method method = RestMLExecuteStreamAction.class.getDeclaredMethod("extractRunId", MLExecuteTaskRequest.class);
+        method.setAccessible(true);
+        return (String) method.invoke(restAction, request);
+    }
+
+    private boolean invokeIsAGUIAgent(MLExecuteTaskRequest request) throws Exception {
+        Method method = RestMLExecuteStreamAction.class.getDeclaredMethod("isAGUIAgent", MLExecuteTaskRequest.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(restAction, request);
+    }
+
+    private HttpChunk invokeConvertToHttpChunk(MLTaskResponse response, boolean isAGUIAgent, String threadId, String runId)
+        throws Exception {
+        Method method = RestMLExecuteStreamAction.class
+            .getDeclaredMethod("convertToHttpChunk", MLTaskResponse.class, boolean.class, String.class, String.class);
+        method.setAccessible(true);
+        return (HttpChunk) method.invoke(restAction, response, isAGUIAgent, threadId, runId);
     }
 }


### PR DESCRIPTION
### Description
Adds token usage tracking to Conversational, AG_UI, and Plan-Execute-Reflect (PER) agents. Every LLM call during agent execution is instrumented to extract and aggregate token counts (input, output, cache read/write, reasoning), which are returned as part of the agent response and logged for monitoring/metering.

Resolves #4662

### Key changes

- **`TokenUsage`** — Immutable data class (common module) normalizing token counts across providers. Supports null-safe aggregation via `addTokens()`.
- **`AgentTokenTracker`** — Per-execution stateful tracker maintaining per-turn usage (each LLM call) and per-model aggregation (totals + call count). Supports sub-agent merge for PER's child ReAct agents.
- **`FunctionCalling.extractTokenUsage()`** — New interface method with provider-specific implementations for Bedrock Converse, Bedrock Converse DeepseekR1, OpenAI v1 Chat, and Gemini v1beta.
- **`MLChatAgentRunner`** — Token extraction after each ReAct loop LLM call and summary generation. Model metadata resolved asynchronously with defensive fallback.
- **`MLPlanExecuteAndReflectAgentRunner`** — Token extraction from planner/reflect LLM calls. Sub-agent token data merged via `mergeSubAgentUsage()` with re-numbered turns. Sub-agent logging suppressed to prevent double-logging (parent logs merged totals).
- **`BedrockStreamingHandler`** — State machine refactor to capture token usage from metadata events and defer finalization to `onComplete()`.
- **`StreamingWrapper`** — Added `sendTokenUsageBatch()` to deliver token usage as a streaming chunk before the completion chunk.
- **`AgentUtils`** — Shared utilities for async model metadata resolution (`getModelMetadata`) and response tensor creation (`addTokenUsageTensor`) with structured per-model logging.

### Response format

To get the token usage in Agent response, we need to pass the flag `include_token_usage` as true
Token usage is appended as a `token_usage` tensor in the agent response:

```json
{
                    "name": "token_usage",
                    "dataAsMap": {
                        "per_turn_usage": [
                            {
                                "model_name": "Sonnet 4",
                                "model_url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-20250514-v1:0/converse",
                                "total_tokens": 1111,
                                "output_tokens": 69,
                                "turn": 1,
                                "model_id": "rk6okJwB_kOxOUbO6853",
                                "cache_creation_input_tokens": 0,
                                "input_tokens": 1042,
                                "cache_read_input_tokens": 0
                            },
                            {
                                "model_name": "Sonnet 4",
                                "model_url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-20250514-v1:0/converse",
                                "total_tokens": 1810,
                                "output_tokens": 269,
                                "turn": 2,
                                "model_id": "rk6okJwB_kOxOUbO6853",
                                "cache_creation_input_tokens": 0,
                                "input_tokens": 1541,
                                "cache_read_input_tokens": 0
                            }
                        ],
                        "per_model_usage": [
                            {
                                "model_name": "Sonnet 4",
                                "model_url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-20250514-v1:0/converse",
                                "call_count": 2,
                                "total_tokens": 2921,
                                "output_tokens": 338,
                                "model_id": "rk6okJwB_kOxOUbO6853",
                                "cache_creation_input_tokens": 0,
                                "input_tokens": 2583,
                                "cache_read_input_tokens": 0
                            }
                        ]
                    }
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
