### PR TITLE
Add ci.opensearch.org maven2 mirror to avoid throttling (ml-commons)

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -6,6 +6,7 @@
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven {url 'https://oss.sonatype.org/content/repositories/snapshots/'}
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -14,6 +14,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/search-processors/build.gradle
+++ b/search-processors/build.gradle
@@ -22,6 +22,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-ml'
 
 include 'client'

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'opensearch.java'
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
 }


### PR DESCRIPTION
### Description
Add ci.opensearch.org maven2 mirror to avoid throttling (ml-commons)

### Related Issues
https://github.com/opensearch-project/opensearch-build/issues/6062

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
