### PR TITLE
Upgrade Bedrock Claude models in ITs for higher rate limits

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestConnectorToolIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestConnectorToolIT.java
@@ -31,7 +31,7 @@ public class RestConnectorToolIT extends RestBaseAgentToolsIT {
     private static final String AWS_SESSION_TOKEN = System.getenv("AWS_SESSION_TOKEN");
 
     private static final String GITHUB_CI_AWS_REGION = "us-west-2";
-    private static final String BEDROCK_ANTHROPIC_CLAUDE_3_5_SONNET = "anthropic.claude-3-5-sonnet-20240620-v1:0";
+    private static final String BEDROCK_ANTHROPIC_CLAUDE_HAIKU_4_5 = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 
     private String bedrockClaudeConnectorId;
     private String bedrockClaudeConnectorIdForPredict;
@@ -52,8 +52,8 @@ public class RestConnectorToolIT extends RestBaseAgentToolsIT {
 
     private String createBedrockClaudeConnector(String action) throws IOException, InterruptedException {
         String bedrockClaudeConnectorEntity = "{\n"
-            + "  \"name\": \"Bedrock Connector: claude 3.5\",\n"
-            + "  \"description\": \"The connector to bedrock claude 3.5 model\",\n"
+            + "  \"name\": \"Bedrock Connector: claude haiku 4.5\",\n"
+            + "  \"description\": \"The connector to bedrock claude haiku 4.5 model\",\n"
             + "  \"version\": 1,\n"
             + "  \"protocol\": \"aws_sigv4\",\n"
             + "  \"parameters\": {\n"
@@ -62,7 +62,7 @@ public class RestConnectorToolIT extends RestBaseAgentToolsIT {
             + "\",\n"
             + "    \"service_name\": \"bedrock\",\n"
             + "    \"model\": \""
-            + BEDROCK_ANTHROPIC_CLAUDE_3_5_SONNET
+            + BEDROCK_ANTHROPIC_CLAUDE_HAIKU_4_5
             + "\",\n"
             + "    \"system_prompt\": \"You are a helpful assistant.\",\n"
             + "\"response_filter\": \"$.output.message.content[0].text\""
@@ -90,9 +90,9 @@ public class RestConnectorToolIT extends RestBaseAgentToolsIT {
             + "            \"url\": \"https://bedrock-runtime."
             + GITHUB_CI_AWS_REGION
             + ".amazonaws.com/model/"
-            + BEDROCK_ANTHROPIC_CLAUDE_3_5_SONNET
+            + BEDROCK_ANTHROPIC_CLAUDE_HAIKU_4_5
             + "/converse\",\n"
-            + "            \"request_body\": \"{ \\\"system\\\": [{\\\"text\\\": \\\"you are a helpful assistant.\\\"}], \\\"messages\\\":[{\\\"role\\\": \\\"user\\\", \\\"content\\\":[ {\\\"type\\\": \\\"text\\\", \\\"text\\\":\\\"${parameters.messages}\\\"}]}] , \\\"inferenceConfig\\\": {\\\"temperature\\\": 0.0, \\\"topP\\\": 0.9, \\\"maxTokens\\\": 1000} }\"\n"
+            + "            \"request_body\": \"{ \\\"system\\\": [{\\\"text\\\": \\\"you are a helpful assistant.\\\"}], \\\"messages\\\":[{\\\"role\\\": \\\"user\\\", \\\"content\\\":[ {\\\"type\\\": \\\"text\\\", \\\"text\\\":\\\"${parameters.messages}\\\"}]}] , \\\"inferenceConfig\\\": {\\\"temperature\\\": 0.0, \\\"maxTokens\\\": 1000} }\"\n"
             + "        }\n"
             + "    ]\n"
             + "}";

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLInferenceSearchResponseProcessorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLInferenceSearchResponseProcessorIT.java
@@ -113,8 +113,8 @@ public class RestMLInferenceSearchResponseProcessorIT extends MLCommonsRestTestC
         + "}";
 
     private final String bedrockClaudeModelConnectorEntity = "{\n"
-        + "  \"name\": \"Bedrock Connector: claude 3.5\",\n"
-        + "  \"description\": \"The connector to bedrock claude 3.5 model\",\n"
+        + "  \"name\": \"Bedrock Connector: claude haiku 4.5\",\n"
+        + "  \"description\": \"The connector to bedrock claude haiku 4.5 model\",\n"
         + "  \"version\": 1,\n"
         + "  \"protocol\": \"aws_sigv4\",\n"
         + "  \"client_config\": {\n"
@@ -126,7 +126,7 @@ public class RestMLInferenceSearchResponseProcessorIT extends MLCommonsRestTestC
         + "\",\n"
         + "    \"service_name\": \"bedrock\",\n"
         + "    \"model\": \""
-        + "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        + "us.anthropic.claude-haiku-4-5-20251001-v1:0"
         + "\",\n"
         + "    \"system_prompt\": \"You are a helpful assistant.\",\n"
         + "\"response_filter\": \"$.output.message.content[0].text\""
@@ -154,9 +154,9 @@ public class RestMLInferenceSearchResponseProcessorIT extends MLCommonsRestTestC
         + "            \"url\": \"https://bedrock-runtime."
         + GITHUB_CI_AWS_REGION
         + ".amazonaws.com/model/"
-        + "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        + "us.anthropic.claude-haiku-4-5-20251001-v1:0"
         + "/converse\",\n"
-        + "            \"request_body\": \"{ \\\"system\\\": [{\\\"text\\\": \\\"you are a helpful assistant.\\\"}], \\\"messages\\\":[{\\\"role\\\": \\\"user\\\", \\\"content\\\":[ {\\\"type\\\": \\\"text\\\", \\\"text\\\":\\\"${parameters.prompt}\\\"}]}] , \\\"inferenceConfig\\\": {\\\"temperature\\\": 0.0, \\\"topP\\\": 0.9, \\\"maxTokens\\\": 1000} }\"\n"
+        + "            \"request_body\": \"{ \\\"system\\\": [{\\\"text\\\": \\\"you are a helpful assistant.\\\"}], \\\"messages\\\":[{\\\"role\\\": \\\"user\\\", \\\"content\\\":[ {\\\"type\\\": \\\"text\\\", \\\"text\\\":\\\"${parameters.prompt}\\\"}]}] , \\\"inferenceConfig\\\": {\\\"temperature\\\": 0.0, \\\"maxTokens\\\": 1000} }\"\n"
         + "        }\n"
         + "    ]\n"
         + "}";

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRAGSearchProcessorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRAGSearchProcessorIT.java
@@ -107,12 +107,12 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
     private static final String AWS_SESSION_TOKEN = System.getenv("AWS_SESSION_TOKEN");
     private static final String GITHUB_CI_AWS_REGION = "us-west-2";
 
-    private static final String BEDROCK_ANTHROPIC_CLAUDE_3_5_SONNET = "anthropic.claude-3-5-sonnet-20241022-v2:0";
-    private static final String BEDROCK_ANTHROPIC_CLAUDE_3_SONNET = "anthropic.claude-3-sonnet-20240229-v1:0";
+    private static final String BEDROCK_ANTHROPIC_CLAUDE_SONNET_4_5 = "us.anthropic.claude-sonnet-4-5-20250929-v1:0";
+    private static final String BEDROCK_ANTHROPIC_CLAUDE_HAIKU_4_5 = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 
     private static final String BEDROCK_CONNECTOR_BLUEPRINT_INVOKE = "{\n"
-        + "  \"name\": \"Bedrock Connector: claude 3.5\",\n"
-        + "  \"description\": \"The connector to bedrock claude 3.5 model\",\n"
+        + "  \"name\": \"Bedrock Connector: claude sonnet 4.5\",\n"
+        + "  \"description\": \"The connector to bedrock claude sonnet 4.5 model\",\n"
         + "  \"version\": 1,\n"
         + "  \"protocol\": \"aws_sigv4\",\n"
         + "  \"parameters\": {\n"
@@ -121,7 +121,7 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
         + "\",\n"
         + "    \"service_name\": \"bedrock\",\n"
         + "    \"model\": \""
-        + "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        + "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         + "\",\n"
         + "    \"system_prompt\": \"You are a helpful assistant.\",\n"
         + "\"response_filter\": \"$.content[0].text\""
@@ -149,86 +149,16 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
         + "            \"url\": \"https://bedrock-runtime."
         + GITHUB_CI_AWS_REGION
         + ".amazonaws.com/model/"
-        + "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        + "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         + "/invoke\",\n"
         + "           \"request_body\": \"{\\\"messages\\\":[{\\\"role\\\": \\\"user\\\", \\\"content\\\":[ {\\\"type\\\": \\\"text\\\", \\\"text\\\":\\\"${parameters.inputs}\\\"}]}], \\\"max_tokens\\\":300, \\\"temperature\\\":0.5,  \\\"anthropic_version\\\":\\\"bedrock-2023-05-31\\\" }\"\n"
         + "        }\n"
         + "    ]\n"
         + "}";
 
-    private static final String BEDROCK_CONNECTOR_BLUEPRINT1 = "{\n"
-        + "  \"name\": \"Bedrock Connector: claude2\",\n"
-        + "  \"description\": \"The connector to bedrock claude2 model\",\n"
-        + "  \"version\": 1,\n"
-        + "  \"protocol\": \"aws_sigv4\",\n"
-        + "  \"parameters\": {\n"
-        + "    \"region\": \""
-        + GITHUB_CI_AWS_REGION
-        + "\",\n"
-        + "    \"service_name\": \"bedrock\"\n"
-        + "  },\n"
-        + "  \"credential\": {\n"
-        + "    \"access_key\": \""
-        + AWS_ACCESS_KEY_ID
-        + "\",\n"
-        + "    \"secret_key\": \""
-        + AWS_SECRET_ACCESS_KEY
-        + "\",\n"
-        + "    \"session_token\": \""
-        + AWS_SESSION_TOKEN
-        + "\"\n"
-        + "  },\n"
-        + "  \"actions\": [\n"
-        + "        {\n"
-        + "            \"action_type\": \"predict\",\n"
-        + "            \"method\": \"POST\",\n"
-        + "            \"headers\": {\n"
-        + "                \"content-type\": \"application/json\"\n"
-        + "            },\n"
-        + "            \"url\": \"https://bedrock-runtime."
-        + GITHUB_CI_AWS_REGION
-        + ".amazonaws.com/model/anthropic.claude-v2/invoke\",\n"
-        + "            \"request_body\": \"{\\\"prompt\\\":\\\"\\\\n\\\\nHuman: ${parameters.inputs}\\\\n\\\\nAssistant:\\\",\\\"max_tokens_to_sample\\\":300,\\\"temperature\\\":0.5,\\\"top_k\\\":250,\\\"top_p\\\":1,\\\"stop_sequences\\\":[\\\"\\\\\\\\n\\\\\\\\nHuman:\\\"]}\"\n"
-        + "        }\n"
-        + "    ]\n"
-        + "}";
-    private static final String BEDROCK_CONNECTOR_BLUEPRINT2 = "{\n"
-        + "  \"name\": \"Bedrock Connector: claude2\",\n"
-        + "  \"description\": \"The connector to bedrock claude2 model\",\n"
-        + "  \"version\": 1,\n"
-        + "  \"protocol\": \"aws_sigv4\",\n"
-        + "  \"parameters\": {\n"
-        + "    \"region\": \""
-        + GITHUB_CI_AWS_REGION
-        + "\",\n"
-        + "    \"service_name\": \"bedrock\"\n"
-        + "  },\n"
-        + "  \"credential\": {\n"
-        + "    \"access_key\": \""
-        + AWS_ACCESS_KEY_ID
-        + "\",\n"
-        + "    \"secret_key\": \""
-        + AWS_SECRET_ACCESS_KEY
-        + "\"\n"
-        + "  },\n"
-        + "  \"actions\": [\n"
-        + "        {\n"
-        + "            \"action_type\": \"predict\",\n"
-        + "            \"method\": \"POST\",\n"
-        + "            \"headers\": {\n"
-        + "                \"content-type\": \"application/json\"\n"
-        + "            },\n"
-        + "            \"url\": \"https://bedrock-runtime."
-        + GITHUB_CI_AWS_REGION
-        + ".amazonaws.com/model/anthropic.claude-v2/invoke\",\n"
-        + "            \"request_body\": \"{\\\"prompt\\\":\\\"\\\\n\\\\nHuman: ${parameters.inputs}\\\\n\\\\nAssistant:\\\",\\\"max_tokens_to_sample\\\":300,\\\"temperature\\\":0.5,\\\"top_k\\\":250,\\\"top_p\\\":1,\\\"stop_sequences\\\":[\\\"\\\\\\\\n\\\\\\\\nHuman:\\\"]}\"\n"
-        + "        }\n"
-        + "    ]\n"
-        + "}";
-
     static final String BEDROCK_CONVERSE_CONNECTOR_BLUEPRINT2 = "{\n"
-        + "  \"name\": \"Bedrock Connector: claude 3.5\",\n"
-        + "  \"description\": \"The connector to bedrock claude 3.5 model\",\n"
+        + "  \"name\": \"Bedrock Connector: claude sonnet 4.5\",\n"
+        + "  \"description\": \"The connector to bedrock claude sonnet 4.5 model\",\n"
         + "  \"version\": 1,\n"
         + "  \"protocol\": \"aws_sigv4\",\n"
         + "  \"client_config\": {\n"
@@ -240,7 +170,7 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
         + "\",\n"
         + "    \"service_name\": \"bedrock\",\n"
         + "    \"model\": \""
-        + BEDROCK_ANTHROPIC_CLAUDE_3_5_SONNET
+        + BEDROCK_ANTHROPIC_CLAUDE_SONNET_4_5
         + "\",\n"
         + "    \"system_prompt\": \"You are a helpful assistant.\"\n"
         + "  },\n"
@@ -265,16 +195,16 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
         + "            \"url\": \"https://bedrock-runtime."
         + GITHUB_CI_AWS_REGION
         + ".amazonaws.com/model/"
-        + BEDROCK_ANTHROPIC_CLAUDE_3_5_SONNET
+        + BEDROCK_ANTHROPIC_CLAUDE_SONNET_4_5
         + "/converse\",\n"
-        + "            \"request_body\": \"{ \\\"system\\\": [{\\\"text\\\": \\\"you are a helpful assistant.\\\"}], \\\"messages\\\": ${parameters.messages} , \\\"inferenceConfig\\\": {\\\"temperature\\\": 0.0, \\\"topP\\\": 0.9, \\\"maxTokens\\\": 1000} }\"\n"
+        + "            \"request_body\": \"{ \\\"system\\\": [{\\\"text\\\": \\\"you are a helpful assistant.\\\"}], \\\"messages\\\": ${parameters.messages} , \\\"inferenceConfig\\\": {\\\"temperature\\\": 0.0, \\\"maxTokens\\\": 1000} }\"\n"
         + "        }\n"
         + "    ]\n"
         + "}";
 
     private static final String BEDROCK_DOCUMENT_CONVERSE_CONNECTOR_BLUEPRINT2 = "{\n"
-        + "  \"name\": \"Bedrock Connector: claude 3\",\n"
-        + "  \"description\": \"The connector to bedrock claude 3 model\",\n"
+        + "  \"name\": \"Bedrock Connector: claude haiku 4.5\",\n"
+        + "  \"description\": \"The connector to bedrock claude haiku 4.5 model\",\n"
         + "  \"version\": 1,\n"
         + "  \"protocol\": \"aws_sigv4\",\n"
         + "  \"parameters\": {\n"
@@ -283,7 +213,7 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
         + "\",\n"
         + "    \"service_name\": \"bedrock\",\n"
         + "    \"model\": \""
-        + BEDROCK_ANTHROPIC_CLAUDE_3_SONNET
+        + BEDROCK_ANTHROPIC_CLAUDE_HAIKU_4_5
         + "\",\n"
         + "    \"system_prompt\": \"You are a helpful assistant.\"\n"
         + "  },\n"
@@ -308,20 +238,16 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
         + "            \"url\": \"https://bedrock-runtime."
         + GITHUB_CI_AWS_REGION
         + ".amazonaws.com/model/"
-        + BEDROCK_ANTHROPIC_CLAUDE_3_SONNET
+        + BEDROCK_ANTHROPIC_CLAUDE_HAIKU_4_5
         + "/converse\",\n"
-        + "            \"request_body\": \"{ \\\"messages\\\": ${parameters.messages} , \\\"inferenceConfig\\\": {\\\"temperature\\\": 0.0, \\\"topP\\\": 0.9, \\\"maxTokens\\\": 1000} }\"\n"
+        + "            \"request_body\": \"{ \\\"messages\\\": ${parameters.messages} , \\\"inferenceConfig\\\": {\\\"temperature\\\": 0.0, \\\"maxTokens\\\": 1000} }\"\n"
         + "        }\n"
         + "    ]\n"
         + "}";
 
-    private static final String BEDROCK_CONNECTOR_BLUEPRINT = AWS_SESSION_TOKEN == null
-        ? BEDROCK_CONNECTOR_BLUEPRINT_INVOKE
-        : BEDROCK_CONNECTOR_BLUEPRINT_INVOKE;
+    private static final String BEDROCK_CONNECTOR_BLUEPRINT = BEDROCK_CONNECTOR_BLUEPRINT_INVOKE;
 
-    private static final String BEDROCK_CONVERSE_CONNECTOR_BLUEPRINT = AWS_SESSION_TOKEN == null
-        ? BEDROCK_CONVERSE_CONNECTOR_BLUEPRINT2
-        : BEDROCK_CONVERSE_CONNECTOR_BLUEPRINT2;
+    private static final String BEDROCK_CONVERSE_CONNECTOR_BLUEPRINT = BEDROCK_CONVERSE_CONNECTOR_BLUEPRINT2;
 
     private static final String COHERE_KEY = System.getenv("COHERE_KEY");
     private static final String COHERE_CONNECTOR_BLUEPRINT = "{\n"
@@ -533,8 +459,8 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
     private static final String OPENAI_MODEL = "gpt-3.5-turbo";
     private static final String OPENAI_40_MODEL = "gpt-4o-mini";
     private static final String BEDROCK_ANTHROPIC_CLAUDE = "bedrock/anthropic-claude";
-    private static final String BEDROCK_CONVERSE_ANTHROPIC_CLAUDE = "bedrock-converse/" + BEDROCK_ANTHROPIC_CLAUDE_3_5_SONNET;
-    private static final String BEDROCK_CONVERSE_ANTHROPIC_CLAUDE_3 = "bedrock-converse/" + BEDROCK_ANTHROPIC_CLAUDE_3_SONNET;
+    private static final String BEDROCK_CONVERSE_ANTHROPIC_CLAUDE_SONNET_4_5 = "bedrock-converse/" + BEDROCK_ANTHROPIC_CLAUDE_SONNET_4_5;
+    private static final String BEDROCK_CONVERSE_ANTHROPIC_CLAUDE_HAIKU_4_5 = "bedrock-converse/" + BEDROCK_ANTHROPIC_CLAUDE_HAIKU_4_5;
     private static final String TEST_DOC_PATH = "org/opensearch/ml/rest/test_data/";
     private static Set<String> testDocs = Set.of("qa_doc1.json", "qa_doc2.json", "qa_doc3.json");
     private static final String DEFAULT_USER_AGENT = "Kibana";
@@ -826,7 +752,7 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
         SearchRequestParameters requestParameters = new SearchRequestParameters();
         requestParameters.source = "text";
         requestParameters.match = "president";
-        requestParameters.llmModel = BEDROCK_CONVERSE_ANTHROPIC_CLAUDE;
+        requestParameters.llmModel = BEDROCK_CONVERSE_ANTHROPIC_CLAUDE_SONNET_4_5;
         requestParameters.llmQuestion = "who is lincoln";
         requestParameters.contextSize = 5;
         requestParameters.interactionSize = 5;
@@ -886,7 +812,7 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
 
         requestParameters.source = "text";
         requestParameters.match = "president";
-        requestParameters.llmModel = BEDROCK_CONVERSE_ANTHROPIC_CLAUDE;
+        requestParameters.llmModel = BEDROCK_CONVERSE_ANTHROPIC_CLAUDE_SONNET_4_5;
         requestParameters.llmQuestion = "describe the image and answer the question: would lincoln have liked this place";
         requestParameters.contextSize = 5;
         requestParameters.interactionSize = 5;
@@ -948,7 +874,7 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
         requestParameters = new SearchRequestParameters();
         requestParameters.source = "text";
         requestParameters.match = "president";
-        requestParameters.llmModel = BEDROCK_CONVERSE_ANTHROPIC_CLAUDE_3;
+        requestParameters.llmModel = BEDROCK_CONVERSE_ANTHROPIC_CLAUDE_HAIKU_4_5;
         requestParameters.llmQuestion = "use the information from the attached document to tell me something interesting about lincoln";
         requestParameters.contextSize = 5;
         requestParameters.interactionSize = 5;


### PR DESCRIPTION
## Summary
- Older Claude models (claude-v2, claude-3-sonnet, claude-3-5-sonnet) used in integration tests have low default Bedrock rate limits (50–500 RPM), causing intermittent `503 Service Unavailable` / "Bedrock is unable to process your request" failures in CI.
- Upgrade to newer models with significantly higher default quotas:
  - **Sonnet 4.5** (`us.anthropic.claude-sonnet-4-5-20250929-v1:0`) — 10,000 RPM cross-region — for vision/image tasks
  - **Haiku 4.5** (`us.anthropic.claude-haiku-4-5-20251001-v1:0`) — 10,000 RPM cross-region — for simple text/summarization tasks
- Use inference profile model IDs (`us.anthropic.` prefix) as required by newer Bedrock models
- Remove `topP` from `inferenceConfig` since newer models disallow specifying both `temperature` and `topP`
- Delete unused claude-v2 connector blueprints (dead code) and simplify redundant ternary expressions

## Test plan
- [x] `RestMLRAGSearchProcessorIT` — all Bedrock tests pass (converse, invoke, image, document chat)
- [x] `RestMLInferenceSearchResponseProcessorIT` — Bedrock claude custom prompt test passes
- [x] `RestConnectorToolIT` — agent connector tool tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)