### PR TITLE
Add provisioned_by field to ML resources for adoption metrics attribution

### DIFF
--- a/client/src/test/java/org/opensearch/ml/client/MachineLearningNodeClientTest.java
+++ b/client/src/test/java/org/opensearch/ml/client/MachineLearningNodeClientTest.java
@@ -962,6 +962,28 @@ public class MachineLearningNodeClientTest {
     }
 
     @Test
+    public void register_withProvisionedBy() {
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterModelResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(new MLRegisterModelResponse("taskId", MLTaskState.CREATED.name()));
+            return null;
+        }).when(client).execute(eq(MLRegisterModelAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<MLRegisterModelRequest> requestCaptor = ArgumentCaptor.forClass(MLRegisterModelRequest.class);
+        MLRegisterModelInput mlInput = MLRegisterModelInput
+            .builder()
+            .functionName(FunctionName.REMOTE)
+            .modelName("testModel")
+            .version("1")
+            .provisionedBy("flow-framework")
+            .build();
+        machineLearningNodeClient.register(mlInput, registerModelActionListener);
+
+        verify(client).execute(eq(MLRegisterModelAction.INSTANCE), requestCaptor.capture(), any());
+        assertEquals("flow-framework", requestCaptor.getValue().getRegisterModelInput().getProvisionedBy());
+    }
+
+    @Test
     public void deploy() {
         String taskId = "taskId";
         String status = MLTaskState.CREATED.name();
@@ -1049,6 +1071,29 @@ public class MachineLearningNodeClientTest {
         verify(createConnectorActionListener).onResponse(argumentCaptor.capture());
         assertEquals(connectorId, (argumentCaptor.getValue()).getConnectorId());
 
+    }
+
+    @Test
+    public void createConnector_withProvisionedBy() {
+        doAnswer(invocation -> {
+            ActionListener<MLCreateConnectorResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(new MLCreateConnectorResponse("connectorId"));
+            return null;
+        }).when(client).execute(eq(MLCreateConnectorAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<MLCreateConnectorRequest> requestCaptor = ArgumentCaptor.forClass(MLCreateConnectorRequest.class);
+        MLCreateConnectorInput input = MLCreateConnectorInput
+            .builder()
+            .name("test")
+            .protocol("http")
+            .version("1")
+            .credential(Map.of("key", "value"))
+            .provisionedBy("flow-framework")
+            .build();
+        machineLearningNodeClient.createConnector(input, createConnectorActionListener);
+
+        verify(client).execute(eq(MLCreateConnectorAction.INSTANCE), requestCaptor.capture(), any());
+        assertEquals("flow-framework", requestCaptor.getValue().getMlCreateConnectorInput().getProvisionedBy());
     }
 
     @Test
@@ -1171,6 +1216,23 @@ public class MachineLearningNodeClientTest {
         verify(client).execute(eq(MLRegisterAgentAction.INSTANCE), isA(MLRegisterAgentRequest.class), any());
         verify(registerAgentResponseActionListener).onResponse(argumentCaptor.capture());
         assertEquals(agentId, (argumentCaptor.getValue()).getAgentId());
+    }
+
+    @Test
+    public void registerAgent_withProvisionedBy() {
+        String agentId = "agentId";
+        doAnswer(invocation -> {
+            ActionListener<MLRegisterAgentResponse> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(new MLRegisterAgentResponse(agentId));
+            return null;
+        }).when(client).execute(eq(MLRegisterAgentAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<MLRegisterAgentRequest> requestCaptor = ArgumentCaptor.forClass(MLRegisterAgentRequest.class);
+        MLAgent mlAgent = MLAgent.builder().name("Agent name").type(MLAgentType.FLOW.name()).provisionedBy("flow-framework").build();
+        machineLearningNodeClient.registerAgent(mlAgent, registerAgentResponseActionListener);
+
+        verify(client).execute(eq(MLRegisterAgentAction.INSTANCE), requestCaptor.capture(), any());
+        assertEquals("flow-framework", requestCaptor.getValue().getMlAgent().getProvisionedBy());
     }
 
     @Test

--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -23,6 +23,7 @@ public class CommonValue {
 
     /** The field name containing the tenant id */
     public static final String TENANT_ID_FIELD = "tenant_id";
+    public static final String PROVISIONED_BY_FIELD = "provisioned_by";
     /**
      * Internal parameter key for propagating the executing agent's ID through the parameter map
      * for logging. Uses a distinct key to avoid colliding with the "agent_id" tool parameter
@@ -108,6 +109,7 @@ public class CommonValue {
     public static final Version VERSION_3_3_0 = Version.fromString("3.3.0");
     public static final Version VERSION_3_4_0 = Version.fromString("3.4.0");
     public static final Version VERSION_3_5_0 = Version.fromString("3.5.0");
+    public static final Version VERSION_3_7_0 = Version.fromString("3.7.0");
 
     // Connector Constants
     public static final String NAME_FIELD = "name";

--- a/common/src/main/java/org/opensearch/ml/common/MLModel.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModel.java
@@ -6,9 +6,11 @@
 package org.opensearch.ml.common;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.PROVISIONED_BY_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.USER;
 import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.connector.Connector.createConnector;
 import static org.opensearch.ml.common.utils.StringUtils.filteredParameterMap;
 
@@ -239,6 +241,7 @@ public class MLModel implements ToXContentObject {
     private String connectorId;
     private Guardrails guardrails;
     private String tenantId;
+    private String provisionedBy;
 
     /**
      * Model interface is a map that contains the input and output fields of the model, with JSON schema as the value.
@@ -306,7 +309,8 @@ public class MLModel implements ToXContentObject {
         String connectorId,
         Guardrails guardrails,
         Map<String, String> modelInterface,
-        String tenantId
+        String tenantId,
+        String provisionedBy
     ) {
         this.name = name;
         this.modelGroupId = modelGroupId;
@@ -343,6 +347,7 @@ public class MLModel implements ToXContentObject {
         this.guardrails = guardrails;
         this.modelInterface = modelInterface;
         this.tenantId = tenantId;
+        this.provisionedBy = provisionedBy;
     }
 
     public MLModel(StreamInput input) throws IOException {
@@ -413,6 +418,7 @@ public class MLModel implements ToXContentObject {
                 modelInterface = input.readMap(StreamInput::readString, StreamInput::readString);
             }
             this.tenantId = streamInputVersion.onOrAfter(VERSION_2_19_0) ? input.readOptionalString() : null;
+            this.provisionedBy = streamInputVersion.onOrAfter(VERSION_3_7_0) ? input.readOptionalString() : null;
         }
     }
 
@@ -499,6 +505,9 @@ public class MLModel implements ToXContentObject {
         }
         if (streamOutputVersion.onOrAfter(VERSION_2_19_0)) {
             out.writeOptionalString(tenantId);
+        }
+        if (streamOutputVersion.onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalString(provisionedBy);
         }
     }
 
@@ -610,6 +619,9 @@ public class MLModel implements ToXContentObject {
         if (tenantId != null) {
             builder.field(TENANT_ID_FIELD, tenantId);
         }
+        if (provisionedBy != null) {
+            builder.field(PROVISIONED_BY_FIELD, provisionedBy);
+        }
         builder.endObject();
         return builder;
     }
@@ -656,6 +668,7 @@ public class MLModel implements ToXContentObject {
         Guardrails guardrails = null;
         Map<String, String> modelInterface = null;
         String tenantId = null;
+        String provisionedBy = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -797,6 +810,9 @@ public class MLModel implements ToXContentObject {
                 case TENANT_ID_FIELD:
                     tenantId = parser.textOrNull();
                     break;
+                case PROVISIONED_BY_FIELD:
+                    provisionedBy = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -839,6 +855,7 @@ public class MLModel implements ToXContentObject {
             .guardrails(guardrails)
             .modelInterface(modelInterface)
             .tenantId(tenantId)
+            .provisionedBy(provisionedBy)
             .build();
     }
 
@@ -931,7 +948,8 @@ public class MLModel implements ToXContentObject {
             .addTag(TAG_SERVICE_PROVIDER, serviceProvider)
             .addTag(TAG_ALGORITHM, algorithm.name())
             .addTag(TAG_MODEL, model)
-            .addTag(TAG_TYPE, modelType);
+            .addTag(TAG_TYPE, modelType)
+            .addTag(PROVISIONED_BY_FIELD, provisionedBy != null ? provisionedBy : TAG_VALUE_UNKNOWN);
 
         if ((serviceProvider.equals(TAG_VALUE_UNKNOWN) || model.equals(TAG_VALUE_UNKNOWN)) && !url.equals(TAG_VALUE_UNKNOWN)) {
             tags = tags.addTag(TAG_URL, url);
@@ -1104,7 +1122,8 @@ public class MLModel implements ToXContentObject {
             .addTag(TAG_SERVICE_PROVIDER, nameParts[0])
             .addTag(TAG_ALGORITHM, this.algorithm.name()) // nameParts[1] is not used
             .addTag(TAG_MODEL, nameParts[2])
-            .addTag(TAG_TYPE, modelType);
+            .addTag(TAG_TYPE, modelType)
+            .addTag(PROVISIONED_BY_FIELD, provisionedBy != null ? provisionedBy : TAG_VALUE_UNKNOWN);
 
         if (this.modelFormat != null) {
             tags = tags.addTag(TAG_MODEL_FORMAT, this.modelFormat.name());
@@ -1135,7 +1154,8 @@ public class MLModel implements ToXContentObject {
             .create()
             .addTag(TAG_DEPLOYMENT, TAG_CUSTOM_DEPLOYMENT_VALUE)
             .addTag(TAG_ALGORITHM, this.algorithm.name())
-            .addTag(TAG_TYPE, modelType);
+            .addTag(TAG_TYPE, modelType)
+            .addTag(PROVISIONED_BY_FIELD, provisionedBy != null ? provisionedBy : TAG_VALUE_UNKNOWN);
 
         if (this.modelFormat != null) {
             tags = tags.addTag(TAG_MODEL_FORMAT, this.modelFormat.name());

--- a/common/src/main/java/org/opensearch/ml/common/agent/MLAgent.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/MLAgent.java
@@ -6,8 +6,10 @@
 package org.opensearch.ml.common.agent;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.PROVISIONED_BY_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.utils.StringUtils.getParameterMap;
 
 import java.io.IOException;
@@ -80,6 +82,7 @@ public class MLAgent implements ToXContentObject, Writeable {
     private String contextManagementName;
     private ContextManagementTemplate contextManagement;
     private String tenantId;
+    private String provisionedBy;
 
     @Builder(toBuilder = true)
     public MLAgent(
@@ -97,7 +100,8 @@ public class MLAgent implements ToXContentObject, Writeable {
         Boolean isHidden,
         String contextManagementName,
         ContextManagementTemplate contextManagement,
-        String tenantId
+        String tenantId,
+        String provisionedBy
     ) {
         this.name = name;
         this.type = type;
@@ -115,6 +119,7 @@ public class MLAgent implements ToXContentObject, Writeable {
         this.contextManagementName = contextManagementName;
         this.contextManagement = contextManagement;
         this.tenantId = tenantId;
+        this.provisionedBy = provisionedBy;
         validate();
     }
 
@@ -150,7 +155,8 @@ public class MLAgent implements ToXContentObject, Writeable {
             isHidden,
             contextManagementName,
             contextManagement,
-            tenantId
+            tenantId,
+            null
         );
     }
 
@@ -243,6 +249,7 @@ public class MLAgent implements ToXContentObject, Writeable {
             }
         }
         this.tenantId = streamInputVersion.onOrAfter(VERSION_2_19_0) ? input.readOptionalString() : null;
+        this.provisionedBy = streamInputVersion.onOrAfter(VERSION_3_7_0) ? input.readOptionalString() : null;
         validate();
     }
 
@@ -302,6 +309,9 @@ public class MLAgent implements ToXContentObject, Writeable {
         }
         if (streamOutputVersion.onOrAfter(VERSION_2_19_0)) {
             out.writeOptionalString(tenantId);
+        }
+        if (streamOutputVersion.onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalString(provisionedBy);
         }
     }
 
@@ -364,6 +374,9 @@ public class MLAgent implements ToXContentObject, Writeable {
         if (tenantId != null) {
             builder.field(TENANT_ID_FIELD, tenantId);
         }
+        if (provisionedBy != null) {
+            builder.field(PROVISIONED_BY_FIELD, provisionedBy);
+        }
         builder.endObject();
         return builder;
     }
@@ -392,6 +405,7 @@ public class MLAgent implements ToXContentObject, Writeable {
         String contextManagementName = null;
         ContextManagementTemplate contextManagement = null;
         String tenantId = null;
+        String provisionedBy = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -449,6 +463,9 @@ public class MLAgent implements ToXContentObject, Writeable {
                 case TENANT_ID_FIELD:
                     tenantId = parser.textOrNull();
                     break;
+                case PROVISIONED_BY_FIELD:
+                    provisionedBy = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -472,6 +489,7 @@ public class MLAgent implements ToXContentObject, Writeable {
             .contextManagementName(contextManagementName)
             .contextManagement(contextManagement)
             .tenantId(tenantId)
+            .provisionedBy(provisionedBy)
             .build();
     }
 
@@ -492,7 +510,8 @@ public class MLAgent implements ToXContentObject, Writeable {
         Tags tags = Tags
             .create()
             .addTag(IS_HIDDEN_FIELD, isHidden != null ? isHidden : false)
-            .addTag(AGENT_TYPE_FIELD, type != null ? type : TAG_VALUE_UNKNOWN);
+            .addTag(AGENT_TYPE_FIELD, type != null ? type : TAG_VALUE_UNKNOWN)
+            .addTag(PROVISIONED_BY_FIELD, provisionedBy != null ? provisionedBy : TAG_VALUE_UNKNOWN);
 
         if (memory != null && memory.getType() != null) {
             tags = tags.addTag(TAG_MEMORY_TYPE, memory.getType());

--- a/common/src/main/java/org/opensearch/ml/common/connector/AbstractConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/AbstractConnector.java
@@ -76,6 +76,8 @@ public abstract class AbstractConnector implements Connector {
     protected ConnectorClientConfig connectorClientConfig;
     @Setter
     protected String tenantId;
+    @Setter
+    protected String provisionedBy;
 
     protected Map<String, String> createDecryptedHeaders(Map<String, String> headers) {
         if (headers == null) {

--- a/common/src/main/java/org/opensearch/ml/common/connector/AwsConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/AwsConnector.java
@@ -42,7 +42,8 @@ public class AwsConnector extends HttpConnector {
         AccessMode accessMode,
         User owner,
         ConnectorClientConfig connectorClientConfig,
-        String tenantId
+        String tenantId,
+        String provisionedBy
     ) {
         super(
             name,
@@ -56,7 +57,8 @@ public class AwsConnector extends HttpConnector {
             accessMode,
             owner,
             connectorClientConfig,
-            tenantId
+            tenantId,
+            provisionedBy
         );
         validate();
     }

--- a/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
@@ -48,6 +48,10 @@ public interface Connector extends ToXContentObject, Writeable {
 
     void setTenantId(String tenantId);
 
+    String getProvisionedBy();
+
+    void setProvisionedBy(String provisionedBy);
+
     String getProtocol();
 
     void setCreatedTime(Instant createdTime);

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -7,8 +7,10 @@ package org.opensearch.ml.common.connector;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.BACKEND_ROLES_FIELD;
+import static org.opensearch.ml.common.CommonValue.PROVISIONED_BY_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.connector.ConnectorProtocols.HTTP;
 import static org.opensearch.ml.common.connector.ConnectorProtocols.validateProtocol;
 import static org.opensearch.ml.common.utils.StringUtils.getParameterMap;
@@ -76,7 +78,8 @@ public class HttpConnector extends AbstractConnector {
         AccessMode accessMode,
         User owner,
         ConnectorClientConfig connectorClientConfig,
-        String tenantId
+        String tenantId,
+        String provisionedBy
     ) {
         validateProtocol(protocol);
         if (actions != null) {
@@ -96,6 +99,7 @@ public class HttpConnector extends AbstractConnector {
         this.owner = owner;
         this.connectorClientConfig = connectorClientConfig;
         this.tenantId = tenantId;
+        this.provisionedBy = provisionedBy;
 
     }
 
@@ -160,6 +164,9 @@ public class HttpConnector extends AbstractConnector {
                 case TENANT_ID_FIELD:
                     tenantId = parser.textOrNull();
                     break;
+                case PROVISIONED_BY_FIELD:
+                    provisionedBy = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -212,6 +219,9 @@ public class HttpConnector extends AbstractConnector {
         if (tenantId != null) {
             builder.field(TENANT_ID_FIELD, tenantId);
         }
+        if (provisionedBy != null) {
+            builder.field(PROVISIONED_BY_FIELD, provisionedBy);
+        }
         builder.endObject();
         return builder;
     }
@@ -257,6 +267,7 @@ public class HttpConnector extends AbstractConnector {
             this.connectorClientConfig = new ConnectorClientConfig(input);
         }
         this.tenantId = streamInputVersion.onOrAfter(VERSION_2_19_0) ? input.readOptionalString() : null;
+        this.provisionedBy = streamInputVersion.onOrAfter(VERSION_3_7_0) ? input.readOptionalString() : null;
     }
 
     @Override
@@ -310,6 +321,9 @@ public class HttpConnector extends AbstractConnector {
         }
         if (streamOutputVersion.onOrAfter(VERSION_2_19_0)) {
             out.writeOptionalString(tenantId);
+        }
+        if (streamOutputVersion.onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalString(provisionedBy);
         }
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/transport/agent/MLRegisterAgentRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/agent/MLRegisterAgentRequest.java
@@ -6,11 +6,14 @@
 package org.opensearch.ml.common.transport.agent;
 
 import static org.opensearch.action.ValidateActions.addValidationError;
+import static org.opensearch.ml.common.utils.StringUtils.validateFields;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
@@ -19,6 +22,7 @@ import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.ml.common.agent.MLAgent;
+import org.opensearch.ml.common.utils.FieldDescriptor;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -45,24 +49,22 @@ public class MLRegisterAgentRequest extends ActionRequest {
 
     @Override
     public ActionRequestValidationException validate() {
-        ActionRequestValidationException exception = null;
         if (mlAgent == null) {
-            exception = addValidationError("ML agent can't be null", exception);
-        } else {
-            // Basic validation - check for conflicting configuration (following connector pattern)
-            if (mlAgent.getContextManagementName() != null && mlAgent.getContextManagement() != null) {
-                exception = addValidationError("Cannot specify both context_management_name and context_management", exception);
-            }
+            return addValidationError("ML agent can't be null", null);
+        }
 
-            // Validate context management template name
-            if (mlAgent.getContextManagementName() != null) {
-                exception = validateContextManagementTemplateName(mlAgent.getContextManagementName(), exception);
-            }
+        Map<String, FieldDescriptor> fieldsToValidate = new HashMap<>();
+        fieldsToValidate.put("Agent provisioned_by field", new FieldDescriptor(mlAgent.getProvisionedBy(), false));
+        ActionRequestValidationException exception = validateFields(fieldsToValidate);
 
-            // Validate inline context management configuration
-            if (mlAgent.getContextManagement() != null) {
-                exception = validateInlineContextManagement(mlAgent.getContextManagement(), exception);
-            }
+        if (mlAgent.getContextManagementName() != null && mlAgent.getContextManagement() != null) {
+            exception = addValidationError("Cannot specify both context_management_name and context_management", exception);
+        }
+        if (mlAgent.getContextManagementName() != null) {
+            exception = validateContextManagementTemplateName(mlAgent.getContextManagementName(), exception);
+        }
+        if (mlAgent.getContextManagement() != null) {
+            exception = validateInlineContextManagement(mlAgent.getContextManagement(), exception);
         }
 
         return exception;

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInput.java
@@ -6,9 +6,11 @@
 package org.opensearch.ml.common.transport.connector;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.PROVISIONED_BY_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
 import static org.opensearch.ml.common.CommonValue.VERSION_3_0_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_SSE;
 import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_STREAMABLE_HTTP;
 import static org.opensearch.ml.common.utils.StringUtils.getParameterMap;
@@ -79,6 +81,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
 
     private String url;
     private Map<String, String> headers;
+    private String provisionedBy;
 
     @Builder(toBuilder = true)
     public MLCreateConnectorInput(
@@ -97,7 +100,8 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
         ConnectorClientConfig connectorClientConfig,
         String tenantId,
         String url,
-        Map<String, String> headers
+        Map<String, String> headers,
+        String provisionedBy
     ) {
         if (!dryRun && !updateConnector) {
 
@@ -140,6 +144,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
         this.tenantId = tenantId;
         this.url = url;
         this.headers = headers;
+        this.provisionedBy = provisionedBy;
     }
 
     public static MLCreateConnectorInput parse(XContentParser parser) throws IOException {
@@ -162,6 +167,7 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
         String tenantId = null;
         String url = null;
         Map<String, String> headers = null;
+        String provisionedBy = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -222,6 +228,9 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
                 case CONNECTOR_HEADER_FIELD:
                     headers = parser.mapStrings();
                     break;
+                case PROVISIONED_BY_FIELD:
+                    provisionedBy = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -243,7 +252,8 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
             connectorClientConfig,
             tenantId,
             url,
-            headers
+            headers,
+            provisionedBy
         );
     }
 
@@ -291,6 +301,9 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
         }
         if (headers != null) {
             builder.field(CONNECTOR_HEADER_FIELD, headers);
+        }
+        if (provisionedBy != null) {
+            builder.field(PROVISIONED_BY_FIELD, provisionedBy);
         }
         builder.endObject();
         return builder;
@@ -361,6 +374,9 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
                 output.writeBoolean(false);
             }
         }
+        if (streamOutputVersion.onOrAfter(VERSION_3_7_0)) {
+            output.writeOptionalString(provisionedBy);
+        }
     }
 
     public MLCreateConnectorInput(StreamInput input) throws IOException {
@@ -403,5 +419,6 @@ public class MLCreateConnectorInput implements ToXContentObject, Writeable {
                 this.headers = input.readMap(s -> s.readString(), s -> s.readString());
             }
         }
+        this.provisionedBy = streamInputVersion.onOrAfter(VERSION_3_7_0) ? input.readOptionalString() : null;
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorRequest.java
@@ -50,6 +50,7 @@ public class MLCreateConnectorRequest extends ActionRequest {
         fieldsToValidate
             .put("Model connector name", new FieldDescriptor(mlCreateConnectorInput.getName(), !mlCreateConnectorInput.isDryRun()));
         fieldsToValidate.put("Model connector description", new FieldDescriptor(mlCreateConnectorInput.getDescription(), false));
+        fieldsToValidate.put("Model connector provisioned_by field", new FieldDescriptor(mlCreateConnectorInput.getProvisionedBy(), false));
 
         return validateFields(fieldsToValidate);
     }

--- a/common/src/main/java/org/opensearch/ml/common/transport/connector/MLUpdateConnectorRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/connector/MLUpdateConnectorRequest.java
@@ -65,7 +65,12 @@ public class MLUpdateConnectorRequest extends ActionRequest {
             Map<String, FieldDescriptor> fieldsToValidate = new HashMap<>();
             fieldsToValidate.put("Model connector name", new FieldDescriptor(updateContent.getName(), false));
             fieldsToValidate.put("Model connector description", new FieldDescriptor(updateContent.getDescription(), false));
-            exception = validateFields(fieldsToValidate);
+            ActionRequestValidationException fieldException = validateFields(fieldsToValidate);
+            if (fieldException != null) {
+                for (String error : fieldException.validationErrors()) {
+                    exception = addValidationError(error, exception);
+                }
+            }
         }
         return exception;
     }

--- a/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java
@@ -6,8 +6,10 @@
 package org.opensearch.ml.common.transport.register;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.PROVISIONED_BY_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.MLModel.allowedInterfaceFieldKeys;
 import static org.opensearch.ml.common.connector.Connector.createConnector;
 import static org.opensearch.ml.common.utils.StringUtils.filteredParameterMap;
@@ -107,6 +109,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
 
     private Map<String, String> modelInterface;
     private String tenantId;
+    private String provisionedBy;
 
     @Builder(toBuilder = true)
     public MLRegisterModelInput(
@@ -133,7 +136,8 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         Boolean isHidden,
         Guardrails guardrails,
         Map<String, String> modelInterface,
-        String tenantId
+        String tenantId,
+        String provisionedBy
     ) {
         this.functionName = Objects.requireNonNullElse(functionName, FunctionName.TEXT_EMBEDDING);
         if (modelName == null) {
@@ -176,6 +180,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         this.guardrails = guardrails;
         this.modelInterface = modelInterface;
         this.tenantId = tenantId;
+        this.provisionedBy = provisionedBy;
     }
 
     public MLRegisterModelInput(StreamInput in) throws IOException {
@@ -240,6 +245,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
             }
         }
         this.tenantId = streamInputVersion.onOrAfter(VERSION_2_19_0) ? in.readOptionalString() : null;
+        this.provisionedBy = streamInputVersion.onOrAfter(VERSION_3_7_0) ? in.readOptionalString() : null;
     }
 
     @Override
@@ -324,6 +330,9 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         if (streamOutputVersion.onOrAfter(VERSION_2_19_0)) {
             out.writeOptionalString(tenantId);
         }
+        if (streamOutputVersion.onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalString(provisionedBy);
+        }
     }
 
     @Override
@@ -395,6 +404,9 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         if (tenantId != null) {
             builder.field(TENANT_ID_FIELD, tenantId);
         }
+        if (provisionedBy != null) {
+            builder.field(PROVISIONED_BY_FIELD, provisionedBy);
+        }
         builder.endObject();
         return builder;
     }
@@ -422,6 +434,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         Guardrails guardrails = null;
         Map<String, String> modelInterface = null;
         String tenantId = null;
+        String provisionedBy = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -505,6 +518,9 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                 case TENANT_ID_FIELD:
                     tenantId = parser.textOrNull();
                     break;
+                case PROVISIONED_BY_FIELD:
+                    provisionedBy = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -534,7 +550,8 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
             isHidden,
             guardrails,
             modelInterface,
-            tenantId
+            tenantId,
+            provisionedBy
         );
     }
 
@@ -562,6 +579,7 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
         Guardrails guardrails = null;
         Map<String, String> modelInterface = null;
         String tenantId = null;
+        String provisionedBy = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -652,6 +670,9 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
                 case TENANT_ID_FIELD:
                     tenantId = parser.textOrNull();
                     break;
+                case PROVISIONED_BY_FIELD:
+                    provisionedBy = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -681,7 +702,8 @@ public class MLRegisterModelInput implements ToXContentObject, Writeable {
             isHidden,
             guardrails,
             modelInterface,
-            tenantId
+            tenantId,
+            provisionedBy
         );
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelRequest.java
@@ -55,6 +55,7 @@ public class MLRegisterModelRequest extends ActionRequest {
         Map<String, FieldDescriptor> fieldsToValidate = new HashMap<>();
         fieldsToValidate.put("Model name", new FieldDescriptor(registerModelInput.getModelName(), true));
         fieldsToValidate.put("Model description", new FieldDescriptor(registerModelInput.getDescription(), false));
+        fieldsToValidate.put("Model provisioned_by field", new FieldDescriptor(registerModelInput.getProvisionedBy(), false));
 
         return validateFields(fieldsToValidate);
     }

--- a/common/src/main/resources/index-mappings/ml_agent.json
+++ b/common/src/main/resources/index-mappings/ml_agent.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "schema_version": 4
+    "schema_version": 5
   },
   "properties": {
     "name": {
@@ -34,6 +34,9 @@
       "type": "boolean"
     },
     "tenant_id": {
+      "type": "keyword"
+    },
+    "provisioned_by": {
       "type": "keyword"
     },
     "created_time": {

--- a/common/src/main/resources/index-mappings/ml_connector.json
+++ b/common/src/main/resources/index-mappings/ml_connector.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "schema_version": 4
+    "schema_version": 5
   },
   "properties": {
     "name": {
@@ -31,6 +31,9 @@
       "type": "flat_object"
     },
     "tenant_id": {
+      "type": "keyword"
+    },
+    "provisioned_by": {
       "type": "keyword"
     },
     "actions": {

--- a/common/src/main/resources/index-mappings/ml_model.json
+++ b/common/src/main/resources/index-mappings/ml_model.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "schema_version": 13
+    "schema_version": 14
   },
   "properties": {
     "algorithm": {
@@ -64,6 +64,9 @@
       "type": "boolean"
     },
     "tenant_id": {
+      "type": "keyword"
+    },
+    "provisioned_by": {
       "type": "keyword"
     },
     "model_config": {

--- a/common/src/test/java/org/opensearch/ml/common/MLModelTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/MLModelTests.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -451,5 +452,155 @@ public class MLModelTests {
             mlModel
                 .identifyModel("anthropic", "https://test-api.anthropic.com/v1/messages", new JSONObject(requestBody), paramsOnlyConnector)
         );
+    }
+
+    // ---- provisioned_by tests ----
+
+    @Test
+    public void builder_WithProvisionedBy() {
+        MLModel model = MLModel.builder().name("test").algorithm(FunctionName.TEXT_EMBEDDING).provisionedBy("flow-framework").build();
+        assertEquals("flow-framework", model.getProvisionedBy());
+    }
+
+    @Test
+    public void builder_WithoutProvisionedBy_DefaultsToNull() {
+        MLModel model = MLModel.builder().name("test").algorithm(FunctionName.TEXT_EMBEDDING).build();
+        assertNull(model.getProvisionedBy());
+    }
+
+    @Test
+    public void toXContent_WithProvisionedBy() throws IOException {
+        MLModel model = MLModel.builder().name("test").algorithm(FunctionName.TEXT_EMBEDDING).provisionedBy("flow-framework").build();
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.core.xcontent.XContentBuilder
+            .builder(XContentType.JSON.xContent());
+        model.toXContent(builder, EMPTY_PARAMS);
+        org.junit.Assert
+            .assertTrue(
+                org.opensearch.ml.common.TestHelper.xContentBuilderToString(builder).contains("\"provisioned_by\":\"flow-framework\"")
+            );
+    }
+
+    @Test
+    public void toXContent_WithoutProvisionedBy_OmitsField() throws IOException {
+        MLModel model = MLModel.builder().name("test").algorithm(FunctionName.TEXT_EMBEDDING).build();
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.core.xcontent.XContentBuilder
+            .builder(XContentType.JSON.xContent());
+        model.toXContent(builder, EMPTY_PARAMS);
+        org.junit.Assert.assertFalse(org.opensearch.ml.common.TestHelper.xContentBuilderToString(builder).contains("provisioned_by"));
+    }
+
+    @Test
+    public void parse_WithProvisionedBy() throws IOException {
+        String modelJson = """
+                {
+                    "name": "model_name",
+                    "algorithm": "KMEANS",
+                    "model_version": "1.0.0",
+                    "provisioned_by": "flow-framework"
+                }
+            """;
+        TestHelper.testParseFromString(config, modelJson, function);
+    }
+
+    @Test
+    public void writeTo_ReadFrom_WithProvisionedBy() throws IOException {
+        MLModel model = MLModel
+            .builder()
+            .name("test")
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .version("1")
+            .provisionedBy("flow-framework")
+            .build();
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(CommonValue.VERSION_3_7_0);
+        model.writeTo(output);
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(CommonValue.VERSION_3_7_0);
+        MLModel deserialized = new MLModel(streamInput);
+        assertEquals("flow-framework", deserialized.getProvisionedBy());
+    }
+
+    @Test
+    public void testGetTags_RemoteModel_ProvisionedBy() {
+        HttpConnector connector = HttpConnector
+            .builder()
+            .name("test")
+            .protocol("http")
+            .version("1")
+            .actions(
+                List
+                    .of(
+                        ConnectorAction
+                            .builder()
+                            .actionType(ConnectorAction.ActionType.PREDICT)
+                            .method("POST")
+                            .url("https://api.openai.com/v1/chat/completions")
+                            .build()
+                    )
+            )
+            .build();
+        MLModel withProvisionedBy = MLModel.builder().algorithm(FunctionName.REMOTE).provisionedBy("flow-framework").build();
+        assertEquals("flow-framework", withProvisionedBy.getTags(connector).getTagsMap().get("provisioned_by"));
+
+        MLModel withoutProvisionedBy = MLModel.builder().algorithm(FunctionName.REMOTE).build();
+        assertEquals("unknown", withoutProvisionedBy.getTags(connector).getTagsMap().get("provisioned_by"));
+    }
+
+    @Test
+    public void testGetTags_PreTrainedModel_ProvisionedBy() {
+        TextEmbeddingModelConfig config = TextEmbeddingModelConfig
+            .builder()
+            .modelType("bert")
+            .embeddingDimension(768)
+            .frameworkType(TextEmbeddingModelConfig.FrameworkType.SENTENCE_TRANSFORMERS)
+            .build();
+        MLModel withProvisionedBy = MLModel
+            .builder()
+            .name("huggingface/sentence-transformers/bert-base-uncased")
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .modelConfig(config)
+            .provisionedBy("flow-framework")
+            .build();
+        assertEquals("flow-framework", withProvisionedBy.getTags().getTagsMap().get("provisioned_by"));
+
+        MLModel withoutProvisionedBy = MLModel
+            .builder()
+            .name("huggingface/sentence-transformers/bert-base-uncased")
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .modelConfig(config)
+            .build();
+        assertEquals("unknown", withoutProvisionedBy.getTags().getTagsMap().get("provisioned_by"));
+    }
+
+    @Test
+    public void testGetTags_CustomModel_ProvisionedBy() {
+        MLModel withProvisionedBy = MLModel
+            .builder()
+            .name("my-custom-model")
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .provisionedBy("flow-framework")
+            .build();
+        assertEquals("flow-framework", withProvisionedBy.getTags().getTagsMap().get("provisioned_by"));
+
+        MLModel withoutProvisionedBy = MLModel.builder().name("my-custom-model").algorithm(FunctionName.TEXT_EMBEDDING).build();
+        assertEquals("unknown", withoutProvisionedBy.getTags().getTagsMap().get("provisioned_by"));
+    }
+
+    @Test
+    public void writeTo_ReadFrom_ProvisionedBy_OldVersion_IsNull() throws IOException {
+        MLModel model = MLModel
+            .builder()
+            .name("test")
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .version("1")
+            .provisionedBy("flow-framework")
+            .build();
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(CommonValue.VERSION_3_5_0);
+        model.writeTo(output);
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(CommonValue.VERSION_3_5_0);
+        MLModel deserialized = new MLModel(streamInput);
+        assertNull(deserialized.getProvisionedBy());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/agent/MLAgentTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/MLAgentTest.java
@@ -18,6 +18,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.opensearch.Version;
+import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
@@ -30,6 +31,7 @@ import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.TestHelper;
 import org.opensearch.ml.common.contextmanager.ContextManagementTemplate;
+import org.opensearch.ml.common.transport.agent.MLRegisterAgentRequest;
 import org.opensearch.search.SearchModule;
 
 public class MLAgentTest {
@@ -69,6 +71,7 @@ public class MLAgentTest {
             false,
             null,
             null,
+            null,
             null
         );
     }
@@ -91,6 +94,7 @@ public class MLAgentTest {
             Instant.EPOCH,
             "test",
             false,
+            null,
             null,
             null,
             null
@@ -117,6 +121,7 @@ public class MLAgentTest {
             false,
             null,
             null,
+            null,
             null
         );
     }
@@ -141,6 +146,7 @@ public class MLAgentTest {
             false,
             null,
             null,
+            null,
             null
         );
     }
@@ -160,6 +166,7 @@ public class MLAgentTest {
             Instant.EPOCH,
             "test",
             false,
+            null,
             null,
             null,
             null
@@ -193,6 +200,7 @@ public class MLAgentTest {
             false,
             null,
             null,
+            null,
             null
         );
         BytesStreamOutput output = new BytesStreamOutput();
@@ -217,6 +225,7 @@ public class MLAgentTest {
             Instant.EPOCH,
             "test",
             false,
+            null,
             null,
             null,
             null
@@ -245,6 +254,7 @@ public class MLAgentTest {
             false,
             null,
             null,
+            null,
             null
         );
         BytesStreamOutput output = new BytesStreamOutput();
@@ -269,6 +279,7 @@ public class MLAgentTest {
             Instant.EPOCH,
             "test",
             false,
+            null,
             null,
             null,
             null
@@ -308,6 +319,7 @@ public class MLAgentTest {
             Instant.EPOCH,
             "test",
             false,
+            null,
             null,
             null,
             null
@@ -370,6 +382,7 @@ public class MLAgentTest {
             false,
             null,
             null,
+            null,
             null
         );
         BytesStreamOutput output = new BytesStreamOutput();
@@ -404,6 +417,7 @@ public class MLAgentTest {
             false,
             null,
             null,
+            null,
             null
         );
     }
@@ -424,6 +438,7 @@ public class MLAgentTest {
                 Instant.EPOCH,
                 "test",
                 false,
+                null,
                 null,
                 null,
                 null
@@ -449,6 +464,7 @@ public class MLAgentTest {
             Instant.EPOCH,
             "test",
             true,
+            null,
             null,
             null,
             null
@@ -519,6 +535,7 @@ public class MLAgentTest {
             true,
             null,
             null,
+            null,
             null
         );
 
@@ -545,6 +562,7 @@ public class MLAgentTest {
             Instant.EPOCH,
             Instant.EPOCH,
             "test_app",
+            null,
             null,
             null,
             null,
@@ -580,6 +598,7 @@ public class MLAgentTest {
             false,
             "template_name",
             new ContextManagementTemplate(),
+            null,
             null
         );
     }
@@ -600,6 +619,7 @@ public class MLAgentTest {
             "test_app",
             false,
             "template_name",
+            null,
             null,
             null
         );
@@ -634,6 +654,7 @@ public class MLAgentTest {
             false,
             null,
             template,
+            null,
             null
         );
 
@@ -658,6 +679,7 @@ public class MLAgentTest {
             Instant.EPOCH,
             "test_app",
             false,
+            null,
             null,
             null,
             null
@@ -685,6 +707,7 @@ public class MLAgentTest {
             "test_app",
             false,
             "template_name",
+            null,
             null,
             null
         );
@@ -727,6 +750,7 @@ public class MLAgentTest {
             false,
             null,
             template,
+            null,
             null
         );
 
@@ -762,6 +786,7 @@ public class MLAgentTest {
             "test_app",
             false,
             "template_name",
+            null,
             null,
             null
         );
@@ -843,6 +868,7 @@ public class MLAgentTest {
             false,
             "template_name",
             null,
+            null,
             null
         );
 
@@ -878,6 +904,7 @@ public class MLAgentTest {
             false,
             null,
             template,
+            null,
             null
         );
 
@@ -888,5 +915,160 @@ public class MLAgentTest {
         assertFalse(content.contains("\"context_management_name\":"));
         assertTrue(content.contains("\"context_management\":"));
         assertTrue(content.contains("\"inline_template\""));
+    }
+
+    // ---- provisioned_by tests ----
+
+    @Test
+    public void builder_WithProvisionedBy() {
+        MLAgent agent = MLAgent.builder().name("test_agent").type(MLAgentType.FLOW.name()).provisionedBy("flow-framework").build();
+
+        assertEquals("flow-framework", agent.getProvisionedBy());
+    }
+
+    @Test
+    public void builder_WithoutProvisionedBy_DefaultsToNull() {
+        MLAgent agent = MLAgent.builder().name("test_agent").type(MLAgentType.FLOW.name()).build();
+
+        assertNull(agent.getProvisionedBy());
+    }
+
+    @Test
+    public void toXContent_WithProvisionedBy() throws IOException {
+        MLAgent agent = MLAgent.builder().name("test").type("FLOW").provisionedBy("flow-framework").build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        agent.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+
+        assertTrue(content.contains("\"provisioned_by\":\"flow-framework\""));
+    }
+
+    @Test
+    public void toXContent_WithoutProvisionedBy_OmitsField() throws IOException {
+        MLAgent agent = MLAgent.builder().name("test").type("FLOW").build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        agent.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+
+        assertFalse(content.contains("provisioned_by"));
+    }
+
+    @Test
+    public void parse_WithProvisionedBy() throws IOException {
+        String jsonStr = "{\"name\":\"test\",\"type\":\"FLOW\",\"provisioned_by\":\"flow-framework\"}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+        MLAgent agent = MLAgent.parse(parser);
+
+        assertEquals("flow-framework", agent.getProvisionedBy());
+    }
+
+    @Test
+    public void parse_WithoutProvisionedBy_IsNull() throws IOException {
+        String jsonStr = "{\"name\":\"test\",\"type\":\"FLOW\"}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+        MLAgent agent = MLAgent.parse(parser);
+
+        assertNull(agent.getProvisionedBy());
+    }
+
+    @Test
+    public void writeTo_ReadFrom_WithProvisionedBy() throws IOException {
+        MLAgent agent = MLAgent.builder().name("test").type("FLOW").provisionedBy("flow-framework").build();
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(CommonValue.VERSION_3_7_0);
+        agent.writeTo(output);
+
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(CommonValue.VERSION_3_7_0);
+        MLAgent deserialized = new MLAgent(streamInput);
+
+        assertEquals("flow-framework", deserialized.getProvisionedBy());
+    }
+
+    @Test
+    public void writeTo_ReadFrom_ProvisionedBy_OldVersion_IsNull() throws IOException {
+        MLAgent agent = MLAgent.builder().name("test").type("FLOW").provisionedBy("flow-framework").build();
+
+        // Serialize with a version that predates provisioned_by support
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(CommonValue.VERSION_3_5_0);
+        agent.writeTo(output);
+
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(CommonValue.VERSION_3_5_0);
+        MLAgent deserialized = new MLAgent(streamInput);
+
+        assertNull(deserialized.getProvisionedBy());
+    }
+
+    @Test
+    public void getTags_WithProvisionedBy() {
+        MLAgent agent = MLAgent.builder().name("test_agent").type("FLOW").provisionedBy("flow-framework").build();
+
+        Map<String, ?> tagsMap = agent.getTags().getTagsMap();
+
+        assertEquals("flow-framework", tagsMap.get("provisioned_by"));
+    }
+
+    @Test
+    public void getTags_WithoutProvisionedBy_DefaultsToUnknown() {
+        MLAgent agent = MLAgent.builder().name("test_agent").type("FLOW").build();
+
+        Map<String, ?> tagsMap = agent.getTags().getTagsMap();
+
+        assertEquals("unknown", tagsMap.get("provisioned_by"));
+    }
+
+    @Test
+    public void validate_ProvisionedBy_ValidValue_Passes() {
+        MLAgent agent = MLAgent.builder().name("test_agent").type(MLAgentType.FLOW.name()).provisionedBy("flow-framework").build();
+
+        MLRegisterAgentRequest request = MLRegisterAgentRequest.builder().mlAgent(agent).build();
+        ActionRequestValidationException exception = request.validate();
+
+        assertNull(exception);
+    }
+
+    @Test
+    public void validate_ProvisionedBy_InvalidChars_Fails() {
+        MLAgent agent = MLAgent
+            .builder()
+            .name("test_agent")
+            .type(MLAgentType.FLOW.name())
+            .provisionedBy("<script>alert('xss')</script>")
+            .build();
+
+        MLRegisterAgentRequest request = MLRegisterAgentRequest.builder().mlAgent(agent).build();
+        ActionRequestValidationException exception = request.validate();
+
+        assertNotNull(exception);
+        assertTrue(exception.validationErrors().stream().anyMatch(e -> e.contains("provisioned_by")));
+    }
+
+    @Test
+    public void validate_ProvisionedBy_Null_Passes() {
+        MLAgent agent = MLAgent.builder().name("test_agent").type(MLAgentType.FLOW.name()).build();
+
+        MLRegisterAgentRequest request = MLRegisterAgentRequest.builder().mlAgent(agent).build();
+        ActionRequestValidationException exception = request.validate();
+
+        assertNull(exception);
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -27,11 +27,13 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.AccessMode;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.TestHelper;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.search.SearchModule;
@@ -681,6 +683,75 @@ public class HttpConnectorTest {
         Assert.assertTrue(foundByName.isPresent());
         Assert.assertEquals("predict_action_2", foundByName.get().getName());
         Assert.assertEquals("https://test2.com", foundByName.get().getUrl());
+    }
+
+    // ---- provisioned_by tests ----
+
+    @Test
+    public void builder_WithProvisionedBy() {
+        HttpConnector connector = HttpConnector.builder().name("test").protocol("http").provisionedBy("flow-framework").build();
+        Assert.assertEquals("flow-framework", connector.getProvisionedBy());
+    }
+
+    @Test
+    public void builder_WithoutProvisionedBy_DefaultsToNull() {
+        HttpConnector connector = HttpConnector.builder().name("test").protocol("http").build();
+        Assert.assertNull(connector.getProvisionedBy());
+    }
+
+    @Test
+    public void toXContent_WithProvisionedBy() throws IOException {
+        HttpConnector connector = HttpConnector.builder().name("test").protocol("http").provisionedBy("flow-framework").build();
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        connector.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        Assert.assertTrue(TestHelper.xContentBuilderToString(builder).contains("\"provisioned_by\":\"flow-framework\""));
+    }
+
+    @Test
+    public void toXContent_WithoutProvisionedBy_OmitsField() throws IOException {
+        HttpConnector connector = HttpConnector.builder().name("test").protocol("http").build();
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        connector.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        Assert.assertFalse(TestHelper.xContentBuilderToString(builder).contains("provisioned_by"));
+    }
+
+    @Test
+    public void parse_WithProvisionedBy() throws IOException {
+        String jsonStr = "{\"name\":\"test\",\"protocol\":\"http\",\"provisioned_by\":\"flow-framework\"}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+        HttpConnector connector = new HttpConnector("http", parser);
+        Assert.assertEquals("flow-framework", connector.getProvisionedBy());
+    }
+
+    @Test
+    public void writeTo_ReadFrom_WithProvisionedBy() throws IOException {
+        HttpConnector connector = HttpConnector.builder().name("test").protocol("http").provisionedBy("flow-framework").build();
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(CommonValue.VERSION_3_7_0);
+        connector.writeTo(output);
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(CommonValue.VERSION_3_7_0);
+        HttpConnector deserialized = new HttpConnector(streamInput);
+        Assert.assertEquals("flow-framework", deserialized.getProvisionedBy());
+    }
+
+    @Test
+    public void writeTo_ReadFrom_ProvisionedBy_OldVersion_IsNull() throws IOException {
+        HttpConnector connector = HttpConnector.builder().name("test").protocol("http").provisionedBy("flow-framework").build();
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(CommonValue.VERSION_3_5_0);
+        connector.writeTo(output);
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(CommonValue.VERSION_3_5_0);
+        HttpConnector deserialized = new HttpConnector(streamInput);
+        Assert.assertNull(deserialized.getProvisionedBy());
     }
 
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/agent/MLAgentGetResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/agent/MLAgentGetResponseTest.java
@@ -99,6 +99,7 @@ public class MLAgentGetResponseTest {
             false,
             null,
             null,
+            null,
             null
         );
         MLAgentGetResponse mlAgentGetResponse = MLAgentGetResponse.builder().mlAgent(mlAgent).build();
@@ -131,6 +132,7 @@ public class MLAgentGetResponseTest {
             null,
             "test",
             false,
+            null,
             null,
             null,
             null

--- a/common/src/test/java/org/opensearch/ml/common/transport/agent/MLRegisterAgentRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/agent/MLRegisterAgentRequestTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.transport.agent;
 
 import static org.junit.Assert.*;
+import static org.opensearch.ml.common.utils.StringUtils.SAFE_INPUT_DESCRIPTION;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -362,6 +363,22 @@ public class MLRegisterAgentRequestTest {
         ActionRequestValidationException exception = request.validate();
 
         assertNull(exception);
+    }
+
+    @Test
+    public void validate_ValidProvisionedBy() {
+        MLAgent agent = MLAgent.builder().name("test_agent").type("flow").provisionedBy("flow-framework").build();
+        MLRegisterAgentRequest request = new MLRegisterAgentRequest(agent);
+        assertNull(request.validate());
+    }
+
+    @Test
+    public void validate_InvalidProvisionedBy() {
+        MLAgent agent = MLAgent.builder().name("test_agent").type("flow").provisionedBy("<script>bad</script>").build();
+        MLRegisterAgentRequest request = new MLRegisterAgentRequest(agent);
+        ActionRequestValidationException exception = request.validate();
+        assertNotNull(exception);
+        assertTrue(exception.getMessage().contains("Agent provisioned_by field " + SAFE_INPUT_DESCRIPTION));
     }
 
     /**

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorInputTests.java
@@ -563,6 +563,93 @@ public class MLCreateConnectorInputTests {
         assertEquals("https://test.com", connector.getUrl());
     }
 
+    // ---- provisioned_by tests ----
+
+    @Test
+    public void builder_WithProvisionedBy() {
+        MLCreateConnectorInput input = MLCreateConnectorInput
+            .builder()
+            .name(TEST_CONNECTOR_NAME)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(TEST_CONNECTOR_PROTOCOL)
+            .credential(Map.of(TEST_CREDENTIAL_KEY, TEST_CREDENTIAL_VALUE))
+            .provisionedBy("flow-framework")
+            .build();
+        assertEquals("flow-framework", input.getProvisionedBy());
+    }
+
+    @Test
+    public void builder_WithoutProvisionedBy_DefaultsToNull() {
+        MLCreateConnectorInput input = MLCreateConnectorInput
+            .builder()
+            .name(TEST_CONNECTOR_NAME)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(TEST_CONNECTOR_PROTOCOL)
+            .credential(Map.of(TEST_CREDENTIAL_KEY, TEST_CREDENTIAL_VALUE))
+            .build();
+        assertNull(input.getProvisionedBy());
+    }
+
+    @Test
+    public void toXContent_WithProvisionedBy() throws Exception {
+        MLCreateConnectorInput input = MLCreateConnectorInput
+            .builder()
+            .name(TEST_CONNECTOR_NAME)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(TEST_CONNECTOR_PROTOCOL)
+            .credential(Map.of(TEST_CREDENTIAL_KEY, TEST_CREDENTIAL_VALUE))
+            .provisionedBy("flow-framework")
+            .build();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        input.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertTrue(builder.toString().contains("\"provisioned_by\":\"flow-framework\""));
+    }
+
+    @Test
+    public void parse_WithProvisionedBy() throws Exception {
+        String json =
+            "{\"name\":\"test\",\"version\":\"1\",\"protocol\":\"http\",\"credential\":{\"key\":\"val\"},\"provisioned_by\":\"flow-framework\"}";
+        testParseFromJsonString(json, parsedInput -> assertEquals("flow-framework", parsedInput.getProvisionedBy()));
+    }
+
+    @Test
+    public void readInputStream_WithProvisionedBy() throws IOException {
+        MLCreateConnectorInput input = MLCreateConnectorInput
+            .builder()
+            .name(TEST_CONNECTOR_NAME)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(TEST_CONNECTOR_PROTOCOL)
+            .credential(Map.of(TEST_CREDENTIAL_KEY, TEST_CREDENTIAL_VALUE))
+            .provisionedBy("flow-framework")
+            .build();
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(CommonValue.VERSION_3_7_0);
+        input.writeTo(output);
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(CommonValue.VERSION_3_7_0);
+        MLCreateConnectorInput deserialized = new MLCreateConnectorInput(streamInput);
+        assertEquals("flow-framework", deserialized.getProvisionedBy());
+    }
+
+    @Test
+    public void readInputStream_ProvisionedBy_OldVersion_IsNull() throws IOException {
+        MLCreateConnectorInput input = MLCreateConnectorInput
+            .builder()
+            .name(TEST_CONNECTOR_NAME)
+            .version(TEST_CONNECTOR_VERSION)
+            .protocol(TEST_CONNECTOR_PROTOCOL)
+            .credential(Map.of(TEST_CREDENTIAL_KEY, TEST_CREDENTIAL_VALUE))
+            .provisionedBy("flow-framework")
+            .build();
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(CommonValue.VERSION_3_5_0);
+        input.writeTo(output);
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(CommonValue.VERSION_3_5_0);
+        MLCreateConnectorInput deserialized = new MLCreateConnectorInput(streamInput);
+        assertNull(deserialized.getProvisionedBy());
+    }
+
     // Helper method to create XContentParser from a JSON string
     private XContentParser createParser(String jsonString) throws IOException {
         XContentParser parser = XContentType.JSON

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLCreateConnectorRequestTests.java
@@ -313,4 +313,34 @@ public class MLCreateConnectorRequestTests {
         assertNotNull("Validation should fail when dry run is false and name is empty", nonDryRunException);
         assertTrue(nonDryRunException.getMessage().contains("Model connector name is required"));
     }
+
+    @Test
+    public void validateWithValidProvisionedBy() {
+        MLCreateConnectorInput input = MLCreateConnectorInput
+            .builder()
+            .name("test")
+            .protocol("http")
+            .version("1")
+            .credential(Map.of("key", "value"))
+            .provisionedBy("flow-framework")
+            .build();
+        MLCreateConnectorRequest request = MLCreateConnectorRequest.builder().mlCreateConnectorInput(input).build();
+        assertNull(request.validate());
+    }
+
+    @Test
+    public void validateWithInvalidProvisionedBy() {
+        MLCreateConnectorInput input = MLCreateConnectorInput
+            .builder()
+            .name("test")
+            .protocol("http")
+            .version("1")
+            .credential(Map.of("key", "value"))
+            .provisionedBy("<script>bad</script>")
+            .build();
+        MLCreateConnectorRequest request = MLCreateConnectorRequest.builder().mlCreateConnectorInput(input).build();
+        ActionRequestValidationException exception = request.validate();
+        assertNotNull(exception);
+        assertTrue(exception.getMessage().contains("Model connector provisioned_by field " + SAFE_INPUT_DESCRIPTION));
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/connector/MLUpdateConnectorRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/connector/MLUpdateConnectorRequestTests.java
@@ -201,6 +201,18 @@ public class MLUpdateConnectorRequestTests {
     }
 
     @Test
+    public void validate_Exception_NullConnectorId_AndUnsafeName() {
+        MLCreateConnectorInput unsafeInput = MLCreateConnectorInput.builder().name("<script>bad</script>").updateConnector(true).build();
+        MLUpdateConnectorRequest request = MLUpdateConnectorRequest.builder().updateContent(unsafeInput).build();
+
+        ActionRequestValidationException exception = request.validate();
+        assertEquals(
+            "Validation Failed: 1: ML connector id can't be null;2: Model connector name " + SAFE_INPUT_DESCRIPTION + ";",
+            exception.getMessage()
+        );
+    }
+
+    @Test
     public void validate_Exception_UnsafeConnectorDescription() {
         MLCreateConnectorInput unsafeInput = MLCreateConnectorInput
             .builder()

--- a/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelInputTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_5_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -689,5 +691,75 @@ public class MLRegisterModelInputTest {
         StreamInput streamInput = bytesStreamOutput.bytes().streamInput();
         MLRegisterModelInput parsedInput = new MLRegisterModelInput(streamInput);
         verify.accept(parsedInput);
+    }
+
+    // ---- provisioned_by tests ----
+
+    @Test
+    public void builder_WithProvisionedBy() {
+        MLRegisterModelInput withProvisionedBy = input.toBuilder().provisionedBy("flow-framework").build();
+        assertEquals("flow-framework", withProvisionedBy.getProvisionedBy());
+    }
+
+    @Test
+    public void builder_WithoutProvisionedBy_DefaultsToNull() {
+        assertNull(input.getProvisionedBy());
+    }
+
+    @Test
+    public void toXContent_WithProvisionedBy() throws Exception {
+        MLRegisterModelInput withProvisionedBy = input.toBuilder().provisionedBy("flow-framework").build();
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        withProvisionedBy.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String jsonStr = builder.toString();
+        assertTrue(jsonStr.contains("\"provisioned_by\":\"flow-framework\""));
+    }
+
+    @Test
+    public void toXContent_WithoutProvisionedBy_OmitsField() throws Exception {
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        input.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String jsonStr = builder.toString();
+        assertFalse(jsonStr.contains("\"provisioned_by\""));
+    }
+
+    @Test
+    public void parse_WithProvisionedBy() throws Exception {
+        String json = "{\"name\":\"modelName\",\"version\":\"version\",\"model_format\":\"ONNX\","
+            + "\"function_name\":\"TEXT_EMBEDDING\",\"provisioned_by\":\"flow-framework\"}";
+        testParseFromJsonString("modelName", "version", true, json, parsedInput -> {
+            assertEquals("flow-framework", parsedInput.getProvisionedBy());
+        });
+    }
+
+    @Test
+    public void parse_WithoutModel_WithProvisionedBy() throws Exception {
+        String json = "{\"name\":\"modelName\",\"version\":\"version\",\"model_format\":\"ONNX\","
+            + "\"function_name\":\"TEXT_EMBEDDING\",\"provisioned_by\":\"flow-framework\"}";
+        testParseFromJsonString(true, json, parsedInput -> { assertEquals("flow-framework", parsedInput.getProvisionedBy()); });
+    }
+
+    @Test
+    public void writeTo_ReadFrom_WithProvisionedBy() throws IOException {
+        MLRegisterModelInput inputWithProvisionedBy = input.toBuilder().provisionedBy("flow-framework").build();
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(VERSION_3_7_0);
+        inputWithProvisionedBy.writeTo(output);
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(VERSION_3_7_0);
+        MLRegisterModelInput deserialized = new MLRegisterModelInput(streamInput);
+        assertEquals("flow-framework", deserialized.getProvisionedBy());
+    }
+
+    @Test
+    public void writeTo_ReadFrom_ProvisionedBy_OldVersion_IsNull() throws IOException {
+        MLRegisterModelInput inputWithProvisionedBy = input.toBuilder().provisionedBy("flow-framework").build();
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(VERSION_3_5_0);
+        inputWithProvisionedBy.writeTo(output);
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(VERSION_3_5_0);
+        MLRegisterModelInput deserialized = new MLRegisterModelInput(streamInput);
+        assertNull(deserialized.getProvisionedBy());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelRequestTest.java
@@ -195,4 +195,20 @@ public class MLRegisterModelRequestTest {
         assertEquals("Validation Failed: 1: Model description " + SAFE_INPUT_DESCRIPTION + ";", exception.getMessage());
     }
 
+    @Test
+    public void validate_ValidProvisionedBy() {
+        MLRegisterModelInput input = mlRegisterModelInput.toBuilder().provisionedBy("flow-framework").build();
+        MLRegisterModelRequest request = MLRegisterModelRequest.builder().registerModelInput(input).build();
+        assertNull(request.validate());
+    }
+
+    @Test
+    public void validate_InvalidProvisionedBy() {
+        MLRegisterModelInput input = mlRegisterModelInput.toBuilder().provisionedBy("<script>bad</script>").build();
+        MLRegisterModelRequest request = MLRegisterModelRequest.builder().registerModelInput(input).build();
+        ActionRequestValidationException exception = request.validate();
+        assertNotNull(exception);
+        assertEquals("Validation Failed: 1: Model provisioned_by field " + SAFE_INPUT_DESCRIPTION + ";", exception.getMessage());
+    }
+
 }

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -649,6 +649,7 @@ public class MLModelManager {
                     .guardrails(registerModelInput.getGuardrails())
                     .modelInterface(registerModelInput.getModelInterface())
                     .tenantId(registerModelInput.getTenantId())
+                    .provisionedBy(registerModelInput.getProvisionedBy())
                     .build();
 
                 PutDataObjectRequest putModelMetaRequest = PutDataObjectRequest
@@ -758,6 +759,7 @@ public class MLModelManager {
                 .guardrails(registerModelInput.getGuardrails())
                 .modelInterface(registerModelInput.getModelInterface())
                 .tenantId(registerModelInput.getTenantId())
+                .provisionedBy(registerModelInput.getProvisionedBy())
                 .build();
 
             PutDataObjectRequest putModelMetaRequest = PutDataObjectRequest
@@ -850,6 +852,8 @@ public class MLModelManager {
                     .isHidden(registerModelInput.getIsHidden())
                     .guardrails(registerModelInput.getGuardrails())
                     .modelInterface(registerModelInput.getModelInterface())
+                    .tenantId(registerModelInput.getTenantId())
+                    .provisionedBy(registerModelInput.getProvisionedBy())
                     .build();
                 IndexRequest indexModelMetaRequest = new IndexRequest(ML_MODEL_INDEX);
                 if (functionName == FunctionName.METRICS_CORRELATION) {

--- a/plugin/src/test/java/org/opensearch/ml/action/agents/DeleteAgentTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agents/DeleteAgentTransportActionTests.java
@@ -356,7 +356,8 @@ public class DeleteAgentTransportActionTests {
             isHidden,
             null, // contextManagementName
             null, // contextManagement
-            tenantId
+            tenantId,
+            null
         );
 
         XContentBuilder content = mlAgent.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);

--- a/plugin/src/test/java/org/opensearch/ml/action/agents/GetAgentTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agents/GetAgentTransportActionTests.java
@@ -339,7 +339,8 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
             isHidden,
             null, // contextManagementName
             null, // contextManagement
-            tenantId
+            tenantId,
+            null
         );
 
         XContentBuilder content = mlAgent.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
@@ -454,6 +455,7 @@ public class GetAgentTransportActionTests extends OpenSearchTestCase {
             Instant.EPOCH,
             "test",
             false,
+            null,
             null,
             null,
             null


### PR DESCRIPTION
### Description

Adds a `provisioned_by` field to ML agents, connectors, and models to enable attribution of adoption metrics by the client that provisioned the resource (e.g., `flow-framework`, `opensearch-dashboards`).

This is distinct from the authenticated user (`User`/FGAC): `provisioned_by` identifies the calling *client*, which may differ from the user when a workflow engine like Flow Framework creates resources on behalf of a user.

#### Data model
- `MLAgent`: new `provisioned_by` field, version-gated serialization at `VERSION_3_7_0`, emitted in `getTags()` (defaults to `"unknown"`)
- `Connector` / `AbstractConnector` / `HttpConnector`: new `provisioned_by` field, version-gated serialization at `VERSION_3_7_0`
- `MLCreateConnectorInput`: new `provisioned_by` field, flows through to connector via XContent round-trip in `TransportCreateConnectorAction`
- `MLModel`: new `provisioned_by` field, version-gated serialization at `VERSION_3_7_0`, emitted in all three `getTags()` methods (`getRemoteModelTags`, `getPreTrainedModelTags`, `getCustomModelTags`), defaults to `"unknown"`
- `MLRegisterModelInput`: new `provisioned_by` field, wired through to
  `MLModel` in `MLModelManager` (all three builder sites)

#### Index mappings
- `ml_agent.json`: schema_version 4 → 5, added `provisioned_by` keyword field
- `ml_connector.json`: schema_version 4 → 5, added `provisioned_by` keyword field
- `ml_model.json`: schema_version 13 → 14, added `provisioned_by` keyword field

#### Validation
- `MLRegisterAgentRequest`: validates `provisioned_by` as optional safe-text field
- `MLCreateConnectorRequest`: validates `provisioned_by` as optional safe-text field
- `MLRegisterModelRequest`: validates `provisioned_by` as optional safe-text field
- `MLUpdateConnectorRequest`: `provisioned_by` is intentionally **not** validated here — it is set at creation time only and is not merged by `HttpConnector.update()`; also fixed a pre-existing bug where `validateFields` result overwrote any prior `connectorId` null error

#### Metrics
- `MLStatsJobProcessor` requires no changes — `provisioned_by` flows through automatically via `model.getTags()` and `agent.getTags()`

#### Versioning
- `CommonValue`: added `VERSION_3_7_0` constant
- All new fields are version-gated: nodes on older versions will deserialize `provisioned_by` as `null`
- `PROVISIONED_BY_FIELD` constant centralized in `CommonValue`

#### Testing
- Unit tests added for serialization (stream in/out at `VERSION_3_7_0` and `VERSION_3_5_0`), XContent parse/write, and `getTags()` emission for all three resource types
- Happy-path `provisionedBy` tests added to `MachineLearningNodeClientTest`   verifying the field is passed through for `registerAgent`, `register` (Model), and `createConnector`
- Validation tests added to `MLRegisterAgentRequestTest`,   `MLCreateConnectorRequestTests`, and `MLRegisterModelRequestTest`
- All existing tests pass

### Related Issues
Resolves #4752

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
    - https://github.com/opensearch-project/opensearch-api-specification/pull/1086
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).
    - https://github.com/opensearch-project/documentation-website/issues/12179
    - https://github.com/opensearch-project/documentation-website/issues/12181

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).