### PR TITLE
fix compaction message processing in AG-UI chat history

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/agui/AGUIInputConverter.java
+++ b/common/src/main/java/org/opensearch/ml/common/agui/AGUIInputConverter.java
@@ -355,7 +355,20 @@ public class AGUIInputConverter {
             // Convert content blocks
             List<ContentBlock> contentBlocks = message.getContent();
             if (contentBlocks != null && !contentBlocks.isEmpty()) {
-                if (contentBlocks.size() == 1 && contentBlocks.get(0).getType() == ContentType.TEXT) {
+                if ("assistant".equalsIgnoreCase(message.getRole())) {
+                    // AssistantMessage.content must be a plain string — concatenate all TEXT blocks,
+                    // skipping internal types such as COMPACTION which are not part of the AGUI schema.
+                    StringBuilder textBuilder = new StringBuilder();
+                    for (ContentBlock block : contentBlocks) {
+                        if (block.getType() == ContentType.TEXT && block.getText() != null) {
+                            textBuilder.append(block.getText());
+                        }
+                    }
+                    String text = textBuilder.toString();
+                    if (!text.isEmpty()) {
+                        aguiMsg.put(AGUI_FIELD_CONTENT, text);
+                    }
+                } else if (contentBlocks.size() == 1 && contentBlocks.get(0).getType() == ContentType.TEXT) {
                     // Single text block → string form
                     aguiMsg.put(AGUI_FIELD_CONTENT, contentBlocks.get(0).getText());
                 } else {


### PR DESCRIPTION
### Description
Previous discussion here: https://github.com/opensearch-project/ml-commons/pull/4698#issuecomment-4027918284

In AG-UI protocol, the assistant message's content should be type string: https://docs.ag-ui.com/sdk/js/core/types#assistantmessage. But in ml-commons `Message.content` is a List type, so the AG-UI converter does not handle it properly at the moment when there are multiple content blocks. This PR will merge the content blocks in `Message.content` when retrieving chat history to be protocol compliant.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
