### PR TITLE
Add Maven cache mirror before mavenCentral to reduce 429 errors

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -6,6 +6,7 @@
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven {url 'https://oss.sonatype.org/content/repositories/snapshots/'}
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -14,6 +14,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/search-processors/build.gradle
+++ b/search-processors/build.gradle
@@ -22,6 +22,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'opensearch.java'
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
 }


### PR DESCRIPTION
### Description

Add `ci.opensearch.org/maven2/` cache mirror above `mavenCentral()` in all repository blocks to reduce direct calls to Maven Central and avoid HTTP 429 Too Many Requests throttling from CI builds.

Maven Central has imposed new rate limiting restrictions ([details](https://central.sonatype.org/faq/429-error/)) which cause CI builds to fail with 429 errors when resolving dependencies. This cache mirror serves as a proxy that caches artifacts for 24 hours, dramatically reducing call count to Maven Central.

### Reference

Core OpenSearch PR: https://github.com/opensearch-project/OpenSearch/pull/21682

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).