### PR TITLE
Fail fast when tool is missing input_schema in function calling

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -240,6 +240,9 @@ public class AgentUtils {
             toolParams.put(NAME, StringEscapeUtils.escapeJson(tool.getName()));
             toolParams.put(DESCRIPTION, StringEscapeUtils.escapeJson(tool.getDescription()));
             Map<String, ?> attributes = tool.getAttributes();
+            if (attributes == null || !attributes.containsKey("input_schema")) {
+                toolParams.putIfAbsent("attributes.input_schema", "{\"type\":\"object\",\"properties\":{}}");
+            }
             if (attributes != null) {
                 for (String key : attributes.keySet()) {
                     toolParams.put("attributes." + key, attributes.get(key));

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -154,7 +154,6 @@ public class AgentUtils {
     private static final String NAME = "name";
     private static final String DESCRIPTION = "description";
     private static final String INPUT_SCHEMA = "input_schema";
-    private static final String DEFAULT_INPUT_SCHEMA = "{\"type\":\"object\",\"properties\":{}}";
     private static final Pattern ADDITIONAL_PROPERTIES_PATTERN = Pattern
         .compile(",\\s*\"additionalProperties\"\\s*:\\s*(?:false|true)", Pattern.CASE_INSENSITIVE);
     public static final String AGENT_LLM_MODEL_ID = "agent_llm_model_id";
@@ -243,18 +242,23 @@ public class AgentUtils {
             toolParams.put(DESCRIPTION, StringEscapeUtils.escapeJson(tool.getDescription()));
             Map<String, ?> attributes = tool.getAttributes();
             if (attributes == null || !attributes.containsKey(INPUT_SCHEMA)) {
-                toolParams.put("attributes." + INPUT_SCHEMA, DEFAULT_INPUT_SCHEMA);
+                throw new IllegalArgumentException(
+                    "Tool ["
+                        + toolName
+                        + "] is missing ["
+                        + INPUT_SCHEMA
+                        + "] in its attributes. "
+                        + "All tools used with function calling must define an input_schema."
+                );
             }
-            if (attributes != null) {
-                for (String key : attributes.keySet()) {
-                    toolParams.put("attributes." + key, attributes.get(key));
-                }
-                // For Gemini, clean input_schema to remove additionalProperties
-                if (parameters.containsKey("gemini.schema.cleaner") && attributes.containsKey(INPUT_SCHEMA)) {
-                    String schema = String.valueOf(attributes.get(INPUT_SCHEMA));
-                    String cleanedSchema = removeAdditionalPropertiesFromSchema(schema);
-                    toolParams.put("attributes.input_schema_cleaned", cleanedSchema);
-                }
+            for (String key : attributes.keySet()) {
+                toolParams.put("attributes." + key, attributes.get(key));
+            }
+            // For Gemini, clean input_schema to remove additionalProperties
+            if (parameters.containsKey("gemini.schema.cleaner") && attributes.containsKey(INPUT_SCHEMA)) {
+                String schema = String.valueOf(attributes.get(INPUT_SCHEMA));
+                String cleanedSchema = removeAdditionalPropertiesFromSchema(schema);
+                toolParams.put("attributes.input_schema_cleaned", cleanedSchema);
             }
             StringSubstitutor substitutor = new StringSubstitutor(toolParams, "${tool.", "}");
             String chatQuestionMessage = substitutor.replace(toolTemplate);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -241,7 +241,7 @@ public class AgentUtils {
             toolParams.put(DESCRIPTION, StringEscapeUtils.escapeJson(tool.getDescription()));
             Map<String, ?> attributes = tool.getAttributes();
             if (attributes == null || !attributes.containsKey("input_schema")) {
-                toolParams.putIfAbsent("attributes.input_schema", "{\"type\":\"object\",\"properties\":{}}");
+                toolParams.put("attributes.input_schema", "{\"type\":\"object\",\"properties\":{}}");
             }
             if (attributes != null) {
                 for (String key : attributes.keySet()) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -153,6 +153,8 @@ public class AgentUtils {
     public static final String TOKEN_USAGE_PATH = "token_usage_path";
     private static final String NAME = "name";
     private static final String DESCRIPTION = "description";
+    private static final String INPUT_SCHEMA = "input_schema";
+    private static final String DEFAULT_INPUT_SCHEMA = "{\"type\":\"object\",\"properties\":{}}";
     private static final Pattern ADDITIONAL_PROPERTIES_PATTERN = Pattern
         .compile(",\\s*\"additionalProperties\"\\s*:\\s*(?:false|true)", Pattern.CASE_INSENSITIVE);
     public static final String AGENT_LLM_MODEL_ID = "agent_llm_model_id";
@@ -240,16 +242,16 @@ public class AgentUtils {
             toolParams.put(NAME, StringEscapeUtils.escapeJson(tool.getName()));
             toolParams.put(DESCRIPTION, StringEscapeUtils.escapeJson(tool.getDescription()));
             Map<String, ?> attributes = tool.getAttributes();
-            if (attributes == null || !attributes.containsKey("input_schema")) {
-                toolParams.put("attributes.input_schema", "{\"type\":\"object\",\"properties\":{}}");
+            if (attributes == null || !attributes.containsKey(INPUT_SCHEMA)) {
+                toolParams.put("attributes." + INPUT_SCHEMA, DEFAULT_INPUT_SCHEMA);
             }
             if (attributes != null) {
                 for (String key : attributes.keySet()) {
                     toolParams.put("attributes." + key, attributes.get(key));
                 }
                 // For Gemini, clean input_schema to remove additionalProperties
-                if (parameters.containsKey("gemini.schema.cleaner") && attributes.containsKey("input_schema")) {
-                    String schema = String.valueOf(attributes.get("input_schema"));
+                if (parameters.containsKey("gemini.schema.cleaner") && attributes.containsKey(INPUT_SCHEMA)) {
+                    String schema = String.valueOf(attributes.get(INPUT_SCHEMA));
                     String cleanedSchema = removeAdditionalPropertiesFromSchema(schema);
                     toolParams.put("attributes.input_schema_cleaned", cleanedSchema);
                 }
@@ -1265,10 +1267,10 @@ public class AgentUtils {
 
             Object parameters = frontendTool.get("parameters");
             if (parameters != null) {
-                toolAttributes.put("input_schema", gson.toJson(parameters));
+                toolAttributes.put(INPUT_SCHEMA, gson.toJson(parameters));
             } else {
                 Map<String, Object> emptySchema = Map.of("type", "object", "properties", Map.of());
-                toolAttributes.put("input_schema", gson.toJson(emptySchema));
+                toolAttributes.put(INPUT_SCHEMA, gson.toJson(emptySchema));
             }
 
             Tool frontendToolObj = new AGUIFrontendTool(toolName, toolDescription, toolAttributes);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -517,7 +517,14 @@ public class MLChatAgentRunner implements MLAgentRunner {
         String sessionId = memory != null ? memory.getId() : null;
 
         Map<String, String> tmpParameters = constructLLMParams(llm, parameters);
-        String prompt = constructLLMPrompt(tools, tmpParameters);
+        String prompt;
+        try {
+            prompt = constructLLMPrompt(tools, tmpParameters);
+        } catch (Exception e) {
+            log.error("Failed to construct LLM prompt. agentId={}", agentId, e);
+            listener.onFailure(e);
+            return;
+        }
         tmpParameters.put(PROMPT, prompt);
         final String finalPrompt = prompt;
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -1270,10 +1270,30 @@ public class AgentUtilsTest extends MLStaticMockBase {
         AgentUtils.addToolsToFunctionCalling(tools, parameters, List.of("VectorDBTool"), "prompt");
 
         String result = parameters.get(TOOLS);
-        // Verify the placeholder was resolved (not left as raw ${tool.attributes.input_schema})
         Assert.assertFalse(result.contains("${tool.attributes.input_schema}"));
-        // Verify it's valid JSON
-        Assert.assertTrue(result.contains("\"inputSchema\":{\"json\":{\"type\":\"object\""));
+        Assert.assertTrue(result.contains("\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{}}}"));
+    }
+
+    @Test
+    public void testAddToolsToFunctionCalling_ToolWithAttributesButNoInputSchema() {
+        Tool toolNoSchema = mock(Tool.class);
+        when(toolNoSchema.getName()).thenReturn("VectorDBTool");
+        when(toolNoSchema.getDescription()).thenReturn("knn dense retrieval tool");
+        when(toolNoSchema.getAttributes()).thenReturn(Map.of("some_other_key", "value"));
+
+        Map<String, Tool> tools = new HashMap<>();
+        tools.put("VectorDBTool", toolNoSchema);
+
+        Map<String, String> parameters = new HashMap<>();
+        String toolTemplate =
+            "{\"toolSpec\":{\"name\":\"${tool.name}\",\"description\":\"${tool.description}\",\"inputSchema\":{\"json\":${tool.attributes.input_schema}}}}";
+        parameters.put(TOOL_TEMPLATE, toolTemplate);
+
+        AgentUtils.addToolsToFunctionCalling(tools, parameters, List.of("VectorDBTool"), "prompt");
+
+        String result = parameters.get(TOOLS);
+        Assert.assertFalse(result.contains("${tool.attributes.input_schema}"));
+        Assert.assertTrue(result.contains("\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{}}}"));
     }
 
     @Test

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -1253,6 +1253,30 @@ public class AgentUtilsTest extends MLStaticMockBase {
     }
 
     @Test
+    public void testAddToolsToFunctionCalling_ToolWithNoInputSchema() {
+        Tool toolNoSchema = mock(Tool.class);
+        when(toolNoSchema.getName()).thenReturn("VectorDBTool");
+        when(toolNoSchema.getDescription()).thenReturn("knn dense retrieval tool");
+        when(toolNoSchema.getAttributes()).thenReturn(null);
+
+        Map<String, Tool> tools = new HashMap<>();
+        tools.put("VectorDBTool", toolNoSchema);
+
+        Map<String, String> parameters = new HashMap<>();
+        String toolTemplate =
+            "{\"toolSpec\":{\"name\":\"${tool.name}\",\"description\":\"${tool.description}\",\"inputSchema\":{\"json\":${tool.attributes.input_schema}}}}";
+        parameters.put(TOOL_TEMPLATE, toolTemplate);
+
+        AgentUtils.addToolsToFunctionCalling(tools, parameters, List.of("VectorDBTool"), "prompt");
+
+        String result = parameters.get(TOOLS);
+        // Verify the placeholder was resolved (not left as raw ${tool.attributes.input_schema})
+        Assert.assertFalse(result.contains("${tool.attributes.input_schema}"));
+        // Verify it's valid JSON
+        Assert.assertTrue(result.contains("\"inputSchema\":{\"json\":{\"type\":\"object\""));
+    }
+
+    @Test
     public void testAddToolsToFunctionCalling_ToolNotRegistered() {
         Map<String, Tool> tools = new HashMap<>();
         tools.put("Tool1", tool1);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -1230,11 +1230,11 @@ public class AgentUtilsTest extends MLStaticMockBase {
 
         when(tool1.getName()).thenReturn("Tool1");
         when(tool1.getDescription()).thenReturn("Description of Tool1");
-        when(tool1.getAttributes()).thenReturn(Map.of("param1", "value1"));
+        when(tool1.getAttributes()).thenReturn(Map.of("param1", "value1", "input_schema", "{\"type\":\"object\",\"properties\":{}}"));
 
         when(tool2.getName()).thenReturn("Tool2");
         when(tool2.getDescription()).thenReturn("Description of Tool2");
-        when(tool2.getAttributes()).thenReturn(Map.of("param2", "value2"));
+        when(tool2.getAttributes()).thenReturn(Map.of("param2", "value2", "input_schema", "{\"type\":\"object\",\"properties\":{}}"));
 
         Map<String, String> parameters = new HashMap<>();
         String toolTemplate = "{\"name\": \"${tool.name}\", \"description\": \"${tool.description}\"}";
@@ -1267,11 +1267,13 @@ public class AgentUtilsTest extends MLStaticMockBase {
             "{\"toolSpec\":{\"name\":\"${tool.name}\",\"description\":\"${tool.description}\",\"inputSchema\":{\"json\":${tool.attributes.input_schema}}}}";
         parameters.put(TOOL_TEMPLATE, toolTemplate);
 
-        AgentUtils.addToolsToFunctionCalling(tools, parameters, List.of("VectorDBTool"), "prompt");
-
-        String result = parameters.get(TOOLS);
-        Assert.assertFalse(result.contains("${tool.attributes.input_schema}"));
-        Assert.assertTrue(result.contains("\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{}}}"));
+        Exception ex = Assert
+            .assertThrows(
+                IllegalArgumentException.class,
+                () -> AgentUtils.addToolsToFunctionCalling(tools, parameters, List.of("VectorDBTool"), "prompt")
+            );
+        Assert.assertTrue(ex.getMessage().contains("VectorDBTool"));
+        Assert.assertTrue(ex.getMessage().contains("input_schema"));
     }
 
     @Test
@@ -1289,11 +1291,13 @@ public class AgentUtilsTest extends MLStaticMockBase {
             "{\"toolSpec\":{\"name\":\"${tool.name}\",\"description\":\"${tool.description}\",\"inputSchema\":{\"json\":${tool.attributes.input_schema}}}}";
         parameters.put(TOOL_TEMPLATE, toolTemplate);
 
-        AgentUtils.addToolsToFunctionCalling(tools, parameters, List.of("VectorDBTool"), "prompt");
-
-        String result = parameters.get(TOOLS);
-        Assert.assertFalse(result.contains("${tool.attributes.input_schema}"));
-        Assert.assertTrue(result.contains("\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{}}}"));
+        Exception ex = Assert
+            .assertThrows(
+                IllegalArgumentException.class,
+                () -> AgentUtils.addToolsToFunctionCalling(tools, parameters, List.of("VectorDBTool"), "prompt")
+            );
+        Assert.assertTrue(ex.getMessage().contains("VectorDBTool"));
+        Assert.assertTrue(ex.getMessage().contains("input_schema"));
     }
 
     @Test

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerTest.java
@@ -317,6 +317,38 @@ public class MLChatAgentRunnerTest {
     }
 
     @Test
+    public void testRunWithToolMissingInputSchemaInFunctionCalling_PropagatesFailureToListener() {
+        // When using function calling (TOOL_TEMPLATE set in params), a tool missing input_schema
+        // must fail fast with an IllegalArgumentException routed to listener.onFailure, not hang
+        // the caller. Mimics the V2 propagation behavior for the V1 chat runner path.
+        LLMSpec llmSpec = LLMSpec.builder().modelId("MODEL_ID").build();
+        // Tool attributes do NOT contain input_schema
+        when(firstTool.getAttributes()).thenReturn(null);
+        MLToolSpec toolSpec = MLToolSpec.builder().name(FIRST_TOOL).type(FIRST_TOOL).build();
+        MLAgent mlAgent = MLAgent
+            .builder()
+            .name("TestAgent")
+            .type(MLAgentType.CONVERSATIONAL.name())
+            .llm(llmSpec)
+            .memory(mlMemorySpec)
+            .tools(Arrays.asList(toolSpec))
+            .parameters(ImmutableMap.of("_llm_interface", "bedrock/converse/claude"))
+            .build();
+        // Force the function-calling code path (addToolsToFunctionCalling) in addToolsToPrompt
+        Map<String, String> params = new HashMap<>();
+        params.put(AgentUtils.TOOL_TEMPLATE, "${tool.attributes.input_schema}");
+
+        mlChatAgentRunner.run(mlAgent, params, agentActionListener, null);
+
+        ArgumentCaptor<Exception> exCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(agentActionListener).onFailure(exCaptor.capture());
+        Exception thrown = exCaptor.getValue();
+        assertTrue("expected IllegalArgumentException but got " + thrown.getClass(), thrown instanceof IllegalArgumentException);
+        assertTrue("expected message to name the tool, got: " + thrown.getMessage(), thrown.getMessage().contains(FIRST_TOOL));
+        assertTrue("expected message to mention input_schema, got: " + thrown.getMessage(), thrown.getMessage().contains("input_schema"));
+    }
+
+    @Test
     public void testRunWithIncludeOutputMLModel() {
         LLMSpec llmSpec = LLMSpec.builder().modelId("MODEL_ID").build();
         Mockito

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerV2Test.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunnerV2Test.java
@@ -202,6 +202,54 @@ public class MLChatAgentRunnerV2Test {
     }
 
     @Test
+    public void testExecuteAgentLogic_ToolMissingInputSchema_PropagatesExceptionToListener() {
+        // Arrange: register a tool whose attributes map does NOT contain input_schema.
+        // addToolsToFunctionCalling should throw IllegalArgumentException synchronously,
+        // which must be routed to listener.onFailure (not swallowed).
+        Map<String, String> params = new HashMap<>();
+        params.put("agent_id", "test-agent");
+
+        List<Message> conversationHistory = createConversationHistory();
+
+        MLToolSpec toolSpec = new MLToolSpec(
+            "bad-tool",
+            "bad-tool",
+            "tool w/o input_schema",
+            Map.of(),
+            Map.of(),
+            false,
+            Map.of(),
+            null,
+            null
+        );
+        when(mlAgent.getTools()).thenReturn(List.of(toolSpec));
+        when(toolFactories.containsKey("bad-tool")).thenReturn(true);
+        when(toolFactories.get("bad-tool")).thenReturn(toolFactory);
+        when(toolFactory.create(anyMap())).thenReturn(tool);
+        when(tool.getName()).thenReturn("bad-tool");
+        when(tool.getDescription()).thenReturn("tool without input_schema");
+        when(tool.getAttributes()).thenReturn(null);
+
+        when(modelProvider.mapMessages(anyList(), any())).thenReturn(Map.of("body", "test body"));
+
+        ActionListener<AbstractV2AgentRunner.AgentLogicResult> listener = mock(ActionListener.class);
+
+        // Act
+        runner.executeAgentLogic(mlAgent, params, conversationHistory, functionCalling, modelProvider, listener);
+
+        // Assert: onFailure invoked with IllegalArgumentException whose message names the
+        // tool and the missing input_schema attribute — confirming propagation to the user.
+        ArgumentCaptor<Exception> exCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener, timeout(5000)).onFailure(exCaptor.capture());
+        Exception thrown = exCaptor.getValue();
+        assertTrue("expected IllegalArgumentException but got " + thrown.getClass(), thrown instanceof IllegalArgumentException);
+        assertTrue("expected message to name the tool, got: " + thrown.getMessage(), thrown.getMessage().contains("bad-tool"));
+        assertTrue("expected message to mention input_schema, got: " + thrown.getMessage(), thrown.getMessage().contains("input_schema"));
+        // LLM must never be invoked when the function-calling payload cannot be built.
+        verify(client, never()).execute(eq(MLPredictionTaskAction.INSTANCE), any(ActionRequest.class), any());
+    }
+
+    @Test
     public void testExecuteAgentLogic_TracksToolInteractions() {
         // Arrange
         Map<String, String> params = new HashMap<>();


### PR DESCRIPTION
### Description

When a conversational agent builds the function calling payload (e.g., for Bedrock Converse or OpenAI), each tool must have an `input_schema` attribute so the LLM knows what parameters to pass. If `input_schema` is missing, the `${tool.attributes.input_schema}` placeholder is left unresolved, producing invalid JSON that the LLM provider rejects with an opaque `Invalid payload` error.

### Fix

1. **`AgentUtils.addToolsToFunctionCalling()`** — Throw a clear `IllegalArgumentException` when a tool is missing `input_schema`, naming the tool and the missing attribute. This fails fast with an actionable error message instead of silent downstream failures.
2. **`MLChatAgentRunner.runReAct()`** — Wrap `constructLLMPrompt` in try/catch so the synchronous `IllegalArgumentException` is routed to `listener.onFailure(e)`. Without this, the V1 chat agent path would throw the exception but the HTTP request would hang indefinitely (the exception was not propagated to the action listener). The V2 runner (`MLChatAgentRunnerV2.executeLLMCall`) already has the equivalent try/catch and propagates correctly.

Tools should define `input_schema` either:
1. In the tool implementation (as built-in ml-commons tools and [skills plugin tools](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java) already do)
2. At agent registration time via the tool's attributes override

### Testing

**Unit tests**
- `AgentUtilsTest`: two cases covering null attributes and non-null attributes missing `input_schema` — both verify the `IllegalArgumentException` is thrown with the correct tool name and attribute name. Existing `testAddToolsToFunctionCalling` updated to include `input_schema` in mock tool attributes.
- `MLChatAgentRunnerTest.testRunWithToolMissingInputSchemaInFunctionCalling_PropagatesFailureToListener`: V1 chat runner — tool missing `input_schema` + `TOOL_TEMPLATE` set → `agentActionListener.onFailure` is invoked with the expected `IllegalArgumentException`.
- `MLChatAgentRunnerV2Test.testExecuteAgentLogic_ToolMissingInputSchema_PropagatesExceptionToListener`: V2 chat runner — same contract, also verifies the LLM is never invoked.

**End-to-end live repro** (Bedrock Claude Sonnet 4, `type: "conversational"`, one `AgentTool` registered without `input_schema` in attributes):

```
curl -X POST http://localhost:9200/_plugins/_ml/agents/<id>/_execute \
     -H 'Content-Type: application/json' \
     -d '{"parameters":{"question":"hello"}}'
```

Response (HTTP 400 in < 1 second):
```json
{
  "status": 400,
  "error": {
    "type": "IllegalArgumentException",
    "reason": "Invalid Request",
    "details": "Tool [MyAgentTool] is missing [input_schema] in its attributes. All tools used with function calling must define an input_schema."
  }
}
```

Without the `runReAct` try/catch added in this PR, the same request hangs indefinitely even though the exception is thrown — because the V1 chat runner did not propagate synchronous exceptions from `constructLLMPrompt` to its action listener.

### Issues Resolved

N/A - discovered during investigation of VectorDBTool support for agentic search