### PR TITLE
add tenantId in summarization manager

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/contextmanager/SummarizationManager.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/contextmanager/SummarizationManager.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.engine.algorithms.contextmanager;
 
 import static java.lang.Math.min;
+import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.FunctionName.REMOTE;
 import static org.opensearch.ml.common.utils.StringUtils.processTextDoc;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
@@ -287,6 +288,14 @@ public class SummarizationManager implements ContextManager {
         return modelId;
     }
 
+    private String resolveTenantId(ContextManagerContext context) {
+        Map<String, String> parameters = context.getParameters();
+        if (parameters != null) {
+            return parameters.get(TENANT_ID_FIELD);
+        }
+        return null;
+    }
+
     protected void executeSummarization(
         ContextManagerContext context,
         String modelId,
@@ -305,8 +314,16 @@ public class SummarizationManager implements ContextManager {
             // Create ML input
             MLInput mlInput = MLInput.builder().algorithm(REMOTE).inputDataset(inputDataset).build();
 
+            // Propagate tenant_id from context so the prediction request passes multi-tenancy validation
+            String tenantId = resolveTenantId(context);
+
             // Create prediction request
-            MLPredictionTaskRequest request = MLPredictionTaskRequest.builder().modelId(modelId).mlInput(mlInput).build();
+            MLPredictionTaskRequest request = MLPredictionTaskRequest
+                .builder()
+                .modelId(modelId)
+                .mlInput(mlInput)
+                .tenantId(tenantId)
+                .build();
 
             // Execute prediction
             ActionListener<MLTaskResponse> listener = ActionListener.wrap(response -> {
@@ -378,8 +395,16 @@ public class SummarizationManager implements ContextManager {
             // Create ML input
             MLInput mlInput = MLInput.builder().algorithm(REMOTE).inputDataset(inputDataset).build();
 
+            // Propagate tenant_id from context so the prediction request passes multi-tenancy validation
+            String tenantId = resolveTenantId(context);
+
             // Create prediction request
-            MLPredictionTaskRequest request = MLPredictionTaskRequest.builder().modelId(modelId).mlInput(mlInput).build();
+            MLPredictionTaskRequest request = MLPredictionTaskRequest
+                .builder()
+                .modelId(modelId)
+                .mlInput(mlInput)
+                .tenantId(tenantId)
+                .build();
 
             // Execute prediction
             ActionListener<MLTaskResponse> listener = ActionListener.wrap(response -> {

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/contextmanager/SummarizationManagerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/contextmanager/SummarizationManagerTest.java
@@ -5,18 +5,28 @@
 
 package org.opensearch.ml.engine.algorithms.contextmanager;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.LLM_RESPONSE_FILTER;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.action.ActionType;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.contextmanager.ContextManagerContext;
 import org.opensearch.ml.common.input.execute.agent.ContentBlock;
 import org.opensearch.ml.common.input.execute.agent.ContentType;
@@ -25,6 +35,8 @@ import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.transport.MLTaskResponse;
+import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
 /**
@@ -606,6 +618,122 @@ public class SummarizationManagerTest {
 
         // Interactions unchanged because client call fails, but model ID resolution worked
         Assert.assertEquals(20, context.getToolInteractions().size());
+    }
+
+    @Test
+    public void testExecuteSummarizationPropagatesTenantId() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("summarization_model_id", "test-model");
+        manager.initialize(config);
+
+        // Set up client mock to capture the prediction request
+        ThreadPool threadPool = mock(ThreadPool.class);
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.generic()).thenReturn(executorService);
+
+        // Make the executor run the submitted task immediately so client.execute() is called
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
+
+        // Set up tenant_id in context parameters
+        String expectedTenantId = "test-tenant-123";
+        Map<String, String> params = new HashMap<>();
+        params.put(TENANT_ID_FIELD, expectedTenantId);
+        params.put("_llm_model_id", "test-model");
+
+        context = ContextManagerContext.builder().toolInteractions(new ArrayList<>()).parameters(params).build();
+
+        // Add enough interactions to trigger summarization
+        addToolInteractionsToContext(20);
+
+        manager.execute(context);
+
+        // Capture the request passed to client.execute()
+        ArgumentCaptor<MLPredictionTaskRequest> requestCaptor = ArgumentCaptor.forClass(MLPredictionTaskRequest.class);
+        verify(client).execute(any(ActionType.class), requestCaptor.capture(), any(ActionListener.class));
+
+        MLPredictionTaskRequest capturedRequest = requestCaptor.getValue();
+        Assert.assertEquals(expectedTenantId, capturedRequest.getTenantId());
+    }
+
+    @Test
+    public void testExecuteSummarizationPropagatesNullTenantIdWhenAbsent() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("summarization_model_id", "test-model");
+        manager.initialize(config);
+
+        // Set up client mock
+        ThreadPool threadPool = mock(ThreadPool.class);
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.generic()).thenReturn(executorService);
+
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
+
+        // No tenant_id in context parameters
+        Map<String, String> params = new HashMap<>();
+        params.put("_llm_model_id", "test-model");
+        context = ContextManagerContext.builder().toolInteractions(new ArrayList<>()).parameters(params).build();
+
+        addToolInteractionsToContext(20);
+
+        manager.execute(context);
+
+        ArgumentCaptor<MLPredictionTaskRequest> requestCaptor = ArgumentCaptor.forClass(MLPredictionTaskRequest.class);
+        verify(client).execute(any(ActionType.class), requestCaptor.capture(), any(ActionListener.class));
+
+        MLPredictionTaskRequest capturedRequest = requestCaptor.getValue();
+        Assert.assertNull(capturedRequest.getTenantId());
+    }
+
+    @Test
+    public void testExecuteStructuredSummarizationPropagatesTenantId() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("summarization_model_id", "test-model");
+        manager.initialize(config);
+
+        // Set up client mock
+        ThreadPool threadPool = mock(ThreadPool.class);
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.generic()).thenReturn(executorService);
+
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
+
+        // Set up tenant_id in context parameters
+        String expectedTenantId = "structured-tenant-456";
+        Map<String, String> params = new HashMap<>();
+        params.put(TENANT_ID_FIELD, expectedTenantId);
+        params.put("_llm_model_id", "test-model");
+
+        List<Message> messages = createStructuredMessages(20);
+        context = ContextManagerContext
+            .builder()
+            .toolInteractions(new ArrayList<>())
+            .parameters(params)
+            .structuredChatHistory(messages)
+            .build();
+
+        manager.execute(context);
+
+        // Capture the request passed to client.execute()
+        ArgumentCaptor<MLPredictionTaskRequest> requestCaptor = ArgumentCaptor.forClass(MLPredictionTaskRequest.class);
+        verify(client).execute(any(ActionType.class), requestCaptor.capture(), any(ActionListener.class));
+
+        MLPredictionTaskRequest capturedRequest = requestCaptor.getValue();
+        Assert.assertEquals(expectedTenantId, capturedRequest.getTenantId());
     }
 
     /**


### PR DESCRIPTION
### Description
Add `tenantId` in summarization manager's request so that it can call the model correctly in multi-tenant environment

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
