### PR TITLE
Strengthen enforcement of `trusted_connector_endpoints_regex`

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/Connector.java
@@ -186,19 +186,27 @@ public interface Connector extends ToXContentObject, Writeable {
         for (ConnectorAction action : getActions()) {
             StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
             String url = substitutor.replace(action.getUrl());
-            boolean hasMatchedUrl = false;
-            for (String urlRegex : urlRegexes) {
-                Pattern pattern = Pattern.compile(urlRegex);
-                Matcher matcher = pattern.matcher(url);
-                if (matcher.matches()) {
-                    hasMatchedUrl = true;
-                    break;
-                }
-            }
-            if (!hasMatchedUrl) {
-                throw new IllegalArgumentException("Connector URL is not matching the trusted connector endpoint regex");
+            validateResolvedEndpoint(url, urlRegexes);
+        }
+    }
+
+    default void validateResolvedEndpoint(String resolvedUrl, List<String> urlRegexes) {
+        if (urlRegexes == null || urlRegexes.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Trusted connector endpoints regex is not configured. Please set plugins.ml_commons.trusted_connector_endpoints_regex."
+            );
+        }
+        if (resolvedUrl == null) {
+            throw new IllegalArgumentException("Resolved connector URL is null");
+        }
+        for (String urlRegex : urlRegexes) {
+            Pattern pattern = Pattern.compile(urlRegex);
+            Matcher matcher = pattern.matcher(resolvedUrl);
+            if (matcher.matches()) {
+                return;
             }
         }
+        throw new IllegalArgumentException("Connector URL is not matching the trusted connector endpoint regex");
     }
 
     Map<String, String> getDecryptedHeaders();

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLFeatureEnabledSetting.java
@@ -25,9 +25,11 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_REM
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_STREAM_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_UNIFIED_AGENT_API_ENABLED;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.opensearch.cluster.service.ClusterService;
@@ -43,6 +45,7 @@ public class MLFeatureEnabledSetting {
 
     private volatile Boolean isLocalModelEnabled;
     private volatile Boolean isConnectorPrivateIpEnabled;
+    private volatile List<String> trustedConnectorEndpointsRegex;
 
     private volatile Boolean isControllerEnabled;
     private volatile Boolean isBatchIngestionEnabled;
@@ -84,6 +87,7 @@ public class MLFeatureEnabledSetting {
         isUnifiedAgentApiEnabled = ML_COMMONS_UNIFIED_AGENT_API_ENABLED.get(settings);
         isLocalModelEnabled = ML_COMMONS_LOCAL_MODEL_ENABLED.get(settings);
         isConnectorPrivateIpEnabled = ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED.get(settings);
+        trustedConnectorEndpointsRegex = ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX.get(settings);
         isControllerEnabled = ML_COMMONS_CONTROLLER_ENABLED.get(settings);
         isBatchIngestionEnabled = ML_COMMONS_OFFLINE_BATCH_INGESTION_ENABLED.get(settings);
         isBatchInferenceEnabled = ML_COMMONS_OFFLINE_BATCH_INFERENCE_ENABLED.get(settings);
@@ -115,6 +119,9 @@ public class MLFeatureEnabledSetting {
         clusterService
             .getClusterSettings()
             .addSettingsUpdateConsumer(ML_COMMONS_CONNECTOR_PRIVATE_IP_ENABLED, it -> isConnectorPrivateIpEnabled = it);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX, it -> trustedConnectorEndpointsRegex = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ML_COMMONS_CONTROLLER_ENABLED, it -> isControllerEnabled = it);
         clusterService
             .getClusterSettings()
@@ -183,6 +190,11 @@ public class MLFeatureEnabledSetting {
 
     public boolean isConnectorPrivateIpEnabled() {
         return isConnectorPrivateIpEnabled;
+    }
+
+    public List<String> getTrustedConnectorEndpointsRegex() {
+        List<String> current = trustedConnectorEndpointsRegex;
+        return current == null ? Collections.emptyList() : Collections.unmodifiableList(current);
     }
 
     /**

--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorTest.java
@@ -94,4 +94,46 @@ public class ConnectorTest {
                     )
             );
     }
+
+    @Test
+    public void validateResolvedEndpoint_matches() {
+        HttpConnector connector = createHttpConnector();
+        connector.validateResolvedEndpoint("https://api.openai.com/v1/chat/completions", Arrays.asList("^https://api\\.openai\\.com/.*$"));
+    }
+
+    @Test
+    public void validateResolvedEndpoint_noMatch_rejected() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Connector URL is not matching the trusted connector endpoint regex");
+        HttpConnector connector = createHttpConnector();
+        connector
+            .validateResolvedEndpoint(
+                "https://attacker.example.com/anything?/v1/chat/completions",
+                Arrays.asList("^https://api\\.openai\\.com/.*$")
+            );
+    }
+
+    @Test
+    public void validateResolvedEndpoint_emptyAllowlist_rejected() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Trusted connector endpoints regex is not configured");
+        HttpConnector connector = createHttpConnector();
+        connector.validateResolvedEndpoint("https://api.openai.com/v1/chat/completions", Collections.emptyList());
+    }
+
+    @Test
+    public void validateResolvedEndpoint_nullAllowlist_rejected() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Trusted connector endpoints regex is not configured");
+        HttpConnector connector = createHttpConnector();
+        connector.validateResolvedEndpoint("https://api.openai.com/v1/chat/completions", null);
+    }
+
+    @Test
+    public void validateResolvedEndpoint_nullResolvedUrl_rejected() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Resolved connector URL is null");
+        HttpConnector connector = createHttpConnector();
+        connector.validateResolvedEndpoint(null, Arrays.asList("^https://api\\.openai\\.com/.*$"));
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/settings/MLFeatureEnabledSettingTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/settings/MLFeatureEnabledSettingTests.java
@@ -54,7 +54,8 @@ public class MLFeatureEnabledSettingTests {
                     MLCommonsSettings.ML_COMMONS_STREAM_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MAX_JSON_SIZE,
                     MLCommonsSettings.ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
-                    MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED
+                    MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX
                 )
         );
         when(mockClusterService.getClusterSettings()).thenReturn(mockClusterSettings);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutor.java
@@ -87,6 +87,10 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
 
     @Setter
     @Getter
+    private volatile List<String> trustedConnectorEndpointsRegex;
+
+    @Setter
+    @Getter
     private StreamTransportService streamTransportService;
 
     public AwsConnectorExecutor(Connector connector) {
@@ -110,6 +114,9 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
         ActionListener<Tuple<Integer, ModelTensors>> actionListener
     ) {
         try {
+            // Re-validate the resolved URL against the trusted-connector-endpoints
+            connector.validateResolvedEndpoint(connector.getActionEndpoint(action, parameters), trustedConnectorEndpointsRegex);
+
             SdkHttpFullRequest request;
             switch (connector.getActionHttpMethod(action).toUpperCase(Locale.ROOT)) {
                 case "POST":
@@ -171,6 +178,9 @@ public class AwsConnectorExecutor extends AbstractConnectorExecutor {
         StreamPredictActionListener<MLTaskResponse, ?> actionListener
     ) {
         try {
+            // Re-validate the resolved URL against the trusted-connector-endpoints
+            connector.validateResolvedEndpoint(connector.getActionEndpoint(action, parameters), trustedConnectorEndpointsRegex);
+
             String llmInterface = parameters.get(LLM_INTERFACE);
             llmInterface = llmInterface.trim().toLowerCase(Locale.ROOT);
             llmInterface = StringEscapeUtils.unescapeJava(llmInterface);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutor.java
@@ -86,6 +86,10 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
 
     @Setter
     @Getter
+    private volatile List<String> trustedConnectorEndpointsRegex;
+
+    @Setter
+    @Getter
     private StreamTransportService streamTransportService;
 
     public HttpJsonConnectorExecutor(Connector connector) {
@@ -109,6 +113,9 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
         ActionListener<Tuple<Integer, ModelTensors>> actionListener
     ) {
         try {
+            // Re-validate the resolved URL against the trusted-connector-endpoints
+            connector.validateResolvedEndpoint(connector.getActionEndpoint(action, parameters), trustedConnectorEndpointsRegex);
+
             SdkHttpFullRequest request;
             switch (connector.getActionHttpMethod(action).toUpperCase(Locale.ROOT)) {
                 case "POST":
@@ -170,6 +177,9 @@ public class HttpJsonConnectorExecutor extends AbstractConnectorExecutor {
         StreamPredictActionListener<MLTaskResponse, ?> actionListener
     ) {
         try {
+            // Re-validate the resolved URL against the trusted-connector-endpoints allowlist
+            connector.validateResolvedEndpoint(connector.getActionEndpoint(action, parameters), trustedConnectorEndpointsRegex);
+
             String llmInterface = parameters.get(LLM_INTERFACE);
             llmInterface = llmInterface.trim().toLowerCase(Locale.ROOT);
             llmInterface = StringEscapeUtils.unescapeJava(llmInterface);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -203,6 +203,8 @@ public interface RemoteConnectorExecutor extends AutoCloseable {
 
     default void setMlGuard(MLGuard mlGuard) {}
 
+    default void setTrustedConnectorEndpointsRegex(List<String> trustedConnectorEndpointsRegex) {}
+
     default void preparePayloadAndInvoke(
         String action,
         MLInput mlInput,

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteModel.java
@@ -55,6 +55,7 @@ public class RemoteModel implements Predictable {
     public static final String CONNECTOR_PRIVATE_IP_ENABLED = "connectorPrivateIpEnabled";
     public static final String CONNECTOR_TRUSTED_PRIVATE_ENDPOINTS = "connectorTrustedPrivateEndpoints";
     public static final String CONNECTOR_RESTRICTED_IP_PATTERNS = "connectorRestrictedIpPatterns";
+    public static final String TRUSTED_CONNECTOR_ENDPOINTS_REGEX = "trustedConnectorEndpointsRegex";
     public static final String SDK_CLIENT = "sdk_client";
     public static final String SETTINGS = "settings";
 
@@ -161,6 +162,7 @@ public class RemoteModel implements Predictable {
                     .setConnectorRestrictedIpPatterns(
                         (List) params.getOrDefault(CONNECTOR_RESTRICTED_IP_PATTERNS, Collections.emptyList())
                     );
+                this.connectorExecutor.setTrustedConnectorEndpointsRegex((List<String>) params.get(TRUSTED_CONNECTOR_ENDPOINTS_REGEX));
                 listener.onResponse(this);
             }, e -> {
                 log.error("Failed to init remote model.", e);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemory.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/memory/RemoteAgenticConversationMemory.java
@@ -122,6 +122,7 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
         this.executor.setClient(client);
         this.executor.setXContentRegistry(xContentRegistry);
         this.executor.setConnectorPrivateIpEnabled(mlFeatureEnabledSetting.isConnectorPrivateIpEnabled());
+        this.executor.setTrustedConnectorEndpointsRegex(mlFeatureEnabledSetting.getTrustedConnectorEndpointsRegex());
 
         // Log creation for debugging/monitoring
         log
@@ -1262,6 +1263,7 @@ public class RemoteAgenticConversationMemory implements Memory<Message, CreateIn
             executor.setClient(client);
             executor.setXContentRegistry(xContentRegistry);
             executor.setConnectorPrivateIpEnabled(mlFeatureEnabledSetting.isConnectorPrivateIpEnabled());
+            executor.setTrustedConnectorEndpointsRegex(mlFeatureEnabledSetting.getTrustedConnectorEndpointsRegex());
 
             // Prepare parameters for the action
             Map<String, String> inputParams = new HashMap<>();

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
@@ -180,6 +180,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
         endecryptConnectorCredentials(connector, encryptor, true);
         endecryptConnectorCredentials(connector, encryptor, false);
         AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://.*$"));
         Settings settings = Settings.builder().build();
         threadContext = new ThreadContext(settings);
         when(executor.getClient()).thenReturn(client);
@@ -282,6 +283,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
         executor.setConnectorPrivateIpEnabled(false);
         executor.setConnectorTrustedPrivateEndpoints(Collections.emptyList());
         executor.setConnectorRestrictedIpPatterns(Collections.emptyList());
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://openai\\.com/.*$"));
         Settings settings = Settings.builder().build();
         threadContext = new ThreadContext(settings);
         executor.setClient(client);
@@ -532,6 +534,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
         endecryptConnectorCredentials(connector, encryptor, true);
         endecryptConnectorCredentials(connector, encryptor, false);
         AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://openai\\.com/.*$"));
         Settings settings = Settings.builder().build();
         threadContext = new ThreadContext(settings);
         when(executor.getClient()).thenReturn(client);
@@ -823,6 +826,7 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
         executor.setConnectorPrivateIpEnabled(false);
         executor.setConnectorTrustedPrivateEndpoints(Collections.emptyList());
         executor.setConnectorRestrictedIpPatterns(Collections.emptyList());
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://openai\\.com/.*$"));
         Settings settings = Settings.builder().build();
         threadContext = new ThreadContext(settings);
         ExecutorService executorService = mock(ExecutorService.class);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AwsConnectorExecutorTest.java
@@ -32,6 +32,7 @@ import static org.opensearch.ml.engine.helper.MLTestHelper.endecryptConnectorCre
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -43,6 +44,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -122,6 +124,8 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         encryptor = new EncryptorImpl(null, "m+dWmfmnNRiNlOdej/QelEkvMTyH//frS2TBeS2BP4w=");
+        settings = Settings.builder().build();
+        threadContext = new ThreadContext(settings);
         when(scriptService.compile(any(), any()))
             .then(invocation -> new TestTemplateService.MockTemplateScript.Factory("{\"result\": \"hello world\"}"));
     }
@@ -1195,5 +1199,136 @@ public class AwsConnectorExecutorTest extends MLStaticMockBase {
             // Assert that skipSslVerification defaults to false when null
             assertFalse("SSL verification should be enabled when null", sslVerificationCaptor.getValue());
         }
+    }
+
+    @Test
+    public void invokeRemoteService_predictTimeUrlOverride_blocked() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("https://${parameters.endpoint}/model/converse")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+
+        Map<String, String> credential = ImmutableMap
+            .of(
+                ACCESS_KEY_FIELD,
+                encryptCredentials(List.of("test_key"), null, encryptor),
+                SECRET_KEY_FIELD,
+                encryptCredentials(List.of("test_secret_key"), null, encryptor)
+            );
+
+        Map<String, String> parameters = ImmutableMap
+            .of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "bedrock", "endpoint", "bedrock-runtime.us-west-2.amazonaws.com");
+
+        Connector connector = AwsConnector
+            .awsConnectorBuilder()
+            .name("test connector")
+            .version("1")
+            .protocol("aws_sigv4")
+            .parameters(parameters)
+            .credential(credential)
+            .actions(Arrays.asList(predictAction))
+            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
+            .build();
+
+        endecryptConnectorCredentials(connector, encryptor, false);
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^https://bedrock-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"));
+        executor.setClient(client);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        // Attacker tries to override endpoint
+        Map<String, String> overrideParams = new HashMap<>();
+        overrideParams.put("endpoint", "attacker.example.com/anything?");
+        overrideParams.put("input", "hello");
+
+        ActionListener<Tuple<Integer, ModelTensors>> tupleActionListener = mock(ActionListener.class);
+        executor
+            .invokeRemoteService(
+                PREDICT.name(),
+                createMLInput(overrideParams),
+                overrideParams,
+                "{\"input\": \"hello\"}",
+                new ExecutionContext(0),
+                tupleActionListener
+            );
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(IllegalArgumentException.class);
+        Mockito.verify(tupleActionListener, times(1)).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof IllegalArgumentException);
+        assertEquals("Connector URL is not matching the trusted connector endpoint regex", captor.getValue().getMessage());
+    }
+
+    @Test
+    public void invokeRemoteService_predictTimeUrlOverride_allowedHost_passesValidation() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("https://${parameters.endpoint}/model/converse")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+
+        Map<String, String> credential = ImmutableMap
+            .of(
+                ACCESS_KEY_FIELD,
+                encryptCredentials(List.of("test_key"), null, encryptor),
+                SECRET_KEY_FIELD,
+                encryptCredentials(List.of("test_secret_key"), null, encryptor)
+            );
+        Map<String, String> parameters = ImmutableMap
+            .of(REGION_FIELD, "us-west-2", SERVICE_NAME_FIELD, "bedrock", "endpoint", "bedrock-runtime.us-west-2.amazonaws.com");
+        Connector connector = AwsConnector
+            .awsConnectorBuilder()
+            .name("test connector")
+            .version("1")
+            .protocol("aws_sigv4")
+            .parameters(parameters)
+            .credential(credential)
+            .actions(Arrays.asList(predictAction))
+            .connectorClientConfig(new ConnectorClientConfig(10, 10, 10, 1, 1, 0, RetryBackoffPolicy.CONSTANT, null))
+            .build();
+
+        endecryptConnectorCredentials(connector, encryptor, false);
+        AwsConnectorExecutor executor = spy(new AwsConnectorExecutor(connector));
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^https://bedrock-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"));
+        executor.setClient(client);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        Map<String, String> validParams = new HashMap<>();
+        validParams.put("endpoint", "bedrock-runtime.us-west-2.amazonaws.com");
+        validParams.put("input", "hello");
+
+        ActionListener<Tuple<Integer, ModelTensors>> tupleActionListener = mock(ActionListener.class);
+        executor
+            .invokeRemoteService(
+                PREDICT.name(),
+                createMLInput(validParams),
+                validParams,
+                "{\"input\": \"hello\"}",
+                new ExecutionContext(0),
+                tupleActionListener
+            );
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(tupleActionListener, Mockito.atMost(1)).onFailure(captor.capture());
+        for (Exception e : captor.getAllValues()) {
+            assertFalse(
+                "Validator must not reject a resolved URL that matches the allowlist",
+                "Connector URL is not matching the trusted connector endpoint regex".equals(e.getMessage())
+            );
+        }
+    }
+
+    private MLInput createMLInput(Map<String, String> parameters) {
+        return MLInput
+            .builder()
+            .algorithm(FunctionName.REMOTE)
+            .inputDataset(RemoteInferenceInputDataSet.builder().parameters(parameters).build())
+            .build();
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
@@ -556,6 +556,98 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
         assertEquals("Fail to execute streaming", captor.getValue().getMessage());
     }
 
+    @Test
+    public void invokeRemoteService_predictTimeUrlOverride_blocked() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("https://${parameters.endpoint}/v1/chat/completions")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .parameters(ImmutableMap.of("endpoint", "api.openai.com"))
+            .actions(Arrays.asList(predictAction))
+            .build();
+        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+        executor.setConnectorPrivateIpEnabled(true);
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^https://api\\.openai\\.com/.*$"));
+        executor.setClient(client);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        Map<String, String> overrideParams = new HashMap<>();
+        overrideParams.put("endpoint", "attacker.example.com/anything?");
+        overrideParams.put("input", "hello");
+
+        executor
+            .invokeRemoteService(
+                PREDICT.name(),
+                createMLInput(),
+                overrideParams,
+                "{\"input\": \"hello\"}",
+                new ExecutionContext(0),
+                actionListener
+            );
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(IllegalArgumentException.class);
+        Mockito.verify(actionListener, times(1)).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof IllegalArgumentException);
+        assertEquals("Connector URL is not matching the trusted connector endpoint regex", captor.getValue().getMessage());
+    }
+
+    @Test
+    public void invokeRemoteService_predictTimeUrlOverride_allowedHost_passesValidation() {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("https://${parameters.endpoint}/v1/chat/completions")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+        Connector connector = HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .parameters(ImmutableMap.of("endpoint", "api.openai.com"))
+            .actions(Arrays.asList(predictAction))
+            .build();
+        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+        executor.setConnectorPrivateIpEnabled(true);
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^https://api\\.openai\\.com/.*$"));
+        executor.setClient(client);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("endpoint", "api.openai.com");
+        params.put("input", "hello");
+
+        executor
+            .invokeRemoteService(
+                PREDICT.name(),
+                createMLInput(),
+                params,
+                "{\"input\": \"hello\"}",
+                new ExecutionContext(0),
+                actionListener
+            );
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(actionListener, Mockito.atMost(1)).onFailure(captor.capture());
+        for (Exception e : captor.getAllValues()) {
+            assertFalse(
+                "Validator must not reject a resolved URL that matches the allowlist",
+                "Connector URL is not matching the trusted connector endpoint regex".equals(e.getMessage())
+            );
+        }
+    }
+
     private MLInput createMLInput() {
         MLInputDataset inputDataSet = RemoteInferenceInputDataSet.builder().parameters(ImmutableMap.of("input", "test input data")).build();
         return MLInput.builder().inputDataset(inputDataSet).algorithm(FunctionName.REMOTE).build();

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/HttpJsonConnectorExecutorTest.java
@@ -99,7 +99,8 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
             .protocol("http")
             .actions(Arrays.asList(predictAction))
             .build();
-        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://openai\\.com/.*$"));
         executor.invokeRemoteService(PREDICT.name(), null, null, null, null, actionListener);
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(IllegalArgumentException.class);
         Mockito.verify(actionListener, times(1)).onFailure(captor.capture());
@@ -126,6 +127,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
         executor.setConnectorPrivateIpEnabled(false);
         executor.setConnectorTrustedPrivateEndpoints(Collections.emptyList());
         executor.setConnectorRestrictedIpPatterns(Collections.emptyList());
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://.*$"));
         executor.setClient(client);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -164,6 +166,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
         executor.setConnectorPrivateIpEnabled(true);
         executor.setConnectorTrustedPrivateEndpoints(Collections.emptyList());
         executor.setConnectorRestrictedIpPatterns(Collections.emptyList());
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://.*$"));
         executor.setClient(client);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -199,6 +202,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
         executor.setConnectorPrivateIpEnabled(false);
         executor.setConnectorTrustedPrivateEndpoints(Collections.emptyList());
         executor.setConnectorRestrictedIpPatterns(Collections.emptyList());
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://.*$"));
         executor.setClient(client);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -233,7 +237,8 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
             .protocol("http")
             .actions(Arrays.asList(predictAction))
             .build();
-        HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://openai\\.com/.*$"));
         executor.invokeRemoteService(PREDICT.name(), createMLInput(), new HashMap<>(), null, new ExecutionContext(0), actionListener);
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(IllegalArgumentException.class);
         Mockito.verify(actionListener, times(1)).onFailure(captor.capture());
@@ -316,6 +321,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                 .thenReturn(mockClient);
 
             HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+            executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://openai\\.com/.*$"));
             executor.setClient(client);
             when(client.threadPool()).thenReturn(threadPool);
             when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -376,6 +382,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                 .thenReturn(mockClient);
 
             HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+            executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://openai\\.com/.*$"));
             executor.setClient(client);
             when(client.threadPool()).thenReturn(threadPool);
             when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -436,6 +443,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
                 .thenReturn(mockClient);
 
             HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+            executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://openai\\.com/.*$"));
             executor.setClient(client);
             when(client.threadPool()).thenReturn(threadPool);
             when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -485,6 +493,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
             .actions(Arrays.asList(predictAction))
             .build();
         HttpJsonConnectorExecutor executor = spy(new HttpJsonConnectorExecutor(connector));
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://openai\\.com/.*$"));
         executor.setClient(client);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -515,6 +524,7 @@ public class HttpJsonConnectorExecutorTest extends MLStaticMockBase {
             .build();
 
         HttpJsonConnectorExecutor executor = new HttpJsonConnectorExecutor(connector);
+        executor.setTrustedConnectorEndpointsRegex(Arrays.asList("^http://openai\\.com/.*$"));
         StreamPredictActionListener<MLTaskResponse, ?> actionListener = mock(StreamPredictActionListener.class);
 
         Map<String, String> parameters = ImmutableMap.of("_llm_interface", "openai/v1/chat/completions", "input", "test input");

--- a/plugin/src/main/java/org/opensearch/ml/action/connector/ExecuteConnectorTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/connector/ExecuteConnectorTransportAction.java
@@ -100,6 +100,7 @@ public class ExecuteConnectorTransportAction extends HandledTransportAction<Acti
                         RemoteConnectorExecutor connectorExecutor = MLEngineClassLoader
                             .initInstance(connector.getProtocol(), connector, Connector.class);
                         connectorExecutor.setConnectorPrivateIpEnabled(mlFeatureEnabledSetting.isConnectorPrivateIpEnabled());
+                        connectorExecutor.setTrustedConnectorEndpointsRegex(mlFeatureEnabledSetting.getTrustedConnectorEndpointsRegex());
                         connectorExecutor.setScriptService(scriptService);
                         connectorExecutor.setClusterService(clusterService);
                         connectorExecutor.setClient(client);

--- a/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/model/MLModelManager.java
@@ -44,6 +44,7 @@ import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.RATE_LIMITE
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.SCRIPT_SERVICE;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.SDK_CLIENT;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.SETTINGS;
+import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.USER_RATE_LIMITER_MAP;
 import static org.opensearch.ml.engine.algorithms.remote.RemoteModel.XCONTENT_REGISTRY;
 import static org.opensearch.ml.engine.algorithms.text_embedding.TextEmbeddingDenseModel.ML_ENGINE;
@@ -1574,6 +1575,7 @@ public class MLModelManager {
         params.put(CONNECTOR_PRIVATE_IP_ENABLED, mlFeatureEnabledSetting.isConnectorPrivateIpEnabled());
         params.put(CONNECTOR_TRUSTED_PRIVATE_ENDPOINTS, connectorTrustedPrivateEndpoints);
         params.put(CONNECTOR_RESTRICTED_IP_PATTERNS, connectorRestrictedIpPatterns);
+        params.put(TRUSTED_CONNECTOR_ENDPOINTS_REGEX, mlFeatureEnabledSetting.getTrustedConnectorEndpointsRegex());
         params.put(SDK_CLIENT, sdkClient);
         params.put(SETTINGS, settings);
         return Collections.unmodifiableMap(params);

--- a/plugin/src/test/java/org/opensearch/ml/settings/MLFeatureEnabledSettingTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/settings/MLFeatureEnabledSettingTests.java
@@ -32,6 +32,7 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_REM
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_REMOTE_INFERENCE_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_STATIC_METRIC_COLLECTION_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_STREAM_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_UNIFIED_AGENT_API_ENABLED;
 
 import java.util.Set;
@@ -90,7 +91,8 @@ public class MLFeatureEnabledSettingTests {
                             ML_COMMONS_MAX_JSON_SIZE,
                             ML_COMMONS_UNIFIED_AGENT_API_ENABLED,
                             ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
-                            ML_COMMONS_AG_UI_ENABLED
+                            ML_COMMONS_AG_UI_ENABLED,
+                            ML_COMMONS_TRUSTED_CONNECTOR_ENDPOINTS_REGEX
                         )
                 )
             );


### PR DESCRIPTION
### Description
Strengthens enforcement of the`plugins.ml_commons.trusted_connector_endpoints_regex` allowlist so the same check is applied consistently across all code paths that issue outbound connector requests.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
