### PR TITLE
fix jar hell

### DIFF
--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -79,12 +79,8 @@ dependencies {
         exclude group: 'org.bouncycastle', module: 'bcprov-ext-jdk18on'
     }
     // needed by aws-encryption-sdk-java
-    // When building with -Pcrypto.standard=FIPS-140-3, bcFips jars are provided by OpenSearch
-    if (FipsBuildParams.isInFipsMode()) {
-        compileOnly "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
-    } else {
-        implementation "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
-    }
+    // bc-fips is provided by OpenSearch core, so always use compileOnly to avoid jar hell
+    compileOnly "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
     compileOnly group: 'software.amazon.awssdk', name: 'aws-core', version: "${versions.aws}"
     compileOnly group: 'software.amazon.awssdk', name: 's3', version: "${versions.aws}"
     compileOnly group: 'software.amazon.awssdk', name: 'regions', version: "${versions.aws}"

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -199,13 +199,11 @@ def _numNodes = findProperty('numNodes') as Integer ?: 1
 test {
     include '**/*Tests.class'
     systemProperty 'tests.security.manager', 'false'
-    // In FIPS mode, bc-fips is excluded from the plugin bundle to avoid jar hell with OpenSearch core.
+    // bc-fips is excluded from the plugin bundle (provided by OpenSearch core).
     // Unit tests don't run inside OpenSearch, so we add bc-fips directly to the test classpath.
-    if (FipsBuildParams.isInFipsMode()) {
-        classpath += configurations.detachedConfiguration(
-            dependencies.create("org.bouncycastle:bc-fips:2.1.2")
-        )
-    }
+    classpath += configurations.detachedConfiguration(
+        dependencies.create("org.bouncycastle:bc-fips:2.1.2")
+    )
 }
 
 def opensearch_tmp_dir = rootProject.file('build/private/opensearch_tmp').absoluteFile
@@ -699,11 +697,8 @@ configurations.all {
     exclude group: "com.google.guava", module: "failureaccess"
     exclude group: "com.google.errorprone", module: "error_prone_annotations"
     
-    // When building with -Pcrypto.standard=FIPS-140-3, bcFips jars are provided by OpenSearch
-    // This prevents jar hell when the plugin is installed
-    if (FipsBuildParams.isInFipsMode()) {
-        exclude group: 'org.bouncycastle', module: 'bc-fips'
-    }
+    // bc-fips is provided by OpenSearch core, always exclude to prevent jar hell
+    exclude group: 'org.bouncycastle', module: 'bc-fips'
     
     resolutionStrategy.force "org.apache.commons:commons-lang3:${versions.commonslang}"
     resolutionStrategy.force 'commons-logging:commons-logging:1.2'


### PR DESCRIPTION
### Description
Build is failing on main branch due to the below error. This fixes the jar hell by removing bc-flips from plugin.

```
| -> Failed installing file:/home/jzeng/github/ml-commons/plugin/build/distributions/opensearch-ml-3.6.0.0-SNAPSHOT.zip
| -> Rolling back transport-reactor-netty4
| -> Rolled back transport-reactor-netty4
| -> Rolling back arrow-flight-rpc
| -> Rolled back arrow-flight-rpc
| -> Rolling back opensearch-job-scheduler
| -> Rolled back opensearch-job-scheduler
| -> Rolling back file:/home/jzeng/github/ml-commons/plugin/build/distributions/opensearch-ml-3.6.0.0-SNAPSHOT.zip
| -> Rolled back file:/home/jzeng/github/ml-commons/plugin/build/distributions/opensearch-ml-3.6.0.0-SNAPSHOT.zip
| Exception in thread "main" java.lang.IllegalStateException: failed to load plugin opensearch-ml due to jar hell
|       at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:779)
|       at org.opensearch.plugins.PluginsService.checkJarHellForPlugin(PluginsService.java:404)
|       at org.opensearch.tools.cli.plugin.InstallPluginCommand.jarHellCheck(InstallPluginCommand.java:834)
|       at org.opensearch.tools.cli.plugin.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:811)
|       at org.opensearch.tools.cli.plugin.InstallPluginCommand.installPlugin(InstallPluginCommand.java:846)
|       at org.opensearch.tools.cli.plugin.InstallPluginCommand.execute(InstallPluginCommand.java:277)
|       at org.opensearch.tools.cli.plugin.InstallPluginCommand.execute(InstallPluginCommand.java:251)
|       at org.opensearch.common.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:110)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.Command.main(Command.java:101)
|       at org.opensearch.tools.cli.plugin.PluginCli.main(PluginCli.java:66)
| Caused by: java.lang.IllegalStateException: jar hell!
| class: META-INF.versions.11.org.bouncycastle.crypto.fips.FipsSecureRandom$Random11Spi
| jar1: /home/jzeng/github/ml-commons/plugin/build/testclusters/integTest-0/distro/3.6.0-ARCHIVE/plugins/.installing-3693580173013388193/bc-fips-2.1.2.jar
| jar2: /home/jzeng/github/ml-commons/plugin/build/testclusters/integTest-0/distro/3.6.0-ARCHIVE/lib/bc-fips-2.1.2.jar
|       at org.opensearch.common.bootstrap.JarHell.checkClass(JarHell.java:316)
|       at org.opensearch.common.bootstrap.JarHell.checkJarHell(JarHell.java:215)
|       at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:777)
|       ... 12 more

[Incubating] Problems report is available at: file:///home/jzeng/github/ml-commons/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
