### PR TITLE
[FEATURE] Support MCP for Flow and Conversational Flow Agent

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -9,6 +9,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.MCP_CONNECTORS_FIELD;
 import static org.opensearch.ml.common.CommonValue.MCP_CONNECTOR_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.MCP_SYNC_CLIENT;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
 import static org.opensearch.ml.common.agent.MLMemorySpec.MEMORY_CONTAINER_ID_FIELD;
@@ -59,6 +60,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
@@ -156,6 +158,9 @@ public class AgentUtils {
     private static final String DESCRIPTION = "description";
     private static final Pattern ADDITIONAL_PROPERTIES_PATTERN = Pattern
         .compile(",\\s*\"additionalProperties\"\\s*:\\s*(?:false|true)", Pattern.CASE_INSENSITIVE);
+
+    private static final Set<String> MCP_SYSTEM_RUNTIME_RESOURCE_KEYS = Set.of(MCP_SYNC_CLIENT);
+
     public static final String AGENT_LLM_MODEL_ID = "agent_llm_model_id";
 
     public static final String TOOLS = "_tools";
@@ -788,6 +793,91 @@ public class AgentUtils {
         return toolSpecs;
     }
 
+    public static void resolveFlowToolSpecsWithMcpValidation(
+        MLAgent mlAgent,
+        Map<String, String> params,
+        Client client,
+        SdkClient sdkClient,
+        Encryptor encryptor,
+        ActionListener<List<MLToolSpec>> listener
+    ) {
+        List<MLToolSpec> configuredToolSpecs = getMlToolSpecs(mlAgent, params);
+        if (configuredToolSpecs == null || configuredToolSpecs.isEmpty()) {
+            listener.onResponse(Collections.emptyList());
+            return;
+        }
+        boolean hasMcpTool = configuredToolSpecs
+            .stream()
+            .anyMatch(toolSpec -> McpSseTool.TYPE.equals(toolSpec.getType()) || McpStreamableHttpTool.TYPE.equals(toolSpec.getType()));
+        if (!hasMcpTool) {
+            listener.onResponse(configuredToolSpecs);
+            return;
+        }
+        getMcpToolSpecs(mlAgent, client, sdkClient, encryptor, ActionListener.wrap(mcpToolSpecs -> {
+            // If several connectors expose a tool with the same name, it picks the first one from the
+            // configured mcp connectors.
+            Map<String, MLToolSpec> mcpToolSpecMap = mcpToolSpecs
+                .stream()
+                .filter(spec -> spec.getName() != null)
+                .collect(Collectors.toMap(MLToolSpec::getName, spec -> spec, (firstSpec, ignoredDuplicate) -> firstSpec));
+            List<MLToolSpec> resolvedSpecs = new ArrayList<>();
+            for (MLToolSpec configuredSpec : configuredToolSpecs) {
+                if (!McpSseTool.TYPE.equals(configuredSpec.getType()) && !McpStreamableHttpTool.TYPE.equals(configuredSpec.getType())) {
+                    resolvedSpecs.add(configuredSpec);
+                } else {
+                    String configuredToolName = getToolName(configuredSpec);
+                    MLToolSpec mcpSpec = mcpToolSpecMap.get(configuredToolName);
+                    if (mcpSpec == null) {
+                        listener
+                            .onFailure(
+                                new IllegalArgumentException(
+                                    "MCP tool ["
+                                        + configuredToolName
+                                        + "] configured in agent is not available in the MCP connector(s). "
+                                        + "Check connector configuration or MCP server logs."
+                                )
+                            );
+                        return;
+                    }
+                    // Layer agent configuration on top of the connector-fetched MCP tool definition:
+                    // - description: configured value wins when non-empty, else remote
+                    // - attributes, runtime_resources: merged with configured values winning on key collision;
+                    // connector-injected runtime keys (e.g. mcp_sync_client) cannot be overridden in agent JSON
+                    Map<String, Object> mergedRuntimeResources = new HashMap<>();
+                    if (mcpSpec.getRuntimeResources() != null) {
+                        mergedRuntimeResources.putAll(mcpSpec.getRuntimeResources());
+                    }
+                    if (configuredSpec.getRuntimeResources() != null) {
+                        for (Map.Entry<String, Object> entry : configuredSpec.getRuntimeResources().entrySet()) {
+                            if (!MCP_SYSTEM_RUNTIME_RESOURCE_KEYS.contains(entry.getKey())) {
+                                mergedRuntimeResources.put(entry.getKey(), entry.getValue());
+                            }
+                        }
+                    }
+                    Map<String, String> mergedAttributes = new HashMap<>();
+                    if (mcpSpec.getAttributes() != null) {
+                        mergedAttributes.putAll(mcpSpec.getAttributes());
+                    }
+                    if (configuredSpec.getAttributes() != null) {
+                        mergedAttributes.putAll(configuredSpec.getAttributes());
+                    }
+                    MLToolSpec resolved = configuredSpec
+                        .toBuilder()
+                        .description(
+                            Strings.isNullOrEmpty(configuredSpec.getDescription())
+                                ? mcpSpec.getDescription()
+                                : configuredSpec.getDescription()
+                        )
+                        .attributes(mergedAttributes)
+                        .runtimeResources(mergedRuntimeResources.isEmpty() ? null : mergedRuntimeResources)
+                        .build();
+                    resolvedSpecs.add(resolved);
+                }
+            }
+            listener.onResponse(resolvedSpecs);
+        }, listener::onFailure));
+    }
+
     public static void getMcpToolSpecs(
         MLAgent mlAgent,
         Client client,
@@ -811,12 +901,15 @@ public class AgentUtils {
         // Use AtomicInteger to track completion of all async operations
         AtomicInteger remainingConnectors = new AtomicInteger(mcpConnectorConfigs.size());
         List<MLToolSpec> finalToolSpecs = Collections.synchronizedList(new ArrayList<>());
+        boolean isLogWarnEnabled = log.isWarnEnabled();
+        Map<String, List<String>> toolNameToConnectorIds = isLogWarnEnabled ? new ConcurrentHashMap<>() : null;
 
         // We make multiple Async calls in for loop, which happen in parallel
         for (Map<String, Object> mcpConnectorConfig : mcpConnectorConfigs) {
             String connectorId = (String) mcpConnectorConfig.get(MCP_CONNECTOR_ID_FIELD);
             List<String> toolFilters = (List<String>) mcpConnectorConfig.get(TOOL_FILTERS_FIELD);
             Map<String, String> toolDescriptionOverrides = toStringMap(mcpConnectorConfig.get(TOOL_DESCRIPTIONS_FIELD));
+
             try {
                 getMCPToolSpecsFromConnector(connectorId, tenantId, sdkClient, client, encryptor, ActionListener.wrap(mcpToolspecs -> {
                     try {
@@ -830,6 +923,7 @@ public class AgentUtils {
                         } else {
                             filteredTools = new ArrayList<>();
                             List<Pattern> compiledPatterns = toolFilters.stream().map(Pattern::compile).collect(Collectors.toList());
+
                             for (MLToolSpec toolSpec : mcpToolspecs) {
                                 if (toolSpec != null && toolSpec.getName() != null) {
                                     for (Pattern pattern : compiledPatterns) {
@@ -842,20 +936,37 @@ public class AgentUtils {
                             }
                         }
                         warnUnusedToolDescriptionOverrides(connectorId, toolDescriptionOverrides, mcpToolspecs, filteredTools);
+                        if (isLogWarnEnabled) {
+                            recordMcpToolNamesForConnector(toolNameToConnectorIds, connectorId, filteredTools);
+                        }
                         finalToolSpecs.addAll(filteredTools);
                     } catch (Throwable t) {
                         log.error("Error post-processing MCP tool specs for connector: " + connectorId, t);
                     } finally {
-                        completeIfLast(remainingConnectors, finalToolSpecs, finalListener);
+                        completeIfLast(remainingConnectors, toolNameToConnectorIds, finalToolSpecs, finalListener);
                     }
                 }, e -> {
                     log.error("Error processing connector: " + connectorId, e);
-                    completeIfLast(remainingConnectors, finalToolSpecs, finalListener);
+                    completeIfLast(remainingConnectors, toolNameToConnectorIds, finalToolSpecs, finalListener);
                 }));
             } catch (Throwable t) {
                 // Catch synchronous throws (including Errors) so one bad connector can't strand the counter.
                 log.error("Synchronous failure initiating MCP tool spec lookup for connector: " + connectorId, t);
-                completeIfLast(remainingConnectors, finalToolSpecs, finalListener);
+                completeIfLast(remainingConnectors, toolNameToConnectorIds, finalToolSpecs, finalListener);
+            }
+        }
+    }
+
+    private static void recordMcpToolNamesForConnector(
+        Map<String, List<String>> toolNameToConnectorIds,
+        String connectorId,
+        List<MLToolSpec> connectorTools
+    ) {
+        for (MLToolSpec toolSpec : connectorTools) {
+            if (toolSpec.getName() != null) {
+                toolNameToConnectorIds
+                    .computeIfAbsent(toolSpec.getName(), arg -> Collections.synchronizedList(new ArrayList<>()))
+                    .add(connectorId);
             }
         }
     }
@@ -863,11 +974,32 @@ public class AgentUtils {
     // Guarantees the final listener fires exactly once; every code path decrements via try/finally.
     private static void completeIfLast(
         AtomicInteger remainingConnectors,
+        Map<String, List<String>> toolNameToConnectorIds,
         List<MLToolSpec> finalToolSpecs,
         ActionListener<List<MLToolSpec>> finalListener
     ) {
         if (remainingConnectors.decrementAndGet() == 0) {
+            if (toolNameToConnectorIds != null) {
+                warnOnDuplicateMcpToolNames(toolNameToConnectorIds);
+            }
             finalListener.onResponse(finalToolSpecs);
+        }
+    }
+
+    private static void warnOnDuplicateMcpToolNames(Map<String, List<String>> toolNameToConnectorIds) {
+        if (!log.isWarnEnabled()) {
+            return;
+        }
+        for (Map.Entry<String, List<String>> entry : toolNameToConnectorIds.entrySet()) {
+            if (entry.getValue().size() > 1) {
+                log
+                    .warn(
+                        "MCP tool name [{}] is exposed by multiple connectors {}. "
+                            + "Only one definition will be used; disambiguate via tool_filters or rename the tool on one connector.",
+                        entry.getKey(),
+                        entry.getValue()
+                    );
+            }
         }
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLConversationalFlowAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLConversationalFlowAgentRunner.java
@@ -17,15 +17,17 @@ import static org.opensearch.ml.common.utils.ToolUtils.filterToolOutput;
 import static org.opensearch.ml.common.utils.ToolUtils.getToolName;
 import static org.opensearch.ml.common.utils.ToolUtils.parseResponse;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.DISABLE_TRACE;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.cleanUpResource;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.createMemoryParams;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.createTool;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.getMessageHistoryLimit;
-import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.getMlToolSpecs;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.resolveFlowToolSpecsWithMcpValidation;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.sanitizeForLogging;
 import static org.opensearch.ml.engine.algorithms.agent.MLAgentExecutor.QUESTION;
 
 import java.security.PrivilegedActionException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -183,14 +185,27 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
         String memoryId,
         String parentInteractionId
     ) {
+        resolveFlowToolSpecsWithMcpValidation(mlAgent, params, client, sdkClient, encryptor, ActionListener.wrap(toolSpecs -> {
+            runAgentWithToolSpecs(mlAgent, params, listener, memory, memoryId, parentInteractionId, toolSpecs);
+        }, listener::onFailure));
+    }
 
+    private void runAgentWithToolSpecs(
+        MLAgent mlAgent,
+        Map<String, String> params,
+        ActionListener<Object> listener,
+        Memory memory,
+        String memoryId,
+        String parentInteractionId,
+        List<MLToolSpec> toolSpecs
+    ) {
         StepListener<Object> firstStepListener = null;
         Tool firstTool = null;
         List<ModelTensor> flowAgentOutput = new ArrayList<>();
         Map<String, String> firstToolExecuteParams = null;
         StepListener<Object> previousStepListener = null;
         Map<String, Object> additionalInfo = new ConcurrentHashMap<>();
-        List<MLToolSpec> toolSpecs = getMlToolSpecs(mlAgent, params);
+        Map<String, Tool> tools = new HashMap<>();
 
         if (toolSpecs == null || toolSpecs.isEmpty()) {
             listener.onFailure(new IllegalArgumentException("no tool configured"));
@@ -208,6 +223,7 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
                 MLToolSpec toolSpec = toolSpecs.get(i);
                 firstToolExecuteParams = ToolUtils.buildToolParameters(params, toolSpec, mlAgent.getTenantId());
                 Tool tool = createTool(toolFactories, firstToolExecuteParams, toolSpec);
+                tools.put(tool.getName(), tool);
                 firstStepListener = new StepListener<>();
                 previousStepListener = firstStepListener;
                 firstTool = tool;
@@ -231,10 +247,12 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
                         finalI,
                         output,
                         mlAgent.getTenantId(),
-                        nextStepListener
+                        nextStepListener,
+                        tools
                     );
                 }, e -> {
                     log.error("Failed to run flow agent", e);
+                    cleanUpResource(tools);
                     listener.onFailure(e);
                 });
                 previousStepListener = nextStepListener;
@@ -258,9 +276,13 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
                     1,
                     output,
                     mlAgent.getTenantId(),
-                    null
+                    null,
+                    tools
                 );
-            }, e -> { listener.onFailure(e); }));
+            }, e -> {
+                cleanUpResource(tools);
+                listener.onFailure(e);
+            }));
         } else {
             firstTool.run(firstToolExecuteParams, firstStepListener);
         }
@@ -282,7 +304,8 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
         int finalI,
         Object output,
         String tenantId,
-        StepListener<Object> nextStepListener
+        StepListener<Object> nextStepListener,
+        Map<String, Tool> tools
     ) throws PrivilegedActionException {
         String toolName = getToolName(previousToolSpec);
         String outputKey = toolName + ".output";
@@ -310,13 +333,16 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
         if (finalI == toolSpecs.size()) {
             ActionListener updateListener = ActionListener.<UpdateResponse>wrap(r -> {
                 log.info("Updated additional info for interaction {} of flow agent.", r.getId());
+                cleanUpResource(tools);
                 listener.onResponse(flowAgentOutput);
             }, e -> {
                 log.error("Failed to update root interaction", e);
+                cleanUpResource(tools);
                 listener.onResponse(flowAgentOutput);
             });
             if (memory == null) {
                 if (memoryId == null || parentInteractionId == null || memorySpec == null || memorySpec.getType() == null) {
+                    cleanUpResource(tools);
                     listener.onResponse(flowAgentOutput);
                 } else {
                     updateMemoryWithListener(additionalInfo, memorySpec, memoryId, parentInteractionId, updateListener);
@@ -338,13 +364,14 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
                         memory.update(parentInteractionId, updateContent, updateListener);
                     }, e -> {
                         log.error("Failed to update root interaction ", e);
+                        cleanUpResource(tools);
                         listener.onFailure(e);
                     })
                 );
             }
         } else {
             if (memory == null) {
-                runNextStep(params, toolSpecs, finalI, tenantId, nextStepListener);
+                runNextStep(params, toolSpecs, finalI, tenantId, nextStepListener, tools);
             } else {
                 saveMessage(
                     params,
@@ -356,9 +383,10 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
                     traceNumber,
                     traceDisabled,
                     ActionListener.wrap(r -> {
-                        runNextStep(params, toolSpecs, finalI, tenantId, nextStepListener);
+                        runNextStep(params, toolSpecs, finalI, tenantId, nextStepListener, tools);
                     }, e -> {
                         log.error("Failed to update root interaction ", e);
+                        cleanUpResource(tools);
                         listener.onFailure(e);
                     })
                 );
@@ -371,11 +399,13 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
         List<MLToolSpec> toolSpecs,
         int finalI,
         String tenantId,
-        StepListener<Object> nextStepListener
+        StepListener<Object> nextStepListener,
+        Map<String, Tool> tools
     ) {
         MLToolSpec toolSpec = toolSpecs.get(finalI);
         Map<String, String> toolExecutionParameters = ToolUtils.buildToolParameters(params, toolSpec, tenantId);
         Tool tool = createTool(toolFactories, toolExecutionParameters, toolSpec);
+        tools.put(tool.getName(), tool);
         if (finalI < toolSpecs.size()) {
             tool.run(toolExecutionParameters, nextStepListener);
         }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunner.java
@@ -11,11 +11,13 @@ import static org.opensearch.ml.common.utils.ToolUtils.convertOutputToModelTenso
 import static org.opensearch.ml.common.utils.ToolUtils.filterToolOutput;
 import static org.opensearch.ml.common.utils.ToolUtils.getToolName;
 import static org.opensearch.ml.common.utils.ToolUtils.parseResponse;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.cleanUpResource;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.createTool;
-import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.getMlToolSpecs;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.resolveFlowToolSpecsWithMcpValidation;
 import static org.opensearch.ml.engine.memory.ConversationIndexMemory.MEMORY_ID;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -83,16 +85,26 @@ public class MLFlowAgentRunner implements MLAgentRunner {
         this.encryptor = encryptor;
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void run(MLAgent mlAgent, Map<String, String> params, ActionListener<Object> listener, TransportChannel channel) {
-        List<MLToolSpec> toolSpecs = getMlToolSpecs(mlAgent, params);
+        resolveFlowToolSpecsWithMcpValidation(mlAgent, params, client, sdkClient, encryptor, ActionListener.wrap(toolSpecs -> {
+            runWithToolSpecs(mlAgent, params, listener, toolSpecs);
+        }, listener::onFailure));
+    }
+
+    private void runWithToolSpecs(
+        MLAgent mlAgent,
+        Map<String, String> params,
+        ActionListener<Object> listener,
+        List<MLToolSpec> toolSpecs
+    ) {
         StepListener<Object> firstStepListener = null;
         Tool firstTool = null;
         List<ModelTensor> flowAgentOutput = new ArrayList<>();
         Map<String, String> firstToolExecuteParams = null;
         StepListener<Object> previousStepListener = null;
         Map<String, Object> additionalInfo = new ConcurrentHashMap<>();
+        Map<String, Tool> tools = new HashMap<>();
         if (toolSpecs == null || toolSpecs.isEmpty()) {
             listener.onFailure(new IllegalArgumentException("no tool configured"));
             return;
@@ -107,6 +119,7 @@ public class MLFlowAgentRunner implements MLAgentRunner {
                 MLToolSpec toolSpec = toolSpecs.get(i);
                 firstToolExecuteParams = ToolUtils.buildToolParameters(params, toolSpec, mlAgent.getTenantId());
                 Tool tool = createTool(toolFactories, firstToolExecuteParams, toolSpec);
+                tools.put(tool.getName(), tool);
                 firstStepListener = new StepListener<>();
                 previousStepListener = firstStepListener;
                 firstTool = tool;
@@ -137,13 +150,16 @@ public class MLFlowAgentRunner implements MLAgentRunner {
 
                     if (finalI == toolSpecs.size()) {
                         if (memoryId == null || parentInteractionId == null || memorySpec == null || memorySpec.getType() == null) {
+                            cleanUpResource(tools);
                             listener.onResponse(flowAgentOutput);
                         } else {
                             ActionListener<UpdateResponse> updateListener = ActionListener.wrap(updateResponse -> {
                                 log.info("Updated additional info for interaction ID: {} in the flow agent.", updateResponse.getId());
+                                cleanUpResource(tools);
                                 listener.onResponse(flowAgentOutput);
                             }, e -> {
                                 log.error("Failed to update root interaction", e);
+                                cleanUpResource(tools);
                                 listener.onResponse(flowAgentOutput);
                             });
                             updateMemoryWithListener(additionalInfo, memorySpec, memoryId, parentInteractionId, updateListener);
@@ -154,19 +170,27 @@ public class MLFlowAgentRunner implements MLAgentRunner {
                     MLToolSpec toolSpec = toolSpecs.get(finalI);
                     Map<String, String> executeParams = ToolUtils.buildToolParameters(params, toolSpec, mlAgent.getTenantId());
                     Tool tool = createTool(toolFactories, executeParams, toolSpec);
+                    tools.put(tool.getName(), tool);
                     if (finalI < toolSpecs.size()) {
                         tool.run(executeParams, nextStepListener);
                     }
 
                 }, e -> {
                     log.error("Failed to run flow agent", e);
+                    cleanUpResource(tools);
                     listener.onFailure(e);
                 });
                 previousStepListener = nextStepListener;
             }
         }
         if (toolSpecs.size() == 1) {
-            firstTool.run(firstToolExecuteParams, listener);
+            firstTool.run(firstToolExecuteParams, ActionListener.wrap(r -> {
+                cleanUpResource(tools);
+                listener.onResponse(r);
+            }, e -> {
+                cleanUpResource(tools);
+                listener.onFailure(e);
+            }));
         } else {
             firstTool.run(firstToolExecuteParams, firstStepListener);
         }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -6,9 +6,11 @@
 package org.opensearch.ml.engine.algorithms.agent;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -22,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.MCP_CONNECTORS_FIELD;
 import static org.opensearch.ml.common.CommonValue.MCP_CONNECTOR_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.MCP_SYNC_CLIENT;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREDENTIAL_FIELD;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.DEFAULT_DATETIME_PREFIX;
@@ -39,8 +42,8 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TO
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_NAME;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALL_ID;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALL_ID_PATH;
-import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_DESCRIPTIONS_FIELD;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_FILTERS_FIELD;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_DESCRIPTIONS_FIELD;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_TEMPLATE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.createTool;
 import static org.opensearch.ml.engine.algorithms.agent.MLChatAgentRunner.ACTION;
@@ -1929,6 +1932,7 @@ public class AgentUtilsTest extends MLStaticMockBase {
         }
     }
 
+
     @Test
     public void testGetMcpToolSpecs_MultipleConnectorsMerged() throws Exception {
         stubGetConnector();                                  // now safe
@@ -1959,6 +1963,100 @@ public class AgentUtilsTest extends MLStaticMockBase {
             AgentUtils.getMcpToolSpecs(agent, client, sdkClient, encryptor, listener);
             verify(listener).onResponse(expected);
         }
+    }
+
+    @Test
+    public void testGetMcpToolSpecs_DuplicateToolNamesWarning() throws Exception {
+        String loggerName = AgentUtils.class.getName();
+        DuplicateToolWarningLogAppender appender = new DuplicateToolWarningLogAppender("DuplicateToolWarningAppender");
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        LoggerConfig loggerConfig = context.getConfiguration().getLoggerConfig(loggerName);
+        Level originalLevel = loggerConfig.getLevel();
+        loggerConfig.addAppender(appender, Level.ALL, null);
+        context.updateLoggers();
+
+        try {
+            loggerConfig.setLevel(Level.WARN);
+            context.updateLoggers();
+            appender.clear();
+
+            List<MLToolSpec> responseWithWarn = fetchMcpToolSpecsFromDuplicateConnectors();
+            assertEquals(2, responseWithWarn.size());
+            assertEquals("shared_tool", responseWithWarn.get(0).getName());
+            assertEquals("shared_tool", responseWithWarn.get(1).getName());
+            assertTrue(hasDuplicateToolNameWarning(appender, "shared_tool", "connector-A", "connector-B"));
+
+            // Setting log level as ERROR disables WARN, so duplicate-tool tracking is skipped.
+            loggerConfig.setLevel(Level.ERROR);
+            context.updateLoggers();
+            appender.clear();
+
+            List<MLToolSpec> responseWhenWarnDisabled = fetchMcpToolSpecsFromDuplicateConnectors();
+            assertEquals(2, responseWhenWarnDisabled.size());
+            assertFalse(hasDuplicateToolNameWarning(appender, "shared_tool", "connector-A", "connector-B"));
+        } finally {
+            loggerConfig.removeAppender(appender.getName());
+            appender.stop();
+            loggerConfig.setLevel(originalLevel);
+            context.updateLoggers();
+        }
+    }
+
+    private List<MLToolSpec> fetchMcpToolSpecsFromDuplicateConnectors() throws Exception {
+        stubGetConnector();
+
+        MLToolSpec toolFromA = MLToolSpec.builder().type(McpSseTool.TYPE).name("shared_tool").description("from-A").build();
+        MLToolSpec toolFromB = MLToolSpec.builder().type(McpSseTool.TYPE).name("shared_tool").description("from-B").build();
+
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpConnector(connStatic);
+
+            McpConnectorExecutor exec = mock(McpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenReturn(List.of(toolFromA), List.of(toolFromB));
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            String mcpJsonConfig = "[{\""
+                + MCP_CONNECTOR_ID_FIELD
+                + "\":\"connector-A\"},"
+                + "{\""
+                + MCP_CONNECTOR_ID_FIELD
+                + "\":\"connector-B\"}]";
+            MLAgent agent = mockAgent(mcpJsonConfig, "tenant");
+
+            AtomicReference<List<MLToolSpec>> response = new AtomicReference<>();
+            ActionListener<List<MLToolSpec>> listener = ActionListener.wrap(response::set, e -> { Assert.fail("Should not fail"); });
+
+            AgentUtils.getMcpToolSpecs(agent, client, sdkClient, encryptor, listener);
+
+            assertNotNull(response.get());
+            return response.get();
+        }
+    }
+
+    private boolean hasDuplicateToolNameWarning(DuplicateToolWarningLogAppender appender, String toolName, String... connectorIds) {
+        for (LogEvent event : appender.getLogEvents()) {
+            if (event.getLevel() != Level.WARN) {
+                continue;
+            }
+            String message = event.getMessage().getFormattedMessage();
+            if (!message.contains(toolName)) {
+                continue;
+            }
+            boolean allConnectorsPresent = true;
+            for (String connectorId : connectorIds) {
+                if (!message.contains(connectorId)) {
+                    allConnectorsPresent = false;
+                    break;
+                }
+            }
+            if (allConnectorsPresent) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Test
@@ -2605,6 +2703,459 @@ public class AgentUtilsTest extends MLStaticMockBase {
 
         AgentUtils.getMcpToolSpecs(mlAgent, client, sdkClient, null, listener);
         verify(listener).onResponse(Collections.emptyList());
+    }
+
+    @Test
+    public void testResolveFlowToolSpecsWithMcpValidation_MixedOpenSearchAndMcpToolsSuccess() throws Exception {
+        stubGetConnector();
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpStreamableHttpConnector(connStatic);
+            List<MLToolSpec> mcpFromConnector = List
+                .of(
+                    MLToolSpec
+                        .builder()
+                        .type(McpStreamableHttpTool.TYPE)
+                        .name("mcp_price")
+                        .description("remote price tool")
+                        .runtimeResources(Map.of(MCP_SYNC_CLIENT, "remote_client"))
+                        .build(),
+                    MLToolSpec
+                        .builder()
+                        .type(McpStreamableHttpTool.TYPE)
+                        .name("mcp_trending")
+                        .description("remote trending tool")
+                        .runtimeResources(Map.of(MCP_SYNC_CLIENT, "remote_client"))
+                        .build()
+                );
+            McpStreamableHttpConnectorExecutor exec = mock(McpStreamableHttpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenReturn(mcpFromConnector);
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            MLToolSpec osTool1 = MLToolSpec.builder().type("VectorDBTool").name("os_vector").description("os vector").build();
+            MLToolSpec mcpTool1 = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("mcp_price")
+                .description(null)
+                .runtimeResources(Map.of("custom_runtime", "agent_value"))
+                .build();
+            MLToolSpec osTool2 = MLToolSpec.builder().type("MLModelTool").name("os_llm").description("os llm").build();
+            MLToolSpec mcpTool2 = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("mcp_trending")
+                .description("configured trending description")
+                .build();
+
+            MLAgent agent = MLAgent
+                .builder()
+                .tenantId("tenant")
+                .name("agent")
+                .type("flow")
+                .tools(List.of(osTool1, mcpTool1, osTool2, mcpTool2))
+                .parameters(Map.of(MCP_CONNECTORS_FIELD, "[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]"))
+                .build();
+
+            AtomicReference<List<MLToolSpec>> response = new AtomicReference<>();
+            ActionListener<List<MLToolSpec>> listener = ActionListener.wrap(response::set, e -> { Assert.fail("Should not fail"); });
+
+            AgentUtils.resolveFlowToolSpecsWithMcpValidation(agent, new HashMap<>(), client, sdkClient, encryptor, listener);
+
+            assertNotNull(response.get());
+            assertEquals(4, response.get().size());
+            // Ensure original configured order is preserved
+            assertEquals("os_vector", response.get().get(0).getName());
+            assertEquals("mcp_price", response.get().get(1).getName());
+            assertEquals("os_llm", response.get().get(2).getName());
+            assertEquals("mcp_trending", response.get().get(3).getName());
+
+            // MCP tool #1 takes remote description fallback and merged runtime resources
+            MLToolSpec resolvedMcp1 = response.get().get(1);
+            assertEquals("remote price tool", resolvedMcp1.getDescription());
+            assertEquals("remote_client", resolvedMcp1.getRuntimeResources().get(MCP_SYNC_CLIENT));
+            assertEquals("agent_value", resolvedMcp1.getRuntimeResources().get("custom_runtime"));
+
+            // MCP tool #2 keeps configured description
+            MLToolSpec resolvedMcp2 = response.get().get(3);
+            assertEquals("configured trending description", resolvedMcp2.getDescription());
+            assertEquals("remote_client", resolvedMcp2.getRuntimeResources().get(MCP_SYNC_CLIENT));
+        }
+    }
+
+    @Test
+    public void testResolveFlowToolSpecsWithMcpValidation_MissingConfiguredMcpTool() throws Exception {
+        stubGetConnector();
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpStreamableHttpConnector(connStatic);
+            McpStreamableHttpConnectorExecutor exec = mock(McpStreamableHttpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs())
+                .thenReturn(
+                    List.of(MLToolSpec.builder().type(McpStreamableHttpTool.TYPE).name("available_tool").description("mock").build())
+                );
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            MLAgent agent = MLAgent
+                .builder()
+                .tenantId("tenant")
+                .name("agent")
+                .type("flow")
+                .tools(List.of(MLToolSpec.builder().type(McpStreamableHttpTool.TYPE).name("missing_tool").build()))
+                .parameters(Map.of(MCP_CONNECTORS_FIELD, "[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]"))
+                .build();
+            AtomicReference<Exception> failure = new AtomicReference<>();
+            ActionListener<List<MLToolSpec>> listener = ActionListener
+                .wrap(r -> { Assert.fail("Expected failure for missing MCP tool"); }, failure::set);
+
+            AgentUtils.resolveFlowToolSpecsWithMcpValidation(agent, new HashMap<>(), client, sdkClient, encryptor, listener);
+
+            assertNotNull(failure.get());
+            assertTrue(failure.get().getMessage().contains("missing_tool"));
+            assertTrue(failure.get().getMessage().contains("not available"));
+        }
+    }
+
+    @Test
+    public void testResolveFlowToolSpecsWithMcpValidation_NoToolConfigured() {
+        MLAgent agent = MLAgent.builder().tenantId("tenant").name("agent").type("flow").tools(Collections.emptyList()).build();
+        AtomicReference<List<MLToolSpec>> response = new AtomicReference<>();
+        ActionListener<List<MLToolSpec>> listener = ActionListener.wrap(response::set, e -> { Assert.fail("Should not fail"); });
+
+        AgentUtils.resolveFlowToolSpecsWithMcpValidation(agent, new HashMap<>(), client, sdkClient, encryptor, listener);
+
+        assertNotNull(response.get());
+        assertTrue(response.get().isEmpty());
+    }
+
+    @Test
+    public void testResolveFlowToolSpecsWithMcpValidation_NullConfiguredToolSpecs() {
+        MLAgent agent = MLAgent.builder().tenantId("tenant").name("agent").type("flow").tools(Collections.emptyList()).build();
+        AtomicReference<List<MLToolSpec>> response = new AtomicReference<>();
+        ActionListener<List<MLToolSpec>> listener = ActionListener.wrap(response::set, e -> { Assert.fail("Should not fail"); });
+
+        try (MockedStatic<AgentUtils> agentUtilsStatic = mockStatic(AgentUtils.class)) {
+            agentUtilsStatic.when(() -> AgentUtils.getMlToolSpecs(any(MLAgent.class), any(Map.class))).thenReturn(null);
+            agentUtilsStatic
+                .when(
+                    () -> AgentUtils
+                        .resolveFlowToolSpecsWithMcpValidation(
+                            any(MLAgent.class),
+                            any(Map.class),
+                            any(Client.class),
+                            any(SdkClient.class),
+                            any(Encryptor.class),
+                            any(ActionListener.class)
+                        )
+                )
+                .thenCallRealMethod();
+
+            AgentUtils.resolveFlowToolSpecsWithMcpValidation(agent, new HashMap<>(), client, sdkClient, encryptor, listener);
+        }
+
+        assertNotNull(response.get());
+        assertTrue(response.get().isEmpty());
+    }
+
+    @Test
+    public void testResolveFlowToolSpecsWithMcpValidation_NoMcpToolConfigured() {
+        MLToolSpec configured = MLToolSpec.builder().type("MLModelTool").name("tool1").description("llm").build();
+        MLAgent agent = MLAgent.builder().tenantId("tenant").name("agent").type("flow").tools(List.of(configured)).build();
+        AtomicReference<List<MLToolSpec>> response = new AtomicReference<>();
+        ActionListener<List<MLToolSpec>> listener = ActionListener.wrap(response::set, e -> { Assert.fail("Should not fail"); });
+
+        AgentUtils.resolveFlowToolSpecsWithMcpValidation(agent, new HashMap<>(), client, sdkClient, encryptor, listener);
+
+        assertNotNull(response.get());
+        assertEquals(1, response.get().size());
+        assertEquals("tool1", response.get().get(0).getName());
+        assertEquals("MLModelTool", response.get().get(0).getType());
+    }
+
+    @Test
+    public void testResolveFlowToolSpecsWithMcpValidation_McpMergeUsesRuntimeResourcesAndFallbacks() throws Exception {
+        stubGetConnector();
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpStreamableHttpConnector(connStatic);
+            MLToolSpec mcpFetched = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("get_simple_price")
+                .description("remote desc")
+                .attributes(
+                    Map
+                        .of(
+                            "input_schema",
+                            "\"{\"type\":\"object\",\"properties\":{\"query\":"
+                                + "{\"type\":\"string\",\"description\":\"The query to search for.\"}}"
+                        )
+                )
+                .runtimeResources(Map.of(MCP_SYNC_CLIENT, "from_remote"))
+                .build();
+            McpStreamableHttpConnectorExecutor exec = mock(McpStreamableHttpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenReturn(List.of(mcpFetched));
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            MLToolSpec configuredMcp = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("get_simple_price")
+                .description(null)
+                .attributes(null)
+                .runtimeResources(Map.of("custom_runtime", "from_agent"))
+                .build();
+            MLToolSpec configuredLlm = MLToolSpec.builder().type("MLModelTool").name("summarizer").description("keep me").build();
+            MLAgent agent = MLAgent
+                .builder()
+                .tenantId("tenant")
+                .name("agent")
+                .type("flow")
+                .tools(List.of(configuredMcp, configuredLlm))
+                .parameters(Map.of(MCP_CONNECTORS_FIELD, "[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]"))
+                .build();
+
+            AtomicReference<List<MLToolSpec>> response = new AtomicReference<>();
+            ActionListener<List<MLToolSpec>> listener = ActionListener.wrap(response::set, e -> { Assert.fail("Should not fail"); });
+
+            AgentUtils.resolveFlowToolSpecsWithMcpValidation(agent, new HashMap<>(), client, sdkClient, encryptor, listener);
+
+            assertNotNull(response.get());
+            assertEquals(2, response.get().size());
+            MLToolSpec mergedMcp = response.get().get(0);
+            assertEquals("get_simple_price", mergedMcp.getName());
+            assertEquals("remote desc", mergedMcp.getDescription());
+            assertEquals(
+                "\"{\"type\":\"object\",\"properties\":{\"query\":" + "{\"type\":\"string\",\"description\":\"The query to search for.\"}}",
+                mergedMcp.getAttributes().get("input_schema")
+            );
+            assertEquals("from_remote", mergedMcp.getRuntimeResources().get(MCP_SYNC_CLIENT));
+            assertEquals("from_agent", mergedMcp.getRuntimeResources().get("custom_runtime"));
+            assertEquals("summarizer", response.get().get(1).getName());
+            assertEquals("keep me", response.get().get(1).getDescription());
+        }
+    }
+
+    @Test
+    public void testResolveFlowToolSpecsWithMcpValidation_ConfiguredMcpSyncClientIsIgnored() throws Exception {
+        stubGetConnector();
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpStreamableHttpConnector(connStatic);
+            Object remoteClient = new Object();
+            MLToolSpec mcpFetched = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("get_price")
+                .description("remote desc")
+                .runtimeResources(Map.of(MCP_SYNC_CLIENT, remoteClient))
+                .build();
+            McpStreamableHttpConnectorExecutor exec = mock(McpStreamableHttpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenReturn(List.of(mcpFetched));
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            MLToolSpec configuredMcp = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("get_price")
+                .runtimeResources(Map.of(MCP_SYNC_CLIENT, "agent_override", "custom_runtime", "agent_value"))
+                .build();
+            MLAgent agent = MLAgent
+                .builder()
+                .tenantId("tenant")
+                .name("agent")
+                .type("flow")
+                .tools(List.of(configuredMcp))
+                .parameters(Map.of(MCP_CONNECTORS_FIELD, "[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]"))
+                .build();
+
+            AtomicReference<List<MLToolSpec>> response = new AtomicReference<>();
+            ActionListener<List<MLToolSpec>> listener = ActionListener.wrap(response::set, e -> { Assert.fail("Should not fail"); });
+
+            AgentUtils.resolveFlowToolSpecsWithMcpValidation(agent, new HashMap<>(), client, sdkClient, encryptor, listener);
+
+            assertNotNull(response.get());
+            assertEquals(1, response.get().size());
+            MLToolSpec mergedMcp = response.get().get(0);
+            assertSame(remoteClient, mergedMcp.getRuntimeResources().get(MCP_SYNC_CLIENT));
+            assertEquals("agent_value", mergedMcp.getRuntimeResources().get("custom_runtime"));
+        }
+    }
+
+    @Test
+    public void testResolveFlowToolSpecsWithMcpValidation_McpMergePreservesConfiguredAndEmptyRuntimeResources() throws Exception {
+        stubGetConnector();
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpStreamableHttpConnector(connStatic);
+            MLToolSpec mcpFetched = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("get_search")
+                .description("remote desc")
+                .attributes(Map.of("remote_attr", "remote"))
+                .runtimeResources(null)
+                .build();
+            McpStreamableHttpConnectorExecutor exec = mock(McpStreamableHttpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenReturn(List.of(mcpFetched));
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            MLToolSpec configuredMcp = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("get_search")
+                .description("configured desc")
+                .attributes(Map.of("configured_attr", "configured"))
+                .runtimeResources(null)
+                .build();
+            MLAgent agent = MLAgent
+                .builder()
+                .tenantId("tenant")
+                .name("agent")
+                .type("flow")
+                .tools(List.of(configuredMcp))
+                .parameters(Map.of(MCP_CONNECTORS_FIELD, "[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]"))
+                .build();
+
+            AtomicReference<List<MLToolSpec>> response = new AtomicReference<>();
+            ActionListener<List<MLToolSpec>> listener = ActionListener.wrap(response::set, e -> { Assert.fail("Should not fail"); });
+
+            AgentUtils.resolveFlowToolSpecsWithMcpValidation(agent, new HashMap<>(), client, sdkClient, encryptor, listener);
+
+            assertNotNull(response.get());
+            assertEquals(1, response.get().size());
+            MLToolSpec mergedMcp = response.get().get(0);
+            assertEquals("configured desc", mergedMcp.getDescription());
+            assertEquals("remote", mergedMcp.getAttributes().get("remote_attr"));
+            assertEquals("configured", mergedMcp.getAttributes().get("configured_attr"));
+            assertNull(mergedMcp.getRuntimeResources());
+        }
+    }
+
+    @Test
+    public void testResolveFlowToolSpecsWithMcpValidation_PartialConfiguredAttributesMergeWithRemote() throws Exception {
+        stubGetConnector();
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpStreamableHttpConnector(connStatic);
+            MLToolSpec mcpFetched = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("get_tool")
+                .description("remote")
+                .attributes(
+                    Map
+                        .of(
+                            "input_schema",
+                            "\"{\"type\":\"object\",\"properties\":{\"query\":"
+                                + "{\"type\":\"string\",\"description\":\"The query to search for.\"}}"
+                        )
+                )
+                .runtimeResources(null)
+                .build();
+            McpStreamableHttpConnectorExecutor exec = mock(McpStreamableHttpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenReturn(List.of(mcpFetched));
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            MLToolSpec configuredMcp = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("get_tool")
+                .attributes(Map.of("cache_ttl", "300"))
+                .build();
+            MLAgent agent = MLAgent
+                .builder()
+                .tenantId("tenant")
+                .name("agent")
+                .type("flow")
+                .tools(List.of(configuredMcp))
+                .parameters(Map.of(MCP_CONNECTORS_FIELD, "[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]"))
+                .build();
+
+            AtomicReference<List<MLToolSpec>> response = new AtomicReference<>();
+            ActionListener<List<MLToolSpec>> listener = ActionListener.wrap(response::set, e -> { Assert.fail("Should not fail"); });
+
+            AgentUtils.resolveFlowToolSpecsWithMcpValidation(agent, new HashMap<>(), client, sdkClient, encryptor, listener);
+
+            assertEquals(1, response.get().size());
+            MLToolSpec merged = response.get().get(0);
+            assertEquals("300", merged.getAttributes().get("cache_ttl"));
+            assertEquals(
+                "\"{\"type\":\"object\",\"properties\":{\"query\":" + "{\"type\":\"string\",\"description\":\"The query to search for.\"}}",
+                merged.getAttributes().get("input_schema")
+            );
+        }
+    }
+
+    @Test
+    public void testResolveFlowToolSpecsWithMcpValidation_EmptyConfiguredAttributesUsesRemote() throws Exception {
+        stubGetConnector();
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpStreamableHttpConnector(connStatic);
+            MLToolSpec mcpFetched = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("get_tool")
+                .description("remote")
+                .attributes(
+                    Map
+                        .of(
+                            "input_schema",
+                            "\"{\"type\":\"object\",\"properties\":{\"query\":"
+                                + "{\"type\":\"string\",\"description\":\"The query to search for.\"}}"
+                        )
+                )
+                .runtimeResources(null)
+                .build();
+            McpStreamableHttpConnectorExecutor exec = mock(McpStreamableHttpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenReturn(List.of(mcpFetched));
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            MLToolSpec configuredMcp = MLToolSpec
+                .builder()
+                .type(McpStreamableHttpTool.TYPE)
+                .name("get_tool")
+                .description("configured")
+                .attributes(Collections.emptyMap())
+                .runtimeResources(null)
+                .build();
+            MLAgent agent = MLAgent
+                .builder()
+                .tenantId("tenant")
+                .name("agent")
+                .type("flow")
+                .tools(List.of(configuredMcp))
+                .parameters(Map.of(MCP_CONNECTORS_FIELD, "[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]"))
+                .build();
+
+            AtomicReference<List<MLToolSpec>> response = new AtomicReference<>();
+            ActionListener<List<MLToolSpec>> listener = ActionListener.wrap(response::set, e -> { Assert.fail("Should not fail"); });
+
+            AgentUtils.resolveFlowToolSpecsWithMcpValidation(agent, new HashMap<>(), client, sdkClient, encryptor, listener);
+
+            assertEquals(1, response.get().size());
+            MLToolSpec merged = response.get().get(0);
+            assertEquals("configured", merged.getDescription());
+            assertEquals(
+                "\"{\"type\":\"object\",\"properties\":{\"query\":" + "{\"type\":\"string\",\"description\":\"The query to search for.\"}}",
+                merged.getAttributes().get("input_schema")
+            );
+        }
     }
 
     // Helper method to mock McpStreamableHttpConnector
@@ -3348,5 +3899,27 @@ public class AgentUtilsTest extends MLStaticMockBase {
         assertNotNull(result.get());
         assertEquals("model-1", result.get()[0]); // falls back to modelId
         assertEquals("model-1", result.get()[1]); // falls back to modelId
+    }
+
+    private static class DuplicateToolWarningLogAppender extends AbstractAppender {
+        private final List<LogEvent> logEvents = new ArrayList<>();
+
+        DuplicateToolWarningLogAppender(String name) {
+            super(name, null, PatternLayout.createDefaultLayout(), false);
+            start();
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            logEvents.add(event.toImmutable());
+        }
+
+        List<LogEvent> getLogEvents() {
+            return logEvents;
+        }
+
+        void clear() {
+            logEvents.clear();
+        }
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -42,8 +42,8 @@ import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TO
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALLS_TOOL_NAME;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALL_ID;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_CALL_ID_PATH;
-import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_FILTERS_FIELD;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_DESCRIPTIONS_FIELD;
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_FILTERS_FIELD;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.TOOL_TEMPLATE;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.createTool;
 import static org.opensearch.ml.engine.algorithms.agent.MLChatAgentRunner.ACTION;
@@ -1931,7 +1931,6 @@ public class AgentUtilsTest extends MLStaticMockBase {
                 );
         }
     }
-
 
     @Test
     public void testGetMcpToolSpecs_MultipleConnectorsMerged() throws Exception {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLConversationalFlowAgentRunnerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLConversationalFlowAgentRunnerTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.agent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.MLAgentType;
+import org.opensearch.ml.common.agent.MLAgent;
+import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.McpConnector;
+import org.opensearch.ml.common.connector.McpStreamableHttpConnector;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.ml.engine.MLEngineClassLoader;
+import org.opensearch.ml.engine.MLStaticMockBase;
+import org.opensearch.ml.engine.algorithms.remote.McpConnectorExecutor;
+import org.opensearch.ml.engine.algorithms.remote.McpStreamableHttpConnectorExecutor;
+import org.opensearch.ml.engine.encryptor.Encryptor;
+import org.opensearch.ml.engine.tools.McpSseTool;
+import org.opensearch.ml.engine.tools.McpStreamableHttpTool;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.GetDataObjectResponse;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+public class MLConversationalFlowAgentRunnerTest extends MLStaticMockBase {
+
+    private static final String FIRST_TOOL = "firstTool";
+    private static final String SECOND_TOOL = "secondTool";
+
+    @Mock
+    private Client client;
+    @Mock
+    private ClusterService clusterService;
+    @Mock
+    private NamedXContentRegistry xContentRegistry;
+    @Mock
+    private ActionListener<Object> agentActionListener;
+    @Mock
+    private Tool.Factory firstToolFactory;
+    @Mock
+    private Tool.Factory secondToolFactory;
+    @Mock
+    private Tool firstTool;
+    @Mock
+    private Tool secondTool;
+    @Mock
+    private SdkClient sdkClient;
+    @Mock
+    private Encryptor encryptor;
+    @Mock
+    private ThreadPool threadPool;
+
+    private MLConversationalFlowAgentRunner runner;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        runner = new MLConversationalFlowAgentRunner(
+            client,
+            Settings.builder().build(),
+            clusterService,
+            xContentRegistry,
+            Map.of(FIRST_TOOL, firstToolFactory, SECOND_TOOL, secondToolFactory),
+            Map.of(),
+            sdkClient,
+            encryptor
+        );
+        when(firstToolFactory.create(anyMap())).thenReturn(firstTool);
+        when(secondToolFactory.create(anyMap())).thenReturn(secondTool);
+        when(firstTool.getDescription()).thenReturn("first tool description");
+        when(secondTool.getDescription()).thenReturn("second tool description");
+        when(firstTool.getName()).thenReturn(FIRST_TOOL);
+        when(secondTool.getName()).thenReturn(SECOND_TOOL);
+        doAnswer(invocation -> {
+            ActionListener<Object> listener = invocation.getArgument(1);
+            listener.onResponse("tool-output");
+            return null;
+        }).when(firstTool).run(anyMap(), any(ActionListener.class));
+        doAnswer(invocation -> {
+            ActionListener<Object> listener = invocation.getArgument(1);
+            listener.onResponse("tool-output");
+            return null;
+        }).when(secondTool).run(anyMap(), any(ActionListener.class));
+    }
+
+    @Test
+    public void testRun_WithMcpStreamableHttp_Tools_Success() throws Exception {
+        runMixedOpenSearchAndMcpToolsSuccessTest(McpStreamableHttpTool.TYPE, McpStreamableHttpTool.TYPE);
+    }
+
+    @Test
+    public void testRun_WithMcpSse_Tools_Success() throws Exception {
+        runMixedOpenSearchAndMcpToolsSuccessTest(McpSseTool.TYPE, McpSseTool.TYPE);
+    }
+
+    private void runMixedOpenSearchAndMcpToolsSuccessTest(String mcpToolType, String mcpProtocol) throws Exception {
+        final Map<String, String> params = new HashMap<>();
+        final MLAgent mlAgent = MLAgent
+            .builder()
+            .name("TestAgent")
+            .type(MLAgentType.CONVERSATIONAL_FLOW.name())
+            .tenantId("tenant")
+            .parameters(Map.of("mcp_connectors", "[{\"mcp_connector_id\":\"connector_1\"}]"))
+            .build();
+        final MLToolSpec osTool1 = MLToolSpec.builder().name("os_tool_1").type(FIRST_TOOL).includeOutputInAgentResponse(true).build();
+        final MLToolSpec mcpTool1 = MLToolSpec.builder().name("mcp_tool_1").type(mcpToolType).includeOutputInAgentResponse(true).build();
+        final MLToolSpec osTool2 = MLToolSpec.builder().name("os_tool_2").type(SECOND_TOOL).includeOutputInAgentResponse(true).build();
+        final MLToolSpec mcpTool2 = MLToolSpec.builder().name("mcp_tool_2").type(mcpToolType).includeOutputInAgentResponse(true).build();
+
+        Map<String, Tool.Factory> extendedFactories = new HashMap<>(Map.of(FIRST_TOOL, firstToolFactory, SECOND_TOOL, secondToolFactory));
+        extendedFactories.put(mcpToolType, firstToolFactory);
+        MLConversationalFlowAgentRunner runnerWithMcp = new MLConversationalFlowAgentRunner(
+            client,
+            Settings.builder().build(),
+            clusterService,
+            xContentRegistry,
+            extendedFactories,
+            Map.of(),
+            sdkClient,
+            encryptor
+        );
+
+        ThreadContext threadContext = new ThreadContext(Settings.builder().build());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenAnswer(inv -> {
+            String json = "{\"_index\":\"i\",\"_id\":\"j\",\"found\":true,\"_source\":{}}";
+            CompletionStage<GetDataObjectResponse> stage = mock(CompletionStage.class);
+            when(stage.whenComplete(any())).thenAnswer(cbInv -> {
+                try (
+                    org.opensearch.core.xcontent.XContentParser parser = XContentType.JSON
+                        .xContent()
+                        .createParser(NamedXContentRegistry.EMPTY, null, json)
+                ) {
+                    GetDataObjectResponse resp = mock(GetDataObjectResponse.class);
+                    when(resp.parser()).thenReturn(parser);
+                    BiConsumer<GetDataObjectResponse, Throwable> cb = cbInv.getArgument(0);
+                    cb.accept(resp, null);
+                }
+                return stage;
+            });
+            return stage;
+        });
+
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            if ("mcp_sse".equals(mcpProtocol)) {
+                McpConnector mockConnector = mock(McpConnector.class);
+                when(mockConnector.getProtocol()).thenReturn("mcp_sse");
+                doAnswer(invocation -> {
+                    ActionListener<Boolean> listener = invocation.getArgument(3);
+                    listener.onResponse(true);
+                    return null;
+                }).when(mockConnector).decrypt(anyString(), any(), anyString(), any(ActionListener.class));
+                connStatic
+                    .when(() -> Connector.createConnector(any(org.opensearch.core.xcontent.XContentParser.class)))
+                    .thenReturn(mockConnector);
+                McpConnectorExecutor exec = mock(McpConnectorExecutor.class);
+                when(exec.getMcpToolSpecs())
+                    .thenReturn(
+                        List
+                            .of(
+                                MLToolSpec.builder().name("mcp_tool_1").type(mcpToolType).runtimeResources(Map.of()).build(),
+                                MLToolSpec.builder().name("mcp_tool_2").type(mcpToolType).runtimeResources(Map.of()).build()
+                            )
+                    );
+                loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+            } else {
+                McpStreamableHttpConnector mockConnector = mock(McpStreamableHttpConnector.class);
+                when(mockConnector.getProtocol()).thenReturn("mcp_streamable_http");
+                doAnswer(invocation -> {
+                    ActionListener<Boolean> listener = invocation.getArgument(3);
+                    listener.onResponse(true);
+                    return null;
+                }).when(mockConnector).decrypt(anyString(), any(), anyString(), any(ActionListener.class));
+                connStatic
+                    .when(() -> Connector.createConnector(any(org.opensearch.core.xcontent.XContentParser.class)))
+                    .thenReturn(mockConnector);
+                McpStreamableHttpConnectorExecutor exec = mock(McpStreamableHttpConnectorExecutor.class);
+                when(exec.getMcpToolSpecs())
+                    .thenReturn(
+                        List
+                            .of(
+                                MLToolSpec.builder().name("mcp_tool_1").type(mcpToolType).runtimeResources(Map.of()).build(),
+                                MLToolSpec.builder().name("mcp_tool_2").type(mcpToolType).runtimeResources(Map.of()).build()
+                            )
+                    );
+                loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+            }
+
+            MLAgent runnableAgent = mlAgent.toBuilder().tools(List.of(osTool1, mcpTool1, osTool2, mcpTool2)).build();
+            runnerWithMcp.run(runnableAgent, params, agentActionListener, null);
+
+            ArgumentCaptor<Object> responseCaptor = ArgumentCaptor.forClass(Object.class);
+            verify(agentActionListener).onResponse(responseCaptor.capture());
+            @SuppressWarnings("unchecked")
+            List<ModelTensor> output = (List<ModelTensor>) responseCaptor.getValue();
+            assertEquals(4, output.size());
+            assertEquals("os_tool_1", output.get(0).getName());
+            assertEquals("mcp_tool_1", output.get(1).getName());
+            assertEquals("os_tool_2", output.get(2).getName());
+            assertEquals("mcp_tool_2", output.get(3).getName());
+        }
+    }
+
+    @Test
+    public void testRun_WhenNoToolConfigured_ShouldFail() {
+        MLAgent mlAgent = MLAgent.builder().name("TestAgent").type(MLAgentType.CONVERSATIONAL_FLOW.name()).tools(List.of()).build();
+        runner.run(mlAgent, new HashMap<>(), agentActionListener, null);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(agentActionListener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("no tool configured"));
+    }
+
+    @Test
+    public void testRun_WhenMcpToolConfiguredButNoMcpConnector_ShouldFail() {
+        MLToolSpec mcpTool = MLToolSpec.builder().name("missing_mcp_tool").type(McpStreamableHttpTool.TYPE).build();
+        MLAgent mlAgent = MLAgent.builder().name("TestAgent").type(MLAgentType.CONVERSATIONAL_FLOW.name()).tools(List.of(mcpTool)).build();
+        runner.run(mlAgent, new HashMap<>(), agentActionListener, null);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(agentActionListener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("missing_mcp_tool"));
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("not available"));
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunnerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunnerTest.java
@@ -26,12 +26,15 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
@@ -40,15 +43,21 @@ import org.opensearch.action.StepListener;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.agent.MLAgent;
 import org.opensearch.ml.common.agent.MLMemorySpec;
 import org.opensearch.ml.common.agent.MLToolSpec;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.McpConnector;
+import org.opensearch.ml.common.connector.McpStreamableHttpConnector;
 import org.opensearch.ml.common.memory.Memory;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
@@ -57,15 +66,26 @@ import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskAction;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskResponse;
 import org.opensearch.ml.common.utils.ToolUtils;
+import org.opensearch.ml.engine.MLEngineClassLoader;
+import org.opensearch.ml.engine.MLStaticMockBase;
+import org.opensearch.ml.engine.algorithms.remote.McpConnectorExecutor;
+import org.opensearch.ml.engine.algorithms.remote.McpStreamableHttpConnectorExecutor;
+import org.opensearch.ml.engine.encryptor.Encryptor;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.engine.memory.ConversationIndexMemory;
 import org.opensearch.ml.engine.memory.MLMemoryManager;
 import org.opensearch.ml.engine.tools.AgentTool;
+import org.opensearch.ml.engine.tools.McpSseTool;
+import org.opensearch.ml.engine.tools.McpStreamableHttpTool;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.GetDataObjectResponse;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
 import software.amazon.awssdk.utils.ImmutableMap;
 
-public class MLFlowAgentRunnerTest {
+public class MLFlowAgentRunnerTest extends MLStaticMockBase {
 
     public static final String FIRST_TOOL = "firstTool";
     public static final String SECOND_TOOL = "secondTool";
@@ -79,6 +99,12 @@ public class MLFlowAgentRunnerTest {
     private Client client;
     @Mock
     MLIndicesHandler indicesHandler;
+    @Mock
+    private SdkClient sdkClient;
+    @Mock
+    private Encryptor encryptor;
+    @Mock
+    private ThreadPool threadPool;
 
     @Mock
     MLMemoryManager memoryManager;
@@ -638,5 +664,141 @@ public class MLFlowAgentRunnerTest {
         assertTrue("Escaped output should contain escaped newline", escapedOutput.contains("\\n"));
         assertTrue("Escaped output should contain escaped tab", escapedOutput.contains("\\t"));
         assertTrue("Escaped output should contain escaped quotes", escapedOutput.contains("\\\""));
+    }
+
+    @Test
+    public void testRun_WithMcpStreamableHttp_Tools_Success() throws Exception {
+        runMixedOpenSearchAndMcpToolsSuccessTest(McpStreamableHttpTool.TYPE, "mcp_streamable_http");
+    }
+
+    @Test
+    public void testRun_WithMcpSse_Tools_Success() throws Exception {
+        runMixedOpenSearchAndMcpToolsSuccessTest(McpSseTool.TYPE, "mcp_sse");
+    }
+
+    private void runMixedOpenSearchAndMcpToolsSuccessTest(String mcpToolType, String mcpProtocol) throws Exception {
+        final Map<String, String> params = new HashMap<>();
+        final MLAgent mlAgent = MLAgent
+            .builder()
+            .name("TestAgent")
+            .type(MLAgentType.FLOW.name())
+            .tenantId("tenant")
+            .parameters(Map.of("mcp_connectors", "[{\"mcp_connector_id\":\"connector_1\"}]"))
+            .build();
+        final MLToolSpec osTool1 = MLToolSpec.builder().name("os_tool_1").type(FIRST_TOOL).includeOutputInAgentResponse(true).build();
+        final MLToolSpec mcpTool1 = MLToolSpec.builder().name("mcp_tool_1").type(mcpToolType).includeOutputInAgentResponse(true).build();
+        final MLToolSpec osTool2 = MLToolSpec.builder().name("os_tool_2").type(SECOND_TOOL).includeOutputInAgentResponse(true).build();
+        final MLToolSpec mcpTool2 = MLToolSpec.builder().name("mcp_tool_2").type(mcpToolType).includeOutputInAgentResponse(true).build();
+
+        Map<String, Tool.Factory> extendedFactories = new HashMap<>(toolFactories);
+        extendedFactories.put(mcpToolType, firstToolFactory);
+        MLFlowAgentRunner runnerWithMcp = new MLFlowAgentRunner(
+            client,
+            settings,
+            clusterService,
+            xContentRegistry,
+            extendedFactories,
+            memoryMap,
+            sdkClient,
+            encryptor
+        );
+
+        ThreadContext threadContext = new ThreadContext(Settings.builder().build());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(sdkClient.getDataObjectAsync(any(GetDataObjectRequest.class))).thenAnswer(inv -> {
+            String json = "{\"_index\":\"i\",\"_id\":\"j\",\"found\":true,\"_source\":{}}";
+            CompletionStage<GetDataObjectResponse> stage = mock(CompletionStage.class);
+            when(stage.whenComplete(any())).thenAnswer(cbInv -> {
+                try (XContentParser parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, null, json)) {
+                    GetDataObjectResponse resp = mock(GetDataObjectResponse.class);
+                    when(resp.parser()).thenReturn(parser);
+                    BiConsumer<GetDataObjectResponse, Throwable> cb = cbInv.getArgument(0);
+                    cb.accept(resp, null);
+                }
+                return stage;
+            });
+            return stage;
+        });
+
+        when(firstToolFactory.create(anyMap())).thenReturn(firstTool);
+        when(firstTool.getDescription()).thenReturn(FIRST_TOOL_DESC);
+        doAnswer(invocation -> {
+            ActionListener<Object> listener = invocation.getArgument(1);
+            listener.onResponse("tool-output");
+            return null;
+        }).when(firstTool).run(anyMap(), any(ActionListener.class));
+
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            if ("mcp_sse".equals(mcpProtocol)) {
+                McpConnector mockConnector = mock(McpConnector.class);
+                when(mockConnector.getProtocol()).thenReturn("mcp_sse");
+                doAnswer(invocation -> {
+                    ActionListener<Boolean> listener = invocation.getArgument(3);
+                    listener.onResponse(true);
+                    return null;
+                }).when(mockConnector).decrypt(anyString(), any(), anyString(), any(ActionListener.class));
+                connStatic.when(() -> Connector.createConnector(any(XContentParser.class))).thenReturn(mockConnector);
+
+                McpConnectorExecutor exec = mock(McpConnectorExecutor.class);
+                when(exec.getMcpToolSpecs())
+                    .thenReturn(
+                        List
+                            .of(
+                                MLToolSpec.builder().name("mcp_tool_1").type(mcpToolType).runtimeResources(Map.of()).build(),
+                                MLToolSpec.builder().name("mcp_tool_2").type(mcpToolType).runtimeResources(Map.of()).build()
+                            )
+                    );
+                loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+            } else {
+                McpStreamableHttpConnector mockConnector = mock(McpStreamableHttpConnector.class);
+                when(mockConnector.getProtocol()).thenReturn("mcp_streamable_http");
+                doAnswer(invocation -> {
+                    ActionListener<Boolean> listener = invocation.getArgument(3);
+                    listener.onResponse(true);
+                    return null;
+                }).when(mockConnector).decrypt(anyString(), any(), anyString(), any(ActionListener.class));
+                connStatic.when(() -> Connector.createConnector(any(XContentParser.class))).thenReturn(mockConnector);
+
+                McpStreamableHttpConnectorExecutor exec = mock(McpStreamableHttpConnectorExecutor.class);
+                when(exec.getMcpToolSpecs())
+                    .thenReturn(
+                        List
+                            .of(
+                                MLToolSpec.builder().name("mcp_tool_1").type(mcpToolType).runtimeResources(Map.of()).build(),
+                                MLToolSpec.builder().name("mcp_tool_2").type(mcpToolType).runtimeResources(Map.of()).build()
+                            )
+                    );
+                loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+            }
+
+            MLAgent runnableAgent = mlAgent.toBuilder().tools(List.of(osTool1, mcpTool1, osTool2, mcpTool2)).build();
+            runnerWithMcp.run(runnableAgent, params, agentActionListener);
+
+            ArgumentCaptor<Object> responseCaptor = ArgumentCaptor.forClass(Object.class);
+            verify(agentActionListener).onResponse(responseCaptor.capture());
+            @SuppressWarnings("unchecked")
+            List<ModelTensor> output = (List<ModelTensor>) responseCaptor.getValue();
+            assertEquals(4, output.size());
+            assertEquals("os_tool_1", output.get(0).getName());
+            assertEquals("mcp_tool_1", output.get(1).getName());
+            assertEquals("os_tool_2", output.get(2).getName());
+            assertEquals("mcp_tool_2", output.get(3).getName());
+        }
+    }
+
+    @Test
+    public void testRun_WhenMcpToolConfiguredButNoMcpConnector_ShouldFail() {
+        MLToolSpec mcpTool = MLToolSpec.builder().name("missing_mcp_tool").type(McpStreamableHttpTool.TYPE).build();
+        MLAgent mlAgent = MLAgent.builder().name("TestAgent").type(MLAgentType.FLOW.name()).tools(List.of(mcpTool)).build();
+        mlFlowAgentRunner.run(mlAgent, new HashMap<>(), agentActionListener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(agentActionListener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("missing_mcp_tool"));
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("not available"));
     }
 }


### PR DESCRIPTION
### Description
Added MCP support for flow and conversational_flow agents by resolving tool specs through MCP connector discovery before execution, while preserving configured tool order.
Implemented strict validation for configured MCP tools: execution now fails fast with a clear error if any configured MCP tool is not available from connected MCP server(s).
Introduced MCP/OpenSearch mixed tool handling so Flow/Conversational Flow can execute standard OpenSearch tools and MCP tools in the same pipeline.
Kept existing flow semantics intact: output chaining (<tool>.output) and sequential execution remain unchanged.

RFC is available here - #4422
PR for 'REST API to list all tools available in a MCP server' - 4705

**Sample Agent format:**
```
curl -XPOST "http://localhost:9200/_plugins/_ml/agents/_register" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "flow_agent",
    "type": "flow",
    "description": "Flow agent using MCP tools in fixed order",
    "parameters": {
      "_llm_interface": "openai/v1/chat/completions",
      "mcp_connectors": [
        {
          "mcp_connector_id": "r3QQVp0BEV6c5jDC9Fa-"
        }
      ]
    },
    "tools": [
      {
        "name": "get_simple_price",
        "type": "McpStreamableHttpTool",
        "description": "Fetch BTC and ETH prices in USD",
        "parameters": {
          "input": "{\"ids\":\"bitcoin,ethereum\",\"vs_currencies\":\"usd\",\"include_24hr_change\":true,\"include_market_cap\":true,\"jq_filter\":\".\"}"
        }
      },
      {
        "name": "get_search_trending",
        "type": "McpStreamableHttpTool",
        "description": "Fetch trending coins",
        "parameters": {
          "input": "{\"show_max\":\"10\",\"jq_filter\":\".coins[:10]\"}"
        }
      },
      {
        "name": "MLModelTool",
        "type": "MLModelTool",
        "description": "Summarize MCP outputs",
        "parameters": {
          "model_id": "tXQRVp0BEV6c5jDCI1ZY",
          "prompt": "You are a crypto market analyst.\\n\\nCurrent prices:\\n${parameters.get_simple_price.output}\\n\\nTrending:\\n${parameters.get_search_trending.output}\\n\\nGive a concise summary with key observations and risks."
        }
      }
    ]
  }'
```

**Scenarios tested manually:**

 - Flow agent with MCP 
              - mcp_streamable_http
              -  mcp_sse
 - Conversational flow agent with MCP (mcp_streamable_http & mcp_sse)
               - mcp_streamable_http
              -  mcp_sse
               - Verified correct conversation context fields (memory_id, parent_interaction_id).
 - Flow agent output chaining
              - Tested flows where output from one MCP tool feeds the next tool input.
              - Confirmed sequential order behavior in flow agents.
- Covered missing/invalid MCP tool resolution behavior (configured tool not available).
 - Flow and conversational flow without MCP
 - Conversational Agent

**Added unit tests:**
MLFlowAgentRunnerTest.testRun_WithMcpStreamableHttp_Tools_Success — verifies flow runner executes successfully with mixed OpenSearch tools and mcp_streamable_http tools.
MLFlowAgentRunnerTest.testRun_WithMcpSse_Tools_Success — verifies flow runner executes successfully with mixed OpenSearch tools and mcp_sse tools.
MLFlowAgentRunnerTest.testRun_WhenMcpToolConfiguredButNoMcpConnector_ShouldFail — verifies flow runner fails with clear error when MCP tools are configured but connectors are missing.
MLConversationalFlowAgentRunnerTest.testRun_WithMcpStreamableHttp_Tools_Success — verifies conversational flow runner success path with mixed tools and mcp_streamable_http.
MLConversationalFlowAgentRunnerTest.testRun_WithMcpSse_Tools_Success — verifies conversational flow runner success path with mixed tools and mcp_sse.
MLConversationalFlowAgentRunnerTest.testRun_WhenNoToolConfigured_ShouldFail — verifies conversational flow runner fails when no tools are configured.
MLConversationalFlowAgentRunnerTest.testRun_WhenMcpToolConfiguredButNoMcpConnector_ShouldFail — verifies conversational flow runner fails when MCP tools exist but connector config is absent.
AgentUtilsTest.testResolveFlowToolSpecsWithMcpValidation_MixedOpenSearchAndMcpToolsSuccess — validates successful mixed resolution of 2 OpenSearch + 2 MCP tools with order preserved.
AgentUtilsTest.testResolveFlowToolSpecsWithMcpValidation_MissingConfiguredMcpTool — verifies failure when an agent-configured MCP tool is not present in connector-discovered tools.
AgentUtilsTest.testResolveFlowToolSpecsWithMcpValidation_NoToolConfigured — confirms empty tool config returns empty resolved list.
AgentUtilsTest.testResolveFlowToolSpecsWithMcpValidation_NoMcpToolConfigured — confirms non-MCP-only tool list is returned as-is without MCP lookup.
AgentUtilsTest.testResolveFlowToolSpecsWithMcpValidation_McpMergeUsesRuntimeResourcesAndFallbacks — checks MCP merge logic for runtime resource merge + description/attribute fallback.
AgentUtilsTest.testResolveFlowToolSpecsWithMcpValidation_McpMergePreservesConfiguredAndEmptyRuntimeResources — checks configured description/attributes are retained and null runtime resources stay null when appropriate.

### Related Issues
Resolves #3807 #4422

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
