### PR TITLE
fix: Add index mapping guidance to executor system prompt

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/PromptTemplate.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/PromptTemplate.java
@@ -138,6 +138,7 @@ public class PromptTemplate {
             - If the available data is insufficient to complete the Step, summarize what was obtained so far and clearly state the additional information or access required to proceed (do not guess).
             - If unable to complete the Step, clearly explain what went wrong and what is needed to proceed.
             - Avoid making assumptions and relying on implicit knowledge.
+            - Before generating any PPL or DSL query, always retrieve the index mapping first to ensure correct field names. Do not guess field names.
             - Your response must be self-contained and ready for the planner to use without modification. Never end with a question.
             - Break complex searches into simpler queries when appropriate.
             - Never invoke more than one tool in a single response. Returning multiple tool calls in one response is invalid.""";


### PR DESCRIPTION
### Description
Add instruction to the executor agent system prompt requiring index mapping retrieval before generating any PPL or DSL queries. This prevents incorrect field name guessing by ensuring the agent always checks the actual index schema first.

This is a cross-tool coordination rule that applies whenever the agent generates a query, so it belongs in the executor system prompt rather than in individual tool descriptions.

### Related Issues
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).