### PR TITLE
feat: Add opt-in settings to enforce unique Agent and Agentic Memory Container names

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -539,4 +539,24 @@ public final class MLCommonsSettings {
         .boolSetting(ML_PLUGIN_SETTING_PREFIX + "ag_ui_enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic);
     public static final String ML_COMMONS_AG_UI_DISABLED_MESSAGE =
         "The AG-UI agent feature is not enabled. To enable, please update the setting " + ML_COMMONS_AG_UI_ENABLED.getKey();
+
+    // When enabled, registering an Agent with a name that already exists (per tenant) is rejected.
+    // Defaults to false for backward compatibility.
+    public static final Setting<Boolean> ML_COMMONS_AGENT_NAME_UNIQUENESS_ENABLED = Setting
+        .boolSetting(
+            ML_PLUGIN_SETTING_PREFIX + "agent_name_uniqueness_enabled",
+            false,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    // When enabled, creating an Agentic Memory Container with a name that already exists (per
+    // tenant) is rejected. Defaults to false for backward compatibility.
+    public static final Setting<Boolean> ML_COMMONS_AGENTIC_MEMORY_NAME_UNIQUENESS_ENABLED = Setting
+        .boolSetting(
+            ML_PLUGIN_SETTING_PREFIX + "agentic_memory_name_uniqueness_enabled",
+            false,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
 }

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
@@ -6,7 +6,9 @@
 package org.opensearch.ml.common.settings;
 
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_NAME_UNIQUENESS_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENT_FRAMEWORK_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENT_NAME_UNIQUENESS_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_CONTROLLER_ENABLED;
@@ -76,6 +78,10 @@ public class MLFeatureEnabledSetting {
 
     private volatile Boolean isAGUIEnabled;
 
+    private volatile Boolean isAgentNameUniquenessEnabled;
+
+    private volatile Boolean isAgenticMemoryNameUniquenessEnabled;
+
     private final List<SettingsChangeListener> listeners = new ArrayList<>();
 
     public MLFeatureEnabledSetting(ClusterService clusterService, Settings settings) {
@@ -101,6 +107,8 @@ public class MLFeatureEnabledSetting {
         maxJsonSize = MLCommonsSettings.ML_COMMONS_MAX_JSON_SIZE.get(settings);
         isMcpHeaderPassthroughEnabled = ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED.get(settings);
         isAGUIEnabled = ML_COMMONS_AG_UI_ENABLED.get(settings);
+        isAgentNameUniquenessEnabled = ML_COMMONS_AGENT_NAME_UNIQUENESS_ENABLED.get(settings);
+        isAgenticMemoryNameUniquenessEnabled = ML_COMMONS_AGENTIC_MEMORY_NAME_UNIQUENESS_ENABLED.get(settings);
 
         clusterService
             .getClusterSettings()
@@ -140,6 +148,12 @@ public class MLFeatureEnabledSetting {
             .getClusterSettings()
             .addSettingsUpdateConsumer(ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED, it -> isMcpHeaderPassthroughEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_AG_UI_ENABLED, it -> isAGUIEnabled = it);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_AGENT_NAME_UNIQUENESS_ENABLED, it -> isAgentNameUniquenessEnabled = it);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_AGENTIC_MEMORY_NAME_UNIQUENESS_ENABLED, it -> isAgenticMemoryNameUniquenessEnabled = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED, it -> {
             isStaticMetricCollectionEnabled = it;
             for (SettingsChangeListener listener : listeners) {
@@ -313,5 +327,25 @@ public class MLFeatureEnabledSetting {
      */
     public boolean isAGUIEnabled() {
         return isAGUIEnabled;
+    }
+
+    /**
+     * Whether agent name uniqueness is enforced. When enabled, registering an agent with a name
+     * that already exists within the same tenant is rejected. Defaults to false for backward
+     * compatibility.
+     * @return whether agent name uniqueness is enforced.
+     */
+    public boolean isAgentNameUniquenessEnabled() {
+        return isAgentNameUniquenessEnabled;
+    }
+
+    /**
+     * Whether agentic memory container name uniqueness is enforced. When enabled, creating a
+     * memory container with a name that already exists within the same tenant is rejected.
+     * Defaults to false for backward compatibility.
+     * @return whether agentic memory container name uniqueness is enforced.
+     */
+    public boolean isAgenticMemoryNameUniquenessEnabled() {
+        return isAgenticMemoryNameUniquenessEnabled;
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLCreateMemoryContainerInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLCreateMemoryContainerInput.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -52,8 +53,8 @@ public class MLCreateMemoryContainerInput implements ToXContentObject, Writeable
         String tenantId,
         List<String> backendRoles
     ) {
-        if (name == null) {
-            throw new IllegalArgumentException("name is null");
+        if (StringUtils.isBlank(name)) {
+            throw new IllegalArgumentException("name cannot be null or blank");
         }
         this.name = name;
         this.description = description;

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLUpdateMemoryContainerInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLUpdateMemoryContainerInput.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -39,6 +40,10 @@ public class MLUpdateMemoryContainerInput implements ToXContentObject, Writeable
 
     @Builder
     public MLUpdateMemoryContainerInput(String name, String description, List<String> backendRoles, MemoryConfiguration configuration) {
+        // Null = "no rename" (name is optional on update), but a non-null blank string is always wrong.
+        if (name != null && StringUtils.isBlank(name)) {
+            throw new IllegalArgumentException("name cannot be blank");
+        }
         this.name = name;
         this.description = description;
         validateBackendRoles(backendRoles);

--- a/common/src/test/java/org/opensearch/ml/common/settings/MLFeatureEnabledSettingTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/settings/MLFeatureEnabledSettingTests.java
@@ -54,7 +54,9 @@ public class MLFeatureEnabledSettingTests {
                     MLCommonsSettings.ML_COMMONS_STREAM_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MAX_JSON_SIZE,
                     MLCommonsSettings.ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
-                    MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED
+                    MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_AGENT_NAME_UNIQUENESS_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_NAME_UNIQUENESS_ENABLED
                 )
         );
         when(mockClusterService.getClusterSettings()).thenReturn(mockClusterSettings);

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLCreateMemoryContainerInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLCreateMemoryContainerInputTests.java
@@ -131,6 +131,16 @@ public class MLCreateMemoryContainerInputTests {
             .build();
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithBlankName() {
+        MLCreateMemoryContainerInput.builder().name("   ").description("blank name").build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithEmptyName() {
+        MLCreateMemoryContainerInput.builder().name("").description("empty name").build();
+    }
+
     @Test
     public void testStreamInputOutput() throws IOException {
         BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLUpdateMemoryContainerInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLUpdateMemoryContainerInputTests.java
@@ -33,6 +33,23 @@ import org.opensearch.ml.common.memorycontainer.MemoryStrategyType;
 
 public class MLUpdateMemoryContainerInputTests {
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorRejectsBlankName() {
+        MLUpdateMemoryContainerInput.builder().name("   ").build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorRejectsEmptyName() {
+        MLUpdateMemoryContainerInput.builder().name("").build();
+    }
+
+    @Test
+    public void testConstructorAllowsNullName() {
+        // Null name on update means "no rename" - must be allowed.
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().name(null).description("desc").build();
+        assertNull(input.getName());
+    }
+
     @Test
     public void testConstructor() {
         List<String> backendRoles = Arrays.asList("role1", "role2");

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
@@ -15,10 +15,12 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
@@ -27,6 +29,9 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.ml.action.agent.MLAgentRegistrationValidator;
 import org.opensearch.ml.action.contextmanagement.ContextManagementTemplateService;
 import org.opensearch.ml.common.MLAgentType;
@@ -49,7 +54,9 @@ import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.ml.utils.TenantAwareHelper;
 import org.opensearch.remote.metadata.client.PutDataObjectRequest;
 import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest;
 import org.opensearch.remote.metadata.common.SdkClientUtils;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
@@ -99,13 +106,107 @@ public class TransportRegisterAgentAction extends HandledTransportAction<ActionR
             return;
         }
 
-        // Check if this agent needs model creation
-        if (mlAgent.usesUnifiedInterface()) {
-            createModelAndRegisterAgent(mlAgent, listener);
+        // Validate tenant id before any metadata search so a missing tenant fails fast in
+        // multi-tenant mode, rather than leaking existence via a 409 from a cross-tenant search.
+        if (!TenantAwareHelper.validateTenantId(mlFeatureEnabledSetting, mlAgent.getTenantId(), listener)) {
             return;
         }
 
-        registerAgent(mlAgent, listener);
+        validateAgentNameUniqueness(mlAgent, ActionListener.wrap(unused -> {
+            // Check if this agent needs model creation
+            if (mlAgent.usesUnifiedInterface()) {
+                createModelAndRegisterAgent(mlAgent, listener);
+                return;
+            }
+            registerAgent(mlAgent, listener);
+        }, listener::onFailure));
+    }
+
+    /**
+     * When {@code plugins.ml_commons.agent_name_uniqueness_enabled} is enabled, reject the
+     * registration if an agent with the same name already exists in the same tenant. When the
+     * setting is disabled (default), this is a no-op so existing clusters remain backward compatible.
+     *
+     * <p>For PLAN_EXECUTE_AND_REFLECT agents without a pre-existing executor-agent-id, an internal
+     * "{@code <name> (ReAct)}" executor agent is auto-created; this method also checks that
+     * derived name so the auto-created agent cannot collide with an existing one.
+     *
+     * <p>Note: this is a best-effort check, not a transactional guard. Two concurrent register
+     * requests with the same name can both pass this check before either write is visible.
+     * See the PR description for a follow-up plan if stricter semantics are required.
+     */
+    private void validateAgentNameUniqueness(MLAgent mlAgent, ActionListener<Void> listener) {
+        if (!mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()) {
+            listener.onResponse(null);
+            return;
+        }
+
+        // MLAgent.validate() already rejects null/blank/over-length names upstream, so we rely on
+        // that invariant here and don't re-check.
+        String name = mlAgent.getName();
+        String tenantId = mlAgent.getTenantId();
+        checkAgentNameAvailable(name, tenantId, ActionListener.wrap(unused -> {
+            // If this is a PLAN_EXECUTE_AND_REFLECT registration that will auto-create an
+            // executor agent named "<name> (ReAct)", validate that derived name too.
+            if (MLAgentType.from(mlAgent.getType()) == MLAgentType.PLAN_EXECUTE_AND_REFLECT
+                && mlAgent.getParameters() != null
+                && !mlAgent.getParameters().containsKey(MLPlanExecuteAndReflectAgentRunner.EXECUTOR_AGENT_ID_FIELD)) {
+                checkAgentNameAvailable(name + " (ReAct)", tenantId, listener);
+            } else {
+                listener.onResponse(null);
+            }
+        }, listener::onFailure));
+    }
+
+    private void checkAgentNameAvailable(String name, String tenantId, ActionListener<Void> listener) {
+        BoolQueryBuilder query = new BoolQueryBuilder().filter(new TermQueryBuilder("name.keyword", name));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).size(1).fetchSource(false);
+        SearchRequest searchRequest = new SearchRequest(ML_AGENT_INDEX).source(sourceBuilder);
+        SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+            .builder()
+            .indices(searchRequest.indices())
+            .searchSourceBuilder(searchRequest.source())
+            .tenantId(tenantId)
+            .build();
+
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            sdkClient.searchDataObjectAsync(searchDataObjectRequest).whenComplete((r, throwable) -> {
+                context.restore();
+                if (throwable != null) {
+                    if (ExceptionsHelper.unwrap(throwable, IndexNotFoundException.class) != null) {
+                        // Index not yet created - no duplicate possible
+                        listener.onResponse(null);
+                        return;
+                    }
+                    Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable);
+                    log.error("Failed to search ML agent index for name uniqueness check", cause);
+                    listener.onFailure(cause);
+                    return;
+                }
+                try {
+                    long totalHits = r.searchResponse().getHits().getTotalHits() == null
+                        ? 0
+                        : r.searchResponse().getHits().getTotalHits().value();
+                    if (totalHits > 0) {
+                        listener
+                            .onFailure(
+                                new OpenSearchStatusException(
+                                    "An agent with name [" + name + "] already exists. Agent names must be unique.",
+                                    RestStatus.CONFLICT
+                                )
+                            );
+                    } else {
+                        listener.onResponse(null);
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to parse search response for agent name uniqueness check", e);
+                    listener.onFailure(e);
+                }
+            });
+        } catch (Exception e) {
+            log.error("Failed to execute agent name uniqueness check", e);
+            listener.onFailure(e);
+        }
     }
 
     private void createModelAndRegisterAgent(MLAgent mlAgent, ActionListener<MLRegisterAgentResponse> listener) {
@@ -185,9 +286,6 @@ public class TransportRegisterAgentAction extends HandledTransportAction<ActionR
         boolean isHiddenAgent = RestActionUtils.isSuperAdminUser(clusterService, client);
         MLAgent mlAgent = agent.toBuilder().createdTime(now).lastUpdateTime(now).isHidden(isHiddenAgent).build();
         String tenantId = agent.getTenantId();
-        if (!TenantAwareHelper.validateTenantId(mlFeatureEnabledSetting, tenantId, listener)) {
-            return;
-        }
 
         // If the agent is a PLAN_EXECUTE_AND_REFLECT agent and does not have an executor agent id, create an executor (reAct) agent
         if (MLAgentType.from(mlAgent.getType()) == MLAgentType.PLAN_EXECUTE_AND_REFLECT

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/TransportRegisterAgentAction.java
@@ -15,12 +15,10 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.index.IndexResponse;
-import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
@@ -29,9 +27,6 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.index.IndexNotFoundException;
-import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.ml.action.agent.MLAgentRegistrationValidator;
 import org.opensearch.ml.action.contextmanagement.ContextManagementTemplateService;
 import org.opensearch.ml.common.MLAgentType;
@@ -50,13 +45,12 @@ import org.opensearch.ml.common.transport.register.MLRegisterModelRequest;
 import org.opensearch.ml.engine.algorithms.agent.MLPlanExecuteAndReflectAgentRunner;
 import org.opensearch.ml.engine.function_calling.FunctionCallingFactory;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
+import org.opensearch.ml.helper.NameUniquenessHelper;
 import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.ml.utils.TenantAwareHelper;
 import org.opensearch.remote.metadata.client.PutDataObjectRequest;
 import org.opensearch.remote.metadata.client.SdkClient;
-import org.opensearch.remote.metadata.client.SearchDataObjectRequest;
 import org.opensearch.remote.metadata.common.SdkClientUtils;
-import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
@@ -159,54 +153,25 @@ public class TransportRegisterAgentAction extends HandledTransportAction<ActionR
     }
 
     private void checkAgentNameAvailable(String name, String tenantId, ActionListener<Void> listener) {
-        BoolQueryBuilder query = new BoolQueryBuilder().filter(new TermQueryBuilder("name.keyword", name));
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).size(1).fetchSource(false);
-        SearchRequest searchRequest = new SearchRequest(ML_AGENT_INDEX).source(sourceBuilder);
-        SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
-            .builder()
-            .indices(searchRequest.indices())
-            .searchSourceBuilder(searchRequest.source())
-            .tenantId(tenantId)
-            .build();
-
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            sdkClient.searchDataObjectAsync(searchDataObjectRequest).whenComplete((r, throwable) -> {
-                context.restore();
-                if (throwable != null) {
-                    if (ExceptionsHelper.unwrap(throwable, IndexNotFoundException.class) != null) {
-                        // Index not yet created - no duplicate possible
-                        listener.onResponse(null);
-                        return;
-                    }
-                    Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable);
-                    log.error("Failed to search ML agent index for name uniqueness check", cause);
-                    listener.onFailure(cause);
-                    return;
-                }
-                try {
-                    long totalHits = r.searchResponse().getHits().getTotalHits() == null
-                        ? 0
-                        : r.searchResponse().getHits().getTotalHits().value();
-                    if (totalHits > 0) {
-                        listener
-                            .onFailure(
-                                new OpenSearchStatusException(
-                                    "An agent with name [" + name + "] already exists. Agent names must be unique.",
-                                    RestStatus.CONFLICT
-                                )
-                            );
-                    } else {
-                        listener.onResponse(null);
-                    }
-                } catch (Exception e) {
-                    log.error("Failed to parse search response for agent name uniqueness check", e);
-                    listener.onFailure(e);
-                }
-            });
-        } catch (Exception e) {
-            log.error("Failed to execute agent name uniqueness check", e);
-            listener.onFailure(e);
-        }
+        NameUniquenessHelper.searchByExactName(client, sdkClient, ML_AGENT_INDEX, name, tenantId, ActionListener.wrap(response -> {
+            if (response == null) {
+                // Index not yet created - no duplicate possible.
+                listener.onResponse(null);
+                return;
+            }
+            long totalHits = response.getHits().getTotalHits() == null ? 0 : response.getHits().getTotalHits().value();
+            if (totalHits > 0) {
+                listener
+                    .onFailure(
+                        new OpenSearchStatusException(
+                            "An agent with name [" + name + "] already exists. Agent names must be unique.",
+                            RestStatus.CONFLICT
+                        )
+                    );
+            } else {
+                listener.onResponse(null);
+            }
+        }, listener::onFailure));
     }
 
     private void createModelAndRegisterAgent(MLAgent mlAgent, ActionListener<MLRegisterAgentResponse> listener) {

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/UpdateAgentTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/UpdateAgentTransportAction.java
@@ -218,7 +218,7 @@ public class UpdateAgentTransportAction extends HandledTransportAction<ActionReq
         }
 
         NameUniquenessHelper
-            .searchByExactName(client, sdkClient, ML_AGENT_INDEX, newName, updateInput.getTenantId(), ActionListener.wrap(response -> {
+            .searchByExactName(client, sdkClient, ML_AGENT_INDEX, newName, originalAgent.getTenantId(), ActionListener.wrap(response -> {
                 if (response == null) {
                     listener.onResponse(null);
                     return;

--- a/plugin/src/main/java/org/opensearch/ml/action/agents/UpdateAgentTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agents/UpdateAgentTransportAction.java
@@ -9,6 +9,7 @@ import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
 
 import java.time.Instant;
 
+import org.apache.commons.lang3.StringUtils;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.DocWriteResponse;
@@ -32,6 +33,7 @@ import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.agent.MLAgentUpdateAction;
 import org.opensearch.ml.common.transport.agent.MLAgentUpdateInput;
 import org.opensearch.ml.common.transport.agent.MLAgentUpdateRequest;
+import org.opensearch.ml.helper.NameUniquenessHelper;
 import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.ml.utils.TenantAwareHelper;
 import org.opensearch.remote.metadata.client.GetDataObjectRequest;
@@ -127,7 +129,15 @@ public class UpdateAgentTransportAction extends HandledTransportAction<ActionReq
                                         )
                                     );
                             } else {
-                                updateAgent(agentId, mlAgentUpdateInput, retrievedAgent, wrappedListener);
+                                validateAgentNameUniquenessForUpdate(
+                                    mlAgentUpdateInput,
+                                    retrievedAgent,
+                                    ActionListener
+                                        .wrap(
+                                            unused -> updateAgent(agentId, mlAgentUpdateInput, retrievedAgent, wrappedListener),
+                                            wrappedListener::onFailure
+                                        )
+                                );
                             }
                         } else {
                             log.error("Failed to validate tenant for Agent ID {}", agentId);
@@ -178,6 +188,54 @@ public class UpdateAgentTransportAction extends HandledTransportAction<ActionReq
                 }
             }
         });
+    }
+
+    /**
+     * When {@code plugins.ml_commons.agent_name_uniqueness_enabled} is enabled and the update
+     * would rename the agent to a new value, reject the update if another agent in the same
+     * tenant already has that name. Skipped if the setting is off, if the update omits a new
+     * name (or provides a blank one), or if the new name equals the existing name (so a PUT
+     * that doesn't actually rename does not 409 against itself). Mirrors the gate shape used
+     * by {@code TransportUpdateModelGroupAction#updateModelGroup}.
+     *
+     * <p>Same best-effort semantics as the register path: two concurrent updates racing on the
+     * same name can both see zero hits and both succeed.
+     */
+    private void validateAgentNameUniquenessForUpdate(
+        MLAgentUpdateInput updateInput,
+        MLAgent originalAgent,
+        ActionListener<Void> listener
+    ) {
+        if (!mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()) {
+            listener.onResponse(null);
+            return;
+        }
+        String newName = updateInput.getName();
+        if (StringUtils.isBlank(newName) || newName.equals(originalAgent.getName())) {
+            // No rename (name omitted/blank), or a no-op rename to the current name.
+            listener.onResponse(null);
+            return;
+        }
+
+        NameUniquenessHelper
+            .searchByExactName(client, sdkClient, ML_AGENT_INDEX, newName, updateInput.getTenantId(), ActionListener.wrap(response -> {
+                if (response == null) {
+                    listener.onResponse(null);
+                    return;
+                }
+                long totalHits = response.getHits().getTotalHits() == null ? 0 : response.getHits().getTotalHits().value();
+                if (totalHits > 0) {
+                    listener
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "An agent with name [" + newName + "] already exists. Agent names must be unique.",
+                                RestStatus.CONFLICT
+                            )
+                        );
+                } else {
+                    listener.onResponse(null);
+                }
+            }, listener::onFailure));
     }
 
     @VisibleForTesting

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -10,11 +10,9 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGE
 
 import java.time.Instant;
 
-import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.index.IndexResponse;
-import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
@@ -23,9 +21,6 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.index.IndexNotFoundException;
-import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
@@ -39,14 +34,13 @@ import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.helper.MemoryContainerModelValidator;
 import org.opensearch.ml.helper.MemoryContainerPipelineHelper;
 import org.opensearch.ml.helper.MemoryContainerSharedIndexValidator;
+import org.opensearch.ml.helper.NameUniquenessHelper;
 import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.ml.utils.TenantAwareHelper;
 import org.opensearch.remote.metadata.client.PutDataObjectRequest;
 import org.opensearch.remote.metadata.client.SdkClient;
-import org.opensearch.remote.metadata.client.SearchDataObjectRequest;
 import org.opensearch.remote.metadata.common.SdkClientUtils;
-import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
@@ -319,54 +313,26 @@ public class TransportCreateMemoryContainerAction extends
 
         // MLCreateMemoryContainerInput rejects null names upstream, so we rely on that invariant
         // here and don't re-check.
-        BoolQueryBuilder query = new BoolQueryBuilder().filter(new TermQueryBuilder("name.keyword", name));
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).size(1).fetchSource(false);
-        SearchRequest searchRequest = new SearchRequest(ML_MEMORY_CONTAINER_INDEX).source(sourceBuilder);
-        SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
-            .builder()
-            .indices(searchRequest.indices())
-            .searchSourceBuilder(searchRequest.source())
-            .tenantId(tenantId)
-            .build();
-
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            sdkClient.searchDataObjectAsync(searchDataObjectRequest).whenComplete((r, throwable) -> {
-                context.restore();
-                if (throwable != null) {
-                    if (ExceptionsHelper.unwrap(throwable, IndexNotFoundException.class) != null) {
-                        // Index not yet created - no duplicate possible
-                        listener.onResponse(null);
-                        return;
-                    }
-                    Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable);
-                    log.error("Failed to search memory container index for name uniqueness check", cause);
-                    listener.onFailure(cause);
+        NameUniquenessHelper
+            .searchByExactName(client, sdkClient, ML_MEMORY_CONTAINER_INDEX, name, tenantId, ActionListener.wrap(response -> {
+                if (response == null) {
+                    // Index not yet created - no duplicate possible.
+                    listener.onResponse(null);
                     return;
                 }
-                try {
-                    long totalHits = r.searchResponse().getHits().getTotalHits() == null
-                        ? 0
-                        : r.searchResponse().getHits().getTotalHits().value();
-                    if (totalHits > 0) {
-                        listener
-                            .onFailure(
-                                new OpenSearchStatusException(
-                                    "A memory container with name [" + name + "] already exists. Memory container names must be unique.",
-                                    RestStatus.CONFLICT
-                                )
-                            );
-                    } else {
-                        listener.onResponse(null);
-                    }
-                } catch (Exception e) {
-                    log.error("Failed to parse search response for memory container name uniqueness check", e);
-                    listener.onFailure(e);
+                long totalHits = response.getHits().getTotalHits() == null ? 0 : response.getHits().getTotalHits().value();
+                if (totalHits > 0) {
+                    listener
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "A memory container with name [" + name + "] already exists. Memory container names must be unique.",
+                                RestStatus.CONFLICT
+                            )
+                        );
+                } else {
+                    listener.onResponse(null);
                 }
-            });
-        } catch (Exception e) {
-            log.error("Failed to execute memory container name uniqueness check", e);
-            listener.onFailure(e);
-        }
+            }, listener::onFailure));
     }
 
     private void validateConfiguration(MemoryConfiguration config, ActionListener<Boolean> listener) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -10,9 +10,11 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGE
 
 import java.time.Instant;
 
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
@@ -21,6 +23,9 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
@@ -39,7 +44,9 @@ import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.ml.utils.TenantAwareHelper;
 import org.opensearch.remote.metadata.client.PutDataObjectRequest;
 import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest;
 import org.opensearch.remote.metadata.common.SdkClientUtils;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
@@ -98,7 +105,18 @@ public class TransportCreateMemoryContainerAction extends
         User user = RestActionUtils.getUserContext(client);
         String tenantId = input.getTenantId();
 
-        // Validate configuration before creating memory container
+        validateMemoryContainerNameUniqueness(input.getName(), tenantId, ActionListener.wrap(unused -> {
+            // Validate configuration before creating memory container
+            validateConfigurationAndCreate(input, user, tenantId, listener);
+        }, listener::onFailure));
+    }
+
+    private void validateConfigurationAndCreate(
+        MLCreateMemoryContainerInput input,
+        User user,
+        String tenantId,
+        ActionListener<MLCreateMemoryContainerResponse> listener
+    ) {
         validateConfiguration(input.getConfiguration(), ActionListener.wrap(isValid -> {
             // Check if memory container index exists, create if not
             ActionListener<Boolean> indexCheckListener = ActionListener.wrap(created -> {
@@ -285,6 +303,69 @@ public class TransportCreateMemoryContainerAction extends
         } catch (Exception e) {
             log.error("Failed to save memory container", e);
             listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    /**
+     * When {@code plugins.ml_commons.agentic_memory_name_uniqueness_enabled} is enabled, reject
+     * creation if a memory container with the same name already exists in the same tenant. When the
+     * setting is disabled (default), this is a no-op so existing clusters remain backward compatible.
+     */
+    private void validateMemoryContainerNameUniqueness(String name, String tenantId, ActionListener<Void> listener) {
+        if (!mlFeatureEnabledSetting.isAgenticMemoryNameUniquenessEnabled()) {
+            listener.onResponse(null);
+            return;
+        }
+
+        // MLCreateMemoryContainerInput rejects null names upstream, so we rely on that invariant
+        // here and don't re-check.
+        BoolQueryBuilder query = new BoolQueryBuilder().filter(new TermQueryBuilder("name.keyword", name));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).size(1).fetchSource(false);
+        SearchRequest searchRequest = new SearchRequest(ML_MEMORY_CONTAINER_INDEX).source(sourceBuilder);
+        SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+            .builder()
+            .indices(searchRequest.indices())
+            .searchSourceBuilder(searchRequest.source())
+            .tenantId(tenantId)
+            .build();
+
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            sdkClient.searchDataObjectAsync(searchDataObjectRequest).whenComplete((r, throwable) -> {
+                context.restore();
+                if (throwable != null) {
+                    if (ExceptionsHelper.unwrap(throwable, IndexNotFoundException.class) != null) {
+                        // Index not yet created - no duplicate possible
+                        listener.onResponse(null);
+                        return;
+                    }
+                    Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable);
+                    log.error("Failed to search memory container index for name uniqueness check", cause);
+                    listener.onFailure(cause);
+                    return;
+                }
+                try {
+                    long totalHits = r.searchResponse().getHits().getTotalHits() == null
+                        ? 0
+                        : r.searchResponse().getHits().getTotalHits().value();
+                    if (totalHits > 0) {
+                        listener
+                            .onFailure(
+                                new OpenSearchStatusException(
+                                    "A memory container with name [" + name + "] already exists. Memory container names must be unique.",
+                                    RestStatus.CONFLICT
+                                )
+                            );
+                    } else {
+                        listener.onResponse(null);
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to parse search response for memory container name uniqueness check", e);
+                    listener.onFailure(e);
+                }
+            });
+        } catch (Exception e) {
+            log.error("Failed to execute memory container name uniqueness check", e);
+            listener.onFailure(e);
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -154,7 +154,7 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
         try {
             // Prepare the update
             Map<String, Object> updateFields = new HashMap<>();
-            if (newName != null) {
+            if (StringUtils.isNotBlank(newName)) {
                 updateFields.put(NAME_FIELD, newName);
             }
             if (newDescription != null) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
@@ -42,6 +43,7 @@ import org.opensearch.ml.helper.MemoryContainerHelper;
 import org.opensearch.ml.helper.MemoryContainerModelValidator;
 import org.opensearch.ml.helper.MemoryContainerPipelineHelper;
 import org.opensearch.ml.helper.MemoryContainerSharedIndexValidator;
+import org.opensearch.ml.helper.NameUniquenessHelper;
 import org.opensearch.ml.helper.StrategyMergeHelper;
 import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.ml.utils.RestActionUtils;
@@ -123,6 +125,33 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
                 return;
             }
 
+            validateMemoryContainerNameUniquenessForUpdate(newName, container, ActionListener.wrap(unused -> {
+                continueUpdate(
+                    container,
+                    newName,
+                    newDescription,
+                    allowedBackendRoles,
+                    updateConfiguration,
+                    memoryContainerId,
+                    actionListener
+                );
+            }, actionListener::onFailure));
+        }, e -> {
+            log.error("Failed to get memory container for update", e);
+            actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+        }));
+    }
+
+    private void continueUpdate(
+        MLMemoryContainer container,
+        String newName,
+        String newDescription,
+        List<String> allowedBackendRoles,
+        MemoryConfiguration updateConfiguration,
+        String memoryContainerId,
+        ActionListener<UpdateResponse> actionListener
+    ) {
+        try {
             // Prepare the update
             Map<String, Object> updateFields = new HashMap<>();
             if (newName != null) {
@@ -195,10 +224,63 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
 
             updateFields.put(LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli());
             performUpdate(ML_MEMORY_CONTAINER_INDEX, memoryContainerId, updateFields, actionListener);
-        }, e -> {
-            log.error("Failed to get memory container for update", e);
+        } catch (Exception e) {
+            log.error("Failed to update memory container {}", memoryContainerId, e);
             actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
-        }));
+        }
+    }
+
+    /**
+     * When {@code plugins.ml_commons.agentic_memory_name_uniqueness_enabled} is enabled and the
+     * update would rename the container to a new value, reject the update if another memory
+     * container in the same tenant already has that name. Skipped if the setting is off, if the
+     * update omits a new name (or provides a blank one), or if the new name equals the existing
+     * name. Mirrors the gate shape used by {@code TransportUpdateModelGroupAction#updateModelGroup}.
+     *
+     * <p>Same best-effort semantics as the create path: two concurrent updates racing on the
+     * same name can both see zero hits and both succeed.
+     */
+    private void validateMemoryContainerNameUniquenessForUpdate(
+        String newName,
+        MLMemoryContainer originalContainer,
+        ActionListener<Void> listener
+    ) {
+        if (!mlFeatureEnabledSetting.isAgenticMemoryNameUniquenessEnabled()) {
+            listener.onResponse(null);
+            return;
+        }
+        if (StringUtils.isBlank(newName) || newName.equals(originalContainer.getName())) {
+            // No rename (name omitted/blank), or a no-op rename to the current name.
+            listener.onResponse(null);
+            return;
+        }
+
+        NameUniquenessHelper
+            .searchByExactName(
+                client,
+                sdkClient,
+                ML_MEMORY_CONTAINER_INDEX,
+                newName,
+                originalContainer.getTenantId(),
+                ActionListener.wrap(response -> {
+                    if (response == null) {
+                        listener.onResponse(null);
+                        return;
+                    }
+                    long totalHits = response.getHits().getTotalHits() == null ? 0 : response.getHits().getTotalHits().value();
+                    if (totalHits > 0) {
+                        listener
+                            .onFailure(
+                                new OpenSearchStatusException(
+                                    "A memory container with name [" + newName + "] already exists. Memory container names must be unique.",
+                                    RestStatus.CONFLICT
+                                )
+                            );
+                    } else {
+                        listener.onResponse(null);
+                    }
+                }, listener::onFailure)
+            );
     }
 
     /**

--- a/plugin/src/main/java/org/opensearch/ml/helper/NameUniquenessHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/NameUniquenessHelper.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.helper;
+
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest;
+import org.opensearch.remote.metadata.common.SdkClientUtils;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.transport.client.Client;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Shared plumbing for "is this name already used in a tenant-scoped index?" checks used by the
+ * agent and memory-container uniqueness flags. Mirrors the pattern in
+ * {@code MLModelGroupManager#validateUniqueModelGroupName}: runs an exact-match query on the
+ * {@code name.keyword} subfield under the tenant's scope and hands the raw {@link SearchResponse}
+ * back to the caller, which is then responsible for interpreting hits, formatting the 409
+ * message, and short-circuiting on blank/same names.
+ *
+ * <p>If the target index has not been created yet, the listener receives {@code null} (treated
+ * as "no conflict possible") rather than an error.
+ *
+ * <p><b>Do not echo the conflicting hit's {@code _id} in the 409 response body.</b> Doing so
+ * would let a caller confirm the existence of resources they cannot otherwise see by probing
+ * names. The name itself is always caller-supplied input, so echoing it back is safe.
+ */
+@Log4j2
+public final class NameUniquenessHelper {
+
+    private NameUniquenessHelper() {}
+
+    /**
+     * Search an index for documents whose {@code name.keyword} exactly matches {@code name}, scoped
+     * to the given tenant.
+     *
+     * @param client     node client (used only for its ThreadContext - the search itself goes
+     *                   through {@code sdkClient})
+     * @param sdkClient  SDK client used to issue the tenant-scoped search
+     * @param indexName  index to query
+     * @param name       value to match on {@code name.keyword}
+     * @param tenantId   tenant scope for the search (may be null in single-tenant mode)
+     * @param listener   receives the {@link SearchResponse} on success, {@code null} if the index
+     *                   does not exist, or a failure otherwise
+     */
+    public static void searchByExactName(
+        Client client,
+        SdkClient sdkClient,
+        String indexName,
+        String name,
+        String tenantId,
+        ActionListener<SearchResponse> listener
+    ) {
+        BoolQueryBuilder query = new BoolQueryBuilder().filter(new TermQueryBuilder("name.keyword", name));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).size(1).fetchSource(false);
+        SearchRequest searchRequest = new SearchRequest(indexName).source(sourceBuilder);
+        SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
+            .builder()
+            .indices(searchRequest.indices())
+            .searchSourceBuilder(searchRequest.source())
+            .tenantId(tenantId)
+            .build();
+
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            sdkClient.searchDataObjectAsync(searchDataObjectRequest).whenComplete((r, throwable) -> {
+                context.restore();
+                if (throwable != null) {
+                    if (ExceptionsHelper.unwrap(throwable, IndexNotFoundException.class) != null) {
+                        // Index not yet created - no duplicate possible.
+                        listener.onResponse(null);
+                        return;
+                    }
+                    Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable);
+                    log.error("Failed to search index [{}] for name uniqueness check", indexName, cause);
+                    listener.onFailure(cause);
+                    return;
+                }
+                try {
+                    listener.onResponse(r.searchResponse());
+                } catch (Exception e) {
+                    log.error("Failed to parse search response for name uniqueness check on index [{}]", indexName, e);
+                    listener.onFailure(e);
+                }
+            });
+        } catch (Exception e) {
+            log.error("Failed to execute name uniqueness check on index [{}]", indexName, e);
+            listener.onFailure(e);
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1434,7 +1434,9 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_MAX_JSON_SIZE,
                 MLCommonsSettings.ML_COMMONS_UNIFIED_AGENT_API_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
-                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED
+                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED,
+                MLCommonsSettings.ML_COMMONS_AGENT_NAME_UNIQUENESS_ENABLED,
+                MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_NAME_UNIQUENESS_ENABLED
             );
         return settings;
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/agents/RegisterAgentTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agents/RegisterAgentTransportActionTests.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.MCP_CONNECTORS_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENT_NAME_UNIQUENESS_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_DISABLED_MESSAGE;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MCP_CONNECTOR_ENABLED;
 import static org.opensearch.ml.engine.algorithms.agent.MLChatAgentRunner.LLM_INTERFACE;
@@ -111,7 +112,8 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
         when(clusterService.getSettings()).thenReturn(settings);
-        when(this.clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, Set.of(ML_COMMONS_MCP_CONNECTOR_ENABLED)));
+        when(this.clusterService.getClusterSettings())
+            .thenReturn(new ClusterSettings(settings, Set.of(ML_COMMONS_MCP_CONNECTOR_ENABLED, ML_COMMONS_AGENT_NAME_UNIQUENESS_ENABLED)));
         transportRegisterAgentAction = new TransportRegisterAgentAction(
             transportService,
             actionFilters,
@@ -608,5 +610,305 @@ public class RegisterAgentTransportActionTests extends OpenSearchTestCase {
         ArgumentCaptor<RuntimeException> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals("Model registration failed", argumentCaptor.getValue().getMessage());
+    }
+
+    @Test
+    public void test_execute_registerAgent_uniquenessEnforced_duplicateNameRejected() {
+        when(mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()).thenReturn(true);
+
+        MLRegisterAgentRequest request = mock(MLRegisterAgentRequest.class);
+        MLAgent mlAgent = MLAgent
+            .builder()
+            .name("duplicate-agent")
+            .type(MLAgentType.CONVERSATIONAL.name())
+            .description("description")
+            .llm(new LLMSpec("model_id", new HashMap<>()))
+            .build();
+        when(request.getMlAgent()).thenReturn(mlAgent);
+
+        // Simulate a search hit (name already exists)
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.search.SearchResponse> al = invocation.getArgument(1);
+            org.apache.lucene.search.TotalHits totalHits = new org.apache.lucene.search.TotalHits(
+                1L,
+                org.apache.lucene.search.TotalHits.Relation.EQUAL_TO
+            );
+            org.opensearch.search.SearchHits hits = new org.opensearch.search.SearchHits(
+                new org.opensearch.search.SearchHit[0],
+                totalHits,
+                Float.NaN
+            );
+            org.opensearch.search.internal.InternalSearchResponse internal = new org.opensearch.search.internal.InternalSearchResponse(
+                hits,
+                org.opensearch.search.aggregations.InternalAggregations.EMPTY,
+                null,
+                null,
+                false,
+                null,
+                0
+            );
+            org.opensearch.action.search.SearchResponse searchResponse = new org.opensearch.action.search.SearchResponse(
+                internal,
+                null,
+                1,
+                1,
+                0,
+                1,
+                org.opensearch.action.search.ShardSearchFailure.EMPTY_ARRAY,
+                org.opensearch.action.search.SearchResponse.Clusters.EMPTY
+            );
+            al.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(), any());
+
+        transportRegisterAgentAction.doExecute(task, request, actionListener);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertTrue(argumentCaptor.getValue().getMessage().contains("already exists"));
+        // Index creation must NOT have been attempted when a duplicate is found
+        verify(mlIndicesHandler, times(0)).initMLAgentIndex(any());
+    }
+
+    @Test
+    public void test_execute_registerAgent_uniquenessEnforced_uniqueNameAllowed() {
+        when(mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()).thenReturn(true);
+
+        MLRegisterAgentRequest request = mock(MLRegisterAgentRequest.class);
+        MLAgent mlAgent = MLAgent
+            .builder()
+            .name("unique-agent")
+            .type(MLAgentType.CONVERSATIONAL.name())
+            .description("description")
+            .llm(new LLMSpec("model_id", new HashMap<>()))
+            .build();
+        when(request.getMlAgent()).thenReturn(mlAgent);
+
+        // Simulate a search returning zero hits (name is unique)
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.search.SearchResponse> al = invocation.getArgument(1);
+            org.apache.lucene.search.TotalHits totalHits = new org.apache.lucene.search.TotalHits(
+                0L,
+                org.apache.lucene.search.TotalHits.Relation.EQUAL_TO
+            );
+            org.opensearch.search.SearchHits hits = new org.opensearch.search.SearchHits(
+                new org.opensearch.search.SearchHit[0],
+                totalHits,
+                Float.NaN
+            );
+            org.opensearch.search.internal.InternalSearchResponse internal = new org.opensearch.search.internal.InternalSearchResponse(
+                hits,
+                org.opensearch.search.aggregations.InternalAggregations.EMPTY,
+                null,
+                null,
+                false,
+                null,
+                0
+            );
+            org.opensearch.action.search.SearchResponse searchResponse = new org.opensearch.action.search.SearchResponse(
+                internal,
+                null,
+                1,
+                1,
+                0,
+                1,
+                org.opensearch.action.search.ShardSearchFailure.EMPTY_ARRAY,
+                org.opensearch.action.search.SearchResponse.Clusters.EMPTY
+            );
+            al.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLAgentIndex(any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> al = invocation.getArgument(1);
+            al.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(), any());
+
+        transportRegisterAgentAction.doExecute(task, request, actionListener);
+
+        ArgumentCaptor<MLRegisterAgentResponse> argumentCaptor = ArgumentCaptor.forClass(MLRegisterAgentResponse.class);
+        verify(actionListener).onResponse(argumentCaptor.capture());
+        assertNotNull(argumentCaptor.getValue());
+    }
+
+    @Test
+    public void test_execute_registerAgent_uniquenessEnforced_indexNotFound_allowsRegistration() {
+        when(mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()).thenReturn(true);
+
+        MLRegisterAgentRequest request = mock(MLRegisterAgentRequest.class);
+        MLAgent mlAgent = MLAgent
+            .builder()
+            .name("first-agent")
+            .type(MLAgentType.CONVERSATIONAL.name())
+            .description("description")
+            .llm(new LLMSpec("model_id", new HashMap<>()))
+            .build();
+        when(request.getMlAgent()).thenReturn(mlAgent);
+
+        // Simulate IndexNotFoundException from search - happens before any agent has ever been registered.
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.search.SearchResponse> al = invocation.getArgument(1);
+            al.onFailure(new org.opensearch.index.IndexNotFoundException(ML_AGENT_INDEX));
+            return null;
+        }).when(client).search(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLAgentIndex(any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> al = invocation.getArgument(1);
+            al.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(), any());
+
+        transportRegisterAgentAction.doExecute(task, request, actionListener);
+
+        ArgumentCaptor<MLRegisterAgentResponse> argumentCaptor = ArgumentCaptor.forClass(MLRegisterAgentResponse.class);
+        verify(actionListener).onResponse(argumentCaptor.capture());
+        assertNotNull(argumentCaptor.getValue());
+    }
+
+    @Test
+    public void test_execute_registerAgent_uniquenessDisabled_skipsSearch() {
+        // Default: uniqueness disabled - no search should occur
+        when(mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()).thenReturn(false);
+
+        MLRegisterAgentRequest request = mock(MLRegisterAgentRequest.class);
+        MLAgent mlAgent = MLAgent
+            .builder()
+            .name("any-agent")
+            .type(MLAgentType.CONVERSATIONAL.name())
+            .description("description")
+            .llm(new LLMSpec("model_id", new HashMap<>()))
+            .build();
+        when(request.getMlAgent()).thenReturn(mlAgent);
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLAgentIndex(any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> al = invocation.getArgument(1);
+            al.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(), any());
+
+        transportRegisterAgentAction.doExecute(task, request, actionListener);
+
+        verify(client, times(0)).search(any(), any());
+        ArgumentCaptor<MLRegisterAgentResponse> argumentCaptor = ArgumentCaptor.forClass(MLRegisterAgentResponse.class);
+        verify(actionListener).onResponse(argumentCaptor.capture());
+    }
+
+    /**
+     * Builds a real SearchResponse with the given total-hit count so we can drive the
+     * ActionListener callback path through mock client.search(...).
+     */
+    private org.opensearch.action.search.SearchResponse buildSearchResponseWithHits(long hitCount) {
+        org.apache.lucene.search.TotalHits totalHits = new org.apache.lucene.search.TotalHits(
+            hitCount,
+            org.apache.lucene.search.TotalHits.Relation.EQUAL_TO
+        );
+        org.opensearch.search.SearchHits hits = new org.opensearch.search.SearchHits(
+            new org.opensearch.search.SearchHit[0],
+            totalHits,
+            Float.NaN
+        );
+        org.opensearch.search.internal.InternalSearchResponse internal = new org.opensearch.search.internal.InternalSearchResponse(
+            hits,
+            org.opensearch.search.aggregations.InternalAggregations.EMPTY,
+            null,
+            null,
+            false,
+            null,
+            0
+        );
+        return new org.opensearch.action.search.SearchResponse(
+            internal,
+            null,
+            1,
+            1,
+            0,
+            1,
+            org.opensearch.action.search.ShardSearchFailure.EMPTY_ARRAY,
+            org.opensearch.action.search.SearchResponse.Clusters.EMPTY
+        );
+    }
+
+    @Test
+    public void test_execute_registerAgent_uniquenessEnforced_planExecuteAndReflect_executorNameCollision_rejected() {
+        when(mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()).thenReturn(true);
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("tools", "[]");
+        MLAgent mlAgent = MLAgent
+            .builder()
+            .name("per_agent")
+            .type(MLAgentType.PLAN_EXECUTE_AND_REFLECT.name())
+            .description("Plan-execute-and-reflect agent")
+            .parameters(parameters)
+            .llm(new LLMSpec("test-model-id", new HashMap<>()))
+            .build();
+
+        MLRegisterAgentRequest request = mock(MLRegisterAgentRequest.class);
+        when(request.getMlAgent()).thenReturn(mlAgent);
+
+        // First search: submitted name is available (0 hits). Second search: derived executor
+        // name "per_agent (ReAct)" already exists (1 hit) -> request must fail before any index write.
+        doAnswer(new org.mockito.stubbing.Answer<Void>() {
+            private int callCount = 0;
+
+            @Override
+            public Void answer(org.mockito.invocation.InvocationOnMock invocation) {
+                ActionListener<org.opensearch.action.search.SearchResponse> al = invocation.getArgument(1);
+                long hits = (callCount++ == 0) ? 0L : 1L;
+                al.onResponse(buildSearchResponseWithHits(hits));
+                return null;
+            }
+        }).when(client).search(any(), any());
+
+        transportRegisterAgentAction.doExecute(task, request, actionListener);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertTrue(argumentCaptor.getValue().getMessage().contains("(ReAct)"));
+        assertTrue(argumentCaptor.getValue().getMessage().contains("already exists"));
+        // Neither the submitted agent nor its executor should have been indexed
+        verify(mlIndicesHandler, times(0)).initMLAgentIndex(any());
+    }
+
+    @Test
+    public void test_execute_registerAgent_multiTenancy_missingTenantId_failsBeforeSearch() {
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()).thenReturn(true);
+
+        // No tenantId on the agent
+        MLAgent mlAgent = MLAgent
+            .builder()
+            .name("some-agent")
+            .type(MLAgentType.CONVERSATIONAL.name())
+            .description("description")
+            .llm(new LLMSpec("model_id", new HashMap<>()))
+            .build();
+        MLRegisterAgentRequest request = mock(MLRegisterAgentRequest.class);
+        when(request.getMlAgent()).thenReturn(mlAgent);
+
+        transportRegisterAgentAction.doExecute(task, request, actionListener);
+
+        // Tenant validation must fail fast, before any metadata search is issued
+        verify(client, times(0)).search(any(), any());
+        verify(actionListener).onFailure(any(Exception.class));
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/agents/UpdateAgentTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agents/UpdateAgentTransportActionTests.java
@@ -6,6 +6,8 @@
 package org.opensearch.ml.action.agents;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
@@ -288,6 +290,228 @@ public class UpdateAgentTransportActionTests {
         ArgumentCaptor<OpenSearchStatusException> argumentCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
         assertEquals(RestStatus.FORBIDDEN, argumentCaptor.getValue().status());
+    }
+
+    @Test
+    public void testDoExecute_uniquenessEnforced_renameToExistingName_rejected() throws IOException {
+        when(mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()).thenReturn(true);
+
+        String agentId = "test_agent_id";
+        MLAgentUpdateInput mlAgentUpdateInput = MLAgentUpdateInput
+            .builder()
+            .agentId(agentId)
+            .name("other_agent")
+            .description("desc")
+            .build();
+
+        GetResponse getResponse = prepareMLAgentGetResponse(agentId, false, null);
+
+        MLAgentUpdateRequest updateRequest = mock(MLAgentUpdateRequest.class);
+        when(updateRequest.getMlAgentUpdateInput()).thenReturn(mlAgentUpdateInput);
+        doReturn(true).when(updateAgentTransportAction).isSuperAdminUserWrapper(clusterService, client);
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.search.SearchResponse> al = invocation.getArgument(1);
+            al.onResponse(buildSearchResponseWithConflictingHit("conflicting_agent_id"));
+            return null;
+        }).when(client).search(any(), any());
+
+        updateAgentTransportAction.doExecute(task, updateRequest, actionListener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.CONFLICT, ((OpenSearchStatusException) captor.getValue()).status());
+        assertTrue(captor.getValue().getMessage().contains("already exists"));
+        assertTrue(captor.getValue().getMessage().contains("other_agent"));
+        assertFalse(captor.getValue().getMessage().contains("conflicting_agent_id"));
+        // The put must not have been issued
+        verify(client, times(0)).update(any(), any());
+    }
+
+    @Test
+    public void testDoExecute_uniquenessEnforced_renameToUnusedName_allowed() throws IOException {
+        when(mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()).thenReturn(true);
+
+        String agentId = "test_agent_id";
+        MLAgentUpdateInput mlAgentUpdateInput = MLAgentUpdateInput
+            .builder()
+            .agentId(agentId)
+            .name("brand_new_name")
+            .description("desc")
+            .build();
+
+        GetResponse getResponse = prepareMLAgentGetResponse(agentId, false, null);
+
+        MLAgentUpdateRequest updateRequest = mock(MLAgentUpdateRequest.class);
+        when(updateRequest.getMlAgentUpdateInput()).thenReturn(mlAgentUpdateInput);
+        doReturn(true).when(updateAgentTransportAction).isSuperAdminUserWrapper(clusterService, client);
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.search.SearchResponse> al = invocation.getArgument(1);
+            al.onResponse(buildSearchResponseWithHits(0L));
+            return null;
+        }).when(client).search(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        updateAgentTransportAction.doExecute(task, updateRequest, actionListener);
+
+        ArgumentCaptor<UpdateResponse> captor = ArgumentCaptor.forClass(UpdateResponse.class);
+        verify(actionListener).onResponse(captor.capture());
+        assertEquals(DocWriteResponse.Result.UPDATED, captor.getValue().getResult());
+    }
+
+    @Test
+    public void testDoExecute_uniquenessEnforced_sameNameNoOp_skipsSearch() throws IOException {
+        when(mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()).thenReturn(true);
+
+        String agentId = "test_agent_id";
+        // prepareMLAgentGetResponse stores name="test"; PUT with the same name must be a no-op.
+        MLAgentUpdateInput mlAgentUpdateInput = MLAgentUpdateInput
+            .builder()
+            .agentId(agentId)
+            .name("test")
+            .description("desc")
+            .build();
+
+        GetResponse getResponse = prepareMLAgentGetResponse(agentId, false, null);
+
+        MLAgentUpdateRequest updateRequest = mock(MLAgentUpdateRequest.class);
+        when(updateRequest.getMlAgentUpdateInput()).thenReturn(mlAgentUpdateInput);
+        doReturn(true).when(updateAgentTransportAction).isSuperAdminUserWrapper(clusterService, client);
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        updateAgentTransportAction.doExecute(task, updateRequest, actionListener);
+
+        verify(client, times(0)).search(any(), any());
+        verify(actionListener).onResponse(any());
+    }
+
+    @Test
+    public void testDoExecute_uniquenessDisabled_renameSkipsSearch() throws IOException {
+        when(mlFeatureEnabledSetting.isAgentNameUniquenessEnabled()).thenReturn(false);
+
+        String agentId = "test_agent_id";
+        MLAgentUpdateInput mlAgentUpdateInput = MLAgentUpdateInput
+            .builder()
+            .agentId(agentId)
+            .name("renamed_but_flag_off")
+            .description("desc")
+            .build();
+
+        GetResponse getResponse = prepareMLAgentGetResponse(agentId, false, null);
+
+        MLAgentUpdateRequest updateRequest = mock(MLAgentUpdateRequest.class);
+        when(updateRequest.getMlAgentUpdateInput()).thenReturn(mlAgentUpdateInput);
+        doReturn(true).when(updateAgentTransportAction).isSuperAdminUserWrapper(clusterService, client);
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        updateAgentTransportAction.doExecute(task, updateRequest, actionListener);
+
+        verify(client, times(0)).search(any(), any());
+        verify(actionListener).onResponse(any());
+    }
+
+    private org.opensearch.action.search.SearchResponse buildSearchResponseWithHits(long hitCount) {
+        org.apache.lucene.search.TotalHits totalHits = new org.apache.lucene.search.TotalHits(
+            hitCount,
+            org.apache.lucene.search.TotalHits.Relation.EQUAL_TO
+        );
+        org.opensearch.search.SearchHits hits = new org.opensearch.search.SearchHits(
+            new org.opensearch.search.SearchHit[0],
+            totalHits,
+            Float.NaN
+        );
+        org.opensearch.search.internal.InternalSearchResponse internal = new org.opensearch.search.internal.InternalSearchResponse(
+            hits,
+            org.opensearch.search.aggregations.InternalAggregations.EMPTY,
+            null,
+            null,
+            false,
+            null,
+            0
+        );
+        return new org.opensearch.action.search.SearchResponse(
+            internal,
+            null,
+            1,
+            1,
+            0,
+            1,
+            org.opensearch.action.search.ShardSearchFailure.EMPTY_ARRAY,
+            org.opensearch.action.search.SearchResponse.Clusters.EMPTY
+        );
+    }
+
+    private org.opensearch.action.search.SearchResponse buildSearchResponseWithConflictingHit(String conflictingId) {
+        org.apache.lucene.search.TotalHits totalHits = new org.apache.lucene.search.TotalHits(
+            1L,
+            org.apache.lucene.search.TotalHits.Relation.EQUAL_TO
+        );
+        org.opensearch.search.SearchHit hit = new org.opensearch.search.SearchHit(0, conflictingId, null, null);
+        org.opensearch.search.SearchHits hits = new org.opensearch.search.SearchHits(
+            new org.opensearch.search.SearchHit[] { hit },
+            totalHits,
+            Float.NaN
+        );
+        org.opensearch.search.internal.InternalSearchResponse internal = new org.opensearch.search.internal.InternalSearchResponse(
+            hits,
+            org.opensearch.search.aggregations.InternalAggregations.EMPTY,
+            null,
+            null,
+            false,
+            null,
+            0
+        );
+        return new org.opensearch.action.search.SearchResponse(
+            internal,
+            null,
+            1,
+            1,
+            0,
+            1,
+            org.opensearch.action.search.ShardSearchFailure.EMPTY_ARRAY,
+            org.opensearch.action.search.SearchResponse.Clusters.EMPTY
+        );
     }
 
     private GetResponse prepareMLAgentGetResponse(String agentId, boolean isHidden, String tenantId) throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -75,6 +75,8 @@ import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.remote.metadata.client.PutDataObjectRequest;
 import org.opensearch.remote.metadata.client.PutDataObjectResponse;
 import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest;
+import org.opensearch.remote.metadata.client.SearchDataObjectResponse;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -1955,5 +1957,93 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
             listener.onResponse(embeddingModel);
             return null;
         }).when(mlModelManager).getModel(eq("test-embedding-model"), any());
+    }
+
+    private SearchDataObjectResponse searchDataObjectResponseWithHits(long hitCount) {
+        org.apache.lucene.search.TotalHits totalHits = new org.apache.lucene.search.TotalHits(
+            hitCount,
+            org.apache.lucene.search.TotalHits.Relation.EQUAL_TO
+        );
+        org.opensearch.search.SearchHits hits = new org.opensearch.search.SearchHits(
+            new org.opensearch.search.SearchHit[0],
+            totalHits,
+            Float.NaN
+        );
+        org.opensearch.search.internal.InternalSearchResponse internal = new org.opensearch.search.internal.InternalSearchResponse(
+            hits,
+            org.opensearch.search.aggregations.InternalAggregations.EMPTY,
+            null,
+            null,
+            false,
+            null,
+            0
+        );
+        org.opensearch.action.search.SearchResponse searchResponse = new org.opensearch.action.search.SearchResponse(
+            internal,
+            null,
+            1,
+            1,
+            0,
+            1,
+            org.opensearch.action.search.ShardSearchFailure.EMPTY_ARRAY,
+            org.opensearch.action.search.SearchResponse.Clusters.EMPTY
+        );
+        SearchDataObjectResponse sdkResp = mock(SearchDataObjectResponse.class);
+        when(sdkResp.searchResponse()).thenReturn(searchResponse);
+        return sdkResp;
+    }
+
+    public void testDoExecute_UniquenessEnforced_DuplicateNameRejected() throws InterruptedException {
+        when(mlFeatureEnabledSetting.isAgenticMemoryNameUniquenessEnabled()).thenReturn(true);
+
+        // Simulate search returning 1 hit (name already exists)
+        CompletableFuture<SearchDataObjectResponse> future = CompletableFuture.completedFuture(searchDataObjectResponseWithHits(1L));
+        when(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, request, actionListener);
+
+        verify(actionListener).onFailure(exceptionCaptor.capture());
+        Exception exception = exceptionCaptor.getValue();
+        assertNotNull(exception);
+        assertTrue(exception instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.CONFLICT, ((OpenSearchStatusException) exception).status());
+        assertTrue(exception.getMessage().contains("already exists"));
+        // putDataObjectAsync must NOT be called when duplicate is detected
+        verify(sdkClient, org.mockito.Mockito.never()).putDataObjectAsync(any(PutDataObjectRequest.class));
+    }
+
+    public void testDoExecute_UniquenessEnforced_UniqueNameAllowed() throws InterruptedException {
+        when(mlFeatureEnabledSetting.isAgenticMemoryNameUniquenessEnabled()).thenReturn(true);
+
+        // Simulate search returning 0 hits (name is unique)
+        CompletableFuture<SearchDataObjectResponse> searchFuture = CompletableFuture.completedFuture(searchDataObjectResponseWithHits(0L));
+        when(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest.class))).thenReturn(searchFuture);
+
+        mockSuccessfulCreatePipeline();
+        mockAndRunExecuteMethod(request);
+
+        verify(sdkClient).searchDataObjectAsync(any(SearchDataObjectRequest.class));
+    }
+
+    public void testDoExecute_UniquenessEnforced_IndexNotFound_AllowsCreation() throws InterruptedException {
+        when(mlFeatureEnabledSetting.isAgenticMemoryNameUniquenessEnabled()).thenReturn(true);
+
+        // Simulate IndexNotFoundException - first time a memory container is ever created
+        CompletableFuture<SearchDataObjectResponse> searchFuture = new CompletableFuture<>();
+        searchFuture.completeExceptionally(new IndexNotFoundException(ML_MEMORY_CONTAINER_INDEX));
+        when(sdkClient.searchDataObjectAsync(any(SearchDataObjectRequest.class))).thenReturn(searchFuture);
+
+        mockSuccessfulCreatePipeline();
+        mockAndRunExecuteMethod(request);
+    }
+
+    public void testDoExecute_UniquenessDisabled_SkipsSearch() throws InterruptedException {
+        // Default: uniqueness disabled
+        when(mlFeatureEnabledSetting.isAgenticMemoryNameUniquenessEnabled()).thenReturn(false);
+
+        mockSuccessfulCreatePipeline();
+        mockAndRunExecuteMethod(request);
+
+        verify(sdkClient, org.mockito.Mockito.never()).searchDataObjectAsync(any(SearchDataObjectRequest.class));
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerActionTests.java
@@ -2283,4 +2283,251 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
         verify(listener, never()).onResponse(any());
     }
 
+    public void testDoExecute_uniquenessEnforced_renameToExistingName_rejected() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryNameUniquenessEnabled()).thenReturn(true);
+
+        String containerId = "test-container-id";
+        String newName = "taken-name";
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().name(newName).build();
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("old-name")
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        java.util.concurrent.CompletableFuture<
+            org.opensearch.remote.metadata.client.SearchDataObjectResponse
+        > future = java.util.concurrent.CompletableFuture.completedFuture(searchDataObjectResponseWithHit("conflicting-container-id"));
+        when(sdkClient.searchDataObjectAsync(any(org.opensearch.remote.metadata.client.SearchDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, request, listener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(captor.capture());
+        Exception exception = captor.getValue();
+        assertTrue(exception instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.CONFLICT, ((OpenSearchStatusException) exception).status());
+        assertTrue(exception.getMessage().contains("already exists"));
+        assertTrue(exception.getMessage().contains(newName));
+        assertFalse(exception.getMessage().contains("conflicting-container-id"));
+        // Must not have attempted a write when a duplicate is found.
+        verify(client, never()).update(any(), any());
+    }
+
+    public void testDoExecute_uniquenessEnforced_renameToUnusedName_allowed() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryNameUniquenessEnabled()).thenReturn(true);
+
+        String containerId = "test-container-id";
+        String newName = "brand-new-name";
+
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().name(newName).build();
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("old-name")
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        java.util.concurrent.CompletableFuture<
+            org.opensearch.remote.metadata.client.SearchDataObjectResponse
+        > future = java.util.concurrent.CompletableFuture.completedFuture(searchDataObjectResponseWithHits(0L));
+        when(sdkClient.searchDataObjectAsync(any(org.opensearch.remote.metadata.client.SearchDataObjectRequest.class))).thenReturn(future);
+
+        UpdateResponse updateResponse = new UpdateResponse(
+            new ShardId(new Index("test", "uuid"), 0),
+            containerId,
+            1L,
+            1L,
+            1L,
+            org.opensearch.action.DocWriteResponse.Result.UPDATED
+        );
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateListener = invocation.getArgument(1);
+            updateListener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        action.doExecute(task, request, listener);
+
+        verify(sdkClient).searchDataObjectAsync(any(org.opensearch.remote.metadata.client.SearchDataObjectRequest.class));
+        verify(listener).onResponse(updateResponse);
+    }
+
+    public void testDoExecute_uniquenessEnforced_sameNameNoOp_skipsSearch() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryNameUniquenessEnabled()).thenReturn(true);
+
+        String containerId = "test-container-id";
+        // A PUT that re-specifies the existing name must be a no-op rename (no search, no 409).
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().name("old-name").description("new desc").build();
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("old-name")
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        UpdateResponse updateResponse = new UpdateResponse(
+            new ShardId(new Index("test", "uuid"), 0),
+            containerId,
+            1L,
+            1L,
+            1L,
+            org.opensearch.action.DocWriteResponse.Result.UPDATED
+        );
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateListener = invocation.getArgument(1);
+            updateListener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        action.doExecute(task, request, listener);
+
+        verify(sdkClient, never()).searchDataObjectAsync(any(org.opensearch.remote.metadata.client.SearchDataObjectRequest.class));
+        verify(listener).onResponse(updateResponse);
+    }
+
+    public void testDoExecute_uniquenessDisabled_renameSkipsSearch() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryNameUniquenessEnabled()).thenReturn(false);
+
+        String containerId = "test-container-id";
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().name("renamed-but-flag-off").build();
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId(containerId)
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        MLMemoryContainer container = MLMemoryContainer
+            .builder()
+            .name("old-name")
+            .owner(new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap()))
+            .build();
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        UpdateResponse updateResponse = new UpdateResponse(
+            new ShardId(new Index("test", "uuid"), 0),
+            containerId,
+            1L,
+            1L,
+            1L,
+            org.opensearch.action.DocWriteResponse.Result.UPDATED
+        );
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> updateListener = invocation.getArgument(1);
+            updateListener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(), any());
+
+        action.doExecute(task, request, listener);
+
+        verify(sdkClient, never()).searchDataObjectAsync(any(org.opensearch.remote.metadata.client.SearchDataObjectRequest.class));
+        verify(listener).onResponse(updateResponse);
+    }
+
+    private org.opensearch.remote.metadata.client.SearchDataObjectResponse searchDataObjectResponseWithHits(long hitCount) {
+        org.apache.lucene.search.TotalHits totalHits = new org.apache.lucene.search.TotalHits(
+            hitCount,
+            org.apache.lucene.search.TotalHits.Relation.EQUAL_TO
+        );
+        org.opensearch.search.SearchHits hits = new org.opensearch.search.SearchHits(
+            new org.opensearch.search.SearchHit[0],
+            totalHits,
+            Float.NaN
+        );
+        return buildSdkSearchResponse(hits);
+    }
+
+    private org.opensearch.remote.metadata.client.SearchDataObjectResponse searchDataObjectResponseWithHit(String conflictingId) {
+        org.apache.lucene.search.TotalHits totalHits = new org.apache.lucene.search.TotalHits(
+            1L,
+            org.apache.lucene.search.TotalHits.Relation.EQUAL_TO
+        );
+        org.opensearch.search.SearchHit hit = new org.opensearch.search.SearchHit(0, conflictingId, null, null);
+        org.opensearch.search.SearchHits hits = new org.opensearch.search.SearchHits(
+            new org.opensearch.search.SearchHit[] { hit },
+            totalHits,
+            Float.NaN
+        );
+        return buildSdkSearchResponse(hits);
+    }
+
+    private org.opensearch.remote.metadata.client.SearchDataObjectResponse buildSdkSearchResponse(org.opensearch.search.SearchHits hits) {
+        org.opensearch.search.internal.InternalSearchResponse internal = new org.opensearch.search.internal.InternalSearchResponse(
+            hits,
+            org.opensearch.search.aggregations.InternalAggregations.EMPTY,
+            null,
+            null,
+            false,
+            null,
+            0
+        );
+        org.opensearch.action.search.SearchResponse searchResponse = new org.opensearch.action.search.SearchResponse(
+            internal,
+            null,
+            1,
+            1,
+            0,
+            1,
+            org.opensearch.action.search.ShardSearchFailure.EMPTY_ARRAY,
+            org.opensearch.action.search.SearchResponse.Clusters.EMPTY
+        );
+        org.opensearch.remote.metadata.client.SearchDataObjectResponse sdkResp = mock(
+            org.opensearch.remote.metadata.client.SearchDataObjectResponse.class
+        );
+        when(sdkResp.searchResponse()).thenReturn(searchResponse);
+        return sdkResp;
+    }
+
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLAgentNameUniquenessIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLAgentNameUniquenessIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.ml.utils.TestHelper;
+
+/**
+ * End-to-end integration tests for the agent-name-uniqueness feature gated by
+ * {@code plugins.ml_commons.agent_name_uniqueness_enabled}.
+ */
+public class RestMLAgentNameUniquenessIT extends MLCommonsRestTestCase {
+
+    private static final String SETTING_KEY = "plugins.ml_commons.agent_name_uniqueness_enabled";
+
+    @Before
+    public void setupUniquenessSetting() throws IOException {
+        // Start every test with the flag explicitly off so tests are independent of persisted state.
+        updateClusterSettings(SETTING_KEY, false);
+    }
+
+    @After
+    public void resetUniquenessSetting() throws IOException {
+        updateClusterSettings(SETTING_KEY, false);
+    }
+
+    public void testDuplicateAllowed_WhenFlagOff() throws IOException {
+        String body = registerAgentBody("it-agent-flag-off");
+
+        Response r1 = registerAgent(body);
+        assertEquals(200, r1.getStatusLine().getStatusCode());
+
+        Response r2 = registerAgent(body);
+        assertEquals(200, r2.getStatusLine().getStatusCode());
+
+        String id1 = (String) parseResponseToMap(r1).get("agent_id");
+        String id2 = (String) parseResponseToMap(r2).get("agent_id");
+        assertNotNull(id1);
+        assertNotNull(id2);
+        assertNotEquals("Duplicate names with flag off should still produce distinct agent IDs", id1, id2);
+    }
+
+    public void testDuplicateRejected_WhenFlagOn() throws IOException {
+        updateClusterSettings(SETTING_KEY, true);
+
+        String body = registerAgentBody("it-agent-flag-on");
+
+        Response r1 = registerAgent(body);
+        assertEquals(200, r1.getStatusLine().getStatusCode());
+
+        try {
+            registerAgent(body);
+            fail("Expected duplicate registration to be rejected with 409 when uniqueness flag is on");
+        } catch (ResponseException e) {
+            assertEquals(409, e.getResponse().getStatusLine().getStatusCode());
+            String payload = TestHelper.httpEntityToString(e.getResponse().getEntity());
+            assertTrue(
+                "409 response should cite the duplicate name, got: " + payload,
+                payload.contains("already exists") && payload.contains("it-agent-flag-on")
+            );
+        }
+    }
+
+    public void testUniqueNameAccepted_WhenFlagOn() throws IOException {
+        updateClusterSettings(SETTING_KEY, true);
+
+        Response r = registerAgent(registerAgentBody("it-agent-unique-" + System.nanoTime()));
+        assertEquals(200, r.getStatusLine().getStatusCode());
+        assertNotNull(parseResponseToMap(r).get("agent_id"));
+    }
+
+    public void testDynamicFlip_OnThenOff() throws IOException {
+        String body = registerAgentBody("it-agent-dynamic-flip");
+
+        updateClusterSettings(SETTING_KEY, true);
+        Response r1 = registerAgent(body);
+        assertEquals(200, r1.getStatusLine().getStatusCode());
+
+        try {
+            registerAgent(body);
+            fail("Expected 409 while flag is on");
+        } catch (ResponseException e) {
+            assertEquals(409, e.getResponse().getStatusLine().getStatusCode());
+        }
+
+        // Flip off; duplicate should now be accepted again without restart.
+        updateClusterSettings(SETTING_KEY, false);
+        Response r2 = registerAgent(body);
+        assertEquals("Duplicate must be accepted again once flag is flipped off", 200, r2.getStatusLine().getStatusCode());
+    }
+
+    private static Response registerAgent(String body) throws IOException {
+        return TestHelper.makeRequest(client(), "POST", "/_plugins/_ml/agents/_register", null, TestHelper.toHttpEntity(body), null);
+    }
+
+    private static String registerAgentBody(String name) {
+        return "{\n"
+            + "  \"name\": \""
+            + name
+            + "\",\n"
+            + "  \"type\": \"flow\",\n"
+            + "  \"description\": \"uniqueness IT agent\",\n"
+            + "  \"tools\": []\n"
+            + "}";
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLAgentNameUniquenessIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLAgentNameUniquenessIT.java
@@ -97,8 +97,75 @@ public class RestMLAgentNameUniquenessIT extends MLCommonsRestTestCase {
         assertEquals("Duplicate must be accepted again once flag is flipped off", 200, r2.getStatusLine().getStatusCode());
     }
 
+    public void testRename_ToUnusedName_Accepted_WhenFlagOn() throws IOException {
+        updateClusterSettings(SETTING_KEY, true);
+
+        Response r = registerAgent(registerAgentBody("it-agent-rename-src"));
+        String agentId = (String) parseResponseToMap(r).get("agent_id");
+        assertNotNull(agentId);
+
+        Response renamed = updateAgent(agentId, "{\"name\":\"it-agent-rename-dst-" + System.nanoTime() + "\"}");
+        assertEquals(200, renamed.getStatusLine().getStatusCode());
+    }
+
+    public void testRename_ToExistingName_Rejected_WhenFlagOn() throws IOException {
+        updateClusterSettings(SETTING_KEY, true);
+
+        // Register two distinct agents
+        Response first = registerAgent(registerAgentBody("it-agent-rename-existing"));
+        assertEquals(200, first.getStatusLine().getStatusCode());
+        String firstId = (String) parseResponseToMap(first).get("agent_id");
+        assertNotNull(firstId);
+
+        Response second = registerAgent(registerAgentBody("it-agent-rename-loser"));
+        String secondId = (String) parseResponseToMap(second).get("agent_id");
+        assertNotNull(secondId);
+
+        // Try to rename the second one onto the first one's name
+        try {
+            updateAgent(secondId, "{\"name\":\"it-agent-rename-existing\"}");
+            fail("Expected rename to an existing name to be rejected with 409");
+        } catch (ResponseException e) {
+            assertEquals(409, e.getResponse().getStatusLine().getStatusCode());
+            String payload = TestHelper.httpEntityToString(e.getResponse().getEntity());
+            assertTrue(
+                "409 response should cite the duplicate name, got: " + payload,
+                payload.contains("already exists") && payload.contains("it-agent-rename-existing")
+            );
+            assertFalse("409 response must not leak the conflicting agent id, got: " + payload, payload.contains(firstId));
+        }
+    }
+
+    public void testRename_SameName_NoOp_Accepted_WhenFlagOn() throws IOException {
+        updateClusterSettings(SETTING_KEY, true);
+
+        Response r = registerAgent(registerAgentBody("it-agent-rename-self"));
+        String agentId = (String) parseResponseToMap(r).get("agent_id");
+        assertNotNull(agentId);
+
+        // PUT with the same name: must NOT 409 against itself.
+        Response same = updateAgent(agentId, "{\"name\":\"it-agent-rename-self\"}");
+        assertEquals(200, same.getStatusLine().getStatusCode());
+    }
+
+    public void testRename_ToExistingName_Allowed_WhenFlagOff() throws IOException {
+        // Flag stays off (default from @Before). Rename onto an existing name must succeed (BWC).
+        Response first = registerAgent(registerAgentBody("it-agent-rename-bwc"));
+        assertEquals(200, first.getStatusLine().getStatusCode());
+
+        Response second = registerAgent(registerAgentBody("it-agent-rename-bwc-other"));
+        String secondId = (String) parseResponseToMap(second).get("agent_id");
+
+        Response renamed = updateAgent(secondId, "{\"name\":\"it-agent-rename-bwc\"}");
+        assertEquals(200, renamed.getStatusLine().getStatusCode());
+    }
+
     private static Response registerAgent(String body) throws IOException {
         return TestHelper.makeRequest(client(), "POST", "/_plugins/_ml/agents/_register", null, TestHelper.toHttpEntity(body), null);
+    }
+
+    private static Response updateAgent(String agentId, String body) throws IOException {
+        return TestHelper.makeRequest(client(), "PUT", "/_plugins/_ml/agents/" + agentId, null, TestHelper.toHttpEntity(body), null);
     }
 
     private static String registerAgentBody(String name) {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryContainerNameUniquenessIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryContainerNameUniquenessIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.ml.utils.TestHelper;
+
+/**
+ * End-to-end integration tests for the memory-container-name-uniqueness feature gated by
+ * {@code plugins.ml_commons.agentic_memory_name_uniqueness_enabled}.
+ */
+public class RestMLMemoryContainerNameUniquenessIT extends MLCommonsRestTestCase {
+
+    private static final String SETTING_KEY = "plugins.ml_commons.agentic_memory_name_uniqueness_enabled";
+
+    @Before
+    public void setupUniquenessSetting() throws IOException {
+        updateClusterSettings(SETTING_KEY, false);
+    }
+
+    @After
+    public void resetUniquenessSetting() throws IOException {
+        updateClusterSettings(SETTING_KEY, false);
+    }
+
+    public void testDuplicateAllowed_WhenFlagOff() throws IOException {
+        String body = createMemoryContainerBody("it-memcontainer-flag-off");
+
+        Response r1 = createMemoryContainer(body);
+        assertEquals(200, r1.getStatusLine().getStatusCode());
+
+        Response r2 = createMemoryContainer(body);
+        assertEquals(200, r2.getStatusLine().getStatusCode());
+
+        String id1 = (String) parseResponseToMap(r1).get("memory_container_id");
+        String id2 = (String) parseResponseToMap(r2).get("memory_container_id");
+        assertNotNull(id1);
+        assertNotNull(id2);
+        assertNotEquals("Duplicate names with flag off should still produce distinct container IDs", id1, id2);
+    }
+
+    public void testDuplicateRejected_WhenFlagOn() throws IOException {
+        updateClusterSettings(SETTING_KEY, true);
+
+        String body = createMemoryContainerBody("it-memcontainer-flag-on");
+
+        Response r1 = createMemoryContainer(body);
+        assertEquals(200, r1.getStatusLine().getStatusCode());
+
+        try {
+            createMemoryContainer(body);
+            fail("Expected duplicate memory container creation to be rejected with 409 when uniqueness flag is on");
+        } catch (ResponseException e) {
+            assertEquals(409, e.getResponse().getStatusLine().getStatusCode());
+            String payload = TestHelper.httpEntityToString(e.getResponse().getEntity());
+            assertTrue(
+                "409 response should cite the duplicate name, got: " + payload,
+                payload.contains("already exists") && payload.contains("it-memcontainer-flag-on")
+            );
+        }
+    }
+
+    public void testUniqueNameAccepted_WhenFlagOn() throws IOException {
+        updateClusterSettings(SETTING_KEY, true);
+
+        Response r = createMemoryContainer(createMemoryContainerBody("it-memcontainer-unique-" + System.nanoTime()));
+        assertEquals(200, r.getStatusLine().getStatusCode());
+        assertNotNull(parseResponseToMap(r).get("memory_container_id"));
+    }
+
+    public void testDynamicFlip_OnThenOff() throws IOException {
+        String body = createMemoryContainerBody("it-memcontainer-dynamic-flip");
+
+        updateClusterSettings(SETTING_KEY, true);
+        Response r1 = createMemoryContainer(body);
+        assertEquals(200, r1.getStatusLine().getStatusCode());
+
+        try {
+            createMemoryContainer(body);
+            fail("Expected 409 while flag is on");
+        } catch (ResponseException e) {
+            assertEquals(409, e.getResponse().getStatusLine().getStatusCode());
+        }
+
+        updateClusterSettings(SETTING_KEY, false);
+        Response r2 = createMemoryContainer(body);
+        assertEquals("Duplicate must be accepted again once flag is flipped off", 200, r2.getStatusLine().getStatusCode());
+    }
+
+    private static Response createMemoryContainer(String body) throws IOException {
+        return TestHelper
+            .makeRequest(client(), "POST", "/_plugins/_ml/memory_containers/_create", null, TestHelper.toHttpEntity(body), null);
+    }
+
+    private static String createMemoryContainerBody(String name) {
+        return "{\n"
+            + "  \"name\": \""
+            + name
+            + "\",\n"
+            + "  \"description\": \"uniqueness IT memory container\",\n"
+            + "  \"configuration\": {}\n"
+            + "}";
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryContainerNameUniquenessIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryContainerNameUniquenessIT.java
@@ -102,8 +102,10 @@ public class RestMLMemoryContainerNameUniquenessIT extends MLCommonsRestTestCase
         String id = (String) parseResponseToMap(r).get("memory_container_id");
         assertNotNull(id);
 
-        Response renamed = updateMemoryContainer(id, "{\"name\":\"it-memc-rename-dst-" + System.nanoTime() + "\"}");
+        String newName = "it-memc-rename-dst-" + System.nanoTime();
+        Response renamed = updateMemoryContainer(id, "{\"name\":\"" + newName + "\"}");
         assertEquals(200, renamed.getStatusLine().getStatusCode());
+        assertEquals("Rename should have been persisted", newName, getMemoryContainerName(id));
     }
 
     public void testRename_ToExistingName_Rejected_WhenFlagOn() throws IOException {
@@ -132,17 +134,24 @@ public class RestMLMemoryContainerNameUniquenessIT extends MLCommonsRestTestCase
         }
     }
 
-    public void testRename_BlankName_NoOp_Accepted_WhenFlagOn() throws IOException {
-        // A PUT with a blank name must be treated as "no rename" (mirrors the StringUtils.isNotBlank
-        // gate in TransportUpdateModelGroupAction.updateModelGroup) - must not 409.
+    public void testRename_BlankName_Rejected_WhenFlagOn() throws IOException {
+        // A PUT with a blank name must be rejected up front (mirrors MLAgentUpdateInput.validate()):
+        // we'd rather 400 than silently either 409 or overwrite the stored name with whitespace.
         updateClusterSettings(SETTING_KEY, true);
 
         Response r = createMemoryContainer(createMemoryContainerBody("it-memc-rename-blank-src"));
         String id = (String) parseResponseToMap(r).get("memory_container_id");
         assertNotNull(id);
 
-        Response blank = updateMemoryContainer(id, "{\"name\":\"   \"}");
-        assertEquals(200, blank.getStatusLine().getStatusCode());
+        try {
+            updateMemoryContainer(id, "{\"name\":\"   \"}");
+            fail("Expected blank name on rename to be rejected");
+        } catch (ResponseException e) {
+            assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+        }
+
+        // Confirm the stored name was not mutated.
+        assertEquals("it-memc-rename-blank-src", getMemoryContainerName(id));
     }
 
     public void testRename_SameName_NoOp_Accepted_WhenFlagOn() throws IOException {
@@ -175,6 +184,12 @@ public class RestMLMemoryContainerNameUniquenessIT extends MLCommonsRestTestCase
 
     private static Response updateMemoryContainer(String id, String body) throws IOException {
         return TestHelper.makeRequest(client(), "PUT", "/_plugins/_ml/memory_containers/" + id, null, TestHelper.toHttpEntity(body), null);
+    }
+
+    private String getMemoryContainerName(String id) throws IOException {
+        Response r = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/memory_containers/" + id, null, "", null);
+        assertEquals(200, r.getStatusLine().getStatusCode());
+        return (String) parseResponseToMap(r).get("name");
     }
 
     private static String createMemoryContainerBody(String name) {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryContainerNameUniquenessIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryContainerNameUniquenessIT.java
@@ -95,9 +95,86 @@ public class RestMLMemoryContainerNameUniquenessIT extends MLCommonsRestTestCase
         assertEquals("Duplicate must be accepted again once flag is flipped off", 200, r2.getStatusLine().getStatusCode());
     }
 
+    public void testRename_ToUnusedName_Accepted_WhenFlagOn() throws IOException {
+        updateClusterSettings(SETTING_KEY, true);
+
+        Response r = createMemoryContainer(createMemoryContainerBody("it-memc-rename-src"));
+        String id = (String) parseResponseToMap(r).get("memory_container_id");
+        assertNotNull(id);
+
+        Response renamed = updateMemoryContainer(id, "{\"name\":\"it-memc-rename-dst-" + System.nanoTime() + "\"}");
+        assertEquals(200, renamed.getStatusLine().getStatusCode());
+    }
+
+    public void testRename_ToExistingName_Rejected_WhenFlagOn() throws IOException {
+        updateClusterSettings(SETTING_KEY, true);
+
+        Response first = createMemoryContainer(createMemoryContainerBody("it-memc-rename-existing"));
+        assertEquals(200, first.getStatusLine().getStatusCode());
+        String firstId = (String) parseResponseToMap(first).get("memory_container_id");
+        assertNotNull(firstId);
+
+        Response second = createMemoryContainer(createMemoryContainerBody("it-memc-rename-loser"));
+        String secondId = (String) parseResponseToMap(second).get("memory_container_id");
+        assertNotNull(secondId);
+
+        try {
+            updateMemoryContainer(secondId, "{\"name\":\"it-memc-rename-existing\"}");
+            fail("Expected rename to an existing name to be rejected with 409");
+        } catch (ResponseException e) {
+            assertEquals(409, e.getResponse().getStatusLine().getStatusCode());
+            String payload = TestHelper.httpEntityToString(e.getResponse().getEntity());
+            assertTrue(
+                "409 response should cite the duplicate name, got: " + payload,
+                payload.contains("already exists") && payload.contains("it-memc-rename-existing")
+            );
+            assertFalse("409 response must not leak the conflicting memory_container_id, got: " + payload, payload.contains(firstId));
+        }
+    }
+
+    public void testRename_BlankName_NoOp_Accepted_WhenFlagOn() throws IOException {
+        // A PUT with a blank name must be treated as "no rename" (mirrors the StringUtils.isNotBlank
+        // gate in TransportUpdateModelGroupAction.updateModelGroup) - must not 409.
+        updateClusterSettings(SETTING_KEY, true);
+
+        Response r = createMemoryContainer(createMemoryContainerBody("it-memc-rename-blank-src"));
+        String id = (String) parseResponseToMap(r).get("memory_container_id");
+        assertNotNull(id);
+
+        Response blank = updateMemoryContainer(id, "{\"name\":\"   \"}");
+        assertEquals(200, blank.getStatusLine().getStatusCode());
+    }
+
+    public void testRename_SameName_NoOp_Accepted_WhenFlagOn() throws IOException {
+        updateClusterSettings(SETTING_KEY, true);
+
+        Response r = createMemoryContainer(createMemoryContainerBody("it-memc-rename-self"));
+        String id = (String) parseResponseToMap(r).get("memory_container_id");
+        assertNotNull(id);
+
+        Response same = updateMemoryContainer(id, "{\"name\":\"it-memc-rename-self\"}");
+        assertEquals(200, same.getStatusLine().getStatusCode());
+    }
+
+    public void testRename_ToExistingName_Allowed_WhenFlagOff() throws IOException {
+        // Flag stays off (default from @Before). Rename onto an existing name must succeed (BWC).
+        Response first = createMemoryContainer(createMemoryContainerBody("it-memc-rename-bwc"));
+        assertEquals(200, first.getStatusLine().getStatusCode());
+
+        Response second = createMemoryContainer(createMemoryContainerBody("it-memc-rename-bwc-other"));
+        String secondId = (String) parseResponseToMap(second).get("memory_container_id");
+
+        Response renamed = updateMemoryContainer(secondId, "{\"name\":\"it-memc-rename-bwc\"}");
+        assertEquals(200, renamed.getStatusLine().getStatusCode());
+    }
+
     private static Response createMemoryContainer(String body) throws IOException {
         return TestHelper
             .makeRequest(client(), "POST", "/_plugins/_ml/memory_containers/_create", null, TestHelper.toHttpEntity(body), null);
+    }
+
+    private static Response updateMemoryContainer(String id, String body) throws IOException {
+        return TestHelper.makeRequest(client(), "PUT", "/_plugins/_ml/memory_containers/" + id, null, TestHelper.toHttpEntity(body), null);
     }
 
     private static String createMemoryContainerBody(String name) {


### PR DESCRIPTION
### Description

Adds two opt-in, dynamic cluster settings, both default `false` for backward compatibility:
- `plugins.ml_commons.agent_name_uniqueness_enabled`
- `plugins.ml_commons.agentic_memory_name_uniqueness_enabled`

When enabled, registering an Agent or creating an Agentic Memory Container with a name that already exists in the same tenant is rejected with HTTP 409 CONFLICT. Default off preserves existing behavior.

**Semantics: best-effort, not atomic.** This matches the existing pattern in `MLModelGroupManager.validateUniqueModelGroupName` (term query on `name.keyword + tenantId`, then unconditional index write) and inherits the same race window 1:1 — two concurrent registrations with the same name can both observe zero hits and both succeed. Closing the race would require a sidecar lock index + `OpType.CREATE` on a deterministic `_id`; that hardening should be applied uniformly across model groups, agents, and memory containers and is intentionally left for a follow-up.

**What this PR adds beyond the model-group precedent:**
- Opt-in via dynamic cluster setting (model group enforces unconditionally).
- HTTP 409 instead of 400 `IllegalArgumentException`.
- Tenant validation runs **before** the uniqueness search, so in multi-tenant mode a missing tenant fails fast with 403 rather than leaking cross-tenant existence via a 409.
- For `PLAN_EXECUTE_AND_REFLECT` agents without a pre-existing `executor_agent_id`, the auto-created `"<name> (ReAct)"` executor agent's name is also validated so the derived agent can't collide with an existing one.
- `IndexNotFoundException` from the search is treated as "no duplicate possible" so first-ever registrations on a fresh cluster work.

### Manual verification

Verified end-to-end on a single-node cluster (`./gradlew :opensearch-ml-plugin:run`):

| # | Scenario | Result |
|---|----------|--------|
| 1 | Both flags surface via `_cluster/settings?include_defaults=true` as `false` | ✅ |
| 2 | Agent: flag OFF → register same name twice | ✅ both 200 (BWC preserved) |
| 3 | Agent: flag ON → register duplicate name | ✅ 409 with clear error |
| 4 | Agent: flag ON → register unique name | ✅ 200 |
| 5 | Agent: flip flag OFF → duplicate allowed (dynamic) | ✅ 200 |
| 6 | Memory container: flag OFF → create twice | ✅ both 200 |
| 7 | Memory container: flag ON → duplicate | ✅ 409 |
| 8 | Memory container: flag ON → unique | ✅ 200 |
| 9 | Memory container: flip flag OFF → duplicate | ✅ 200 |
| 10 | Cross-independence: flags gate only their own resource | ✅ |

### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md). _(No REST API contract change — only new cluster settings.)_
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).