### PR TITLE
Propagate stream error

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskAction.java
@@ -91,7 +91,7 @@ public class TransportExecuteStreamTaskAction extends HandledTransportAction<Act
 
                     public void handleException(TransportException exp) {
                         try {
-                            channel.sendResponse(exp);
+                            channel.sendResponse((Exception) exp.unwrapCause());
                         } catch (Exception e) {
                             log.error("Failed to send error response", e);
                         }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteStreamAction.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import org.opensearch.OpenSearchStatusException;
@@ -203,12 +204,14 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
                 );
             channel.prepareResponse(RestStatus.OK, headers);
 
+            AtomicBoolean isAGUIRef = new AtomicBoolean(false);
             Flux.from(channel).ofType(HttpChunk.class).collectList().flatMap(chunks -> {
                 try (ThreadContext.StoredContext context = supplier.get()) {
 
                     BytesReference completeContent = combineChunks(chunks);
                     MLExecuteTaskRequest mlExecuteTaskRequest = getRequest(agentId, request, completeContent);
                     boolean isAGUI = isAGUIAgent(mlExecuteTaskRequest);
+                    isAGUIRef.set(isAGUI);
                     String threadId = extractThreadId(mlExecuteTaskRequest);
                     String runId = extractRunId(mlExecuteTaskRequest);
 
@@ -281,10 +284,7 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
             }).doOnNext(channel::sendChunk).onErrorResume(ex -> {
                 log.error("Error occurred", ex);
                 try {
-                    String errorMessage = ex instanceof IOException
-                        ? "Failed to parse request: " + ex.getMessage()
-                        : "Error processing request: " + ex.getMessage();
-                    HttpChunk errorChunk = createHttpChunk("data: {\"error\": \"" + errorMessage.replace("\"", "\\\"") + "\"}\n\n", true);
+                    HttpChunk errorChunk = buildStreamErrorChunk(ex, isAGUIRef.get());
                     channel.sendChunk(errorChunk);
                 } catch (Exception e) {
                     log.error("Failed to send error chunk", e);
@@ -622,6 +622,27 @@ public class RestMLExecuteStreamAction extends BaseRestHandler {
         } catch (IOException e) {
             log.error("Failed to combine chunks", e);
             throw new OpenSearchStatusException("Failed to combine request chunks", RestStatus.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+
+    @VisibleForTesting
+    HttpChunk buildStreamErrorChunk(Throwable ex, boolean isAGUI) {
+        // Unwrap to get the actual root cause message and status
+        Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+        String errorMessage;
+        if (ex instanceof IOException) {
+            errorMessage = "Failed to parse request: " + ex.getMessage();
+        } else if (cause instanceof OpenSearchStatusException statusEx) {
+            errorMessage = statusEx.getMessage();
+        } else {
+            errorMessage = cause.getMessage() != null ? cause.getMessage() : ex.getMessage();
+        }
+        if (isAGUI) {
+            // Emit a RunErrorEvent so the AG-UI client receives a structured error
+            BaseEvent runErrorEvent = new RunErrorEvent(errorMessage, null);
+            return createHttpChunk("data: " + runErrorEvent.toJsonString() + "\n\n", true);
+        } else {
+            return createHttpChunk("data: {\"error\": \"" + errorMessage.replace("\"", "\\\"") + "\"}\n\n", true);
         }
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskActionTests.java
@@ -40,6 +40,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.RemoteTransportException;
 import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.TransportChannel;
+import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
@@ -182,6 +183,27 @@ public class TransportExecuteStreamTaskActionTests extends OpenSearchTestCase {
 
         transportExecuteStreamTaskAction.messageReceived(mlExecuteTaskRequest, transportChannel, task);
         verify(transportChannel).sendResponse(any(Exception.class));
+    }
+
+    @Test
+    public void testMessageReceivedHandlerPlainTransportException() throws Exception {
+        Task task = mock(Task.class);
+
+        doAnswer(invocation -> {
+            TransportResponseHandler<MLExecuteTaskResponse> handler = invocation.getArgument(3);
+
+            // Plain TransportException without OpenSearchWrapperException - unwrapCause returns itself
+            TransportException transportException = new TransportException("plain error");
+            handler.handleException(transportException);
+
+            return null;
+        }).when(transportService).sendRequest(any(), any(), any(), any(TransportResponseHandler.class));
+
+        transportExecuteStreamTaskAction.messageReceived(mlExecuteTaskRequest, transportChannel, task);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(transportChannel).sendResponse(captor.capture());
+        assertEquals("plain error", captor.getValue().getMessage());
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/execute/TransportExecuteStreamTaskActionTests.java
@@ -37,9 +37,9 @@ import org.opensearch.ml.task.MLExecuteTaskRunner;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.RemoteTransportException;
 import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.TransportChannel;
-import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
@@ -139,8 +139,14 @@ public class TransportExecuteStreamTaskActionTests extends OpenSearchTestCase {
             MLExecuteTaskResponse mockResponse = mock(MLExecuteTaskResponse.class);
             handler.handleResponse(mockResponse);
 
-            // Test handleException method
-            TransportException transportException = new TransportException("test exception");
+            // Test handleException - should unwrap TransportException to send root cause
+            Exception rootCause = new RuntimeException("Memory container not found");
+            RemoteTransportException transportException = new RemoteTransportException(
+                "node1",
+                null,
+                "cluster:admin/opensearch/ml/execute/stream",
+                rootCause
+            );
             handler.handleException(transportException);
 
             return null;
@@ -148,7 +154,10 @@ public class TransportExecuteStreamTaskActionTests extends OpenSearchTestCase {
 
         transportExecuteStreamTaskAction.messageReceived(mlExecuteTaskRequest, transportChannel, task);
 
-        verify(transportChannel).sendResponse(any(TransportException.class));
+        // Verify the unwrapped root cause is sent, not the TransportException wrapper
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(transportChannel).sendResponse(captor.capture());
+        assertEquals("Memory container not found", captor.getValue().getMessage());
     }
 
     @Test
@@ -159,14 +168,20 @@ public class TransportExecuteStreamTaskActionTests extends OpenSearchTestCase {
         doAnswer(invocation -> {
             TransportResponseHandler<MLExecuteTaskResponse> handler = invocation.getArgument(3);
 
-            TransportException transportException = new TransportException("test exception");
+            Exception rootCause = new RuntimeException("test error");
+            RemoteTransportException transportException = new RemoteTransportException(
+                "node1",
+                null,
+                "cluster:admin/opensearch/ml/execute/stream",
+                rootCause
+            );
             handler.handleException(transportException);
 
             return null;
         }).when(transportService).sendRequest(any(), any(), any(), any(TransportResponseHandler.class));
 
         transportExecuteStreamTaskAction.messageReceived(mlExecuteTaskRequest, transportChannel, task);
-        verify(transportChannel).sendResponse(any(TransportException.class));
+        verify(transportChannel).sendResponse(any(Exception.class));
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteStreamActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteStreamActionTests.java
@@ -759,6 +759,83 @@ public class RestMLExecuteStreamActionTests extends OpenSearchTestCase {
         assertTrue(content.contains("Something went wrong"));
     }
 
+    // ===== buildStreamErrorChunk tests =====
+
+    @Test
+    public void testBuildStreamErrorChunk_nonAGUI_opensearchStatusException() {
+        OpenSearchStatusException rootCause = new OpenSearchStatusException("Memory container not found", RestStatus.NOT_FOUND);
+        RuntimeException wrapper = new RuntimeException(rootCause);
+
+        HttpChunk chunk = restAction.buildStreamErrorChunk(wrapper, false);
+
+        assertNotNull(chunk);
+        assertTrue(chunk.isLast());
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertTrue(content.contains("Memory container not found"));
+        assertTrue(content.startsWith("data: {\"error\":"));
+    }
+
+    @Test
+    public void testBuildStreamErrorChunk_nonAGUI_runtimeException() {
+        RuntimeException ex = new RuntimeException("Something went wrong");
+
+        HttpChunk chunk = restAction.buildStreamErrorChunk(ex, false);
+
+        assertNotNull(chunk);
+        assertTrue(chunk.isLast());
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertTrue(content.contains("Something went wrong"));
+    }
+
+    @Test
+    public void testBuildStreamErrorChunk_nonAGUI_ioException() {
+        IOException ex = new IOException("bad input");
+
+        HttpChunk chunk = restAction.buildStreamErrorChunk(ex, false);
+
+        assertNotNull(chunk);
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertTrue(content.contains("Failed to parse request: bad input"));
+    }
+
+    @Test
+    public void testBuildStreamErrorChunk_AGUI_emitsRunErrorEvent() {
+        OpenSearchStatusException rootCause = new OpenSearchStatusException("Memory container not found", RestStatus.NOT_FOUND);
+        RuntimeException wrapper = new RuntimeException(rootCause);
+
+        HttpChunk chunk = restAction.buildStreamErrorChunk(wrapper, true);
+
+        assertNotNull(chunk);
+        assertTrue(chunk.isLast());
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertTrue(content.contains("RUN_ERROR"));
+        assertTrue(content.contains("Memory container not found"));
+    }
+
+    @Test
+    public void testBuildStreamErrorChunk_noCause_usesExMessage() {
+        RuntimeException ex = new RuntimeException("top level error");
+
+        HttpChunk chunk = restAction.buildStreamErrorChunk(ex, false);
+
+        assertNotNull(chunk);
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        // RuntimeException has no cause, but it IS its own "cause" fallback, so its message is used
+        assertTrue(content.contains("top level error"));
+    }
+
+    @Test
+    public void testBuildStreamErrorChunk_causeWithNullMessage_fallsBackToExMessage() {
+        RuntimeException cause = new RuntimeException((String) null);
+        RuntimeException ex = new RuntimeException("outer message", cause);
+
+        HttpChunk chunk = restAction.buildStreamErrorChunk(ex, false);
+
+        assertNotNull(chunk);
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertTrue(content.contains("outer message"));
+    }
+
     // ===== Reflection helpers for testing private methods =====
 
     @SuppressWarnings("unchecked")

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteStreamActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteStreamActionTests.java
@@ -836,6 +836,41 @@ public class RestMLExecuteStreamActionTests extends OpenSearchTestCase {
         assertTrue(content.contains("outer message"));
     }
 
+    @Test
+    public void testBuildStreamErrorChunk_nonAGUI_exactFormat() {
+        RuntimeException ex = new RuntimeException("test error");
+
+        HttpChunk chunk = restAction.buildStreamErrorChunk(ex, false);
+
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertEquals("data: {\"error\": \"test error\"}\n\n", content);
+    }
+
+    @Test
+    public void testBuildStreamErrorChunk_nonAGUI_escapesQuotesInMessage() {
+        RuntimeException ex = new RuntimeException("field \"name\" is invalid");
+
+        HttpChunk chunk = restAction.buildStreamErrorChunk(ex, false);
+
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertEquals("data: {\"error\": \"field \\\"name\\\" is invalid\"}\n\n", content);
+    }
+
+    @Test
+    public void testBuildStreamErrorChunk_AGUI_exactFormat() {
+        RuntimeException ex = new RuntimeException("test error");
+
+        HttpChunk chunk = restAction.buildStreamErrorChunk(ex, true);
+
+        String content = new String(BytesReference.toBytes(chunk.content()));
+        assertTrue(content.startsWith("data: "));
+        assertTrue(content.endsWith("\n\n"));
+        // Verify it's valid JSON by extracting the data payload
+        String jsonPayload = content.substring("data: ".length(), content.length() - 2);
+        assertTrue(jsonPayload.contains("\"type\":\"RUN_ERROR\""));
+        assertTrue(jsonPayload.contains("\"message\":\"test error\""));
+    }
+
     // ===== Reflection helpers for testing private methods =====
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Description
Propagate stream error. Resolves https://github.com/opensearch-project/ml-commons/issues/4749.

Tested that when there is an underlying error (e.g. agentic memory error), the error is propagated properly.
```
data: {"type":"RUN_STARTED","timestamp":1776197477955,"threadId":"6930a356-dd3b-4620-8b5f-d41512d10453","runId":"ec330a5e-e247-46e3-bc27-dd920cf2b6af"}

data: {"type":"RUN_ERROR","timestamp":1776197478098,"message":"Memory container not found"}
```

### Related Issues
Resolves https://github.com/opensearch-project/ml-commons/issues/4749

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
