### PR TITLE
Update GitHub username: rithin-pullela-aws -> rithinpullela

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @b4sjoo @dhrubo-os @mingshl @jngz-es @model-collapse @rbhavna @ylwu-amzn @zane-neo @Zhangxunmt @austintlee @HenryL27 @sam-herman @xinyual @pyek-bot @rithin-pullela-aws @akolarkunnu
+*   @b4sjoo @dhrubo-os @mingshl @jngz-es @model-collapse @rbhavna @ylwu-amzn @zane-neo @Zhangxunmt @austintlee @HenryL27 @sam-herman @xinyual @pyek-bot @rithinpullela @akolarkunnu

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,7 +14,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sicheng Song         | [b4sjoo](https://github.com/b4sjoo)                 | Amazon    |
 | Mingshi Liu          | [mingshl](https://github.com/mingshl)               | Amazon    |
 | Pavan Yekbote        | [pyek-bot](https://github.com/pyek-bot)             | Amazon    |
-| Rithin Pullela       | [rithin-pullela-aws](https://github.com/rithin-pullela-aws)             | Amazon    |
+| Rithin Pullela       | [rithinpullela](https://github.com/rithinpullela)             | Amazon    |
 | Xinyuan Lu           | [xinyual](https://github.com/xinyual)               | Amazon    |
 | Xun Zhang            | [Zhangxunmt](https://github.com/Zhangxunmt)         | Amazon    |
 | Yaliang Wu           | [ylwu-amzn](https://github.com/ylwu-amzn)           | Amazon    |


### PR DESCRIPTION
## Summary

I changed my GitHub username from `@rithin-pullela-aws` to `@rithinpullela`. This PR updates the two places that reference the old handle so review routing and maintainer attribution continue to resolve correctly:

- `MAINTAINERS.md` — current-maintainers row.
- `.github/CODEOWNERS` — repo-wide owners line.

## Test plan
- [x] Verified diff only touches the two references.
- [x] Confirmed `https://github.com/rithinpullela` resolves.