### PR TITLE
Fix stream error propagation to surface root cause message

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskAction.java
@@ -91,10 +91,6 @@ public class TransportExecuteStreamTaskAction extends HandledTransportAction<Act
 
                     public void handleException(TransportException exp) {
                         try {
-                            // Unwrap the TransportException so the caller receives the actual root cause
-                            // instead of a transport-wrapped message that only carries the node address.
-                            // TransportException/StreamException don't implement OpenSearchWrapperException,
-                            // so exp.unwrapCause() returns exp itself — walk the cause chain manually.
                             Throwable cause = exp.getCause() != null ? exp.getCause() : exp;
                             Exception toSend = cause instanceof Exception ? (Exception) cause : exp;
                             channel.sendResponse(toSend);

--- a/plugin/src/main/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskAction.java
@@ -91,7 +91,13 @@ public class TransportExecuteStreamTaskAction extends HandledTransportAction<Act
 
                     public void handleException(TransportException exp) {
                         try {
-                            channel.sendResponse(exp);
+                            // Unwrap the TransportException so the caller receives the actual root cause
+                            // instead of a transport-wrapped message that only carries the node address.
+                            // TransportException/StreamException don't implement OpenSearchWrapperException,
+                            // so exp.unwrapCause() returns exp itself — walk the cause chain manually.
+                            Throwable cause = exp.getCause() != null ? exp.getCause() : exp;
+                            Exception toSend = cause instanceof Exception ? (Exception) cause : exp;
+                            channel.sendResponse(toSend);
                         } catch (Exception e) {
                             log.error("Failed to send error response", e);
                         }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
@@ -79,6 +79,7 @@ import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.ml.repackage.com.google.common.annotations.VisibleForTesting;
 import org.opensearch.ml.repackage.com.google.common.collect.ImmutableList;
+import org.opensearch.ml.utils.MLExceptionUtils;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
@@ -281,9 +282,7 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
             }).doOnNext(channel::sendChunk).onErrorResume(ex -> {
                 log.error("Error occurred", ex);
                 try {
-                    String errorMessage = ex instanceof IOException
-                        ? "Failed to parse request: " + ex.getMessage()
-                        : "Error processing request: " + ex.getMessage();
+                    String errorMessage = buildStreamErrorMessage(ex);
                     HttpChunk errorChunk = createHttpChunk("data: {\"error\": \"" + errorMessage.replace("\"", "\\\"") + "\"}\n\n", true);
                     channel.sendChunk(errorChunk);
                 } catch (Exception e) {
@@ -623,6 +622,15 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
             log.error("Failed to combine chunks", e);
             throw new OpenSearchStatusException("Failed to combine request chunks", RestStatus.INTERNAL_SERVER_ERROR, e);
         }
+    }
+
+    @VisibleForTesting
+    String buildStreamErrorMessage(Throwable ex) {
+        String rootCause = MLExceptionUtils.getRootCauseMessage(ex);
+        if (rootCause == null || rootCause.isEmpty()) {
+            rootCause = ex.getClass().getSimpleName();
+        }
+        return ex instanceof IOException ? "Failed to parse request: " + rootCause : "Error processing request: " + rootCause;
     }
 
     private HttpChunk createHttpChunk(String sseData, boolean isLast) {

--- a/plugin/src/test/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskActionTests.java
@@ -139,7 +139,7 @@ public class TransportExecuteStreamTaskActionTests extends OpenSearchTestCase {
             MLExecuteTaskResponse mockResponse = mock(MLExecuteTaskResponse.class);
             handler.handleResponse(mockResponse);
 
-            // Test handleException method
+            // Test handleException method — no wrapped cause, should forward the TransportException itself
             TransportException transportException = new TransportException("test exception");
             handler.handleException(transportException);
 
@@ -149,6 +149,35 @@ public class TransportExecuteStreamTaskActionTests extends OpenSearchTestCase {
         transportExecuteStreamTaskAction.messageReceived(mlExecuteTaskRequest, transportChannel, task);
 
         verify(transportChannel).sendResponse(any(TransportException.class));
+    }
+
+    @Test
+    public void testMessageReceivedHandlerUnwrapsWrappedCause() throws Exception {
+        // When TransportException wraps a real cause (e.g. OpenSearchStatusException from a remote handler),
+        // the channel must receive the unwrapped cause so callers see the real error rather than just
+        // the transport node-address string.
+        Task task = mock(Task.class);
+        org.opensearch.OpenSearchStatusException rootCause = new org.opensearch.OpenSearchStatusException(
+            "Memory container not found",
+            org.opensearch.core.rest.RestStatus.NOT_FOUND
+        );
+        TransportException wrapped = new TransportException(
+            "[integTest-0][127.0.0.1:9300][cluster:admin/opensearch/ml/execute/stream]",
+            rootCause
+        );
+
+        doAnswer(invocation -> {
+            TransportResponseHandler<MLExecuteTaskResponse> handler = invocation.getArgument(3);
+            handler.handleException(wrapped);
+            return null;
+        }).when(transportService).sendRequest(any(), any(), any(), any(TransportResponseHandler.class));
+
+        transportExecuteStreamTaskAction.messageReceived(mlExecuteTaskRequest, transportChannel, task);
+
+        ArgumentCaptor<Exception> sentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(transportChannel).sendResponse(sentCaptor.capture());
+        Exception sent = sentCaptor.getValue();
+        assertSame("expected unwrapped root cause, got: " + sent.getClass(), rootCause, sent);
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteStreamActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteStreamActionTests.java
@@ -759,6 +759,64 @@ public class RestMLExecuteStreamActionTests extends OpenSearchTestCase {
         assertTrue(content.contains("Something went wrong"));
     }
 
+    // ===== Error message propagation tests (issue #4749) =====
+
+    @Test
+    public void testBuildStreamErrorMessage_transportException() {
+        RuntimeException rootCause = new RuntimeException("Unable to access memory service");
+        org.opensearch.transport.RemoteTransportException transportException = new org.opensearch.transport.RemoteTransportException(
+            "node1",
+            null,
+            "cluster:admin/opensearch/ml/execute/stream",
+            rootCause
+        );
+
+        String message = restAction.buildStreamErrorMessage(transportException);
+
+        assertTrue(message.contains("Unable to access memory service"));
+        assertTrue(message.startsWith("Error processing request: "));
+        assertFalse(message.contains("node1"));
+    }
+
+    @Test
+    public void testBuildStreamErrorMessage_ioException() {
+        IOException ioException = new IOException("Malformed JSON");
+
+        String message = restAction.buildStreamErrorMessage(ioException);
+
+        assertTrue(message.startsWith("Failed to parse request: "));
+        assertTrue(message.contains("Malformed JSON"));
+    }
+
+    @Test
+    public void testBuildStreamErrorMessage_nestedTransportException() {
+        RuntimeException realCause = new RuntimeException("Error from remote service: Too many requests");
+        RuntimeException wrapper = new RuntimeException("wrapped", realCause);
+        org.opensearch.transport.RemoteTransportException transportException = new org.opensearch.transport.RemoteTransportException(
+            "node1",
+            null,
+            "cluster:admin/opensearch/ml/execute/stream",
+            wrapper
+        );
+
+        String message = restAction.buildStreamErrorMessage(transportException);
+
+        assertTrue(message.contains("Too many requests"));
+        assertFalse(message.contains("node1"));
+        assertFalse(message.contains("wrapped"));
+    }
+
+    @Test
+    public void testBuildStreamErrorMessage_nullMessage() {
+        RuntimeException noMessage = new RuntimeException((String) null);
+
+        String message = restAction.buildStreamErrorMessage(noMessage);
+
+        assertTrue(message.startsWith("Error processing request: "));
+        assertTrue(message.contains("RuntimeException"));
+        assertFalse(message.contains("null"));
+    }
+
     // ===== Reflection helpers for testing private methods =====
 
     @SuppressWarnings("unchecked")

--- a/plugin/src/test/java/org/opensearch/ml/utils/MLExceptionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/MLExceptionUtilsTests.java
@@ -20,6 +20,7 @@ import org.opensearch.core.common.io.stream.NotSerializableExceptionWrapper;
 import org.opensearch.ml.common.exception.MLLimitExceededException;
 import org.opensearch.ml.common.exception.MLResourceNotFoundException;
 import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.transport.RemoteTransportException;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -100,5 +101,32 @@ public class MLExceptionUtilsTests extends OpenSearchIntegTestCase {
         ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(logger).warn(argumentCaptor.capture());
         assertEquals(error, argumentCaptor.getValue());
+    }
+
+    public void testGetRootCauseMessage_RemoteTransportException() {
+        String realError = "Unable to access memory service";
+        Exception rootCause = new RuntimeException(realError);
+        RemoteTransportException transportException = new RemoteTransportException(
+            "node1",
+            null,
+            "cluster:admin/opensearch/ml/execute/stream",
+            rootCause
+        );
+        String rootCauseMessage = MLExceptionUtils.getRootCauseMessage(transportException);
+        assertEquals(realError, rootCauseMessage);
+    }
+
+    public void testGetRootCauseMessage_NestedTransportException() {
+        String realError = "Error from remote service: Too many requests";
+        Exception innerCause = new RuntimeException(realError);
+        Exception middleCause = new RuntimeException("wrapped", innerCause);
+        RemoteTransportException transportException = new RemoteTransportException(
+            "node1",
+            null,
+            "cluster:admin/opensearch/ml/execute/stream",
+            middleCause
+        );
+        String rootCauseMessage = MLExceptionUtils.getRootCauseMessage(transportException);
+        assertEquals(realError, rootCauseMessage);
     }
 }


### PR DESCRIPTION
### Description

Fixes #4749.

When stream errors occur (e.g., agent cannot access memory service), the error message sent to the user only contains the transport-level node address:

```
data: {"error": "[ip-10-0-105-16.us-west-2.compute.internal][10.0.105.16:9300][cluster:admin/opensearch/ml/execute/stream]"}
```

This is because `TransportException.getMessage()` returns the transport wrapper message, not the actual root cause. The fix uses the existing `MLExceptionUtils.getRootCauseMessage()` to unwrap the exception chain and surface the real error.

After this fix, users will see the actual error:

```
data: {"error": "Error processing request: Unable to access memory service"}
```

### Existing pattern

This follows the same pattern used throughout the codebase for surfacing errors — unwrapping with `getRootCauseMessage()` rather than using `getMessage()` directly:

- [`TransportDeployModelAction.java#L325`](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelAction.java#L325) — deploy failure
- [`TransportDeployModelOnNodeAction.java#L199`](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelOnNodeAction.java#L199) — per-node deploy failure
- [`TransportBatchIngestionAction.java#L173`](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/action/batch/TransportBatchIngestionAction.java#L173) — batch ingestion failure
- [`TransportRegisterModelAction.java#L443`](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/action/register/TransportRegisterModelAction.java#L443) — model registration failure
- [`MLModelManager.java#L1158`](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java#L1158) — model loading failure
- [`MemoryOperationsService.java#L266`](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryOperationsService.java#L266) — memory operation failure

The streaming error handler in `RestMLExecuteStreamAction` was the one place not following this pattern.

### Changes

- `RestMLExecuteStreamAction.java`:
  - Extracted error message building from the inline `onErrorResume` lambda into a `@VisibleForTesting` method `buildStreamErrorMessage(Throwable)`
  - Uses `MLExceptionUtils.getRootCauseMessage()` instead of `ex.getMessage()` to unwrap the exception chain
  - Added null-safe fallback to exception class name when root cause message is null
- `RestMLExecuteStreamActionTests.java`: Added 4 tests that directly validate `buildStreamErrorMessage`:
  - `RemoteTransportException` wrapping a real cause → root cause surfaced, node address excluded
  - `IOException` → correct "Failed to parse request" prefix
  - Deeply nested `TransportException` → multi-level unwrapping verified (asserts intermediate wrapper text is excluded)
  - Null message exception → falls back to class name instead of "null"
- `MLExceptionUtilsTests.java`: Added 2 tests for `getRootCauseMessage` with `RemoteTransportException`

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).