### PR TITLE
support plain text credentials

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/AbstractConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/AbstractConnector.java
@@ -61,10 +61,6 @@ public abstract class AbstractConnector implements Connector {
     @Setter
     protected Map<String, String> decryptedCredential;
 
-    // Indicates whether credentials should be encrypted. Default is true.
-    // This flag is extracted from the credentials map and stored separately.
-    protected Boolean isEncrypted = true;
-
     protected List<ConnectorAction> actions;
 
     @Setter
@@ -167,6 +163,14 @@ public abstract class AbstractConnector implements Connector {
         return predictEndpoint;
     }
 
+    /**
+     * Check if credentials are configured for plaintext storage (not encrypted).
+     * Returns true if the credential map contains "encrypted" = "false".
+     */
+    public boolean isPlaintextCredentials() {
+        return credential != null && "false".equalsIgnoreCase(credential.get(ENCRYPTED_FIELD));
+    }
+
     @Override
     public void encrypt(
         TriConsumer<List<String>, String, ActionListener<List<String>>> function,
@@ -177,8 +181,8 @@ public abstract class AbstractConnector implements Connector {
             listener.onResponse(true);
             return;
         }
-        // Skip encryption if isEncrypted is false (plaintext mode)
-        if (Boolean.FALSE.equals(isEncrypted)) {
+        // Skip encryption if credentials are configured for plaintext storage
+        if (isPlaintextCredentials()) {
             log.warn("Connector credentials are configured for plaintext storage (not encrypted)");
             listener.onResponse(true);
             return;
@@ -186,6 +190,10 @@ public abstract class AbstractConnector implements Connector {
         List<String> orderedEncryptKeys = new ArrayList<>();
         List<String> orderedToEncrypt = new ArrayList<>();
         for (String key : credential.keySet()) {
+            // Skip the encrypted flag itself
+            if (ENCRYPTED_FIELD.equals(key)) {
+                continue;
+            }
             orderedEncryptKeys.add(key);
             orderedToEncrypt.add(credential.get(key));
         }
@@ -215,10 +223,12 @@ public abstract class AbstractConnector implements Connector {
             listener.onResponse(true);
             return;
         }
-        // Skip decryption if isEncrypted is false (plaintext mode)
-        if (Boolean.FALSE.equals(isEncrypted)) {
+        // Skip decryption if credentials are configured for plaintext storage
+        if (isPlaintextCredentials()) {
             log.debug("Connector credentials are in plaintext mode, using as-is");
             decryptedCredential = new HashMap<>(credential);
+            // Remove the encrypted flag from decrypted credentials
+            decryptedCredential.remove(ENCRYPTED_FIELD);
             this.decryptedHeaders = createDecryptedHeaders(getAllHeaders(action));
             listener.onResponse(true);
             return;
@@ -226,6 +236,10 @@ public abstract class AbstractConnector implements Connector {
         List<String> orderedDecryptKeys = new ArrayList<>();
         List<String> orderedToDecrypt = new ArrayList<>();
         for (Map.Entry<String, String> entry : credential.entrySet()) {
+            // Skip the encrypted flag itself
+            if (ENCRYPTED_FIELD.equals(entry.getKey())) {
+                continue;
+            }
             orderedDecryptKeys.add(entry.getKey());
             orderedToDecrypt.add(entry.getValue());
         }

--- a/common/src/main/java/org/opensearch/ml/common/connector/AbstractConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/AbstractConnector.java
@@ -48,6 +48,7 @@ public abstract class AbstractConnector implements Connector {
     public static final String OWNER_FIELD = "owner";
     public static final String ACCESS_FIELD = "access";
     public static final String CLIENT_CONFIG_FIELD = "client_config";
+    public static final String ENCRYPTED_FIELD = "encrypted";
 
     protected String name;
     protected String description;
@@ -59,6 +60,10 @@ public abstract class AbstractConnector implements Connector {
     protected Map<String, String> decryptedHeaders;
     @Setter
     protected Map<String, String> decryptedCredential;
+
+    // Indicates whether credentials should be encrypted. Default is true.
+    // This flag is extracted from the credentials map and stored separately.
+    protected Boolean isEncrypted = true;
 
     protected List<ConnectorAction> actions;
 
@@ -172,6 +177,12 @@ public abstract class AbstractConnector implements Connector {
             listener.onResponse(true);
             return;
         }
+        // Skip encryption if isEncrypted is false (plaintext mode)
+        if (Boolean.FALSE.equals(isEncrypted)) {
+            log.warn("Connector credentials are configured for plaintext storage (not encrypted)");
+            listener.onResponse(true);
+            return;
+        }
         List<String> orderedEncryptKeys = new ArrayList<>();
         List<String> orderedToEncrypt = new ArrayList<>();
         for (String key : credential.keySet()) {
@@ -200,6 +211,14 @@ public abstract class AbstractConnector implements Connector {
         ActionListener<Boolean> listener
     ) {
         if (credential == null || credential.isEmpty()) {
+            this.decryptedHeaders = createDecryptedHeaders(getAllHeaders(action));
+            listener.onResponse(true);
+            return;
+        }
+        // Skip decryption if isEncrypted is false (plaintext mode)
+        if (Boolean.FALSE.equals(isEncrypted)) {
+            log.debug("Connector credentials are in plaintext mode, using as-is");
+            decryptedCredential = new HashMap<>(credential);
             this.decryptedHeaders = createDecryptedHeaders(getAllHeaders(action));
             listener.onResponse(true);
             return;

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -90,11 +90,6 @@ public class HttpConnector extends AbstractConnector {
         this.protocol = protocol;
         this.parameters = parameters;
         this.credential = credential;
-        // Extract and remove the encrypted flag if present in credentials
-        if (credential != null && credential.containsKey(ENCRYPTED_FIELD)) {
-            String encryptedValue = credential.remove(ENCRYPTED_FIELD);
-            this.isEncrypted = encryptedValue == null || Boolean.parseBoolean(encryptedValue);
-        }
         this.actions = actions;
         this.backendRoles = backendRoles;
         this.access = accessMode;
@@ -132,11 +127,6 @@ public class HttpConnector extends AbstractConnector {
                 case CREDENTIAL_FIELD:
                     credential = new HashMap<>();
                     credential.putAll(parser.mapStrings());
-                    // Extract and remove the 'encrypted' flag from credentials map
-                    if (credential.containsKey(ENCRYPTED_FIELD)) {
-                        String encryptedValue = credential.remove(ENCRYPTED_FIELD);
-                        isEncrypted = encryptedValue == null || Boolean.parseBoolean(encryptedValue);
-                    }
                     break;
                 case ACTIONS_FIELD:
                     actions = new ArrayList<>();
@@ -196,15 +186,7 @@ public class HttpConnector extends AbstractConnector {
             builder.field(PARAMETERS_FIELD, parameters);
         }
         if (credential != null) {
-            // Only include the encrypted flag when isEncrypted is false to avoid document pollution
-            // and maintain backward compatibility with existing connectors
-            if (Boolean.FALSE.equals(isEncrypted)) {
-                Map<String, String> credentialWithFlag = new HashMap<>(credential);
-                credentialWithFlag.put(ENCRYPTED_FIELD, "false");
-                builder.field(CREDENTIAL_FIELD, credentialWithFlag);
-            } else {
-                builder.field(CREDENTIAL_FIELD, credential);
-            }
+            builder.field(CREDENTIAL_FIELD, credential);
         }
         if (actions != null) {
             builder.field(ACTIONS_FIELD, actions);
@@ -275,10 +257,6 @@ public class HttpConnector extends AbstractConnector {
             this.connectorClientConfig = new ConnectorClientConfig(input);
         }
         this.tenantId = streamInputVersion.onOrAfter(VERSION_2_19_0) ? input.readOptionalString() : null;
-        // Read isEncrypted flag (default to true for backward compatibility)
-        if (streamInputVersion.onOrAfter(VERSION_2_19_0)) {
-            this.isEncrypted = input.readBoolean();
-        }
     }
 
     @Override
@@ -332,7 +310,6 @@ public class HttpConnector extends AbstractConnector {
         }
         if (streamOutputVersion.onOrAfter(VERSION_2_19_0)) {
             out.writeOptionalString(tenantId);
-            out.writeBoolean(isEncrypted != null ? isEncrypted : true);
         }
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -196,10 +196,15 @@ public class HttpConnector extends AbstractConnector {
             builder.field(PARAMETERS_FIELD, parameters);
         }
         if (credential != null) {
-            // Include the encrypted flag in the credential map for serialization
-            Map<String, String> credentialWithFlag = new HashMap<>(credential);
-            credentialWithFlag.put(ENCRYPTED_FIELD, String.valueOf(isEncrypted));
-            builder.field(CREDENTIAL_FIELD, credentialWithFlag);
+            // Only include the encrypted flag when isEncrypted is false to avoid document pollution
+            // and maintain backward compatibility with existing connectors
+            if (Boolean.FALSE.equals(isEncrypted)) {
+                Map<String, String> credentialWithFlag = new HashMap<>(credential);
+                credentialWithFlag.put(ENCRYPTED_FIELD, "false");
+                builder.field(CREDENTIAL_FIELD, credentialWithFlag);
+            } else {
+                builder.field(CREDENTIAL_FIELD, credential);
+            }
         }
         if (actions != null) {
             builder.field(ACTIONS_FIELD, actions);

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -90,6 +90,11 @@ public class HttpConnector extends AbstractConnector {
         this.protocol = protocol;
         this.parameters = parameters;
         this.credential = credential;
+        // Extract and remove the encrypted flag if present in credentials
+        if (credential != null && credential.containsKey(ENCRYPTED_FIELD)) {
+            String encryptedValue = credential.remove(ENCRYPTED_FIELD);
+            this.isEncrypted = encryptedValue == null || Boolean.parseBoolean(encryptedValue);
+        }
         this.actions = actions;
         this.backendRoles = backendRoles;
         this.access = accessMode;
@@ -127,6 +132,11 @@ public class HttpConnector extends AbstractConnector {
                 case CREDENTIAL_FIELD:
                     credential = new HashMap<>();
                     credential.putAll(parser.mapStrings());
+                    // Extract and remove the 'encrypted' flag from credentials map
+                    if (credential.containsKey(ENCRYPTED_FIELD)) {
+                        String encryptedValue = credential.remove(ENCRYPTED_FIELD);
+                        isEncrypted = encryptedValue == null || Boolean.parseBoolean(encryptedValue);
+                    }
                     break;
                 case ACTIONS_FIELD:
                     actions = new ArrayList<>();
@@ -186,7 +196,10 @@ public class HttpConnector extends AbstractConnector {
             builder.field(PARAMETERS_FIELD, parameters);
         }
         if (credential != null) {
-            builder.field(CREDENTIAL_FIELD, credential);
+            // Include the encrypted flag in the credential map for serialization
+            Map<String, String> credentialWithFlag = new HashMap<>(credential);
+            credentialWithFlag.put(ENCRYPTED_FIELD, String.valueOf(isEncrypted));
+            builder.field(CREDENTIAL_FIELD, credentialWithFlag);
         }
         if (actions != null) {
             builder.field(ACTIONS_FIELD, actions);
@@ -257,6 +270,10 @@ public class HttpConnector extends AbstractConnector {
             this.connectorClientConfig = new ConnectorClientConfig(input);
         }
         this.tenantId = streamInputVersion.onOrAfter(VERSION_2_19_0) ? input.readOptionalString() : null;
+        // Read isEncrypted flag (default to true for backward compatibility)
+        if (streamInputVersion.onOrAfter(VERSION_2_19_0)) {
+            this.isEncrypted = input.readBoolean();
+        }
     }
 
     @Override
@@ -310,6 +327,7 @@ public class HttpConnector extends AbstractConnector {
         }
         if (streamOutputVersion.onOrAfter(VERSION_2_19_0)) {
             out.writeOptionalString(tenantId);
+            out.writeBoolean(isEncrypted != null ? isEncrypted : true);
         }
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -539,4 +539,17 @@ public final class MLCommonsSettings {
         .boolSetting(ML_PLUGIN_SETTING_PREFIX + "ag_ui_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final String ML_COMMONS_AG_UI_DISABLED_MESSAGE =
         "The AG-UI agent feature is not enabled. To enable, please update the setting " + ML_COMMONS_AG_UI_ENABLED.getKey();
+
+    /**
+     * Controls whether plaintext (unencrypted) credentials are allowed in connectors.
+     *
+     * When false (default for open source): All credentials are always encrypted regardless of connector configuration.
+     * When true (default for managed service): Connectors can specify encryption preference via the "encrypted" flag in credentials.
+     *
+     * Default: false (ensures security by default in open source)
+     *
+     * This is a dynamic setting that can be changed at runtime via cluster settings API.
+     */
+    public static final Setting<Boolean> ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS = Setting
+        .boolSetting(ML_PLUGIN_SETTING_PREFIX + "allow_plaintext_credentials", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
 }

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.settings;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONTROLLER_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_ENABLED;
@@ -76,6 +77,8 @@ public class MLFeatureEnabledSetting {
 
     private volatile Boolean isAGUIEnabled;
 
+    private volatile Boolean isPlaintextCredentialsAllowed;
+
     private final List<SettingsChangeListener> listeners = new ArrayList<>();
 
     public MLFeatureEnabledSetting(ClusterService clusterService, Settings settings) {
@@ -101,6 +104,7 @@ public class MLFeatureEnabledSetting {
         maxJsonSize = MLCommonsSettings.ML_COMMONS_MAX_JSON_SIZE.get(settings);
         isMcpHeaderPassthroughEnabled = ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED.get(settings);
         isAGUIEnabled = ML_COMMONS_AG_UI_ENABLED.get(settings);
+        isPlaintextCredentialsAllowed = ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS.get(settings);
 
         clusterService
             .getClusterSettings()
@@ -140,6 +144,9 @@ public class MLFeatureEnabledSetting {
             .getClusterSettings()
             .addSettingsUpdateConsumer(ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED, it -> isMcpHeaderPassthroughEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_AG_UI_ENABLED, it -> isAGUIEnabled = it);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS, it -> isPlaintextCredentialsAllowed = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED, it -> {
             isStaticMetricCollectionEnabled = it;
             for (SettingsChangeListener listener : listeners) {
@@ -313,5 +320,15 @@ public class MLFeatureEnabledSetting {
      */
     public boolean isAGUIEnabled() {
         return isAGUIEnabled;
+    }
+
+    /**
+     * Whether plaintext (unencrypted) credentials are allowed in connectors.
+     * When false (default): All credentials must be encrypted.
+     * When true: Connectors can optionally store credentials in plaintext.
+     * @return whether plaintext credentials are allowed.
+     */
+    public boolean isPlaintextCredentialsAllowed() {
+        return isPlaintextCredentialsAllowed;
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -6,8 +6,6 @@
 package org.opensearch.ml.common.connector;
 
 import static org.mockito.Mockito.mock;
-import static org.opensearch.ml.common.CommonValue.VERSION_2_18_0;
-import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
 
 import java.io.IOException;
@@ -29,7 +27,6 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -652,13 +649,12 @@ public class HttpConnectorTest {
 
         HttpConnector connector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
 
-        // Verify isEncrypted is false
-        Assert.assertFalse(connector.getIsEncrypted());
-        // Verify encrypted key was removed from credential map
-        Assert.assertFalse(connector.getCredential().containsKey("encrypted"));
-        Assert.assertEquals(1, connector.getCredential().size());
+        // Verify plaintext credentials is detected
+        Assert.assertTrue(connector.isPlaintextCredentials());
+        // Verify encrypted key stays in credential map
+        Assert.assertTrue(connector.getCredential().containsKey("encrypted"));
 
-        // Encryption should be skipped when isEncrypted is false
+        // Encryption should be skipped when credentials are plaintext
         connector.encrypt(encryptFunction, null, listener);
 
         // Credential should not be encrypted (still has original value)
@@ -690,24 +686,26 @@ public class HttpConnectorTest {
             .actions(Arrays.asList(action))
             .build();
 
-        Assert.assertFalse(connector.getIsEncrypted());
+        Assert.assertTrue(connector.isPlaintextCredentials());
 
-        // Decryption should be skipped when isEncrypted is false
+        // Decryption should be skipped when credentials are plaintext
         connector.decrypt(PREDICT.name(), decryptFunction, null, listener);
 
         // Decrypted credential should be same as original (not passed through decrypt function)
         Assert.assertEquals("plaintext_value", connector.getDecryptedCredential().get("key"));
+        // encrypted flag should be removed from decrypted credentials
+        Assert.assertFalse(connector.getDecryptedCredential().containsKey("encrypted"));
     }
 
     @Test
-    public void testIsEncryptedDefaultsToTrue() {
+    public void testPlaintextCredentialsDefaultsToFalse() {
         Map<String, String> credential = new HashMap<>();
         credential.put("key", "test_key_value");
 
         HttpConnector connector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
 
-        // isEncrypted should default to true when not specified
-        Assert.assertTrue(connector.getIsEncrypted());
+        // isPlaintextCredentials should default to false when not specified (meaning encrypted)
+        Assert.assertFalse(connector.isPlaintextCredentials());
     }
 
     @Test
@@ -724,9 +722,9 @@ public class HttpConnectorTest {
         parser.nextToken();
 
         HttpConnector connector = new HttpConnector("http", parser);
-        Assert.assertFalse(connector.getIsEncrypted());
-        // encrypted key should be removed from credential map
-        Assert.assertFalse(connector.getCredential().containsKey("encrypted"));
+        Assert.assertTrue(connector.isPlaintextCredentials());
+        // encrypted key should remain in credential map
+        Assert.assertTrue(connector.getCredential().containsKey("encrypted"));
     }
 
     @Test
@@ -745,20 +743,21 @@ public class HttpConnectorTest {
     }
 
     @Test
-    public void testWriteToAndReadFromWithIsEncryptedFalse() throws IOException {
+    public void testWriteToAndReadFromWithPlaintextCredentials() throws IOException {
         Map<String, String> credential = new HashMap<>();
         credential.put("key", "test_key_value");
         credential.put("encrypted", "false");
 
         HttpConnector originalConnector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
 
-        Assert.assertFalse(originalConnector.getIsEncrypted());
+        Assert.assertTrue(originalConnector.isPlaintextCredentials());
 
         BytesStreamOutput output = new BytesStreamOutput();
         originalConnector.writeTo(output);
 
         HttpConnector deserializedConnector = new HttpConnector(output.bytes().streamInput());
-        Assert.assertFalse(deserializedConnector.getIsEncrypted());
+        // encrypted flag is preserved in credential map through stream serialization
+        Assert.assertTrue(deserializedConnector.isPlaintextCredentials());
         Assert.assertEquals(originalConnector.getCredential(), deserializedConnector.getCredential());
     }
 
@@ -802,98 +801,6 @@ public class HttpConnectorTest {
         Assert.assertTrue(foundByName.isPresent());
         Assert.assertEquals("predict_action_2", foundByName.get().getName());
         Assert.assertEquals("https://test2.com", foundByName.get().getUrl());
-    }
-
-    // ============== Backward Compatibility Tests for isEncrypted field ==============
-
-    @Test
-    public void testBWC_WriteToVersion2_19_0_IncludesIsEncrypted() throws IOException {
-        Map<String, String> credential = new HashMap<>();
-        credential.put("key", "test_key_value");
-        credential.put("encrypted", "false");
-
-        HttpConnector connector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
-
-        Assert.assertFalse(connector.getIsEncrypted());
-
-        // Serialize with VERSION_2_19_0
-        BytesStreamOutput output = new BytesStreamOutput();
-        output.setVersion(VERSION_2_19_0);
-        connector.writeTo(output);
-
-        // Deserialize with VERSION_2_19_0
-        StreamInput streamInput = output.bytes().streamInput();
-        streamInput.setVersion(VERSION_2_19_0);
-        HttpConnector deserializedConnector = new HttpConnector(streamInput);
-
-        // isEncrypted should be preserved
-        Assert.assertFalse(deserializedConnector.getIsEncrypted());
-    }
-
-    @Test
-    public void testBWC_WriteToOlderVersion_DoesNotIncludeIsEncrypted() throws IOException {
-        Map<String, String> credential = new HashMap<>();
-        credential.put("key", "test_key_value");
-        credential.put("encrypted", "false");
-
-        HttpConnector connector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
-
-        Assert.assertFalse(connector.getIsEncrypted());
-
-        // Serialize with older version (VERSION_2_18_0)
-        BytesStreamOutput output = new BytesStreamOutput();
-        output.setVersion(VERSION_2_18_0);
-        connector.writeTo(output);
-
-        // Deserialize with older version - isEncrypted should default to true
-        StreamInput streamInput = output.bytes().streamInput();
-        streamInput.setVersion(VERSION_2_18_0);
-        HttpConnector deserializedConnector = new HttpConnector(streamInput);
-
-        // isEncrypted should default to true when not present in stream (for backward compatibility)
-        Assert.assertTrue(deserializedConnector.getIsEncrypted());
-    }
-
-    @Test
-    public void testBWC_ReadFromOlderVersionDefaultsToTrue() throws IOException {
-        // Create connector with isEncrypted=true (the default)
-        HttpConnector connector = createHttpConnector();
-
-        Assert.assertTrue(connector.getIsEncrypted());
-
-        // Serialize with older version (simulating data from an older node)
-        BytesStreamOutput output = new BytesStreamOutput();
-        output.setVersion(VERSION_2_18_0);
-        connector.writeTo(output);
-
-        // Deserialize with VERSION_2_19_0 - should handle missing isEncrypted gracefully
-        StreamInput streamInput = output.bytes().streamInput();
-        streamInput.setVersion(VERSION_2_18_0);
-        HttpConnector deserializedConnector = new HttpConnector(streamInput);
-
-        // isEncrypted should default to true (backward compatible behavior)
-        Assert.assertTrue(deserializedConnector.getIsEncrypted());
-    }
-
-    @Test
-    public void testBWC_CrossVersionCommunication_NewToOld() throws IOException {
-        Map<String, String> credential = new HashMap<>();
-        credential.put("key", "test_key_value");
-
-        HttpConnector connector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
-
-        // New node writes with VERSION_2_18_0 (to communicate with old node)
-        BytesStreamOutput output = new BytesStreamOutput();
-        output.setVersion(VERSION_2_18_0);
-        connector.writeTo(output);
-
-        // Old node reads - should work without errors
-        StreamInput streamInput = output.bytes().streamInput();
-        streamInput.setVersion(VERSION_2_18_0);
-        HttpConnector deserializedConnector = new HttpConnector(streamInput);
-
-        Assert.assertEquals("test_connector", deserializedConnector.getName());
-        Assert.assertNotNull(deserializedConnector.getCredential());
     }
 
 }

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -52,7 +52,7 @@ public class HttpConnectorTest {
 
     String TEST_CONNECTOR_JSON_STRING = "{\"name\":\"test_connector_name\",\"version\":\"1\","
         + "\"description\":\"this is a test connector\",\"protocol\":\"http\","
-        + "\"parameters\":{\"input\":\"test input value\"},\"credential\":{\"encrypted\":\"true\",\"key\":\"test_key_value\"},"
+        + "\"parameters\":{\"input\":\"test input value\"},\"credential\":{\"key\":\"test_key_value\"},"
         + "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\","
         + "\"headers\":{\"api_key\":\"${credential.key}\"},"
         + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -6,6 +6,8 @@
 package org.opensearch.ml.common.connector;
 
 import static org.mockito.Mockito.mock;
+import static org.opensearch.ml.common.CommonValue.VERSION_2_18_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
 
 import java.io.IOException;
@@ -27,6 +29,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -49,7 +52,7 @@ public class HttpConnectorTest {
 
     String TEST_CONNECTOR_JSON_STRING = "{\"name\":\"test_connector_name\",\"version\":\"1\","
         + "\"description\":\"this is a test connector\",\"protocol\":\"http\","
-        + "\"parameters\":{\"input\":\"test input value\"},\"credential\":{\"key\":\"test_key_value\"},"
+        + "\"parameters\":{\"input\":\"test input value\"},\"credential\":{\"encrypted\":\"true\",\"key\":\"test_key_value\"},"
         + "\"actions\":[{\"action_type\":\"PREDICT\",\"method\":\"POST\",\"url\":\"https://test.com\","
         + "\"headers\":{\"api_key\":\"${credential.key}\"},"
         + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
@@ -642,6 +645,124 @@ public class HttpConnectorTest {
     }
 
     @Test
+    public void testEncryptSkippedWhenIsEncryptedFalse() {
+        Map<String, String> credential = new HashMap<>();
+        credential.put("key", "test_key_value");
+        credential.put("encrypted", "false");
+
+        HttpConnector connector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
+
+        // Verify isEncrypted is false
+        Assert.assertFalse(connector.getIsEncrypted());
+        // Verify encrypted key was removed from credential map
+        Assert.assertFalse(connector.getCredential().containsKey("encrypted"));
+        Assert.assertEquals(1, connector.getCredential().size());
+
+        // Encryption should be skipped when isEncrypted is false
+        connector.encrypt(encryptFunction, null, listener);
+
+        // Credential should not be encrypted (still has original value)
+        Assert.assertEquals("test_key_value", connector.getCredential().get("key"));
+    }
+
+    @Test
+    public void testDecryptSkippedWhenIsEncryptedFalse() {
+        Map<String, String> credential = new HashMap<>();
+        credential.put("key", "plaintext_value");
+        credential.put("encrypted", "false");
+
+        ConnectorAction action = new ConnectorAction(
+            ConnectorAction.ActionType.PREDICT,
+            null,
+            "POST",
+            "https://test.com",
+            null,
+            "{\"input\": \"test\"}",
+            null,
+            null
+        );
+
+        HttpConnector connector = HttpConnector
+            .builder()
+            .name("test_connector")
+            .protocol("http")
+            .credential(credential)
+            .actions(Arrays.asList(action))
+            .build();
+
+        Assert.assertFalse(connector.getIsEncrypted());
+
+        // Decryption should be skipped when isEncrypted is false
+        connector.decrypt(PREDICT.name(), decryptFunction, null, listener);
+
+        // Decrypted credential should be same as original (not passed through decrypt function)
+        Assert.assertEquals("plaintext_value", connector.getDecryptedCredential().get("key"));
+    }
+
+    @Test
+    public void testIsEncryptedDefaultsToTrue() {
+        Map<String, String> credential = new HashMap<>();
+        credential.put("key", "test_key_value");
+
+        HttpConnector connector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
+
+        // isEncrypted should default to true when not specified
+        Assert.assertTrue(connector.getIsEncrypted());
+    }
+
+    @Test
+    public void testParseEncryptedFlagFromXContent() throws IOException {
+        String jsonStr = "{\"name\":\"test_connector\",\"protocol\":\"http\",\"credential\":{\"key\":\"value\",\"encrypted\":\"false\"}}";
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+
+        HttpConnector connector = new HttpConnector("http", parser);
+        Assert.assertFalse(connector.getIsEncrypted());
+        // encrypted key should be removed from credential map
+        Assert.assertFalse(connector.getCredential().containsKey("encrypted"));
+    }
+
+    @Test
+    public void testToXContentIncludesEncryptedFlag() throws IOException {
+        Map<String, String> credential = new HashMap<>();
+        credential.put("key", "test_key_value");
+        credential.put("encrypted", "false");
+
+        HttpConnector connector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        connector.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+
+        Assert.assertTrue(content.contains("\"encrypted\":\"false\""));
+    }
+
+    @Test
+    public void testWriteToAndReadFromWithIsEncryptedFalse() throws IOException {
+        Map<String, String> credential = new HashMap<>();
+        credential.put("key", "test_key_value");
+        credential.put("encrypted", "false");
+
+        HttpConnector originalConnector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
+
+        Assert.assertFalse(originalConnector.getIsEncrypted());
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        originalConnector.writeTo(output);
+
+        HttpConnector deserializedConnector = new HttpConnector(output.bytes().streamInput());
+        Assert.assertFalse(deserializedConnector.getIsEncrypted());
+        Assert.assertEquals(originalConnector.getCredential(), deserializedConnector.getCredential());
+    }
+
+    @Test
     public void testFindAction_MultipleActionsWithSameType() {
         ConnectorAction action1 = new ConnectorAction(
             PREDICT,
@@ -681,6 +802,98 @@ public class HttpConnectorTest {
         Assert.assertTrue(foundByName.isPresent());
         Assert.assertEquals("predict_action_2", foundByName.get().getName());
         Assert.assertEquals("https://test2.com", foundByName.get().getUrl());
+    }
+
+    // ============== Backward Compatibility Tests for isEncrypted field ==============
+
+    @Test
+    public void testBWC_WriteToVersion2_19_0_IncludesIsEncrypted() throws IOException {
+        Map<String, String> credential = new HashMap<>();
+        credential.put("key", "test_key_value");
+        credential.put("encrypted", "false");
+
+        HttpConnector connector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
+
+        Assert.assertFalse(connector.getIsEncrypted());
+
+        // Serialize with VERSION_2_19_0
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(VERSION_2_19_0);
+        connector.writeTo(output);
+
+        // Deserialize with VERSION_2_19_0
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(VERSION_2_19_0);
+        HttpConnector deserializedConnector = new HttpConnector(streamInput);
+
+        // isEncrypted should be preserved
+        Assert.assertFalse(deserializedConnector.getIsEncrypted());
+    }
+
+    @Test
+    public void testBWC_WriteToOlderVersion_DoesNotIncludeIsEncrypted() throws IOException {
+        Map<String, String> credential = new HashMap<>();
+        credential.put("key", "test_key_value");
+        credential.put("encrypted", "false");
+
+        HttpConnector connector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
+
+        Assert.assertFalse(connector.getIsEncrypted());
+
+        // Serialize with older version (VERSION_2_18_0)
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(VERSION_2_18_0);
+        connector.writeTo(output);
+
+        // Deserialize with older version - isEncrypted should default to true
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(VERSION_2_18_0);
+        HttpConnector deserializedConnector = new HttpConnector(streamInput);
+
+        // isEncrypted should default to true when not present in stream (for backward compatibility)
+        Assert.assertTrue(deserializedConnector.getIsEncrypted());
+    }
+
+    @Test
+    public void testBWC_ReadFromOlderVersionDefaultsToTrue() throws IOException {
+        // Create connector with isEncrypted=true (the default)
+        HttpConnector connector = createHttpConnector();
+
+        Assert.assertTrue(connector.getIsEncrypted());
+
+        // Serialize with older version (simulating data from an older node)
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(VERSION_2_18_0);
+        connector.writeTo(output);
+
+        // Deserialize with VERSION_2_19_0 - should handle missing isEncrypted gracefully
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(VERSION_2_18_0);
+        HttpConnector deserializedConnector = new HttpConnector(streamInput);
+
+        // isEncrypted should default to true (backward compatible behavior)
+        Assert.assertTrue(deserializedConnector.getIsEncrypted());
+    }
+
+    @Test
+    public void testBWC_CrossVersionCommunication_NewToOld() throws IOException {
+        Map<String, String> credential = new HashMap<>();
+        credential.put("key", "test_key_value");
+
+        HttpConnector connector = HttpConnector.builder().name("test_connector").protocol("http").credential(credential).build();
+
+        // New node writes with VERSION_2_18_0 (to communicate with old node)
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(VERSION_2_18_0);
+        connector.writeTo(output);
+
+        // Old node reads - should work without errors
+        StreamInput streamInput = output.bytes().streamInput();
+        streamInput.setVersion(VERSION_2_18_0);
+        HttpConnector deserializedConnector = new HttpConnector(streamInput);
+
+        Assert.assertEquals("test_connector", deserializedConnector.getName());
+        Assert.assertNotNull(deserializedConnector.getCredential());
     }
 
 }

--- a/common/src/test/java/org/opensearch/ml/common/settings/MLFeatureEnabledSettingTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/settings/MLFeatureEnabledSettingTests.java
@@ -54,7 +54,8 @@ public class MLFeatureEnabledSettingTests {
                     MLCommonsSettings.ML_COMMONS_STREAM_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MAX_JSON_SIZE,
                     MLCommonsSettings.ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
-                    MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED
+                    MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS
                 )
         );
         when(mockClusterService.getClusterSettings()).thenReturn(mockClusterSettings);
@@ -307,5 +308,48 @@ public class MLFeatureEnabledSettingTests {
         mockClusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.mcp_header_passthrough_enabled", false).build());
 
         assertFalse(setting.isMcpHeaderPassthroughEnabled());
+    }
+
+    @Test
+    public void testPlaintextCredentialsDisabledByDefault() {
+        Settings settings = Settings.EMPTY;
+        MLFeatureEnabledSetting setting = new MLFeatureEnabledSetting(mockClusterService, settings);
+
+        // Should be disabled by default for security
+        assertFalse(setting.isPlaintextCredentialsAllowed());
+    }
+
+    @Test
+    public void testPlaintextCredentialsCanBeEnabled() {
+        Settings settings = Settings.builder().put("plugins.ml_commons.allow_plaintext_credentials", true).build();
+        MLFeatureEnabledSetting setting = new MLFeatureEnabledSetting(mockClusterService, settings);
+
+        assertTrue(setting.isPlaintextCredentialsAllowed());
+    }
+
+    @Test
+    public void testPlaintextCredentialsCanBeDisabled() {
+        Settings settings = Settings.builder().put("plugins.ml_commons.allow_plaintext_credentials", false).build();
+        MLFeatureEnabledSetting setting = new MLFeatureEnabledSetting(mockClusterService, settings);
+
+        assertFalse(setting.isPlaintextCredentialsAllowed());
+    }
+
+    @Test
+    public void testPlaintextCredentialsDynamicUpdate() {
+        Settings settings = Settings.builder().put("plugins.ml_commons.allow_plaintext_credentials", false).build();
+        MLFeatureEnabledSetting setting = new MLFeatureEnabledSetting(mockClusterService, settings);
+
+        assertFalse(setting.isPlaintextCredentialsAllowed());
+
+        // Update the setting dynamically to enable
+        mockClusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.allow_plaintext_credentials", true).build());
+
+        assertTrue(setting.isPlaintextCredentialsAllowed());
+
+        // Update the setting dynamically to disable again
+        mockClusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.allow_plaintext_credentials", false).build());
+
+        assertFalse(setting.isPlaintextCredentialsAllowed());
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
@@ -29,6 +29,7 @@ import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.AccessMode;
+import org.opensearch.ml.common.connector.AbstractConnector;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorProtocols;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
@@ -118,6 +119,27 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
             mlCreateConnectorInput.toXContent(builder, ToXContent.EMPTY_PARAMS);
             Connector connector = Connector.createConnector(builder, mlCreateConnectorInput.getProtocol());
             connector.validateConnectorURL(trustedConnectorEndpointsRegex);
+
+            // Enforce cluster-level plaintext credentials policy
+            if (connector instanceof AbstractConnector) {
+                AbstractConnector abstractConnector = (AbstractConnector) connector;
+                if (Boolean.FALSE.equals(abstractConnector.getIsEncrypted())) {
+                    if (!mlFeatureEnabledSetting.isPlaintextCredentialsAllowed()) {
+                        // Cluster setting does not allow plaintext credentials - throw exception
+                        throw new IllegalArgumentException(
+                            "Plaintext credentials are not allowed. Please set cluster setting 'plugins.ml_commons.allow_plaintext_credentials' to true to enable plaintext credentials storage."
+                        );
+                    } else {
+                        // Cluster setting allows plaintext credentials
+                        log
+                            .warn(
+                                "Connector '{}' is configured to store credentials in plaintext (unencrypted). "
+                                    + "This is less secure. Only use this for testing or when encryption is handled externally.",
+                                connectorName
+                            );
+                    }
+                }
+            }
 
             User user = RestActionUtils.getUserContext(client);
             if (connectorAccessControlHelper.accessControlNotEnabled(user)) {

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
@@ -125,10 +125,14 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
                 AbstractConnector abstractConnector = (AbstractConnector) connector;
                 if (abstractConnector.isPlaintextCredentials()) {
                     if (!mlFeatureEnabledSetting.isPlaintextCredentialsAllowed()) {
-                        // Cluster setting does not allow plaintext credentials - throw exception
-                        throw new IllegalArgumentException(
-                            "Plaintext credentials are not allowed. Please set cluster setting 'plugins.ml_commons.allow_plaintext_credentials' to true to enable plaintext credentials storage."
-                        );
+                        // Cluster setting does not allow plaintext credentials
+                        listener
+                            .onFailure(
+                                new IllegalArgumentException(
+                                    "Plaintext credentials are not allowed. Please set cluster setting 'plugins.ml_commons.allow_plaintext_credentials' to true to enable plaintext credentials storage."
+                                )
+                            );
+                        return;
                     } else {
                         // Cluster setting allows plaintext credentials
                         log

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/TransportCreateConnectorAction.java
@@ -123,7 +123,7 @@ public class TransportCreateConnectorAction extends HandledTransportAction<Actio
             // Enforce cluster-level plaintext credentials policy
             if (connector instanceof AbstractConnector) {
                 AbstractConnector abstractConnector = (AbstractConnector) connector;
-                if (Boolean.FALSE.equals(abstractConnector.getIsEncrypted())) {
+                if (abstractConnector.isPlaintextCredentials()) {
                     if (!mlFeatureEnabledSetting.isPlaintextCredentialsAllowed()) {
                         // Cluster setting does not allow plaintext credentials - throw exception
                         throw new IllegalArgumentException(

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
@@ -33,6 +33,7 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.connector.AbstractConnector;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
 import org.opensearch.ml.common.transport.connector.MLUpdateConnectorAction;
@@ -121,6 +122,32 @@ public class UpdateConnectorTransportAction extends HandledTransportAction<Actio
                         boolean hasPermission = connectorAccessControlHelper.validateConnectorAccess(client, connector);
                         if (hasPermission) {
                             connector.update(mlUpdateConnectorAction.getUpdateContent());
+
+                            // Enforce cluster-level plaintext credentials policy
+                            if (connector instanceof AbstractConnector) {
+                                AbstractConnector abstractConnector = (AbstractConnector) connector;
+                                if (Boolean.FALSE.equals(abstractConnector.getIsEncrypted())) {
+                                    if (!mlFeatureEnabledSetting.isPlaintextCredentialsAllowed()) {
+                                        // Cluster setting does not allow plaintext credentials - throw exception
+                                        listener
+                                            .onFailure(
+                                                new IllegalArgumentException(
+                                                    "Plaintext credentials are not allowed. Please set cluster setting 'plugins.ml_commons.allow_plaintext_credentials' to true to enable plaintext credentials storage."
+                                                )
+                                            );
+                                        return;
+                                    } else {
+                                        // Cluster setting allows plaintext credentials
+                                        log
+                                            .warn(
+                                                "Connector '{}' is configured to store credentials in plaintext (unencrypted). "
+                                                    + "This is less secure. Only use this for testing or when encryption is handled externally.",
+                                                connectorId
+                                            );
+                                    }
+                                }
+                            }
+
                             ActionListener<Boolean> encryptCredentialListener = ActionListener.wrap(r -> {
                                 connector.validateConnectorURL(trustedConnectorEndpointsRegex);
                                 connector.setLastUpdateTime(Instant.now());

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/UpdateConnectorTransportAction.java
@@ -126,7 +126,7 @@ public class UpdateConnectorTransportAction extends HandledTransportAction<Actio
                             // Enforce cluster-level plaintext credentials policy
                             if (connector instanceof AbstractConnector) {
                                 AbstractConnector abstractConnector = (AbstractConnector) connector;
-                                if (Boolean.FALSE.equals(abstractConnector.getIsEncrypted())) {
+                                if (abstractConnector.isPlaintextCredentials()) {
                                     if (!mlFeatureEnabledSetting.isPlaintextCredentialsAllowed()) {
                                         // Cluster setting does not allow plaintext credentials - throw exception
                                         listener

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1434,7 +1434,8 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_MAX_JSON_SIZE,
                 MLCommonsSettings.ML_COMMONS_UNIFIED_AGENT_API_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
-                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED
+                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED,
+                MLCommonsSettings.ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS
             );
         return settings;
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/TransportCreateConnectorActionTests.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED;
@@ -149,7 +150,8 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
             settings,
             ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX,
             ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED,
-            ML_COMMONS_MCP_CONNECTOR_ENABLED
+            ML_COMMONS_MCP_CONNECTOR_ENABLED,
+            ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
@@ -644,6 +646,90 @@ public class TransportCreateConnectorActionTests extends OpenSearchTestCase {
         ArgumentCaptor<OpenSearchException> argCaptor = ArgumentCaptor.forClass(OpenSearchException.class);
         verify(actionListener).onFailure(argCaptor.capture());
         assertEquals(argCaptor.getValue().getMessage(), ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE);
+    }
+
+    public void test_execute_plaintext_credentials_blocked_when_not_allowed() {
+        when(connectorAccessControlHelper.accessControlNotEnabled(any(User.class))).thenReturn(true);
+        when(mlFeatureEnabledSetting.isPlaintextCredentialsAllowed()).thenReturn(false);
+
+        List<ConnectorAction> actions = new ArrayList<>();
+        actions
+            .add(
+                ConnectorAction
+                    .builder()
+                    .actionType(ConnectorAction.ActionType.PREDICT)
+                    .method("POST")
+                    .url("https://api.openai.com/v1/completions")
+                    .build()
+            );
+
+        // Include "encrypted": "false" in credentials to request plaintext storage
+        Map<String, String> credential = ImmutableMap.of("access_key", "mockKey", "secret_key", "mockSecret", "encrypted", "false");
+        MLCreateConnectorInput mlCreateConnectorInput = MLCreateConnectorInput
+            .builder()
+            .name("test_connector")
+            .version("1")
+            .protocol(ConnectorProtocols.HTTP)
+            .credential(credential)
+            .actions(actions)
+            .build();
+
+        MLCreateConnectorRequest request = new MLCreateConnectorRequest(mlCreateConnectorInput);
+        action.doExecute(task, request, actionListener);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertTrue(argumentCaptor.getValue().getMessage().contains("Plaintext credentials are not allowed"));
+    }
+
+    public void test_execute_plaintext_credentials_allowed_when_setting_enabled() {
+        when(connectorAccessControlHelper.accessControlNotEnabled(any(User.class))).thenReturn(true);
+        when(mlFeatureEnabledSetting.isPlaintextCredentialsAllowed()).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLConnectorIndex(isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(IndexRequest.class), isA(ActionListener.class));
+
+        List<ConnectorAction> actions = new ArrayList<>();
+        actions
+            .add(
+                ConnectorAction
+                    .builder()
+                    .actionType(ConnectorAction.ActionType.PREDICT)
+                    .method("POST")
+                    .url("https://api.openai.com/v1/completions")
+                    .build()
+            );
+
+        // Include "encrypted": "false" in credentials to request plaintext storage
+        Map<String, String> credential = ImmutableMap.of("access_key", "mockKey", "secret_key", "mockSecret", "encrypted", "false");
+        MLCreateConnectorInput mlCreateConnectorInput = MLCreateConnectorInput
+            .builder()
+            .name("test_connector")
+            .version("1")
+            .protocol(ConnectorProtocols.HTTP)
+            .credential(credential)
+            .actions(actions)
+            .build();
+
+        MLCreateConnectorRequest request = new MLCreateConnectorRequest(mlCreateConnectorInput);
+        action.doExecute(task, request, actionListener);
+
+        // Capture and verify the response - should succeed
+        ArgumentCaptor<MLCreateConnectorResponse> captor = ArgumentCaptor.forClass(MLCreateConnectorResponse.class);
+        verify(actionListener).onResponse(captor.capture());
+
+        MLCreateConnectorResponse actualResponse = captor.getValue();
+        assertNotNull(actualResponse);
+        assertEquals(CONNECTOR_ID, actualResponse.getConnectorId());
     }
 
     public void test_connector_creation_success_rekognition() {

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.action.connector;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
 import static org.opensearch.ml.utils.TestHelper.clusterSetting;
@@ -139,7 +140,8 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
         ClusterSettings clusterSettings = clusterSetting(
             settings,
             ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX,
-            ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED
+            ML_COMMONS_CONNECTOR_ACCESS_CONTROL_ENABLED,
+            ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS
         );
 
         when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
@@ -467,6 +469,118 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
         ArgumentCaptor<UpdateResponse> argumentCaptor = ArgumentCaptor.forClass(UpdateResponse.class);
         verify(actionListener).onResponse(argumentCaptor.capture());
         assertEquals(Result.UPDATED, argumentCaptor.getValue().getResult());
+    }
+
+    @Test
+    public void testExecutePlaintextCredentialsBlockedWhenNotAllowed() {
+        when(mlFeatureEnabledSetting.isPlaintextCredentialsAllowed()).thenReturn(false);
+
+        // Create a connector with plaintext credentials (encrypted=false) using mutable map
+        Map<String, String> plaintextCredential = new java.util.HashMap<>();
+        plaintextCredential.put("api_key", "plaintext_value");
+        plaintextCredential.put("encrypted", "false");
+
+        Map<String, String> parameters = new java.util.HashMap<>();
+        parameters.put("param1", "value1");
+
+        Map<String, String> headers = new java.util.HashMap<>();
+        headers.put("Authorization", "Bearer ${credential.api_key}");
+
+        doAnswer(invocation -> {
+            ActionListener<Connector> listener = invocation.getArgument(5);
+            Connector connector = HttpConnector
+                .builder()
+                .name("test")
+                .protocol("http")
+                .version("1")
+                .credential(plaintextCredential)
+                .parameters(parameters)
+                .actions(
+                    Arrays
+                        .asList(
+                            ConnectorAction
+                                .builder()
+                                .actionType(ConnectorAction.ActionType.PREDICT)
+                                .method("POST")
+                                .url("https://api.openai.com/v1/chat/completions")
+                                .headers(headers)
+                                .requestBody("{ \"model\": \"${parameters.model}\", \"messages\": ${parameters.messages} }")
+                                .build()
+                        )
+                )
+                .build();
+            listener.onResponse(connector);
+            return null;
+        }).when(connectorAccessControlHelper).getConnector(any(), any(), any(), any(), any(), any());
+
+        doReturn(true).when(connectorAccessControlHelper).validateConnectorAccess(any(Client.class), any(Connector.class));
+
+        updateConnectorTransportAction.doExecute(task, updateRequest, actionListener);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertTrue(argumentCaptor.getValue().getMessage().contains("Plaintext credentials are not allowed"));
+    }
+
+    @Test
+    public void testExecutePlaintextCredentialsAllowedWhenSettingEnabled() {
+        when(mlFeatureEnabledSetting.isPlaintextCredentialsAllowed()).thenReturn(true);
+        doReturn(true).when(connectorAccessControlHelper).validateConnectorAccess(any(Client.class), any(Connector.class));
+
+        // Create a connector with plaintext credentials (encrypted=false) using mutable map
+        Map<String, String> plaintextCredential = new java.util.HashMap<>();
+        plaintextCredential.put("api_key", "plaintext_value");
+        plaintextCredential.put("encrypted", "false");
+
+        Map<String, String> parameters = new java.util.HashMap<>();
+        parameters.put("param1", "value1");
+
+        Map<String, String> headers = new java.util.HashMap<>();
+        headers.put("Authorization", "Bearer ${credential.api_key}");
+
+        doAnswer(invocation -> {
+            ActionListener<Connector> listener = invocation.getArgument(5);
+            Connector connector = HttpConnector
+                .builder()
+                .name("test")
+                .protocol("http")
+                .version("1")
+                .credential(plaintextCredential)
+                .parameters(parameters)
+                .actions(
+                    Arrays
+                        .asList(
+                            ConnectorAction
+                                .builder()
+                                .actionType(ConnectorAction.ActionType.PREDICT)
+                                .method("POST")
+                                .url("https://api.openai.com/v1/chat/completions")
+                                .headers(headers)
+                                .requestBody("{ \"model\": \"${parameters.model}\", \"messages\": ${parameters.messages} }")
+                                .build()
+                        )
+                )
+                .build();
+            listener.onResponse(connector);
+            return null;
+        }).when(connectorAccessControlHelper).getConnector(any(), any(), any(), any(), any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), isA(ActionListener.class));
+
+        updateConnectorTransportAction.doExecute(task, updateRequest, actionListener);
+
+        // Should succeed when plaintext credentials are allowed
+        verify(actionListener).onResponse(any(UpdateResponse.class));
     }
 
     private SearchResponse noneEmptySearchResponse() throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLPlaintextCredentialsIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLPlaintextCredentialsIT.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.ml.utils.TestHelper;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Integration tests for the plaintext credentials feature.
+ * Tests the cluster setting 'plugins.ml_commons.allow_plaintext_credentials'.
+ */
+public class RestMLPlaintextCredentialsIT extends MLCommonsRestTestCase {
+
+    private static final String PLAINTEXT_CREDENTIALS_SETTING = "plugins.ml_commons.allow_plaintext_credentials";
+
+    // Connector with encrypted credentials (default behavior)
+    private final String encryptedCredentialsConnector = "{\n"
+        + "  \"name\": \"Test Connector with Encrypted Credentials\",\n"
+        + "  \"description\": \"Connector for testing encrypted credentials\",\n"
+        + "  \"version\": 1,\n"
+        + "  \"protocol\": \"http\",\n"
+        + "  \"parameters\": {\n"
+        + "    \"endpoint\": \"api.openai.com\"\n"
+        + "  },\n"
+        + "  \"credential\": {\n"
+        + "    \"api_key\": \"test_api_key\"\n"
+        + "  },\n"
+        + "  \"actions\": [\n"
+        + "    {\n"
+        + "      \"action_type\": \"predict\",\n"
+        + "      \"method\": \"POST\",\n"
+        + "      \"url\": \"https://api.openai.com/v1/completions\",\n"
+        + "      \"headers\": {\n"
+        + "        \"Authorization\": \"Bearer ${credential.api_key}\"\n"
+        + "      },\n"
+        + "      \"request_body\": \"{\\\"model\\\": \\\"gpt-3.5-turbo\\\", \\\"prompt\\\": \\\"${parameters.prompt}\\\"}\"\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    // Connector with plaintext credentials (encrypted: false)
+    private final String plaintextCredentialsConnector = "{\n"
+        + "  \"name\": \"Test Connector with Plaintext Credentials\",\n"
+        + "  \"description\": \"Connector for testing plaintext credentials\",\n"
+        + "  \"version\": 1,\n"
+        + "  \"protocol\": \"http\",\n"
+        + "  \"parameters\": {\n"
+        + "    \"endpoint\": \"api.openai.com\"\n"
+        + "  },\n"
+        + "  \"credential\": {\n"
+        + "    \"api_key\": \"test_api_key\",\n"
+        + "    \"encrypted\": \"false\"\n"
+        + "  },\n"
+        + "  \"actions\": [\n"
+        + "    {\n"
+        + "      \"action_type\": \"predict\",\n"
+        + "      \"method\": \"POST\",\n"
+        + "      \"url\": \"https://api.openai.com/v1/completions\",\n"
+        + "      \"headers\": {\n"
+        + "        \"Authorization\": \"Bearer ${credential.api_key}\"\n"
+        + "      },\n"
+        + "      \"request_body\": \"{\\\"model\\\": \\\"gpt-3.5-turbo\\\", \\\"prompt\\\": \\\"${parameters.prompt}\\\"}\"\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        // Ensure the setting is disabled (default) before each test
+        updateClusterSettings(PLAINTEXT_CREDENTIALS_SETTING, false);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Reset to default after each test
+        updateClusterSettings(PLAINTEXT_CREDENTIALS_SETTING, false);
+        super.tearDown();
+    }
+
+    @Test
+    public void testCreateConnectorWithEncryptedCredentials_Success() throws Exception {
+        // Creating a connector with encrypted credentials (default) should always succeed
+        Response response = createConnector(encryptedCredentialsConnector);
+        Map<String, Object> responseMap = parseResponseToMap(response);
+
+        assertNotNull("Response should contain connector_id", responseMap.get("connector_id"));
+        String connectorId = (String) responseMap.get("connector_id");
+        assertFalse("Connector ID should not be empty", connectorId.isEmpty());
+
+        // Clean up
+        deleteConnector(connectorId);
+    }
+
+    @Test
+    public void testCreateConnectorWithPlaintextCredentials_BlockedByDefault() throws Exception {
+        // Creating a connector with plaintext credentials should fail when setting is disabled
+        try {
+            createConnector(plaintextCredentialsConnector);
+            fail("Expected exception when creating connector with plaintext credentials while setting is disabled");
+        } catch (ResponseException e) {
+            String responseBody = TestHelper.httpEntityToString(e.getResponse().getEntity());
+            assertTrue(
+                "Error message should mention plaintext credentials not allowed",
+                responseBody.contains("Plaintext credentials are not allowed")
+            );
+        }
+    }
+
+    @Test
+    public void testCreateConnectorWithPlaintextCredentials_AllowedWhenEnabled() throws Exception {
+        // Enable plaintext credentials
+        updateClusterSettings(PLAINTEXT_CREDENTIALS_SETTING, true);
+
+        // Creating a connector with plaintext credentials should succeed when setting is enabled
+        Response response = createConnector(plaintextCredentialsConnector);
+        Map<String, Object> responseMap = parseResponseToMap(response);
+
+        assertNotNull("Response should contain connector_id", responseMap.get("connector_id"));
+        String connectorId = (String) responseMap.get("connector_id");
+        assertFalse("Connector ID should not be empty", connectorId.isEmpty());
+
+        // Verify the connector was created by getting it
+        Response getResponse = getConnector(connectorId);
+        Map<String, Object> connectorMap = parseResponseToMap(getResponse);
+        assertEquals("Test Connector with Plaintext Credentials", connectorMap.get("name"));
+
+        // Clean up
+        deleteConnector(connectorId);
+    }
+
+    @Test
+    public void testUpdateConnectorWithPlaintextCredentials_BlockedByDefault() throws Exception {
+        // First create a connector with encrypted credentials
+        Response response = createConnector(encryptedCredentialsConnector);
+        Map<String, Object> responseMap = parseResponseToMap(response);
+        String connectorId = (String) responseMap.get("connector_id");
+
+        // Try to update the connector with plaintext credentials - should fail
+        String updateContent = "{\n"
+            + "  \"credential\": {\n"
+            + "    \"api_key\": \"new_api_key\",\n"
+            + "    \"encrypted\": \"false\"\n"
+            + "  }\n"
+            + "}";
+
+        try {
+            updateConnector(connectorId, updateContent);
+            fail("Expected exception when updating connector with plaintext credentials while setting is disabled");
+        } catch (ResponseException e) {
+            String responseBody = TestHelper.httpEntityToString(e.getResponse().getEntity());
+            assertTrue(
+                "Error message should mention plaintext credentials not allowed",
+                responseBody.contains("Plaintext credentials are not allowed")
+            );
+        }
+
+        // Clean up
+        deleteConnector(connectorId);
+    }
+
+    @Test
+    public void testUpdateConnectorWithPlaintextCredentials_AllowedWhenEnabled() throws Exception {
+        // Enable plaintext credentials
+        updateClusterSettings(PLAINTEXT_CREDENTIALS_SETTING, true);
+
+        // Create a connector with plaintext credentials
+        Response response = createConnector(plaintextCredentialsConnector);
+        Map<String, Object> responseMap = parseResponseToMap(response);
+        String connectorId = (String) responseMap.get("connector_id");
+
+        // Update the connector with new plaintext credentials - should succeed
+        String updateContent = "{\n"
+            + "  \"description\": \"Updated description\",\n"
+            + "  \"credential\": {\n"
+            + "    \"api_key\": \"new_api_key\",\n"
+            + "    \"encrypted\": \"false\"\n"
+            + "  }\n"
+            + "}";
+
+        Response updateResponse = updateConnector(connectorId, updateContent);
+        assertEquals(200, updateResponse.getStatusLine().getStatusCode());
+
+        // Verify the update
+        Response getResponse = getConnector(connectorId);
+        Map<String, Object> connectorMap = parseResponseToMap(getResponse);
+        assertEquals("Updated description", connectorMap.get("description"));
+
+        // Clean up
+        deleteConnector(connectorId);
+    }
+
+    @Test
+    public void testDynamicSettingChange() throws Exception {
+        // Verify setting is initially disabled
+        try {
+            createConnector(plaintextCredentialsConnector);
+            fail("Expected exception when creating connector with plaintext credentials while setting is disabled");
+        } catch (ResponseException e) {
+            assertTrue(
+                "Error should mention plaintext credentials",
+                TestHelper.httpEntityToString(e.getResponse().getEntity()).contains("Plaintext credentials are not allowed")
+            );
+        }
+
+        // Enable the setting dynamically
+        updateClusterSettings(PLAINTEXT_CREDENTIALS_SETTING, true);
+
+        // Now it should succeed
+        Response response = createConnector(plaintextCredentialsConnector);
+        Map<String, Object> responseMap = parseResponseToMap(response);
+        String connectorId = (String) responseMap.get("connector_id");
+        assertNotNull("Connector should be created after enabling setting", connectorId);
+
+        // Disable the setting again
+        updateClusterSettings(PLAINTEXT_CREDENTIALS_SETTING, false);
+
+        // Creating new connector with plaintext credentials should fail again
+        try {
+            createConnector(plaintextCredentialsConnector);
+            fail("Expected exception after disabling setting again");
+        } catch (ResponseException e) {
+            assertTrue(
+                "Error should mention plaintext credentials",
+                TestHelper.httpEntityToString(e.getResponse().getEntity()).contains("Plaintext credentials are not allowed")
+            );
+        }
+
+        // Clean up
+        deleteConnector(connectorId);
+    }
+
+    // Helper methods
+
+    private Response createConnector(String input) throws IOException {
+        return TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                "/_plugins/_ml/connectors/_create",
+                null,
+                TestHelper.toHttpEntity(input),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+            );
+    }
+
+    private Response getConnector(String connectorId) throws IOException {
+        return TestHelper
+            .makeRequest(
+                client(),
+                "GET",
+                "/_plugins/_ml/connectors/" + connectorId,
+                null,
+                "",
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+            );
+    }
+
+    private Response updateConnector(String connectorId, String updateContent) throws IOException {
+        return TestHelper
+            .makeRequest(
+                client(),
+                "PUT",
+                "/_plugins/_ml/connectors/" + connectorId,
+                null,
+                TestHelper.toHttpEntity(updateContent),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+            );
+    }
+
+    private Response deleteConnector(String connectorId) throws IOException {
+        return TestHelper
+            .makeRequest(
+                client(),
+                "DELETE",
+                "/_plugins/_ml/connectors/" + connectorId,
+                null,
+                "",
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, ""))
+            );
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/settings/MLFeatureEnabledSettingTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/settings/MLFeatureEnabledSettingTests.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONTROLLER_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_EXECUTE_TOOL_ENABLED;
@@ -90,7 +91,8 @@ public class MLFeatureEnabledSettingTests {
                             ML_COMMONS_MAX_JSON_SIZE,
                             ML_COMMONS_UNIFIED_AGENT_API_ENABLED,
                             ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
-                            ML_COMMONS_AG_UI_ENABLED
+                            ML_COMMONS_AG_UI_ENABLED,
+                            ML_COMMONS_ALLOW_PLAINTEXT_CREDENTIALS
                         )
                 )
             );


### PR DESCRIPTION
### Description
Currently, ml-commons requires all connector credentials to be encrypted using EncryptorImpl with AWS Encryption SDK. This creates challenges in certain use cases where encryption is unnecessary, redundant, or problematic. This issue proposes adding support for optionally storing credentials in plaintext, controlled by a cluster-level setting (plugins.ml_commons.allow_plaintext_credentials, default: false) to ensure security by default.

### Related Issues
https://github.com/opensearch-project/ml-commons/issues/4704

### Testing
Below is an example request body for different testing cases:
```
{
    "name": "Cohere Connector: embedding",
    "description": "The connector to cohere embedding model",
    "version": 1,
    "protocol": "http",
    "parameters": {
      "model_name": "embed-english-v3.0"
    },
    "credential": {
      "encrypted": "xxx",
      "cohere_key": "YOUR_COHERE_KEY"
    },
    "actions": [
      {
        "action_type": "predict",
        "method": "POST",
        "url": "https://api.cohere.com/v2/embed",
        "headers": {
          "content-type": "application/json",
          "Authorization": "Bearer ${credential.cohere_key}"
        },
        "request_body": "{ \"texts\": ${parameters.texts}, \"truncate\": \"END\", \"model\": \"${parameters.model_name}\", \"embedding_types\": [\"float\", \"int8\", \"uint8\", \"binary\", \"ubinary\"], \"input_type\": \"classification\"}",
        "pre_process_function": "connector.pre_process.cohere.embedding",
        "post_process_function": "connector.post_process.cohere_v2.embedding.float"
      }
    ]
}
```
#### Allow plain text credentials not enabled
Keep the cluster setting: `plugins.ml_commons.allow_plaintext_credentials` unchanged and try to create a connector with `encrypted` to false like below:
```
...
  "credential": {
      "encrypted": "false",
      "cohere_key": "YOUR_COHERE_KEY"
    },
...
```
The result should like below:
```
{
    "error": {
        "root_cause": [
            {
                "type": "illegal_argument_exception",
                "reason": "Plaintext credentials are not allowed. Please set cluster setting 'plugins.ml_commons.allow_plaintext_credentials' to true to enable plaintext credentials storage."
            }
        ],
        "type": "illegal_argument_exception",
        "reason": "Plaintext credentials are not allowed. Please set cluster setting 'plugins.ml_commons.allow_plaintext_credentials' to true to enable plaintext credentials storage."
    },
    "status": 400
}
```
Remove the key `encrypted` or change the key's value to true can get successful response.

#### Allow plain text credentials enabled
Use plain text credentials with request body like below:
```
...
  "credential": {
      "encrypted": "false",
      "cohere_key": "YOUR_COHERE_KEY"
    },
...
```
Response like below:
```
{
    "connector_id": "6VzuZp0B-y9qd6CWXP-L"
}
```
If you have permission to check the raw documents you will see:
```
...
"_source": {
    "name": "Cohere Connector: embedding",
     ...
    "credential": {
        "encrypted": "false",
        "cohere_key": "YOUR_COHERE_KEY"
    },
...
```

Use encrypted credentials with request body like below:
```
...
  "credential": {
      "cohere_key": "YOUR_COHERE_KEY"
    },
...
```
Response like below:
```
{
    "connector_id": "6lzvZp0B-y9qd6CWZv95"
}
```
If you have permission to read raw documents you will see:
```
...
"_source": {
  "name": "Cohere Connector: embedding",
  ...
  "credential": {
      "cohere_key": "AgV4djTpfnlByArLgWmAo7Y30CBFX9k/jB5ZirpeeccveYcAXwABABVhd3MtY3J5cHRvLXB1YmxpYy1rZXkAREExZlFTRFNtbHlTVnNCSEpWdHA0TDBZV0FQblp1eWJTS0NGL3FVVHhPdlk5VEp1ODhyejVjL2djS0VsUGJsSWVFQT09AAEABkN1c3RvbQAUAAAAgAAAAAxeqnZKVagWpsqAHm4AMASNOiiwECY1Rfvj2gHrqHKZ8v3y/k6kYl36YlISczDq8//Ry4wrbSroT0RAG/y6CwIAABAAL8BD5fT5HlQkSCvFtJKbgb8zZKn4cLR+TWhFQbg3WJT8m5TmM6Sx++aM5+GjRXjF/////wAAAAEAAAAAAAAAAAAAAAEAAAAoVbbRKUon+0+E7KxbnkLF1le/N2x+EKhcym8gAvHfsSWWUqjU097BWzDMYe9kHobdrDv5mXEcfJwAZzBlAjEAisLXWdOCzHbQra0X0u91DZGB4V3iWySEvHMxmvZ4QRZWc/tZkuR5xWBKAwMj01e8AjB33WjvCQ9kwEu7lUf/k8faOx26D4dTYRjA4baTbn+Czl5Z5MXPUv11hDFzsXZVlHM="
  },
...
```
#### Allow plain text credentials changed to disabled
If allow plain text credentials are set to enabled and registered with several connectors with plain text credentials and   the setting are changed back to disabled after that, then the plain text credentials should still work.
*Predict model*
```
POST /_plugins/_ml/models/BmuyZp0BfDnPLd6M65JO/_predict
{
    "parameters": {
        "texts": ["Say this is a test", "world"]
    }
}
```
Response:
```
{
    "inference_results": [
        {
            "output": [
                {
                    "name": "sentence_embedding",
                    "data_type": "FLOAT32",
                    "shape": [
                        1024
                    ],
                    "data": [
                        -0.015640259,
                        -0.0048446655,
                        -0.02684021,
                        -0.020339966,
                        -0.014762878,
                        0.004890442,
                        -0.003250122,
                        ...
                 ]
             }
          ]
      }
   ]
}
```
#### Update connector when allow plain text credentials are set to false
*Update Failed*
```
POST /_plugins/_ml/connectors/AGuyZp0BfDnPLd6MaJLr
{
    "credential": {
        "encrypted": "false",
        "cohere_key": "YOUR_COHERE_KEY"
    },
    "description": "Change the connector credentials to use plain text credential"
}
```
Response:
```
{
    "error": {
        "root_cause": [
            {
                "type": "illegal_argument_exception",
                "reason": "Plaintext credentials are not allowed. Please set cluster setting 'plugins.ml_commons.allow_plaintext_credentials' to true to enable plaintext credentials storage."
            }
        ],
        "type": "illegal_argument_exception",
        "reason": "Plaintext credentials are not allowed. Please set cluster setting 'plugins.ml_commons.allow_plaintext_credentials' to true to enable plaintext credentials storage."
    },
    "status": 400
}
```
*Update succeed*
```
POST /_plugins/_ml/connectors/AGuyZp0BfDnPLd6MaJLr
{
    "credential": {
        "cohere_key": "YOUR_COHERE_KEY"
    },
    "description": "Change the connector credentials to use plain text credential"
}
```
Response:
```
{
    "_index": ".plugins-ml-connector",
    "_id": "AGuyZp0BfDnPLd6MaJLr",
    "_version": 2,
    "result": "updated",
    "forced_refresh": true,
    "_shards": {
        "total": 1,
        "successful": 1,
        "failed": 0
    },
    "_seq_no": 5,
    "_primary_term": 3
}
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
