### PR TITLE
Upgrade setup-java to v4 and add Gradle dependency caching

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -32,9 +32,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       # Spotless requires JDK 17+
       - name: Setup Java 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 21
+          distribution: temurin
+          cache: gradle
       - name: Spotless Check
         run: ./gradlew spotlessCheck
 
@@ -60,9 +62,11 @@ jobs:
       - name: Run start commands
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: gradle
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -122,9 +126,11 @@ jobs:
           aws-region: us-west-2
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: gradle
 
       - name: Checkout MLCommons
         uses: actions/checkout@v4
@@ -213,9 +219,11 @@ jobs:
 
     steps:
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: gradle
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
+          cache: gradle
       - uses: actions/checkout@v3
 
       - name: Load secret


### PR DESCRIPTION
### Description

Upgrades `actions/setup-java` from v1 to v4 in `CI-workflow.yml` and adds `cache: gradle` to all `setup-java` steps across CI and publish workflows. This speeds up PR builds by caching Gradle dependencies between runs.

### Why the version bump is needed

The `cache` parameter is not available in `setup-java@v1` — it was introduced in v3. Additionally, v1 is deprecated and v2+ requires an explicit `distribution` field (set to `temurin` here, matching the existing `maven-publish.yml` configuration). There are no breaking changes in the upgrade path from v1 → v4 beyond adding the required `distribution` field.

### Changes

- **CI-workflow.yml**: Upgraded all 4 `setup-java` steps from `@v1` → `@v4`, added `distribution: temurin` and `cache: gradle`
- **maven-publish.yml**: Added `cache: gradle` (already on v3 with `distribution: temurin`)

### Reference

- [actions/setup-java caching documentation](https://github.com/actions/setup-java#caching-packages-dependencies)

### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing
  - N/A (infrastructure-only change, CI runs will validate)
- [x] New functionality has been documented
  - N/A
- [x] Commits are signed per the DCO using `--signoff`