### PR TITLE
fix: change OpenSearchStatusException check to OpenSearchException to include more client side error type

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingService.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingService.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.core.action.ActionListener;
@@ -186,8 +187,8 @@ public class MemoryProcessingService {
                 listener.onResponse(facts);
             } catch (Exception e) {
                 // Preserve client errors (4XX) with their detailed messages
-                if (e instanceof OpenSearchStatusException) {
-                    OpenSearchStatusException osException = (OpenSearchStatusException) e;
+                if (e instanceof OpenSearchException) {
+                    OpenSearchException osException = (OpenSearchException) e;
                     if (osException.status().getStatus() >= 400 && osException.status().getStatus() < 500) {
                         listener.onFailure(e);
                         return;
@@ -286,8 +287,8 @@ public class MemoryProcessingService {
                     listener.onResponse(decisions);
                 } catch (Exception e) {
                     // Preserve client errors (4XX) with their detailed messages
-                    if (e instanceof OpenSearchStatusException) {
-                        OpenSearchStatusException osException = (OpenSearchStatusException) e;
+                    if (e instanceof OpenSearchException) {
+                        OpenSearchException osException = (OpenSearchException) e;
                         if (osException.status().getStatus() >= 400 && osException.status().getStatus() < 500) {
                             listener.onFailure(e);
                             return;
@@ -435,8 +436,8 @@ public class MemoryProcessingService {
             }
         } catch (Exception e) {
             // Preserve client errors (4XX) with their detailed messages
-            if (e instanceof OpenSearchStatusException) {
-                OpenSearchStatusException osException = (OpenSearchStatusException) e;
+            if (e instanceof OpenSearchException) {
+                OpenSearchException osException = (OpenSearchException) e;
                 if (osException.status().getStatus() >= 400 && osException.status().getStatus() < 500) {
                     throw osException;
                 }
@@ -488,8 +489,8 @@ public class MemoryProcessingService {
                         listener.onResponse(summary);
                     } catch (Exception e) {
                         // Preserve client errors (4XX) with their detailed messages
-                        if (e instanceof OpenSearchStatusException) {
-                            OpenSearchStatusException osException = (OpenSearchStatusException) e;
+                        if (e instanceof OpenSearchException) {
+                            OpenSearchException osException = (OpenSearchException) e;
                             if (osException.status().getStatus() >= 400 && osException.status().getStatus() < 500) {
                                 listener.onFailure(e);
                                 return;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
@@ -192,8 +193,8 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                     memoryContainerHelper.indexData(configuration, indexRequest, responseActionListener);
                 }, exception -> {
                     // Preserve client errors (4XX) with their detailed messages
-                    if (exception instanceof OpenSearchStatusException) {
-                        OpenSearchStatusException osException = (OpenSearchStatusException) exception;
+                    if (exception instanceof OpenSearchException) {
+                        OpenSearchException osException = (OpenSearchException) exception;
                         if (osException.status().getStatus() >= 400 && osException.status().getStatus() < 500) {
                             actionListener.onFailure(exception);
                             return;
@@ -303,8 +304,8 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                         storeLongTermMemory(strategy, strategyNameSpace, input, messages, user, facts, memoryConfig, actionListener);
                     }, e -> {
                         // Preserve client errors (4XX) with their detailed messages
-                        if (e instanceof OpenSearchStatusException) {
-                            OpenSearchStatusException osException = (OpenSearchStatusException) e;
+                        if (e instanceof OpenSearchException) {
+                            OpenSearchException osException = (OpenSearchException) e;
                             if (osException.status().getStatus() >= 400 && osException.status().getStatus() < 500) {
                                 actionListener.onFailure(e);
                                 return;
@@ -369,8 +370,8 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                                 );
                         }, e -> {
                             // Preserve client errors (4XX) with their detailed messages
-                            if (e instanceof OpenSearchStatusException) {
-                                OpenSearchStatusException osException = (OpenSearchStatusException) e;
+                            if (e instanceof OpenSearchException) {
+                                OpenSearchException osException = (OpenSearchException) e;
                                 if (osException.status().getStatus() >= 400 && osException.status().getStatus() < 500) {
                                     actionListener.onFailure(e);
                                     return;

--- a/plugin/src/main/java/org/opensearch/ml/action/session/TransportCreateSessionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/session/TransportCreateSessionAction.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.time.Instant;
 
 import org.apache.commons.lang3.StringUtils;
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.index.IndexRequest;
@@ -98,6 +99,10 @@ public class TransportCreateSessionAction extends HandledTransportAction<MLCreat
                     );
                 return;
             }
+            if (container.getConfiguration().isDisableSession()) {
+                actionListener.onFailure(new OpenSearchStatusException("Session is disabled for this container", RestStatus.BAD_REQUEST));
+                return;
+            }
             createNewSession(input, container, user, tenantId, actionListener);
         }, actionListener::onFailure));
     }
@@ -142,6 +147,14 @@ public class TransportCreateSessionAction extends HandledTransportAction<MLCreat
                     MLCreateSessionResponse response = MLCreateSessionResponse.builder().sessionId(sessionId).status("exists").build();
                     actionListener.onResponse(response);
                 } else {
+                    // Preserve client errors (4XX) with their detailed messages
+                    if (e instanceof OpenSearchException) {
+                        OpenSearchException osException = (OpenSearchException) e;
+                        if (osException.status().getStatus() >= 400 && osException.status().getStatus() < 500) {
+                            actionListener.onFailure(e);
+                            return;
+                        }
+                    }
                     log.error("Failed to create session in container {}", input.getMemoryContainerId(), e);
                     actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
                 }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLPredictTaskRunner.java
@@ -740,8 +740,8 @@ public class MLPredictTaskRunner extends MLTaskRunner<MLPredictionTaskRequest, M
         }
 
         // Don't track any 4xx client errors (user/configuration issues)
-        if (e instanceof OpenSearchStatusException) {
-            RestStatus status = ((OpenSearchStatusException) e).status();
+        if (e instanceof OpenSearchException) {
+            RestStatus status = ((OpenSearchException) e).status();
             if (status.getStatus() >= 400 && status.getStatus() < 500) {
                 return false;
             }

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportDeleteMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportDeleteMemoryContainerActionTests.java
@@ -248,6 +248,7 @@ public class TransportDeleteMemoryContainerActionTests extends OpenSearchTestCas
         assertTrue(exception instanceof OpenSearchStatusException);
         assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) exception).status());
         assertTrue(exception.getMessage().contains("Internal server error"));
+
     }
 
     public void testDeleteMemoryContainer_MultiTenancyEnabled_ValidTenantId() {

--- a/plugin/src/test/java/org/opensearch/ml/action/session/TransportCreateSessionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/session/TransportCreateSessionActionTests.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,6 +22,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
@@ -30,6 +32,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
@@ -347,6 +350,99 @@ public class TransportCreateSessionActionTests extends OpenSearchTestCase {
         assertTrue(exception instanceof OpenSearchStatusException);
         assertEquals("User doesn't have permissions to add memory to this container", exception.getMessage());
         assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) exception).status());
+    }
+
+    @Test
+    public void testDoExecute_DisabledSession_BadRequest() {
+        // Setup mocks
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+
+        // Create container with session disabled
+        MemoryConfiguration disabledSessionConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-memory")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("test-embedding-model")
+            .dimension(768)
+            .disableSession(true)
+            .build();
+
+        MLMemoryContainer containerWithDisabledSession = MLMemoryContainer
+            .builder()
+            .name("test-container")
+            .description("Test memory container")
+            .configuration(disabledSessionConfig)
+            .build();
+
+        // Mock memory container helper to return container with disabled session
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(containerWithDisabledSession);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("memory-container-abc"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), any())).thenReturn(true);
+
+        // Execute
+        transportCreateSessionAction.doExecute(task, request, actionListener);
+
+        // Verify - should fail with BAD_REQUEST before reaching indexData
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(exceptionCaptor.capture());
+
+        Exception exception = exceptionCaptor.getValue();
+        assertTrue(exception instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) exception).status());
+        assertEquals("Session is disabled for this container", exception.getMessage());
+
+        // Verify indexData was never called
+        verify(memoryContainerHelper, never()).indexData(any(), any(), any());
+    }
+
+    @Test
+    public void testDoExecute_IndexData_4XXErrorPreserved() {
+        // Setup mocks
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+
+        // Mock memory container helper
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(memoryContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("memory-container-abc"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), any())).thenReturn(true);
+        when(memoryContainerHelper.getOwnerId(any())).thenReturn("owner-456");
+
+        // Mock indexData to fail with 4XX client error (e.g., IndexNotFoundException)
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            listener.onFailure(new IndexNotFoundException("Session index not found"));
+            return null;
+        }).when(memoryContainerHelper).indexData(any(), any(), any());
+
+        // Execute
+        transportCreateSessionAction.doExecute(task, request, actionListener);
+
+        // Verify - 4XX errors are preserved and passed through (not converted to INTERNAL_SERVER_ERROR)
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(exceptionCaptor.capture());
+
+        Exception exception = exceptionCaptor.getValue();
+        assertTrue(
+            "Expected OpenSearchException or subclass, got: " + exception.getClass().getName(),
+            exception instanceof OpenSearchException
+        );
+        RestStatus status = exception instanceof OpenSearchStatusException
+            ? ((OpenSearchStatusException) exception).status()
+            : ((IndexNotFoundException) exception).status();
+        assertEquals(RestStatus.NOT_FOUND, status);
+        assertTrue(
+            "Expected message about index not found, got: " + exception.getMessage(),
+            exception.getMessage().contains("Session index not found") || exception.getMessage().contains("index not found")
+        );
     }
 
     @Test


### PR DESCRIPTION
### Description
#### Summary
Updates error handling to use `OpenSearchException` instead of `OpenSearchStatusException` when preserving 4XX client errors. This covers more client-side error types (e.g. `IndexNotFoundException`, `ResourceNotFoundException`) and avoids masking them as internal server errors.

#### Changes
1. Error handling (`OpenSearchStatusException` → `OpenSearchException`)
* `MemoryProcessingService` – Replaced `OpenSearchStatusException` checks with `OpenSearchException` in 4 error paths (fact extraction, decision extraction, summary generation).
* `TransportAddMemoriesAction` – Same change in 3 error handlers.
* `TransportCreateSessionAction` – Added 4XX preservation in the indexData error handler.
* `MLPredictTaskRunner` – Updated 4XX check when deciding whether to track errors.
2. `TransportCreateSessionAction` – Session disabled check
* Returns `BAD_REQUEST` with message "Session is disabled for this container" when `container.getConfiguration().isDisableSession()` is `true`.
* Fails fast before indexing when sessions are disabled.

#### Rationale
`OpenSearchStatusException` is a subclass of `OpenSearchException`. Exceptions such as `IndexNotFoundException` and `ResourceNotFoundException` extend `OpenSearchException` but not `OpenSearchStatusException`, so they were previously turned into generic 500 errors. Checking for `OpenSearchException` ensures all 4XX client errors are preserved and returned to the client with the correct status and message.

#### Testing
New unit tests added for TransportCreateSessionAction.
All existing tests pass.
Now create session calls in the memory container where `disableSession` is `true` will return a 400

```
# Request
POST /_plugins/_ml/memory_containers/{{container_id}}/memories/sessions

# Response with BAD_REQUEST
{
    "error": {
        "root_cause": [
            {
                "type": "status_exception",
                "reason": "Session is disabled for this container"
            }
        ],
        "type": "status_exception",
        "reason": "Session is disabled for this container"
    },
    "status": 400
}
```

### Related Issues
Resolves #4724

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
