### PR TITLE
Support Jackson 3.x release line

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     }
     compileOnly ('net.minidev:json-smart:2.5.2')
     compileOnly("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
-    compileOnly("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
-    compileOnly group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
+    compileOnly("tools.jackson.core:jackson-databind:${versions.jackson3_databind}")
+    compileOnly group: 'com.networknt' , name: 'json-schema-validator', version: '3.0.2'
     // Multi-tenant SDK Client
     compileOnly "org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}"
     compileOnly (group: 'software.amazon.awssdk', name: 'netty-nio-client', version: "${versions.aws}") {

--- a/common/src/main/java/org/opensearch/ml/common/connector/functions/preprocess/NovaMultiModalEmbeddingPreProcessFunction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/functions/preprocess/NovaMultiModalEmbeddingPreProcessFunction.java
@@ -15,11 +15,10 @@ import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.extern.log4j.Log4j2;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @Log4j2
 public class NovaMultiModalEmbeddingPreProcessFunction extends ConnectorPreProcessFunction {
@@ -65,16 +64,16 @@ public class NovaMultiModalEmbeddingPreProcessFunction extends ConnectorPreProce
             JsonNode value;
 
             if ((value = node.get("text")) != null)
-                return value.asText();
+                return value.asString();
             if ((value = node.get("image")) != null)
-                return value.asText();
+                return value.asString();
             if ((value = node.get("audio")) != null)
-                return value.asText();
+                return value.asString();
             if ((value = node.get("video")) != null)
-                return value.asText();
+                return value.asString();
 
             return input;
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             log.warn("Failed to parse JSON: {}", e.getMessage());
             return input;
         }
@@ -92,7 +91,7 @@ public class NovaMultiModalEmbeddingPreProcessFunction extends ConnectorPreProce
             if (node.has("audio"))
                 return "audio";
             return "text";
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             log.warn("Failed to detect modality from input, defaulting to text: {}", e.getMessage());
             return "text";
         }

--- a/common/src/main/java/org/opensearch/ml/common/indexInsight/LogRelatedIndexCheckTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/indexInsight/LogRelatedIndexCheckTask.java
@@ -22,9 +22,8 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.transport.client.Client;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-
 import lombok.extern.log4j.Log4j2;
+import tools.jackson.core.type.TypeReference;
 
 /** Check whether the index is log-related for downstream task：Log-based RCA analysis
 1. Judge whether the index is related to log

--- a/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
+++ b/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java
@@ -40,10 +40,6 @@ import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -56,12 +52,19 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.SpecVersion;
-import com.networknt.schema.ValidationMessage;
+import com.networknt.schema.Error;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
 
 import lombok.extern.log4j.Log4j2;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.introspect.DefaultAccessorNamingStrategy;
+import tools.jackson.databind.json.JsonMapper;
 
 @Log4j2
 public class StringUtils {
@@ -112,9 +115,12 @@ public class StringUtils {
     }
     public static final String TO_STRING_FUNCTION_NAME = ".toString()";
 
-    public static final ObjectMapper MAPPER = new ObjectMapper()
-        .configure(com.fasterxml.jackson.core.JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true)
-        .configure(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY, true);
+    public static final ObjectMapper MAPPER = JsonMapper
+        .builder()
+        .accessorNaming(new DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true))
+        .configure(StreamReadFeature.STRICT_DUPLICATE_DETECTION, true)
+        .configure(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY, true)
+        .build();
 
     public static boolean isValidJsonString(String json) {
         if (json == null || json.isBlank()) {
@@ -235,7 +241,7 @@ public class StringUtils {
             } else {
                 throw new IllegalArgumentException("Unsupported response type");
             }
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalArgumentException("Invalid JSON format: " + e.getMessage(), e);
         }
     }
@@ -354,7 +360,7 @@ public class StringUtils {
                 } else {
                     try {
                         return MAPPER.writeValueAsString(value);
-                    } catch (JsonProcessingException e) {
+                    } catch (JacksonException e) {
                         throw new RuntimeException("Failed to serialize to JSON", e);
                     }
                 }
@@ -641,21 +647,21 @@ public class StringUtils {
         try {
             // parse the schema JSON as string
             JsonNode schemaNode = MAPPER.readTree(schemaString);
-            JsonSchema schema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(schemaNode);
+            Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12).getSchema(schemaNode);
 
             // JSON data to validate
             JsonNode jsonNode = MAPPER.readTree(instanceString);
 
             // Validate JSON node against the schema
-            Set<ValidationMessage> errors = schema.validate(jsonNode);
+            List<Error> errors = schema.validate(jsonNode);
             if (!errors.isEmpty()) {
-                String errorMessage = errors.stream().map(ValidationMessage::getMessage).collect(Collectors.joining(", "));
+                String errorMessage = errors.stream().map(Error::getMessage).collect(Collectors.joining(", "));
 
                 throw new OpenSearchParseException(
                     "Validation failed: " + errorMessage + " for instance: " + instanceString + " with schema: " + schemaString
                 );
             }
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalArgumentException("Invalid JSON format: " + e.getMessage(), e);
         } catch (Exception e) {
             throw new OpenSearchParseException("Schema validation failed: " + e.getMessage(), e);

--- a/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
@@ -1402,7 +1402,7 @@ public class StringUtilsTest {
             () -> StringUtils.fromJson(jsonWithDuplicateKeys, "response")
         );
         assertTrue(exception.getMessage().contains("Invalid JSON format"));
-        assertTrue(exception.getCause() instanceof com.fasterxml.jackson.core.JsonParseException);
+        assertTrue(exception.getCause() instanceof tools.jackson.core.exc.StreamReadException);
     }
 
     @Test

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     testImplementation group: 'com.google.code.gson', name: 'gson', version: "${versions.gson}"
     testImplementation group: 'org.json', name: 'json', version: '20231013'
     testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
-    testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
-    testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
+    testImplementation("tools.jackson.core:jackson-databind:${versions.jackson3_databind}")
+    testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '3.0.2'
     testImplementation ('com.jayway.jsonpath:json-path:2.9.0') {
         exclude group: 'net.minidev', module: 'json-smart'
     }

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -97,10 +97,10 @@ dependencies {
     implementation group: 'software.amazon.awssdk', name: 'netty-nio-client', version: "${versions.aws}"
     api('io.modelcontextprotocol.sdk:mcp:0.12.1')
     testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
-    testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
-    testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
+    testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '3.0.2'
     api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.12.0'
     implementation group: 'com.squareup.okhttp3', name: 'okhttp-sse', version: '4.12.0'
+    compileOnly("tools.jackson.core:jackson-databind:${versions.jackson3_databind}")   
 }
 
 lombok {

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -95,7 +95,8 @@ dependencies {
     implementation('net.minidev:json-smart:2.5.2')
     implementation group: 'org.json', name: 'json', version: '20231013'
     implementation group: 'software.amazon.awssdk', name: 'netty-nio-client', version: "${versions.aws}"
-    api('io.modelcontextprotocol.sdk:mcp:0.12.1')
+    api('io.modelcontextprotocol.sdk:mcp:1.1.1')
+    api('io.modelcontextprotocol.sdk:mcp-json-jackson3:1.1.1')
     testImplementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
     testImplementation group: 'com.networknt' , name: 'json-schema-validator', version: '3.0.2'
     api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.12.0'

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandler.java
@@ -9,7 +9,6 @@ import static org.opensearch.ml.common.CommonValue.REMOTE_SERVICE_ERROR;
 import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_MESSAGE_ID;
 import static org.opensearch.ml.common.agui.AGUIConstants.AGUI_PARAM_TEXT_MESSAGE_STARTED;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -40,11 +39,6 @@ import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.engine.algorithms.agent.AgentUtils;
 import org.opensearch.ml.engine.algorithms.remote.RemoteConnectorThrottlingException;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 
 import lombok.extern.log4j.Log4j2;
@@ -78,6 +72,12 @@ import software.amazon.awssdk.services.bedrockruntime.model.ToolResultContentBlo
 import software.amazon.awssdk.services.bedrockruntime.model.ToolSpecification;
 import software.amazon.awssdk.services.bedrockruntime.model.ValidationException;
 import software.amazon.awssdk.services.s3.model.InvalidRequestException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Bedrock ConverseStream handler supporting three streaming paths:
@@ -645,7 +645,7 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
         String accumulated = toolInputAccumulator.toString();
 
         try {
-            JsonParser parser = objectMapper.getFactory().createParser(accumulated);
+            JsonParser parser = objectMapper.createParser(accumulated);
             JsonToken firstToken = parser.nextToken();
 
             // Check if it starts with an object
@@ -657,7 +657,7 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
             // Parse through the entire structure
             int objectDepth = 1;
             while (parser.nextToken() != null) {
-                JsonToken currentToken = parser.getCurrentToken();
+                JsonToken currentToken = parser.currentToken();
                 if (currentToken == JsonToken.START_OBJECT) {
                     objectDepth++;
                 } else if (currentToken == JsonToken.END_OBJECT) {
@@ -683,9 +683,9 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
             // JSON is incomplete
             log.debug("Incomplete JSON object: {}", accumulated);
 
-        } catch (JsonParseException e) {
+        } catch (StreamReadException e) {
             log.debug("Invalid or incomplete JSON: {}", accumulated);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             log.error("Error parsing JSON input", e);
         }
     }
@@ -708,7 +708,7 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
 
     private List<SystemContentBlock> parseSystemMessages(JsonNode systemArray) {
         return systemArray
-            .findValuesAsText("text")
+            .findValuesAsString("text")
             .stream()
             .map(text -> SystemContentBlock.builder().text(text).build())
             .collect(Collectors.toList());
@@ -868,7 +868,7 @@ public class BedrockStreamingHandler extends BaseStreamingHandler {
     private Document buildDocumentFromJsonNode(JsonNode node) {
         if (node.isObject()) {
             Map<String, Document> map = new HashMap<>();
-            node.fields().forEachRemaining(entry -> map.put(entry.getKey(), buildDocumentFromJsonNode(entry.getValue())));
+            node.properties().spliterator().forEachRemaining(entry -> map.put(entry.getKey(), buildDocumentFromJsonNode(entry.getValue())));
             return Document.fromMap(map);
         }
         if (node.isArray()) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/processor/MLExtractJsonProcessor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/processor/MLExtractJsonProcessor.java
@@ -10,10 +10,11 @@ import java.util.Map;
 
 import org.opensearch.ml.engine.annotation.Processor;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.extern.log4j.Log4j2;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Processor that extracts JSON content from text strings.
@@ -94,7 +95,7 @@ public class MLExtractJsonProcessor extends AbstractMLProcessor {
         super(config);
         this.extractType = (String) config.getOrDefault("extract_type", EXTRACT_TYPE_AUTO);
         this.defaultValue = config.get("default");
-        this.mapper = new ObjectMapper();
+        this.mapper = JsonMapper.builder().disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS).build();
     }
 
     @Override

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
@@ -26,8 +26,10 @@ import org.opensearch.ml.engine.MLStaticMockBase;
 
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
+import tools.jackson.databind.json.JsonMapper;
 
 public class McpConnectorExecutorTest extends MLStaticMockBase {
 
@@ -58,7 +60,12 @@ public class McpConnectorExecutorTest extends MLStaticMockBase {
         String inputSchemaJSON =
             "{\"type\":\"object\",\"properties\":{\"state\":{\"title\":\"State\",\"type\":\"string\"}},\"required\":[\"state\"],\"additionalProperties\":false}";
 
-        McpSchema.Tool tool = new McpSchema.Tool("tool1", "desc1", inputSchemaJSON);
+        McpSchema.Tool tool = McpSchema.Tool
+            .builder()
+            .name("tool1")
+            .description("desc1")
+            .inputSchema(new JacksonMcpJsonMapper(JsonMapper.shared()), inputSchemaJSON)
+            .build();
         McpSchema.ListToolsResult mockTools = new McpSchema.ListToolsResult(List.of(tool), null);
 
         when(mcpClient.listTools()).thenReturn(mockTools);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
@@ -26,8 +26,10 @@ import org.opensearch.ml.engine.MLStaticMockBase;
 
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
+import tools.jackson.databind.json.JsonMapper;
 
 public class McpStreamableHttpConnectorExecutorTest extends MLStaticMockBase {
 
@@ -58,7 +60,12 @@ public class McpStreamableHttpConnectorExecutorTest extends MLStaticMockBase {
         String inputSchemaJSON =
             "{\"type\":\"object\",\"properties\":{\"state\":{\"title\":\"State\",\"type\":\"string\"}},\"required\":[\"state\"],\"additionalProperties\":false}";
 
-        McpSchema.Tool tool = new McpSchema.Tool("tool1", "desc1", inputSchemaJSON);
+        McpSchema.Tool tool = McpSchema.Tool
+            .builder()
+            .name("tool1")
+            .description("desc1")
+            .inputSchema(new JacksonMcpJsonMapper(JsonMapper.shared()), inputSchemaJSON)
+            .build();
         McpSchema.ListToolsResult mockTools = new McpSchema.ListToolsResult(List.of(tool), null);
 
         when(mcpClient.listTools()).thenReturn(mockTools);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandlerTest.java
@@ -19,12 +19,11 @@ import org.opensearch.ml.common.connector.AwsConnector;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.GuardrailStreamConfiguration;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class BedrockStreamingHandlerTest {
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.MCP_SYNC_CLIENT;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
@@ -50,7 +51,12 @@ public class McpSseToolTests {
     @Test
     public void testRunSuccess() {
         // create a CallToolResult wrapping a JSON string
-        McpSchema.CallToolResult result = new McpSchema.CallToolResult("{\"foo\":\"bar\"}", false);
+        McpSchema.CallToolResult result = new McpSchema.CallToolResult(
+            List.of(new McpSchema.TextContent("{\"foo\":\"bar\"}")),
+            false,
+            null,
+            Map.of()
+        );
         when(mcpSyncClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(result);
 
         tool.run(validParams, listener);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpStreamableHttpToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpStreamableHttpToolTests.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.MCP_SYNC_CLIENT;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
@@ -50,7 +51,12 @@ public class McpStreamableHttpToolTests {
     @Test
     public void testRunSuccess() {
         // create a CallToolResult wrapping a JSON string
-        McpSchema.CallToolResult result = new McpSchema.CallToolResult("{\"foo\":\"bar\"}", false);
+        McpSchema.CallToolResult result = new McpSchema.CallToolResult(
+            List.of(new McpSchema.TextContent("{\"foo\":\"bar\"}")),
+            false,
+            null,
+            Map.of()
+        );
         when(mcpSyncClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(result);
 
         tool.run(validParams, listener);

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -114,7 +114,6 @@ dependencies {
 
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
-    implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     implementation("tools.jackson.core:jackson-databind:${versions.jackson3_databind}")
     implementation group: 'com.networknt' , name: 'json-schema-validator', version: '3.0.2'
     implementation (group: 'com.google.guava', name: 'guava', version: '32.1.3-jre') {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -115,7 +115,8 @@ dependencies {
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
     implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
-    implementation group: 'com.networknt' , name: 'json-schema-validator', version: '1.4.0'
+    implementation("tools.jackson.core:jackson-databind:${versions.jackson3_databind}")
+    implementation group: 'com.networknt' , name: 'json-schema-validator', version: '3.0.2'
     implementation (group: 'com.google.guava', name: 'guava', version: '32.1.3-jre') {
 	exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
@@ -684,8 +685,8 @@ configurations.all {
     resolutionStrategy.force "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     resolutionStrategy.force "org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}"
     resolutionStrategy.force "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
-    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
-    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${versions.jackson_databind}"
+    resolutionStrategy.force "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
+    resolutionStrategy.force "tools.jackson.core:jackson-core:${versions.jackson3_databind}"
     resolutionStrategy.force "jakarta.json:jakarta.json-api:2.1.3"
     resolutionStrategy.force "org.opensearch:opensearch:${opensearch_version}"
     resolutionStrategy.force "org.bouncycastle:bcprov-jdk18on:1.78.1"
@@ -706,13 +707,17 @@ configurations.all {
     resolutionStrategy.force "software.amazon.awssdk:netty-nio-client:${versions.aws}"
     resolutionStrategy.force "software.amazon.awssdk:s3:${versions.aws}"
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
-    resolutionStrategy.force 'com.networknt:json-schema-validator:1.5.7'
-    resolutionStrategy.force 'com.fasterxml.jackson:jackson-bom:2.18.3'
-    resolutionStrategy.force 'org.yaml:snakeyaml:2.3'
-    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.18.3'
-    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.3'
-    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.18.3'
-    resolutionStrategy.force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.3'
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    resolutionStrategy.force 'com.networknt:json-schema-validator:3.0.2'
+    resolutionStrategy.force "org.yaml:snakeyaml:${versions.snakeyaml}"
+    resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${versions.jackson}"
+    resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
+    resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
+    resolutionStrategy.force "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
+    resolutionStrategy.force "tools.jackson.dataformat:jackson-dataformat-smile:${versions.jackson3}"
+    resolutionStrategy.force "tools.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson3}"
+    resolutionStrategy.force "tools.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson3}"
     resolutionStrategy.force "io.netty:netty-codec-http:${versions.netty}"
     resolutionStrategy.force "io.netty:netty-codec-http2:${versions.netty}"
     resolutionStrategy.force "io.netty:netty-codec:${versions.netty}"

--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/McpStatelessServerHolder.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/McpStatelessServerHolder.java
@@ -18,13 +18,12 @@ import org.opensearch.ml.common.transport.mcpserver.requests.register.McpToolReg
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpStatelessAsyncServer;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.extern.log4j.Log4j2;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.ObjectMapper;
 
 @Log4j2
 public class McpStatelessServerHolder {

--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/McpStatelessServerHolder.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/McpStatelessServerHolder.java
@@ -18,12 +18,14 @@ import org.opensearch.ml.common.transport.mcpserver.requests.register.McpToolReg
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.schema.jackson3.DefaultJsonSchemaValidator;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpStatelessAsyncServer;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.extern.log4j.Log4j2;
 import reactor.core.publisher.Mono;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @Log4j2
 public class McpStatelessServerHolder {
@@ -52,7 +54,7 @@ public class McpStatelessServerHolder {
                 return;
             }
             try {
-                mcpStatelessServerTransportProvider = new OpenSearchMcpStatelessServerTransportProvider(new ObjectMapper());
+                mcpStatelessServerTransportProvider = new OpenSearchMcpStatelessServerTransportProvider();
 
                 McpSchema.ServerCapabilities serverCapabilities = McpSchema.ServerCapabilities
                     .builder()
@@ -65,6 +67,8 @@ public class McpStatelessServerHolder {
                 log.info("Building MCP server ...");
                 mcpStatelessAsyncServer = McpServer
                     .async(mcpStatelessServerTransportProvider)
+                    .jsonMapper(new JacksonMcpJsonMapper(JsonMapper.shared()))
+                    .jsonSchemaValidator(new DefaultJsonSchemaValidator())
                     .serverInfo("OpenSearch-MCP-Stateless-Server", "0.1.0")
                     .capabilities(serverCapabilities)
                     .instructions("OpenSearch MCP Stateless Server - provides access to ML tools without sessions")

--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/McpToolsHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/McpToolsHelper.java
@@ -42,10 +42,12 @@ import org.opensearch.transport.client.Client;
 
 import com.google.common.collect.ImmutableMap;
 
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.extern.log4j.Log4j2;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Helper for creating stateless MCP tool specifications.
@@ -81,13 +83,21 @@ public class McpToolsHelper {
         String description = Optional.ofNullable(tool.getDescription()).orElse(factory.getDefaultDescription());
 
         return new McpStatelessServerFeatures.AsyncToolSpecification(
-            new McpSchema.Tool(toolName, String.valueOf(description), schema),
+            McpSchema.Tool
+                .builder()
+                .name(toolName)
+                .description(String.valueOf(description))
+                .inputSchema(new JacksonMcpJsonMapper(JsonMapper.shared()), schema)
+                .build(),
             (ctx, request) -> Mono.create(sink -> {
                 ActionListener<String> actionListener = ActionListener
-                    .wrap(r -> sink.success(new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(r)), false)), e -> {
-                        log.error("Failed to execute tool, tool name: {}", toolName, e);
-                        sink.error(e);
-                    });
+                    .wrap(
+                        r -> sink.success(new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(r)), false, null, Map.of())),
+                        e -> {
+                            log.error("Failed to execute tool, tool name: {}", toolName, e);
+                            sink.error(e);
+                        }
+                    );
 
                 actualTool.run(StringUtils.getParameterMap(request.arguments()), actionListener);
             })

--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/OpenSearchMcpStatelessServerTransportProvider.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/OpenSearchMcpStatelessServerTransportProvider.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.ml.action.mcpserver;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerHandler;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -14,6 +12,7 @@ import io.modelcontextprotocol.spec.McpStatelessServerTransport;
 import io.modelcontextprotocol.util.Assert;
 import lombok.extern.log4j.Log4j2;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Simple transport provider that delegates everything to the MCP framework.

--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/OpenSearchMcpStatelessServerTransportProvider.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/OpenSearchMcpStatelessServerTransportProvider.java
@@ -9,24 +9,15 @@ import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerHandler;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpStatelessServerTransport;
-import io.modelcontextprotocol.util.Assert;
 import lombok.extern.log4j.Log4j2;
 import reactor.core.publisher.Mono;
-import tools.jackson.databind.ObjectMapper;
 
 /**
  * Simple transport provider that delegates everything to the MCP framework.
  */
 @Log4j2
 public class OpenSearchMcpStatelessServerTransportProvider implements McpStatelessServerTransport {
-
-    private final ObjectMapper objectMapper;
     private McpStatelessServerHandler mcpHandler;
-
-    public OpenSearchMcpStatelessServerTransportProvider(ObjectMapper objectMapper) {
-        Assert.notNull(objectMapper, "ObjectMapper must not be null");
-        this.objectMapper = objectMapper;
-    }
 
     @Override
     public void setMcpHandler(McpStatelessServerHandler mcpHandler) {

--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/TransportMcpServerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/TransportMcpServerAction.java
@@ -29,16 +29,16 @@ import org.opensearch.ml.common.transport.mcpserver.responses.server.MLMcpServer
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.extern.log4j.Log4j2;
+import tools.jackson.databind.json.JsonMapper;
 
 @Log4j2
 public class TransportMcpServerAction extends HandledTransportAction<ActionRequest, MLMcpServerResponse> {
 
     MLFeatureEnabledSetting mlFeatureEnabledSetting;
-    ObjectMapper objectMapper;
+    JsonMapper objectMapper;
     McpStatelessServerHolder mcpStatelessServerHolder;
 
     @Inject
@@ -50,7 +50,7 @@ public class TransportMcpServerAction extends HandledTransportAction<ActionReque
     ) {
         super(MLMcpServerAction.NAME, transportService, actionFilters, MLMcpServerRequest::new);
         this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = JsonMapper.builder().build();
         this.mcpStatelessServerHolder = mcpStatelessServerHolder;
     }
 
@@ -78,7 +78,7 @@ public class TransportMcpServerAction extends HandledTransportAction<ActionReque
 
             final McpSchema.JSONRPCMessage message;
             try {
-                message = McpSchema.deserializeJsonRpcMessage(objectMapper, mlMcpServerRequest.getRequestBody());
+                message = McpSchema.deserializeJsonRpcMessage(new JacksonMcpJsonMapper(objectMapper), mlMcpServerRequest.getRequestBody());
             } catch (Exception e) {
                 log.error("Parse error: " + e.getMessage(), e);
                 handleError(null, JSON_RPC_PARSE_ERROR, "Parse error: " + e.getMessage(), listener);

--- a/plugin/src/main/java/org/opensearch/ml/rest/mcpserver/RestMcpServerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/mcpserver/RestMcpServerAction.java
@@ -32,9 +32,8 @@ import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.transport.client.node.NodeClient;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.extern.log4j.Log4j2;
+import tools.jackson.databind.ObjectMapper;
 
 @Log4j2
 public class RestMcpServerAction extends BaseRestHandler {

--- a/plugin/src/main/java/org/opensearch/ml/utils/MLNodeUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/MLNodeUtils.java
@@ -10,6 +10,7 @@ import static org.opensearch.ml.plugin.MachineLearningPlugin.ML_ROLE_NAME;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -28,15 +29,16 @@ import org.opensearch.ml.breaker.ThresholdCircuitBreaker;
 import org.opensearch.ml.stats.MLNodeLevelStat;
 import org.opensearch.ml.stats.MLStats;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.SpecVersion.VersionFlag;
-import com.networknt.schema.ValidationMessage;
+import com.networknt.schema.Error;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
 
 import lombok.experimental.UtilityClass;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 @UtilityClass
 public class MLNodeUtils {
@@ -71,17 +73,17 @@ public class MLNodeUtils {
         ObjectMapper mapper = new ObjectMapper();
         // parse the schema JSON as string
         JsonNode schemaNode = mapper.readTree(schemaString);
-        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaNode);
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12).getSchema(schemaNode);
 
         // JSON data to validate
         JsonNode jsonNode = mapper.readTree(instanceString);
 
         // Validate JSON node against the schema
-        Set<ValidationMessage> errors = schema.validate(jsonNode);
+        List<Error> errors = schema.validate(jsonNode);
         if (!errors.isEmpty()) {
             throw new OpenSearchParseException(
                 "Validation failed: "
-                    + Arrays.toString(errors.toArray(new ValidationMessage[0]))
+                    + Arrays.toString(errors.toArray(new Error[0]))
                     + " for instance: "
                     + instanceString
                     + " with schema: "
@@ -107,7 +109,7 @@ public class MLNodeUtils {
         if (rootNode.has("parameters") && rootNode.get("parameters").isObject()) {
             ObjectNode parametersNode = (ObjectNode) rootNode.get("parameters");
 
-            parametersNode.fields().forEachRemaining(entry -> {
+            parametersNode.properties().spliterator().forEachRemaining(entry -> {
                 String key = entry.getKey();
                 JsonNode value = entry.getValue();
 
@@ -115,7 +117,7 @@ public class MLNodeUtils {
                     try {
                         JsonNode parsedValue = mapper.readTree(value.asText());
                         parametersNode.set(key, parsedValue);
-                    } catch (IOException e) {
+                    } catch (JacksonException e) {
                         // If parsing fails, keep it as is
                         parametersNode.set(key, value);
                     }

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -49,11 +49,11 @@ import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.transport.client.Client;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 
 import lombok.extern.log4j.Log4j2;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @Log4j2
 public class RestActionUtils {

--- a/plugin/src/main/java/org/opensearch/ml/utils/error/ErrorMessage.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/error/ErrorMessage.java
@@ -11,10 +11,9 @@ import java.util.Map;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.transport.ActionTransportException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.Getter;
 import lombok.SneakyThrows;
+import tools.jackson.databind.ObjectMapper;
 
 /** Error Message. */
 public class ErrorMessage {

--- a/plugin/src/test/java/org/opensearch/ml/action/mcpserver/OpenSearchMcpStatelessServerTransportProviderTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/mcpserver/OpenSearchMcpStatelessServerTransportProviderTests.java
@@ -14,11 +14,12 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.test.OpenSearchTestCase;
 
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpStatelessServerHandler;
 import io.modelcontextprotocol.spec.McpSchema;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class OpenSearchMcpStatelessServerTransportProviderTests extends OpenSearchTestCase {
 
@@ -31,7 +32,7 @@ public class OpenSearchMcpStatelessServerTransportProviderTests extends OpenSear
     public void setUp() throws Exception {
         super.setUp();
         MockitoAnnotations.openMocks(this);
-        provider = new OpenSearchMcpStatelessServerTransportProvider(new ObjectMapper());
+        provider = new OpenSearchMcpStatelessServerTransportProvider();
         provider.setMcpHandler(mcpHandler);
     }
 
@@ -46,7 +47,7 @@ public class OpenSearchMcpStatelessServerTransportProviderTests extends OpenSear
               "method": "tools/list"
             }
             """;
-        McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(new ObjectMapper(), requestBody);
+        McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(new JacksonMcpJsonMapper(JsonMapper.shared()), requestBody);
         StepVerifier.create(provider.handleRequest(message))
             .expectNextMatches(response -> response instanceof McpSchema.JSONRPCResponse)
             .verifyComplete();
@@ -61,15 +62,13 @@ public class OpenSearchMcpStatelessServerTransportProviderTests extends OpenSear
             }
             """;
 
-        McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(new ObjectMapper(), requestBody);
+        McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(new JacksonMcpJsonMapper(JsonMapper.shared()), requestBody);
         StepVerifier.create(provider.handleRequest(message)).expectErrorMatches(e -> e instanceof Exception).verify();
     }
 
     @Test
     public void test_handleRequest_handlerNotSet() throws Exception {
-        OpenSearchMcpStatelessServerTransportProvider providerWithoutHandler = new OpenSearchMcpStatelessServerTransportProvider(
-            new ObjectMapper()
-        );
+        OpenSearchMcpStatelessServerTransportProvider providerWithoutHandler = new OpenSearchMcpStatelessServerTransportProvider();
 
         String requestBody = """
             {
@@ -78,7 +77,7 @@ public class OpenSearchMcpStatelessServerTransportProviderTests extends OpenSear
               "method": "tools/list"
             }
             """;
-        McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(new ObjectMapper(), requestBody);
+        McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(new JacksonMcpJsonMapper(JsonMapper.shared()), requestBody);
         StepVerifier
             .create(providerWithoutHandler.handleRequest(message))
             .expectErrorMatches(e -> e.getMessage().contains("MCP handler not initialized"))
@@ -96,7 +95,7 @@ public class OpenSearchMcpStatelessServerTransportProviderTests extends OpenSear
               "method": "tools/list"
             }
             """;
-        McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(new ObjectMapper(), requestBody);
+        McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(new JacksonMcpJsonMapper(JsonMapper.shared()), requestBody);
         StepVerifier.create(provider.handleRequest(message))
             .expectErrorMatches(e -> e.getMessage().contains("Handler error"))
             .verify();

--- a/plugin/src/test/java/org/opensearch/ml/action/mcpserver/OpenSearchMcpStatelessServerTransportProviderTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/mcpserver/OpenSearchMcpStatelessServerTransportProviderTests.java
@@ -14,12 +14,11 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.test.OpenSearchTestCase;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.modelcontextprotocol.server.McpStatelessServerHandler;
 import io.modelcontextprotocol.spec.McpSchema;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import tools.jackson.databind.ObjectMapper;
 
 public class OpenSearchMcpStatelessServerTransportProviderTests extends OpenSearchTestCase {
 

--- a/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceIngestProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/processor/MLInferenceIngestProcessorTests.java
@@ -45,11 +45,12 @@ import org.opensearch.script.ScriptService;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.Client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 public class MLInferenceIngestProcessorTests extends OpenSearchTestCase {
 
@@ -771,7 +772,7 @@ public class MLInferenceIngestProcessorTests extends OpenSearchTestCase {
 
     }
 
-    public void testExecute_IOExceptionWithIgnoreMissingFalse() throws JsonProcessingException {
+    public void testExecute_IOExceptionWithIgnoreMissingFalse() {
         List<Map<String, String>> inputMap = new ArrayList<>();
         Map<String, String> input = new HashMap<>();
         String documentFieldPath = "text";
@@ -785,7 +786,7 @@ public class MLInferenceIngestProcessorTests extends OpenSearchTestCase {
         model_config.put("position_embedding_type", "absolute");
 
         ObjectMapper mapper = mock(ObjectMapper.class);
-        when(mapper.readValue(Mockito.anyString(), eq(Object.class))).thenThrow(JsonProcessingException.class);
+        when(mapper.readValue(Mockito.anyString(), eq(Object.class))).thenThrow(JacksonException.class);
 
         MLInferenceIngestProcessor processor = createMLInferenceProcessor(
             "model1",

--- a/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/MLNodeUtilsTests.java
@@ -29,7 +29,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.test.OpenSearchTestCase;
 
-import com.fasterxml.jackson.core.JsonParseException;
+import tools.jackson.core.JacksonException;
 
 public class MLNodeUtilsTests extends OpenSearchTestCase {
 
@@ -128,7 +128,7 @@ public class MLNodeUtilsTests extends OpenSearchTestCase {
     public void testProcessRemoteInferenceInputDataSetInvalidJson() {
         String schema = "{\"type\": \"object\",\"properties\": {}}";
         String json = "{\"key1\":\"foo\",\"key2\":123,\"key3\":true,\"parameters\":{\"a\"}}";
-        assertThrows(JsonParseException.class, () -> MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json, schema));
+        assertThrows(JacksonException.class, () -> MLNodeUtils.processRemoteInferenceInputDataSetParametersValue(json, schema));
     }
 
     @Test


### PR DESCRIPTION
### Description
Support Jackson 3.x release line. As part of the migration:
 - updated MCP SDK to 1.1.1 (supports Jackson 3)
 - updated json-schema-validaton to 3.0.4 (supports Jackson 3)

### Related Issues
Closes https://github.com/opensearch-project/ml-commons/issues/4783
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
