### PR TITLE
Simplify memory container creation with inline model config

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agent;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLAgentType;
+import org.opensearch.ml.common.connector.AwsConnector;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.ConnectorAction;
+import org.opensearch.ml.common.connector.ConnectorClientConfig;
+import org.opensearch.ml.common.connector.ConnectorProtocols;
+import org.opensearch.ml.common.input.execute.agent.ContentBlock;
+import org.opensearch.ml.common.input.execute.agent.Message;
+import org.opensearch.ml.common.model.ModelProvider;
+import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
+
+/**
+ * Model provider for Bedrock Embedding API (Titan, Cohere).
+ * Uses the /invoke endpoint (not /converse) with inputText-based request body.
+ */
+public class BedrockEmbeddingModelProvider extends ModelProvider {
+
+    private static final String DEFAULT_REGION = "us-east-1";
+
+    private static final String REQUEST_BODY_TEMPLATE =
+        "{ \"inputText\": \"${parameters.inputText}\", \"dimensions\": ${parameters.dimensions},"
+            + " \"normalize\": ${parameters.normalize}, \"embeddingTypes\": ${parameters.embeddingTypes} }";
+
+    /**
+     * Known Bedrock embedding models with their type and default dimension.
+     */
+    public static final Map<String, EmbeddingModelInfo> KNOWN_MODELS = Map.of(
+        "amazon.titan-embed-text-v2:0", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
+        "amazon.titan-embed-text-v1", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536),
+        "amazon.titan-embed-image-v1", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
+        "cohere.embed-english-v3", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
+        "cohere.embed-multilingual-v3", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024)
+    );
+
+    @Override
+    public Connector createConnector(String modelId, Map<String, String> credential, Map<String, String> modelParameters) {
+        EmbeddingModelInfo info = KNOWN_MODELS.get(modelId);
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("region", DEFAULT_REGION);
+        parameters.put("service_name", "bedrock");
+        parameters.put("model", modelId);
+        parameters.put("dimensions", String.valueOf(info != null ? info.dimension : 1024));
+        parameters.put("normalize", "true");
+        parameters.put("embeddingTypes", "[\"float\"]");
+
+        if (modelParameters != null) {
+            parameters.putAll(modelParameters);
+        }
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("content-type", "application/json");
+        headers.put("x-amz-content-sha256", "required");
+
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke")
+            .headers(headers)
+            .requestBody(REQUEST_BODY_TEMPLATE)
+            .preProcessFunction("connector.pre_process.bedrock.embedding")
+            .postProcessFunction("connector.post_process.bedrock.embedding")
+            .build();
+
+        ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig();
+        connectorClientConfig.setMaxRetryTimes(3);
+
+        return AwsConnector
+            .awsConnectorBuilder()
+            .name("Auto-generated Bedrock Embedding connector")
+            .description("Auto-generated connector for Bedrock Embedding API")
+            .version("1")
+            .protocol(ConnectorProtocols.AWS_SIGV4)
+            .parameters(parameters)
+            .credential(credential != null ? credential : new HashMap<>())
+            .actions(List.of(predictAction))
+            .connectorClientConfig(connectorClientConfig)
+            .build();
+    }
+
+    @Override
+    public MLRegisterModelInput createModelInput(String modelName, Connector connector, Map<String, String> modelParameters) {
+        EmbeddingModelInfo info = KNOWN_MODELS.get(modelName);
+        FunctionName functionName = info != null ? info.functionName : FunctionName.TEXT_EMBEDDING;
+
+        return MLRegisterModelInput
+            .builder()
+            .functionName(functionName)
+            .modelName("Auto-generated embedding model for " + modelName)
+            .description("Auto-generated embedding model for memory container")
+            .connector(connector)
+            .build();
+    }
+
+    @Override
+    public String getLLMInterface() {
+        return null; // Embedding models don't have an LLM interface
+    }
+
+    // Embedding models don't support agent input mapping — these are LLM-only operations
+    @Override
+    public Map<String, String> mapTextInput(String text, MLAgentType type) {
+        throw new UnsupportedOperationException("Embedding model providers do not support agent input mapping");
+    }
+
+    @Override
+    public Map<String, String> mapContentBlocks(List<ContentBlock> contentBlocks, MLAgentType type) {
+        throw new UnsupportedOperationException("Embedding model providers do not support agent input mapping");
+    }
+
+    @Override
+    public Map<String, String> mapMessages(List<Message> messages, MLAgentType type) {
+        throw new UnsupportedOperationException("Embedding model providers do not support agent input mapping");
+    }
+
+    @Override
+    public String extractMessageFromResponse(Map<String, ?> responseData) {
+        throw new UnsupportedOperationException("Embedding model providers do not support response extraction");
+    }
+
+    @Override
+    public Message parseToUnifiedMessage(String json) {
+        throw new UnsupportedOperationException("Embedding model providers do not support message parsing");
+    }
+
+    /**
+     * Look up embedding model info from known models registry.
+     * @param modelId the Bedrock model ID
+     * @return EmbeddingModelInfo if known, null otherwise
+     */
+    public static EmbeddingModelInfo getModelInfo(String modelId) {
+        return KNOWN_MODELS.get(modelId);
+    }
+
+    /**
+     * Info about a known embedding model.
+     */
+    public static class EmbeddingModelInfo {
+        public final FunctionName functionName;
+        public final int dimension;
+
+        public EmbeddingModelInfo(FunctionName functionName, int dimension) {
+            this.functionName = functionName;
+            this.dimension = dimension;
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
@@ -29,9 +29,12 @@ public class BedrockEmbeddingModelProvider extends ModelProvider {
 
     private static final String DEFAULT_REGION = "us-east-1";
 
-    private static final String REQUEST_BODY_TEMPLATE =
+    private static final String TITAN_REQUEST_BODY =
         "{ \"inputText\": \"${parameters.inputText}\", \"dimensions\": ${parameters.dimensions},"
             + " \"normalize\": ${parameters.normalize}, \"embeddingTypes\": ${parameters.embeddingTypes} }";
+
+    private static final String COHERE_REQUEST_BODY =
+        "{ \"texts\": ${parameters.texts}, \"input_type\": \"${parameters.input_type}\" }";
 
     /**
      * Known Bedrock embedding models with their type and default dimension.
@@ -47,14 +50,30 @@ public class BedrockEmbeddingModelProvider extends ModelProvider {
     @Override
     public Connector createConnector(String modelId, Map<String, String> credential, Map<String, String> modelParameters) {
         EmbeddingModelInfo info = KNOWN_MODELS.get(modelId);
+        boolean isCohere = modelId != null && modelId.startsWith("cohere.");
 
         Map<String, String> parameters = new HashMap<>();
         parameters.put("region", DEFAULT_REGION);
         parameters.put("service_name", "bedrock");
         parameters.put("model", modelId);
-        parameters.put("dimensions", String.valueOf(info != null ? info.dimension : 1024));
-        parameters.put("normalize", "true");
-        parameters.put("embeddingTypes", "[\"float\"]");
+
+        String requestBody;
+        String preProcess;
+        String postProcess;
+
+        if (isCohere) {
+            parameters.put("input_type", "search_document");
+            requestBody = COHERE_REQUEST_BODY;
+            preProcess = "connector.pre_process.cohere.embedding";
+            postProcess = "connector.post_process.cohere.embedding";
+        } else {
+            parameters.put("dimensions", String.valueOf(info != null ? info.dimension : 1024));
+            parameters.put("normalize", "true");
+            parameters.put("embeddingTypes", "[\"float\"]");
+            requestBody = TITAN_REQUEST_BODY;
+            preProcess = "connector.pre_process.bedrock.embedding";
+            postProcess = "connector.post_process.bedrock.embedding";
+        }
 
         if (modelParameters != null) {
             parameters.putAll(modelParameters);
@@ -70,9 +89,9 @@ public class BedrockEmbeddingModelProvider extends ModelProvider {
             .method("POST")
             .url("https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke")
             .headers(headers)
-            .requestBody(REQUEST_BODY_TEMPLATE)
-            .preProcessFunction("connector.pre_process.bedrock.embedding")
-            .postProcessFunction("connector.post_process.bedrock.embedding")
+            .requestBody(requestBody)
+            .preProcessFunction(preProcess)
+            .postProcessFunction(postProcess)
             .build();
 
         ConnectorClientConfig connectorClientConfig = new ConnectorClientConfig();

--- a/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
@@ -93,12 +93,9 @@ public class BedrockEmbeddingModelProvider extends ModelProvider {
 
     @Override
     public MLRegisterModelInput createModelInput(String modelName, Connector connector, Map<String, String> modelParameters) {
-        EmbeddingModelInfo info = KNOWN_MODELS.get(modelName);
-        FunctionName functionName = info != null ? info.functionName : FunctionName.TEXT_EMBEDDING;
-
         return MLRegisterModelInput
             .builder()
-            .functionName(functionName)
+            .functionName(FunctionName.REMOTE)
             .modelName("Auto-generated embedding model for " + modelName)
             .description("Auto-generated embedding model for memory container")
             .connector(connector)

--- a/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
@@ -41,17 +41,12 @@ public class BedrockEmbeddingModelProvider extends ModelProvider {
      * Known Bedrock embedding models with their type and default dimension.
      */
     public static final Map<String, EmbeddingModelInfo> KNOWN_MODELS = Map
-        .of(
-            "amazon.titan-embed-text-v2:0",
-            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
-            "amazon.titan-embed-text-v1",
-            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536),
-            "amazon.titan-embed-image-v1",
-            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
-            "cohere.embed-english-v3",
-            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
-            "cohere.embed-multilingual-v3",
-            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024)
+        .ofEntries(
+            Map.entry("amazon.titan-embed-text-v2:0", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024)),
+            Map.entry("amazon.titan-embed-text-v1", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536)),
+            Map.entry("amazon.titan-embed-image-v1", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024)),
+            Map.entry("cohere.embed-english-v3", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024)),
+            Map.entry("cohere.embed-multilingual-v3", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024))
         );
 
     @Override

--- a/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
@@ -57,7 +57,7 @@ public class BedrockEmbeddingModelProvider extends ModelProvider {
     @Override
     public Connector createConnector(String modelId, Map<String, String> credential, Map<String, String> modelParameters) {
         EmbeddingModelInfo info = KNOWN_MODELS.get(modelId);
-        boolean isCohere = modelId != null && modelId.startsWith("cohere.");
+        boolean isCohere = info != null && modelId.startsWith("cohere.embed");
 
         Map<String, String> parameters = new HashMap<>();
         parameters.put("region", DEFAULT_REGION);
@@ -74,14 +74,12 @@ public class BedrockEmbeddingModelProvider extends ModelProvider {
             preProcess = "connector.pre_process.cohere.embedding";
             postProcess = "connector.post_process.cohere.embedding";
         } else {
-            if (info == null) {
-                log
-                    .warn(
-                        "Unknown Bedrock embedding model: {}. Defaulting to dimension 1024. " + "Override via model_parameters if needed.",
-                        modelId
-                    );
+            if (info == null && (modelParameters == null || !modelParameters.containsKey("dimensions"))) {
+                throw new IllegalArgumentException(
+                    "Unknown Bedrock embedding model: " + modelId + ". Please provide 'dimensions' in model_parameters."
+                );
             }
-            parameters.put("dimensions", String.valueOf(info != null ? info.dimension : 1024));
+            parameters.put("dimensions", String.valueOf(info != null ? info.dimension() : 1024));
             parameters.put("normalize", "true");
             parameters.put("embeddingTypes", "[\"float\"]");
             requestBody = TITAN_REQUEST_BODY;
@@ -94,10 +92,7 @@ public class BedrockEmbeddingModelProvider extends ModelProvider {
         }
 
         // Validate region to prevent SSRF via URL injection
-        String region = parameters.get("region");
-        if (region != null && !REGION_PATTERN.matcher(region).matches()) {
-            throw new IllegalArgumentException("Invalid AWS region format: " + region);
-        }
+        MemoryContainerConstants.requireValidAwsRegion(parameters.get("region"));
 
         Map<String, String> headers = new HashMap<>();
         headers.put("content-type", "application/json");

--- a/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
@@ -18,17 +18,17 @@ import org.opensearch.ml.common.connector.ConnectorClientConfig;
 import org.opensearch.ml.common.connector.ConnectorProtocols;
 import org.opensearch.ml.common.input.execute.agent.ContentBlock;
 import org.opensearch.ml.common.input.execute.agent.Message;
+import org.opensearch.ml.common.memorycontainer.MemoryContainerConstants;
 import org.opensearch.ml.common.model.ModelProvider;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 
-/**
- * Model provider for Bedrock Embedding API (Titan, Cohere).
- * Uses the /invoke endpoint (not /converse) with inputText-based request body.
- */
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
 public class BedrockEmbeddingModelProvider extends ModelProvider {
 
-    private static final String DEFAULT_REGION = "us-east-1";
-    private static final java.util.regex.Pattern REGION_PATTERN = java.util.regex.Pattern.compile("^[a-z]{2}(-[a-z]+-\\d+)?$");
+    private static final String DEFAULT_REGION = MemoryContainerConstants.DEFAULT_AWS_REGION;
+    private static final java.util.regex.Pattern REGION_PATTERN = MemoryContainerConstants.AWS_REGION_PATTERN;
 
     private static final String TITAN_REQUEST_BODY =
         "{ \"inputText\": \"${parameters.inputText}\", \"dimensions\": ${parameters.dimensions},"
@@ -73,6 +73,13 @@ public class BedrockEmbeddingModelProvider extends ModelProvider {
             preProcess = "connector.pre_process.cohere.embedding";
             postProcess = "connector.post_process.cohere.embedding";
         } else {
+            if (info == null) {
+                log
+                    .warn(
+                        "Unknown Bedrock embedding model: {}. Defaulting to dimension 1024. " + "Override via model_parameters if needed.",
+                        modelId
+                    );
+            }
             parameters.put("dimensions", String.valueOf(info != null ? info.dimension : 1024));
             parameters.put("normalize", "true");
             parameters.put("embeddingTypes", "[\"float\"]");

--- a/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
@@ -18,6 +18,7 @@ import org.opensearch.ml.common.connector.ConnectorClientConfig;
 import org.opensearch.ml.common.connector.ConnectorProtocols;
 import org.opensearch.ml.common.input.execute.agent.ContentBlock;
 import org.opensearch.ml.common.input.execute.agent.Message;
+import org.opensearch.ml.common.memorycontainer.EmbeddingModelInfo;
 import org.opensearch.ml.common.memorycontainer.MemoryContainerConstants;
 import org.opensearch.ml.common.model.ModelProvider;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
@@ -180,16 +181,4 @@ public class BedrockEmbeddingModelProvider extends ModelProvider {
         return KNOWN_MODELS.get(modelId);
     }
 
-    /**
-     * Info about a known embedding model.
-     */
-    public static class EmbeddingModelInfo {
-        public final FunctionName functionName;
-        public final int dimension;
-
-        public EmbeddingModelInfo(FunctionName functionName, int dimension) {
-            this.functionName = functionName;
-            this.dimension = dimension;
-        }
-    }
 }

--- a/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
@@ -28,24 +28,30 @@ import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 public class BedrockEmbeddingModelProvider extends ModelProvider {
 
     private static final String DEFAULT_REGION = "us-east-1";
+    private static final java.util.regex.Pattern REGION_PATTERN = java.util.regex.Pattern.compile("^[a-z]{2}(-[a-z]+-\\d+)?$");
 
     private static final String TITAN_REQUEST_BODY =
         "{ \"inputText\": \"${parameters.inputText}\", \"dimensions\": ${parameters.dimensions},"
             + " \"normalize\": ${parameters.normalize}, \"embeddingTypes\": ${parameters.embeddingTypes} }";
 
-    private static final String COHERE_REQUEST_BODY =
-        "{ \"texts\": ${parameters.texts}, \"input_type\": \"${parameters.input_type}\" }";
+    private static final String COHERE_REQUEST_BODY = "{ \"texts\": ${parameters.texts}, \"input_type\": \"${parameters.input_type}\" }";
 
     /**
      * Known Bedrock embedding models with their type and default dimension.
      */
-    public static final Map<String, EmbeddingModelInfo> KNOWN_MODELS = Map.of(
-        "amazon.titan-embed-text-v2:0", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
-        "amazon.titan-embed-text-v1", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536),
-        "amazon.titan-embed-image-v1", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
-        "cohere.embed-english-v3", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
-        "cohere.embed-multilingual-v3", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024)
-    );
+    public static final Map<String, EmbeddingModelInfo> KNOWN_MODELS = Map
+        .of(
+            "amazon.titan-embed-text-v2:0",
+            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
+            "amazon.titan-embed-text-v1",
+            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536),
+            "amazon.titan-embed-image-v1",
+            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
+            "cohere.embed-english-v3",
+            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024),
+            "cohere.embed-multilingual-v3",
+            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1024)
+        );
 
     @Override
     public Connector createConnector(String modelId, Map<String, String> credential, Map<String, String> modelParameters) {
@@ -77,6 +83,12 @@ public class BedrockEmbeddingModelProvider extends ModelProvider {
 
         if (modelParameters != null) {
             parameters.putAll(modelParameters);
+        }
+
+        // Validate region to prevent SSRF via URL injection
+        String region = parameters.get("region");
+        if (region != null && !REGION_PATTERN.matcher(region).matches()) {
+            throw new IllegalArgumentException("Invalid AWS region format: " + region);
         }
 
         Map<String, String> headers = new HashMap<>();

--- a/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProvider.java
@@ -29,7 +29,6 @@ import lombok.extern.log4j.Log4j2;
 public class BedrockEmbeddingModelProvider extends ModelProvider {
 
     private static final String DEFAULT_REGION = MemoryContainerConstants.DEFAULT_AWS_REGION;
-    private static final java.util.regex.Pattern REGION_PATTERN = MemoryContainerConstants.AWS_REGION_PATTERN;
 
     private static final String TITAN_REQUEST_BODY =
         "{ \"inputText\": \"${parameters.inputText}\", \"dimensions\": ${parameters.dimensions},"

--- a/common/src/main/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProvider.java
@@ -28,11 +28,15 @@ public class OpenaiEmbeddingModelProvider extends ModelProvider {
 
     private static final String REQUEST_BODY = "{ \"input\": ${parameters.input}, \"model\": \"${parameters.model}\" }";
 
-    public static final Map<String, EmbeddingModelInfo> KNOWN_MODELS = Map.of(
-        "text-embedding-3-small", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536),
-        "text-embedding-3-large", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 3072),
-        "text-embedding-ada-002", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536)
-    );
+    public static final Map<String, EmbeddingModelInfo> KNOWN_MODELS = Map
+        .of(
+            "text-embedding-3-small",
+            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536),
+            "text-embedding-3-large",
+            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 3072),
+            "text-embedding-ada-002",
+            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536)
+        );
 
     @Override
     public Connector createConnector(String modelId, Map<String, String> credential, Map<String, String> modelParameters) {
@@ -88,16 +92,40 @@ public class OpenaiEmbeddingModelProvider extends ModelProvider {
     }
 
     // Embedding providers don't support agent operations
-    @Override public String getLLMInterface() { return null; }
-    @Override public Map<String, String> mapTextInput(String t, MLAgentType a) { throw new UnsupportedOperationException(); }
-    @Override public Map<String, String> mapContentBlocks(List<ContentBlock> c, MLAgentType a) { throw new UnsupportedOperationException(); }
-    @Override public Map<String, String> mapMessages(List<Message> m, MLAgentType a) { throw new UnsupportedOperationException(); }
-    @Override public String extractMessageFromResponse(Map<String, ?> r) { throw new UnsupportedOperationException(); }
-    @Override public Message parseToUnifiedMessage(String j) { throw new UnsupportedOperationException(); }
+    @Override
+    public String getLLMInterface() {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> mapTextInput(String t, MLAgentType a) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, String> mapContentBlocks(List<ContentBlock> c, MLAgentType a) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, String> mapMessages(List<Message> m, MLAgentType a) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String extractMessageFromResponse(Map<String, ?> r) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Message parseToUnifiedMessage(String j) {
+        throw new UnsupportedOperationException();
+    }
 
     public static class EmbeddingModelInfo {
         public final FunctionName functionName;
         public final int dimension;
+
         public EmbeddingModelInfo(FunctionName functionName, int dimension) {
             this.functionName = functionName;
             this.dimension = dimension;

--- a/common/src/main/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProvider.java
@@ -18,6 +18,7 @@ import org.opensearch.ml.common.connector.ConnectorProtocols;
 import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.input.execute.agent.ContentBlock;
 import org.opensearch.ml.common.input.execute.agent.Message;
+import org.opensearch.ml.common.memorycontainer.EmbeddingModelInfo;
 import org.opensearch.ml.common.model.ModelProvider;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 
@@ -122,13 +123,4 @@ public class OpenaiEmbeddingModelProvider extends ModelProvider {
         throw new UnsupportedOperationException();
     }
 
-    public static class EmbeddingModelInfo {
-        public final FunctionName functionName;
-        public final int dimension;
-
-        public EmbeddingModelInfo(FunctionName functionName, int dimension) {
-            this.functionName = functionName;
-            this.dimension = dimension;
-        }
-    }
 }

--- a/common/src/main/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProvider.java
@@ -22,21 +22,21 @@ import org.opensearch.ml.common.memorycontainer.EmbeddingModelInfo;
 import org.opensearch.ml.common.model.ModelProvider;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 
+import lombok.extern.log4j.Log4j2;
+
 /**
  * Model provider for OpenAI Embedding API (text-embedding-3-small, text-embedding-3-large, etc.)
  */
+@Log4j2
 public class OpenaiEmbeddingModelProvider extends ModelProvider {
 
     private static final String REQUEST_BODY = "{ \"input\": ${parameters.input}, \"model\": \"${parameters.model}\" }";
 
     public static final Map<String, EmbeddingModelInfo> KNOWN_MODELS = Map
-        .of(
-            "text-embedding-3-small",
-            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536),
-            "text-embedding-3-large",
-            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 3072),
-            "text-embedding-ada-002",
-            new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536)
+        .ofEntries(
+            Map.entry("text-embedding-3-small", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536)),
+            Map.entry("text-embedding-3-large", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 3072)),
+            Map.entry("text-embedding-ada-002", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536))
         );
 
     @Override

--- a/common/src/main/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProvider.java
+++ b/common/src/main/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProvider.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agent;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLAgentType;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.ConnectorAction;
+import org.opensearch.ml.common.connector.ConnectorClientConfig;
+import org.opensearch.ml.common.connector.ConnectorProtocols;
+import org.opensearch.ml.common.connector.HttpConnector;
+import org.opensearch.ml.common.input.execute.agent.ContentBlock;
+import org.opensearch.ml.common.input.execute.agent.Message;
+import org.opensearch.ml.common.model.ModelProvider;
+import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
+
+/**
+ * Model provider for OpenAI Embedding API (text-embedding-3-small, text-embedding-3-large, etc.)
+ */
+public class OpenaiEmbeddingModelProvider extends ModelProvider {
+
+    private static final String REQUEST_BODY = "{ \"input\": ${parameters.input}, \"model\": \"${parameters.model}\" }";
+
+    public static final Map<String, EmbeddingModelInfo> KNOWN_MODELS = Map.of(
+        "text-embedding-3-small", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536),
+        "text-embedding-3-large", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 3072),
+        "text-embedding-ada-002", new EmbeddingModelInfo(FunctionName.TEXT_EMBEDDING, 1536)
+    );
+
+    @Override
+    public Connector createConnector(String modelId, Map<String, String> credential, Map<String, String> modelParameters) {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("model", modelId);
+        if (modelParameters != null) {
+            parameters.putAll(modelParameters);
+        }
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer ${credential.openAI_key}");
+
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("https://api.openai.com/v1/embeddings")
+            .headers(headers)
+            .requestBody(REQUEST_BODY)
+            .preProcessFunction("connector.pre_process.openai.embedding")
+            .postProcessFunction("connector.post_process.openai.embedding")
+            .build();
+
+        ConnectorClientConfig clientConfig = new ConnectorClientConfig();
+        clientConfig.setMaxRetryTimes(3);
+
+        return HttpConnector
+            .builder()
+            .name("Auto-generated OpenAI Embedding connector")
+            .description("Auto-generated connector for OpenAI Embedding API")
+            .version("1")
+            .protocol(ConnectorProtocols.HTTP)
+            .parameters(parameters)
+            .credential(credential != null ? credential : new HashMap<>())
+            .actions(List.of(predictAction))
+            .connectorClientConfig(clientConfig)
+            .build();
+    }
+
+    @Override
+    public MLRegisterModelInput createModelInput(String modelName, Connector connector, Map<String, String> modelParameters) {
+        return MLRegisterModelInput
+            .builder()
+            .functionName(FunctionName.REMOTE)
+            .modelName("Auto-generated OpenAI embedding model for " + modelName)
+            .description("Auto-generated embedding model for memory container")
+            .connector(connector)
+            .build();
+    }
+
+    public static EmbeddingModelInfo getModelInfo(String modelId) {
+        return KNOWN_MODELS.get(modelId);
+    }
+
+    // Embedding providers don't support agent operations
+    @Override public String getLLMInterface() { return null; }
+    @Override public Map<String, String> mapTextInput(String t, MLAgentType a) { throw new UnsupportedOperationException(); }
+    @Override public Map<String, String> mapContentBlocks(List<ContentBlock> c, MLAgentType a) { throw new UnsupportedOperationException(); }
+    @Override public Map<String, String> mapMessages(List<Message> m, MLAgentType a) { throw new UnsupportedOperationException(); }
+    @Override public String extractMessageFromResponse(Map<String, ?> r) { throw new UnsupportedOperationException(); }
+    @Override public Message parseToUnifiedMessage(String j) { throw new UnsupportedOperationException(); }
+
+    public static class EmbeddingModelInfo {
+        public final FunctionName functionName;
+        public final int dimension;
+        public EmbeddingModelInfo(FunctionName functionName, int dimension) {
+            this.functionName = functionName;
+            this.dimension = dimension;
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/input/execute/agent/ModelProviderType.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/execute/agent/ModelProviderType.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 public enum ModelProviderType {
     BEDROCK_CONVERSE("bedrock/converse"),
     BEDROCK_EMBEDDING("bedrock/embedding"),
+    OPENAI_EMBEDDING("openai/v1/embeddings"),
     GEMINI_V1BETA_GENERATE_CONTENT("gemini/v1beta/generatecontent"),
     OPENAI_V1_CHAT_COMPLETIONS("openai/v1/chat/completions");
 

--- a/common/src/main/java/org/opensearch/ml/common/input/execute/agent/ModelProviderType.java
+++ b/common/src/main/java/org/opensearch/ml/common/input/execute/agent/ModelProviderType.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
  */
 public enum ModelProviderType {
     BEDROCK_CONVERSE("bedrock/converse"),
+    BEDROCK_EMBEDDING("bedrock/embedding"),
     GEMINI_V1BETA_GENERATE_CONTENT("gemini/v1beta/generatecontent"),
     OPENAI_V1_CHAT_COMPLETIONS("openai/v1/chat/completions");
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/EmbeddingModelInfo.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/EmbeddingModelInfo.java
@@ -10,12 +10,5 @@ import org.opensearch.ml.common.FunctionName;
 /**
  * Info about a known embedding model — type (dense/sparse) and default dimension.
  */
-public class EmbeddingModelInfo {
-    public final FunctionName functionName;
-    public final int dimension;
-
-    public EmbeddingModelInfo(FunctionName functionName, int dimension) {
-        this.functionName = functionName;
-        this.dimension = dimension;
-    }
+public record EmbeddingModelInfo(FunctionName functionName, int dimension) {
 }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/EmbeddingModelInfo.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/EmbeddingModelInfo.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import org.opensearch.ml.common.FunctionName;
+
+/**
+ * Info about a known embedding model — type (dense/sparse) and default dimension.
+ */
+public class EmbeddingModelInfo {
+    public final FunctionName functionName;
+    public final int dimension;
+
+    public EmbeddingModelInfo(FunctionName functionName, int dimension) {
+        this.functionName = functionName;
+        this.dimension = dimension;
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -47,6 +47,7 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.agent.MLAgentModelSpec;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -86,6 +87,14 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     private boolean useSystemIndex = true;
     private String tenantId;
 
+    // Transient fields for inline model creation (not stored in container document)
+    public static final String EMBEDDING_MODEL_SPEC_FIELD = "embedding_model";
+    public static final String LLM_SPEC_FIELD = "llm";
+    @EqualsAndHashCode.Exclude
+    private transient MLAgentModelSpec embeddingModelSpec;
+    @EqualsAndHashCode.Exclude
+    private transient MLAgentModelSpec llmSpec;
+
     public MemoryConfiguration(
         String indexPrefix,
         FunctionName embeddingModelType,
@@ -99,10 +108,14 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         boolean disableHistory,
         boolean disableSession,
         boolean useSystemIndex,
-        String tenantId
+        String tenantId,
+        MLAgentModelSpec embeddingModelSpec,
+        MLAgentModelSpec llmSpec
     ) {
-        // Validate first
-        validateInputs(embeddingModelType, embeddingModelId, dimension, maxInferSize);
+        // Skip validation when inline model specs are present (models not yet created)
+        if (embeddingModelSpec == null && llmSpec == null) {
+            validateInputs(embeddingModelType, embeddingModelId, dimension, maxInferSize);
+        }
 
         // Assign values after validation
         this.indexPrefix = buildIndexPrefix(indexPrefix, useSystemIndex);
@@ -127,6 +140,8 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = disableSession;
         this.useSystemIndex = useSystemIndex;
         this.tenantId = tenantId;
+        this.embeddingModelSpec = embeddingModelSpec;
+        this.llmSpec = llmSpec;
     }
 
     private String buildIndexPrefix(String indexPrefix, boolean useSystemIndex) {
@@ -268,6 +283,8 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         boolean disableSession = false;
         boolean useSystemIndex = true;
         String tenantId = null;
+        MLAgentModelSpec embeddingModelSpec = null;
+        MLAgentModelSpec llmSpec = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -287,6 +304,12 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 case LLM_ID_FIELD:
                     llmId = parser.text();
                     break;
+                case EMBEDDING_MODEL_SPEC_FIELD:
+                    embeddingModelSpec = MLAgentModelSpec.parse(parser);
+                    break;
+                case LLM_SPEC_FIELD:
+                    llmSpec = MLAgentModelSpec.parse(parser);
+                    break;
                 case DIMENSION_FIELD:
                     // Handle explicit null: {"dimension": null}
                     if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
@@ -300,8 +323,16 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                     break;
                 case STRATEGIES_FIELD:
                     ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
-                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                        strategies.add(MemoryStrategy.parse(parser));
+                    XContentParser.Token nextToken = parser.nextToken();
+                    while (nextToken != XContentParser.Token.END_ARRAY) {
+                        if (nextToken == XContentParser.Token.VALUE_STRING) {
+                            // Strategy preset: "SEMANTIC" → auto-fill defaults
+                            strategies.add(MemoryStrategy.fromPreset(MemoryStrategyType.fromString(parser.text())));
+                        } else {
+                            // Full strategy object (existing behavior)
+                            strategies.add(MemoryStrategy.parse(parser));
+                        }
+                        nextToken = parser.nextToken();
                     }
                     break;
                 case INDEX_SETTINGS_FIELD:
@@ -341,7 +372,23 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             .disableSession(disableSession)
             .useSystemIndex(useSystemIndex)
             .tenantId(tenantId)
+            .embeddingModelSpec(embeddingModelSpec)
+            .llmSpec(llmSpec)
             .build();
+    }
+
+    /**
+     * Returns true if inline embedding model spec is provided (needs auto-creation).
+     */
+    public boolean hasInlineEmbeddingModel() {
+        return embeddingModelSpec != null;
+    }
+
+    /**
+     * Returns true if inline LLM spec is provided (needs auto-creation).
+     */
+    public boolean hasInlineLlm() {
+        return llmSpec != null;
     }
 
     public String getFinalMemoryIndexPrefix() {

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -123,7 +123,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.embeddingModelId = embeddingModelId;
         this.llmId = llmId;
         this.dimension = dimension;
-        this.maxInferSize = (llmId != null) ? (maxInferSize != null ? maxInferSize : MAX_INFER_SIZE_DEFAULT_VALUE) : null;
+        this.maxInferSize = (llmId != null || llmSpec != null)
+            ? (maxInferSize != null ? maxInferSize : MAX_INFER_SIZE_DEFAULT_VALUE)
+            : null;
         this.strategies = new ArrayList<>();
         if (strategies != null && !strategies.isEmpty()) {
             this.strategies.addAll(strategies);

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -91,9 +91,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     public static final String EMBEDDING_MODEL_SPEC_FIELD = "embedding_model";
     public static final String LLM_SPEC_FIELD = "llm";
     @EqualsAndHashCode.Exclude
-    private transient MLAgentModelSpec embeddingModelSpec;
+    private MLAgentModelSpec embeddingModelSpec;
     @EqualsAndHashCode.Exclude
-    private transient MLAgentModelSpec llmSpec;
+    private MLAgentModelSpec llmSpec;
 
     public MemoryConfiguration(
         String indexPrefix,
@@ -183,6 +183,12 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = input.readBoolean();
         this.useSystemIndex = input.readBoolean();
         this.tenantId = input.readOptionalString();
+        if (input.readBoolean()) {
+            this.embeddingModelSpec = new MLAgentModelSpec(input);
+        }
+        if (input.readBoolean()) {
+            this.llmSpec = new MLAgentModelSpec(input);
+        }
     }
 
     @Override
@@ -215,6 +221,18 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         out.writeBoolean(disableSession);
         out.writeBoolean(useSystemIndex);
         out.writeOptionalString(tenantId);
+        if (embeddingModelSpec != null) {
+            out.writeBoolean(true);
+            embeddingModelSpec.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (llmSpec != null) {
+            out.writeBoolean(true);
+            llmSpec.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
     }
 
     @Override
@@ -380,6 +398,34 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     /**
      * Returns true if inline embedding model spec is provided (needs auto-creation).
      */
+    /**
+     * Validates inputs that don't depend on model creation (maxInferSize, strategies, index prefix).
+     * Called before inline model creation to catch user errors early and avoid orphan models.
+     */
+    public void validateNonModelInputs() {
+        if (maxInferSize != null && maxInferSize > 10) {
+            throw new IllegalArgumentException(MAX_INFER_SIZE_LIMIT_ERROR);
+        }
+        if (strategies != null) {
+            for (MemoryStrategy strategy : strategies) {
+                MemoryStrategy.validate(strategy);
+            }
+        }
+        if (indexPrefix != null) {
+            validateIndexPrefix(indexPrefix);
+        }
+    }
+
+    private static void validateIndexPrefix(String prefix) {
+        if (prefix != null && !prefix.isEmpty()) {
+            for (char c : prefix.toCharArray()) {
+                if (Character.isISOControl(c)) {
+                    throw new IllegalArgumentException(INDEX_PREFIX_INVALID_CHARACTERS_ERROR);
+                }
+            }
+        }
+    }
+
     public boolean hasInlineEmbeddingModel() {
         return embeddingModelSpec != null;
     }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -405,6 +405,15 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
      * Called before inline model creation to catch user errors early and avoid orphan models.
      */
     public void validateNonModelInputs() {
+        // Reject conflicting configurations
+        if (embeddingModelSpec != null && embeddingModelId != null) {
+            throw new IllegalArgumentException(
+                "Cannot specify both 'embedding_model' (inline) and 'embedding_model_id'. Use one or the other."
+            );
+        }
+        if (llmSpec != null && llmId != null) {
+            throw new IllegalArgumentException("Cannot specify both 'llm' (inline) and 'llm_id'. Use one or the other.");
+        }
         if (maxInferSize != null && maxInferSize > 10) {
             throw new IllegalArgumentException(MAX_INFER_SIZE_LIMIT_ERROR);
         }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -370,6 +370,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 case USE_SYSTEM_INDEX_FIELD:
                     useSystemIndex = parser.booleanValue();
                     break;
+                case TENANT_ID_FIELD:
+                    tenantId = parser.textOrNull();
+                    break;
                 default:
                     parser.skipChildren();
                     break;

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -401,9 +401,6 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     }
 
     /**
-     * Returns true if inline embedding model spec is provided (needs auto-creation).
-     */
-    /**
      * Validates inputs that don't depend on model creation (maxInferSize, strategies, index prefix).
      * Called before inline model creation to catch user errors early and avoid orphan models.
      */
@@ -440,6 +437,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         }
     }
 
+    /**
+     * Returns true if inline embedding model spec is provided (needs auto-creation).
+     */
     public boolean hasInlineEmbeddingModel() {
         return embeddingModelSpec != null;
     }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -10,6 +10,10 @@ package org.opensearch.ml.common.memorycontainer;
  */
 public class MemoryContainerConstants {
 
+    // AWS region constants for inline model creation
+    public static final String DEFAULT_AWS_REGION = "us-east-1";
+    public static final java.util.regex.Pattern AWS_REGION_PATTERN = java.util.regex.Pattern.compile("^[a-z]{2}(-[a-z]+-\\d+)?$");
+
     public static final String DEFAULT_LLM_RESULT_PATH = "$.output.message.content[0].text";
     public static final String LLM_RESULT_PATH_FIELD = "llm_result_path";
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.common.memorycontainer;
 
+import java.util.regex.Pattern;
+
 /**
  * Constants for Memory Container feature
  */
@@ -12,7 +14,13 @@ public class MemoryContainerConstants {
 
     // AWS region constants for inline model creation
     public static final String DEFAULT_AWS_REGION = "us-east-1";
-    public static final java.util.regex.Pattern AWS_REGION_PATTERN = java.util.regex.Pattern.compile("^[a-z]{2}(-[a-z]+-\\d+)?$");
+    public static final Pattern AWS_REGION_PATTERN = Pattern.compile("^[a-z]{2}(-[a-z]+-\\d+)?$");
+
+    public static void requireValidAwsRegion(String region) {
+        if (region == null || !AWS_REGION_PATTERN.matcher(region).matches()) {
+            throw new IllegalArgumentException("Invalid AWS region format: " + region);
+        }
+    }
 
     public static final String DEFAULT_LLM_RESULT_PATH = "$.output.message.content[0].text";
     public static final String LLM_RESULT_PATH_FIELD = "llm_result_path";

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
@@ -100,6 +100,7 @@ public class MemoryModelService {
             url = "https://generativelanguage.googleapis.com/v1beta/models/${parameters.model}:generateContent";
             requestBody = GEMINI_MEMORY_TEMPLATE;
             protocol = ConnectorProtocols.HTTP;
+            headers.put("x-goog-api-key", "${credential.gemini_api_key}");
         } else {
             throw new IllegalArgumentException("Unsupported LLM provider for memory: " + modelSpec.getModelProvider());
         }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
@@ -172,6 +172,22 @@ public class MemoryModelService {
         return null;
     }
 
+    /**
+     * Returns the correct llm_result_path for a given LLM provider.
+     */
+    public static String getLlmResultPath(String modelProvider) {
+        if (modelProvider == null) return null;
+        String provider = modelProvider.toLowerCase();
+        if (provider.equals("bedrock/converse")) {
+            return "$.output.message.content[0].text";
+        } else if (provider.equals("openai/v1/chat/completions")) {
+            return "$.choices[0].message.content";
+        } else if (provider.equals("gemini/v1beta/generatecontent")) {
+            return "$.candidates[0].content.parts[0].text";
+        }
+        return null;
+    }
+
     private static void validateModelSpec(MLAgentModelSpec modelSpec) {
         if (modelSpec == null) {
             throw new IllegalArgumentException("Model specification not found");

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
@@ -162,20 +162,20 @@ public class MemoryModelService {
      * @return FunctionName or null if unknown
      */
     public static FunctionName detectEmbeddingType(String modelId) {
-        BedrockEmbeddingModelProvider.EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
+        EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
         if (info != null)
             return info.functionName;
-        OpenaiEmbeddingModelProvider.EmbeddingModelInfo openaiInfo = OpenaiEmbeddingModelProvider.getModelInfo(modelId);
+        EmbeddingModelInfo openaiInfo = OpenaiEmbeddingModelProvider.getModelInfo(modelId);
         if (openaiInfo != null)
             return openaiInfo.functionName;
         return null;
     }
 
     public static Integer detectEmbeddingDimension(String modelId) {
-        BedrockEmbeddingModelProvider.EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
+        EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
         if (info != null)
             return info.dimension;
-        OpenaiEmbeddingModelProvider.EmbeddingModelInfo openaiInfo = OpenaiEmbeddingModelProvider.getModelInfo(modelId);
+        EmbeddingModelInfo openaiInfo = OpenaiEmbeddingModelProvider.getModelInfo(modelId);
         if (openaiInfo != null)
             return openaiInfo.dimension;
         return null;

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
@@ -18,6 +18,7 @@ import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.ConnectorClientConfig;
 import org.opensearch.ml.common.connector.ConnectorProtocols;
+import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.input.execute.agent.ModelProviderType;
 import org.opensearch.ml.common.model.ModelProvider;
 import org.opensearch.ml.common.model.ModelProviderFactory;
@@ -136,7 +137,7 @@ public class MemoryModelService {
                 .connectorClientConfig(clientConfig)
                 .build();
         } else {
-            connector = org.opensearch.ml.common.connector.HttpConnector
+            connector = HttpConnector
                 .builder()
                 .name("Auto-generated " + modelSpec.getModelProvider() + " connector for Memory")
                 .description("Auto-generated LLM connector for memory container")

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.agent.BedrockEmbeddingModelProvider;
 import org.opensearch.ml.common.agent.MLAgentModelSpec;
+import org.opensearch.ml.common.agent.OpenaiEmbeddingModelProvider;
 import org.opensearch.ml.common.connector.AwsConnector;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
@@ -30,13 +31,18 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class MemoryModelService {
 
-    /**
-     * Memory LLM request body template using system_prompt/user_prompt parameters.
-     * This differs from the agent template which uses body/_chat_history/_interactions.
-     * The memory processing service calls the LLM with system_prompt and user_prompt.
-     */
-    private static final String MEMORY_LLM_REQUEST_BODY = "{\"system\":[{\"text\":\"${parameters.system_prompt}\"}],"
-        + "\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}]}";
+    // Memory LLM templates — use system_prompt/user_prompt (not agent-style body/_chat_history)
+    private static final String BEDROCK_CONVERSE_MEMORY_TEMPLATE =
+        "{\"system\":[{\"text\":\"${parameters.system_prompt}\"}],"
+            + "\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}]}";
+
+    private static final String OPENAI_MEMORY_TEMPLATE =
+        "{\"model\":\"${parameters.model}\",\"messages\":[{\"role\":\"system\",\"content\":\"${parameters.system_prompt}\"},"
+            + "{\"role\":\"user\",\"content\":\"${parameters.user_prompt}\"}]}";
+
+    private static final String GEMINI_MEMORY_TEMPLATE =
+        "{\"system_instruction\":{\"parts\":[{\"text\":\"${parameters.system_prompt}\"}]},"
+            + "\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"${parameters.user_prompt}\"}]}]}";
 
     private static final String DEFAULT_REGION = "us-east-1";
 
@@ -48,7 +54,7 @@ public class MemoryModelService {
     public static MLRegisterModelInput createModelFromSpec(MLAgentModelSpec modelSpec, boolean isMemoryLlm) {
         validateModelSpec(modelSpec);
 
-        if (isMemoryLlm && modelSpec.getModelProvider().equalsIgnoreCase("bedrock/converse")) {
+        if (isMemoryLlm) {
             return createMemoryLlmInput(modelSpec);
         }
 
@@ -67,37 +73,75 @@ public class MemoryModelService {
      * Uses system_prompt/user_prompt instead of agent-style body/_chat_history.
      */
     private static MLRegisterModelInput createMemoryLlmInput(MLAgentModelSpec modelSpec) {
+        String provider = modelSpec.getModelProvider().toLowerCase();
+        String url;
+        String requestBody;
+        String protocol;
+        Map<String, String> headers = new HashMap<>(Map.of("content-type", "application/json"));
+
         Map<String, String> parameters = new HashMap<>();
-        parameters.put("region", DEFAULT_REGION);
-        parameters.put("service_name", "bedrock");
         parameters.put("model", modelSpec.getModelId());
         if (modelSpec.getModelParameters() != null) {
             parameters.putAll(modelSpec.getModelParameters());
+        }
+
+        if (provider.equals("bedrock/converse")) {
+            parameters.putIfAbsent("region", DEFAULT_REGION);
+            parameters.put("service_name", "bedrock");
+            url = "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse";
+            requestBody = BEDROCK_CONVERSE_MEMORY_TEMPLATE;
+            protocol = ConnectorProtocols.AWS_SIGV4;
+        } else if (provider.equals("openai/v1/chat/completions")) {
+            url = "https://api.openai.com/v1/chat/completions";
+            requestBody = OPENAI_MEMORY_TEMPLATE;
+            protocol = ConnectorProtocols.HTTP;
+            headers.put("Authorization", "Bearer ${credential.openAI_key}");
+        } else if (provider.equals("gemini/v1beta/generatecontent")) {
+            url = "https://generativelanguage.googleapis.com/v1beta/models/${parameters.model}:generateContent";
+            requestBody = GEMINI_MEMORY_TEMPLATE;
+            protocol = ConnectorProtocols.HTTP;
+        } else {
+            throw new IllegalArgumentException("Unsupported LLM provider for memory: " + modelSpec.getModelProvider());
         }
 
         ConnectorAction predictAction = ConnectorAction
             .builder()
             .actionType(ConnectorAction.ActionType.PREDICT)
             .method("POST")
-            .url("https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse")
-            .headers(Map.of("content-type", "application/json"))
-            .requestBody(MEMORY_LLM_REQUEST_BODY)
+            .url(url)
+            .headers(headers)
+            .requestBody(requestBody)
             .build();
 
         ConnectorClientConfig clientConfig = new ConnectorClientConfig();
         clientConfig.setMaxRetryTimes(3);
 
-        Connector connector = AwsConnector
-            .awsConnectorBuilder()
-            .name("Auto-generated Bedrock Converse connector for Memory")
-            .description("Auto-generated LLM connector for memory container (uses system_prompt/user_prompt)")
-            .version("1")
-            .protocol(ConnectorProtocols.AWS_SIGV4)
-            .parameters(parameters)
-            .credential(modelSpec.getCredential() != null ? modelSpec.getCredential() : new HashMap<>())
-            .actions(List.of(predictAction))
-            .connectorClientConfig(clientConfig)
-            .build();
+        Connector connector;
+        if (protocol.equals(ConnectorProtocols.AWS_SIGV4)) {
+            connector = AwsConnector
+                .awsConnectorBuilder()
+                .name("Auto-generated " + modelSpec.getModelProvider() + " connector for Memory")
+                .description("Auto-generated LLM connector for memory container")
+                .version("1")
+                .protocol(protocol)
+                .parameters(parameters)
+                .credential(modelSpec.getCredential() != null ? modelSpec.getCredential() : new HashMap<>())
+                .actions(List.of(predictAction))
+                .connectorClientConfig(clientConfig)
+                .build();
+        } else {
+            connector = org.opensearch.ml.common.connector.HttpConnector
+                .builder()
+                .name("Auto-generated " + modelSpec.getModelProvider() + " connector for Memory")
+                .description("Auto-generated LLM connector for memory container")
+                .version("1")
+                .protocol(protocol)
+                .parameters(parameters)
+                .credential(modelSpec.getCredential() != null ? modelSpec.getCredential() : new HashMap<>())
+                .actions(List.of(predictAction))
+                .connectorClientConfig(clientConfig)
+                .build();
+        }
 
         return MLRegisterModelInput
             .builder()
@@ -114,16 +158,18 @@ public class MemoryModelService {
      */
     public static FunctionName detectEmbeddingType(String modelId) {
         BedrockEmbeddingModelProvider.EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
-        return info != null ? info.functionName : null;
+        if (info != null) return info.functionName;
+        OpenaiEmbeddingModelProvider.EmbeddingModelInfo openaiInfo = OpenaiEmbeddingModelProvider.getModelInfo(modelId);
+        if (openaiInfo != null) return openaiInfo.functionName;
+        return null;
     }
 
-    /**
-     * Auto-detect embedding dimension from model ID.
-     * @return dimension or null if unknown
-     */
     public static Integer detectEmbeddingDimension(String modelId) {
         BedrockEmbeddingModelProvider.EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
-        return info != null ? info.dimension : null;
+        if (info != null) return info.dimension;
+        OpenaiEmbeddingModelProvider.EmbeddingModelInfo openaiInfo = OpenaiEmbeddingModelProvider.getModelInfo(modelId);
+        if (openaiInfo != null) return openaiInfo.dimension;
+        return null;
     }
 
     private static void validateModelSpec(MLAgentModelSpec modelSpec) {

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
@@ -32,19 +32,18 @@ import lombok.extern.log4j.Log4j2;
 public class MemoryModelService {
 
     // Memory LLM templates — use system_prompt/user_prompt (not agent-style body/_chat_history)
-    private static final String BEDROCK_CONVERSE_MEMORY_TEMPLATE =
-        "{\"system\":[{\"text\":\"${parameters.system_prompt}\"}],"
-            + "\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}]}";
+    private static final String BEDROCK_CONVERSE_MEMORY_TEMPLATE = "{\"system\":[{\"text\":\"${parameters.system_prompt}\"}],"
+        + "\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}]}";
 
     private static final String OPENAI_MEMORY_TEMPLATE =
         "{\"model\":\"${parameters.model}\",\"messages\":[{\"role\":\"system\",\"content\":\"${parameters.system_prompt}\"},"
             + "{\"role\":\"user\",\"content\":\"${parameters.user_prompt}\"}]}";
 
-    private static final String GEMINI_MEMORY_TEMPLATE =
-        "{\"system_instruction\":{\"parts\":[{\"text\":\"${parameters.system_prompt}\"}]},"
-            + "\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"${parameters.user_prompt}\"}]}]}";
+    private static final String GEMINI_MEMORY_TEMPLATE = "{\"system_instruction\":{\"parts\":[{\"text\":\"${parameters.system_prompt}\"}]},"
+        + "\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"${parameters.user_prompt}\"}]}]}";
 
     private static final String DEFAULT_REGION = "us-east-1";
+    private static final java.util.regex.Pattern REGION_PATTERN = java.util.regex.Pattern.compile("^[a-z]{2}(-[a-z]+-\\d+)?$");
 
     /**
      * Creates a model registration input from an inline model spec.
@@ -88,6 +87,11 @@ public class MemoryModelService {
         if (provider.equals("bedrock/converse")) {
             parameters.putIfAbsent("region", DEFAULT_REGION);
             parameters.put("service_name", "bedrock");
+            // Validate region to prevent SSRF via URL injection
+            String region = parameters.get("region");
+            if (!REGION_PATTERN.matcher(region).matches()) {
+                throw new IllegalArgumentException("Invalid AWS region format: " + region);
+            }
             url = "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse";
             requestBody = BEDROCK_CONVERSE_MEMORY_TEMPLATE;
             protocol = ConnectorProtocols.AWS_SIGV4;
@@ -159,17 +163,21 @@ public class MemoryModelService {
      */
     public static FunctionName detectEmbeddingType(String modelId) {
         BedrockEmbeddingModelProvider.EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
-        if (info != null) return info.functionName;
+        if (info != null)
+            return info.functionName;
         OpenaiEmbeddingModelProvider.EmbeddingModelInfo openaiInfo = OpenaiEmbeddingModelProvider.getModelInfo(modelId);
-        if (openaiInfo != null) return openaiInfo.functionName;
+        if (openaiInfo != null)
+            return openaiInfo.functionName;
         return null;
     }
 
     public static Integer detectEmbeddingDimension(String modelId) {
         BedrockEmbeddingModelProvider.EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
-        if (info != null) return info.dimension;
+        if (info != null)
+            return info.dimension;
         OpenaiEmbeddingModelProvider.EmbeddingModelInfo openaiInfo = OpenaiEmbeddingModelProvider.getModelInfo(modelId);
-        if (openaiInfo != null) return openaiInfo.dimension;
+        if (openaiInfo != null)
+            return openaiInfo.dimension;
         return null;
     }
 
@@ -177,7 +185,8 @@ public class MemoryModelService {
      * Returns the correct llm_result_path for a given LLM provider.
      */
     public static String getLlmResultPath(String modelProvider) {
-        if (modelProvider == null) return null;
+        if (modelProvider == null)
+            return null;
         String provider = modelProvider.toLowerCase();
         if (provider.equals("bedrock/converse")) {
             return "$.output.message.content[0].text";

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
@@ -18,6 +18,7 @@ import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.ConnectorClientConfig;
 import org.opensearch.ml.common.connector.ConnectorProtocols;
+import org.opensearch.ml.common.input.execute.agent.ModelProviderType;
 import org.opensearch.ml.common.model.ModelProvider;
 import org.opensearch.ml.common.model.ModelProviderFactory;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
@@ -72,7 +73,7 @@ public class MemoryModelService {
      * Uses system_prompt/user_prompt instead of agent-style body/_chat_history.
      */
     private static MLRegisterModelInput createMemoryLlmInput(MLAgentModelSpec modelSpec) {
-        String provider = modelSpec.getModelProvider().toLowerCase();
+        ModelProviderType providerType = ModelProviderType.from(modelSpec.getModelProvider());
         String url;
         String requestBody;
         String protocol;
@@ -84,29 +85,29 @@ public class MemoryModelService {
             parameters.putAll(modelSpec.getModelParameters());
         }
 
-        if (provider.equals("bedrock/converse")) {
-            parameters.putIfAbsent("region", DEFAULT_REGION);
-            parameters.put("service_name", "bedrock");
-            // Validate region to prevent SSRF via URL injection
-            String region = parameters.get("region");
-            if (!REGION_PATTERN.matcher(region).matches()) {
-                throw new IllegalArgumentException("Invalid AWS region format: " + region);
-            }
-            url = "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse";
-            requestBody = BEDROCK_CONVERSE_MEMORY_TEMPLATE;
-            protocol = ConnectorProtocols.AWS_SIGV4;
-        } else if (provider.equals("openai/v1/chat/completions")) {
-            url = "https://api.openai.com/v1/chat/completions";
-            requestBody = OPENAI_MEMORY_TEMPLATE;
-            protocol = ConnectorProtocols.HTTP;
-            headers.put("Authorization", "Bearer ${credential.openAI_key}");
-        } else if (provider.equals("gemini/v1beta/generatecontent")) {
-            url = "https://generativelanguage.googleapis.com/v1beta/models/${parameters.model}:generateContent";
-            requestBody = GEMINI_MEMORY_TEMPLATE;
-            protocol = ConnectorProtocols.HTTP;
-            headers.put("x-goog-api-key", "${credential.gemini_api_key}");
-        } else {
-            throw new IllegalArgumentException("Unsupported LLM provider for memory: " + modelSpec.getModelProvider());
+        switch (providerType) {
+            case BEDROCK_CONVERSE:
+                parameters.putIfAbsent("region", DEFAULT_REGION);
+                parameters.put("service_name", "bedrock");
+                MemoryContainerConstants.requireValidAwsRegion(parameters.get("region"));
+                url = "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse";
+                requestBody = BEDROCK_CONVERSE_MEMORY_TEMPLATE;
+                protocol = ConnectorProtocols.AWS_SIGV4;
+                break;
+            case OPENAI_V1_CHAT_COMPLETIONS:
+                url = "https://api.openai.com/v1/chat/completions";
+                requestBody = OPENAI_MEMORY_TEMPLATE;
+                protocol = ConnectorProtocols.HTTP;
+                headers.put("Authorization", "Bearer ${credential.openAI_key}");
+                break;
+            case GEMINI_V1BETA_GENERATE_CONTENT:
+                url = "https://generativelanguage.googleapis.com/v1beta/models/${parameters.model}:generateContent";
+                requestBody = GEMINI_MEMORY_TEMPLATE;
+                protocol = ConnectorProtocols.HTTP;
+                headers.put("x-goog-api-key", "${credential.gemini_api_key}");
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported LLM provider for memory: " + modelSpec.getModelProvider());
         }
 
         ConnectorAction predictAction = ConnectorAction
@@ -164,20 +165,20 @@ public class MemoryModelService {
     public static FunctionName detectEmbeddingType(String modelId) {
         EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
         if (info != null)
-            return info.functionName;
+            return info.functionName();
         EmbeddingModelInfo openaiInfo = OpenaiEmbeddingModelProvider.getModelInfo(modelId);
         if (openaiInfo != null)
-            return openaiInfo.functionName;
+            return openaiInfo.functionName();
         return null;
     }
 
     public static Integer detectEmbeddingDimension(String modelId) {
         EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
         if (info != null)
-            return info.dimension;
+            return info.dimension();
         EmbeddingModelInfo openaiInfo = OpenaiEmbeddingModelProvider.getModelInfo(modelId);
         if (openaiInfo != null)
-            return openaiInfo.dimension;
+            return openaiInfo.dimension();
         return null;
     }
 
@@ -187,15 +188,17 @@ public class MemoryModelService {
     public static String getLlmResultPath(String modelProvider) {
         if (modelProvider == null)
             return null;
-        String provider = modelProvider.toLowerCase();
-        if (provider.equals("bedrock/converse")) {
-            return "$.output.message.content[0].text";
-        } else if (provider.equals("openai/v1/chat/completions")) {
-            return "$.choices[0].message.content";
-        } else if (provider.equals("gemini/v1beta/generatecontent")) {
-            return "$.candidates[0].content.parts[0].text";
+        try {
+            ModelProviderType type = ModelProviderType.from(modelProvider);
+            return switch (type) {
+                case BEDROCK_CONVERSE -> "$.output.message.content[0].text";
+                case OPENAI_V1_CHAT_COMPLETIONS -> "$.choices[0].message.content";
+                case GEMINI_V1BETA_GENERATE_CONTENT -> "$.candidates[0].content.parts[0].text";
+                default -> null;
+            };
+        } catch (IllegalArgumentException e) {
+            return null;
         }
-        return null;
     }
 
     private static void validateModelSpec(MLAgentModelSpec modelSpec) {

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.agent.BedrockEmbeddingModelProvider;
+import org.opensearch.ml.common.agent.MLAgentModelSpec;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.model.ModelProvider;
+import org.opensearch.ml.common.model.ModelProviderFactory;
+import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Service for creating models during memory container creation.
+ * Translates inline model specs into registered models, analogous to AgentModelService.
+ */
+@Log4j2
+public class MemoryModelService {
+
+    /**
+     * Creates a model registration input from an inline model spec.
+     */
+    public static MLRegisterModelInput createModelFromSpec(MLAgentModelSpec modelSpec) {
+        validateModelSpec(modelSpec);
+        ModelProvider provider = ModelProviderFactory.getProvider(modelSpec.getModelProvider());
+        Connector connector = provider.createConnector(modelSpec.getModelId(), modelSpec.getCredential(), modelSpec.getModelParameters());
+        return provider.createModelInput(modelSpec.getModelId(), connector, modelSpec.getModelParameters());
+    }
+
+    /**
+     * Auto-detect embedding model type (TEXT_EMBEDDING or SPARSE_ENCODING) from model ID.
+     * @return FunctionName or null if unknown
+     */
+    public static FunctionName detectEmbeddingType(String modelId) {
+        BedrockEmbeddingModelProvider.EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
+        return info != null ? info.functionName : null;
+    }
+
+    /**
+     * Auto-detect embedding dimension from model ID.
+     * @return dimension or null if unknown
+     */
+    public static Integer detectEmbeddingDimension(String modelId) {
+        BedrockEmbeddingModelProvider.EmbeddingModelInfo info = BedrockEmbeddingModelProvider.getModelInfo(modelId);
+        return info != null ? info.dimension : null;
+    }
+
+    private static void validateModelSpec(MLAgentModelSpec modelSpec) {
+        if (modelSpec == null) {
+            throw new IllegalArgumentException("Model specification not found");
+        }
+        if (modelSpec.getModelId() == null || modelSpec.getModelId().trim().isEmpty()) {
+            throw new IllegalArgumentException("model_id cannot be null or empty");
+        }
+        if (modelSpec.getModelProvider() == null || modelSpec.getModelProvider().trim().isEmpty()) {
+            throw new IllegalArgumentException("model_provider cannot be null or empty");
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
@@ -42,8 +42,8 @@ public class MemoryModelService {
     private static final String GEMINI_MEMORY_TEMPLATE = "{\"system_instruction\":{\"parts\":[{\"text\":\"${parameters.system_prompt}\"}]},"
         + "\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"${parameters.user_prompt}\"}]}]}";
 
-    private static final String DEFAULT_REGION = "us-east-1";
-    private static final java.util.regex.Pattern REGION_PATTERN = java.util.regex.Pattern.compile("^[a-z]{2}(-[a-z]+-\\d+)?$");
+    private static final String DEFAULT_REGION = MemoryContainerConstants.DEFAULT_AWS_REGION;
+    private static final java.util.regex.Pattern REGION_PATTERN = MemoryContainerConstants.AWS_REGION_PATTERN;
 
     /**
      * Creates a model registration input from an inline model spec.

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
@@ -5,10 +5,18 @@
 
 package org.opensearch.ml.common.memorycontainer;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.agent.BedrockEmbeddingModelProvider;
 import org.opensearch.ml.common.agent.MLAgentModelSpec;
+import org.opensearch.ml.common.connector.AwsConnector;
 import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.ConnectorAction;
+import org.opensearch.ml.common.connector.ConnectorClientConfig;
+import org.opensearch.ml.common.connector.ConnectorProtocols;
 import org.opensearch.ml.common.model.ModelProvider;
 import org.opensearch.ml.common.model.ModelProviderFactory;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
@@ -23,13 +31,81 @@ import lombok.extern.log4j.Log4j2;
 public class MemoryModelService {
 
     /**
-     * Creates a model registration input from an inline model spec.
+     * Memory LLM request body template using system_prompt/user_prompt parameters.
+     * This differs from the agent template which uses body/_chat_history/_interactions.
+     * The memory processing service calls the LLM with system_prompt and user_prompt.
      */
-    public static MLRegisterModelInput createModelFromSpec(MLAgentModelSpec modelSpec) {
+    private static final String MEMORY_LLM_REQUEST_BODY = "{\"system\":[{\"text\":\"${parameters.system_prompt}\"}],"
+        + "\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}]}";
+
+    private static final String DEFAULT_REGION = "us-east-1";
+
+    /**
+     * Creates a model registration input from an inline model spec.
+     * For embedding models, uses the standard provider.
+     * For LLM models used by memory, uses a memory-specific connector template.
+     */
+    public static MLRegisterModelInput createModelFromSpec(MLAgentModelSpec modelSpec, boolean isMemoryLlm) {
         validateModelSpec(modelSpec);
+
+        if (isMemoryLlm && modelSpec.getModelProvider().equalsIgnoreCase("bedrock/converse")) {
+            return createMemoryLlmInput(modelSpec);
+        }
+
         ModelProvider provider = ModelProviderFactory.getProvider(modelSpec.getModelProvider());
         Connector connector = provider.createConnector(modelSpec.getModelId(), modelSpec.getCredential(), modelSpec.getModelParameters());
         return provider.createModelInput(modelSpec.getModelId(), connector, modelSpec.getModelParameters());
+    }
+
+    /** Backward-compatible overload for embedding models. */
+    public static MLRegisterModelInput createModelFromSpec(MLAgentModelSpec modelSpec) {
+        return createModelFromSpec(modelSpec, false);
+    }
+
+    /**
+     * Creates a Bedrock Converse LLM model with memory-compatible request body.
+     * Uses system_prompt/user_prompt instead of agent-style body/_chat_history.
+     */
+    private static MLRegisterModelInput createMemoryLlmInput(MLAgentModelSpec modelSpec) {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("region", DEFAULT_REGION);
+        parameters.put("service_name", "bedrock");
+        parameters.put("model", modelSpec.getModelId());
+        if (modelSpec.getModelParameters() != null) {
+            parameters.putAll(modelSpec.getModelParameters());
+        }
+
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse")
+            .headers(Map.of("content-type", "application/json"))
+            .requestBody(MEMORY_LLM_REQUEST_BODY)
+            .build();
+
+        ConnectorClientConfig clientConfig = new ConnectorClientConfig();
+        clientConfig.setMaxRetryTimes(3);
+
+        Connector connector = AwsConnector
+            .awsConnectorBuilder()
+            .name("Auto-generated Bedrock Converse connector for Memory")
+            .description("Auto-generated LLM connector for memory container (uses system_prompt/user_prompt)")
+            .version("1")
+            .protocol(ConnectorProtocols.AWS_SIGV4)
+            .parameters(parameters)
+            .credential(modelSpec.getCredential() != null ? modelSpec.getCredential() : new HashMap<>())
+            .actions(List.of(predictAction))
+            .connectorClientConfig(clientConfig)
+            .build();
+
+        return MLRegisterModelInput
+            .builder()
+            .functionName(FunctionName.REMOTE)
+            .modelName("Auto-generated LLM for memory: " + modelSpec.getModelId())
+            .description("Auto-generated LLM for memory container")
+            .connector(connector)
+            .build();
     }
 
     /**

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryModelService.java
@@ -45,7 +45,6 @@ public class MemoryModelService {
         + "\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"${parameters.user_prompt}\"}]}]}";
 
     private static final String DEFAULT_REGION = MemoryContainerConstants.DEFAULT_AWS_REGION;
-    private static final java.util.regex.Pattern REGION_PATTERN = MemoryContainerConstants.AWS_REGION_PATTERN;
 
     /**
      * Creates a model registration input from an inline model spec.

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryStrategy.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryStrategy.java
@@ -200,4 +200,23 @@ public class MemoryStrategy implements ToXContentObject, Writeable {
         return type.getValue().toLowerCase() + "_" + UUID.randomUUID().toString().substring(0, 8);
     }
 
+    /**
+     * Create a strategy with sensible defaults from a preset type.
+     * Used when user passes strategies as a simple string array: ["SEMANTIC", "USER_PREFERENCE"]
+     */
+    public static MemoryStrategy fromPreset(MemoryStrategyType type) {
+        List<String> namespace;
+        switch (type) {
+            case SUMMARY:
+                namespace = List.of("user_id", "session_id");
+                break;
+            case SEMANTIC:
+            case USER_PREFERENCE:
+            default:
+                namespace = List.of("user_id");
+                break;
+        }
+        return MemoryStrategy.builder().type(type).namespace(namespace).enabled(true).build();
+    }
+
 }

--- a/common/src/main/java/org/opensearch/ml/common/model/ModelProviderFactory.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/ModelProviderFactory.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.model;
 import org.opensearch.ml.common.agent.BedrockConverseModelProvider;
 import org.opensearch.ml.common.agent.BedrockEmbeddingModelProvider;
 import org.opensearch.ml.common.agent.GeminiV1BetaGenerateContentModelProvider;
+import org.opensearch.ml.common.agent.OpenaiEmbeddingModelProvider;
 import org.opensearch.ml.common.agent.OpenaiV1ChatCompletionsModelProvider;
 import org.opensearch.ml.common.input.execute.agent.ModelProviderType;
 
@@ -29,6 +30,7 @@ public class ModelProviderFactory {
         return switch (type) {
             case BEDROCK_CONVERSE -> new BedrockConverseModelProvider();
             case BEDROCK_EMBEDDING -> new BedrockEmbeddingModelProvider();
+            case OPENAI_EMBEDDING -> new OpenaiEmbeddingModelProvider();
             case GEMINI_V1BETA_GENERATE_CONTENT -> new GeminiV1BetaGenerateContentModelProvider();
             case OPENAI_V1_CHAT_COMPLETIONS -> new OpenaiV1ChatCompletionsModelProvider();
             default -> throw new IllegalArgumentException("Unsupported model provider type");

--- a/common/src/main/java/org/opensearch/ml/common/model/ModelProviderFactory.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/ModelProviderFactory.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.model;
 
 import org.opensearch.ml.common.agent.BedrockConverseModelProvider;
+import org.opensearch.ml.common.agent.BedrockEmbeddingModelProvider;
 import org.opensearch.ml.common.agent.GeminiV1BetaGenerateContentModelProvider;
 import org.opensearch.ml.common.agent.OpenaiV1ChatCompletionsModelProvider;
 import org.opensearch.ml.common.input.execute.agent.ModelProviderType;
@@ -27,6 +28,7 @@ public class ModelProviderFactory {
         ModelProviderType type = ModelProviderType.from(providerType);
         return switch (type) {
             case BEDROCK_CONVERSE -> new BedrockConverseModelProvider();
+            case BEDROCK_EMBEDDING -> new BedrockEmbeddingModelProvider();
             case GEMINI_V1BETA_GENERATE_CONTENT -> new GeminiV1BetaGenerateContentModelProvider();
             case OPENAI_V1_CHAT_COMPLETIONS -> new OpenaiV1ChatCompletionsModelProvider();
             default -> throw new IllegalArgumentException("Unsupported model provider type");

--- a/common/src/test/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProviderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProviderTest.java
@@ -55,27 +55,33 @@ public class BedrockEmbeddingModelProviderTest {
     }
 
     @Test
-    public void testCreateModelInput_unknownModel_defaultsToRemote() {
-        Connector connector = provider.createConnector("some.unknown-model", testCredential, null);
-        MLRegisterModelInput input = provider.createModelInput("some.unknown-model", connector, null);
+    public void testCreateConnector_unknownModel_requiresDimension() {
+        assertThrows(IllegalArgumentException.class, () -> provider.createConnector("some.unknown-model", testCredential, null));
+    }
 
-        assertEquals(FunctionName.REMOTE, input.getFunctionName());
+    @Test
+    public void testCreateConnector_unknownModel_withDimensionProvided() {
+        Map<String, String> params = new HashMap<>();
+        params.put("dimensions", "768");
+        Connector connector = provider.createConnector("some.unknown-model", testCredential, params);
+        assertNotNull(connector);
+        assertEquals("768", connector.getParameters().get("dimensions"));
     }
 
     @Test
     public void testGetModelInfo_knownModels() {
         EmbeddingModelInfo titanV2 = BedrockEmbeddingModelProvider.getModelInfo("amazon.titan-embed-text-v2:0");
         assertNotNull(titanV2);
-        assertEquals(FunctionName.TEXT_EMBEDDING, titanV2.functionName);
-        assertEquals(1024, titanV2.dimension);
+        assertEquals(FunctionName.TEXT_EMBEDDING, titanV2.functionName());
+        assertEquals(1024, titanV2.dimension());
 
         EmbeddingModelInfo titanV1 = BedrockEmbeddingModelProvider.getModelInfo("amazon.titan-embed-text-v1");
         assertNotNull(titanV1);
-        assertEquals(1536, titanV1.dimension);
+        assertEquals(1536, titanV1.dimension());
 
         EmbeddingModelInfo cohere = BedrockEmbeddingModelProvider.getModelInfo("cohere.embed-english-v3");
         assertNotNull(cohere);
-        assertEquals(1024, cohere.dimension);
+        assertEquals(1024, cohere.dimension());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProviderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProviderTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
+
+public class BedrockEmbeddingModelProviderTest {
+
+    private final BedrockEmbeddingModelProvider provider = new BedrockEmbeddingModelProvider();
+    private final Map<String, String> testCredential = Map.of("access_key", "test_key", "secret_key", "test_secret");
+
+    @Test
+    public void testCreateConnector_knownModel() {
+        Connector connector = provider.createConnector("amazon.titan-embed-text-v2:0", testCredential, null);
+
+        assertNotNull(connector);
+        assertEquals("aws_sigv4", connector.getProtocol());
+        assertEquals("amazon.titan-embed-text-v2:0", connector.getParameters().get("model"));
+        assertEquals("1024", connector.getParameters().get("dimensions"));
+        assertEquals("bedrock", connector.getParameters().get("service_name"));
+    }
+
+    @Test
+    public void testCreateConnector_withRegionOverride() {
+        Map<String, String> params = new HashMap<>();
+        params.put("region", "us-west-2");
+
+        Connector connector = provider.createConnector("amazon.titan-embed-text-v2:0", testCredential, params);
+        assertEquals("us-west-2", connector.getParameters().get("region"));
+    }
+
+    @Test
+    public void testCreateModelInput_knownDenseModel() {
+        Connector connector = provider.createConnector("amazon.titan-embed-text-v2:0", testCredential, null);
+        MLRegisterModelInput input = provider.createModelInput("amazon.titan-embed-text-v2:0", connector, null);
+
+        assertEquals(FunctionName.REMOTE, input.getFunctionName());
+        assertNotNull(input.getModelName());
+        assertNotNull(input.getConnector());
+    }
+
+    @Test
+    public void testCreateModelInput_unknownModel_defaultsToRemote() {
+        Connector connector = provider.createConnector("some.unknown-model", testCredential, null);
+        MLRegisterModelInput input = provider.createModelInput("some.unknown-model", connector, null);
+
+        assertEquals(FunctionName.REMOTE, input.getFunctionName());
+    }
+
+    @Test
+    public void testGetModelInfo_knownModels() {
+        BedrockEmbeddingModelProvider.EmbeddingModelInfo titanV2 =
+            BedrockEmbeddingModelProvider.getModelInfo("amazon.titan-embed-text-v2:0");
+        assertNotNull(titanV2);
+        assertEquals(FunctionName.TEXT_EMBEDDING, titanV2.functionName);
+        assertEquals(1024, titanV2.dimension);
+
+        BedrockEmbeddingModelProvider.EmbeddingModelInfo titanV1 =
+            BedrockEmbeddingModelProvider.getModelInfo("amazon.titan-embed-text-v1");
+        assertNotNull(titanV1);
+        assertEquals(1536, titanV1.dimension);
+
+        BedrockEmbeddingModelProvider.EmbeddingModelInfo cohere =
+            BedrockEmbeddingModelProvider.getModelInfo("cohere.embed-english-v3");
+        assertNotNull(cohere);
+        assertEquals(1024, cohere.dimension);
+    }
+
+    @Test
+    public void testGetModelInfo_unknownModel() {
+        assertNull(BedrockEmbeddingModelProvider.getModelInfo("unknown-model"));
+    }
+
+    @Test
+    public void testGetLLMInterface_returnsNull() {
+        assertNull(provider.getLLMInterface());
+    }
+
+    @Test
+    public void testMapTextInput_throwsUnsupported() {
+        assertThrows(UnsupportedOperationException.class, () -> provider.mapTextInput("test", null));
+    }
+
+    @Test
+    public void testMapMessages_throwsUnsupported() {
+        assertThrows(UnsupportedOperationException.class, () -> provider.mapMessages(null, null));
+    }
+
+    @Test
+    public void testParseToUnifiedMessage_throwsUnsupported() {
+        assertThrows(UnsupportedOperationException.class, () -> provider.parseToUnifiedMessage("{}"));
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProviderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProviderTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.memorycontainer.EmbeddingModelInfo;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 
 public class BedrockEmbeddingModelProviderTest {
@@ -63,17 +64,16 @@ public class BedrockEmbeddingModelProviderTest {
 
     @Test
     public void testGetModelInfo_knownModels() {
-        BedrockEmbeddingModelProvider.EmbeddingModelInfo titanV2 = BedrockEmbeddingModelProvider
-            .getModelInfo("amazon.titan-embed-text-v2:0");
+        EmbeddingModelInfo titanV2 = BedrockEmbeddingModelProvider.getModelInfo("amazon.titan-embed-text-v2:0");
         assertNotNull(titanV2);
         assertEquals(FunctionName.TEXT_EMBEDDING, titanV2.functionName);
         assertEquals(1024, titanV2.dimension);
 
-        BedrockEmbeddingModelProvider.EmbeddingModelInfo titanV1 = BedrockEmbeddingModelProvider.getModelInfo("amazon.titan-embed-text-v1");
+        EmbeddingModelInfo titanV1 = BedrockEmbeddingModelProvider.getModelInfo("amazon.titan-embed-text-v1");
         assertNotNull(titanV1);
         assertEquals(1536, titanV1.dimension);
 
-        BedrockEmbeddingModelProvider.EmbeddingModelInfo cohere = BedrockEmbeddingModelProvider.getModelInfo("cohere.embed-english-v3");
+        EmbeddingModelInfo cohere = BedrockEmbeddingModelProvider.getModelInfo("cohere.embed-english-v3");
         assertNotNull(cohere);
         assertEquals(1024, cohere.dimension);
     }

--- a/common/src/test/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProviderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/BedrockEmbeddingModelProviderTest.java
@@ -63,19 +63,17 @@ public class BedrockEmbeddingModelProviderTest {
 
     @Test
     public void testGetModelInfo_knownModels() {
-        BedrockEmbeddingModelProvider.EmbeddingModelInfo titanV2 =
-            BedrockEmbeddingModelProvider.getModelInfo("amazon.titan-embed-text-v2:0");
+        BedrockEmbeddingModelProvider.EmbeddingModelInfo titanV2 = BedrockEmbeddingModelProvider
+            .getModelInfo("amazon.titan-embed-text-v2:0");
         assertNotNull(titanV2);
         assertEquals(FunctionName.TEXT_EMBEDDING, titanV2.functionName);
         assertEquals(1024, titanV2.dimension);
 
-        BedrockEmbeddingModelProvider.EmbeddingModelInfo titanV1 =
-            BedrockEmbeddingModelProvider.getModelInfo("amazon.titan-embed-text-v1");
+        BedrockEmbeddingModelProvider.EmbeddingModelInfo titanV1 = BedrockEmbeddingModelProvider.getModelInfo("amazon.titan-embed-text-v1");
         assertNotNull(titanV1);
         assertEquals(1536, titanV1.dimension);
 
-        BedrockEmbeddingModelProvider.EmbeddingModelInfo cohere =
-            BedrockEmbeddingModelProvider.getModelInfo("cohere.embed-english-v3");
+        BedrockEmbeddingModelProvider.EmbeddingModelInfo cohere = BedrockEmbeddingModelProvider.getModelInfo("cohere.embed-english-v3");
         assertNotNull(cohere);
         assertEquals(1024, cohere.dimension);
     }

--- a/common/src/test/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProviderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProviderTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.memorycontainer.EmbeddingModelInfo;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 
 public class OpenaiEmbeddingModelProviderTest {
@@ -39,11 +40,11 @@ public class OpenaiEmbeddingModelProviderTest {
 
     @Test
     public void testGetModelInfo_knownModels() {
-        OpenaiEmbeddingModelProvider.EmbeddingModelInfo small = OpenaiEmbeddingModelProvider.getModelInfo("text-embedding-3-small");
+        EmbeddingModelInfo small = OpenaiEmbeddingModelProvider.getModelInfo("text-embedding-3-small");
         assertNotNull(small);
         assertEquals(1536, small.dimension);
 
-        OpenaiEmbeddingModelProvider.EmbeddingModelInfo large = OpenaiEmbeddingModelProvider.getModelInfo("text-embedding-3-large");
+        EmbeddingModelInfo large = OpenaiEmbeddingModelProvider.getModelInfo("text-embedding-3-large");
         assertNotNull(large);
         assertEquals(3072, large.dimension);
     }

--- a/common/src/test/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProviderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProviderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
+
+public class OpenaiEmbeddingModelProviderTest {
+
+    private final OpenaiEmbeddingModelProvider provider = new OpenaiEmbeddingModelProvider();
+    private final Map<String, String> testCredential = Map.of("openAI_key", "test-key");
+
+    @Test
+    public void testCreateConnector() {
+        Connector connector = provider.createConnector("text-embedding-3-small", testCredential, null);
+        assertNotNull(connector);
+        assertEquals("http", connector.getProtocol());
+        assertEquals("text-embedding-3-small", connector.getParameters().get("model"));
+    }
+
+    @Test
+    public void testCreateModelInput() {
+        Connector connector = provider.createConnector("text-embedding-3-small", testCredential, null);
+        MLRegisterModelInput input = provider.createModelInput("text-embedding-3-small", connector, null);
+        assertEquals(FunctionName.REMOTE, input.getFunctionName());
+    }
+
+    @Test
+    public void testGetModelInfo_knownModels() {
+        OpenaiEmbeddingModelProvider.EmbeddingModelInfo small = OpenaiEmbeddingModelProvider.getModelInfo("text-embedding-3-small");
+        assertNotNull(small);
+        assertEquals(1536, small.dimension);
+
+        OpenaiEmbeddingModelProvider.EmbeddingModelInfo large = OpenaiEmbeddingModelProvider.getModelInfo("text-embedding-3-large");
+        assertNotNull(large);
+        assertEquals(3072, large.dimension);
+    }
+
+    @Test
+    public void testGetModelInfo_unknown() {
+        assertNull(OpenaiEmbeddingModelProvider.getModelInfo("unknown"));
+    }
+
+    @Test
+    public void testGetLLMInterface_returnsNull() {
+        assertNull(provider.getLLMInterface());
+    }
+
+    @Test
+    public void testUnsupportedOperations() {
+        assertThrows(UnsupportedOperationException.class, () -> provider.mapTextInput("t", null));
+        assertThrows(UnsupportedOperationException.class, () -> provider.mapMessages(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> provider.mapContentBlocks(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> provider.extractMessageFromResponse(null));
+        assertThrows(UnsupportedOperationException.class, () -> provider.parseToUnifiedMessage("{}"));
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProviderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/OpenaiEmbeddingModelProviderTest.java
@@ -42,11 +42,11 @@ public class OpenaiEmbeddingModelProviderTest {
     public void testGetModelInfo_knownModels() {
         EmbeddingModelInfo small = OpenaiEmbeddingModelProvider.getModelInfo("text-embedding-3-small");
         assertNotNull(small);
-        assertEquals(1536, small.dimension);
+        assertEquals(1536, small.dimension());
 
         EmbeddingModelInfo large = OpenaiEmbeddingModelProvider.getModelInfo("text-embedding-3-large");
         assertNotNull(large);
-        assertEquals(3072, large.dimension);
+        assertEquals(3072, large.dimension());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1098,4 +1098,73 @@ public class MemoryConfigurationTests {
         MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("valid_prefix-with-chars").build();
         assertEquals("valid_prefix-with-chars", config.getIndexPrefix());
     }
+
+    @Test
+    public void testInlineModelSpec_embeddingModel() {
+        org.opensearch.ml.common.agent.MLAgentModelSpec embeddingSpec = org.opensearch.ml.common.agent.MLAgentModelSpec.builder()
+            .modelId("amazon.titan-embed-text-v2:0")
+            .modelProvider("bedrock/embedding")
+            .build();
+
+        MemoryConfiguration config = MemoryConfiguration.builder()
+            .embeddingModelSpec(embeddingSpec)
+            .build();
+
+        assertTrue(config.hasInlineEmbeddingModel());
+        assertEquals("amazon.titan-embed-text-v2:0", config.getEmbeddingModelSpec().getModelId());
+    }
+
+    @Test
+    public void testInlineModelSpec_llm() {
+        org.opensearch.ml.common.agent.MLAgentModelSpec llmSpec = org.opensearch.ml.common.agent.MLAgentModelSpec.builder()
+            .modelId("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+            .modelProvider("bedrock/converse")
+            .build();
+
+        MemoryConfiguration config = MemoryConfiguration.builder()
+            .llmSpec(llmSpec)
+            .build();
+
+        assertTrue(config.hasInlineLlm());
+        assertNull(config.getLlmId()); // Not set yet — will be set after model creation
+    }
+
+    @Test
+    public void testInlineModelSpec_skipsValidation() {
+        // With inline specs, validation is skipped (no embeddingModelId/type yet)
+        org.opensearch.ml.common.agent.MLAgentModelSpec embeddingSpec = org.opensearch.ml.common.agent.MLAgentModelSpec.builder()
+            .modelId("amazon.titan-embed-text-v2:0")
+            .modelProvider("bedrock/embedding")
+            .build();
+
+        // This should NOT throw even though embeddingModelId/type are null
+        MemoryConfiguration config = MemoryConfiguration.builder()
+            .embeddingModelSpec(embeddingSpec)
+            .strategies(List.of(MemoryStrategy.fromPreset(MemoryStrategyType.SEMANTIC)))
+            .build();
+
+        assertNotNull(config);
+        assertTrue(config.hasInlineEmbeddingModel());
+    }
+
+    @Test
+    public void testStrategyPreset_fromBuilder() {
+        List<MemoryStrategy> strategies = List.of(
+            MemoryStrategy.fromPreset(MemoryStrategyType.SEMANTIC),
+            MemoryStrategy.fromPreset(MemoryStrategyType.USER_PREFERENCE)
+        );
+
+        MemoryConfiguration config = MemoryConfiguration.builder()
+            .embeddingModelId("test-model")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(1024)
+            .llmId("test-llm")
+            .strategies(strategies)
+            .build();
+
+        assertEquals(2, config.getStrategies().size());
+        assertEquals(MemoryStrategyType.SEMANTIC, config.getStrategies().get(0).getType());
+        assertEquals(MemoryStrategyType.USER_PREFERENCE, config.getStrategies().get(1).getType());
+        assertTrue(config.getStrategies().get(0).getEnabled());
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1101,14 +1101,13 @@ public class MemoryConfigurationTests {
 
     @Test
     public void testInlineModelSpec_embeddingModel() {
-        org.opensearch.ml.common.agent.MLAgentModelSpec embeddingSpec = org.opensearch.ml.common.agent.MLAgentModelSpec.builder()
+        org.opensearch.ml.common.agent.MLAgentModelSpec embeddingSpec = org.opensearch.ml.common.agent.MLAgentModelSpec
+            .builder()
             .modelId("amazon.titan-embed-text-v2:0")
             .modelProvider("bedrock/embedding")
             .build();
 
-        MemoryConfiguration config = MemoryConfiguration.builder()
-            .embeddingModelSpec(embeddingSpec)
-            .build();
+        MemoryConfiguration config = MemoryConfiguration.builder().embeddingModelSpec(embeddingSpec).build();
 
         assertTrue(config.hasInlineEmbeddingModel());
         assertEquals("amazon.titan-embed-text-v2:0", config.getEmbeddingModelSpec().getModelId());
@@ -1116,14 +1115,13 @@ public class MemoryConfigurationTests {
 
     @Test
     public void testInlineModelSpec_llm() {
-        org.opensearch.ml.common.agent.MLAgentModelSpec llmSpec = org.opensearch.ml.common.agent.MLAgentModelSpec.builder()
+        org.opensearch.ml.common.agent.MLAgentModelSpec llmSpec = org.opensearch.ml.common.agent.MLAgentModelSpec
+            .builder()
             .modelId("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
             .modelProvider("bedrock/converse")
             .build();
 
-        MemoryConfiguration config = MemoryConfiguration.builder()
-            .llmSpec(llmSpec)
-            .build();
+        MemoryConfiguration config = MemoryConfiguration.builder().llmSpec(llmSpec).build();
 
         assertTrue(config.hasInlineLlm());
         assertNull(config.getLlmId()); // Not set yet — will be set after model creation
@@ -1132,13 +1130,15 @@ public class MemoryConfigurationTests {
     @Test
     public void testInlineModelSpec_skipsValidation() {
         // With inline specs, validation is skipped (no embeddingModelId/type yet)
-        org.opensearch.ml.common.agent.MLAgentModelSpec embeddingSpec = org.opensearch.ml.common.agent.MLAgentModelSpec.builder()
+        org.opensearch.ml.common.agent.MLAgentModelSpec embeddingSpec = org.opensearch.ml.common.agent.MLAgentModelSpec
+            .builder()
             .modelId("amazon.titan-embed-text-v2:0")
             .modelProvider("bedrock/embedding")
             .build();
 
         // This should NOT throw even though embeddingModelId/type are null
-        MemoryConfiguration config = MemoryConfiguration.builder()
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
             .embeddingModelSpec(embeddingSpec)
             .strategies(List.of(MemoryStrategy.fromPreset(MemoryStrategyType.SEMANTIC)))
             .build();
@@ -1149,12 +1149,11 @@ public class MemoryConfigurationTests {
 
     @Test
     public void testStrategyPreset_fromBuilder() {
-        List<MemoryStrategy> strategies = List.of(
-            MemoryStrategy.fromPreset(MemoryStrategyType.SEMANTIC),
-            MemoryStrategy.fromPreset(MemoryStrategyType.USER_PREFERENCE)
-        );
+        List<MemoryStrategy> strategies = List
+            .of(MemoryStrategy.fromPreset(MemoryStrategyType.SEMANTIC), MemoryStrategy.fromPreset(MemoryStrategyType.USER_PREFERENCE));
 
-        MemoryConfiguration config = MemoryConfiguration.builder()
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
             .embeddingModelId("test-model")
             .embeddingModelType(FunctionName.TEXT_EMBEDDING)
             .dimension(1024)

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryModelServiceTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryModelServiceTest.java
@@ -14,14 +14,15 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.opensearch.ml.common.FunctionName;
-import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.agent.MLAgentModelSpec;
+import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 
 public class MemoryModelServiceTest {
 
     @Test
     public void testCreateModelFromSpec_bedrockEmbedding() {
-        MLAgentModelSpec spec = MLAgentModelSpec.builder()
+        MLAgentModelSpec spec = MLAgentModelSpec
+            .builder()
             .modelId("amazon.titan-embed-text-v2:0")
             .modelProvider("bedrock/embedding")
             .credential(Map.of("access_key", "test", "secret_key", "test"))
@@ -34,7 +35,8 @@ public class MemoryModelServiceTest {
 
     @Test
     public void testCreateModelFromSpec_bedrockConverseLLM() {
-        MLAgentModelSpec spec = MLAgentModelSpec.builder()
+        MLAgentModelSpec spec = MLAgentModelSpec
+            .builder()
             .modelId("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
             .modelProvider("bedrock/converse")
             .credential(Map.of("access_key", "test", "secret_key", "test"))
@@ -52,19 +54,18 @@ public class MemoryModelServiceTest {
 
     @Test
     public void testCreateModelFromSpec_nullModelId() {
-        assertThrows(IllegalArgumentException.class, () ->
-            MemoryModelService.createModelFromSpec(
-                MLAgentModelSpec.builder().modelId(null).modelProvider("bedrock/embedding").build()
-            )
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> MemoryModelService
+                .createModelFromSpec(MLAgentModelSpec.builder().modelId(null).modelProvider("bedrock/embedding").build())
         );
     }
 
     @Test
     public void testCreateModelFromSpec_nullProvider() {
-        assertThrows(IllegalArgumentException.class, () ->
-            MemoryModelService.createModelFromSpec(
-                MLAgentModelSpec.builder().modelId("test").modelProvider(null).build()
-            )
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> MemoryModelService.createModelFromSpec(MLAgentModelSpec.builder().modelId("test").modelProvider(null).build())
         );
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryModelServiceTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryModelServiceTest.java
@@ -89,4 +89,107 @@ public class MemoryModelServiceTest {
     public void testDetectEmbeddingDimension_unknownModel() {
         assertNull(MemoryModelService.detectEmbeddingDimension("unknown-model"));
     }
+
+    @Test
+    public void testCreateModelFromSpec_memoryLlm_bedrock() {
+        MLAgentModelSpec spec = MLAgentModelSpec
+            .builder()
+            .modelId("us.anthropic.claude-sonnet-4-6")
+            .modelProvider("bedrock/converse")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .build();
+
+        MLRegisterModelInput input = MemoryModelService.createModelFromSpec(spec, true);
+        assertNotNull(input);
+        assertEquals(FunctionName.REMOTE, input.getFunctionName());
+    }
+
+    @Test
+    public void testCreateModelFromSpec_memoryLlm_openai() {
+        MLAgentModelSpec spec = MLAgentModelSpec
+            .builder()
+            .modelId("gpt-4o-mini")
+            .modelProvider("openai/v1/chat/completions")
+            .credential(Map.of("openAI_key", "test"))
+            .build();
+
+        MLRegisterModelInput input = MemoryModelService.createModelFromSpec(spec, true);
+        assertNotNull(input);
+        assertEquals(FunctionName.REMOTE, input.getFunctionName());
+    }
+
+    @Test
+    public void testCreateModelFromSpec_memoryLlm_gemini() {
+        MLAgentModelSpec spec = MLAgentModelSpec
+            .builder()
+            .modelId("gemini-2.0-flash")
+            .modelProvider("gemini/v1beta/generatecontent")
+            .credential(Map.of("gemini_api_key", "test"))
+            .build();
+
+        MLRegisterModelInput input = MemoryModelService.createModelFromSpec(spec, true);
+        assertNotNull(input);
+        assertEquals(FunctionName.REMOTE, input.getFunctionName());
+    }
+
+    @Test
+    public void testCreateModelFromSpec_memoryLlm_unsupportedProvider() {
+        MLAgentModelSpec spec = MLAgentModelSpec
+            .builder()
+            .modelId("test")
+            .modelProvider("unknown/provider")
+            .credential(Map.of("key", "test"))
+            .build();
+
+        assertThrows(IllegalArgumentException.class, () -> MemoryModelService.createModelFromSpec(spec, true));
+    }
+
+    @Test
+    public void testCreateModelFromSpec_memoryLlm_bedrockRegionValidation() {
+        MLAgentModelSpec spec = MLAgentModelSpec
+            .builder()
+            .modelId("us.anthropic.claude-sonnet-4-6")
+            .modelProvider("bedrock/converse")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .modelParameters(Map.of("region", "attacker.com"))
+            .build();
+
+        assertThrows(IllegalArgumentException.class, () -> MemoryModelService.createModelFromSpec(spec, true));
+    }
+
+    @Test
+    public void testGetLlmResultPath_bedrock() {
+        assertEquals("$.output.message.content[0].text", MemoryModelService.getLlmResultPath("bedrock/converse"));
+    }
+
+    @Test
+    public void testGetLlmResultPath_openai() {
+        assertEquals("$.choices[0].message.content", MemoryModelService.getLlmResultPath("openai/v1/chat/completions"));
+    }
+
+    @Test
+    public void testGetLlmResultPath_gemini() {
+        assertEquals("$.candidates[0].content.parts[0].text", MemoryModelService.getLlmResultPath("gemini/v1beta/generatecontent"));
+    }
+
+    @Test
+    public void testGetLlmResultPath_unknown() {
+        assertNull(MemoryModelService.getLlmResultPath("unknown"));
+    }
+
+    @Test
+    public void testGetLlmResultPath_null() {
+        assertNull(MemoryModelService.getLlmResultPath(null));
+    }
+
+    @Test
+    public void testDetectEmbeddingType_openaiModel() {
+        assertEquals(FunctionName.TEXT_EMBEDDING, MemoryModelService.detectEmbeddingType("text-embedding-3-small"));
+    }
+
+    @Test
+    public void testDetectEmbeddingDimension_openaiModel() {
+        assertEquals(Integer.valueOf(1536), MemoryModelService.detectEmbeddingDimension("text-embedding-3-small"));
+        assertEquals(Integer.valueOf(3072), MemoryModelService.detectEmbeddingDimension("text-embedding-3-large"));
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryModelServiceTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryModelServiceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
+import org.opensearch.ml.common.agent.MLAgentModelSpec;
+
+public class MemoryModelServiceTest {
+
+    @Test
+    public void testCreateModelFromSpec_bedrockEmbedding() {
+        MLAgentModelSpec spec = MLAgentModelSpec.builder()
+            .modelId("amazon.titan-embed-text-v2:0")
+            .modelProvider("bedrock/embedding")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .build();
+
+        MLRegisterModelInput input = MemoryModelService.createModelFromSpec(spec);
+        assertNotNull(input);
+        assertEquals(FunctionName.REMOTE, input.getFunctionName());
+    }
+
+    @Test
+    public void testCreateModelFromSpec_bedrockConverseLLM() {
+        MLAgentModelSpec spec = MLAgentModelSpec.builder()
+            .modelId("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+            .modelProvider("bedrock/converse")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .build();
+
+        MLRegisterModelInput input = MemoryModelService.createModelFromSpec(spec);
+        assertNotNull(input);
+        assertEquals(FunctionName.REMOTE, input.getFunctionName());
+    }
+
+    @Test
+    public void testCreateModelFromSpec_nullSpec() {
+        assertThrows(IllegalArgumentException.class, () -> MemoryModelService.createModelFromSpec(null));
+    }
+
+    @Test
+    public void testCreateModelFromSpec_nullModelId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            MemoryModelService.createModelFromSpec(
+                MLAgentModelSpec.builder().modelId(null).modelProvider("bedrock/embedding").build()
+            )
+        );
+    }
+
+    @Test
+    public void testCreateModelFromSpec_nullProvider() {
+        assertThrows(IllegalArgumentException.class, () ->
+            MemoryModelService.createModelFromSpec(
+                MLAgentModelSpec.builder().modelId("test").modelProvider(null).build()
+            )
+        );
+    }
+
+    @Test
+    public void testDetectEmbeddingType_knownModel() {
+        assertEquals(FunctionName.TEXT_EMBEDDING, MemoryModelService.detectEmbeddingType("amazon.titan-embed-text-v2:0"));
+    }
+
+    @Test
+    public void testDetectEmbeddingType_unknownModel() {
+        assertNull(MemoryModelService.detectEmbeddingType("unknown-model"));
+    }
+
+    @Test
+    public void testDetectEmbeddingDimension_knownModel() {
+        assertEquals(Integer.valueOf(1024), MemoryModelService.detectEmbeddingDimension("amazon.titan-embed-text-v2:0"));
+        assertEquals(Integer.valueOf(1536), MemoryModelService.detectEmbeddingDimension("amazon.titan-embed-text-v1"));
+    }
+
+    @Test
+    public void testDetectEmbeddingDimension_unknownModel() {
+        assertNull(MemoryModelService.detectEmbeddingDimension("unknown-model"));
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryModelServiceTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryModelServiceTest.java
@@ -6,15 +6,18 @@
 package org.opensearch.ml.common.memorycontainer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 
 import org.junit.Test;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.agent.MLAgentModelSpec;
+import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 
 public class MemoryModelServiceTest {
@@ -102,6 +105,10 @@ public class MemoryModelServiceTest {
         MLRegisterModelInput input = MemoryModelService.createModelFromSpec(spec, true);
         assertNotNull(input);
         assertEquals(FunctionName.REMOTE, input.getFunctionName());
+        ConnectorAction action = input.getConnector().getActions().get(0);
+        assertTrue(action.getUrl().contains("/converse"));
+        assertTrue(action.getRequestBody().contains("${parameters.system_prompt}"));
+        assertTrue(action.getRequestBody().contains("${parameters.user_prompt}"));
     }
 
     @Test
@@ -116,6 +123,10 @@ public class MemoryModelServiceTest {
         MLRegisterModelInput input = MemoryModelService.createModelFromSpec(spec, true);
         assertNotNull(input);
         assertEquals(FunctionName.REMOTE, input.getFunctionName());
+        ConnectorAction action = input.getConnector().getActions().get(0);
+        assertTrue(action.getUrl().contains("api.openai.com"));
+        assertTrue(action.getHeaders().containsKey("Authorization"));
+        assertTrue(action.getRequestBody().contains("${parameters.system_prompt}"));
     }
 
     @Test
@@ -130,6 +141,11 @@ public class MemoryModelServiceTest {
         MLRegisterModelInput input = MemoryModelService.createModelFromSpec(spec, true);
         assertNotNull(input);
         assertEquals(FunctionName.REMOTE, input.getFunctionName());
+        ConnectorAction action = input.getConnector().getActions().get(0);
+        assertTrue(action.getUrl().contains("generativelanguage.googleapis.com"));
+        assertTrue(action.getHeaders().containsKey("x-goog-api-key"));
+        assertFalse(action.getUrl().contains("key="));
+        assertTrue(action.getRequestBody().contains("${parameters.system_prompt}"));
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryStrategyTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryStrategyTest.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.memorycontainer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.opensearch.ml.common.memorycontainer.MemoryStrategy.generateStrategyId;
 
@@ -181,5 +182,30 @@ public class MemoryStrategyTest {
             .build();
 
         assertEquals(customId, strategy.getId());
+    }
+
+    @Test
+    public void testFromPreset_semantic() {
+        MemoryStrategy strategy = MemoryStrategy.fromPreset(MemoryStrategyType.SEMANTIC);
+        assertEquals(MemoryStrategyType.SEMANTIC, strategy.getType());
+        assertTrue(strategy.getEnabled());
+        assertEquals(List.of("user_id"), strategy.getNamespace());
+        assertNull(strategy.getStrategyConfig());
+    }
+
+    @Test
+    public void testFromPreset_userPreference() {
+        MemoryStrategy strategy = MemoryStrategy.fromPreset(MemoryStrategyType.USER_PREFERENCE);
+        assertEquals(MemoryStrategyType.USER_PREFERENCE, strategy.getType());
+        assertTrue(strategy.getEnabled());
+        assertEquals(List.of("user_id"), strategy.getNamespace());
+    }
+
+    @Test
+    public void testFromPreset_summary() {
+        MemoryStrategy strategy = MemoryStrategy.fromPreset(MemoryStrategyType.SUMMARY);
+        assertEquals(MemoryStrategyType.SUMMARY, strategy.getType());
+        assertTrue(strategy.getEnabled());
+        assertEquals(List.of("user_id", "session_id"), strategy.getNamespace());
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -134,46 +134,40 @@ public class TransportCreateMemoryContainerAction extends
      * on the configuration. After this, the config looks identical to one created the old way.
      */
     private void createInlineModels(MemoryConfiguration config, String tenantId, ActionListener<Void> listener) {
-        // Step 1: Create embedding model if inline spec provided
-        if (config.hasInlineEmbeddingModel()) {
-            createModelFromSpec(config.getEmbeddingModelSpec(), false, ActionListener.wrap(embeddingModelId -> {
-                config.setEmbeddingModelId(embeddingModelId);
+        createInlineEmbeddingModel(config, ActionListener.wrap(v -> createInlineLlmModel(config, listener), listener::onFailure));
+    }
 
-                // Auto-detect type and dimension from known models
-                FunctionName detectedType = MemoryModelService.detectEmbeddingType(config.getEmbeddingModelSpec().getModelId());
-                Integer detectedDimension = MemoryModelService.detectEmbeddingDimension(config.getEmbeddingModelSpec().getModelId());
-                if (detectedType != null) {
-                    config.setEmbeddingModelType(detectedType);
-                }
-                if (detectedDimension != null) {
-                    config.setDimension(detectedDimension);
-                }
-
-                log.info("Auto-created embedding model: {}, type: {}, dimension: {}", embeddingModelId, detectedType, detectedDimension);
-
-                // Step 2: Create LLM model if inline spec provided
-                if (config.hasInlineLlm()) {
-                    createModelFromSpec(config.getLlmSpec(), true, ActionListener.wrap(llmModelId -> {
-                        config.setLlmId(llmModelId);
-                        setLlmResultPathFromProvider(config);
-                        log.info("Auto-created LLM model: {}", llmModelId);
-                        listener.onResponse(null);
-                    }, listener::onFailure));
-                } else {
-                    listener.onResponse(null);
-                }
-            }, listener::onFailure));
-        } else if (config.hasInlineLlm()) {
-            // Only LLM inline, no embedding
-            createModelFromSpec(config.getLlmSpec(), true, ActionListener.wrap(llmModelId -> {
-                config.setLlmId(llmModelId);
-                setLlmResultPathFromProvider(config);
-                log.info("Auto-created LLM model: {}", llmModelId);
-                listener.onResponse(null);
-            }, listener::onFailure));
-        } else {
+    private void createInlineEmbeddingModel(MemoryConfiguration config, ActionListener<Void> listener) {
+        if (!config.hasInlineEmbeddingModel()) {
             listener.onResponse(null);
+            return;
         }
+        createModelFromSpec(config.getEmbeddingModelSpec(), false, ActionListener.wrap(embeddingModelId -> {
+            config.setEmbeddingModelId(embeddingModelId);
+            FunctionName detectedType = MemoryModelService.detectEmbeddingType(config.getEmbeddingModelSpec().getModelId());
+            Integer detectedDimension = MemoryModelService.detectEmbeddingDimension(config.getEmbeddingModelSpec().getModelId());
+            if (detectedType != null) {
+                config.setEmbeddingModelType(detectedType);
+            }
+            if (detectedDimension != null) {
+                config.setDimension(detectedDimension);
+            }
+            log.info("Auto-created embedding model: {}, type: {}, dimension: {}", embeddingModelId, detectedType, detectedDimension);
+            listener.onResponse(null);
+        }, listener::onFailure));
+    }
+
+    private void createInlineLlmModel(MemoryConfiguration config, ActionListener<Void> listener) {
+        if (!config.hasInlineLlm()) {
+            listener.onResponse(null);
+            return;
+        }
+        createModelFromSpec(config.getLlmSpec(), true, ActionListener.wrap(llmModelId -> {
+            config.setLlmId(llmModelId);
+            setLlmResultPathFromProvider(config);
+            log.info("Auto-created LLM model: {}", llmModelId);
+            listener.onResponse(null);
+        }, listener::onFailure));
     }
 
     private void createModelFromSpec(MLAgentModelSpec modelSpec, boolean isMemoryLlm, ActionListener<String> listener) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -22,6 +22,7 @@ import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.agent.MLAgentModelSpec;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryModelService;
@@ -106,10 +107,22 @@ public class TransportCreateMemoryContainerAction extends
         // Pre-process: if inline model specs are present, create models first
         MemoryConfiguration config = input.getConfiguration();
         if (config != null && (config.hasInlineEmbeddingModel() || config.hasInlineLlm())) {
+            // Run cheap validations before creating models to avoid orphans
+            try {
+                config.validateNonModelInputs();
+            } catch (Exception e) {
+                listener.onFailure(e);
+                return;
+            }
+
             createInlineModels(
                 config,
                 tenantId,
-                ActionListener.wrap(v -> { proceedWithContainerCreation(input, user, tenantId, listener); }, listener::onFailure)
+                ActionListener.wrap(v -> { proceedWithContainerCreation(input, user, tenantId, listener); }, e -> {
+                    // Best-effort cleanup of any models created before failure
+                    cleanupOrphanModels(config);
+                    listener.onFailure(e);
+                })
             );
         } else {
             proceedWithContainerCreation(input, user, tenantId, listener);
@@ -163,11 +176,7 @@ public class TransportCreateMemoryContainerAction extends
         }
     }
 
-    private void createModelFromSpec(
-        org.opensearch.ml.common.agent.MLAgentModelSpec modelSpec,
-        boolean isMemoryLlm,
-        ActionListener<String> listener
-    ) {
+    private void createModelFromSpec(MLAgentModelSpec modelSpec, boolean isMemoryLlm, ActionListener<String> listener) {
         try {
             MLRegisterModelInput modelInput = MemoryModelService.createModelFromSpec(modelSpec, isMemoryLlm);
             MLRegisterModelRequest modelRequest = new MLRegisterModelRequest(modelInput);
@@ -179,13 +188,49 @@ public class TransportCreateMemoryContainerAction extends
                         log.error("Failed to auto-create model for memory container: {}", modelSpec.getModelId(), e);
                         listener
                             .onFailure(
-                                new OpenSearchStatusException("Failed to create model: " + e.getMessage(), RestStatus.INTERNAL_SERVER_ERROR)
+                                e instanceof IllegalArgumentException
+                                    ? e
+                                    : new OpenSearchStatusException("Failed to create model", RestStatus.INTERNAL_SERVER_ERROR)
                             );
                     })
                 );
         } catch (Exception e) {
             log.error("Failed to build model registration input: {}", modelSpec.getModelId(), e);
             listener.onFailure(new IllegalArgumentException("Invalid model specification: " + e.getMessage()));
+        }
+    }
+
+    private void cleanupOrphanModels(MemoryConfiguration config) {
+        if (config.getEmbeddingModelId() != null && config.hasInlineEmbeddingModel()) {
+            log.info("Cleaning up orphan embedding model: {}", config.getEmbeddingModelId());
+            try {
+                client
+                    .execute(
+                        org.opensearch.ml.common.transport.model.MLModelDeleteAction.INSTANCE,
+                        new org.opensearch.ml.common.transport.model.MLModelDeleteRequest(config.getEmbeddingModelId(), null),
+                        ActionListener
+                            .wrap(
+                                r -> log.info("Cleaned up orphan embedding model"),
+                                e -> log.warn("Failed to cleanup orphan embedding model", e)
+                            )
+                    );
+            } catch (Exception e) {
+                log.warn("Failed to cleanup orphan embedding model: {}", config.getEmbeddingModelId(), e);
+            }
+        }
+        if (config.getLlmId() != null && config.hasInlineLlm()) {
+            log.info("Cleaning up orphan LLM model: {}", config.getLlmId());
+            try {
+                client
+                    .execute(
+                        org.opensearch.ml.common.transport.model.MLModelDeleteAction.INSTANCE,
+                        new org.opensearch.ml.common.transport.model.MLModelDeleteRequest(config.getLlmId(), null),
+                        ActionListener
+                            .wrap(r -> log.info("Cleaned up orphan LLM model"), e -> log.warn("Failed to cleanup orphan LLM model", e))
+                    );
+            } catch (Exception e) {
+                log.warn("Failed to cleanup orphan LLM model: {}", config.getLlmId(), e);
+            }
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -141,6 +141,7 @@ public class TransportCreateMemoryContainerAction extends
                 if (config.hasInlineLlm()) {
                     createModelFromSpec(config.getLlmSpec(), true, ActionListener.wrap(llmModelId -> {
                         config.setLlmId(llmModelId);
+                        setLlmResultPathFromProvider(config);
                         log.info("Auto-created LLM model: {}", llmModelId);
                         listener.onResponse(null);
                     }, listener::onFailure));
@@ -152,6 +153,7 @@ public class TransportCreateMemoryContainerAction extends
             // Only LLM inline, no embedding
             createModelFromSpec(config.getLlmSpec(), true, ActionListener.wrap(llmModelId -> {
                 config.setLlmId(llmModelId);
+                setLlmResultPathFromProvider(config);
                 log.info("Auto-created LLM model: {}", llmModelId);
                 listener.onResponse(null);
             }, listener::onFailure));
@@ -178,6 +180,16 @@ public class TransportCreateMemoryContainerAction extends
         } catch (Exception e) {
             log.error("Failed to build model registration input: {}", modelSpec.getModelId(), e);
             listener.onFailure(new IllegalArgumentException("Invalid model specification: " + e.getMessage()));
+        }
+    }
+
+    private void setLlmResultPathFromProvider(MemoryConfiguration config) {
+        String resultPath = MemoryModelService.getLlmResultPath(config.getLlmSpec().getModelProvider());
+        if (resultPath != null) {
+            config.getParameters().put(
+                org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LLM_RESULT_PATH_FIELD,
+                resultPath
+            );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -21,9 +21,8 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.FunctionName;
-import org.opensearch.ml.common.agent.BedrockEmbeddingModelProvider;
+import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryModelService;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
@@ -107,9 +106,11 @@ public class TransportCreateMemoryContainerAction extends
         // Pre-process: if inline model specs are present, create models first
         MemoryConfiguration config = input.getConfiguration();
         if (config != null && (config.hasInlineEmbeddingModel() || config.hasInlineLlm())) {
-            createInlineModels(config, tenantId, ActionListener.wrap(v -> {
-                proceedWithContainerCreation(input, user, tenantId, listener);
-            }, listener::onFailure));
+            createInlineModels(
+                config,
+                tenantId,
+                ActionListener.wrap(v -> { proceedWithContainerCreation(input, user, tenantId, listener); }, listener::onFailure)
+            );
         } else {
             proceedWithContainerCreation(input, user, tenantId, listener);
         }
@@ -170,13 +171,18 @@ public class TransportCreateMemoryContainerAction extends
         try {
             MLRegisterModelInput modelInput = MemoryModelService.createModelFromSpec(modelSpec, isMemoryLlm);
             MLRegisterModelRequest modelRequest = new MLRegisterModelRequest(modelInput);
-            client.execute(MLRegisterModelAction.INSTANCE, modelRequest, ActionListener.wrap(response -> {
-                listener.onResponse(response.getModelId());
-            }, e -> {
-                log.error("Failed to auto-create model for memory container: {}", modelSpec.getModelId(), e);
-                listener.onFailure(new OpenSearchStatusException(
-                    "Failed to create model: " + e.getMessage(), RestStatus.INTERNAL_SERVER_ERROR));
-            }));
+            client
+                .execute(
+                    MLRegisterModelAction.INSTANCE,
+                    modelRequest,
+                    ActionListener.wrap(response -> { listener.onResponse(response.getModelId()); }, e -> {
+                        log.error("Failed to auto-create model for memory container: {}", modelSpec.getModelId(), e);
+                        listener
+                            .onFailure(
+                                new OpenSearchStatusException("Failed to create model: " + e.getMessage(), RestStatus.INTERNAL_SERVER_ERROR)
+                            );
+                    })
+                );
         } catch (Exception e) {
             log.error("Failed to build model registration input: {}", modelSpec.getModelId(), e);
             listener.onFailure(new IllegalArgumentException("Invalid model specification: " + e.getMessage()));
@@ -186,10 +192,7 @@ public class TransportCreateMemoryContainerAction extends
     private void setLlmResultPathFromProvider(MemoryConfiguration config) {
         String resultPath = MemoryModelService.getLlmResultPath(config.getLlmSpec().getModelProvider());
         if (resultPath != null) {
-            config.getParameters().put(
-                org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LLM_RESULT_PATH_FIELD,
-                resultPath
-            );
+            config.getParameters().put(org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LLM_RESULT_PATH_FIELD, resultPath);
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -122,7 +122,7 @@ public class TransportCreateMemoryContainerAction extends
     private void createInlineModels(MemoryConfiguration config, String tenantId, ActionListener<Void> listener) {
         // Step 1: Create embedding model if inline spec provided
         if (config.hasInlineEmbeddingModel()) {
-            createModelFromSpec(config.getEmbeddingModelSpec(), ActionListener.wrap(embeddingModelId -> {
+            createModelFromSpec(config.getEmbeddingModelSpec(), false, ActionListener.wrap(embeddingModelId -> {
                 config.setEmbeddingModelId(embeddingModelId);
 
                 // Auto-detect type and dimension from known models
@@ -139,7 +139,7 @@ public class TransportCreateMemoryContainerAction extends
 
                 // Step 2: Create LLM model if inline spec provided
                 if (config.hasInlineLlm()) {
-                    createModelFromSpec(config.getLlmSpec(), ActionListener.wrap(llmModelId -> {
+                    createModelFromSpec(config.getLlmSpec(), true, ActionListener.wrap(llmModelId -> {
                         config.setLlmId(llmModelId);
                         log.info("Auto-created LLM model: {}", llmModelId);
                         listener.onResponse(null);
@@ -150,7 +150,7 @@ public class TransportCreateMemoryContainerAction extends
             }, listener::onFailure));
         } else if (config.hasInlineLlm()) {
             // Only LLM inline, no embedding
-            createModelFromSpec(config.getLlmSpec(), ActionListener.wrap(llmModelId -> {
+            createModelFromSpec(config.getLlmSpec(), true, ActionListener.wrap(llmModelId -> {
                 config.setLlmId(llmModelId);
                 log.info("Auto-created LLM model: {}", llmModelId);
                 listener.onResponse(null);
@@ -162,10 +162,11 @@ public class TransportCreateMemoryContainerAction extends
 
     private void createModelFromSpec(
         org.opensearch.ml.common.agent.MLAgentModelSpec modelSpec,
+        boolean isMemoryLlm,
         ActionListener<String> listener
     ) {
         try {
-            MLRegisterModelInput modelInput = MemoryModelService.createModelFromSpec(modelSpec);
+            MLRegisterModelInput modelInput = MemoryModelService.createModelFromSpec(modelSpec, isMemoryLlm);
             MLRegisterModelRequest modelRequest = new MLRegisterModelRequest(modelInput);
             client.execute(MLRegisterModelAction.INSTANCE, modelRequest, ActionListener.wrap(response -> {
                 listener.onResponse(response.getModelId());

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -22,13 +22,19 @@ import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.agent.BedrockEmbeddingModelProvider;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
+import org.opensearch.ml.common.memorycontainer.MemoryModelService;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerRequest;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerResponse;
+import org.opensearch.ml.common.transport.register.MLRegisterModelAction;
+import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
+import org.opensearch.ml.common.transport.register.MLRegisterModelRequest;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.helper.MemoryContainerModelValidator;
@@ -97,6 +103,89 @@ public class TransportCreateMemoryContainerAction extends
 
         User user = RestActionUtils.getUserContext(client);
         String tenantId = input.getTenantId();
+
+        // Pre-process: if inline model specs are present, create models first
+        MemoryConfiguration config = input.getConfiguration();
+        if (config != null && (config.hasInlineEmbeddingModel() || config.hasInlineLlm())) {
+            createInlineModels(config, tenantId, ActionListener.wrap(v -> {
+                proceedWithContainerCreation(input, user, tenantId, listener);
+            }, listener::onFailure));
+        } else {
+            proceedWithContainerCreation(input, user, tenantId, listener);
+        }
+    }
+
+    /**
+     * Pre-processing step: create models from inline specs, then set the resulting IDs
+     * on the configuration. After this, the config looks identical to one created the old way.
+     */
+    private void createInlineModels(MemoryConfiguration config, String tenantId, ActionListener<Void> listener) {
+        // Step 1: Create embedding model if inline spec provided
+        if (config.hasInlineEmbeddingModel()) {
+            createModelFromSpec(config.getEmbeddingModelSpec(), ActionListener.wrap(embeddingModelId -> {
+                config.setEmbeddingModelId(embeddingModelId);
+
+                // Auto-detect type and dimension from known models
+                FunctionName detectedType = MemoryModelService.detectEmbeddingType(config.getEmbeddingModelSpec().getModelId());
+                Integer detectedDimension = MemoryModelService.detectEmbeddingDimension(config.getEmbeddingModelSpec().getModelId());
+                if (detectedType != null) {
+                    config.setEmbeddingModelType(detectedType);
+                }
+                if (detectedDimension != null) {
+                    config.setDimension(detectedDimension);
+                }
+
+                log.info("Auto-created embedding model: {}, type: {}, dimension: {}", embeddingModelId, detectedType, detectedDimension);
+
+                // Step 2: Create LLM model if inline spec provided
+                if (config.hasInlineLlm()) {
+                    createModelFromSpec(config.getLlmSpec(), ActionListener.wrap(llmModelId -> {
+                        config.setLlmId(llmModelId);
+                        log.info("Auto-created LLM model: {}", llmModelId);
+                        listener.onResponse(null);
+                    }, listener::onFailure));
+                } else {
+                    listener.onResponse(null);
+                }
+            }, listener::onFailure));
+        } else if (config.hasInlineLlm()) {
+            // Only LLM inline, no embedding
+            createModelFromSpec(config.getLlmSpec(), ActionListener.wrap(llmModelId -> {
+                config.setLlmId(llmModelId);
+                log.info("Auto-created LLM model: {}", llmModelId);
+                listener.onResponse(null);
+            }, listener::onFailure));
+        } else {
+            listener.onResponse(null);
+        }
+    }
+
+    private void createModelFromSpec(
+        org.opensearch.ml.common.agent.MLAgentModelSpec modelSpec,
+        ActionListener<String> listener
+    ) {
+        try {
+            MLRegisterModelInput modelInput = MemoryModelService.createModelFromSpec(modelSpec);
+            MLRegisterModelRequest modelRequest = new MLRegisterModelRequest(modelInput);
+            client.execute(MLRegisterModelAction.INSTANCE, modelRequest, ActionListener.wrap(response -> {
+                listener.onResponse(response.getModelId());
+            }, e -> {
+                log.error("Failed to auto-create model for memory container: {}", modelSpec.getModelId(), e);
+                listener.onFailure(new OpenSearchStatusException(
+                    "Failed to create model: " + e.getMessage(), RestStatus.INTERNAL_SERVER_ERROR));
+            }));
+        } catch (Exception e) {
+            log.error("Failed to build model registration input: {}", modelSpec.getModelId(), e);
+            listener.onFailure(new IllegalArgumentException("Invalid model specification: " + e.getMessage()));
+        }
+    }
+
+    private void proceedWithContainerCreation(
+        MLCreateMemoryContainerInput input,
+        User user,
+        String tenantId,
+        ActionListener<MLCreateMemoryContainerResponse> listener
+    ) {
 
         // Validate configuration before creating memory container
         validateConfiguration(input.getConfiguration(), ActionListener.wrap(isValid -> {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -118,15 +118,16 @@ public class TransportCreateMemoryContainerAction extends
                 return;
             }
 
-            createInlineModels(
-                config,
-                tenantId,
-                ActionListener.wrap(v -> { proceedWithContainerCreation(input, user, tenantId, listener); }, e -> {
-                    // Best-effort cleanup of any models created before failure
-                    cleanupOrphanModels(config);
-                    listener.onFailure(e);
-                })
-            );
+            createInlineModels(config, tenantId, ActionListener.wrap(v -> {
+                // TODO: Wire cleanupOrphanModels into proceedWithContainerCreation failure paths
+                // (validateConfiguration, initMemoryContainerIndex, indexMemoryContainer, createMemoryDataIndices)
+                // to clean up auto-created models if downstream steps fail.
+                proceedWithContainerCreation(input, user, tenantId, listener);
+            }, e -> {
+                // Best-effort cleanup of any models created before failure
+                cleanupOrphanModels(config);
+                listener.onFailure(e);
+            }));
         } else {
             proceedWithContainerCreation(input, user, tenantId, listener);
         }
@@ -191,9 +192,11 @@ public class TransportCreateMemoryContainerAction extends
                             );
                     })
                 );
+        } catch (IllegalArgumentException e) {
+            listener.onFailure(e);
         } catch (Exception e) {
             log.error("Failed to build model registration input: {}", modelSpec.getModelId(), e);
-            listener.onFailure(new IllegalArgumentException("Invalid model specification: " + e.getMessage()));
+            listener.onFailure(new OpenSearchStatusException("Failed to build model registration input", RestStatus.INTERNAL_SERVER_ERROR));
         }
     }
 
@@ -204,7 +207,7 @@ public class TransportCreateMemoryContainerAction extends
                 client
                     .execute(
                         MLModelDeleteAction.INSTANCE,
-                        new MLModelDeleteRequest(config.getEmbeddingModelId(), null),
+                        new MLModelDeleteRequest(config.getEmbeddingModelId(), config.getTenantId()),
                         ActionListener
                             .wrap(
                                 r -> log.info("Cleaned up orphan embedding model"),
@@ -221,7 +224,7 @@ public class TransportCreateMemoryContainerAction extends
                 client
                     .execute(
                         MLModelDeleteAction.INSTANCE,
-                        new MLModelDeleteRequest(config.getLlmId(), null),
+                        new MLModelDeleteRequest(config.getLlmId(), config.getTenantId()),
                         ActionListener
                             .wrap(r -> log.info("Cleaned up orphan LLM model"), e -> log.warn("Failed to cleanup orphan LLM model", e))
                     );

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -25,6 +25,7 @@ import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.agent.MLAgentModelSpec;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
+import org.opensearch.ml.common.memorycontainer.MemoryContainerConstants;
 import org.opensearch.ml.common.memorycontainer.MemoryModelService;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
@@ -32,6 +33,8 @@ import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContaine
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerRequest;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerResponse;
+import org.opensearch.ml.common.transport.model.MLModelDeleteAction;
+import org.opensearch.ml.common.transport.model.MLModelDeleteRequest;
 import org.opensearch.ml.common.transport.register.MLRegisterModelAction;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 import org.opensearch.ml.common.transport.register.MLRegisterModelRequest;
@@ -200,8 +203,8 @@ public class TransportCreateMemoryContainerAction extends
             try {
                 client
                     .execute(
-                        org.opensearch.ml.common.transport.model.MLModelDeleteAction.INSTANCE,
-                        new org.opensearch.ml.common.transport.model.MLModelDeleteRequest(config.getEmbeddingModelId(), null),
+                        MLModelDeleteAction.INSTANCE,
+                        new MLModelDeleteRequest(config.getEmbeddingModelId(), null),
                         ActionListener
                             .wrap(
                                 r -> log.info("Cleaned up orphan embedding model"),
@@ -217,8 +220,8 @@ public class TransportCreateMemoryContainerAction extends
             try {
                 client
                     .execute(
-                        org.opensearch.ml.common.transport.model.MLModelDeleteAction.INSTANCE,
-                        new org.opensearch.ml.common.transport.model.MLModelDeleteRequest(config.getLlmId(), null),
+                        MLModelDeleteAction.INSTANCE,
+                        new MLModelDeleteRequest(config.getLlmId(), null),
                         ActionListener
                             .wrap(r -> log.info("Cleaned up orphan LLM model"), e -> log.warn("Failed to cleanup orphan LLM model", e))
                     );
@@ -231,7 +234,7 @@ public class TransportCreateMemoryContainerAction extends
     private void setLlmResultPathFromProvider(MemoryConfiguration config) {
         String resultPath = MemoryModelService.getLlmResultPath(config.getLlmSpec().getModelProvider());
         if (resultPath != null) {
-            config.getParameters().put(org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LLM_RESULT_PATH_FIELD, resultPath);
+            config.getParameters().put(MemoryContainerConstants.LLM_RESULT_PATH_FIELD, resultPath);
         }
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -1955,5 +1956,259 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
             listener.onResponse(embeddingModel);
             return null;
         }).when(mlModelManager).getModel(eq("test-embedding-model"), any());
+    }
+
+    @Test
+    public void testDoExecute_withInlineEmbeddingModel() {
+        // Setup inline embedding model spec
+        org.opensearch.ml.common.agent.MLAgentModelSpec embeddingSpec = org.opensearch.ml.common.agent.MLAgentModelSpec
+            .builder()
+            .modelId("amazon.titan-embed-text-v2:0")
+            .modelProvider("bedrock/embedding")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .build();
+
+        MemoryConfiguration inlineConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("inline-test")
+            .embeddingModelSpec(embeddingSpec)
+            .llmId("test-llm-model")
+            .strategies(
+                List
+                    .of(
+                        MemoryStrategy
+                            .builder()
+                            .namespace(List.of("user_id"))
+                            .id("strategy-id1")
+                            .enabled(true)
+                            .type(MemoryStrategyType.SEMANTIC)
+                            .build()
+                    )
+            )
+            .build();
+
+        MLCreateMemoryContainerInput inlineInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("test-inline")
+            .configuration(inlineConfig)
+            .build();
+
+        MLCreateMemoryContainerRequest request = new MLCreateMemoryContainerRequest(inlineInput);
+
+        // Mock model registration
+        doAnswer(invocation -> {
+            ActionListener listener = invocation.getArgument(2);
+            listener
+                .onResponse(new org.opensearch.ml.common.transport.register.MLRegisterModelResponse("task-1", "CREATED", "auto-embed-id"));
+            return null;
+        })
+            .when(client)
+            .execute(
+                eq(org.opensearch.ml.common.transport.register.MLRegisterModelAction.INSTANCE),
+                any(org.opensearch.ml.common.transport.register.MLRegisterModelRequest.class),
+                any(ActionListener.class)
+            );
+
+        action.doExecute(null, request, actionListener);
+
+        // Verify embedding model ID was set from auto-creation
+        assertEquals("auto-embed-id", inlineConfig.getEmbeddingModelId());
+        assertEquals(FunctionName.TEXT_EMBEDDING, inlineConfig.getEmbeddingModelType());
+        assertEquals(Integer.valueOf(1024), inlineConfig.getDimension());
+    }
+
+    @Test
+    public void testDoExecute_withInlineLlmModel() {
+        org.opensearch.ml.common.agent.MLAgentModelSpec llmSpec = org.opensearch.ml.common.agent.MLAgentModelSpec
+            .builder()
+            .modelId("us.anthropic.claude-sonnet-4-6")
+            .modelProvider("bedrock/converse")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .build();
+
+        MemoryConfiguration inlineConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("inline-llm-test")
+            .embeddingModelId("test-embedding-model")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .dimension(768)
+            .llmSpec(llmSpec)
+            .strategies(
+                List
+                    .of(
+                        MemoryStrategy
+                            .builder()
+                            .namespace(List.of("user_id"))
+                            .id("strategy-id1")
+                            .enabled(true)
+                            .type(MemoryStrategyType.SEMANTIC)
+                            .build()
+                    )
+            )
+            .build();
+
+        MLCreateMemoryContainerInput inlineInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("test-inline-llm")
+            .configuration(inlineConfig)
+            .build();
+
+        MLCreateMemoryContainerRequest request = new MLCreateMemoryContainerRequest(inlineInput);
+
+        doAnswer(invocation -> {
+            ActionListener listener = invocation.getArgument(2);
+            listener
+                .onResponse(new org.opensearch.ml.common.transport.register.MLRegisterModelResponse("task-2", "CREATED", "auto-llm-id"));
+            return null;
+        })
+            .when(client)
+            .execute(
+                eq(org.opensearch.ml.common.transport.register.MLRegisterModelAction.INSTANCE),
+                any(org.opensearch.ml.common.transport.register.MLRegisterModelRequest.class),
+                any(ActionListener.class)
+            );
+
+        action.doExecute(null, request, actionListener);
+
+        assertEquals("auto-llm-id", inlineConfig.getLlmId());
+        // Verify llm_result_path was auto-set for bedrock/converse
+        assertEquals("$.output.message.content[0].text", inlineConfig.getParameters().get("llm_result_path"));
+    }
+
+    @Test
+    public void testDoExecute_withBothInlineModels() {
+        org.opensearch.ml.common.agent.MLAgentModelSpec embeddingSpec = org.opensearch.ml.common.agent.MLAgentModelSpec
+            .builder()
+            .modelId("amazon.titan-embed-text-v2:0")
+            .modelProvider("bedrock/embedding")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .build();
+
+        org.opensearch.ml.common.agent.MLAgentModelSpec llmSpec = org.opensearch.ml.common.agent.MLAgentModelSpec
+            .builder()
+            .modelId("us.anthropic.claude-sonnet-4-6")
+            .modelProvider("bedrock/converse")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .build();
+
+        MemoryConfiguration inlineConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("both-inline")
+            .embeddingModelSpec(embeddingSpec)
+            .llmSpec(llmSpec)
+            .strategies(
+                List
+                    .of(
+                        MemoryStrategy
+                            .builder()
+                            .namespace(List.of("user_id"))
+                            .id("strategy-id1")
+                            .enabled(true)
+                            .type(MemoryStrategyType.SEMANTIC)
+                            .build()
+                    )
+            )
+            .build();
+
+        MLCreateMemoryContainerInput inlineInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("test-both-inline")
+            .configuration(inlineConfig)
+            .build();
+
+        MLCreateMemoryContainerRequest request = new MLCreateMemoryContainerRequest(inlineInput);
+
+        // Mock: first call returns embedding model ID, second returns LLM model ID
+        java.util.concurrent.atomic.AtomicInteger callCount = new java.util.concurrent.atomic.AtomicInteger(0);
+        doAnswer(invocation -> {
+            ActionListener listener = invocation.getArgument(2);
+            int count = callCount.getAndIncrement();
+            String modelId = count == 0 ? "auto-embed-id" : "auto-llm-id";
+            listener
+                .onResponse(new org.opensearch.ml.common.transport.register.MLRegisterModelResponse("task-" + count, "CREATED", modelId));
+            return null;
+        })
+            .when(client)
+            .execute(
+                eq(org.opensearch.ml.common.transport.register.MLRegisterModelAction.INSTANCE),
+                any(org.opensearch.ml.common.transport.register.MLRegisterModelRequest.class),
+                any(ActionListener.class)
+            );
+
+        action.doExecute(null, request, actionListener);
+
+        assertEquals("auto-embed-id", inlineConfig.getEmbeddingModelId());
+        assertEquals("auto-llm-id", inlineConfig.getLlmId());
+        assertEquals(FunctionName.TEXT_EMBEDDING, inlineConfig.getEmbeddingModelType());
+        assertEquals(Integer.valueOf(1024), inlineConfig.getDimension());
+    }
+
+    @Test
+    public void testDoExecute_inlineModelCreationFailure() {
+        org.opensearch.ml.common.agent.MLAgentModelSpec embeddingSpec = org.opensearch.ml.common.agent.MLAgentModelSpec
+            .builder()
+            .modelId("amazon.titan-embed-text-v2:0")
+            .modelProvider("bedrock/embedding")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .build();
+
+        MemoryConfiguration inlineConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("fail-test")
+            .embeddingModelSpec(embeddingSpec)
+            .llmId("test-llm-model")
+            .strategies(
+                List
+                    .of(
+                        MemoryStrategy
+                            .builder()
+                            .namespace(List.of("user_id"))
+                            .id("strategy-id1")
+                            .enabled(true)
+                            .type(MemoryStrategyType.SEMANTIC)
+                            .build()
+                    )
+            )
+            .build();
+
+        MLCreateMemoryContainerInput inlineInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("test-fail")
+            .configuration(inlineConfig)
+            .build();
+
+        MLCreateMemoryContainerRequest request = new MLCreateMemoryContainerRequest(inlineInput);
+
+        // Mock model registration failure
+        doAnswer(invocation -> {
+            ActionListener listener = invocation.getArgument(2);
+            listener.onFailure(new RuntimeException("Model creation failed"));
+            return null;
+        })
+            .when(client)
+            .execute(
+                eq(org.opensearch.ml.common.transport.register.MLRegisterModelAction.INSTANCE),
+                any(org.opensearch.ml.common.transport.register.MLRegisterModelRequest.class),
+                any(ActionListener.class)
+            );
+
+        action.doExecute(null, request, actionListener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assertTrue(captor.getValue().getMessage().contains("Failed to create model"));
+    }
+
+    @Test
+    public void testDoExecute_noInlineModels_backwardCompat() {
+        // Standard request without inline specs — should work as before
+        action.doExecute(null, new MLCreateMemoryContainerRequest(input), actionListener);
+        // Should not call MLRegisterModelAction
+        verify(client, never())
+            .execute(
+                eq(org.opensearch.ml.common.transport.register.MLRegisterModelAction.INSTANCE),
+                any(org.opensearch.ml.common.transport.register.MLRegisterModelRequest.class),
+                any(ActionListener.class)
+            );
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -2211,4 +2211,54 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
                 any(ActionListener.class)
             );
     }
+
+    @Test
+    public void testDoExecute_inlineModel_preValidationFails_maxInferSize() {
+        org.opensearch.ml.common.agent.MLAgentModelSpec embeddingSpec = org.opensearch.ml.common.agent.MLAgentModelSpec
+            .builder()
+            .modelId("amazon.titan-embed-text-v2:0")
+            .modelProvider("bedrock/embedding")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .build();
+
+        MemoryConfiguration inlineConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("pre-val-test")
+            .embeddingModelSpec(embeddingSpec)
+            .llmId("test-llm-model")
+            .maxInferSize(999)
+            .strategies(
+                List
+                    .of(
+                        MemoryStrategy
+                            .builder()
+                            .namespace(List.of("user_id"))
+                            .id("strategy-id1")
+                            .enabled(true)
+                            .type(MemoryStrategyType.SEMANTIC)
+                            .build()
+                    )
+            )
+            .build();
+
+        MLCreateMemoryContainerInput inlineInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("test-pre-val")
+            .configuration(inlineConfig)
+            .build();
+
+        MLCreateMemoryContainerRequest request = new MLCreateMemoryContainerRequest(inlineInput);
+        action.doExecute(null, request, actionListener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof IllegalArgumentException);
+        // No models should have been created
+        verify(client, never())
+            .execute(
+                eq(org.opensearch.ml.common.transport.register.MLRegisterModelAction.INSTANCE),
+                any(org.opensearch.ml.common.transport.register.MLRegisterModelRequest.class),
+                any(ActionListener.class)
+            );
+    }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -2261,4 +2261,97 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
                 any(ActionListener.class)
             );
     }
+
+    @Test
+    public void testDoExecute_embeddingSucceeds_llmFails_cleanupInvoked() {
+        org.opensearch.ml.common.agent.MLAgentModelSpec embeddingSpec = org.opensearch.ml.common.agent.MLAgentModelSpec
+            .builder()
+            .modelId("amazon.titan-embed-text-v2:0")
+            .modelProvider("bedrock/embedding")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .build();
+
+        org.opensearch.ml.common.agent.MLAgentModelSpec llmSpec = org.opensearch.ml.common.agent.MLAgentModelSpec
+            .builder()
+            .modelId("us.anthropic.claude-sonnet-4-6")
+            .modelProvider("bedrock/converse")
+            .credential(Map.of("access_key", "test", "secret_key", "test"))
+            .build();
+
+        MemoryConfiguration inlineConfig = MemoryConfiguration
+            .builder()
+            .indexPrefix("cleanup-test")
+            .embeddingModelSpec(embeddingSpec)
+            .llmSpec(llmSpec)
+            .strategies(
+                List
+                    .of(
+                        MemoryStrategy
+                            .builder()
+                            .namespace(List.of("user_id"))
+                            .id("strategy-id1")
+                            .enabled(true)
+                            .type(MemoryStrategyType.SEMANTIC)
+                            .build()
+                    )
+            )
+            .build();
+
+        MLCreateMemoryContainerInput inlineInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("test-cleanup")
+            .configuration(inlineConfig)
+            .build();
+
+        MLCreateMemoryContainerRequest request = new MLCreateMemoryContainerRequest(inlineInput);
+
+        // First call (embedding) succeeds, second call (LLM) fails
+        java.util.concurrent.atomic.AtomicInteger callCount = new java.util.concurrent.atomic.AtomicInteger(0);
+        doAnswer(invocation -> {
+            ActionListener listener = invocation.getArgument(2);
+            if (callCount.getAndIncrement() == 0) {
+                listener
+                    .onResponse(
+                        new org.opensearch.ml.common.transport.register.MLRegisterModelResponse("task-1", "CREATED", "auto-embed-id")
+                    );
+            } else {
+                listener.onFailure(new RuntimeException("LLM creation failed"));
+            }
+            return null;
+        })
+            .when(client)
+            .execute(
+                eq(org.opensearch.ml.common.transport.register.MLRegisterModelAction.INSTANCE),
+                any(org.opensearch.ml.common.transport.register.MLRegisterModelRequest.class),
+                any(ActionListener.class)
+            );
+
+        // Mock delete to succeed
+        doAnswer(invocation -> {
+            ActionListener listener = invocation.getArgument(2);
+            listener.onResponse(null);
+            return null;
+        })
+            .when(client)
+            .execute(
+                eq(org.opensearch.ml.common.transport.model.MLModelDeleteAction.INSTANCE),
+                any(org.opensearch.ml.common.transport.model.MLModelDeleteRequest.class),
+                any(ActionListener.class)
+            );
+
+        action.doExecute(null, request, actionListener);
+
+        // Verify failure surfaced
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assertTrue(captor.getValue().getMessage().contains("Failed to create model"));
+
+        // Verify cleanup was invoked for the orphan embedding model
+        verify(client)
+            .execute(
+                eq(org.opensearch.ml.common.transport.model.MLModelDeleteAction.INSTANCE),
+                any(org.opensearch.ml.common.transport.model.MLModelDeleteRequest.class),
+                any(ActionListener.class)
+            );
+    }
 }


### PR DESCRIPTION
### Description

Reduces memory container creation from **5 API calls to 1** by supporting inline model specifications.

**Before:** 5 API calls (register embedding connector, register embedding model, register LLM connector, register LLM model, create container)

**After:** Single API call with inline `embedding_model` and `llm`:

#### What the user sends:
```json
POST /_plugins/_ml/memory_containers/_create
{
  "name": "my-memory",
  "configuration": {
    "embedding_model": {
      "model_id": "amazon.titan-embed-text-v2:0",
      "model_provider": "bedrock/embedding",
      "credential": { "access_key": "...", "secret_key": "...", "session_token": "..." }
    },
    "llm": {
      "model_id": "us.anthropic.claude-sonnet-4-6",
      "model_provider": "bedrock/converse",
      "credential": { "access_key": "...", "secret_key": "...", "session_token": "..." }
    },
    "strategies": [
      { "type": "SEMANTIC", "namespace": ["user_id"] },
      { "type": "USER_PREFERENCE", "namespace": ["user_id"] }
    ]
  }
}
```

#### What gets stored in the container index:
The inline specs are **never stored**. The system auto-creates the models, then stores the resulting IDs in the container document — identical to the existing format:
```json
{
  "name": "my-memory",
  "configuration": {
    "embedding_model_id": "auto_created_abc123",
    "embedding_model_type": "TEXT_EMBEDDING",
    "embedding_dimension": 1024,
    "llm_id": "auto_created_def456",
    "strategies": [
      { "type": "SEMANTIC", "namespace": ["user_id"], "id": "semantic_a1b2c3d4", "enabled": true },
      { "type": "USER_PREFERENCE", "namespace": ["user_id"], "id": "user_preference_e5f6g7h8", "enabled": true }
    ],
    "index_prefix": "...",
    "parameters": { "llm_result_path": "$.output.message.content[0].text" }
  },
  "owner": { ... },
  "created_time": "...",
  "last_updated_time": "..."
}
```

This means:
- Full backward compatibility — existing `embedding_model_id`/`llm_id` format still works
- Model IDs are visible in the container document for credential rotation via `PUT /_plugins/_ml/models/<id>`
- No new storage format, no migration needed
- Embedding type (dense/sparse) and dimension auto-detected from known model IDs
- `llm_result_path` auto-set per LLM provider (Bedrock, OpenAI, Gemini)

### Supported Providers

| Embedding | LLM |
|-----------|-----|
| `bedrock/embedding` (Titan, Cohere) | `bedrock/converse` |
| `openai/v1/embeddings` | `openai/v1/chat/completions` |
| | `gemini/v1beta/generatecontent` |

### E2E Verified

All combos tested against Docker cluster (OpenSearch 3.6.0):

| Embedding | LLM | Infer | Semantic Search |
|-----------|-----|-------|-----------------|
| Bedrock Titan v2 | Bedrock Claude | ✅ | ✅ |
| Bedrock Cohere v3 | Bedrock Claude | ✅ | ✅ |
| OpenAI text-embedding-3-small | Bedrock Claude | ✅ | ✅ |
| OpenAI text-embedding-3-small | OpenAI gpt-4o-mini | ✅ | ✅ |
| OpenAI text-embedding-3-small | Gemini 2.0 flash | ✅ | ✅ |

### Known Limitations (Phase 1)
- No rollback if LLM model creation fails after embedding model was created (same gap as agent revamp)
- Orphaned models not auto-cleaned on container deletion (same as agent revamp)

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using --signoff.