### PR TITLE
[FIX] Simplify USER_PREFERENCE prompt to produce plain sentences

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -197,9 +197,8 @@ public class MemoryContainerConstants {
             Respond NOW with ONE LINE of valid JSON ONLY exactly as {"facts":["fact1","fact2",...]}. No extra text, no code fences, no newlines or tabs, no spaces after commas or colons.""";
 
     // JSON enforcement message for user preference extraction
-    public static final String USER_PREFERENCE_JSON_ENFORCEMENT_MESSAGE =
-        """
-            Return ONLY ONE LINE of valid JSON exactly as {"facts":["<Preference sentence>. Context: <why/how>. Categories: <cat1,cat2>"]}. Begin with { and end with }. No extra text.""";
+    public static final String USER_PREFERENCE_JSON_ENFORCEMENT_MESSAGE = """
+        Return ONLY ONE LINE of valid JSON exactly as {"facts":["<fact sentence>"]}. Begin with { and end with }. No extra text.""";
 
     public static final String USER_PREFERENCE_FACTS_EXTRACTION_PROMPT =
         """
@@ -216,12 +215,14 @@ public class MemoryContainerConstants {
             </EXTRACT>
 
             <STYLE & RULES>
-            • One sentence per preference; merge related details; no duplicates; preserve user wording and numbers; avoid relative time; keep each fact < 350 chars.
-            • Format: "Preference sentence. Context: <why/how>. Categories: cat1,cat2"
+            • One self-contained sentence per preference. Include the subject's name and enough context to be meaningful on its own.
+            • Merge closely related details into the same sentence. No duplicates.
+            • Preserve user wording, names, numbers, and units. Avoid relative time references; use absolute dates when available.
+            • Keep each fact under 350 characters.
             </STYLE & RULES>
 
             <OUTPUT>
-            Return ONLY one minified JSON object exactly as {"facts":["Preference sentence. Context: <why/how>. Categories: cat1,cat2"]}. If none, return {"facts":[]}. The first character MUST be '{' and the last MUST be '}'. No preambles, explanations, code fences, XML, or other text.
+            Return ONLY one minified JSON object exactly as {"facts":["fact sentence"]}. If none, return {"facts":[]}. The first character MUST be '{' and the last MUST be '}'. No preambles, explanations, code fences, XML, or other text.
             </OUTPUT>""";
 
     public static final String SUMMARY_FACTS_EXTRACTION_PROMPT =

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingService.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingService.java
@@ -356,7 +356,7 @@ public class MemoryProcessingService {
                             }
                         }
                     } catch (IOException e) {
-                        log.error("Failed to extract content from dataMap", e);
+                        log.error("Failed to parse {} strategy LLM response as JSON", strategy.getType(), e);
                         throw new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR);
                     }
                 }

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
@@ -1027,8 +1027,8 @@ public class MemoryProcessingServiceTests {
         assertTrue("Should be role-based", prompt.contains("USER PREFERENCE EXTRACTOR"));
 
         // Verify key requirements
-        assertTrue("Should have character limit", prompt.contains("< 350 chars"));
-        assertTrue("Should specify context format", prompt.contains("Context: <why/how>"));
+        assertTrue("Should have character limit", prompt.contains("350 characters"));
+        assertTrue("Should specify self-contained sentences", prompt.contains("self-contained sentence"));
 
         // Verify old problematic format is removed
         assertFalse("Should not use pipe delimiters", prompt.contains("preference | context:"));
@@ -1039,7 +1039,7 @@ public class MemoryProcessingServiceTests {
         // Test that enforcement message matches the new format
         String enforcement = USER_PREFERENCE_JSON_ENFORCEMENT_MESSAGE;
 
-        assertTrue("Should specify natural language format", enforcement.contains("Context: <why/how>. Categories:"));
+        assertTrue("Should specify fact sentence format", enforcement.contains("fact sentence"));
         assertFalse("Should not use old pipe format", enforcement.contains("preference | context:"));
     }
 
@@ -1070,8 +1070,8 @@ public class MemoryProcessingServiceTests {
         );
 
         assertTrue(
-            "User preference enforcement should be for natural format",
-            USER_PREFERENCE_JSON_ENFORCEMENT_MESSAGE.contains("Context: <why/how>")
+            "User preference enforcement should be for plain fact format",
+            USER_PREFERENCE_JSON_ENFORCEMENT_MESSAGE.contains("fact sentence")
         );
         assertTrue("Semantic enforcement should be for standard format", JSON_ENFORCEMENT_MESSAGE.contains("fact1"));
     }
@@ -1087,8 +1087,8 @@ public class MemoryProcessingServiceTests {
 
         // Verify format requirements
         assertTrue("Should require JSON format", prompt.contains("{\"facts\":["));
-        assertTrue("Should specify context format", prompt.contains("Context: <why/how>"));
-        assertTrue("Should limit character count", prompt.contains("< 350 chars"));
+        assertTrue("Should specify self-contained sentences", prompt.contains("self-contained sentence"));
+        assertTrue("Should limit character count", prompt.contains("350 characters"));
     }
 
     @Test


### PR DESCRIPTION
### Description

Simplify the USER_PREFERENCE extraction prompt to produce plain self-contained sentences instead of the structured `Context:/Categories:` format. Also improve error logging when JSON parsing fails to include the strategy type.

**Before:**
```
"Bob prefers phone calls over email. Context: wife Sarah is hard of hearing. Categories: communication,time_preference"
```

**After:**
```
"Bob always prefers phone calls over email because his wife Sarah is hard of hearing."
```

### Motivation

1. **Fixes silent JSON parse failures with smaller LLMs** — The `Context: <why/how>. Categories: cat1,cat2` format contains commas inside JSON string values that confuse smaller models (e.g., Claude Haiku 3) into producing malformed JSON. When this happens, USER_PREFERENCE results are silently discarded with no error returned to the caller. Plain sentences eliminate this failure mode.

2. **Improves search quality** — The `Context:` and `Categories:` boilerplate text was stored in the `memory` field alongside the actual preference, diluting embedding quality for semantic search and creating false keyword matches for BM25/hybrid search. Plain sentences produce cleaner embeddings.

3. **No downstream consumers** — The Context and Categories metadata is not consumed by any code path today — no filtering by category, no surfacing of context to users.

### Testing

Validated on LoCoMo benchmark (1,540 questions, 10 conversations) with Claude Sonnet 4.6. USER_PREFERENCE extraction count actually increased slightly (685 vs 678 baseline).

### Issues Resolved

Resolves #4780

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`