### PR TITLE
fix stream thread pool leak

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/task/MLExecuteTaskRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLExecuteTaskRunner.java
@@ -170,6 +170,18 @@ public class MLExecuteTaskRunner extends MLTaskRunner<MLExecuteTaskRequest, MLEx
     protected void executeTask(MLExecuteTaskRequest request, ActionListener<MLExecuteTaskResponse> listener) {
         TransportChannel channel = request.getStreamingChannel();
         String threadPoolName = (channel != null) ? STREAM_EXECUTE_THREAD_POOL : EXECUTE_THREAD_POOL;
+
+        // Wrap listener to complete the stream transport channel when execution finishes.
+        // Without this, nextResponse() in RestMLExecuteStreamAction blocks forever and leaks
+        // a STREAM_EXECUTE_THREAD_POOL thread per streaming request.
+        ActionListener<MLExecuteTaskResponse> wrappedListener = (channel != null) ? ActionListener.runAfter(listener, () -> {
+            try {
+                channel.completeStream();
+            } catch (Exception e) {
+                log.debug("Failed to complete stream channel", e);
+            }
+        }) : listener;
+
         threadPool.executor(threadPoolName).execute(() -> {
             try {
                 mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).increment();
@@ -187,14 +199,14 @@ public class MLExecuteTaskRunner extends MLTaskRunner<MLExecuteTaskRequest, MLEx
                     getEffectiveContextManagementNameAsync(agentInput, ActionListener.wrap(contextManagementName -> {
                         if (contextManagementName != null && !contextManagementName.trim().isEmpty()) {
                             // Execute agent with context management
-                            executeAgentWithContextManagement(request, contextManagementName, channel, listener);
+                            executeAgentWithContextManagement(request, contextManagementName, channel, wrappedListener);
                         } else {
                             // Continue with normal execution
-                            continueNormalExecution(request, channel, listener);
+                            continueNormalExecution(request, channel, wrappedListener);
                         }
                     }, e -> {
                         log.debug("Failed to get context management name, continuing with normal execution: {}", e.getMessage());
-                        continueNormalExecution(request, channel, listener);
+                        continueNormalExecution(request, channel, wrappedListener);
                     }));
                     return;
                 }
@@ -202,7 +214,7 @@ public class MLExecuteTaskRunner extends MLTaskRunner<MLExecuteTaskRequest, MLEx
                 if (FunctionName.METRICS_CORRELATION.equals(functionName)) {
                     if (!isPythonModelEnabled) {
                         Exception exception = new IllegalArgumentException("This algorithm is not enabled from settings");
-                        listener.onFailure(exception);
+                        wrappedListener.onFailure(exception);
                         return;
                     }
                 }
@@ -211,17 +223,17 @@ public class MLExecuteTaskRunner extends MLTaskRunner<MLExecuteTaskRequest, MLEx
                 try {
                     mlEngine.execute(input, ActionListener.wrap(output -> {
                         MLExecuteTaskResponse response = new MLExecuteTaskResponse(functionName, output);
-                        listener.onResponse(response);
-                    }, e -> { listener.onFailure(e); }), channel);
+                        wrappedListener.onResponse(response);
+                    }, e -> { wrappedListener.onFailure(e); }), channel);
                 } catch (Exception e) {
                     log.error("Failed to execute ML function", e);
-                    listener.onFailure(e);
+                    wrappedListener.onFailure(e);
                 }
             } catch (Exception e) {
                 mlStats
                     .createCounterStatIfAbsent(request.getFunctionName(), ActionName.EXECUTE, MLActionLevelStat.ML_ACTION_FAILURE_COUNT)
                     .increment();
-                listener.onFailure(e);
+                wrappedListener.onFailure(e);
             } finally {
                 mlStats.getStat(MLNodeLevelStat.ML_EXECUTING_TASK_COUNT).decrement();
             }


### PR DESCRIPTION
### Description
While testing on the managed service, noticed that as new stream requests come in, the number of open threads go up and never come down even after the request completes. Once the thread pool is exhausted, new requests will hang as it can never acquire a thread.

Symptom:
```
bash-5.2# jstack $pid > /tmp/t.txt 2>/dev/null
bash-5.2# grep "org.opensearch.ml" /tmp/t.txt | sort | uniq -c | sort -rn | head -20
     23     at org.opensearch.ml.rest.RestMLExecuteStreamAction$1.lambda$handleStreamResponse$0(RestMLExecuteStreamAction.java:236)
     23     at org.opensearch.ml.rest.RestMLExecuteStreamAction$1.handleStreamResponse(RestMLExecuteStreamAction.java:226)
     23     at org.opensearch.ml.rest.RestMLExecuteStreamAction$1$$Lambda/0x00007f940a010448.run(Unknown Source)
```

Tested in real time via this script and noticed that every request will increment the number:
```
while true; do echo "$(date +%H:%M:%S) leaked: $(jstack $pid 2>/dev/null | grep -B15 'handleStreamResponse' | grep 'opensearch_ml_execute_stream\]' | sort -u | wc -l)"; sleep 5; done

23:25:42 leaked: 23
23:25:47 leaked: 23
23:25:53 leaked: 24
23:25:58 leaked: 25
23:26:03 leaked: 25
23:26:08 leaked: 25
23:26:14 leaked: 25
23:26:19 leaked: 25
23:26:24 leaked: 26
23:26:29 leaked: 27
```

Once this number reached 320 (thread pool size based on 8vCPU), subsequent requests will hang until network timeout.

This PR fixes the issue by completing the stream properly.

```
while true; do echo "$(date +%H:%M:%S) leaked: $(jstack $pid 2>/dev/null | grep -B15 'handleStreamResponse' | grep 'opensearch_ml_execute_stream\]' | sort -u | wc -l)"; sleep 5; done

23:54:32 leaked: 0
23:54:37 leaked: 0
23:55:08 leaked: 0
23:56:09 leaked: 1   <-- caught a request mid-flight
23:56:15 leaked: 0   <-- released after completeStream()
23:56:20 leaked: 0
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
