### PR TITLE
Update Gradle to 9.4.1 and Jacoco to 0.8.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ allprojects {
     }
 
     plugins.withId('jacoco') {
-        jacoco.toolVersion = '0.8.13'
+        jacoco.toolVersion = '0.8.14'
     }
 
     project.getExtensions().getExtraProperties().set("versions", VersionProperties.getVersions());

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=16f2b95838c1ddcf7242b1c39e7bbbb43c842f1f1a1a0dc4959b6d4d68abcac3
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=708d2c6ecc97ca9a11838ef64a6c2301151b8dd10387e22dc1a12c30557cab5b


### PR DESCRIPTION
## Description

Bumps the Gradle wrapper from **9.2.0 → 9.4.1** and the Jacoco tool version from **0.8.13 → 0.8.14**. This mirrors the change already landed in OpenSearch core: [opensearch-project/OpenSearch#21153](https://github.com/opensearch-project/OpenSearch/pull/21153) (merged 2026-04-07).

### Why

OpenSearch's `build-tools` `GlobalBuildInfoPlugin` now requires **Gradle 9.4.1+**. Since ml-commons still pins the wrapper to 9.2.0, every CI run — including pushes to `main` — fails during project evaluation with:

```
* What went wrong:
A problem occurred evaluating project ':opensearch-ml-plugin'.
> Failed to apply plugin class 'org.opensearch.gradle.info.GlobalBuildInfoPlugin'.
   > Gradle 9.4.1+ is required
```

### Failing CI examples

- **PR #4808 Spotless Check:** [runs/25388318335](https://github.com/opensearch-project/ml-commons/actions/runs/25388318335/job/74455601368?pr=4808) — fails before spotless can even run, during project evaluation.
- **`main` Build and Test (commit `20889dc2a`):** [runs/25350445058](https://github.com/opensearch-project/ml-commons/actions/runs/25350445058) — same failure, not PR-specific.
- Multiple consecutive `main` runs have been red for the same reason.

### Precedence

OpenSearch core hit and fixed this exact issue one month ago in [opensearch-project/OpenSearch#21153](https://github.com/opensearch-project/OpenSearch/pull/21153):

- Same Gradle target (9.4.1) and same SHA-256.
- Same Jacoco bump (0.8.13 → 0.8.14).
- This PR's diff is byte-identical to core's, just applied to ml-commons' root `build.gradle` (where the `jacoco.toolVersion` lives) instead of core's `gradle/code-coverage.gradle`.

Sibling plugin repos (`neural-search`, `k-NN`) are still on 9.2.0 and will need the same bump.

## Changes

- `gradle/wrapper/gradle-wrapper.properties`: `gradle-9.2.0-all.zip` → `gradle-9.4.1-all.zip` (+ updated SHA-256; line ordering matched to core).
- `build.gradle`: `jacoco.toolVersion = '0.8.13'` → `'0.8.14'`.

## Test plan

- [x] Ran `./gradlew spotlessCheck` locally with the updated wrapper — **BUILD SUCCESSFUL** across all 7 modules.
- [ ] CI spotless job goes green on this PR.
- [ ] CI Build and Test job proceeds past project evaluation.

## Issues resolved

Unblocks all failing CI runs on `main` and on open PRs caused by the Gradle version requirement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).