### PR TITLE
Fix tool output json escapse issue

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLConversationalFlowAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLConversationalFlowAgentRunner.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.engine.algorithms.agent;
 
+import static org.apache.commons.text.StringEscapeUtils.escapeJson;
 import static org.opensearch.ml.common.CommonValue.ENDPOINT_FIELD;
 import static org.opensearch.ml.common.conversation.ActionConstants.ADDITIONAL_INFO_FIELD;
 import static org.opensearch.ml.common.conversation.ActionConstants.AI_RESPONSE_FIELD;
@@ -287,7 +288,7 @@ public class MLConversationalFlowAgentRunner implements MLAgentRunner {
         String outputKey = toolName + ".output";
         Map<String, String> toolParameters = ToolUtils.buildToolParameters(params, previousToolSpec, tenantId);
         String filteredOutput = parseResponse(filterToolOutput(toolParameters, output));
-        params.put(outputKey, StringUtils.prepareJsonValue(filteredOutput));
+        params.put(outputKey, escapeJson(filteredOutput));
         boolean traceDisabled = params.containsKey(DISABLE_TRACE) && Boolean.parseBoolean(params.get(DISABLE_TRACE));
 
         if (previousToolSpec.isIncludeOutputInAgentResponse() || finalI == toolSpecs.size()) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunner.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.engine.algorithms.agent;
 
+import static org.apache.commons.text.StringEscapeUtils.escapeJson;
 import static org.opensearch.ml.common.utils.ToolUtils.TOOL_OUTPUT_FILTERS_FIELD;
 import static org.opensearch.ml.common.utils.ToolUtils.convertOutputToModelTensor;
 import static org.opensearch.ml.common.utils.ToolUtils.filterToolOutput;
@@ -118,7 +119,7 @@ public class MLFlowAgentRunner implements MLAgentRunner {
                     String outputKey = toolName + ".output";
                     Map<String, String> toolParameters = ToolUtils.buildToolParameters(params, previousToolSpec, mlAgent.getTenantId());
                     String filteredOutput = parseResponse(filterToolOutput(toolParameters, output));
-                    params.put(outputKey, StringUtils.prepareJsonValue(filteredOutput));
+                    params.put(outputKey, escapeJson(filteredOutput));
                     if (previousToolSpec.isIncludeOutputInAgentResponse() || finalI == toolSpecs.size()) {
                         if (toolParameters.containsKey(TOOL_OUTPUT_FILTERS_FIELD)) {
                             flowAgentOutput.add(ModelTensor.builder().name(outputKey).result(filteredOutput).build());

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelation.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelation.java
@@ -317,12 +317,7 @@ public class MetricsCorrelation extends DLModelExecute {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder
             .fetchSource(
-                new String[] {
-                    MLModel.MODEL_ID_FIELD,
-                    MLModel.MODEL_NAME_FIELD,
-                    MODEL_STATE_FIELD,
-                    MLModel.MODEL_VERSION_FIELD,
-                    MLModel.MODEL_CONTENT_FIELD },
+                new String[] { MLModel.MODEL_ID_FIELD, MLModel.MODEL_NAME_FIELD, MODEL_STATE_FIELD, MLModel.MODEL_VERSION_FIELD },
                 new String[] { MLModel.MODEL_CONTENT_FIELD }
             );
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunnerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunnerTest.java
@@ -5,9 +5,11 @@
 
 package org.opensearch.ml.engine.algorithms.agent;
 
+import static org.apache.commons.text.StringEscapeUtils.escapeJson;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -540,5 +542,101 @@ public class MLFlowAgentRunnerTest {
         runner.run(flowAgent, params, agentActionListener);
 
         verify(agentActionListener).onResponse(any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testToolOutputJsonIsEscapedForNextTool() {
+        // This test verifies that when a tool returns valid JSON, it is properly escaped
+        // before being stored in params, so it can be safely used in string substitution
+        // by subsequent tools (e.g., in connector request body templates).
+        final Map<String, String> params = new HashMap<>();
+
+        // First tool returns valid JSON
+        String jsonToolOutput = "{\"logs\":[{\"message\":\"error occurred\",\"level\":\"ERROR\"}]}";
+        doAnswer(invocation -> {
+            ActionListener<Object> listener = invocation.getArgument(1);
+            listener.onResponse(jsonToolOutput);
+            return null;
+        }).when(firstTool).run(anyMap(), nextStepListenerCaptor.capture());
+
+        // Capture the params passed to second tool to verify escaping
+        ArgumentCaptor<Map<String, String>> secondToolParamsCaptor = ArgumentCaptor.forClass(Map.class);
+        doAnswer(invocation -> {
+            ActionListener<Object> listener = invocation.getArgument(1);
+            listener.onResponse(SECOND_TOOL_RESPONSE);
+            return null;
+        }).when(secondTool).run(secondToolParamsCaptor.capture(), any());
+
+        MLToolSpec firstToolSpec = MLToolSpec.builder().name(FIRST_TOOL).type(FIRST_TOOL).build();
+        MLToolSpec secondToolSpec = MLToolSpec.builder().name(SECOND_TOOL).type(SECOND_TOOL).build();
+        final MLAgent mlAgent = MLAgent
+            .builder()
+            .name("TestAgent")
+            .type(MLAgentType.FLOW.name())
+            .tools(Arrays.asList(firstToolSpec, secondToolSpec))
+            .build();
+
+        mlFlowAgentRunner.run(mlAgent, params, agentActionListener);
+
+        // Verify the first tool's JSON output is escaped when passed to second tool
+        Map<String, String> secondToolParams = secondToolParamsCaptor.getValue();
+        String escapedOutput = secondToolParams.get(FIRST_TOOL + ".output");
+        assertNotNull("First tool output should be present in second tool params", escapedOutput);
+
+        // The JSON should be escaped (quotes become \", etc.)
+        String expectedEscaped = escapeJson(jsonToolOutput);
+        assertEquals("Tool output should be JSON-escaped", expectedEscaped, escapedOutput);
+
+        // Verify the escaped string contains escaped quotes
+        assertTrue("Escaped output should contain escaped quotes", escapedOutput.contains("\\\""));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testToolOutputPlainTextIsEscapedForNextTool() {
+        // This test verifies that plain text tool output is also properly escaped
+        final Map<String, String> params = new HashMap<>();
+
+        // First tool returns plain text with special characters
+        String plainTextOutput = "Line1\nLine2\tTabbed \"quoted\"";
+        doAnswer(invocation -> {
+            ActionListener<Object> listener = invocation.getArgument(1);
+            listener.onResponse(plainTextOutput);
+            return null;
+        }).when(firstTool).run(anyMap(), nextStepListenerCaptor.capture());
+
+        // Capture the params passed to second tool to verify escaping
+        ArgumentCaptor<Map<String, String>> secondToolParamsCaptor = ArgumentCaptor.forClass(Map.class);
+        doAnswer(invocation -> {
+            ActionListener<Object> listener = invocation.getArgument(1);
+            listener.onResponse(SECOND_TOOL_RESPONSE);
+            return null;
+        }).when(secondTool).run(secondToolParamsCaptor.capture(), any());
+
+        MLToolSpec firstToolSpec = MLToolSpec.builder().name(FIRST_TOOL).type(FIRST_TOOL).build();
+        MLToolSpec secondToolSpec = MLToolSpec.builder().name(SECOND_TOOL).type(SECOND_TOOL).build();
+        final MLAgent mlAgent = MLAgent
+            .builder()
+            .name("TestAgent")
+            .type(MLAgentType.FLOW.name())
+            .tools(Arrays.asList(firstToolSpec, secondToolSpec))
+            .build();
+
+        mlFlowAgentRunner.run(mlAgent, params, agentActionListener);
+
+        // Verify the first tool's output is escaped when passed to second tool
+        Map<String, String> secondToolParams = secondToolParamsCaptor.getValue();
+        String escapedOutput = secondToolParams.get(FIRST_TOOL + ".output");
+        assertNotNull("First tool output should be present in second tool params", escapedOutput);
+
+        // The plain text should be escaped (newlines become \n, tabs become \t, quotes become \")
+        String expectedEscaped = escapeJson(plainTextOutput);
+        assertEquals("Tool output should be JSON-escaped", expectedEscaped, escapedOutput);
+
+        // Verify the escaped string contains escaped special characters
+        assertTrue("Escaped output should contain escaped newline", escapedOutput.contains("\\n"));
+        assertTrue("Escaped output should contain escaped tab", escapedOutput.contains("\\t"));
+        assertTrue("Escaped output should contain escaped quotes", escapedOutput.contains("\\\""));
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelationTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/metrics_correlation/MetricsCorrelationTest.java
@@ -320,12 +320,7 @@ public class MetricsCorrelationTest {
     @Test
     public void testSearchRequest() {
         String expectedIndex = CommonValue.ML_MODEL_INDEX;
-        String[] expectedIncludes = {
-            MLModel.MODEL_ID_FIELD,
-            MLModel.MODEL_NAME_FIELD,
-            MODEL_STATE_FIELD,
-            MLModel.MODEL_VERSION_FIELD,
-            MLModel.MODEL_CONTENT_FIELD };
+        String[] expectedIncludes = { MLModel.MODEL_ID_FIELD, MLModel.MODEL_NAME_FIELD, MODEL_STATE_FIELD, MLModel.MODEL_VERSION_FIELD };
         String[] expectedExcludes = { MLModel.MODEL_CONTENT_FIELD };
         String expectedNameQuery = FunctionName.METRICS_CORRELATION.name();
         String expectedVersionQuery = MCORR_ML_VERSION;

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchAgentActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchAgentActionTests.java
@@ -144,7 +144,7 @@ public class RestMLSearchAgentActionTests extends OpenSearchTestCase {
         String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_AGENT_INDEX }, indices);
         assertEquals(
-            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
+            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
             mlSearchActionRequest.source().toString()
         );
         RestResponse agentResponse = responseCaptor.getValue();
@@ -197,7 +197,7 @@ public class RestMLSearchAgentActionTests extends OpenSearchTestCase {
         String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_AGENT_INDEX }, indices);
         assertEquals(
-            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
+            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
             mlSearchActionRequest.source().toString()
         );
         RestResponse agentResponse = responseCaptor.getValue();

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchConnectorActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchConnectorActionTests.java
@@ -146,7 +146,7 @@ public class RestMLSearchConnectorActionTests extends OpenSearchTestCase {
         String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_CONNECTOR_INDEX }, indices);
         assertEquals(
-            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
+            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
             mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();
@@ -192,7 +192,7 @@ public class RestMLSearchConnectorActionTests extends OpenSearchTestCase {
         String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_CONNECTOR_INDEX }, indices);
         assertEquals(
-            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
+            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
             mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelActionTests.java
@@ -143,7 +143,7 @@ public class RestMLSearchModelActionTests extends OpenSearchTestCase {
         String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_MODEL_INDEX }, indices);
         assertEquals(
-            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
+            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
             mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();
@@ -163,7 +163,7 @@ public class RestMLSearchModelActionTests extends OpenSearchTestCase {
         String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_MODEL_INDEX }, indices);
         assertEquals(
-                "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
+                "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
                 mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();
@@ -209,7 +209,7 @@ public class RestMLSearchModelActionTests extends OpenSearchTestCase {
         String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_MODEL_INDEX }, indices);
         assertEquals(
-            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
+            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
             mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelGroupActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLSearchModelGroupActionTests.java
@@ -142,7 +142,7 @@ public class RestMLSearchModelGroupActionTests extends OpenSearchTestCase {
         String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_MODEL_GROUP_INDEX }, indices);
         assertEquals(
-            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
+            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
             mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();
@@ -188,7 +188,7 @@ public class RestMLSearchModelGroupActionTests extends OpenSearchTestCase {
         String[] indices = mlSearchActionRequest.indices();
         assertArrayEquals(new String[] { ML_MODEL_GROUP_INDEX }, indices);
         assertEquals(
-            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"includes\":[],\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
+            "{\"query\":{\"match_all\":{\"boost\":1.0}},\"version\":true,\"seq_no_primary_term\":true,\"_source\":{\"excludes\":[\"content\",\"model_content\",\"ui_metadata\"]}}",
             mlSearchActionRequest.source().toString()
         );
         RestResponse restResponse = responseCaptor.getValue();


### PR DESCRIPTION
### Description
After a tool execution it's output is not escaped to a raw string if the response is a json, see [here](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLFlowAgentRunner.java#L121), and when replacing the placeholder during executing prediction, the json input also not escaped, see [here](https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java#L192-L194), which means if a tool's response is a json and it's been replaced into a placeholder, then it's concatenating a raw string with a json, which causing the final string not a valid json string.

There are two different cases using the `MLFlowAgentRunner` or `MLConversationalFlowAgentRunner`:
1. The agent only have one tool and the tool's result is the final response to user.
2. The agent has multiple tools and a tool's result will be replaced into the request body to LLM.
Note that we only escape the json when putting them into the parameter map, which means the parameter is used for case 2, for case 1 we're not changing the original tool's response so it doesn't break case 1.


The failure UTs are not related to this change and they're caused by this change: https://github.com/opensearch-project/OpenSearch/pull/21203, we need make corresponding changes to ensure UTs pass.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
