### PR TITLE
fix error code for delete api 

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/contextmanagement/DeleteContextManagementTemplateTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/contextmanagement/DeleteContextManagementTemplateTransportAction.java
@@ -5,11 +5,13 @@
 
 package org.opensearch.ml.action.contextmanagement;
 
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.transport.contextmanagement.MLDeleteContextManagementTemplateAction;
 import org.opensearch.ml.common.transport.contextmanagement.MLDeleteContextManagementTemplateRequest;
 import org.opensearch.ml.common.transport.contextmanagement.MLDeleteContextManagementTemplateResponse;
@@ -53,7 +55,13 @@ public class DeleteContextManagementTemplateTransportAction extends
                     listener.onResponse(new MLDeleteContextManagementTemplateResponse(request.getTemplateName(), "deleted"));
                 } else {
                     log.warn("Context management template not found for deletion: {}", request.getTemplateName());
-                    listener.onFailure(new RuntimeException("Context management template not found: " + request.getTemplateName()));
+                    listener
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "Context management template not found: " + request.getTemplateName(),
+                                RestStatus.NOT_FOUND
+                            )
+                        );
                 }
             }, exception -> {
                 log.error("Error deleting context management template: {}", request.getTemplateName(), exception);

--- a/plugin/src/test/java/org/opensearch/ml/action/contextmanagement/DeleteContextManagementTemplateTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/contextmanagement/DeleteContextManagementTemplateTransportActionTests.java
@@ -15,10 +15,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.transport.contextmanagement.MLDeleteContextManagementTemplateRequest;
 import org.opensearch.ml.common.transport.contextmanagement.MLDeleteContextManagementTemplateResponse;
 import org.opensearch.tasks.Task;
@@ -107,11 +109,64 @@ public class DeleteContextManagementTemplateTransportActionTests extends OpenSea
 
         transportAction.doExecute(task, request, listener);
 
-        ArgumentCaptor<RuntimeException> exceptionCaptor = ArgumentCaptor.forClass(RuntimeException.class);
+        ArgumentCaptor<OpenSearchStatusException> exceptionCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
         verify(listener).onFailure(exceptionCaptor.capture());
 
-        RuntimeException exception = exceptionCaptor.getValue();
+        OpenSearchStatusException exception = exceptionCaptor.getValue();
         assertEquals("Context management template not found: test_template", exception.getMessage());
+        assertEquals(RestStatus.NOT_FOUND, exception.status());
+    }
+
+    @Test
+    public void testDoExecute_TemplateNotFound_Returns404() {
+        String templateName = "sliding_window_max_40000_tokens_managers123";
+        MLDeleteContextManagementTemplateRequest request = new MLDeleteContextManagementTemplateRequest(templateName);
+        Task task = mock(Task.class);
+        ActionListener<MLDeleteContextManagementTemplateResponse> listener = mock(ActionListener.class);
+
+        // Mock template not found (service returns false)
+        doAnswer(invocation -> {
+            ActionListener<Boolean> deleteListener = invocation.getArgument(1);
+            deleteListener.onResponse(false);
+            return null;
+        }).when(contextManagementTemplateService).deleteTemplate(eq(templateName), any());
+
+        transportAction.doExecute(task, request, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+
+        Exception exception = exceptionCaptor.getValue();
+        assertTrue(
+            "Expected OpenSearchStatusException but got " + exception.getClass().getName(),
+            exception instanceof OpenSearchStatusException
+        );
+        OpenSearchStatusException statusException = (OpenSearchStatusException) exception;
+        assertEquals(RestStatus.NOT_FOUND, statusException.status());
+        assertTrue(statusException.getMessage().contains(templateName));
+    }
+
+    @Test
+    public void testDoExecute_TemplateNotFound_ExceptionIsNotRuntimeException() {
+        String templateName = "nonexistent_template";
+        MLDeleteContextManagementTemplateRequest request = new MLDeleteContextManagementTemplateRequest(templateName);
+        Task task = mock(Task.class);
+        ActionListener<MLDeleteContextManagementTemplateResponse> listener = mock(ActionListener.class);
+
+        // Mock template not found
+        doAnswer(invocation -> {
+            ActionListener<Boolean> deleteListener = invocation.getArgument(1);
+            deleteListener.onResponse(false);
+            return null;
+        }).when(contextManagementTemplateService).deleteTemplate(eq(templateName), any());
+
+        transportAction.doExecute(task, request, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+
+        // Verify it's NOT a plain RuntimeException (which would cause a 500)
+        assertFalse("Should not be a plain RuntimeException", exceptionCaptor.getValue().getClass().equals(RuntimeException.class));
     }
 
     @Test


### PR DESCRIPTION
### Description
                                                                      
  Summary of all changes:                                                                                                                                      
                                                                                                                                                               
  - DeleteContextManagementTemplateTransportAction.java — Changed RuntimeException → OpenSearchStatusException with RestStatus.NOT_FOUND so deleting a
  non-existent template returns HTTP 404 instead of 500                                                                                                        
  - DeleteContextManagementTemplateTransportActionTests.java — Updated existing test + added 2 new tests:
    - testDoExecute_TemplateNotFound_Returns404 — verifies 404 status with realistic template name
    - testDoExecute_TemplateNotFound_ExceptionIsNotRuntimeException — ensures it's not a plain RuntimeException

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
