### PR TITLE
Override ValidatingObjectInputStream.resolveClass()

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/ModelSerDeSer.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/ModelSerDeSer.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
 import java.util.Base64;
 
 import org.apache.commons.io.serialization.ValidatingObjectInputStream;
@@ -89,7 +90,16 @@ public class ModelSerDeSer {
     public static Object deserialize(byte[] modelBin) {
         try (
             ByteArrayInputStream inputStream = new ByteArrayInputStream(modelBin);
-            ValidatingObjectInputStream validatingObjectInputStream = new ValidatingObjectInputStream(inputStream)
+            ValidatingObjectInputStream validatingObjectInputStream = new ValidatingObjectInputStream(inputStream) {
+                @Override
+                protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+                    try {
+                        return super.resolveClass(desc);
+                    } catch (ClassNotFoundException e) {
+                        return Class.forName(desc.getName(), false, ModelSerDeSer.class.getClassLoader());
+                    }
+                }
+            }
         ) {
             // Validate the model class type to avoid deserialization attack.
             validatingObjectInputStream.accept(ACCEPT_CLASS_PATTERNS).reject(REJECT_CLASS_PATTERNS);


### PR DESCRIPTION
### Description
Override `ValidatingObjectInputStream.resolveClass()`:
- Primary path: `super.resolveClass()` — runs accept/reject validation and loads via the default classloader.
- Fallback path: On `ClassNotFoundException`, falls back to `ModelSerDeSer.class.getClassLoader()` (the plugin classloader).
- Security preserved: Validation failures throw `InvalidClassException` (an IOException), which is not caught by the `ClassNotFoundException` handler — rejected classes are still blocked.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
