### PR TITLE
feat: Add structured output (constrained decoding) support for agentic memory fact extraction

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -108,6 +108,8 @@ public class CommonValue {
     public static final Version VERSION_3_3_0 = Version.fromString("3.3.0");
     public static final Version VERSION_3_4_0 = Version.fromString("3.4.0");
     public static final Version VERSION_3_5_0 = Version.fromString("3.5.0");
+    public static final Version VERSION_3_6_0 = Version.fromString("3.6.0");
+    public static final Version VERSION_3_7_0 = Version.fromString("3.7.0");
 
     // Connector Constants
     public static final String NAME_FIELD = "name";

--- a/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.connector;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.VERSION_3_5_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -43,6 +44,7 @@ public class ConnectorAction implements ToXContentObject, Writeable {
     public static final String REQUEST_BODY_FIELD = "request_body";
     public static final String ACTION_PRE_PROCESS_FUNCTION = "pre_process_function";
     public static final String ACTION_POST_PROCESS_FUNCTION = "post_process_function";
+    public static final String SUPPORTS_STRUCTURED_OUTPUT_FIELD = "supports_structured_output";
     public static final String OPENAI = "openai";
     public static final String COHERE = "cohere";
     public static final String BEDROCK = "bedrock";
@@ -70,6 +72,20 @@ public class ConnectorAction implements ToXContentObject, Writeable {
     private String requestBody;
     private String preProcessFunction;
     private String postProcessFunction;
+    private boolean supportsStructuredOutput;
+
+    public ConnectorAction(
+        ActionType actionType,
+        String name,
+        String method,
+        String url,
+        Map<String, String> headers,
+        String requestBody,
+        String preProcessFunction,
+        String postProcessFunction
+    ) {
+        this(actionType, name, method, url, headers, requestBody, preProcessFunction, postProcessFunction, false);
+    }
 
     @Builder(toBuilder = true)
     public ConnectorAction(
@@ -80,7 +96,8 @@ public class ConnectorAction implements ToXContentObject, Writeable {
         Map<String, String> headers,
         String requestBody,
         String preProcessFunction,
-        String postProcessFunction
+        String postProcessFunction,
+        boolean supportsStructuredOutput
     ) {
         if (actionType == null) {
             throw new IllegalArgumentException("action type can't be null");
@@ -101,6 +118,7 @@ public class ConnectorAction implements ToXContentObject, Writeable {
         this.requestBody = requestBody;
         this.preProcessFunction = preProcessFunction;
         this.postProcessFunction = postProcessFunction;
+        this.supportsStructuredOutput = supportsStructuredOutput;
     }
 
     public ConnectorAction(StreamInput input) throws IOException {
@@ -115,6 +133,9 @@ public class ConnectorAction implements ToXContentObject, Writeable {
         this.postProcessFunction = input.readOptionalString();
         if (input.getVersion().onOrAfter(VERSION_3_5_0)) {
             this.name = input.readOptionalString();
+        }
+        if (input.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.supportsStructuredOutput = input.readBoolean();
         }
     }
 
@@ -134,6 +155,9 @@ public class ConnectorAction implements ToXContentObject, Writeable {
         out.writeOptionalString(postProcessFunction);
         if (out.getVersion().onOrAfter(VERSION_3_5_0)) {
             out.writeOptionalString(name);
+        }
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeBoolean(supportsStructuredOutput);
         }
     }
 
@@ -164,6 +188,9 @@ public class ConnectorAction implements ToXContentObject, Writeable {
         if (name != null) {
             builder.field(NAME_FIELD, name);
         }
+        if (supportsStructuredOutput) {
+            builder.field(SUPPORTS_STRUCTURED_OUTPUT_FIELD, true);
+        }
         return builder.endObject();
     }
 
@@ -181,6 +208,7 @@ public class ConnectorAction implements ToXContentObject, Writeable {
         String requestBody = null;
         String preProcessFunction = null;
         String postProcessFunction = null;
+        boolean supportsStructuredOutput = false;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -212,6 +240,9 @@ public class ConnectorAction implements ToXContentObject, Writeable {
                 case ACTION_POST_PROCESS_FUNCTION:
                     postProcessFunction = parser.text();
                     break;
+                case SUPPORTS_STRUCTURED_OUTPUT_FIELD:
+                    supportsStructuredOutput = parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -227,6 +258,7 @@ public class ConnectorAction implements ToXContentObject, Writeable {
             .requestBody(requestBody)
             .preProcessFunction(preProcessFunction)
             .postProcessFunction(postProcessFunction)
+            .supportsStructuredOutput(supportsStructuredOutput)
             .build();
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -69,9 +69,7 @@ public class HttpConnector extends AbstractConnector {
     static final Set<String> STRUCTURED_OUTPUT_ALLOWED_FIELDS = Set
         .of(
             "response_format",  // OpenAI, Azure OpenAI, DeepSeek, Ollama, Cohere
-            "generationConfig", // Google Gemini
-            "tools",            // Bedrock Converse (future)
-            "tool_choice"       // Bedrock Converse (future)
+            "generationConfig"  // Google Gemini
         );
 
     // TODO: add RequestConfig like request time out,

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -378,7 +378,7 @@ public class HttpConnector extends AbstractConnector {
                     payload = jsonObject.toString();
                 }
             }
-            if (parameters != null && isJson(payload)) {
+            if (parameters != null && isJson(payload) && connectorAction.get().isSupportsStructuredOutput()) {
                 payload = injectStructuredOutputParams(parameters, payload);
             }
             return (T) payload;

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -69,7 +69,8 @@ public class HttpConnector extends AbstractConnector {
     static final Set<String> STRUCTURED_OUTPUT_ALLOWED_FIELDS = Set
         .of(
             "response_format",  // OpenAI, Azure OpenAI, DeepSeek, Ollama, Cohere
-            "generationConfig"  // Google Gemini
+            "generationConfig", // Google Gemini
+            "toolConfig"        // Amazon Bedrock Converse
         );
 
     // TODO: add RequestConfig like request time out,

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -385,56 +385,59 @@ public class HttpConnector extends AbstractConnector {
         return (T) parameters.get("http_body");
     }
 
-    // Convention: parameters named _<fieldname>_additions_json are merged into an existing top-level
-    // JSON object; parameters named _<fieldname>_json are injected as a new top-level JSON object.
-    // Both conventions require the value to be a valid JSON object string and the target field name
-    // must be in STRUCTURED_OUTPUT_ALLOWED_FIELDS to prevent callers from overriding provider control fields.
+    // Convention: parameters named _<fieldname>_json inject/replace a top-level JSON object field;
+    // parameters named _<fieldname>_additions_json merge into an existing top-level JSON object field.
+    // Both conventions require: (a) the payload is a JSON object (array payloads are left untouched),
+    // (b) a non-empty, allowlisted field name, and (c) a valid JSON object value string.
+    // Replacements (_X_json) are applied before merges (_X_additions_json) so behaviour is
+    // deterministic when both are present for the same field.
+    // Note: matched parameters are read but not removed from the map.
     private String injectStructuredOutputParams(Map<String, String> parameters, String payload) {
+        JsonElement parsed = JsonParser.parseString(payload);
+        if (!parsed.isJsonObject()) return payload;
+        JsonObject body = parsed.getAsJsonObject();
+        boolean modified = false;
+
+        // Pass 1: _<field>_json — inject or replace a top-level field
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
-            String key = entry.getKey();
-            if (key.startsWith("_") && key.endsWith("_additions_json")) {
-                String fieldName = key.substring(1, key.length() - "_additions_json".length());
-                if (STRUCTURED_OUTPUT_ALLOWED_FIELDS.contains(fieldName)) {
-                    payload = mergeIntoJsonObject(payload, fieldName, entry.getValue());
-                }
-            } else if (key.startsWith("_") && key.endsWith("_json")) {
-                String fieldName = key.substring(1, key.length() - "_json".length());
-                if (STRUCTURED_OUTPUT_ALLOWED_FIELDS.contains(fieldName)) {
-                    payload = injectTopLevelJsonField(payload, fieldName, entry.getValue());
-                }
-            }
+            if (entry.getKey().endsWith("_additions_json")) continue;
+            String fieldName = allowedFieldName(entry.getKey(), "_json");
+            JsonObject value = asJsonObject(entry.getValue());
+            if (fieldName == null || value == null) continue;
+            body.add(fieldName, value);
+            modified = true;
         }
-        return payload;
+
+        // Pass 2: _<field>_additions_json — merge into an existing top-level object
+        for (Map.Entry<String, String> entry : parameters.entrySet()) {
+            String fieldName = allowedFieldName(entry.getKey(), "_additions_json");
+            JsonObject additions = asJsonObject(entry.getValue());
+            if (fieldName == null || additions == null) continue;
+            JsonObject target = body.has(fieldName) && body.get(fieldName).isJsonObject()
+                ? body.getAsJsonObject(fieldName)
+                : new JsonObject();
+            additions.entrySet().forEach(e -> target.add(e.getKey(), e.getValue()));
+            body.add(fieldName, target);
+            modified = true;
+        }
+
+        return modified ? body.toString() : payload;
     }
 
-    private String injectTopLevelJsonField(String payload, String fieldName, String valueStr) {
-        if (valueStr == null || !isJson(valueStr)) {
-            return payload;
-        }
-        JsonElement valueElement = JsonParser.parseString(valueStr);
-        if (!valueElement.isJsonObject()) {
-            return payload;
-        }
-        JsonObject jsonObject = JsonParser.parseString(payload).getAsJsonObject();
-        jsonObject.add(fieldName, valueElement.getAsJsonObject());
-        return jsonObject.toString();
+    /** Returns the allowlisted field name encoded in a _&lt;field&gt;_&lt;suffix&gt; key, or null if invalid. */
+    private static String allowedFieldName(String key, String suffix) {
+        if (!key.startsWith("_") || !key.endsWith(suffix)) return null;
+        int end = key.length() - suffix.length();
+        if (end <= 1) return null;
+        String fieldName = key.substring(1, end);
+        return STRUCTURED_OUTPUT_ALLOWED_FIELDS.contains(fieldName) ? fieldName : null;
     }
 
-    private String mergeIntoJsonObject(String payload, String fieldName, String additionsStr) {
-        if (additionsStr == null || !isJson(additionsStr)) {
-            return payload;
-        }
-        JsonElement additionsElement = JsonParser.parseString(additionsStr);
-        if (!additionsElement.isJsonObject()) {
-            return payload;
-        }
-        JsonObject jsonObject = JsonParser.parseString(payload).getAsJsonObject();
-        JsonObject target = jsonObject.has(fieldName) && jsonObject.get(fieldName).isJsonObject()
-            ? jsonObject.getAsJsonObject(fieldName)
-            : new JsonObject();
-        additionsElement.getAsJsonObject().entrySet().forEach(e -> target.add(e.getKey(), e.getValue()));
-        jsonObject.add(fieldName, target);
-        return jsonObject.toString();
+    /** Parses a JSON string as an object, returning null if absent, invalid, or not an object. */
+    private static JsonObject asJsonObject(String json) {
+        if (json == null || !isJson(json)) return null;
+        JsonElement el = JsonParser.parseString(json);
+        return el.isJsonObject() ? el.getAsJsonObject() : null;
     }
 
     private boolean neededStreamParameterInPayload(Map<String, String> parameters) {

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -61,6 +62,17 @@ public class HttpConnector extends AbstractConnector {
     public static final String REGION_FIELD = "region";
     // TODO: move the AgentUtils class from algorithm module to common module
     public static final String LLM_INTERFACE_OPENAI_V1_CHAT_COMPLETIONS = "openai/v1/chat/completions";
+
+    // Allowlist of top-level JSON fields that _<field>_json / _<field>_additions_json parameters may inject.
+    // Restricts injection to structured-output fields only; prevents callers from overriding
+    // provider control fields such as "model", "stream", or "max_tokens".
+    static final Set<String> STRUCTURED_OUTPUT_ALLOWED_FIELDS = Set
+        .of(
+            "response_format",  // OpenAI, Azure OpenAI, DeepSeek, Ollama, Cohere
+            "generationConfig", // Google Gemini
+            "tools",            // Bedrock Converse (future)
+            "tool_choice"       // Bedrock Converse (future)
+        );
 
     // TODO: add RequestConfig like request time out,
 
@@ -377,16 +389,21 @@ public class HttpConnector extends AbstractConnector {
 
     // Convention: parameters named _<fieldname>_additions_json are merged into an existing top-level
     // JSON object; parameters named _<fieldname>_json are injected as a new top-level JSON object.
-    // Both conventions require the value to be a valid JSON object string.
+    // Both conventions require the value to be a valid JSON object string and the target field name
+    // must be in STRUCTURED_OUTPUT_ALLOWED_FIELDS to prevent callers from overriding provider control fields.
     private String injectStructuredOutputParams(Map<String, String> parameters, String payload) {
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
             String key = entry.getKey();
             if (key.startsWith("_") && key.endsWith("_additions_json")) {
                 String fieldName = key.substring(1, key.length() - "_additions_json".length());
-                payload = mergeIntoJsonObject(payload, fieldName, entry.getValue());
+                if (STRUCTURED_OUTPUT_ALLOWED_FIELDS.contains(fieldName)) {
+                    payload = mergeIntoJsonObject(payload, fieldName, entry.getValue());
+                }
             } else if (key.startsWith("_") && key.endsWith("_json")) {
                 String fieldName = key.substring(1, key.length() - "_json".length());
-                payload = injectTopLevelJsonField(payload, fieldName, entry.getValue());
+                if (STRUCTURED_OUTPUT_ALLOWED_FIELDS.contains(fieldName)) {
+                    payload = injectTopLevelJsonField(payload, fieldName, entry.getValue());
+                }
             }
         }
         return payload;

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -395,16 +395,19 @@ public class HttpConnector extends AbstractConnector {
     // Note: matched parameters are read but not removed from the map.
     private String injectStructuredOutputParams(Map<String, String> parameters, String payload) {
         JsonElement parsed = JsonParser.parseString(payload);
-        if (!parsed.isJsonObject()) return payload;
+        if (!parsed.isJsonObject())
+            return payload;
         JsonObject body = parsed.getAsJsonObject();
         boolean modified = false;
 
         // Pass 1: _<field>_json — inject or replace a top-level field
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
-            if (entry.getKey().endsWith("_additions_json")) continue;
+            if (entry.getKey().endsWith("_additions_json"))
+                continue;
             String fieldName = allowedFieldName(entry.getKey(), "_json");
             JsonObject value = asJsonObject(entry.getValue());
-            if (fieldName == null || value == null) continue;
+            if (fieldName == null || value == null)
+                continue;
             body.add(fieldName, value);
             modified = true;
         }
@@ -413,7 +416,8 @@ public class HttpConnector extends AbstractConnector {
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
             String fieldName = allowedFieldName(entry.getKey(), "_additions_json");
             JsonObject additions = asJsonObject(entry.getValue());
-            if (fieldName == null || additions == null) continue;
+            if (fieldName == null || additions == null)
+                continue;
             JsonObject target = body.has(fieldName) && body.get(fieldName).isJsonObject()
                 ? body.getAsJsonObject(fieldName)
                 : new JsonObject();
@@ -427,16 +431,19 @@ public class HttpConnector extends AbstractConnector {
 
     /** Returns the allowlisted field name encoded in a _&lt;field&gt;_&lt;suffix&gt; key, or null if invalid. */
     private static String allowedFieldName(String key, String suffix) {
-        if (!key.startsWith("_") || !key.endsWith(suffix)) return null;
+        if (!key.startsWith("_") || !key.endsWith(suffix))
+            return null;
         int end = key.length() - suffix.length();
-        if (end <= 1) return null;
+        if (end <= 1)
+            return null;
         String fieldName = key.substring(1, end);
         return STRUCTURED_OUTPUT_ALLOWED_FIELDS.contains(fieldName) ? fieldName : null;
     }
 
     /** Parses a JSON string as an object, returning null if absent, invalid, or not an object. */
     private static JsonObject asJsonObject(String json) {
-        if (json == null || !isJson(json)) return null;
+        if (json == null || !isJson(json))
+            return null;
         JsonElement el = JsonParser.parseString(json);
         return el.isJsonObject() ? el.getAsJsonObject() : null;
     }

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -40,6 +40,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.AccessMode;
 import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
@@ -366,9 +367,59 @@ public class HttpConnector extends AbstractConnector {
                     payload = jsonObject.toString();
                 }
             }
+            if (parameters != null && isJson(payload)) {
+                payload = injectStructuredOutputParams(parameters, payload);
+            }
             return (T) payload;
         }
         return (T) parameters.get("http_body");
+    }
+
+    // Convention: parameters named _<fieldname>_additions_json are merged into an existing top-level
+    // JSON object; parameters named _<fieldname>_json are injected as a new top-level JSON object.
+    // Both conventions require the value to be a valid JSON object string.
+    private String injectStructuredOutputParams(Map<String, String> parameters, String payload) {
+        for (Map.Entry<String, String> entry : parameters.entrySet()) {
+            String key = entry.getKey();
+            if (key.startsWith("_") && key.endsWith("_additions_json")) {
+                String fieldName = key.substring(1, key.length() - "_additions_json".length());
+                payload = mergeIntoJsonObject(payload, fieldName, entry.getValue());
+            } else if (key.startsWith("_") && key.endsWith("_json")) {
+                String fieldName = key.substring(1, key.length() - "_json".length());
+                payload = injectTopLevelJsonField(payload, fieldName, entry.getValue());
+            }
+        }
+        return payload;
+    }
+
+    private String injectTopLevelJsonField(String payload, String fieldName, String valueStr) {
+        if (valueStr == null || !isJson(valueStr)) {
+            return payload;
+        }
+        JsonElement valueElement = JsonParser.parseString(valueStr);
+        if (!valueElement.isJsonObject()) {
+            return payload;
+        }
+        JsonObject jsonObject = JsonParser.parseString(payload).getAsJsonObject();
+        jsonObject.add(fieldName, valueElement.getAsJsonObject());
+        return jsonObject.toString();
+    }
+
+    private String mergeIntoJsonObject(String payload, String fieldName, String additionsStr) {
+        if (additionsStr == null || !isJson(additionsStr)) {
+            return payload;
+        }
+        JsonElement additionsElement = JsonParser.parseString(additionsStr);
+        if (!additionsElement.isJsonObject()) {
+            return payload;
+        }
+        JsonObject jsonObject = JsonParser.parseString(payload).getAsJsonObject();
+        JsonObject target = jsonObject.has(fieldName) && jsonObject.get(fieldName).isJsonObject()
+            ? jsonObject.getAsJsonObject(fieldName)
+            : new JsonObject();
+        additionsElement.getAsJsonObject().entrySet().forEach(e -> target.add(e.getKey(), e.getValue()));
+        jsonObject.add(fieldName, target);
+        return jsonObject.toString();
     }
 
     private boolean neededStreamParameterInPayload(Map<String, String> parameters) {

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -245,60 +245,6 @@ public class MemoryContainerConstants {
             }
         }""";
 
-    // Anthropic Messages API (direct) — value for _output_json.
-    // IMPORTANT: Using this requires the connector's headers to include the appropriate
-    // anthropic-beta header (e.g. "anthropic-beta": "output-128k-2025-02-19").
-    // Auto-detection via schemaForUrl is not enabled because that header cannot be injected
-    // via parameters. Admins can wire this up manually by setting _output_json in the connector.
-    // TODO: Enable auto-detection once MemoryContainerHelper can inject connector-level headers.
-    // Track in: https://github.com/opensearch-project/ml-commons/issues (open follow-up issue)
-    public static final String FACTS_EXTRACTION_ANTHROPIC_OUTPUT_JSON = """
-        {
-            "type": "json_schema",
-            "schema": {
-                "type": "object",
-                "properties": {
-                    "facts": {
-                        "type": "array",
-                        "items": {"type": "string"}
-                    }
-                },
-                "required": ["facts"],
-                "additionalProperties": false
-            }
-        }""";
-
-    // AWS Bedrock Converse API — reserved for future structured output support.
-    // Bedrock Converse structured output requires toolConfig+toolChoice, which changes the
-    // response shape from a text field to a tool-use block and requires additional post-processing.
-    // Not yet auto-detected by schemaForUrl.
-    // TODO: Enable once MemoryProcessingService can parse Bedrock Converse tool-use responses.
-    // Track in: https://github.com/opensearch-project/ml-commons/issues (open follow-up issue)
-    public static final String FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON = """
-        {
-            "tools": [
-                {
-                    "toolSpec": {
-                        "name": "facts_extraction",
-                        "description": "Extract user preference facts",
-                        "inputSchema": {
-                            "json": {
-                                "type": "object",
-                                "properties": {
-                                    "facts": {
-                                        "type": "array",
-                                        "items": {"type": "string"}
-                                    }
-                                },
-                                "required": ["facts"]
-                            }
-                        }
-                    }
-                }
-            ],
-            "toolChoice": {"tool": {"name": "facts_extraction"}}
-        }""";
-
     // Google Gemini / Vertex AI — value for _generationConfig_additions_json.
     // These keys are merged into the existing generationConfig object in the request payload.
     public static final String FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON = """

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -267,6 +267,38 @@ public class MemoryContainerConstants {
             }
         }""";
 
+    // Amazon Bedrock Converse — value for _toolConfig_json.
+    // Forces the model to call the extract_facts tool, returning facts as a structured JSON object
+    // at output.message.content[0].toolUse.input rather than the normal content[0].text path.
+    public static final String FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON = """
+        {
+            "tools": [{
+                "toolSpec": {
+                    "name": "extract_facts",
+                    "description": "Extract factual statements from the conversation",
+                    "inputSchema": {
+                        "json": {
+                            "type": "object",
+                            "properties": {
+                                "facts": {
+                                    "type": "array",
+                                    "items": {"type": "string"}
+                                }
+                            },
+                            "required": ["facts"],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }],
+            "toolChoice": {"tool": {"name": "extract_facts"}}
+        }""";
+
+    // JsonPath to the facts object in a Bedrock Converse tool-use response.
+    // Used by MemoryProcessingService when structured output is active for Bedrock connectors.
+    public static final String BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH =
+        "$.output.message.content[0].toolUse.input";
+
     public static final String USER_PREFERENCE_FACTS_EXTRACTION_PROMPT =
         """
             <ROLE>You are a USER PREFERENCE EXTRACTOR, not a chat assistant. Your only job is to output JSON facts. Do not answer questions, make suggestions, ask follow-ups, or perform actions.</ROLE>

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -258,7 +258,8 @@ public class MemoryContainerConstants {
                         "items": {"type": "string"}
                     }
                 },
-                "required": ["facts"]
+                "required": ["facts"],
+                "additionalProperties": false
             }
         }""";
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -251,7 +251,7 @@ public class MemoryContainerConstants {
     // Auto-detection via schemaForUrl is not enabled because that header cannot be injected
     // via parameters. Admins can wire this up manually by setting _output_json in the connector.
     // TODO: Enable auto-detection once MemoryContainerHelper can inject connector-level headers.
-    //       Track in: https://github.com/opensearch-project/ml-commons/issues (open follow-up issue)
+    // Track in: https://github.com/opensearch-project/ml-commons/issues (open follow-up issue)
     public static final String FACTS_EXTRACTION_ANTHROPIC_OUTPUT_JSON = """
         {
             "type": "json_schema",
@@ -273,7 +273,7 @@ public class MemoryContainerConstants {
     // response shape from a text field to a tool-use block and requires additional post-processing.
     // Not yet auto-detected by schemaForUrl.
     // TODO: Enable once MemoryProcessingService can parse Bedrock Converse tool-use responses.
-    //       Track in: https://github.com/opensearch-project/ml-commons/issues (open follow-up issue)
+    // Track in: https://github.com/opensearch-project/ml-commons/issues (open follow-up issue)
     public static final String FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON = """
         {
             "tools": [

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -296,8 +296,7 @@ public class MemoryContainerConstants {
 
     // JsonPath to the facts object in a Bedrock Converse tool-use response.
     // Used by MemoryProcessingService when structured output is active for Bedrock connectors.
-    public static final String BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH =
-        "$.output.message.content[0].toolUse.input";
+    public static final String BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH = "$.output.message.content[0].toolUse.input";
 
     public static final String USER_PREFERENCE_FACTS_EXTRACTION_PROMPT =
         """

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -200,6 +200,122 @@ public class MemoryContainerConstants {
     public static final String USER_PREFERENCE_JSON_ENFORCEMENT_MESSAGE = """
         Return ONLY ONE LINE of valid JSON exactly as {"facts":["<fact sentence>"]}. Begin with { and end with }. No extra text.""";
 
+    // Provider-specific structured output schemas for constrained decoding.
+    // Each constant is the value for the corresponding _xxx_json injection parameter in HttpConnector.
+    // The full MemoryContainerHelper.getStructuredOutputParameters() implementation selects the right
+    // constant and parameter name based on the model's connector URL.
+
+    // OpenAI, Azure OpenAI, Ollama (OpenAI-compatible), DeepSeek — value for _response_format_json
+    public static final String FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON = """
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "facts_extraction",
+                "strict": true,
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "facts": {
+                            "type": "array",
+                            "items": {"type": "string"}
+                        }
+                    },
+                    "required": ["facts"],
+                    "additionalProperties": false
+                }
+            }
+        }""";
+
+    // Cohere Chat API v2 (/v2/chat) — value for _response_format_json.
+    // Uses type "json_schema" (Cohere v2 structured output). Requires the connector to point at
+    // the /v2/chat endpoint; the legacy /v1/chat endpoint does not support json_schema enforcement.
+    public static final String FACTS_EXTRACTION_COHERE_RESPONSE_FORMAT_JSON = """
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "type": "object",
+                "properties": {
+                    "facts": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    }
+                },
+                "required": ["facts"],
+                "additionalProperties": false
+            }
+        }""";
+
+    // Anthropic Messages API (direct) — value for _output_json.
+    // IMPORTANT: Using this requires the connector's headers to include the appropriate
+    // anthropic-beta header (e.g. "anthropic-beta": "output-128k-2025-02-19").
+    // Auto-detection via schemaForUrl is not enabled because that header cannot be injected
+    // via parameters. Admins can wire this up manually by setting _output_json in the connector.
+    // TODO: Enable auto-detection once MemoryContainerHelper can inject connector-level headers.
+    //       Track in: https://github.com/opensearch-project/ml-commons/issues (open follow-up issue)
+    public static final String FACTS_EXTRACTION_ANTHROPIC_OUTPUT_JSON = """
+        {
+            "type": "json_schema",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "facts": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    }
+                },
+                "required": ["facts"],
+                "additionalProperties": false
+            }
+        }""";
+
+    // AWS Bedrock Converse API — reserved for future structured output support.
+    // Bedrock Converse structured output requires toolConfig+toolChoice, which changes the
+    // response shape from a text field to a tool-use block and requires additional post-processing.
+    // Not yet auto-detected by schemaForUrl.
+    // TODO: Enable once MemoryProcessingService can parse Bedrock Converse tool-use responses.
+    //       Track in: https://github.com/opensearch-project/ml-commons/issues (open follow-up issue)
+    public static final String FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON = """
+        {
+            "tools": [
+                {
+                    "toolSpec": {
+                        "name": "facts_extraction",
+                        "description": "Extract user preference facts",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {
+                                    "facts": {
+                                        "type": "array",
+                                        "items": {"type": "string"}
+                                    }
+                                },
+                                "required": ["facts"]
+                            }
+                        }
+                    }
+                }
+            ],
+            "toolChoice": {"tool": {"name": "facts_extraction"}}
+        }""";
+
+    // Google Gemini / Vertex AI — value for _generationConfig_additions_json.
+    // These keys are merged into the existing generationConfig object in the request payload.
+    public static final String FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON = """
+        {
+            "responseMimeType": "application/json",
+            "responseSchema": {
+                "type": "object",
+                "properties": {
+                    "facts": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    }
+                },
+                "required": ["facts"]
+            }
+        }""";
+
     public static final String USER_PREFERENCE_FACTS_EXTRACTION_PROMPT =
         """
             <ROLE>You are a USER PREFERENCE EXTRACTOR, not a chat assistant. Your only job is to output JSON facts. Do not answer questions, make suggestions, ask follow-ups, or perform actions.</ROLE>

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -196,6 +196,10 @@ public class MemoryContainerConstants {
         """
             Respond NOW with ONE LINE of valid JSON ONLY exactly as {"facts":["fact1","fact2",...]}. No extra text, no code fences, no newlines or tabs, no spaces after commas or colons.""";
 
+    // Stable prefix of JSON_ENFORCEMENT_MESSAGE with no JSON-special characters.
+    // Use this in assertions instead of parsing the full message out of a serialized JSON string.
+    public static final String JSON_ENFORCEMENT_SENTINEL = "Respond NOW with ONE LINE of valid JSON ONLY";
+
     // JSON enforcement message for user preference extraction
     public static final String USER_PREFERENCE_JSON_ENFORCEMENT_MESSAGE = """
         Return ONLY ONE LINE of valid JSON exactly as {"facts":["<fact sentence>"]}. Begin with { and end with }. No extra text.""";

--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorActionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorActionTest.java
@@ -48,6 +48,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
@@ -710,6 +711,72 @@ public class ConnectorActionTest {
     }
 
     @Test
+    public void toXContent_WritesSupportsStructuredOutputWhenTrue() throws IOException {
+        ConnectorAction action = ConnectorAction
+            .builder()
+            .actionType(TEST_ACTION_TYPE)
+            .method(TEST_METHOD_POST)
+            .url(URL)
+            .requestBody(TEST_REQUEST_BODY)
+            .supportsStructuredOutput(true)
+            .build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        action.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+        assertTrue(content.contains("\"supports_structured_output\":true"));
+    }
+
+    @Test
+    public void toXContent_OmitsSupportsStructuredOutputWhenFalse() throws IOException {
+        ConnectorAction action = ConnectorAction
+            .builder()
+            .actionType(TEST_ACTION_TYPE)
+            .method(TEST_METHOD_POST)
+            .url(URL)
+            .requestBody(TEST_REQUEST_BODY)
+            .build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        action.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+        assertFalse(content.contains("supports_structured_output"));
+    }
+
+    @Test
+    public void parse_ReadsSupportsStructuredOutputTrue() throws IOException {
+        String jsonStr = "{\"action_type\":\"PREDICT\",\"method\":\"post\",\"url\":\"https://test.com\","
+            + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\","
+            + "\"supports_structured_output\":true}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+        ConnectorAction action = ConnectorAction.parse(parser);
+        assertTrue(action.isSupportsStructuredOutput());
+    }
+
+    @Test
+    public void parse_DefaultsSupportsStructuredOutputFalse() throws IOException {
+        String jsonStr = "{\"action_type\":\"PREDICT\",\"method\":\"post\",\"url\":\"https://test.com\","
+            + "\"request_body\":\"{\\\"input\\\": \\\"${parameters.input}\\\"}\"}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+        ConnectorAction action = ConnectorAction.parse(parser);
+        assertFalse(action.isSupportsStructuredOutput());
+    }
+
+    @Test
     public void test_wrongActionType() {
         Throwable exception = assertThrows(IllegalArgumentException.class, () -> { ConnectorAction.ActionType.from("badAction"); });
         assertEquals("Wrong Action Type of badAction", exception.getMessage());
@@ -719,6 +786,73 @@ public class ConnectorActionTest {
     public void test_invalidActionInModelPrediction() {
         ConnectorAction.ActionType actionType = ConnectorAction.ActionType.from("execute");
         assertEquals(isValidActionInModelPrediction(actionType), false);
+    }
+
+    @Test
+    public void supportsStructuredOutput_DefaultsFalse() {
+        ConnectorAction action = ConnectorAction
+            .builder()
+            .actionType(TEST_ACTION_TYPE)
+            .method(TEST_METHOD_POST)
+            .url(URL)
+            .requestBody(TEST_REQUEST_BODY)
+            .build();
+
+        assertFalse(action.isSupportsStructuredOutput());
+    }
+
+    @Test
+    public void supportsStructuredOutput_CanBeSetTrue() {
+        ConnectorAction action = ConnectorAction
+            .builder()
+            .actionType(TEST_ACTION_TYPE)
+            .method(TEST_METHOD_POST)
+            .url(URL)
+            .requestBody(TEST_REQUEST_BODY)
+            .supportsStructuredOutput(true)
+            .build();
+
+        assertTrue(action.isSupportsStructuredOutput());
+    }
+
+    @Test
+    public void writeTo_AndReadFrom_PreservesSupportsStructuredOutput() throws IOException {
+        ConnectorAction original = ConnectorAction
+            .builder()
+            .actionType(TEST_ACTION_TYPE)
+            .method(TEST_METHOD_POST)
+            .url(URL)
+            .requestBody(TEST_REQUEST_BODY)
+            .supportsStructuredOutput(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        ConnectorAction deserialized = new ConnectorAction(out.bytes().streamInput());
+
+        assertTrue(deserialized.isSupportsStructuredOutput());
+    }
+
+    @Test
+    public void writeTo_PreVersion370_SupportsStructuredOutputNotWritten() throws IOException {
+        ConnectorAction original = ConnectorAction
+            .builder()
+            .actionType(TEST_ACTION_TYPE)
+            .method(TEST_METHOD_POST)
+            .url(URL)
+            .requestBody(TEST_REQUEST_BODY)
+            .supportsStructuredOutput(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.fromString("3.6.0"));
+        original.writeTo(out);
+
+        org.opensearch.core.common.io.stream.StreamInput in = out.bytes().streamInput();
+        in.setVersion(Version.fromString("3.6.0"));
+        ConnectorAction deserialized = new ConnectorAction(in);
+
+        assertFalse(deserialized.isSupportsStructuredOutput());
     }
 
     /**

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -381,26 +381,34 @@ public class HttpConnectorTest {
     }
 
     public static HttpConnector createHttpConnectorWithRequestBody(String requestBody) {
-        ConnectorAction.ActionType actionType = ConnectorAction.ActionType.PREDICT;
-        String name = null;
-        String method = "POST";
-        String url = "https://test.com";
-        Map<String, String> headers = new HashMap<>();
-        headers.put("api_key", "${credential.key}");
-        String preProcessFunction = MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT;
-        String postProcessFunction = MLPostProcessFunction.OPENAI_EMBEDDING;
-
         ConnectorAction action = new ConnectorAction(
-            actionType,
-            name,
-            method,
-            url,
-            headers,
+            ConnectorAction.ActionType.PREDICT,
+            null,
+            "POST",
+            "https://test.com",
+            Map.of("api_key", "${credential.key}"),
             requestBody,
-            preProcessFunction,
-            postProcessFunction
+            MLPreProcessFunction.TEXT_DOCS_TO_OPENAI_EMBEDDING_INPUT,
+            MLPostProcessFunction.OPENAI_EMBEDDING
         );
+        return buildConnector(action);
+    }
 
+    /** Creates a connector whose PREDICT action has {@code supports_structured_output: true}. */
+    public static HttpConnector createHttpConnectorWithStructuredOutputEnabled(String requestBody) {
+        ConnectorAction action = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("https://test.com")
+            .headers(Map.of("api_key", "${credential.key}"))
+            .requestBody(requestBody)
+            .supportsStructuredOutput(true)
+            .build();
+        return buildConnector(action);
+    }
+
+    private static HttpConnector buildConnector(ConnectorAction action) {
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test input value");
 
@@ -409,7 +417,7 @@ public class HttpConnectorTest {
 
         ConnectorClientConfig httpClientConfig = new ConnectorClientConfig(30, 30, 30, 10, 10, -1, RetryBackoffPolicy.CONSTANT, null);
 
-        HttpConnector connector = HttpConnector
+        return HttpConnector
             .builder()
             .name("test_connector_name")
             .description("this is a test connector")
@@ -422,7 +430,6 @@ public class HttpConnectorTest {
             .accessMode(AccessMode.PUBLIC)
             .connectorClientConfig(httpClientConfig)
             .build();
-        return connector;
     }
 
     @Test
@@ -647,7 +654,7 @@ public class HttpConnectorTest {
     @Test
     public void createPayload_WithResponseFormatJson_MergesIntoPayload() {
         String requestBody = "{\"model\": \"gpt-4\", \"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "Hello");
         parameters
@@ -669,7 +676,7 @@ public class HttpConnectorTest {
     @Test
     public void createPayload_WithoutResponseFormatJson_NoResponseFormatField() {
         String requestBody = "{\"model\": \"gpt-4\", \"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "Hello");
 
@@ -682,7 +689,7 @@ public class HttpConnectorTest {
     @Test
     public void createPayload_ResponseFormatJson_IsJsonObjectNotString() {
         String requestBody = "{\"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
         parameters.put("_response_format_json", "{\"type\":\"json_object\"}");
@@ -697,7 +704,7 @@ public class HttpConnectorTest {
     @Test
     public void createPayload_ResponseFormatJson_InvalidJson_IgnoresParameter() {
         String requestBody = "{\"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
         parameters.put("_response_format_json", "not-valid-json");
@@ -711,7 +718,7 @@ public class HttpConnectorTest {
     @Test
     public void createPayload_ResponseFormatJson_JsonArray_IgnoresParameter() {
         String requestBody = "{\"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
         parameters.put("_response_format_json", "[\"not\", \"an\", \"object\"]");
@@ -729,7 +736,7 @@ public class HttpConnectorTest {
     @Test
     public void createPayload_WithDisallowedField_IsNotInjected() {
         String requestBody = "{\"model\": \"gpt-4\", \"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
         // "model" is not in STRUCTURED_OUTPUT_ALLOWED_FIELDS — must be silently ignored
@@ -744,7 +751,7 @@ public class HttpConnectorTest {
     @Test
     public void createPayload_WithAllowedCamelCaseField_IsInjected() {
         String requestBody = "{\"contents\": [{\"role\": \"user\", \"parts\": [{\"text\": \"${parameters.input}\"}]}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
         // "generationConfig" is in STRUCTURED_OUTPUT_ALLOWED_FIELDS — camelCase field must be injected
@@ -761,7 +768,7 @@ public class HttpConnectorTest {
     public void createPayload_WithGenerationConfigAdditionsJson_MergesIntoExistingField() {
         String requestBody = "{\"generationConfig\":{\"maxOutputTokens\":1024},\"contents\":[{\"role\":\"user\","
             + "\"parts\":[{\"text\":\"${parameters.input}\"}]}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
         parameters
@@ -784,7 +791,7 @@ public class HttpConnectorTest {
     public void createPayload_WithToolConfigJson_IsInjected() {
         // "toolConfig" is in STRUCTURED_OUTPUT_ALLOWED_FIELDS for Bedrock Converse structured output
         String requestBody = "{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\"," + "\"text\":\"${parameters.input}\"}]}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
         parameters.put("_toolConfig_json", "{\"toolChoice\":{\"tool\":{\"name\":\"extract_facts\"}}}");
@@ -799,7 +806,7 @@ public class HttpConnectorTest {
     @Test
     public void createPayload_WithGenerationConfigAdditionsJson_CreatesFieldIfAbsent() {
         String requestBody = "{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"${parameters.input}\"}]}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
         parameters.put("_generationConfig_additions_json", "{\"responseMimeType\":\"application/json\"}");
@@ -821,7 +828,7 @@ public class HttpConnectorTest {
         // Payload is a JSON array, not an object — structured output injection must be skipped
         // without throwing IllegalStateException from getAsJsonObject().
         String requestBody = "[{\"role\":\"user\",\"content\":\"hello\"}]";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("_response_format_json", "{\"type\":\"json_object\"}");
 
@@ -836,7 +843,7 @@ public class HttpConnectorTest {
         // Keys exactly "_additions_json" or "_json" produce an empty field name after slicing —
         // must be silently ignored, not throw StringIndexOutOfBoundsException.
         String requestBody = "{\"messages\":[{\"role\":\"user\",\"content\":\"${parameters.input}\"}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
         parameters.put("_additions_json", "{\"type\":\"json_object\"}");
@@ -853,7 +860,7 @@ public class HttpConnectorTest {
         // When _response_format_json (replace) and _response_format_additions_json (merge) are both
         // present, the replace pass runs first; the merge then merges into the replaced value.
         String requestBody = "{\"messages\":[{\"role\":\"user\",\"content\":\"${parameters.input}\"}]}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
         parameters.put("_response_format_json", "{\"type\":\"json_schema\"}");

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -727,33 +727,34 @@ public class HttpConnectorTest {
     }
 
     @Test
-    public void createPayload_WithOutputConfigJson_InjectsTopLevelField() {
-        String requestBody = "{\"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
+    public void createPayload_WithDisallowedField_IsNotInjected() {
+        String requestBody = "{\"model\": \"gpt-4\", \"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
         HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
-        parameters.put("_output_config_json", "{\"format\":{\"type\":\"json_schema\"}}");
+        // "model" is not in STRUCTURED_OUTPUT_ALLOWED_FIELDS — must be silently ignored
+        parameters.put("_model_json", "{\"id\":\"attacker-model\"}");
 
         String payload = connector.createPayload(PREDICT.name(), parameters);
 
         JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
-        Assert.assertTrue("output_config should be present", json.has("output_config"));
-        Assert.assertTrue("output_config must be a JSON object", json.get("output_config").isJsonObject());
+        Assert.assertEquals("model field must not be overridden by disallowed injection", "gpt-4", json.get("model").getAsString());
     }
 
     @Test
-    public void createPayload_WithOutputConfigJsonCamelCase_InjectsTopLevelField() {
-        String requestBody = "{\"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
+    public void createPayload_WithAllowedCamelCaseField_IsInjected() {
+        String requestBody = "{\"contents\": [{\"role\": \"user\", \"parts\": [{\"text\": \"${parameters.input}\"}]}]}";
         HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
-        parameters.put("_outputConfig_json", "{\"textFormat\":{\"type\":\"json_schema\"}}");
+        // "generationConfig" is in STRUCTURED_OUTPUT_ALLOWED_FIELDS — camelCase field must be injected
+        parameters.put("_generationConfig_json", "{\"responseMimeType\":\"application/json\"}");
 
         String payload = connector.createPayload(PREDICT.name(), parameters);
 
         JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
-        Assert.assertTrue("outputConfig should be present", json.has("outputConfig"));
-        Assert.assertTrue("outputConfig must be a JSON object", json.get("outputConfig").isJsonObject());
+        Assert.assertTrue("generationConfig should be present", json.has("generationConfig"));
+        Assert.assertTrue("generationConfig must be a JSON object", json.get("generationConfig").isJsonObject());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -801,6 +801,58 @@ public class HttpConnectorTest {
     }
 
     @Test
+    public void createPayload_ArrayPayload_StructuredOutputNotInjected() {
+        // Payload is a JSON array, not an object — structured output injection must be skipped
+        // without throwing IllegalStateException from getAsJsonObject().
+        String requestBody = "[{\"role\":\"user\",\"content\":\"hello\"}]";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("_response_format_json", "{\"type\":\"json_object\"}");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        Assert.assertTrue("Payload must remain a JSON array", payload.startsWith("["));
+        Assert.assertFalse("response_format must not be injected into an array payload", payload.contains("response_format"));
+    }
+
+    @Test
+    public void createPayload_EmptyFieldNameKey_DoesNotThrow() {
+        // Keys exactly "_additions_json" or "_json" produce an empty field name after slicing —
+        // must be silently ignored, not throw StringIndexOutOfBoundsException.
+        String requestBody = "{\"messages\":[{\"role\":\"user\",\"content\":\"${parameters.input}\"}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test");
+        parameters.put("_additions_json", "{\"type\":\"json_object\"}");
+        parameters.put("_json", "{\"type\":\"json_object\"}");
+
+        // Must not throw; payload must be returned unchanged since field names are empty
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert.assertFalse("Empty-field-name keys must be ignored", json.has(""));
+    }
+
+    @Test
+    public void createPayload_BothReplaceAndMergeForSameField_ReplaceTakesPrecedence() {
+        // When _response_format_json (replace) and _response_format_additions_json (merge) are both
+        // present, the replace pass runs first; the merge then merges into the replaced value.
+        String requestBody = "{\"messages\":[{\"role\":\"user\",\"content\":\"${parameters.input}\"}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test");
+        parameters.put("_response_format_json", "{\"type\":\"json_schema\"}");
+        parameters.put("_response_format_additions_json", "{\"extra\":\"field\"}");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        JsonObject rf = json.getAsJsonObject("response_format");
+        Assert.assertNotNull("response_format must be present", rf);
+        Assert.assertEquals("type from replace pass must be preserved", "json_schema", rf.get("type").getAsString());
+        Assert.assertEquals("extra field from merge pass must be added", "field", rf.get("extra").getAsString());
+    }
+
+    @Test
     public void testFindAction_MultipleActionsWithSameType() {
         ConnectorAction action1 = new ConnectorAction(
             PREDICT,

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -789,17 +789,21 @@ public class HttpConnectorTest {
 
     @Test
     public void createPayload_WithToolConfigJson_IsInjected() {
-        // "toolConfig" is in STRUCTURED_OUTPUT_ALLOWED_FIELDS for Bedrock Converse structured output
+        // "toolConfig" is in STRUCTURED_OUTPUT_ALLOWED_FIELDS for Bedrock Converse tool-use structured output
         String requestBody = "{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\"," + "\"text\":\"${parameters.input}\"}]}]}";
         HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
-        parameters.put("_toolConfig_json", "{\"toolChoice\":{\"tool\":{\"name\":\"extract_facts\"}}}");
+        parameters
+            .put(
+                "_toolConfig_json",
+                "{\"tools\":[{\"toolSpec\":{\"name\":\"extract_facts\"}}],\"toolChoice\":{\"tool\":{\"name\":\"extract_facts\"}}}"
+            );
 
         String payload = connector.createPayload(PREDICT.name(), parameters);
 
         JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
-        Assert.assertTrue("toolConfig must be injected for Bedrock Converse", json.has("toolConfig"));
+        Assert.assertTrue("toolConfig must be injected for Bedrock Converse tool-use structured output", json.has("toolConfig"));
         Assert.assertTrue("toolConfig must be a JSON object", json.get("toolConfig").isJsonObject());
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -36,6 +36,9 @@ import org.opensearch.ml.common.TestHelper;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.search.SearchModule;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 public class HttpConnectorTest {
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
@@ -639,6 +642,161 @@ public class HttpConnectorTest {
         Assert.assertTrue(foundByName.isPresent());
         Assert.assertEquals(customActionName, foundByName.get().getName());
         Assert.assertEquals("https://test2.com", foundByName.get().getUrl());
+    }
+
+    @Test
+    public void createPayload_WithResponseFormatJson_MergesIntoPayload() {
+        String requestBody = "{\"model\": \"gpt-4\", \"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "Hello");
+        parameters
+            .put(
+                "_response_format_json",
+                "{\"type\":\"json_schema\",\"json_schema\":{\"name\":\"result\","
+                    + "\"schema\":{\"type\":\"object\",\"properties\":{\"facts\":{\"type\":\"array\","
+                    + "\"items\":{\"type\":\"string\"}}},\"required\":[\"facts\"]}}}"
+            );
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert.assertTrue("response_format should be present", json.has("response_format"));
+        Assert.assertEquals("json_schema", json.getAsJsonObject("response_format").get("type").getAsString());
+        Assert.assertEquals("Hello", json.getAsJsonArray("messages").get(0).getAsJsonObject().get("content").getAsString());
+    }
+
+    @Test
+    public void createPayload_WithoutResponseFormatJson_NoResponseFormatField() {
+        String requestBody = "{\"model\": \"gpt-4\", \"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "Hello");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert.assertFalse("response_format should NOT be present when parameter is absent", json.has("response_format"));
+    }
+
+    @Test
+    public void createPayload_ResponseFormatJson_IsJsonObjectNotString() {
+        String requestBody = "{\"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test");
+        parameters.put("_response_format_json", "{\"type\":\"json_object\"}");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert.assertTrue("response_format must be a JSON object, not a string", json.get("response_format").isJsonObject());
+        Assert.assertEquals("json_object", json.getAsJsonObject("response_format").get("type").getAsString());
+    }
+
+    @Test
+    public void createPayload_ResponseFormatJson_InvalidJson_IgnoresParameter() {
+        String requestBody = "{\"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test");
+        parameters.put("_response_format_json", "not-valid-json");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert.assertFalse("response_format must be absent when _response_format_json is not valid JSON", json.has("response_format"));
+    }
+
+    @Test
+    public void createPayload_ResponseFormatJson_JsonArray_IgnoresParameter() {
+        String requestBody = "{\"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test");
+        parameters.put("_response_format_json", "[\"not\", \"an\", \"object\"]");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert
+            .assertFalse(
+                "response_format must be absent when _response_format_json is a JSON array, not an object",
+                json.has("response_format")
+            );
+    }
+
+    @Test
+    public void createPayload_WithOutputConfigJson_InjectsTopLevelField() {
+        String requestBody = "{\"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test");
+        parameters.put("_output_config_json", "{\"format\":{\"type\":\"json_schema\"}}");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert.assertTrue("output_config should be present", json.has("output_config"));
+        Assert.assertTrue("output_config must be a JSON object", json.get("output_config").isJsonObject());
+    }
+
+    @Test
+    public void createPayload_WithOutputConfigJsonCamelCase_InjectsTopLevelField() {
+        String requestBody = "{\"messages\": [{\"role\": \"user\", \"content\": \"${parameters.input}\"}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test");
+        parameters.put("_outputConfig_json", "{\"textFormat\":{\"type\":\"json_schema\"}}");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert.assertTrue("outputConfig should be present", json.has("outputConfig"));
+        Assert.assertTrue("outputConfig must be a JSON object", json.get("outputConfig").isJsonObject());
+    }
+
+    @Test
+    public void createPayload_WithGenerationConfigAdditionsJson_MergesIntoExistingField() {
+        String requestBody = "{\"generationConfig\":{\"maxOutputTokens\":1024},\"contents\":[{\"role\":\"user\","
+            + "\"parts\":[{\"text\":\"${parameters.input}\"}]}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test");
+        parameters
+            .put(
+                "_generationConfig_additions_json",
+                "{\"responseMimeType\":\"application/json\",\"responseSchema\":{\"type\":\"OBJECT\"}}"
+            );
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert.assertTrue("generationConfig should be present", json.has("generationConfig"));
+        JsonObject genConfig = json.getAsJsonObject("generationConfig");
+        Assert.assertEquals("maxOutputTokens must be preserved", 1024, genConfig.get("maxOutputTokens").getAsInt());
+        Assert.assertEquals("responseMimeType must be merged in", "application/json", genConfig.get("responseMimeType").getAsString());
+        Assert.assertTrue("responseSchema must be merged in", genConfig.has("responseSchema"));
+    }
+
+    @Test
+    public void createPayload_WithGenerationConfigAdditionsJson_CreatesFieldIfAbsent() {
+        String requestBody = "{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"${parameters.input}\"}]}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test");
+        parameters.put("_generationConfig_additions_json", "{\"responseMimeType\":\"application/json\"}");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert.assertTrue("generationConfig should be created when absent", json.has("generationConfig"));
+        Assert
+            .assertEquals(
+                "responseMimeType should be set",
+                "application/json",
+                json.getAsJsonObject("generationConfig").get("responseMimeType").getAsString()
+            );
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -783,8 +783,7 @@ public class HttpConnectorTest {
     @Test
     public void createPayload_WithToolConfigJson_IsInjected() {
         // "toolConfig" is in STRUCTURED_OUTPUT_ALLOWED_FIELDS for Bedrock Converse structured output
-        String requestBody = "{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\","
-            + "\"text\":\"${parameters.input}\"}]}]}";
+        String requestBody = "{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\"," + "\"text\":\"${parameters.input}\"}]}]}";
         HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -781,6 +781,23 @@ public class HttpConnectorTest {
     }
 
     @Test
+    public void createPayload_WithToolConfigJson_IsInjected() {
+        // "toolConfig" is in STRUCTURED_OUTPUT_ALLOWED_FIELDS for Bedrock Converse structured output
+        String requestBody = "{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\","
+            + "\"text\":\"${parameters.input}\"}]}]}";
+        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test");
+        parameters.put("_toolConfig_json", "{\"toolChoice\":{\"tool\":{\"name\":\"extract_facts\"}}}");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert.assertTrue("toolConfig must be injected for Bedrock Converse", json.has("toolConfig"));
+        Assert.assertTrue("toolConfig must be a JSON object", json.get("toolConfig").isJsonObject());
+    }
+
+    @Test
     public void createPayload_WithGenerationConfigAdditionsJson_CreatesFieldIfAbsent() {
         String requestBody = "{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"${parameters.input}\"}]}]}";
         HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);

--- a/docs/remote_inference_blueprints/azure_openai_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/azure_openai_connector_chat_blueprint.md
@@ -42,6 +42,7 @@ POST /_plugins/_ml/connectors/_create
       "action_type": "predict",
       "method": "POST",
       "url": "https://${parameters.endpoint}/openai/deployments/${parameters.deploy-name}/chat/completions?api-version=${parameters.api-version}",
+      "supports_structured_output": true,
       "headers": {
         "api-key": "${credential.openAI_key}"
       },

--- a/docs/remote_inference_blueprints/azure_openai_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/azure_openai_connector_chat_blueprint.md
@@ -17,6 +17,8 @@ PUT /_cluster/settings
 
 Refer to [Azure OpenAI Service REST API reference - Chat Completion](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions).
 
+> **Note:** `supports_structured_output: true` enables JSON schema enforcement for agentic memory fact extraction. See [connector action parameters](../tutorials/remote_inference.md#connector) for details.
+
 If you are using self-managed Opensearch, you should supply OpenAI API key:
 
 

--- a/docs/remote_inference_blueprints/bedrock_connector_converse_blueprint.md
+++ b/docs/remote_inference_blueprints/bedrock_connector_converse_blueprint.md
@@ -1,5 +1,7 @@
 # Bedrock connector blueprint example for Converse
 
+> **Note:** `supports_structured_output: true` enables JSON schema enforcement for agentic memory fact extraction. See [connector action parameters](../tutorials/remote_inference.md#connector) for details.
+
 ## 1. Add connector endpoint to trusted URLs:
 
 Note: no need to do this after 2.11.0
@@ -41,6 +43,7 @@ POST /_plugins/_ml/connectors/_create
         {
             "action_type": "predict",
             "method": "POST",
+            "supports_structured_output": true,
             "headers": {
                 "content-type": "application/json"
             },
@@ -74,6 +77,7 @@ POST /_plugins/_ml/connectors/_create
         {
             "action_type": "predict",
             "method": "POST",
+            "supports_structured_output": true,
             "headers": {
                 "content-type": "application/json"
             },

--- a/docs/remote_inference_blueprints/bedrock_connector_converse_blueprint.md
+++ b/docs/remote_inference_blueprints/bedrock_connector_converse_blueprint.md
@@ -1,6 +1,6 @@
 # Bedrock connector blueprint example for Converse
 
-> **Note:** `supports_structured_output: true` enables JSON schema enforcement for agentic memory fact extraction. See [connector action parameters](../tutorials/remote_inference.md#connector) for details.
+> **Note:** `supports_structured_output: true` enables tool-use constrained decoding for agentic memory fact extraction. When set, the memory pipeline injects a `toolConfig` into the Bedrock Converse request, forcing the model to call the `extract_facts` tool and return structured JSON. See [connector action parameters](../tutorials/remote_inference.md#connector) for details.
 
 ## 1. Add connector endpoint to trusted URLs:
 
@@ -37,7 +37,7 @@ POST /_plugins/_ml/connectors/_create
         "region": "<PLEASE ADD YOUR AWS REGION HERE>",
         "service_name": "bedrock",
         "response_filter": "$.output.message.content[0].text",
-        "model": "anthropic.claude-3-sonnet-20240229-v1:0"
+        "model": "anthropic.claude-sonnet-4-5-20251101-v1:0"
     },
     "actions": [
         {
@@ -48,7 +48,7 @@ POST /_plugins/_ml/connectors/_create
                 "content-type": "application/json"
             },
             "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
-            "request_body": "{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"${parameters.inputs}\"}]}]}"
+            "request_body": "{\"system\":[{\"text\":\"${parameters.system_prompt}\"}],\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"${parameters.user_prompt}\"}]}]}"
         }
     ]
 }
@@ -71,7 +71,7 @@ POST /_plugins/_ml/connectors/_create
         "region": "<PLEASE ADD YOUR AWS REGION HERE>",
         "service_name": "bedrock",
         "response_filter": "$.output.message.content[0].text",
-        "model": "anthropic.claude-3-sonnet-20240229-v1:0"
+        "model": "anthropic.claude-sonnet-4-5-20251101-v1:0"
     },
     "actions": [
         {
@@ -82,7 +82,7 @@ POST /_plugins/_ml/connectors/_create
                 "content-type": "application/json"
             },
             "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
-            "request_body": "{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"${parameters.inputs}\"}]}]}"
+            "request_body": "{\"system\":[{\"text\":\"${parameters.system_prompt}\"}],\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"${parameters.user_prompt}\"}]}]}"
         }
     ]
 }
@@ -141,7 +141,8 @@ Sample response:
 POST /_plugins/_ml/models/rcormY8B8aiZvtEZIe89/_predict
 {
   "parameters": {
-    "inputs": "What is the meaning of life?"
+    "system_prompt": "You are a helpful assistant.",
+    "user_prompt": "What is the meaning of life?"
   }
 }
 ```
@@ -155,7 +156,7 @@ Sample response:
         {
           "name": "response",
           "dataAsMap": {
-            "response": "There is no single, universally accepted answer to the meaning of life. It's a question that has been pondered by philosophers, theologians, and thinkers across cultures for centuries. Here are some of the major perspectives on deriving meaning in life:\n\n- Religious/spiritual views - Many religions provide a framework for finding meaning through connection to the divine, fulfilling religious teachings/duties, and an afterlife.\n\n- Existentialist philosophy - Thinkers like Sartre and Camus emphasized that we each have the freedom and responsibility to create our own subjective meaning in an objectively meaningless universe.\n\n- Hedonism - The view that the pursuit of pleasure and avoiding suffering is the highest good and most meaningful way to live.\n\n- Virtue ethics - Finding meaning through living an ethical life based on virtues like courage, temperance, justice, and wisdom.\n\n- Humanistic psychology - Psychologists like Maslow and Frankl emphasized fulfillment from reaching one's full human potential and finding a sense of purpose.\n\n- Naturalism/Nihilism - Some believe life itself has no inherent meaning beyond the physical/natural world we empirically experience.\n\nUltimately, the \"meaning of life\" is an existential question that challenges each individual to decide what makes their own life feel meaningful, based on their own worldview, beliefs, and values. There is no objectively \"correct\" universal answer."
+            "response": "The meaning of life is a profound philosophical question..."
           }
         }
       ],

--- a/docs/remote_inference_blueprints/cohere_connector_chat_v2_blueprint.md
+++ b/docs/remote_inference_blueprints/cohere_connector_chat_v2_blueprint.md
@@ -1,0 +1,85 @@
+# Cohere Chat v2 Connector Blueprint
+
+This blueprint connects a Cohere v2 chat model to your OpenSearch cluster using the [Cohere v2 Chat API](https://docs.cohere.com/reference/chat). You will need a Cohere API key.
+
+The v2 API uses the OpenAI-compatible messages format (`messages` array with `role`/`content`). Use this blueprint instead of the v1 blueprint when you want structured output support for agentic memory.
+
+> **Note:** `supports_structured_output: true` enables JSON schema enforcement for agentic memory fact extraction. See [connector action parameters](../tutorials/remote_inference.md#connector) for details.
+
+## 1. Add connector endpoint to trusted URLs
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "plugins.ml_commons.trusted_connector_endpoints_regex": [
+      "^https://api\\.cohere\\.com/.*$"
+    ]
+  }
+}
+```
+
+## 2. Create connector
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Cohere Chat v2",
+  "description": "Connector to Cohere v2 Chat API",
+  "version": "1",
+  "protocol": "http",
+  "credential": {
+    "cohere_key": "<ENTER_COHERE_API_KEY_HERE>"
+  },
+  "parameters": {
+    "model": "command-r-plus"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://api.cohere.com/v2/chat",
+      "supports_structured_output": true,
+      "headers": {
+        "Authorization": "Bearer ${credential.cohere_key}",
+        "Request-Source": "unspecified:opensearch"
+      },
+      "request_body": "{ \"model\": \"${parameters.model}\", \"stream\": false, \"messages\": ${parameters.messages} }"
+    }
+  ]
+}
+```
+
+## 3. Register and deploy model
+
+```json
+POST /_plugins/_ml/models/_register
+{
+  "name": "Cohere Chat v2",
+  "function_name": "remote",
+  "description": "Cohere v2 chat model",
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+Poll the returned `task_id` until `status` is `COMPLETED`, then deploy:
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_deploy
+```
+
+## 4. Test model
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_predict
+{
+  "parameters": {
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is OpenSearch?"
+      }
+    ]
+  }
+}
+```

--- a/docs/remote_inference_blueprints/deepseek_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/deepseek_connector_chat_blueprint.md
@@ -2,6 +2,8 @@
 This blueprint integrates [DeepSeek Chat Model](https://api-docs.deepseek.com/api/create-chat-completion) for question-answering capabilities for standalone interactions. Full conversational functionality requires additional development. 
 Adapt and extend this blueprint as needed for your specific use case.
 
+> **Note:** `supports_structured_output: true` enables JSON schema enforcement for agentic memory fact extraction. See [connector action parameters](../tutorials/remote_inference.md#connector) for details.
+
 ## 1. Add connector endpoint to trusted URLs:
 Note: skip this step starting 2.19.0
 

--- a/docs/remote_inference_blueprints/deepseek_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/deepseek_connector_chat_blueprint.md
@@ -36,6 +36,7 @@ POST /_plugins/_ml/connectors/_create
       "action_type": "predict",
       "method": "POST",
       "url": "https://${parameters.endpoint}/v1/chat/completions",
+      "supports_structured_output": true,
       "headers": {
         "Content-Type": "application/json",
         "Authorization": "Bearer ${credential.deepSeek_key}"

--- a/docs/remote_inference_blueprints/google_gemini_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/google_gemini_connector_chat_blueprint.md
@@ -1,0 +1,84 @@
+# Google Gemini Connector Blueprint for Chat
+
+This blueprint connects a Google Gemini chat model to your OpenSearch cluster using the [Gemini API](https://ai.google.dev/api/generate-content). You will need a Gemini API key from [Google AI Studio](https://aistudio.google.com/apikey).
+
+> **Note:** `supports_structured_output: true` enables JSON schema enforcement for agentic memory fact extraction. See [connector action parameters](../tutorials/remote_inference.md#connector) for details.
+
+## 1. Add connector endpoint to trusted URLs
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "plugins.ml_commons.trusted_connector_endpoints_regex": [
+      "^https://generativelanguage\\.googleapis\\.com/.*$"
+    ]
+  }
+}
+```
+
+## 2. Create connector
+
+The Gemini API uses `contents` (not `messages`) with `role` and `parts`. `generationConfig` is optional and can be passed per-request if needed.
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Google Gemini Chat",
+  "description": "Connector to Google Gemini generateContent API",
+  "version": "1",
+  "protocol": "http",
+  "credential": {
+    "gemini_key": "<ENTER_GEMINI_API_KEY_HERE>"
+  },
+  "parameters": {
+    "model": "gemini-2.0-flash"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://generativelanguage.googleapis.com/v1beta/models/${parameters.model}:generateContent?key=${credential.gemini_key}",
+      "supports_structured_output": true,
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "request_body": "{ \"contents\": ${parameters.contents} }"
+    }
+  ]
+}
+```
+
+## 3. Register and deploy model
+
+```json
+POST /_plugins/_ml/models/_register
+{
+  "name": "Google Gemini Chat",
+  "function_name": "remote",
+  "description": "Google Gemini chat model",
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+Poll the returned `task_id` until `status` is `COMPLETED`, then deploy:
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_deploy
+```
+
+## 4. Test model
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_predict
+{
+  "parameters": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [{"text": "What is OpenSearch?"}]
+      }
+    ]
+  }
+}
+```

--- a/docs/remote_inference_blueprints/ollama_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/ollama_connector_chat_blueprint.md
@@ -2,6 +2,8 @@
 
 This is an AI connector blueprint for Ollama or any other local/self-hosted LLM as long as it is OpenAI compatible (Ollama, llama.cpp, vLLM, etc)
 
+> **Note:** `supports_structured_output: true` enables JSON schema enforcement for agentic memory fact extraction. See [connector action parameters](../tutorials/remote_inference.md#connector) for details.
+
 ## 1. Add connector endpoint to trusted URLs
 
 Adjust the Regex to your local IP. The following example allows all URLs.

--- a/docs/remote_inference_blueprints/ollama_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/ollama_connector_chat_blueprint.md
@@ -51,6 +51,7 @@ POST /_plugins/_ml/connectors/_create
       "action_type": "predict",
       "method": "POST",
       "url": "https://${parameters.endpoint}/v1/chat/completions",
+      "supports_structured_output": true,
       "headers": {
         "Authorization": "Bearer ${credential.openAI_key}"
       },

--- a/docs/remote_inference_blueprints/open_ai_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/open_ai_connector_chat_blueprint.md
@@ -20,6 +20,7 @@ POST /_plugins/_ml/connectors/_create
       "action_type": "predict",
       "method": "POST",
       "url": "https://${parameters.endpoint}/v1/chat/completions",
+      "supports_structured_output": true,
       "headers": {
         "Authorization": "Bearer ${credential.openAI_key}"
       },

--- a/docs/remote_inference_blueprints/open_ai_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/open_ai_connector_chat_blueprint.md
@@ -1,6 +1,8 @@
 ### OpenAI connector blueprint example for chat:
 
 #### this blueprint is created from OpenAI doc: https://platform.openai.com/docs/api-reference/chat
+
+> **Note:** `supports_structured_output: true` enables JSON schema enforcement for agentic memory fact extraction. See [connector action parameters](../tutorials/remote_inference.md#connector) for details.
 ```json
 POST /_plugins/_ml/connectors/_create
 {

--- a/docs/tutorials/agentic_memory/agentic_memory_with_strands_agent.md
+++ b/docs/tutorials/agentic_memory/agentic_memory_with_strands_agent.md
@@ -76,7 +76,9 @@ POST /_plugins/_ml/models/_register
 
 ## 3. Create LLM for Fact Extraction
 
-Register a Bedrock Claude model for fact extraction:
+Register a Bedrock Claude model for fact extraction using the Converse API:
+
+> **Note:** `supports_structured_output: true` enables tool-use constrained decoding for agentic memory fact extraction. When the memory pipeline runs, it injects a `toolConfig` into the Bedrock Converse request, forcing the model to call the `extract_facts` tool and return structured JSON.
 
 ```
 POST /_plugins/_ml/models/_register
@@ -86,16 +88,13 @@ POST /_plugins/_ml/models/_register
   "description": "LLM model for memory processing",
   "connector": {
     "name": "Amazon Bedrock Connector: LLM",
-    "description": "The connector to bedrock Claude 3.7 sonnet model",
+    "description": "The connector to bedrock Claude model via Converse API",
     "version": 1,
     "protocol": "aws_sigv4",
     "parameters": {
       "region": "your_aws_region",
       "service_name": "bedrock",
-      "max_tokens": 8000,
-      "temperature": 1,
-      "anthropic_version": "bedrock-2023-05-31",
-      "model": "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+      "model": "anthropic.claude-sonnet-4-5-20251101-v1:0"
     },
     "credential": {
       "access_key": "your_aws_access_key",
@@ -105,9 +104,10 @@ POST /_plugins/_ml/models/_register
     "actions": [{
       "action_type": "predict",
       "method": "POST",
+      "supports_structured_output": true,
       "headers": {"content-type": "application/json"},
-      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke",
-      "request_body": "{ \"system\": \"${parameters.system_prompt}\", \"anthropic_version\": \"${parameters.anthropic_version}\", \"max_tokens\": ${parameters.max_tokens}, \"temperature\": ${parameters.temperature}, \"messages\": ${parameters.messages} }"
+      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+      "request_body": "{\"system\":[{\"text\":\"${parameters.system_prompt}\"}],\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"${parameters.user_prompt}\"}]}]}"
     }]
   }
 }

--- a/docs/tutorials/remote_inference.md
+++ b/docs/tutorials/remote_inference.md
@@ -74,7 +74,7 @@ A connector consists of 7 parts
     * `request_body`: string, http request body template, User can use `${parameters.<key>}` to use variables defined in `parameters`.
     * `pre_process_function`: string: painless script, pre-process the input data. We have built-in pre-process functions for cohere and openAI embedding models connector.pre_process.cohere.embedding and connector.pre_process.openai.embedding. You can also writer your own functions.
     * `post_process_function`: string: painless script, post-process the model output data. We have built-in post-process functions for cohere and openAI embedding models connector.post_process.cohere.embedding and connector.post_process.openai.embedding. You can also writer your own functions.
-    * `supports_structured_output`: boolean (default `false`). When `true`, agentic memory will inject provider-specific JSON schema parameters into fact-extraction requests so the provider enforces output structure at the token level. Supported for OpenAI, Azure OpenAI, DeepSeek, Ollama, Cohere v2, and Google Gemini/Vertex AI connectors.
+    * `supports_structured_output`: boolean (default `false`). When `true`, agentic memory will inject provider-specific JSON schema parameters into fact-extraction requests so the provider enforces output structure at the token level. Supported for OpenAI, Azure OpenAI, DeepSeek, Ollama, Cohere v2, and Google Gemini/Vertex AI connectors. For unsupported providers the flag is ignored and no schema parameters are injected; fact extraction falls back to being enforced at the prompting level.
 
 ## connector settings
 ### connector access control

--- a/docs/tutorials/remote_inference.md
+++ b/docs/tutorials/remote_inference.md
@@ -66,7 +66,7 @@ A connector consists of 7 parts
     * use "aws_sigv4" for any AWS services which supports SigV4. For example, Amazon Sagemaker
 5. `credential`: map<string, string>,  all variables in this block will be encrypted with "AES/GCM/NoPadding" symmetric encryption algorithm. The encryption key will be generated when the cluster first start and persisted in system index. User has no way to read/set that encryption key.  Credentials can only be used by `headers` of action.
 6. `parameters`: map<string, object>. all variables in this block will be overridable in predict request. In predict request, user can provide same name parameter to override the default parameter value defined in connector.  Parameters can be used by `url` , `headers` and `request_body` of action.
-7. `actions`: list,  it contains a list of action. For one action, it consists of 7 parts:
+7. `actions`: list,  it contains a list of action. For one action, it consists of the following parts:
     * `action_type`: string,  we only support predict in 2.9
     * `method`: string, http method, we only support POST and GET in 2.9
     * `url`:  string, remote service url. User can use ${parameters.<key>} to use variables defined in parameters.
@@ -74,6 +74,7 @@ A connector consists of 7 parts
     * `request_body`: string, http request body template, User can use `${parameters.<key>}` to use variables defined in `parameters`.
     * `pre_process_function`: string: painless script, pre-process the input data. We have built-in pre-process functions for cohere and openAI embedding models connector.pre_process.cohere.embedding and connector.pre_process.openai.embedding. You can also writer your own functions.
     * `post_process_function`: string: painless script, post-process the model output data. We have built-in post-process functions for cohere and openAI embedding models connector.post_process.cohere.embedding and connector.post_process.openai.embedding. You can also writer your own functions.
+    * `supports_structured_output`: boolean (default `false`). When `true`, agentic memory will inject provider-specific JSON schema parameters into fact-extraction requests so the provider enforces output structure at the token level. Supported for OpenAI, Azure OpenAI, DeepSeek, Ollama, Cohere v2, and Google Gemini/Vertex AI connectors.
 
 ## connector settings
 ### connector access control

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java
@@ -57,6 +57,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
 
 import lombok.extern.log4j.Log4j2;
 import okhttp3.MediaType;
@@ -269,9 +270,9 @@ public class ConnectorUtils {
             ProcessorChain processorChain = new ProcessorChain(processorConfigs);
 
             if (responseFilter != null) {
-                // Apply filter first, then processor chain
-                Object filteredResponse = JsonPath.parse(response).read(responseFilter);
-                processedOutput = processorChain.process(filteredResponse);
+                // Apply filter first, then processor chain; fall back to full response on path miss
+                Object filteredResponse = tryReadResponseFilter(response, responseFilter);
+                processedOutput = processorChain.process(filteredResponse != null ? filteredResponse : response);
             } else {
                 // Apply processor chain to whole response
                 processedOutput = processorChain.process(response);
@@ -284,8 +285,8 @@ public class ConnectorUtils {
             if (responseFilter == null) {
                 connector.parseResponse(response, modelTensors, scriptReturnModelTensor);
             } else {
-                Object filteredResponse = JsonPath.parse(response).read(responseFilter);
-                connector.parseResponse(filteredResponse, modelTensors, scriptReturnModelTensor);
+                Object filteredResponse = tryReadResponseFilter(response, responseFilter);
+                connector.parseResponse(filteredResponse != null ? filteredResponse : response, modelTensors, scriptReturnModelTensor);
             }
         }
         return ModelTensors.builder().mlModelTensors(modelTensors).build();
@@ -484,6 +485,17 @@ public class ConnectorUtils {
             .requestBody(requestBody)
             .headers(batchPredictAction.get().getHeaders())
             .build();
+    }
+
+    // Returns null when the path is absent so callers can fall back to the full response.
+    // Needed for tool-use responses (e.g. Bedrock Converse) where content[0].toolUse replaces content[0].text.
+    private static Object tryReadResponseFilter(String response, String responseFilter) {
+        try {
+            return JsonPath.parse(response).read(responseFilter);
+        } catch (PathNotFoundException e) {
+            log.debug("response_filter path '{}' not found in response, using full response", responseFilter);
+            return null;
+        }
     }
 
     private static String cleanPayloadIfNeeded(String payload, Map<String, String> parameters) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingService.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingService.java
@@ -127,14 +127,13 @@ public class MemoryProcessingService {
         Map<String, String> stringParameters = new HashMap<>();
         stringParameters.put("system_prompt", systemPrompt);
 
-        memoryContainerHelper.getStructuredOutputParameters(llmModelId, ActionListener.wrap(rawStructuredOutputParams -> {
-            // Copy to a mutable map so we can extract the result path override before merging.
-            Map<String, String> structuredOutputParams = new HashMap<>(rawStructuredOutputParams);
-            // Extract the result path override before merging so it is never sent to the model.
-            String structuredOutputResultPath = structuredOutputParams.remove("_structured_output_result_path");
+        memoryContainerHelper.getStructuredOutputParameters(llmModelId, ActionListener.wrap(structuredOutputParams -> {
+            String structuredOutputResultPath = null;
             try {
                 if (!structuredOutputParams.isEmpty()) {
-                    stringParameters.putAll(structuredOutputParams);
+                    Map<String, String> params = new HashMap<>(structuredOutputParams);
+                    structuredOutputResultPath = params.remove("_structured_output_result_path");
+                    stringParameters.putAll(params);
                     stringParameters.put("user_prompt", buildUserPrompt(serializeMessagesToJson(messages)));
                 } else {
                     stringParameters.put("user_prompt", buildUserPromptWithEnforcement(messages, strategy.getType()));
@@ -183,7 +182,7 @@ public class MemoryProcessingService {
         client.execute(MLPredictionTaskAction.INSTANCE, predictionRequest, ActionListener.wrap(response -> {
             try {
                 log.debug("Received LLM response, parsing facts...");
-                List<String> facts = parseFactsFromLLMResponse(structuredOutputResultPath, strategy, memoryConfig, response.getOutput());
+                List<String> facts = parseFactsFromLLMResponse(strategy, memoryConfig, structuredOutputResultPath, response.getOutput());
                 log.debug("Extracted {} facts from LLM response", facts.size());
                 listener.onResponse(facts);
             } catch (Exception e) {
@@ -346,9 +345,9 @@ public class MemoryProcessingService {
     }
 
     private List<String> parseFactsFromLLMResponse(
-        String structuredOutputResultPath,
         MemoryStrategy strategy,
         MemoryConfiguration memoryConfig,
+        String structuredOutputResultPath,
         MLOutput mlOutput
     ) {
         List<String> facts = new ArrayList<>();
@@ -372,8 +371,6 @@ public class MemoryProcessingService {
 
         for (int i = 0; i < modelTensors.getMlModelTensors().size(); i++) {
             Map<String, ?> dataMap = modelTensors.getMlModelTensors().get(i).getDataAsMap();
-            // Use the structured output result path override when present (e.g. Bedrock Converse
-            // tool-use responses arrive at toolUse.input rather than content[0].text).
             String llmResultPath = structuredOutputResultPath != null
                 ? structuredOutputResultPath
                 : memoryContainerHelper.getLlmResultPath(strategy, memoryConfig);

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingService.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingService.java
@@ -119,52 +119,49 @@ public class MemoryProcessingService {
                 isOverride ? "strategy-override" : "container-config"
             );
 
-        Map<String, String> stringParameters = new HashMap<>();
-
-        // Determine default prompt based on strategy type
-        String defaultPrompt;
-        MemoryStrategyType type = strategy.getType();
-        if (type == MemoryStrategyType.USER_PREFERENCE) {
-            defaultPrompt = USER_PREFERENCE_FACTS_EXTRACTION_PROMPT;
-        } else if (type == MemoryStrategyType.SUMMARY) {
-            defaultPrompt = SUMMARY_FACTS_EXTRACTION_PROMPT;
-        } else {
-            defaultPrompt = SEMANTIC_FACTS_EXTRACTION_PROMPT;
-        }
-
-        if (strategy.getStrategyConfig() == null || strategy.getStrategyConfig().isEmpty()) {
-            stringParameters.put("system_prompt", defaultPrompt);
-        } else {
-            Object customPrompt = strategy.getStrategyConfig().get("system_prompt");
-            if (customPrompt == null || customPrompt.toString().isBlank()) {
-                stringParameters.put("system_prompt", defaultPrompt);
-            } else if (!validatePromptFormat(customPrompt.toString())) {
-                log.error("Invalid custom prompt format - must specify JSON response format with 'facts' array");
-                listener.onFailure(new IllegalArgumentException("Custom prompt must specify JSON response format with 'facts' array"));
-                return;
-            } else {
-                stringParameters.put("system_prompt", customPrompt.toString()); // use custom strategy
-            }
-        }
-
-        try {
-            // Always add JSON enforcement message for fact extraction
-            String enforcementMsg = (strategy.getType() == MemoryStrategyType.USER_PREFERENCE)
-                ? USER_PREFERENCE_JSON_ENFORCEMENT_MESSAGE
-                : JSON_ENFORCEMENT_MESSAGE;
-            MessageInput enforcementMessage = getMessageInput(enforcementMsg);
-            // Create mutable copy to avoid UnsupportedOperationException
-            List<MessageInput> mutableMessages = new ArrayList<>(messages);
-            mutableMessages.add(enforcementMessage);
-            String conversationJson = serializeMessagesToJson(mutableMessages);
-            String userPrompt = "Analyze the following conversation and extract information:\n```json\n" + conversationJson + "\n```";
-            stringParameters.put("user_prompt", userPrompt);
-        } catch (Exception e) {
-            log.error("Failed to build messages JSON", e);
-            listener.onResponse(new ArrayList<>());
+        String systemPrompt = resolveSystemPrompt(strategy, listener);
+        if (systemPrompt == null) {
             return;
         }
 
+        Map<String, String> stringParameters = new HashMap<>();
+        stringParameters.put("system_prompt", systemPrompt);
+
+        memoryContainerHelper.getStructuredOutputParameters(llmModelId, ActionListener.wrap(structuredOutputParams -> {
+            try {
+                if (!structuredOutputParams.isEmpty()) {
+                    stringParameters.putAll(structuredOutputParams);
+                    stringParameters.put("user_prompt", buildUserPrompt(serializeMessagesToJson(messages)));
+                } else {
+                    stringParameters.put("user_prompt", buildUserPromptWithEnforcement(messages, strategy.getType()));
+                }
+            } catch (Exception e) {
+                log.error("Failed to build messages JSON", e);
+                listener.onResponse(new ArrayList<>());
+                return;
+            }
+            sendFactExtractionRequest(tenantId, llmModelId, stringParameters, strategy, memoryConfig, listener);
+        }, e -> {
+            log.warn("Unexpected error fetching structured output parameters, falling back to prompt enforcement", e);
+            try {
+                stringParameters.put("user_prompt", buildUserPromptWithEnforcement(messages, strategy.getType()));
+            } catch (Exception buildEx) {
+                log.error("Failed to build messages JSON", buildEx);
+                listener.onResponse(new ArrayList<>());
+                return;
+            }
+            sendFactExtractionRequest(tenantId, llmModelId, stringParameters, strategy, memoryConfig, listener);
+        }));
+    }
+
+    private void sendFactExtractionRequest(
+        String tenantId,
+        String llmModelId,
+        Map<String, String> stringParameters,
+        MemoryStrategy strategy,
+        MemoryConfiguration memoryConfig,
+        ActionListener<List<String>> listener
+    ) {
         MLInput mlInput = MLInput
             .builder()
             .algorithm(FunctionName.REMOTE)
@@ -181,12 +178,10 @@ public class MemoryProcessingService {
         client.execute(MLPredictionTaskAction.INSTANCE, predictionRequest, ActionListener.wrap(response -> {
             try {
                 log.debug("Received LLM response, parsing facts...");
-                MLOutput mlOutput = response.getOutput();
-                List<String> facts = parseFactsFromLLMResponse(strategy, memoryConfig, mlOutput);
+                List<String> facts = parseFactsFromLLMResponse(strategy, memoryConfig, response.getOutput());
                 log.debug("Extracted {} facts from LLM response", facts.size());
                 listener.onResponse(facts);
             } catch (Exception e) {
-                // Preserve client errors (4XX) with their detailed messages
                 if (e instanceof OpenSearchException) {
                     OpenSearchException osException = (OpenSearchException) e;
                     if (osException.status().getStatus() >= 400 && osException.status().getStatus() < 500) {
@@ -194,7 +189,6 @@ public class MemoryProcessingService {
                         return;
                     }
                 }
-                // Wrap server errors and unexpected exceptions
                 log.error("Failed to parse facts from LLM response", e);
                 listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
             }
@@ -202,6 +196,44 @@ public class MemoryProcessingService {
             log.error("Failed to call LLM for fact extraction", e);
             listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
         }));
+    }
+
+    private String resolveSystemPrompt(MemoryStrategy strategy, ActionListener<List<String>> listener) {
+        String defaultPrompt = getDefaultPromptForStrategy(strategy.getType());
+        if (strategy.getStrategyConfig() == null || strategy.getStrategyConfig().isEmpty()) {
+            return defaultPrompt;
+        }
+        Object customPrompt = strategy.getStrategyConfig().get("system_prompt");
+        if (customPrompt == null || customPrompt.toString().isBlank()) {
+            return defaultPrompt;
+        }
+        if (!validatePromptFormat(customPrompt.toString())) {
+            log.error("Invalid custom prompt format - must specify JSON response format with 'facts' array");
+            listener.onFailure(new IllegalArgumentException("Custom prompt must specify JSON response format with 'facts' array"));
+            return null;
+        }
+        return customPrompt.toString();
+    }
+
+    private String getDefaultPromptForStrategy(MemoryStrategyType type) {
+        if (type == MemoryStrategyType.USER_PREFERENCE)
+            return USER_PREFERENCE_FACTS_EXTRACTION_PROMPT;
+        if (type == MemoryStrategyType.SUMMARY)
+            return SUMMARY_FACTS_EXTRACTION_PROMPT;
+        return SEMANTIC_FACTS_EXTRACTION_PROMPT;
+    }
+
+    private String buildUserPromptWithEnforcement(List<MessageInput> messages, MemoryStrategyType type) throws IOException {
+        String enforcementMsg = (type == MemoryStrategyType.USER_PREFERENCE)
+            ? USER_PREFERENCE_JSON_ENFORCEMENT_MESSAGE
+            : JSON_ENFORCEMENT_MESSAGE;
+        List<MessageInput> mutableMessages = new ArrayList<>(messages);
+        mutableMessages.add(getMessageInput(enforcementMsg));
+        return buildUserPrompt(serializeMessagesToJson(mutableMessages));
+    }
+
+    private String buildUserPrompt(String conversationJson) {
+        return "Analyze the following conversation and extract information:\n```json\n" + conversationJson + "\n```";
     }
 
     private static MessageInput getMessageInput(String userPrompt) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingService.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingService.java
@@ -127,7 +127,11 @@ public class MemoryProcessingService {
         Map<String, String> stringParameters = new HashMap<>();
         stringParameters.put("system_prompt", systemPrompt);
 
-        memoryContainerHelper.getStructuredOutputParameters(llmModelId, ActionListener.wrap(structuredOutputParams -> {
+        memoryContainerHelper.getStructuredOutputParameters(llmModelId, ActionListener.wrap(rawStructuredOutputParams -> {
+            // Copy to a mutable map so we can extract the result path override before merging.
+            Map<String, String> structuredOutputParams = new HashMap<>(rawStructuredOutputParams);
+            // Extract the result path override before merging so it is never sent to the model.
+            String structuredOutputResultPath = structuredOutputParams.remove("_structured_output_result_path");
             try {
                 if (!structuredOutputParams.isEmpty()) {
                     stringParameters.putAll(structuredOutputParams);
@@ -140,7 +144,7 @@ public class MemoryProcessingService {
                 listener.onResponse(new ArrayList<>());
                 return;
             }
-            sendFactExtractionRequest(tenantId, llmModelId, stringParameters, strategy, memoryConfig, listener);
+            sendFactExtractionRequest(tenantId, llmModelId, stringParameters, structuredOutputResultPath, strategy, memoryConfig, listener);
         }, e -> {
             log.warn("Unexpected error fetching structured output parameters, falling back to prompt enforcement", e);
             try {
@@ -150,7 +154,7 @@ public class MemoryProcessingService {
                 listener.onResponse(new ArrayList<>());
                 return;
             }
-            sendFactExtractionRequest(tenantId, llmModelId, stringParameters, strategy, memoryConfig, listener);
+            sendFactExtractionRequest(tenantId, llmModelId, stringParameters, null, strategy, memoryConfig, listener);
         }));
     }
 
@@ -158,6 +162,7 @@ public class MemoryProcessingService {
         String tenantId,
         String llmModelId,
         Map<String, String> stringParameters,
+        String structuredOutputResultPath,
         MemoryStrategy strategy,
         MemoryConfiguration memoryConfig,
         ActionListener<List<String>> listener
@@ -178,7 +183,7 @@ public class MemoryProcessingService {
         client.execute(MLPredictionTaskAction.INSTANCE, predictionRequest, ActionListener.wrap(response -> {
             try {
                 log.debug("Received LLM response, parsing facts...");
-                List<String> facts = parseFactsFromLLMResponse(strategy, memoryConfig, response.getOutput());
+                List<String> facts = parseFactsFromLLMResponse(structuredOutputResultPath, strategy, memoryConfig, response.getOutput());
                 log.debug("Extracted {} facts from LLM response", facts.size());
                 listener.onResponse(facts);
             } catch (Exception e) {
@@ -340,7 +345,12 @@ public class MemoryProcessingService {
         }
     }
 
-    private List<String> parseFactsFromLLMResponse(MemoryStrategy strategy, MemoryConfiguration memoryConfig, MLOutput mlOutput) {
+    private List<String> parseFactsFromLLMResponse(
+        String structuredOutputResultPath,
+        MemoryStrategy strategy,
+        MemoryConfiguration memoryConfig,
+        MLOutput mlOutput
+    ) {
         List<String> facts = new ArrayList<>();
 
         if (!(mlOutput instanceof ModelTensorOutput)) {
@@ -362,7 +372,11 @@ public class MemoryProcessingService {
 
         for (int i = 0; i < modelTensors.getMlModelTensors().size(); i++) {
             Map<String, ?> dataMap = modelTensors.getMlModelTensors().get(i).getDataAsMap();
-            String llmResultPath = memoryContainerHelper.getLlmResultPath(strategy, memoryConfig);
+            // Use the structured output result path override when present (e.g. Bedrock Converse
+            // tool-use responses arrive at toolUse.input rather than content[0].text).
+            String llmResultPath = structuredOutputResultPath != null
+                ? structuredOutputResultPath
+                : memoryContainerHelper.getLlmResultPath(strategy, memoryConfig);
             try {
                 Object filterdResult = JsonPath.read(dataMap, llmResultPath);
                 String llmResult = null;

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
@@ -569,6 +569,11 @@ public class MemoryContainerHelper {
         if (lower.contains("cohere.") && lower.contains("/v2/")) {
             return Map.of("_response_format_json", FACTS_EXTRACTION_COHERE_RESPONSE_FORMAT_JSON);
         }
+        // "/v1/chat/completions" is the de-facto path for OpenAI-compatible servers (Ollama, vLLM,
+        // LM Studio, etc.) that do not contain "openai" or "deepseek" in their URL. Matching on the
+        // path alone is intentional: supports_structured_output must be explicitly set to true on the
+        // connector action, which requires admin access, so an unintended match only results in an
+        // extra response_format field being sent — the upstream server will ignore or reject it safely.
         if (lower.contains("openai") || lower.contains("deepseek") || lower.contains("/v1/chat/completions")) {
             return Map.of("_response_format_json", FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON);
         }

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
@@ -9,8 +9,8 @@ import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.BACKEND_ROLES_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
-import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DEFAULT_LLM_RESULT_PATH;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DEFAULT_LLM_RESULT_PATH;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_COHERE_RESPONSE_FORMAT_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON;
@@ -599,12 +599,14 @@ public class MemoryContainerHelper {
         // content[0].toolUse.input rather than content[0].text, so a result path override is returned
         // alongside the schema. MemoryProcessingService strips the override key before the predict call.
         if (hostHasSegment(host, URL_TOKEN_AMAZONAWS) && pathHasSegment(path, URL_TOKEN_CONVERSE_SEGMENT)) {
-            return Map.of(
-                "_toolConfig_json", FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON,
-                "_structured_output_result_path", BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH
-            );
+            return Map
+                .of(
+                    "_toolConfig_json",
+                    FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON,
+                    "_structured_output_result_path",
+                    BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH
+                );
         }
-        // Anthropic direct API is not yet supported — see follow-up issues.
         if (hostHasSegment(host, URL_TOKEN_GOOGLEAPIS)) {
             return Map.of("_generationConfig_additions_json", FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON);
         }
@@ -623,7 +625,8 @@ public class MemoryContainerHelper {
         // (requires admin access), so an unintended match only results in an extra response_format
         // field being sent. Note: if the upstream provider rejects the extra field with a 4xx,
         // that surfaces as a failed predict call, not a silent fallback.
-        if (hostHasSegment(host, URL_TOKEN_OPENAI) || pathHasSegment(path, URL_TOKEN_OPENAI)
+        if (hostHasSegment(host, URL_TOKEN_OPENAI)
+            || pathHasSegment(path, URL_TOKEN_OPENAI)
             || hostHasSegment(host, URL_TOKEN_DEEPSEEK)
             || path.contains(URL_TOKEN_OPENAI_COMPAT_PATH)) {
             return Map.of("_response_format_json", FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON);
@@ -633,14 +636,16 @@ public class MemoryContainerHelper {
 
     private static boolean hostHasSegment(String host, String segment) {
         for (String label : host.split("\\.", -1)) {
-            if (label.equals(segment)) return true;
+            if (label.equals(segment))
+                return true;
         }
         return false;
     }
 
     private static boolean pathHasSegment(String path, String segment) {
         for (String seg : path.split("/", -1)) {
-            if (seg.equals(segment)) return true;
+            if (seg.equals(segment))
+                return true;
         }
         return false;
     }

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
@@ -595,9 +595,8 @@ public class MemoryContainerHelper {
         String host = m.group(1).toLowerCase(Locale.ROOT);
         String path = m.group(2).toLowerCase(Locale.ROOT);
 
-        // Bedrock Converse: toolConfig forces the model into tool-use mode; the response arrives at
-        // content[0].toolUse.input rather than content[0].text, so a result path override is returned
-        // alongside the schema. MemoryProcessingService strips the override key before the predict call.
+        // Bedrock Converse: tool use forces constrained decoding via extract_facts.
+        // The tool response arrives at content[0].toolUse.input, so a result path override is included.
         if (hostHasSegment(host, URL_TOKEN_AMAZONAWS) && pathHasSegment(path, URL_TOKEN_CONVERSE_SEGMENT)) {
             return Map
                 .of(

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
@@ -22,6 +22,8 @@ import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleSearch
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.ExceptionsHelper;
@@ -83,6 +85,23 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class MemoryContainerHelper {
+
+    // URL host/path tokens used to identify LLM providers for structured output schema selection.
+    // Each constant is a single host label or path segment — matched with exact equality after
+    // splitting on '.' (host) or '/' (path), so "my-openai-proxy.internal" does not match "openai".
+    // Keeping them as named constants makes the precedence order in schemaForUrl explicit.
+    private static final String URL_TOKEN_GOOGLEAPIS = "googleapis";
+    private static final String URL_TOKEN_COHERE = "cohere";
+    private static final String URL_TOKEN_V2_PATH_SEGMENT = "v2";
+    private static final String URL_TOKEN_OPENAI = "openai";
+    private static final String URL_TOKEN_DEEPSEEK = "deepseek";
+    // Multi-segment path — used with path.contains() on a query-stripped path, which is safe.
+    private static final String URL_TOKEN_OPENAI_COMPAT_PATH = "/v1/chat/completions";
+
+    // Captures (1) host and (2) path from a URL, stopping before '?' or '#'.
+    // Handles connector template URLs such as https://${parameters.endpoint}/openai/...
+    // where the host may be a placeholder — in that case path matching takes over.
+    private static final Pattern URL_PARTS = Pattern.compile("^[^:]+://([^/?#]*)(/?[^?#]*)");
 
     Client client;
     SdkClient sdkClient;
@@ -521,6 +540,9 @@ public class MemoryContainerHelper {
                 if (connector != null) {
                     listener.onResponse(schemaForConnector(connector));
                 } else if (mlModel.getConnectorId() != null) {
+                    // getConnector stashes its own ThreadContext internally, so this secondary
+                    // async call is safe even though the outer stashed context has already been
+                    // restored by the runBefore above.
                     modelManager
                         .getConnector(
                             mlModel.getConnectorId(),
@@ -544,6 +566,7 @@ public class MemoryContainerHelper {
         if (connector.getActions() == null) {
             return Map.of();
         }
+        // first matching PREDICT action wins; assumes one PREDICT per connector for fact extraction
         return connector
             .getActions()
             .stream()
@@ -557,25 +580,56 @@ public class MemoryContainerHelper {
         if (url == null) {
             return Map.of();
         }
-        String lower = url.toLowerCase(Locale.ROOT);
+        Matcher m = URL_PARTS.matcher(url);
+        if (!m.find()) {
+            return Map.of();
+        }
+        // Match against host and path only — never against query string, credentials, or fragment —
+        // so a query parameter or anchor containing a provider name can't cause a false match.
+        // hostHasSegment / pathHasSegment use exact label/segment equality after splitting on
+        // '.' or '/', so "my-openai-proxy.internal" does not match the "openai" token.
+        String host = m.group(1).toLowerCase(Locale.ROOT);
+        String path = m.group(2).toLowerCase(Locale.ROOT);
+
         // Anthropic direct API and Bedrock Converse are not yet supported — see follow-up issues.
-        if (lower.contains("googleapis.com")) {
+        if (hostHasSegment(host, URL_TOKEN_GOOGLEAPIS)) {
             return Map.of("_generationConfig_additions_json", FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON);
         }
         // Cohere structured output (json_schema type) requires the v2 Chat API (/v2/chat).
         // The legacy /v1/chat endpoint only supports json_object and ignores json_schema.
-        if (lower.contains("cohere.") && lower.contains("/v2/")) {
+        if (hostHasSegment(host, URL_TOKEN_COHERE) && pathHasSegment(path, URL_TOKEN_V2_PATH_SEGMENT)) {
             return Map.of("_response_format_json", FACTS_EXTRACTION_COHERE_RESPONSE_FORMAT_JSON);
         }
-        // "/v1/chat/completions" is the de-facto path for OpenAI-compatible servers (Ollama, vLLM,
-        // LM Studio, etc.) that do not contain "openai" or "deepseek" in their URL. Matching on the
-        // path alone is intentional: supports_structured_output must be explicitly set to true on the
-        // connector action, which requires admin access, so an unintended match only results in an
-        // extra response_format field being sent — the upstream server will ignore or reject it safely.
-        if (lower.contains("openai") || lower.contains("deepseek") || lower.contains("/v1/chat/completions")) {
+        // hostHasSegment(host, URL_TOKEN_OPENAI) catches api.openai.com and similar.
+        // pathHasSegment(path, URL_TOKEN_OPENAI) is specifically for Azure, whose connector URL uses
+        // a template host (${parameters.endpoint}), so "openai" only appears in the path
+        // (/openai/deployments/...) rather than the host.
+        // URL_TOKEN_OPENAI_COMPAT_PATH ("/v1/chat/completions") catches Ollama, vLLM, LM Studio,
+        // and other OpenAI-compatible servers whose hostnames contain neither "openai" nor "deepseek".
+        // supports_structured_output must be explicitly set to true on the connector action
+        // (requires admin access), so an unintended match only results in an extra response_format
+        // field being sent. Note: if the upstream provider rejects the extra field with a 4xx,
+        // that surfaces as a failed predict call, not a silent fallback.
+        if (hostHasSegment(host, URL_TOKEN_OPENAI) || pathHasSegment(path, URL_TOKEN_OPENAI)
+            || hostHasSegment(host, URL_TOKEN_DEEPSEEK)
+            || path.contains(URL_TOKEN_OPENAI_COMPAT_PATH)) {
             return Map.of("_response_format_json", FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON);
         }
         return Map.of();
+    }
+
+    private static boolean hostHasSegment(String host, String segment) {
+        for (String label : host.split("\\.", -1)) {
+            if (label.equals(segment)) return true;
+        }
+        return false;
+    }
+
+    private static boolean pathHasSegment(String path, String segment) {
+        for (String seg : path.split("/", -1)) {
+            if (seg.equals(segment)) return true;
+        }
+        return false;
     }
 
     /**

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
@@ -10,6 +10,8 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.ml.common.CommonValue.BACKEND_ROLES_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DEFAULT_LLM_RESULT_PATH;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_COHERE_RESPONSE_FORMAT_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON;
@@ -97,6 +99,8 @@ public class MemoryContainerHelper {
     private static final String URL_TOKEN_DEEPSEEK = "deepseek";
     // Multi-segment path — used with path.contains() on a query-stripped path, which is safe.
     private static final String URL_TOKEN_OPENAI_COMPAT_PATH = "/v1/chat/completions";
+    private static final String URL_TOKEN_AMAZONAWS = "amazonaws";
+    private static final String URL_TOKEN_CONVERSE_SEGMENT = "converse";
 
     // Captures (1) host and (2) path from a URL, stopping before '?' or '#'.
     // Handles connector template URLs such as https://${parameters.endpoint}/openai/...
@@ -591,7 +595,16 @@ public class MemoryContainerHelper {
         String host = m.group(1).toLowerCase(Locale.ROOT);
         String path = m.group(2).toLowerCase(Locale.ROOT);
 
-        // Anthropic direct API and Bedrock Converse are not yet supported — see follow-up issues.
+        // Bedrock Converse: toolConfig forces the model into tool-use mode; the response arrives at
+        // content[0].toolUse.input rather than content[0].text, so a result path override is returned
+        // alongside the schema. MemoryProcessingService strips the override key before the predict call.
+        if (hostHasSegment(host, URL_TOKEN_AMAZONAWS) && pathHasSegment(path, URL_TOKEN_CONVERSE_SEGMENT)) {
+            return Map.of(
+                "_toolConfig_json", FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON,
+                "_structured_output_result_path", BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH
+            );
+        }
+        // Anthropic direct API is not yet supported — see follow-up issues.
         if (hostHasSegment(host, URL_TOKEN_GOOGLEAPIS)) {
             return Map.of("_generationConfig_additions_json", FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON);
         }

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
@@ -558,9 +558,7 @@ public class MemoryContainerHelper {
             return Map.of();
         }
         String lower = url.toLowerCase(Locale.ROOT);
-        // Anthropic direct API: requires the `anthropic-beta` header, which cannot be injected
-        // via parameters — skipped until header injection is supported at this layer.
-        // Bedrock Converse: requires toolConfig+toolChoice and additional response parsing — not yet implemented.
+        // Anthropic direct API and Bedrock Converse are not yet supported — see follow-up issues.
         if (lower.contains("googleapis.com")) {
             return Map.of("_generationConfig_additions_json", FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON);
         }

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
@@ -10,6 +10,9 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.ml.common.CommonValue.BACKEND_ROLES_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DEFAULT_LLM_RESULT_PATH;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_COHERE_RESPONSE_FORMAT_JSON;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LLM_RESULT_PATH_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_FIELD;
@@ -17,6 +20,8 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleSearchIndexNotFound;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.ExceptionsHelper;
@@ -53,10 +58,13 @@ import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryAction;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.remote.metadata.client.GetDataObjectRequest;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.client.SearchDataObjectRequest;
@@ -79,12 +87,14 @@ public class MemoryContainerHelper {
     Client client;
     SdkClient sdkClient;
     NamedXContentRegistry xContentRegistry;
+    MLModelManager modelManager;
 
     @Inject
-    public MemoryContainerHelper(Client client, SdkClient sdkClient, NamedXContentRegistry xContentRegistry) {
+    public MemoryContainerHelper(Client client, SdkClient sdkClient, NamedXContentRegistry xContentRegistry, MLModelManager modelManager) {
         this.client = client;
         this.sdkClient = sdkClient;
         this.xContentRegistry = xContentRegistry;
+        this.modelManager = modelManager;
     }
 
     /**
@@ -495,6 +505,74 @@ public class MemoryContainerHelper {
             log.error("Failed to search for containers with prefix: " + indexPrefix, e);
             listener.onFailure(e);
         }
+    }
+
+    /**
+     * Resolves the structured output injection parameters for the given model asynchronously.
+     * Looks up the model's connector, checks its PREDICT action's {@code supports_structured_output}
+     * flag, then derives the provider from the connector URL to select the correct injection
+     * parameter and schema constant. Returns an empty map if the connector does not support native
+     * structured output or if the lookup fails; callers should fall back to prompt enforcement.
+     */
+    public void getStructuredOutputParameters(String modelId, ActionListener<Map<String, String>> listener) {
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            modelManager.getModel(modelId, ActionListener.runBefore(ActionListener.wrap(mlModel -> {
+                Connector connector = mlModel.getConnector();
+                if (connector != null) {
+                    listener.onResponse(schemaForConnector(connector));
+                } else if (mlModel.getConnectorId() != null) {
+                    modelManager
+                        .getConnector(
+                            mlModel.getConnectorId(),
+                            null,
+                            ActionListener.wrap(c -> listener.onResponse(schemaForConnector(c)), e -> {
+                                log.warn("Failed to fetch connector {} for structured output detection", mlModel.getConnectorId(), e);
+                                listener.onResponse(Map.of());
+                            })
+                        );
+                } else {
+                    listener.onResponse(Map.of());
+                }
+            }, e -> {
+                log.warn("Failed to fetch model {} for structured output detection, falling back to prompt enforcement", modelId, e);
+                listener.onResponse(Map.of());
+            }), context::restore));
+        }
+    }
+
+    private Map<String, String> schemaForConnector(Connector connector) {
+        if (connector.getActions() == null) {
+            return Map.of();
+        }
+        return connector
+            .getActions()
+            .stream()
+            .filter(a -> ConnectorAction.ActionType.PREDICT.equals(a.getActionType()) && a.isSupportsStructuredOutput())
+            .findFirst()
+            .map(a -> schemaForUrl(a.getUrl()))
+            .orElse(Map.of());
+    }
+
+    private Map<String, String> schemaForUrl(String url) {
+        if (url == null) {
+            return Map.of();
+        }
+        String lower = url.toLowerCase(Locale.ROOT);
+        // Anthropic direct API: requires the `anthropic-beta` header, which cannot be injected
+        // via parameters — skipped until header injection is supported at this layer.
+        // Bedrock Converse: requires toolConfig+toolChoice and additional response parsing — not yet implemented.
+        if (lower.contains("googleapis.com")) {
+            return Map.of("_generationConfig_additions_json", FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON);
+        }
+        // Cohere structured output (json_schema type) requires the v2 Chat API (/v2/chat).
+        // The legacy /v1/chat endpoint only supports json_object and ignores json_schema.
+        if (lower.contains("cohere.") && lower.contains("/v2/")) {
+            return Map.of("_response_format_json", FACTS_EXTRACTION_COHERE_RESPONSE_FORMAT_JSON);
+        }
+        if (lower.contains("openai") || lower.contains("deepseek") || lower.contains("/v1/chat/completions")) {
+            return Map.of("_response_format_json", FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON);
+        }
+        return Map.of();
     }
 
     /**

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceAdditionalTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceAdditionalTests.java
@@ -64,6 +64,12 @@ public class MemoryProcessingServiceAdditionalTests {
         MockitoAnnotations.openMocks(this);
         memoryStrategy = new MemoryStrategy("id", true, MemoryStrategyType.SEMANTIC, Arrays.asList("user_id"), new HashMap<>());
         memoryProcessingService = new MemoryProcessingService(client, xContentRegistry, memoryContainerHelper);
+        // Default: no structured output params (prompt enforcement fallback).
+        doAnswer(invocation -> {
+            ActionListener<Map<String, String>> listener = invocation.getArgument(1);
+            listener.onResponse(Map.of());
+            return null;
+        }).when(memoryContainerHelper).getStructuredOutputParameters(any(), any());
         // Mock the getLlmResultPath to return the default path
         when(memoryContainerHelper.getLlmResultPath(any(), any())).thenReturn("$.content[0].text");
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
@@ -15,8 +15,10 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.JSON_ENFORCEMENT_MESSAGE;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LLM_RESULT_PATH_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.USER_PREFERENCE_FACTS_EXTRACTION_PROMPT;
@@ -88,6 +90,11 @@ public class MemoryProcessingServiceTests {
         memoryProcessingService = new MemoryProcessingService(client, xContentRegistry, memoryContainerHelper);
         testContent = createTestContent("Hello");
         when(memoryConfig.getParameters()).thenReturn(new HashMap<>());
+        doAnswer(invocation -> {
+            ActionListener<Map<String, String>> l = invocation.getArgument(1);
+            l.onResponse(Map.of());
+            return null;
+        }).when(memoryContainerHelper).getStructuredOutputParameters(any(), any());
         // Mock the getLlmResultPath to return the default path
         when(memoryContainerHelper.getLlmResultPath(any(), any())).thenReturn("$.content[0].text");
     }
@@ -1103,6 +1110,167 @@ public class MemoryProcessingServiceTests {
         // Verify role clarity
         assertTrue("Should not be a chat assistant", prompt.contains("not a chat assistant"));
         assertTrue("Should only output JSON facts", prompt.contains("only job is to output JSON facts"));
+    }
+
+    @Test
+    public void testExtractFacts_StructuredOutputConnector_PassesSchemaParameter() {
+        doAnswer(invocation -> {
+            ActionListener<Map<String, String>> l = invocation.getArgument(1);
+            l.onResponse(Map.of("_response_format_json", FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON));
+            return null;
+        }).when(memoryContainerHelper).getStructuredOutputParameters(eq("llm-model-123"), any());
+
+        List<MessageInput> messages = Arrays
+            .asList(MessageInput.builder().content(createTestContent("I prefer dark mode")).role("user").build());
+        MemoryConfiguration storageConfig = mock(MemoryConfiguration.class);
+        when(storageConfig.getLlmId()).thenReturn("llm-model-123");
+
+        doAnswer(invocation -> {
+            MLPredictionTaskRequest request = invocation.getArgument(1);
+            RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) request.getMlInput().getInputDataset();
+            Map<String, String> parameters = dataset.getParameters();
+
+            assertTrue(
+                "_response_format_json should be present for structured output connector",
+                parameters.containsKey("_response_format_json")
+            );
+            assertFalse(
+                "JSON enforcement message must NOT be in user_prompt when using structured output",
+                parameters.get("user_prompt").contains("Respond NOW with ONE LINE of valid JSON ONLY")
+            );
+
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            List<ModelTensors> mlModelOutputs = new ArrayList<>();
+            List<ModelTensor> tensors = new ArrayList<>();
+            Map<String, Object> contents = new HashMap<>();
+            contents.put("content", List.of(Map.of("text", "{\"facts\":[\"User prefers dark mode\"]}")));
+            tensors.add(ModelTensor.builder().name("response").dataAsMap(contents).build());
+            mlModelOutputs.add(ModelTensors.builder().mlModelTensors(tensors).build());
+            actionListener
+                .onResponse(MLTaskResponse.builder().output(ModelTensorOutput.builder().mlModelOutputs(mlModelOutputs).build()).build());
+            return null;
+        }).when(client).execute(eq(MLPredictionTaskAction.INSTANCE), any(), any());
+
+        memoryProcessingService.extractFactsFromConversation(null, messages, memoryStrategy, storageConfig, factsListener);
+
+        verify(client).execute(any(), any(), any());
+    }
+
+    @Test
+    public void testExtractFacts_PromptFallbackConnector_AppendsEnforcementMessage() {
+        doAnswer(invocation -> {
+            ActionListener<Map<String, String>> l = invocation.getArgument(1);
+            l.onResponse(Map.of());
+            return null;
+        }).when(memoryContainerHelper).getStructuredOutputParameters(eq("llm-model-123"), any());
+
+        List<MessageInput> messages = Arrays
+            .asList(MessageInput.builder().content(createTestContent("I prefer dark mode")).role("user").build());
+        MemoryConfiguration storageConfig = mock(MemoryConfiguration.class);
+        when(storageConfig.getLlmId()).thenReturn("llm-model-123");
+
+        doAnswer(invocation -> {
+            MLPredictionTaskRequest request = invocation.getArgument(1);
+            RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) request.getMlInput().getInputDataset();
+            Map<String, String> parameters = dataset.getParameters();
+
+            assertFalse(
+                "_response_format_json must NOT be present for prompt-based connector",
+                parameters.containsKey("_response_format_json")
+            );
+            assertTrue(
+                "JSON enforcement message MUST be in user_prompt for prompt-based connector",
+                parameters.get("user_prompt").contains("Respond NOW with ONE LINE of valid JSON ONLY")
+            );
+
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            List<ModelTensors> mlModelOutputs = new ArrayList<>();
+            List<ModelTensor> tensors = new ArrayList<>();
+            Map<String, Object> contents = new HashMap<>();
+            contents.put("content", List.of(Map.of("text", "{\"facts\":[\"User prefers dark mode\"]}")));
+            tensors.add(ModelTensor.builder().name("response").dataAsMap(contents).build());
+            mlModelOutputs.add(ModelTensors.builder().mlModelTensors(tensors).build());
+            actionListener
+                .onResponse(MLTaskResponse.builder().output(ModelTensorOutput.builder().mlModelOutputs(mlModelOutputs).build()).build());
+            return null;
+        }).when(client).execute(eq(MLPredictionTaskAction.INSTANCE), any(), any());
+
+        memoryProcessingService.extractFactsFromConversation(null, messages, memoryStrategy, storageConfig, factsListener);
+
+        verify(client).execute(any(), any(), any());
+    }
+
+    @Test
+    public void testExtractFacts_StructuredOutputParseFails_CallsOnFailure() {
+        doAnswer(invocation -> {
+            ActionListener<Map<String, String>> l = invocation.getArgument(1);
+            l.onResponse(Map.of("_response_format_json", FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON));
+            return null;
+        }).when(memoryContainerHelper).getStructuredOutputParameters(eq("llm-model-123"), any());
+
+        List<MessageInput> messages = Arrays
+            .asList(MessageInput.builder().content(createTestContent("I prefer dark mode")).role("user").build());
+        MemoryConfiguration storageConfig = mock(MemoryConfiguration.class);
+        when(storageConfig.getLlmId()).thenReturn("llm-model-123");
+
+        doAnswer(invocation -> {
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            List<ModelTensors> mlModelOutputs = new ArrayList<>();
+            List<ModelTensor> tensors = new ArrayList<>();
+            Map<String, Object> contents = new HashMap<>();
+            contents.put("content", List.of(Map.of("text", "not valid json at all")));
+            tensors.add(ModelTensor.builder().name("response").dataAsMap(contents).build());
+            mlModelOutputs.add(ModelTensors.builder().mlModelTensors(tensors).build());
+            actionListener
+                .onResponse(MLTaskResponse.builder().output(ModelTensorOutput.builder().mlModelOutputs(mlModelOutputs).build()).build());
+            return null;
+        }).when(client).execute(eq(MLPredictionTaskAction.INSTANCE), any(), any());
+
+        memoryProcessingService.extractFactsFromConversation(null, messages, memoryStrategy, storageConfig, factsListener);
+
+        verify(client, times(1)).execute(any(), any(), any());
+        verify(factsListener).onFailure(any(OpenSearchStatusException.class));
+    }
+
+    @Test
+    public void testExtractFacts_StructuredOutputLookupFails_FallsBackToPromptEnforcement() {
+        doAnswer(invocation -> {
+            ActionListener<Map<String, String>> l = invocation.getArgument(1);
+            l.onFailure(new RuntimeException("model lookup failed"));
+            return null;
+        }).when(memoryContainerHelper).getStructuredOutputParameters(eq("llm-model-123"), any());
+
+        List<MessageInput> messages = Arrays
+            .asList(MessageInput.builder().content(createTestContent("I prefer dark mode")).role("user").build());
+        MemoryConfiguration storageConfig = mock(MemoryConfiguration.class);
+        when(storageConfig.getLlmId()).thenReturn("llm-model-123");
+
+        doAnswer(invocation -> {
+            MLPredictionTaskRequest request = invocation.getArgument(1);
+            RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) request.getMlInput().getInputDataset();
+            Map<String, String> parameters = dataset.getParameters();
+
+            assertFalse("_response_format_json must NOT be present on fallback path", parameters.containsKey("_response_format_json"));
+            assertTrue(
+                "JSON enforcement message MUST be in user_prompt on fallback path",
+                parameters.get("user_prompt").contains("Respond NOW with ONE LINE of valid JSON ONLY")
+            );
+
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            List<ModelTensors> mlModelOutputs = new ArrayList<>();
+            List<ModelTensor> tensors = new ArrayList<>();
+            Map<String, Object> contents = new HashMap<>();
+            contents.put("content", List.of(Map.of("text", "{\"facts\":[\"User prefers dark mode\"]}")));
+            tensors.add(ModelTensor.builder().name("response").dataAsMap(contents).build());
+            mlModelOutputs.add(ModelTensors.builder().mlModelTensors(tensors).build());
+            actionListener
+                .onResponse(MLTaskResponse.builder().output(ModelTensorOutput.builder().mlModelOutputs(mlModelOutputs).build()).build());
+            return null;
+        }).when(client).execute(eq(MLPredictionTaskAction.INSTANCE), any(), any());
+
+        memoryProcessingService.extractFactsFromConversation(null, messages, memoryStrategy, storageConfig, factsListener);
+
+        verify(client).execute(any(), any(), any());
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.JSON_ENFORCEMENT_MESSAGE;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.JSON_ENFORCEMENT_SENTINEL;
@@ -1158,6 +1160,67 @@ public class MemoryProcessingServiceTests {
         memoryProcessingService.extractFactsFromConversation(null, messages, memoryStrategy, storageConfig, factsListener);
 
         verify(client).execute(any(), any(), any());
+    }
+
+    @Test
+    public void testExtractFacts_BedrockConverseStructuredOutput_UsesToolUseResultPath() {
+        // Bedrock Converse tool-use response arrives at toolUse.input (a Map), not content[0].text.
+        // The result path override must be stripped from predict parameters and used for extraction.
+        doAnswer(invocation -> {
+            ActionListener<Map<String, String>> l = invocation.getArgument(1);
+            l.onResponse(new HashMap<>(Map.of(
+                "_toolConfig_json", FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON,
+                "_structured_output_result_path", BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH
+            )));
+            return null;
+        }).when(memoryContainerHelper).getStructuredOutputParameters(eq("llm-model-123"), any());
+
+        List<MessageInput> messages = Arrays
+            .asList(MessageInput.builder().content(createTestContent("I use Java")).role("user").build());
+        MemoryConfiguration storageConfig = mock(MemoryConfiguration.class);
+        when(storageConfig.getLlmId()).thenReturn("llm-model-123");
+
+        doAnswer(invocation -> {
+            MLPredictionTaskRequest request = invocation.getArgument(1);
+            RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) request.getMlInput().getInputDataset();
+            Map<String, String> parameters = dataset.getParameters();
+
+            assertTrue("_toolConfig_json must be present for Bedrock structured output",
+                parameters.containsKey("_toolConfig_json"));
+            assertFalse("_structured_output_result_path must be stripped before predict call",
+                parameters.containsKey("_structured_output_result_path"));
+
+            // Simulate Bedrock Converse tool-use response: toolUse.input is a pre-parsed Map
+            ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
+            Map<String, Object> toolUseInput = new HashMap<>();
+            toolUseInput.put("facts", List.of("User programs in Java"));
+            Map<String, Object> toolUse = new HashMap<>();
+            toolUse.put("name", "extract_facts");
+            toolUse.put("input", toolUseInput);
+            Map<String, Object> content = new HashMap<>();
+            content.put("toolUse", toolUse);
+            Map<String, Object> message = new HashMap<>();
+            message.put("content", List.of(content));
+            Map<String, Object> output = new HashMap<>();
+            output.put("message", message);
+            Map<String, Object> dataAsMap = new HashMap<>();
+            dataAsMap.put("output", output);
+            List<ModelTensors> mlModelOutputs = new ArrayList<>();
+            mlModelOutputs.add(ModelTensors.builder()
+                .mlModelTensors(List.of(ModelTensor.builder().name("response").dataAsMap(dataAsMap).build()))
+                .build());
+            actionListener.onResponse(
+                MLTaskResponse.builder().output(ModelTensorOutput.builder().mlModelOutputs(mlModelOutputs).build()).build()
+            );
+            return null;
+        }).when(client).execute(eq(MLPredictionTaskAction.INSTANCE), any(), any());
+
+        memoryProcessingService.extractFactsFromConversation(null, messages, memoryStrategy, storageConfig, factsListener);
+
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        verify(factsListener).onResponse(captor.capture());
+        assertEquals(1, captor.getValue().size());
+        assertEquals("User programs in Java", captor.getValue().get(0));
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
@@ -94,8 +94,8 @@ public class MemoryProcessingServiceTests {
         testContent = createTestContent("Hello");
         when(memoryConfig.getParameters()).thenReturn(new HashMap<>());
         doAnswer(invocation -> {
-            ActionListener<Map<String, String>> l = invocation.getArgument(1);
-            l.onResponse(Map.of());
+            ActionListener<Map<String, String>> listener = invocation.getArgument(1);
+            listener.onResponse(Map.of());
             return null;
         }).when(memoryContainerHelper).getStructuredOutputParameters(any(), any());
         // Mock the getLlmResultPath to return the default path

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
@@ -1002,10 +1002,7 @@ public class MemoryProcessingServiceTests {
 
             // Verify that the JSON enforcement message is included in the user_prompt
             assertNotNull("user_prompt should not be null", userPrompt);
-            assertTrue(
-                "JSON enforcement message should be included",
-                userPrompt.contains(JSON_ENFORCEMENT_SENTINEL)
-            );
+            assertTrue("JSON enforcement message should be included", userPrompt.contains(JSON_ENFORCEMENT_SENTINEL));
 
             // Mock successful response
             ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
@@ -1168,15 +1165,22 @@ public class MemoryProcessingServiceTests {
         // The result path override must be stripped from predict parameters and used for extraction.
         doAnswer(invocation -> {
             ActionListener<Map<String, String>> l = invocation.getArgument(1);
-            l.onResponse(new HashMap<>(Map.of(
-                "_toolConfig_json", FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON,
-                "_structured_output_result_path", BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH
-            )));
+            l
+                .onResponse(
+                    new HashMap<>(
+                        Map
+                            .of(
+                                "_toolConfig_json",
+                                FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON,
+                                "_structured_output_result_path",
+                                BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH
+                            )
+                    )
+                );
             return null;
         }).when(memoryContainerHelper).getStructuredOutputParameters(eq("llm-model-123"), any());
 
-        List<MessageInput> messages = Arrays
-            .asList(MessageInput.builder().content(createTestContent("I use Java")).role("user").build());
+        List<MessageInput> messages = Arrays.asList(MessageInput.builder().content(createTestContent("I use Java")).role("user").build());
         MemoryConfiguration storageConfig = mock(MemoryConfiguration.class);
         when(storageConfig.getLlmId()).thenReturn("llm-model-123");
 
@@ -1185,10 +1189,11 @@ public class MemoryProcessingServiceTests {
             RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) request.getMlInput().getInputDataset();
             Map<String, String> parameters = dataset.getParameters();
 
-            assertTrue("_toolConfig_json must be present for Bedrock structured output",
-                parameters.containsKey("_toolConfig_json"));
-            assertFalse("_structured_output_result_path must be stripped before predict call",
-                parameters.containsKey("_structured_output_result_path"));
+            assertTrue("_toolConfig_json must be present for Bedrock structured output", parameters.containsKey("_toolConfig_json"));
+            assertFalse(
+                "_structured_output_result_path must be stripped before predict call",
+                parameters.containsKey("_structured_output_result_path")
+            );
 
             // Simulate Bedrock Converse tool-use response: toolUse.input is a pre-parsed Map
             ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
@@ -1206,12 +1211,15 @@ public class MemoryProcessingServiceTests {
             Map<String, Object> dataAsMap = new HashMap<>();
             dataAsMap.put("output", output);
             List<ModelTensors> mlModelOutputs = new ArrayList<>();
-            mlModelOutputs.add(ModelTensors.builder()
-                .mlModelTensors(List.of(ModelTensor.builder().name("response").dataAsMap(dataAsMap).build()))
-                .build());
-            actionListener.onResponse(
-                MLTaskResponse.builder().output(ModelTensorOutput.builder().mlModelOutputs(mlModelOutputs).build()).build()
-            );
+            mlModelOutputs
+                .add(
+                    ModelTensors
+                        .builder()
+                        .mlModelTensors(List.of(ModelTensor.builder().name("response").dataAsMap(dataAsMap).build()))
+                        .build()
+                );
+            actionListener
+                .onResponse(MLTaskResponse.builder().output(ModelTensorOutput.builder().mlModelOutputs(mlModelOutputs).build()).build());
             return null;
         }).when(client).execute(eq(MLPredictionTaskAction.INSTANCE), any(), any());
 

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
@@ -1161,11 +1161,11 @@ public class MemoryProcessingServiceTests {
 
     @Test
     public void testExtractFacts_BedrockConverseStructuredOutput_UsesToolUseResultPath() {
-        // Bedrock Converse tool-use response arrives at toolUse.input (a Map), not content[0].text.
-        // The result path override must be stripped from predict parameters and used for extraction.
+        // Bedrock Converse tool use: _toolConfig_json is sent to the model, _structured_output_result_path
+        // is stripped from the predict params and used to extract facts from the tool-use response shape.
         doAnswer(invocation -> {
-            ActionListener<Map<String, String>> l = invocation.getArgument(1);
-            l
+            ActionListener<Map<String, String>> listener = invocation.getArgument(1);
+            listener
                 .onResponse(
                     new HashMap<>(
                         Map
@@ -1189,23 +1189,25 @@ public class MemoryProcessingServiceTests {
             RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) request.getMlInput().getInputDataset();
             Map<String, String> parameters = dataset.getParameters();
 
-            assertTrue("_toolConfig_json must be present for Bedrock structured output", parameters.containsKey("_toolConfig_json"));
+            assertTrue(
+                "_toolConfig_json must be present for Bedrock tool-use structured output",
+                parameters.containsKey("_toolConfig_json")
+            );
             assertFalse(
-                "_structured_output_result_path must be stripped before predict call",
+                "_structured_output_result_path must be stripped before predict",
                 parameters.containsKey("_structured_output_result_path")
             );
 
-            // Simulate Bedrock Converse tool-use response: toolUse.input is a pre-parsed Map
+            // Response shaped to match BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH = $.output.message.content[0].toolUse.input
             ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
             Map<String, Object> toolUseInput = new HashMap<>();
             toolUseInput.put("facts", List.of("User programs in Java"));
             Map<String, Object> toolUse = new HashMap<>();
-            toolUse.put("name", "extract_facts");
             toolUse.put("input", toolUseInput);
-            Map<String, Object> content = new HashMap<>();
-            content.put("toolUse", toolUse);
+            Map<String, Object> contentItem = new HashMap<>();
+            contentItem.put("toolUse", toolUse);
             Map<String, Object> message = new HashMap<>();
-            message.put("content", List.of(content));
+            message.put("content", List.of(contentItem));
             Map<String, Object> output = new HashMap<>();
             output.put("message", message);
             Map<String, Object> dataAsMap = new HashMap<>();

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/MemoryProcessingServiceTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.JSON_ENFORCEMENT_MESSAGE;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.JSON_ENFORCEMENT_SENTINEL;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LLM_RESULT_PATH_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.USER_PREFERENCE_FACTS_EXTRACTION_PROMPT;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.USER_PREFERENCE_JSON_ENFORCEMENT_MESSAGE;
@@ -999,7 +1000,10 @@ public class MemoryProcessingServiceTests {
 
             // Verify that the JSON enforcement message is included in the user_prompt
             assertNotNull("user_prompt should not be null", userPrompt);
-            assertTrue("JSON enforcement message should be included", userPrompt.contains("Respond NOW with ONE LINE of valid JSON ONLY"));
+            assertTrue(
+                "JSON enforcement message should be included",
+                userPrompt.contains(JSON_ENFORCEMENT_SENTINEL)
+            );
 
             // Mock successful response
             ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
@@ -1136,7 +1140,7 @@ public class MemoryProcessingServiceTests {
             );
             assertFalse(
                 "JSON enforcement message must NOT be in user_prompt when using structured output",
-                parameters.get("user_prompt").contains("Respond NOW with ONE LINE of valid JSON ONLY")
+                parameters.get("user_prompt").contains(JSON_ENFORCEMENT_SENTINEL)
             );
 
             ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
@@ -1180,7 +1184,7 @@ public class MemoryProcessingServiceTests {
             );
             assertTrue(
                 "JSON enforcement message MUST be in user_prompt for prompt-based connector",
-                parameters.get("user_prompt").contains("Respond NOW with ONE LINE of valid JSON ONLY")
+                parameters.get("user_prompt").contains(JSON_ENFORCEMENT_SENTINEL)
             );
 
             ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);
@@ -1253,7 +1257,7 @@ public class MemoryProcessingServiceTests {
             assertFalse("_response_format_json must NOT be present on fallback path", parameters.containsKey("_response_format_json"));
             assertTrue(
                 "JSON enforcement message MUST be in user_prompt on fallback path",
-                parameters.get("user_prompt").contains("Respond NOW with ONE LINE of valid JSON ONLY")
+                parameters.get("user_prompt").contains(JSON_ENFORCEMENT_SENTINEL)
             );
 
             ActionListener<MLTaskResponse> actionListener = invocation.getArgument(2);

--- a/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
@@ -5,12 +5,18 @@
 
 package org.opensearch.ml.helper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DEFAULT_LLM_RESULT_PATH;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_COHERE_RESPONSE_FORMAT_JSON;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LLM_RESULT_PATH_FIELD;
 
 import java.io.IOException;
@@ -24,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.bulk.BulkRequest;
@@ -57,6 +64,9 @@ import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryAction;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.connector.Connector;
+import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
@@ -84,6 +94,7 @@ public class MemoryContainerHelperTests extends OpenSearchTestCase {
     private org.opensearch.remote.metadata.client.SdkClient sdkClient;
     private ThreadPool threadPool;
     private ThreadContext threadContext;
+    private org.opensearch.ml.model.MLModelManager modelManager;
     private MemoryContainerHelper helper;
 
     @Before
@@ -94,8 +105,9 @@ public class MemoryContainerHelperTests extends OpenSearchTestCase {
         threadContext = new ThreadContext(Settings.builder().build());
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        modelManager = mock(org.opensearch.ml.model.MLModelManager.class);
 
-        helper = new MemoryContainerHelper(client, sdkClient, NamedXContentRegistry.EMPTY);
+        helper = new MemoryContainerHelper(client, sdkClient, NamedXContentRegistry.EMPTY, modelManager);
     }
 
     public void testGetMemoryContainerSuccess() throws Exception {
@@ -706,6 +718,352 @@ public class MemoryContainerHelperTests extends OpenSearchTestCase {
             .owner(owner)
             .configuration(configuration)
             .backendRoles(Arrays.asList("roleA", "roleB"));
+    }
+
+    // ---- getStructuredOutputParameters / schemaForUrl tests ----
+
+    private ConnectorAction mockPredictAction(boolean supportsStructuredOutput, String url) {
+        ConnectorAction action = mock(ConnectorAction.class);
+        when(action.getActionType()).thenReturn(ConnectorAction.ActionType.PREDICT);
+        when(action.isSupportsStructuredOutput()).thenReturn(supportsStructuredOutput);
+        when(action.getUrl()).thenReturn(url);
+        return action;
+    }
+
+    private void stubModelWithEmbeddedConnector(MLModel model) {
+        doAnswer(invocation -> {
+            ActionListener<MLModel> l = invocation.getArgument(1);
+            l.onResponse(model);
+            return null;
+        }).when(modelManager).getModel(any(), any());
+    }
+
+    public void testGetStructuredOutputParameters_OpenAI_ReturnsCorrectSchema() {
+        Connector connector = mock(Connector.class);
+        ConnectorAction openAiAction = mockPredictAction(true, "https://api.openai.com/v1/chat/completions");
+        when(connector.getActions()).thenReturn(Arrays.asList(openAiAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
+    }
+
+    public void testGetStructuredOutputParameters_AzureOpenAI_ReturnsOpenAISchema() {
+        Connector connector = mock(Connector.class);
+        ConnectorAction azureAction = mockPredictAction(
+            true,
+            "https://my-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2024-02-01"
+        );
+        when(connector.getActions()).thenReturn(Arrays.asList(azureAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
+    }
+
+    public void testGetStructuredOutputParameters_BedrockConverse_ReturnsEmptyMap() {
+        // Bedrock Converse structured output requires toolConfig+toolChoice, which changes the
+        // response shape; auto-detection is intentionally disabled so we fall back to prompt enforcement.
+        Connector connector = mock(Connector.class);
+        ConnectorAction bedrockAction = mockPredictAction(
+            true,
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-sonnet/converse"
+        );
+        when(connector.getActions()).thenReturn(Arrays.asList(bedrockAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_Anthropic_ReturnsEmptyMap() {
+        // Anthropic direct API requires an anthropic-beta header that cannot be injected via
+        // parameters; auto-detection is intentionally disabled so we fall back to prompt enforcement.
+        Connector connector = mock(Connector.class);
+        ConnectorAction anthropicAction = mockPredictAction(true, "https://api.anthropic.com/v1/messages");
+        when(connector.getActions()).thenReturn(Arrays.asList(anthropicAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_Gemini_ReturnsGeminiSchema() {
+        Connector connector = mock(Connector.class);
+        ConnectorAction geminiAction = mockPredictAction(
+            true,
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent"
+        );
+        when(connector.getActions()).thenReturn(Arrays.asList(geminiAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON, captor.getValue().get("_generationConfig_additions_json"));
+    }
+
+    public void testGetStructuredOutputParameters_CohereV2_ReturnsCohereSchema() {
+        Connector connector = mock(Connector.class);
+        ConnectorAction cohereAction = mockPredictAction(true, "https://api.cohere.com/v2/chat");
+        when(connector.getActions()).thenReturn(Arrays.asList(cohereAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(FACTS_EXTRACTION_COHERE_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
+    }
+
+    public void testGetStructuredOutputParameters_CohereV1_ReturnsEmptyMap() {
+        // Cohere v1 endpoint does not support json_schema — falls back to prompt enforcement.
+        Connector connector = mock(Connector.class);
+        ConnectorAction cohereV1Action = mockPredictAction(true, "https://api.cohere.ai/v1/chat");
+        when(connector.getActions()).thenReturn(Arrays.asList(cohereV1Action));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_Ollama_ReturnsOpenAISchema() {
+        Connector connector = mock(Connector.class);
+        ConnectorAction ollamaAction = mockPredictAction(true, "http://localhost:11434/v1/chat/completions");
+        when(connector.getActions()).thenReturn(Arrays.asList(ollamaAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
+    }
+
+    public void testGetStructuredOutputParameters_FlagFalse_ReturnsEmptyMap() {
+        Connector connector = mock(Connector.class);
+        ConnectorAction disabledAction = mockPredictAction(false, "https://api.openai.com/v1/chat/completions");
+        when(connector.getActions()).thenReturn(Arrays.asList(disabledAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_DeepSeek_ReturnsOpenAISchema() {
+        Connector connector = mock(Connector.class);
+        ConnectorAction deepSeekAction = mockPredictAction(true, "https://api.deepseek.com/v1/chat/completions");
+        when(connector.getActions()).thenReturn(Arrays.asList(deepSeekAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
+    }
+
+    public void testGetStructuredOutputParameters_TemplateUrl_ReturnsOpenAISchema() {
+        // Verifies that a connector URL with an unresolved ${parameters.endpoint} placeholder
+        // still matches via the literal /v1/chat/completions path segment.
+        Connector connector = mock(Connector.class);
+        ConnectorAction templateAction = mockPredictAction(true, "https://${parameters.endpoint}/v1/chat/completions");
+        when(connector.getActions()).thenReturn(Arrays.asList(templateAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
+    }
+
+    public void testGetStructuredOutputParameters_UnknownUrl_ReturnsEmptyMap() {
+        Connector connector = mock(Connector.class);
+        ConnectorAction unknownAction = mockPredictAction(true, "https://custom.internal.llm/api/chat");
+        when(connector.getActions()).thenReturn(Arrays.asList(unknownAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_ConnectorIdPath_ReturnsSchema() {
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(null);
+        when(model.getConnectorId()).thenReturn("connector-123");
+        stubModelWithEmbeddedConnector(model);
+
+        Connector connector = mock(Connector.class);
+        ConnectorAction connectorIdAction = mockPredictAction(true, "https://api.openai.com/v1/chat/completions");
+        when(connector.getActions()).thenReturn(Arrays.asList(connectorIdAction));
+        doAnswer(invocation -> {
+            ActionListener<Connector> l = invocation.getArgument(2);
+            l.onResponse(connector);
+            return null;
+        }).when(modelManager).getConnector(eq("connector-123"), any(), any());
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
+    }
+
+    public void testGetStructuredOutputParameters_ConnectorLookupFails_ReturnsEmptyMap() {
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(null);
+        when(model.getConnectorId()).thenReturn("connector-123");
+        stubModelWithEmbeddedConnector(model);
+
+        doAnswer(invocation -> {
+            ActionListener<Connector> l = invocation.getArgument(2);
+            l.onFailure(new RuntimeException("connector not found"));
+            return null;
+        }).when(modelManager).getConnector(eq("connector-123"), any(), any());
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_ModelLookupFails_ReturnsEmptyMap() {
+        doAnswer(invocation -> {
+            ActionListener<MLModel> l = invocation.getArgument(1);
+            l.onFailure(new RuntimeException("model not found"));
+            return null;
+        }).when(modelManager).getModel(any(), any());
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_NoConnectorOrConnectorId_ReturnsEmptyMap() {
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(null);
+        when(model.getConnectorId()).thenReturn(null);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_NullUrl_ReturnsEmptyMap() {
+        Connector connector = mock(Connector.class);
+        ConnectorAction nullUrlAction = mockPredictAction(true, null);
+        when(connector.getActions()).thenReturn(Arrays.asList(nullUrlAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_NullActions_ReturnsEmptyMap() {
+        Connector connector = mock(Connector.class);
+        when(connector.getActions()).thenReturn(null);
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_NoMatchingPredictAction_ReturnsEmptyMap() {
+        Connector connector = mock(Connector.class);
+        ConnectorAction executeAction = mock(ConnectorAction.class);
+        when(executeAction.getActionType()).thenReturn(ConnectorAction.ActionType.EXECUTE);
+        when(connector.getActions()).thenReturn(Arrays.asList(executeAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
     }
 
     private String containerToJson(MLMemoryContainer container) throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
@@ -795,24 +795,6 @@ public class MemoryContainerHelperTests extends OpenSearchTestCase {
         assertEquals(BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH, captor.getValue().get("_structured_output_result_path"));
     }
 
-    public void testGetStructuredOutputParameters_Anthropic_ReturnsEmptyMap() {
-        // Anthropic direct API requires an anthropic-beta header that cannot be injected via
-        // parameters; auto-detection is intentionally disabled so we fall back to prompt enforcement.
-        Connector connector = mock(Connector.class);
-        ConnectorAction anthropicAction = mockPredictAction(true, "https://api.anthropic.com/v1/messages");
-        when(connector.getActions()).thenReturn(Arrays.asList(anthropicAction));
-        MLModel model = mock(MLModel.class);
-        when(model.getConnector()).thenReturn(connector);
-        stubModelWithEmbeddedConnector(model);
-
-        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
-        helper.getStructuredOutputParameters("m1", listener);
-
-        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
-        verify(listener).onResponse(captor.capture());
-        assertTrue(captor.getValue().isEmpty());
-    }
-
     public void testGetStructuredOutputParameters_Gemini_ReturnsGeminiSchema() {
         Connector connector = mock(Connector.class);
         ConnectorAction geminiAction = mockPredictAction(

--- a/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
@@ -930,6 +930,62 @@ public class MemoryContainerHelperTests extends OpenSearchTestCase {
         assertEquals(FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
     }
 
+    public void testGetStructuredOutputParameters_AzureTemplateUrl_ReturnsOpenAISchema() {
+        // Azure connector URLs use ${parameters.endpoint} as the host, so "openai" only appears
+        // in the path (/openai/deployments/...) — verified via path segment matching.
+        Connector connector = mock(Connector.class);
+        ConnectorAction azureTemplateAction = mockPredictAction(
+            true,
+            "https://${parameters.endpoint}/openai/deployments/${parameters.deploy-name}/chat/completions"
+        );
+        when(connector.getActions()).thenReturn(Arrays.asList(azureTemplateAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
+    }
+
+    public void testGetStructuredOutputParameters_SubstringInHostLabel_ReturnsEmptyMap() {
+        // "my-openai-proxy" is a single host label — it does not equal the "openai" token,
+        // so token-based matching must not mis-route it.
+        Connector connector = mock(Connector.class);
+        ConnectorAction proxyAction = mockPredictAction(true, "https://my-openai-proxy.internal/api/chat");
+        when(connector.getActions()).thenReturn(Arrays.asList(proxyAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_OpenAIInQueryParam_ReturnsEmptyMap() {
+        // "openai" appearing only in the query string must not trigger a match.
+        Connector connector = mock(Connector.class);
+        ConnectorAction queryAction = mockPredictAction(true, "https://custom.proxy.internal/api/chat?source=openai");
+        when(connector.getActions()).thenReturn(Arrays.asList(queryAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
     public void testGetStructuredOutputParameters_UnknownUrl_ReturnsEmptyMap() {
         Connector connector = mock(Connector.class);
         ConnectorAction unknownAction = mockPredictAction(true, "https://custom.internal.llm/api/chat");

--- a/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
@@ -13,7 +13,9 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DEFAULT_LLM_RESULT_PATH;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_COHERE_RESPONSE_FORMAT_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_GEMINI_GENERATION_CONFIG_JSON;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON;
@@ -773,9 +775,7 @@ public class MemoryContainerHelperTests extends OpenSearchTestCase {
         assertEquals(FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
     }
 
-    public void testGetStructuredOutputParameters_BedrockConverse_ReturnsEmptyMap() {
-        // Bedrock Converse structured output requires toolConfig+toolChoice, which changes the
-        // response shape; auto-detection is intentionally disabled so we fall back to prompt enforcement.
+    public void testGetStructuredOutputParameters_BedrockConverse_ReturnsToolConfigAndResultPath() {
         Connector connector = mock(Connector.class);
         ConnectorAction bedrockAction = mockPredictAction(
             true,
@@ -791,7 +791,8 @@ public class MemoryContainerHelperTests extends OpenSearchTestCase {
 
         ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
         verify(listener).onResponse(captor.capture());
-        assertTrue(captor.getValue().isEmpty());
+        assertEquals(FACTS_EXTRACTION_BEDROCK_CONVERSE_TOOL_CONFIG_JSON, captor.getValue().get("_toolConfig_json"));
+        assertEquals(BEDROCK_STRUCTURED_OUTPUT_RESULT_PATH, captor.getValue().get("_structured_output_result_path"));
     }
 
     public void testGetStructuredOutputParameters_Anthropic_ReturnsEmptyMap() {

--- a/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.OpenSearchStatusException;
@@ -775,6 +776,7 @@ public class MemoryContainerHelperTests extends OpenSearchTestCase {
         assertEquals(FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
     }
 
+    @Test
     public void testGetStructuredOutputParameters_BedrockConverse_ReturnsToolConfigAndResultPath() {
         Connector connector = mock(Connector.class);
         ConnectorAction bedrockAction = mockPredictAction(

--- a/release-notes/opensearch-ml-commons.release-notes-3.7.0.0.md
+++ b/release-notes/opensearch-ml-commons.release-notes-3.7.0.0.md
@@ -1,0 +1,6 @@
+## Version 3.7.0 Release Notes
+
+Compatible with OpenSearch and OpenSearch Dashboards version 3.7.0
+
+### Enhancements
+* Add structured output (constrained decoding) support for agentic memory fact extraction ([#4824](https://github.com/opensearch-project/ml-commons/pull/4824))


### PR DESCRIPTION
### Description
Adds structured output (constrained decoding) support for agentic memory fact extraction. When a connector's predict action has `supports_structured_output: true`, `MemoryContainerHelper` resolves the provider from the connector URL and injects a provider-specific JSON schema into fact-extraction requests. `HttpConnector` reads `_*_json` / `_*_additions_json` parameters and injects them as top-level fields in the outgoing request body, so the provider enforces output structure at the token level rather than relying on prompt instructions.

**Implemented providers:** OpenAI, Azure OpenAI, DeepSeek, Ollama, Cohere v2, Google Gemini/Vertex AI, Amazon Bedrock Converse

#### How it works

1. **`ConnectorAction`** — adds a `supportsStructuredOutput` boolean field (default `false`); wire-serialized for clusters ≥ 3.7.0 only.
2. **`HttpConnector.injectStructuredOutputParams`** — reads `_<X>_json` / `_<X>_additions_json` parameters and injects them as top-level fields in the outgoing request body.
3. **`MemoryContainerHelper.getStructuredOutputParameters`** — async lookup that resolves the model's connector, checks the flag, and returns the provider-specific schema parameters. Returns empty map on any failure; callers fall back to prompt enforcement.
4. **`MemoryProcessingService`** — merges structured output params into the predict request when available, skipping the prompt enforcement sentence. Falls back gracefully on lookup failure.

#### Manual testing
- [x] Ollama : A smoke test via a direct _predict call with _response_format_json confirmed that HttpConnector.injectStructuredOutputParams correctly reads the _*_json naming convention and injects response_format into the Ollama request body. Ollama then enforces the schema at the token level, returning {"facts": ["The user prefers dark mode."]} instead of free-forming the structure.

- [x] Bedrock Converse (claude-sonnet-4-6)

### Related Issues
Resolves [#4799](https://github.com/opensearch-project/ml-commons/issues/4799)

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/pull/1130).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
