### PR TITLE
Add configurable connectionAcquisitionTimeout to connector client config

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -103,6 +103,7 @@ public class CommonValue {
     public static final Version VERSION_3_3_0 = Version.fromString("3.3.0");
     public static final Version VERSION_3_4_0 = Version.fromString("3.4.0");
     public static final Version VERSION_3_5_0 = Version.fromString("3.5.0");
+    public static final Version VERSION_3_6_0 = Version.fromString("3.6.0");
 
     // Connector Constants
     public static final String NAME_FIELD = "name";

--- a/common/src/main/java/org/opensearch/ml/common/connector/ConnectorClientConfig.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/ConnectorClientConfig.java
@@ -18,6 +18,7 @@ import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -32,6 +33,7 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
     public static final String MAX_CONNECTION_FIELD = "max_connection";
     public static final String CONNECTION_TIMEOUT_FIELD = "connection_timeout";
     public static final String READ_TIMEOUT_FIELD = "read_timeout";
+    public static final String CONNECTION_ACQUISITION_TIMEOUT_FIELD = "connection_acquisition_timeout";
     public static final String RETRY_BACKOFF_MILLIS_FIELD = "retry_backoff_millis";
     public static final String RETRY_TIMEOUT_SECONDS_FIELD = "retry_timeout_seconds";
     public static final String MAX_RETRY_TIMES_FIELD = "max_retry_times";
@@ -41,15 +43,18 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
     public static final Integer MAX_CONNECTION_DEFAULT_VALUE = Integer.valueOf(30);
     public static final Integer CONNECTION_TIMEOUT_DEFAULT_VALUE = Integer.valueOf(30000);
     public static final Integer READ_TIMEOUT_DEFAULT_VALUE = Integer.valueOf(30000);
+    public static final Integer CONNECTION_ACQUISITION_TIMEOUT_DEFAULT_VALUE = Integer.valueOf(10000);
     public static final Integer RETRY_BACKOFF_MILLIS_DEFAULT_VALUE = 200;
     public static final Integer RETRY_TIMEOUT_SECONDS_DEFAULT_VALUE = 30;
     public static final Integer MAX_RETRY_TIMES_DEFAULT_VALUE = 0;
     public static final RetryBackoffPolicy RETRY_BACKOFF_POLICY_DEFAULT_VALUE = RetryBackoffPolicy.CONSTANT;
     public static final Boolean SKIP_SSL_VERIFICATION_DEFAULT_VALUE = Boolean.FALSE;
     public static final Version MINIMAL_SUPPORTED_VERSION_FOR_RETRY = Version.V_2_15_0;
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_CONNECTION_ACQUISITION_TIMEOUT = CommonValue.VERSION_3_6_0;
     private Integer maxConnections;
     private Integer connectionTimeout;
     private Integer readTimeout;
+    private Integer connectionAcquisitionTimeout;
     private Integer retryBackoffMillis;
     private Integer retryTimeoutSeconds;
     private Integer maxRetryTimes;
@@ -61,6 +66,7 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
         Integer maxConnections,
         Integer connectionTimeout,
         Integer readTimeout,
+        Integer connectionAcquisitionTimeout,
         Integer retryBackoffMillis,
         Integer retryTimeoutSeconds,
         Integer maxRetryTimes,
@@ -70,6 +76,10 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
         this.maxConnections = maxConnections;
         this.connectionTimeout = connectionTimeout;
         this.readTimeout = readTimeout;
+        this.connectionAcquisitionTimeout = connectionAcquisitionTimeout;
+        if (connectionAcquisitionTimeout != null && connectionAcquisitionTimeout <= 0) {
+            throw new IllegalArgumentException("connection_acquisition_timeout must be positive, got: " + connectionAcquisitionTimeout);
+        }
         this.retryBackoffMillis = retryBackoffMillis;
         this.retryTimeoutSeconds = retryTimeoutSeconds;
         this.maxRetryTimes = maxRetryTimes;
@@ -90,6 +100,9 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
                 this.retryBackoffPolicy = RetryBackoffPolicy.from(input.readString());
             }
             this.skipSslVerification = input.readOptionalBoolean();
+        }
+        if (streamInputVersion.onOrAfter(MINIMAL_SUPPORTED_VERSION_FOR_CONNECTION_ACQUISITION_TIMEOUT)) {
+            this.connectionAcquisitionTimeout = input.readOptionalInt();
         }
     }
 
@@ -122,6 +135,9 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
             }
             out.writeOptionalBoolean(skipSslVerification);
         }
+        if (streamOutputVersion.onOrAfter(MINIMAL_SUPPORTED_VERSION_FOR_CONNECTION_ACQUISITION_TIMEOUT)) {
+            out.writeOptionalInt(connectionAcquisitionTimeout);
+        }
     }
 
     @Override
@@ -135,6 +151,9 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
         }
         if (readTimeout != null) {
             builder.field(READ_TIMEOUT_FIELD, readTimeout);
+        }
+        if (connectionAcquisitionTimeout != null) {
+            builder.field(CONNECTION_ACQUISITION_TIMEOUT_FIELD, connectionAcquisitionTimeout);
         }
         if (retryBackoffMillis != null) {
             builder.field(RETRY_BACKOFF_MILLIS_FIELD, retryBackoffMillis);
@@ -163,6 +182,7 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
         Integer maxConnections = MAX_CONNECTION_DEFAULT_VALUE;
         Integer connectionTimeout = CONNECTION_TIMEOUT_DEFAULT_VALUE;
         Integer readTimeout = READ_TIMEOUT_DEFAULT_VALUE;
+        Integer connectionAcquisitionTimeout = null;
         Integer retryBackoffMillis = RETRY_BACKOFF_MILLIS_DEFAULT_VALUE;
         Integer retryTimeoutSeconds = RETRY_TIMEOUT_SECONDS_DEFAULT_VALUE;
         Integer maxRetryTimes = MAX_RETRY_TIMES_DEFAULT_VALUE;
@@ -183,6 +203,9 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
                     break;
                 case READ_TIMEOUT_FIELD:
                     readTimeout = parser.intValue();
+                    break;
+                case CONNECTION_ACQUISITION_TIMEOUT_FIELD:
+                    connectionAcquisitionTimeout = parser.intValue();
                     break;
                 case RETRY_BACKOFF_MILLIS_FIELD:
                     retryBackoffMillis = parser.intValue();
@@ -209,6 +232,7 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
             .maxConnections(maxConnections)
             .connectionTimeout(connectionTimeout)
             .readTimeout(readTimeout)
+            .connectionAcquisitionTimeout(connectionAcquisitionTimeout)
             .retryBackoffMillis(retryBackoffMillis)
             .retryTimeoutSeconds(retryTimeoutSeconds)
             .maxRetryTimes(maxRetryTimes)

--- a/common/src/main/java/org/opensearch/ml/common/httpclient/MLHttpClientFactory.java
+++ b/common/src/main/java/org/opensearch/ml/common/httpclient/MLHttpClientFactory.java
@@ -9,6 +9,8 @@ import static org.opensearch.secure_sm.AccessController.doPrivileged;
 
 import java.time.Duration;
 
+import org.opensearch.ml.common.connector.ConnectorClientConfig;
+
 import lombok.extern.log4j.Log4j2;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -27,9 +29,63 @@ public class MLHttpClientFactory {
         return getAsyncHttpClient(connectionTimeout, readTimeout, maxConnections, connectorPrivateIpEnabled, false);
     }
 
+    /**
+     * Legacy overload kept for backward compatibility. Sets connectionAcquisitionTimeout
+     * equal to readTimeout to prevent connection pool exhaustion when readTimeout exceeds
+     * the SDK default of 10 seconds.
+     */
     public static SdkAsyncHttpClient getAsyncHttpClient(
         Duration connectionTimeout,
         Duration readTimeout,
+        int maxConnections,
+        boolean connectorPrivateIpEnabled,
+        boolean skipSslVerification
+    ) {
+        return buildHttpClient(
+            connectionTimeout,
+            readTimeout,
+            Duration.ofMillis(ConnectorClientConfig.CONNECTION_ACQUISITION_TIMEOUT_DEFAULT_VALUE),
+            maxConnections,
+            connectorPrivateIpEnabled,
+            skipSslVerification
+        );
+    }
+
+    public static SdkAsyncHttpClient getAsyncHttpClient(ConnectorClientConfig config, boolean connectorPrivateIpEnabled) {
+        Duration connectionTimeout = Duration
+            .ofMillis(
+                config.getConnectionTimeout() != null
+                    ? config.getConnectionTimeout()
+                    : ConnectorClientConfig.CONNECTION_TIMEOUT_DEFAULT_VALUE
+            );
+        Duration readTimeout = Duration
+            .ofMillis(config.getReadTimeout() != null ? config.getReadTimeout() : ConnectorClientConfig.READ_TIMEOUT_DEFAULT_VALUE);
+        int maxConnections = config.getMaxConnections() != null
+            ? config.getMaxConnections()
+            : ConnectorClientConfig.MAX_CONNECTION_DEFAULT_VALUE;
+        boolean skipSslVerification = config.getSkipSslVerification() != null ? config.getSkipSslVerification() : false;
+        Integer acquisitionTimeoutValue = config.getConnectionAcquisitionTimeout();
+        Duration connectionAcquisitionTimeout = Duration
+            .ofMillis(
+                acquisitionTimeoutValue != null
+                    ? acquisitionTimeoutValue
+                    : ConnectorClientConfig.CONNECTION_ACQUISITION_TIMEOUT_DEFAULT_VALUE
+            );
+
+        return buildHttpClient(
+            connectionTimeout,
+            readTimeout,
+            connectionAcquisitionTimeout,
+            maxConnections,
+            connectorPrivateIpEnabled,
+            skipSslVerification
+        );
+    }
+
+    private static SdkAsyncHttpClient buildHttpClient(
+        Duration connectionTimeout,
+        Duration readTimeout,
+        Duration connectionAcquisitionTimeout,
         int maxConnections,
         boolean connectorPrivateIpEnabled,
         boolean skipSslVerification
@@ -44,9 +100,11 @@ public class MLHttpClientFactory {
             }
             log
                 .debug(
-                    "Creating MLHttpClient with connectionTimeout: {}, readTimeout: {}, maxConnections: {}," + " skipSslVerification: {}",
+                    "Creating MLHttpClient with connectionTimeout: {}, readTimeout: {}, connectionAcquisitionTimeout: {},"
+                        + " maxConnections: {}, skipSslVerification: {}",
                     connectionTimeout,
                     readTimeout,
+                    connectionAcquisitionTimeout,
                     maxConnections,
                     skipSslVerification
                 );
@@ -55,6 +113,7 @@ public class MLHttpClientFactory {
                 .connectionTimeout(connectionTimeout)
                 .readTimeout(readTimeout)
                 .maxConcurrency(maxConnections)
+                .connectionAcquisitionTimeout(connectionAcquisitionTimeout)
                 .buildWithDefaults(
                     AttributeMap.builder().put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, skipSslVerification).build()
                 );

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -405,7 +405,17 @@ public class HttpConnectorTest {
         Map<String, String> credential = new HashMap<>();
         credential.put("key", "test_key_value");
 
-        ConnectorClientConfig httpClientConfig = new ConnectorClientConfig(30, 30000, 30000, 10, 10, -1, RetryBackoffPolicy.CONSTANT, null);
+        ConnectorClientConfig httpClientConfig = new ConnectorClientConfig(
+            30,
+            30000,
+            30000,
+            null,
+            10,
+            10,
+            -1,
+            RetryBackoffPolicy.CONSTANT,
+            null
+        );
 
         HttpConnector connector = HttpConnector
             .builder()

--- a/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
@@ -188,7 +188,7 @@ public class McpConnectorTest {
         updatedCredential.put("new_key", "new_value");
         List<String> updatedBackendRoles = List.of("role3", "role4");
         AccessMode updatedAccessMode = AccessMode.PRIVATE;
-        ConnectorClientConfig updatedClientConfig = new ConnectorClientConfig(40, 40000, 40000, 20, 20, 5, CONSTANT, null);
+        ConnectorClientConfig updatedClientConfig = new ConnectorClientConfig(40, 40000, 40000, null, 20, 20, 5, CONSTANT, null);
         String updatedUrl = "https://updated.test.com";
         Map<String, String> updatedHeaders = new HashMap<>();
         updatedHeaders.put("new_header", "new_header_value");
@@ -257,7 +257,17 @@ public class McpConnectorTest {
         Map<String, String> parameters = new HashMap<>();
         parameters.put("sse_endpoint", "/custom/sse");
 
-        ConnectorClientConfig clientConfig = new ConnectorClientConfig(30, 30000, 30000, 10, 10, -1, RetryBackoffPolicy.CONSTANT, null);
+        ConnectorClientConfig clientConfig = new ConnectorClientConfig(
+            30,
+            30000,
+            30000,
+            null,
+            10,
+            10,
+            -1,
+            RetryBackoffPolicy.CONSTANT,
+            null
+        );
 
         return McpConnector
             .builder()

--- a/common/src/test/java/org/opensearch/ml/common/connector/McpStreamableHttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/McpStreamableHttpConnectorTest.java
@@ -193,7 +193,7 @@ public class McpStreamableHttpConnectorTest {
         updatedCredential.put("new_key", "new_value");
         List<String> updatedBackendRoles = List.of("role3", "role4");
         AccessMode updatedAccessMode = AccessMode.PRIVATE;
-        ConnectorClientConfig updatedClientConfig = new ConnectorClientConfig(40, 40000, 40000, 20, 20, 5, CONSTANT, null);
+        ConnectorClientConfig updatedClientConfig = new ConnectorClientConfig(40, 40000, 40000, null, 20, 20, 5, CONSTANT, null);
         String updatedUrl = "https://updated.test.com";
         Map<String, String> updatedHeaders = new HashMap<>();
         updatedHeaders.put("new_header", "new_header_value");
@@ -280,7 +280,17 @@ public class McpStreamableHttpConnectorTest {
         Map<String, String> parameters = new HashMap<>();
         parameters.put("endpoint", "/custom/endpoint");
 
-        ConnectorClientConfig clientConfig = new ConnectorClientConfig(30, 30000, 30000, 10, 10, -1, RetryBackoffPolicy.CONSTANT, null);
+        ConnectorClientConfig clientConfig = new ConnectorClientConfig(
+            30,
+            30000,
+            30000,
+            null,
+            10,
+            10,
+            -1,
+            RetryBackoffPolicy.CONSTANT,
+            null
+        );
 
         return McpStreamableHttpConnector
             .builder()

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -96,6 +96,7 @@ public class MLCreateConnectorInputTests {
             20,
             10000,
             10000,
+            null,
             10,
             10,
             -1,

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -16,7 +16,6 @@ import static software.amazon.awssdk.http.SdkHttpMethod.PUT;
 
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
-import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -203,34 +202,16 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
     @VisibleForTesting
     protected SdkAsyncHttpClient getHttpClient() {
         if (httpClientRef.get() == null) {
-            Duration connectionTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getConnectionTimeout());
-            Duration readTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getReadTimeout());
-            Integer maxConnection = super.getConnectorClientConfig().getMaxConnections();
-            Boolean skipSslVerification = super.getConnectorClientConfig().getSkipSslVerification();
-            boolean skipSslVerificationValue = skipSslVerification != null ? skipSslVerification : false;
-            if (skipSslVerificationValue) {
-                log.warn("SSL certificate verification is DISABLED for connector {}", connector.getName());
-            }
             log
                 .info(
                     "AwsConnectorExecutor creating HTTP client for connector: {} - maxConnections: {}, connectionTimeout: {}s, readTimeout: {}s",
                     connector.getName(),
-                    maxConnection,
+                    super.getConnectorClientConfig().getMaxConnections(),
                     super.getConnectorClientConfig().getConnectionTimeout(),
                     super.getConnectorClientConfig().getReadTimeout()
                 );
             this.httpClientRef
-                .compareAndSet(
-                    null,
-                    MLHttpClientFactory
-                        .getAsyncHttpClient(
-                            connectionTimeout,
-                            readTimeout,
-                            maxConnection,
-                            connectorPrivateIpEnabled,
-                            skipSslVerificationValue
-                        )
-                );
+                .compareAndSet(null, MLHttpClientFactory.getAsyncHttpClient(super.getConnectorClientConfig(), connectorPrivateIpEnabled));
         }
         return httpClientRef.get();
     }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
@@ -15,7 +15,6 @@ import static software.amazon.awssdk.http.SdkHttpMethod.PUT;
 
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
-import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -193,34 +192,16 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
     @VisibleForTesting
     protected SdkAsyncHttpClient getHttpClient() {
         if (httpClientRef.get() == null) {
-            Duration connectionTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getConnectionTimeout());
-            Duration readTimeout = Duration.ofSeconds(super.getConnectorClientConfig().getReadTimeout());
-            Integer maxConnection = super.getConnectorClientConfig().getMaxConnections();
-            Boolean skipSslVerification = super.getConnectorClientConfig().getSkipSslVerification();
-            boolean skipSslVerificationValue = skipSslVerification != null ? skipSslVerification : false;
-            if (skipSslVerificationValue) {
-                log.warn("SSL certificate verification is DISABLED for connector {}", connector.getName());
-            }
             log
                 .info(
                     "HttpJsonConnectorExecutor creating HTTP client for connector: {} - maxConnections: {}, connectionTimeout: {}s, readTimeout: {}s",
                     connector.getName(),
-                    maxConnection,
+                    super.getConnectorClientConfig().getMaxConnections(),
                     super.getConnectorClientConfig().getConnectionTimeout(),
                     super.getConnectorClientConfig().getReadTimeout()
                 );
             this.httpClientRef
-                .compareAndSet(
-                    null,
-                    MLHttpClientFactory
-                        .getAsyncHttpClient(
-                            connectionTimeout,
-                            readTimeout,
-                            maxConnection,
-                            connectorPrivateIpEnabled,
-                            skipSslVerificationValue
-                        )
-                );
+                .compareAndSet(null, MLHttpClientFactory.getAsyncHttpClient(super.getConnectorClientConfig(), connectorPrivateIpEnabled));
         }
         return httpClientRef.get();
     }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
@@ -7,10 +7,10 @@ package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -27,7 +27,6 @@ import static org.opensearch.ml.common.connector.HttpConnector.SERVICE_NAME_FIEL
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_INTERFACE_BEDROCK_CONVERSE_CLAUDE;
 import static org.opensearch.ml.engine.algorithms.agent.MLChatAgentRunner.LLM_INTERFACE;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -163,7 +162,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             .parameters(parameters)
             .credential(credential)
             .actions(Arrays.asList(predictAction))
-            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
+            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
             .build();
         connector.decrypt(PREDICT.name(), (c, tenantId) -> encryptor.decrypt(c, null), null);
         AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
@@ -250,7 +249,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             .parameters(parameters)
             .credential(credential)
             .actions(Arrays.asList(predictAction))
-            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
+            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
             .build();
         connector.decrypt(PREDICT.name(), (c, tenantId) -> encryptor.decrypt(c, null), null);
         AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
@@ -302,7 +301,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             .parameters(parameters)
             .credential(credential)
             .actions(Arrays.asList(predictAction))
-            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
+            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
             .build();
         connector.decrypt(PREDICT.name(), (c, tenantId) -> encryptor.decrypt(c, null), null);
         AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
@@ -362,7 +361,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             .parameters(parameters)
             .credential(credential)
             .actions(Arrays.asList(predictAction))
-            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
+            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
             .build();
         connector.decrypt(PREDICT.name(), (c, tenantId) -> encryptor.decrypt(c, null), null);
         AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
@@ -419,7 +418,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             .parameters(parameters)
             .credential(credential)
             .actions(Arrays.asList(predictAction))
-            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
+            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
             .build();
         connector.decrypt(PREDICT.name(), (c, tenantId) -> encryptor.decrypt(c, null), null);
         AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
@@ -719,7 +718,17 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
         Map<String, String> parameters = ImmutableMap
             .of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "sagemaker", "input_docs_processed_step_size", "5");
         // execute with retry disabled
-        ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null);
+        ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig(
+            10,
+            10,
+            10,
+            null,
+            1,
+            1,
+            0,
+            RetryBackoffPolicy.CONSTANT,
+            null
+        );
         Connector connector = AwsConnector
             .awsConnectorBuilder()
             .name("test connector")
@@ -753,7 +762,17 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
         verify(executor, times(1)).invokeRemoteService(any(), any(), any(), any(), any(), any());
 
         // execute with retry enabled
-        ConnectorClientConfig connectorClientConfig2 = new ConnectorClientConfig(10, 10, 10, 1, 1, 1, RetryBackoffPolicy.CONSTANT, null);
+        ConnectorClientConfig connectorClientConfig2 = new ConnectorClientConfig(
+            10,
+            10,
+            10,
+            null,
+            1,
+            1,
+            1,
+            RetryBackoffPolicy.CONSTANT,
+            null
+        );
         Connector connector2 = AwsConnector
             .awsConnectorBuilder()
             .name("test connector")
@@ -811,7 +830,17 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
         MLInput mlInput = mock(MLInput.class);
         Map<String, String> parameters = Map.of();
         String payload = "";
-        ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig(10, 10, 10, 1, 10, -1, RetryBackoffPolicy.CONSTANT, null);
+        ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig(
+            10,
+            10,
+            10,
+            null,
+            1,
+            10,
+            -1,
+            RetryBackoffPolicy.CONSTANT,
+            null
+        );
         ExecutionContext executionContext = new ExecutionContext(123);
         ActionListener<Tuple<Integer, ModelTensors>> actionListener = mock(ActionListener.class);
         AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(mock(AwsConnector.class)));
@@ -858,7 +887,17 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
         MLInput mlInput = mock(MLInput.class);
         Map<String, String> parameters = Map.of();
         String payload = "";
-        ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig(10, 10, 10, 1, 10, 5, RetryBackoffPolicy.CONSTANT, null);
+        ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig(
+            10,
+            10,
+            10,
+            null,
+            1,
+            10,
+            5,
+            RetryBackoffPolicy.CONSTANT,
+            null
+        );
         ExecutionContext executionContext = new ExecutionContext(123);
         ActionListener<Tuple<Integer, ModelTensors>> actionListener = mock(ActionListener.class);
         AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(mock(AwsConnector.class)));
@@ -905,7 +944,17 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
         MLInput mlInput = mock(MLInput.class);
         Map<String, String> parameters = Map.of();
         String payload = "";
-        ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig(10, 10, 10, 1, 10, -1, RetryBackoffPolicy.CONSTANT, null);
+        ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig(
+            10,
+            10,
+            10,
+            null,
+            1,
+            10,
+            -1,
+            RetryBackoffPolicy.CONSTANT,
+            null
+        );
         ExecutionContext executionContext = new ExecutionContext(123);
         ActionListener<Tuple<Integer, ModelTensors>> actionListener = mock(ActionListener.class);
         AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(mock(AwsConnector.class)));
@@ -978,7 +1027,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
     @Test
     public void testInvokeRemoteServiceStream_With_SkipSslVerification_True() {
         try (MockedStatic<MLHttpClientFactory> mockedFactory = mockStatic(MLHttpClientFactory.class)) {
-            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, true);
+            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, true);
             AwsConnector mockConnector = mock(AwsConnector.class);
             when(mockConnector.getAccessKey()).thenReturn("test-access-key");
             when(mockConnector.getSecretKey()).thenReturn("test-secret-key");
@@ -986,10 +1035,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             when(mockConnector.getConnectorClientConfig()).thenReturn(clientConfig);
             SdkAsyncHttpClient mockClient = mock(SdkAsyncHttpClient.class);
             mockedFactory
-                .when(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(any(Duration.class), any(Duration.class), anyInt(), anyBoolean(), anyBoolean())
-                )
+                .when(() -> MLHttpClientFactory.getAsyncHttpClient(any(ConnectorClientConfig.class), anyBoolean()))
                 .thenReturn(mockClient);
 
             AwsConnectorExecutor executor = new AwsConnectorExecutor(mockConnector);
@@ -1001,27 +1047,17 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             StreamPredictActionListener<MLTaskResponse, ?> actionListener = mock(StreamPredictActionListener.class);
 
             executor.invokeRemoteServiceStream("predict", mlInput, parameters, payload, executionContext, actionListener);
-            ArgumentCaptor<Boolean> sslVerificationCaptor = ArgumentCaptor.forClass(Boolean.class);
-            mockedFactory
-                .verify(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(
-                            any(Duration.class),
-                            any(Duration.class),
-                            anyInt(),
-                            anyBoolean(),
-                            sslVerificationCaptor.capture()
-                        )
-                );
+            ArgumentCaptor<ConnectorClientConfig> configCaptor = ArgumentCaptor.forClass(ConnectorClientConfig.class);
+            mockedFactory.verify(() -> MLHttpClientFactory.getAsyncHttpClient(configCaptor.capture(), anyBoolean()));
             // Assert that skipSslVerification was set to true
-            assertTrue("SSL verification should be disabled", sslVerificationCaptor.getValue());
+            assertTrue("SSL verification should be disabled", configCaptor.getValue().getSkipSslVerification());
         }
     }
 
     @Test
     public void testInvokeRemoteServiceStream_With_SkipSslVerification_False() {
         try (MockedStatic<MLHttpClientFactory> mockedFactory = mockStatic(MLHttpClientFactory.class)) {
-            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, false);
+            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, false);
             AwsConnector mockConnector = mock(AwsConnector.class);
             when(mockConnector.getAccessKey()).thenReturn("test-access-key");
             when(mockConnector.getSecretKey()).thenReturn("test-secret-key");
@@ -1029,10 +1065,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             when(mockConnector.getConnectorClientConfig()).thenReturn(clientConfig);
             SdkAsyncHttpClient mockClient = mock(SdkAsyncHttpClient.class);
             mockedFactory
-                .when(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(any(Duration.class), any(Duration.class), anyInt(), anyBoolean(), anyBoolean())
-                )
+                .when(() -> MLHttpClientFactory.getAsyncHttpClient(any(ConnectorClientConfig.class), anyBoolean()))
                 .thenReturn(mockClient);
 
             AwsConnectorExecutor executor = new AwsConnectorExecutor(mockConnector);
@@ -1044,27 +1077,17 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             StreamPredictActionListener<MLTaskResponse, ?> actionListener = mock(StreamPredictActionListener.class);
             executor.invokeRemoteServiceStream("predict", mlInput, parameters, payload, executionContext, actionListener);
 
-            ArgumentCaptor<Boolean> sslVerificationCaptor = ArgumentCaptor.forClass(Boolean.class);
-            mockedFactory
-                .verify(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(
-                            any(Duration.class),
-                            any(Duration.class),
-                            anyInt(),
-                            anyBoolean(),
-                            sslVerificationCaptor.capture()
-                        )
-                );
+            ArgumentCaptor<ConnectorClientConfig> configCaptor = ArgumentCaptor.forClass(ConnectorClientConfig.class);
+            mockedFactory.verify(() -> MLHttpClientFactory.getAsyncHttpClient(configCaptor.capture(), anyBoolean()));
             // Assert that skipSslVerification was set to false
-            assertFalse("SSL verification should be enabled", sslVerificationCaptor.getValue());
+            assertFalse("SSL verification should be enabled", configCaptor.getValue().getSkipSslVerification());
         }
     }
 
     @Test
     public void testInvokeRemoteServiceStream_With_SkipSslVerification_Null() {
         try (MockedStatic<MLHttpClientFactory> mockedFactory = mockStatic(MLHttpClientFactory.class)) {
-            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null);
+            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null);
             AwsConnector mockConnector = mock(AwsConnector.class);
             when(mockConnector.getAccessKey()).thenReturn("test-access-key");
             when(mockConnector.getSecretKey()).thenReturn("test-secret-key");
@@ -1072,10 +1095,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             when(mockConnector.getConnectorClientConfig()).thenReturn(clientConfig);
             SdkAsyncHttpClient mockClient = mock(SdkAsyncHttpClient.class);
             mockedFactory
-                .when(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(any(Duration.class), any(Duration.class), anyInt(), anyBoolean(), anyBoolean())
-                )
+                .when(() -> MLHttpClientFactory.getAsyncHttpClient(any(ConnectorClientConfig.class), anyBoolean()))
                 .thenReturn(mockClient);
 
             AwsConnectorExecutor executor = new AwsConnectorExecutor(mockConnector);
@@ -1087,20 +1107,10 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             StreamPredictActionListener<MLTaskResponse, ?> actionListener = mock(StreamPredictActionListener.class);
             executor.invokeRemoteServiceStream("predict", mlInput, parameters, payload, executionContext, actionListener);
 
-            ArgumentCaptor<Boolean> sslVerificationCaptor = ArgumentCaptor.forClass(Boolean.class);
-            mockedFactory
-                .verify(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(
-                            any(Duration.class),
-                            any(Duration.class),
-                            anyInt(),
-                            anyBoolean(),
-                            sslVerificationCaptor.capture()
-                        )
-                );
-            // Assert that skipSslVerification defaults to false when null
-            assertFalse("SSL verification should be enabled when null", sslVerificationCaptor.getValue());
+            ArgumentCaptor<ConnectorClientConfig> configCaptor = ArgumentCaptor.forClass(ConnectorClientConfig.class);
+            mockedFactory.verify(() -> MLHttpClientFactory.getAsyncHttpClient(configCaptor.capture(), anyBoolean()));
+            // Assert that skipSslVerification is null in config (factory defaults null to false)
+            assertNull(configCaptor.getValue().getSkipSslVerification());
         }
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
@@ -7,10 +7,10 @@ package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -291,7 +290,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                 .url("http://openai.com/mock")
                 .requestBody("hello world")
                 .build();
-            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, true);
+            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, true);
             Connector connector = HttpConnector
                 .builder()
                 .name("test connector")
@@ -302,10 +301,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                 .build();
             SdkAsyncHttpClient mockClient = mock(SdkAsyncHttpClient.class);
             mockedFactory
-                .when(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(any(Duration.class), any(Duration.class), anyInt(), anyBoolean(), anyBoolean())
-                )
+                .when(() -> MLHttpClientFactory.getAsyncHttpClient(any(ConnectorClientConfig.class), anyBoolean()))
                 .thenReturn(mockClient);
 
             HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
@@ -322,20 +318,10 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                     actionListener
                 );
             verify(actionListener, never()).onFailure(any());
-            ArgumentCaptor<Boolean> sslVerificationCaptor = ArgumentCaptor.forClass(Boolean.class);
-            mockedFactory
-                .verify(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(
-                            any(Duration.class),
-                            any(Duration.class),
-                            anyInt(),
-                            anyBoolean(),
-                            sslVerificationCaptor.capture()
-                        )
-                );
+            ArgumentCaptor<ConnectorClientConfig> configCaptor = ArgumentCaptor.forClass(ConnectorClientConfig.class);
+            mockedFactory.verify(() -> MLHttpClientFactory.getAsyncHttpClient(configCaptor.capture(), anyBoolean()));
             // Assert that skipSslVerification was set to true
-            assertTrue("SSL verification should be disabled", sslVerificationCaptor.getValue());
+            assertTrue("SSL verification should be disabled", configCaptor.getValue().getSkipSslVerification());
         }
     }
 
@@ -349,7 +335,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                 .url("http://openai.com/mock")
                 .requestBody("hello world")
                 .build();
-            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, false);
+            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, false);
             Connector connector = HttpConnector
                 .builder()
                 .name("test connector")
@@ -360,10 +346,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                 .build();
             SdkAsyncHttpClient mockClient = mock(SdkAsyncHttpClient.class);
             mockedFactory
-                .when(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(any(Duration.class), any(Duration.class), anyInt(), anyBoolean(), anyBoolean())
-                )
+                .when(() -> MLHttpClientFactory.getAsyncHttpClient(any(ConnectorClientConfig.class), anyBoolean()))
                 .thenReturn(mockClient);
 
             HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
@@ -380,20 +363,10 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                     actionListener
                 );
             verify(actionListener, never()).onFailure(any());
-            ArgumentCaptor<Boolean> sslVerificationCaptor = ArgumentCaptor.forClass(Boolean.class);
-            mockedFactory
-                .verify(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(
-                            any(Duration.class),
-                            any(Duration.class),
-                            anyInt(),
-                            anyBoolean(),
-                            sslVerificationCaptor.capture()
-                        )
-                );
+            ArgumentCaptor<ConnectorClientConfig> configCaptor = ArgumentCaptor.forClass(ConnectorClientConfig.class);
+            mockedFactory.verify(() -> MLHttpClientFactory.getAsyncHttpClient(configCaptor.capture(), anyBoolean()));
             // Assert that skipSslVerification was set to false
-            assertFalse("SSL verification should be enabled", sslVerificationCaptor.getValue());
+            assertFalse("SSL verification should be enabled", configCaptor.getValue().getSkipSslVerification());
         }
     }
 
@@ -407,7 +380,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                 .url("http://openai.com/mock")
                 .requestBody("hello world")
                 .build();
-            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null);
+            ConnectorClientConfig clientConfig = new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null);
             Connector connector = HttpConnector
                 .builder()
                 .name("test connector")
@@ -418,10 +391,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                 .build();
             SdkAsyncHttpClient mockClient = mock(SdkAsyncHttpClient.class);
             mockedFactory
-                .when(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(any(Duration.class), any(Duration.class), anyInt(), anyBoolean(), anyBoolean())
-                )
+                .when(() -> MLHttpClientFactory.getAsyncHttpClient(any(ConnectorClientConfig.class), anyBoolean()))
                 .thenReturn(mockClient);
 
             HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
@@ -438,20 +408,10 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                     actionListener
                 );
             verify(actionListener, never()).onFailure(any());
-            ArgumentCaptor<Boolean> sslVerificationCaptor = ArgumentCaptor.forClass(Boolean.class);
-            mockedFactory
-                .verify(
-                    () -> MLHttpClientFactory
-                        .getAsyncHttpClient(
-                            any(Duration.class),
-                            any(Duration.class),
-                            anyInt(),
-                            anyBoolean(),
-                            sslVerificationCaptor.capture()
-                        )
-                );
-            // Assert that skipSslVerification defaults to false when null
-            assertFalse("SSL verification should be enabled when null", sslVerificationCaptor.getValue());
+            ArgumentCaptor<ConnectorClientConfig> configCaptor = ArgumentCaptor.forClass(ConnectorClientConfig.class);
+            mockedFactory.verify(() -> MLHttpClientFactory.getAsyncHttpClient(configCaptor.capture(), anyBoolean()));
+            // Assert that skipSslVerification is null in config (factory defaults null to false)
+            assertNull(configCaptor.getValue().getSkipSslVerification());
         }
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutorTest.java
@@ -114,7 +114,7 @@ public class RemoteConnectorExecutorTest {
             .parameters(parameters)
             .credential(credential)
             .actions(Arrays.asList(predictAction))
-            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
+            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, null, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
             .build();
     }
 


### PR DESCRIPTION
### Description

The AWS SDK's `NettyNioAsyncHttpClient` defaults `connectionAcquisitionTimeout` to 10 seconds. When all connections in the pool are in use, new requests fail with:

```
Acquire operation took longer than the configured maximum time.
```

This happens even when `connection_timeout` and `read_timeout` are set to generous values via `client_config`, because `connectionAcquisitionTimeout` is a separate SDK setting that controls how long a request waits for a connection **from the pool**.

### Changes

- Add `connection_acquisition_timeout` as an optional field in `ConnectorClientConfig` (`client_config`). When not set, defaults to `read_timeout`.
- Add `VERSION_3_6_0` constant with stream version gate for rolling upgrade compatibility.
- Add new `MLHttpClientFactory.getAsyncHttpClient(ConnectorClientConfig, boolean)` overload that accepts the config object directly, eliminating parameter explosion.
- Simplify `AwsConnectorExecutor.getHttpClient()` and `HttpJsonConnectorExecutor.getHttpClient()` to use the new factory overload — future config fields require no executor changes.
- Old factory overloads retained for backward compatibility.

### Usage

```json
"client_config": {
    "max_connection": 30,
    "connection_timeout": 30,
    "read_timeout": 30,
    "connection_acquisition_timeout": 60
}
```

If `connection_acquisition_timeout` is omitted, it defaults to the `read_timeout` value.

### Testing

- Compilation verified locally across all modules (`compileJava` + `compileTestJava` for `common`, `ml-algorithms`, and `plugin`)
- Spotless passed

### Issues Resolved

Closes #4717