### PR TITLE
Fix MCP agent execution hang after MCP SDK 1.1.1 bump

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -810,13 +810,6 @@ public class AgentUtils {
         AtomicInteger remainingConnectors = new AtomicInteger(mcpConnectorConfigs.size());
         List<MLToolSpec> finalToolSpecs = Collections.synchronizedList(new ArrayList<>());
 
-        // Guarantees final listener fires exactly once; every code path decrements via try/finally.
-        Runnable completeIfLast = () -> {
-            if (remainingConnectors.decrementAndGet() == 0) {
-                finalListener.onResponse(finalToolSpecs);
-            }
-        };
-
         // We make multiple Async calls in for loop, which happen in parallel
         for (Map<String, Object> mcpConnectorConfig : mcpConnectorConfigs) {
             String connectorId = (String) mcpConnectorConfig.get(MCP_CONNECTOR_ID_FIELD);
@@ -846,17 +839,28 @@ public class AgentUtils {
                     } catch (Throwable t) {
                         log.error("Error post-processing MCP tool specs for connector: " + connectorId, t);
                     } finally {
-                        completeIfLast.run();
+                        completeIfLast(remainingConnectors, finalToolSpecs, finalListener);
                     }
                 }, e -> {
                     log.error("Error processing connector: " + connectorId, e);
-                    completeIfLast.run();
+                    completeIfLast(remainingConnectors, finalToolSpecs, finalListener);
                 }));
             } catch (Throwable t) {
                 // Catch synchronous throws (including Errors) so one bad connector can't strand the counter.
                 log.error("Synchronous failure initiating MCP tool spec lookup for connector: " + connectorId, t);
-                completeIfLast.run();
+                completeIfLast(remainingConnectors, finalToolSpecs, finalListener);
             }
+        }
+    }
+
+    // Guarantees the final listener fires exactly once; every code path decrements via try/finally.
+    private static void completeIfLast(
+        AtomicInteger remainingConnectors,
+        List<MLToolSpec> finalToolSpecs,
+        ActionListener<List<MLToolSpec>> finalListener
+    ) {
+        if (remainingConnectors.decrementAndGet() == 0) {
+            finalListener.onResponse(finalToolSpecs);
         }
     }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -810,42 +810,53 @@ public class AgentUtils {
         AtomicInteger remainingConnectors = new AtomicInteger(mcpConnectorConfigs.size());
         List<MLToolSpec> finalToolSpecs = Collections.synchronizedList(new ArrayList<>());
 
+        // Guarantees final listener fires exactly once; every code path decrements via try/finally.
+        Runnable completeIfLast = () -> {
+            if (remainingConnectors.decrementAndGet() == 0) {
+                finalListener.onResponse(finalToolSpecs);
+            }
+        };
+
         // We make multiple Async calls in for loop, which happen in parallel
         for (Map<String, Object> mcpConnectorConfig : mcpConnectorConfigs) {
             String connectorId = (String) mcpConnectorConfig.get(MCP_CONNECTOR_ID_FIELD);
             List<String> toolFilters = (List<String>) mcpConnectorConfig.get(TOOL_FILTERS_FIELD);
 
-            getMCPToolSpecsFromConnector(connectorId, tenantId, sdkClient, client, encryptor, ActionListener.wrap(mcpToolspecs -> {
-                List<MLToolSpec> filteredTools;
-                if (toolFilters == null || toolFilters.isEmpty()) {
-                    filteredTools = mcpToolspecs;
-                } else {
-                    filteredTools = new ArrayList<>();
-                    List<Pattern> compiledPatterns = toolFilters.stream().map(Pattern::compile).collect(Collectors.toList());
+            try {
+                getMCPToolSpecsFromConnector(connectorId, tenantId, sdkClient, client, encryptor, ActionListener.wrap(mcpToolspecs -> {
+                    try {
+                        List<MLToolSpec> filteredTools;
+                        if (toolFilters == null || toolFilters.isEmpty()) {
+                            filteredTools = mcpToolspecs;
+                        } else {
+                            filteredTools = new ArrayList<>();
+                            List<Pattern> compiledPatterns = toolFilters.stream().map(Pattern::compile).collect(Collectors.toList());
 
-                    for (MLToolSpec toolSpec : mcpToolspecs) {
-                        for (Pattern pattern : compiledPatterns) {
-                            if (pattern.matcher(toolSpec.getName()).matches()) {
-                                filteredTools.add(toolSpec);
-                                break;
+                            for (MLToolSpec toolSpec : mcpToolspecs) {
+                                for (Pattern pattern : compiledPatterns) {
+                                    if (pattern.matcher(toolSpec.getName()).matches()) {
+                                        filteredTools.add(toolSpec);
+                                        break;
+                                    }
+                                }
                             }
                         }
+
+                        finalToolSpecs.addAll(filteredTools);
+                    } catch (Throwable t) {
+                        log.error("Error post-processing MCP tool specs for connector: " + connectorId, t);
+                    } finally {
+                        completeIfLast.run();
                     }
-                }
-
-                finalToolSpecs.addAll(filteredTools);
-
-                // If this is the last connector, send the final response
-                if (remainingConnectors.decrementAndGet() == 0) {
-                    finalListener.onResponse(finalToolSpecs);
-                }
-            }, e -> {
-                log.error("Error processing connector: " + connectorId, e);
-                // Even on error, we need to check if this is the last connector
-                if (remainingConnectors.decrementAndGet() == 0) {
-                    finalListener.onResponse(finalToolSpecs);
-                }
-            }));
+                }, e -> {
+                    log.error("Error processing connector: " + connectorId, e);
+                    completeIfLast.run();
+                }));
+            } catch (Throwable t) {
+                // Catch synchronous throws (including Errors) so one bad connector can't strand the counter.
+                log.error("Synchronous failure initiating MCP tool spec lookup for connector: " + connectorId, t);
+                completeIfLast.run();
+            }
         }
     }
 
@@ -893,12 +904,13 @@ public class AgentUtils {
                     toolListener.onFailure(e);
                 });
                 connector.decrypt("", encryptor::decrypt, tenantId, decryptSuccessfulListener);
-            } catch (Exception e) {
-                log.error("Failed to get tools from connector: " + connectorId, e);
+            } catch (Throwable t) {
+                // Throwable, not Exception: ServiceConfigurationError would otherwise stall the async chain.
+                log.error("Error retrieving MCP tool specs from connector: " + connectorId, t);
                 toolListener.onResponse(Collections.emptyList());
             }
         }, e -> {
-            log.error("Failed to get the MCP Connector: " + connectorId, e);
+            log.error("Failed to get connector for MCP tool specs, connectorId=" + connectorId, e);
             toolListener.onResponse(Collections.emptyList());
         }));
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -1695,7 +1695,7 @@ public class MLChatAgentRunner implements MLAgentRunner {
             processUnifiedToolsWithBackend(mlAgent, params, listener, memory, functionCalling, frontendTools, backendToolsMap, toolSpecMap);
         }, e -> {
             // Even if MCP tools fail, continue with base backend tools
-
+            log.warn("Failed to load MCP tools, continuing with backend tools only", e);
             Map<String, Tool> backendToolsMap = new HashMap<>();
             Map<String, MLToolSpec> toolSpecMap = new HashMap<>();
             createTools(toolFactories, params, backendToolSpecs, backendToolsMap, toolSpecMap, mlAgent);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -1685,23 +1685,27 @@ public class MLChatAgentRunner implements MLAgentRunner {
         getMcpToolSpecs(mlAgent, client, sdkClient, encryptor, ActionListener.wrap(mcpTools -> {
             // Add MCP tools to backend tools
             backendToolSpecs.addAll(mcpTools);
-
-            // Create backend tools map
-            Map<String, Tool> backendToolsMap = new HashMap<>();
-            Map<String, MLToolSpec> toolSpecMap = new HashMap<>();
-            createTools(toolFactories, params, backendToolSpecs, backendToolsMap, toolSpecMap, mlAgent);
-
-            // Create unified tool list for function calling (frontend + backend)
-            processUnifiedToolsWithBackend(mlAgent, params, listener, memory, functionCalling, frontendTools, backendToolsMap, toolSpecMap);
+            buildAndProcessUnifiedTools(mlAgent, params, listener, memory, functionCalling, frontendTools, backendToolSpecs);
         }, e -> {
             // Even if MCP tools fail, continue with base backend tools
             log.warn("Failed to load MCP tools, continuing with backend tools only", e);
-            Map<String, Tool> backendToolsMap = new HashMap<>();
-            Map<String, MLToolSpec> toolSpecMap = new HashMap<>();
-            createTools(toolFactories, params, backendToolSpecs, backendToolsMap, toolSpecMap, mlAgent);
-
-            processUnifiedToolsWithBackend(mlAgent, params, listener, memory, functionCalling, frontendTools, backendToolsMap, toolSpecMap);
+            buildAndProcessUnifiedTools(mlAgent, params, listener, memory, functionCalling, frontendTools, backendToolSpecs);
         }));
+    }
+
+    private void buildAndProcessUnifiedTools(
+        MLAgent mlAgent,
+        Map<String, String> params,
+        ActionListener<Object> listener,
+        Memory memory,
+        FunctionCalling functionCalling,
+        List<Map<String, Object>> frontendTools,
+        List<MLToolSpec> backendToolSpecs
+    ) {
+        Map<String, Tool> backendToolsMap = new HashMap<>();
+        Map<String, MLToolSpec> toolSpecMap = new HashMap<>();
+        createTools(toolFactories, params, backendToolSpecs, backendToolsMap, toolSpecMap, mlAgent);
+        processUnifiedToolsWithBackend(mlAgent, params, listener, memory, functionCalling, frontendTools, backendToolsMap, toolSpecMap);
     }
 
     /**

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
@@ -47,6 +47,8 @@ import com.google.gson.Gson;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapperSupplier;
+import io.modelcontextprotocol.json.schema.jackson3.JacksonJsonSchemaValidatorSupplier;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.Getter;
@@ -88,9 +90,10 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
                 getMcpRequestHeaders(builder);
             };
 
-            // Create transport
+            // Explicit jsonMapper() bypasses MCP SDK's ServiceLoader lookup, which fails under plugin classloader isolation.
             McpClientTransport transport = HttpClientSseClientTransport
                 .builder(mcpServerUrl)
+                .jsonMapper(new JacksonMcpJsonMapperSupplier().get())
                 .sseEndpoint(sseEndpoint)
                 .customizeClient(clientBuilder -> {
                     clientBuilder.connectTimeout(connectionTimeout);
@@ -98,11 +101,12 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
                 .customizeRequest(headerConfig)
                 .build();
 
-            // Create and initialize client
+            // Explicit jsonSchemaValidator() bypasses another ServiceLoader lookup under plugin classloader isolation.
             McpSyncClient client = McpClient
                 .sync(transport)
                 .requestTimeout(readTimeout)
                 .capabilities(McpSchema.ClientCapabilities.builder().roots(false).build())
+                .jsonSchemaValidator(new JacksonJsonSchemaValidatorSupplier().get())
                 .build();
 
             client.initialize();

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
@@ -47,7 +47,9 @@ import com.google.gson.Gson;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapperSupplier;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import io.modelcontextprotocol.json.schema.jackson3.JacksonJsonSchemaValidatorSupplier;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -58,6 +60,11 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 @ConnectorExecutor(MCP_SSE)
 public class McpConnectorExecutor extends AbstractConnectorExecutor {
+
+    // Cached singletons; the suppliers' outputs are thread-safe and the schema validator caches compiled schemas.
+    // Explicit instances also bypass the MCP SDK's ServiceLoader lookup, which fails under plugin classloader isolation.
+    private static final McpJsonMapper JSON_MAPPER = new JacksonMcpJsonMapperSupplier().get();
+    private static final JsonSchemaValidator JSON_SCHEMA_VALIDATOR = new JacksonJsonSchemaValidatorSupplier().get();
 
     @Getter
     private McpConnector connector;
@@ -90,10 +97,9 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
                 getMcpRequestHeaders(builder);
             };
 
-            // Explicit jsonMapper() bypasses MCP SDK's ServiceLoader lookup, which fails under plugin classloader isolation.
             McpClientTransport transport = HttpClientSseClientTransport
                 .builder(mcpServerUrl)
-                .jsonMapper(new JacksonMcpJsonMapperSupplier().get())
+                .jsonMapper(JSON_MAPPER)
                 .sseEndpoint(sseEndpoint)
                 .customizeClient(clientBuilder -> {
                     clientBuilder.connectTimeout(connectionTimeout);
@@ -101,12 +107,11 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
                 .customizeRequest(headerConfig)
                 .build();
 
-            // Explicit jsonSchemaValidator() bypasses another ServiceLoader lookup under plugin classloader isolation.
             McpSyncClient client = McpClient
                 .sync(transport)
                 .requestTimeout(readTimeout)
                 .capabilities(McpSchema.ClientCapabilities.builder().roots(false).build())
-                .jsonSchemaValidator(new JacksonJsonSchemaValidatorSupplier().get())
+                .jsonSchemaValidator(JSON_SCHEMA_VALIDATOR)
                 .build();
 
             client.initialize();

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
@@ -49,6 +49,8 @@ import com.google.gson.Gson;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapperSupplier;
+import io.modelcontextprotocol.json.schema.jackson3.JacksonJsonSchemaValidatorSupplier;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.Getter;
@@ -91,9 +93,10 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
                 getMcpRequestHeaders(builder);
             };
 
-            // Create streamable HTTP transport
+            // Explicit jsonMapper() bypasses MCP SDK's ServiceLoader lookup, which fails under plugin classloader isolation.
             McpClientTransport transport = HttpClientStreamableHttpTransport
                 .builder(mcpServerUrl)
+                .jsonMapper(new JacksonMcpJsonMapperSupplier().get())
                 .endpoint(endpoint)
                 .customizeClient(clientBuilder -> {
                     clientBuilder.connectTimeout(connectionTimeout);
@@ -102,11 +105,12 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
                 .customizeRequest(headerConfig)
                 .build();
 
-            // Create and initialize client
+            // Explicit jsonSchemaValidator() bypasses another ServiceLoader lookup under plugin classloader isolation.
             McpSyncClient client = McpClient
                 .sync(transport)
                 .requestTimeout(readTimeout)
                 .capabilities(McpSchema.ClientCapabilities.builder().roots(false).build())
+                .jsonSchemaValidator(new JacksonJsonSchemaValidatorSupplier().get())
                 .build();
 
             client.initialize();

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
@@ -49,7 +49,9 @@ import com.google.gson.Gson;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapperSupplier;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import io.modelcontextprotocol.json.schema.jackson3.JacksonJsonSchemaValidatorSupplier;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -60,6 +62,11 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 @ConnectorExecutor(MCP_STREAMABLE_HTTP)
 public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecutor {
+
+    // Cached singletons; the suppliers' outputs are thread-safe and the schema validator caches compiled schemas.
+    // Explicit instances also bypass the MCP SDK's ServiceLoader lookup, which fails under plugin classloader isolation.
+    private static final McpJsonMapper JSON_MAPPER = new JacksonMcpJsonMapperSupplier().get();
+    private static final JsonSchemaValidator JSON_SCHEMA_VALIDATOR = new JacksonJsonSchemaValidatorSupplier().get();
 
     @Getter
     private McpStreamableHttpConnector connector;
@@ -93,10 +100,9 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
                 getMcpRequestHeaders(builder);
             };
 
-            // Explicit jsonMapper() bypasses MCP SDK's ServiceLoader lookup, which fails under plugin classloader isolation.
             McpClientTransport transport = HttpClientStreamableHttpTransport
                 .builder(mcpServerUrl)
-                .jsonMapper(new JacksonMcpJsonMapperSupplier().get())
+                .jsonMapper(JSON_MAPPER)
                 .endpoint(endpoint)
                 .customizeClient(clientBuilder -> {
                     clientBuilder.connectTimeout(connectionTimeout);
@@ -105,12 +111,11 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
                 .customizeRequest(headerConfig)
                 .build();
 
-            // Explicit jsonSchemaValidator() bypasses another ServiceLoader lookup under plugin classloader isolation.
             McpSyncClient client = McpClient
                 .sync(transport)
                 .requestTimeout(readTimeout)
                 .capabilities(McpSchema.ClientCapabilities.builder().roots(false).build())
-                .jsonSchemaValidator(new JacksonJsonSchemaValidatorSupplier().get())
+                .jsonSchemaValidator(JSON_SCHEMA_VALIDATOR)
                 .build();
 
             client.initialize();

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -1981,6 +1981,57 @@ public class AgentUtilsTest extends MLStaticMockBase {
     }
 
     @Test
+    public void testGetMcpToolSpecs_ErrorInGetMcpToolSpecsDoesNotHang() throws Exception {
+        // Regression test for the MCP SDK 1.1.1 hang: ServiceConfigurationError is an Error (not an
+        // Exception), so a naive catch(Exception) would have let it escape and leave the async
+        // counter in getMcpToolSpecs stranded, hanging the agent forever.
+        stubGetConnector();
+
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpConnector(connStatic);
+            McpConnectorExecutor exec = mock(McpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenThrow(new java.util.ServiceConfigurationError("boom"));
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            MLAgent mlAgent = mockAgent("[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]", "tenant");
+            ActionListener<List<MLToolSpec>> listener = mock(ActionListener.class);
+
+            AgentUtils.getMcpToolSpecs(mlAgent, client, sdkClient, null, listener);
+            verify(listener).onResponse(Collections.emptyList());
+        }
+    }
+
+    @Test
+    public void testGetMcpToolSpecs_OneConnectorFailsOthersSucceed() throws Exception {
+        // Regression test: one connector throwing an Error must not strand the AtomicInteger
+        // counter and prevent the listener from firing for the remaining connectors.
+        stubGetConnector();
+
+        List<MLToolSpec> goodTools = List.of(buildTool("good1"));
+
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpConnector(connStatic);
+            McpConnectorExecutor exec = mock(McpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenThrow(new java.util.ServiceConfigurationError("boom")).thenReturn(goodTools);
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            String mcpJsonConfig = "[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"bad\"}," + "{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"good\"}]";
+            MLAgent agent = mockAgent(mcpJsonConfig, "tenant");
+            ActionListener<List<MLToolSpec>> listener = mock(ActionListener.class);
+
+            AgentUtils.getMcpToolSpecs(agent, client, sdkClient, encryptor, listener);
+            // Listener fires exactly once with just the good connector's tools.
+            verify(listener).onResponse(goodTools);
+        }
+    }
+
+    @Test
     public void testGetMcpToolSpecs_ExceptionInGetConnector() throws Exception {
         // Mock getConnector to throw an exception
         threadContext = new ThreadContext(Settings.builder().build());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
@@ -51,6 +51,7 @@ public class McpConnectorExecutorTest extends MLStaticMockBase {
         /* ---------- stub the fluent builder chain ------------------------ */
         when(builder.requestTimeout(any())).thenReturn(builder);
         when(builder.capabilities(any())).thenReturn(builder);
+        when(builder.jsonSchemaValidator(any())).thenReturn(builder);
         when(builder.build()).thenReturn(mcpClient);
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
@@ -51,6 +51,7 @@ public class McpStreamableHttpConnectorExecutorTest extends MLStaticMockBase {
         /* ---------- stub the fluent builder chain ------------------------ */
         when(builder.requestTimeout(any())).thenReturn(builder);
         when(builder.capabilities(any())).thenReturn(builder);
+        when(builder.jsonSchemaValidator(any())).thenReturn(builder);
         when(builder.build()).thenReturn(mcpClient);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.opensearch.client.Response;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.utils.TestHelper;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Integration test for a conversational agent backed by an MCP streamable-http connector that
+ * points at the very same cluster (which also hosts an MCP server at /_plugins/_ml/mcp).
+ *
+ * <p>This exercises the full MCP-client path end-to-end:
+ * <ol>
+ *   <li>Register ListIndexTool with the cluster's MCP server.</li>
+ *   <li>Create an MCP streamable-http connector whose URL is the cluster's own HTTP endpoint.</li>
+ *   <li>Register a conversational agent wired to Bedrock Claude plus the MCP connector.</li>
+ *   <li>Execute the agent with an "list indices" question and assert that the pre-seeded
+ *       iris_data index shows up in the final response — which can only happen if the MCP
+ *       tool list succeeded and ListIndexTool was actually invoked.</li>
+ * </ol>
+ *
+ * <p>Requires {@code AWS_ACCESS_KEY_ID} + {@code AWS_SECRET_ACCESS_KEY} (and optionally
+ * {@code AWS_SESSION_TOKEN}); skipped automatically when absent.
+ */
+public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
+
+    private static final String AWS_ACCESS_KEY_ID = System.getenv("AWS_ACCESS_KEY_ID");
+    private static final String AWS_SECRET_ACCESS_KEY = System.getenv("AWS_SECRET_ACCESS_KEY");
+    private static final String AWS_SESSION_TOKEN = System.getenv("AWS_SESSION_TOKEN");
+    private static final String REGION = "us-west-2";
+    private static final String MODEL_ID_BEDROCK = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+    // Random suffix so the LLM can't hallucinate the canonical "iris_data" and pass the assertion
+    // without actually calling ListIndexTool through MCP.
+    private final String irisIndex = "iris_data_mcp_it_" + randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
+    private String llmModelId;
+
+    @Before
+    public void setup() throws IOException, ParseException, InterruptedException {
+        Assume.assumeNotNull(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY);
+
+        RestMLRemoteInferenceIT.disableClusterConnectorAccessControl();
+        updateClusterSettings("plugins.ml_commons.memory_feature_enabled", true);
+        updateClusterSettings("plugins.ml_commons.only_run_on_ml_node", false);
+        updateClusterSettings("plugins.ml_commons.trusted_connector_endpoints_regex", List.of("^.*$"));
+        updateClusterSettings("plugins.ml_commons.mcp_connector_enabled", true);
+        updateClusterSettings("plugins.ml_commons.mcp_server_enabled", true);
+
+        // Register ListIndexTool with the cluster's MCP server so the MCP client can discover it.
+        String toolRegistrationBody = "{\"tools\":[{\"name\":\"ListIndexTool\",\"type\":\"ListIndexTool\"}]}";
+        Response registerResponse = TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                "/_plugins/_ml/mcp/tools/_register",
+                null,
+                toolRegistrationBody,
+                ImmutableList.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
+            );
+        assertEquals(200, registerResponse.getStatusLine().getStatusCode());
+
+        ingestIrisData(irisIndex);
+        llmModelId = registerAndDeployBedrockModel();
+    }
+
+    @After
+    public void teardown() throws IOException {
+        if (AWS_ACCESS_KEY_ID == null || AWS_SECRET_ACCESS_KEY == null) {
+            return;
+        }
+        try {
+            TestHelper
+                .makeRequest(
+                    client(),
+                    "POST",
+                    "/_plugins/_ml/mcp/tools/_remove",
+                    null,
+                    "[\"ListIndexTool\"]",
+                    ImmutableList.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
+                );
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
+        deleteIndexWithAdminClient(irisIndex);
+    }
+
+    public void testChatAgentWithMcpStreamableHttpConnector() throws IOException {
+        HttpHost host = getClusterHosts().get(0);
+        String mcpServerUrl = host.getSchemeName() + "://" + host.getHostName() + ":" + host.getPort();
+
+        // Step 1 – create the MCP streamable-http connector pointing at this cluster's own MCP server.
+        String connectorBody = "{\n"
+            + "  \"name\": \"Self MCP Connector\",\n"
+            + "  \"description\": \"MCP streamable-http connector pointing back at the same cluster's MCP server\",\n"
+            + "  \"version\": 1,\n"
+            + "  \"protocol\": \"mcp_streamable_http\",\n"
+            + "  \"url\": \""
+            + mcpServerUrl
+            + "\",\n"
+            + "  \"parameters\": {\n"
+            + "    \"endpoint\": \"/_plugins/_ml/mcp\"\n"
+            + "  },\n"
+            + "  \"credential\": {}\n"
+            + "}";
+        Response response = RestMLRemoteInferenceIT.createConnector(connectorBody);
+        String mcpConnectorId = (String) parseResponseToMap(response).get("connector_id");
+        assertNotNull(mcpConnectorId);
+
+        // Step 2 – register a conversational agent wired to Bedrock + the MCP connector.
+        String agentBody = "{\n"
+            + "  \"name\": \"Test_Chat_Agent_With_MCP\",\n"
+            + "  \"type\": \"conversational\",\n"
+            + "  \"description\": \"Conversational agent that lists indices via an MCP tool\",\n"
+            + "  \"llm\": {\n"
+            + "    \"model_id\": \""
+            + llmModelId
+            + "\",\n"
+            + "    \"parameters\": {\n"
+            + "      \"prompt\": \"${parameters.question}\"\n"
+            + "    }\n"
+            + "  },\n"
+            + "  \"parameters\": {\n"
+            + "    \"_llm_interface\": \"bedrock/converse/claude\",\n"
+            + "    \"mcp_connectors\": [\n"
+            + "      {\n"
+            + "        \"mcp_connector_id\": \""
+            + mcpConnectorId
+            + "\",\n"
+            + "        \"tool_filters\": []\n"
+            + "      }\n"
+            + "    ]\n"
+            + "  },\n"
+            + "  \"memory\": {\n"
+            + "    \"type\": \"conversation_index\"\n"
+            + "  }\n"
+            + "}";
+        response = TestHelper
+            .makeRequest(client(), "POST", "/_plugins/_ml/agents/_register", null, TestHelper.toHttpEntity(agentBody), null);
+        String agentId = (String) parseResponseToMap(response).get("agent_id");
+        assertNotNull(agentId);
+
+        // Step 3 – execute. The LLM must pick ListIndexTool (sourced via MCP) to answer this.
+        response = TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                "/_plugins/_ml/agents/" + agentId + "/_execute",
+                null,
+                TestHelper
+                    .toHttpEntity("{\"parameters\":{\"question\":\"Use the ListIndexTool to list user indices and return their names.\"}}"),
+                null
+            );
+        Map responseMap = parseResponseToMap(response);
+
+        List inferenceResults = (List) responseMap.get("inference_results");
+        assertNotNull(inferenceResults);
+        assertFalse(inferenceResults.isEmpty());
+
+        Map firstResult = (Map) inferenceResults.get(0);
+        List output = (List) firstResult.get("output");
+        assertNotNull(output);
+        assertFalse(output.isEmpty());
+
+        // The index name carries a random suffix seeded at test time, so the LLM cannot produce it
+        // without the actual ListIndexTool output flowing back through MCP. Substring-matching this
+        // exact name is therefore a sufficient proof that the MCP tool was invoked end-to-end.
+        String finalResponse = output.toString();
+        assertTrue(
+            "Expected randomized index name '" + irisIndex + "' to appear in agent response, got: " + finalResponse,
+            finalResponse.contains(irisIndex)
+        );
+    }
+
+    private String registerAndDeployBedrockModel() throws IOException, InterruptedException {
+        String sessionTokenLine = AWS_SESSION_TOKEN != null ? "    \"session_token\": \"" + AWS_SESSION_TOKEN + "\"\n" : "";
+        String connectorBody = "{\n"
+            + "  \"name\": \"Bedrock Claude Connector\",\n"
+            + "  \"description\": \"Connector for AWS Bedrock Claude (converse API)\",\n"
+            + "  \"version\": 1,\n"
+            + "  \"protocol\": \"aws_sigv4\",\n"
+            + "  \"parameters\": {\n"
+            + "    \"region\": \""
+            + REGION
+            + "\",\n"
+            + "    \"service_name\": \"bedrock\",\n"
+            + "    \"model\": \""
+            + MODEL_ID_BEDROCK
+            + "\"\n"
+            + "  },\n"
+            + "  \"credential\": {\n"
+            + "    \"access_key\": \""
+            + AWS_ACCESS_KEY_ID
+            + "\",\n"
+            + "    \"secret_key\": \""
+            + AWS_SECRET_ACCESS_KEY
+            + "\",\n"
+            + sessionTokenLine
+            + "  },\n"
+            + "  \"actions\": [\n"
+            + "    {\n"
+            + "      \"action_type\": \"predict\",\n"
+            + "      \"method\": \"POST\",\n"
+            + "      \"url\": \"https://bedrock-runtime."
+            + REGION
+            + ".amazonaws.com/model/"
+            + MODEL_ID_BEDROCK
+            + "/converse\",\n"
+            + "      \"headers\": {\n"
+            + "        \"content-type\": \"application/json\",\n"
+            + "        \"x-amz-content-sha256\": \"required\"\n"
+            + "      },\n"
+            + "      \"request_body\": \"{\\\"system\\\": [{\\\"text\\\": \\\"You are a helpful assistant.\\\"}], \\\"messages\\\": [${parameters._chat_history:-}{\\\"role\\\":\\\"user\\\",\\\"content\\\":[{\\\"text\\\":\\\"${parameters.prompt}\\\"}]}${parameters._interactions:-}]${parameters.tool_configs:-} }\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+
+        Response response = RestMLRemoteInferenceIT.createConnector(connectorBody);
+        String connectorId = (String) parseResponseToMap(response).get("connector_id");
+        assertNotNull(connectorId);
+
+        response = RestMLRemoteInferenceIT.registerRemoteModel("bedrock_claude_mcp_model", connectorId);
+        String taskId = (String) parseResponseToMap(response).get("task_id");
+        assertNotNull(taskId);
+        waitForTask(taskId, MLTaskState.COMPLETED);
+
+        response = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/tasks/" + taskId, null, "", null);
+        String modelId = (String) parseResponseToMap(response).get("model_id");
+        assertNotNull(modelId);
+
+        response = RestMLRemoteInferenceIT.deployRemoteModel(modelId);
+        taskId = (String) parseResponseToMap(response).get("task_id");
+        assertNotNull(taskId);
+        waitForTask(taskId, MLTaskState.COMPLETED);
+
+        return modelId;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes opensearch-project/ml-commons#4815 — agents wired to MCP connectors hang indefinitely on latest main but work on 3.6 and on main without MCP.

## Root cause

Commit c9a4bd8636 (#4795) bumped the MCP SDK from 0.12.1 to 1.1.1. The new SDK uses `ServiceLoader` at two points:
1. `McpJsonMapperSupplier` — during `HttpClient*Transport.Builder.build()`.
2. `JsonSchemaValidatorSupplier` — during `McpClient.SyncSpec.build()`.

`ServiceLoader` uses the thread context classloader, which in OpenSearch server threads is the **core** classloader, not the **plugin** classloader where `mcp-json-jackson3` lives. Both lookups throw `ServiceConfigurationError` — an `Error`, not an `Exception` — so the existing `catch (Exception)` in `AgentUtils.getMCPToolSpecsFromConnector` did not catch it. The per-connector `AtomicInteger` counter in `getMcpToolSpecs` never reached zero → the final listener was never invoked → agent hung forever at `getMcpToolSpecs`, right before `Starting chat agent execution`.

## Fix

1. **`McpStreamableHttpConnectorExecutor` / `McpConnectorExecutor`** — bypass `ServiceLoader` entirely by passing explicit suppliers:
   - `.jsonMapper(new JacksonMcpJsonMapperSupplier().get())` on the transport builder.
   - `.jsonSchemaValidator(new JacksonJsonSchemaValidatorSupplier().get())` on the `McpClient.sync(transport)` chain.

2. **`AgentUtils.getMCPToolSpecsFromConnector`** — broaden the outer `catch (Exception)` to `catch (Throwable)` so future `Error`s always complete the listener rather than stranding the chain.

3. **`AgentUtils.getMcpToolSpecs`** — restructure the async counter so the decrement runs inside a `try/finally` on every path (success, filter exception, handled failure, synchronous `Throwable` from `getMCPToolSpecsFromConnector`). Extracted the decrement+complete logic into a `completeIfLast` runnable. This makes the final listener guaranteed to fire once per call — one bad connector can no longer hang the agent even if it throws an unexpected `Error`.

4. **`MLChatAgentRunner.processUnifiedTools`** — add `log.warn(..., e)` on the MCP-failure branch so future MCP failures are observable instead of silent.

## Test plan

- [x] Reproduced the hang locally against latest main (agent stuck indefinitely at `getMcpToolSpecs`, ServiceConfigurationError in logs, async counter never decremented).
- [x] Applied fix, rebuilt plugin, restarted local integTest cluster.
- [x] Registered Bedrock model + MCP streamable-http connector (`http://localhost:9900/mcp`) + chat agent with MCP.
- [x] Executed agent end-to-end: returned in ~11s with real MCP tool output (index list from `cat_indexes` tool). No `ServiceConfigurationError` in cluster logs.
- [x] Verified MCP client initialization log: `Server response with Protocol: 2025-11-25, Capabilities: ToolCapabilities[listChanged=false]`.