### PR TITLE
Fix 3.7 failing IT and CVE

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -726,8 +726,8 @@ configurations.all {
     resolutionStrategy.force "io.netty:netty-handler:${versions.netty}"
     resolutionStrategy.force "io.netty:netty-resolver:${versions.netty}"
     resolutionStrategy.force "io.netty:netty-transport-native-unix-common:${versions.netty}"
-    resolutionStrategy.force 'org.apache.logging.log4j:log4j-api:2.25.3'
-    resolutionStrategy.force 'org.apache.logging.log4j:log4j-core:2.25.3'
+    resolutionStrategy.force "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+    resolutionStrategy.force "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 }
 
 apply plugin: 'com.netflix.nebula.ospackage'

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
@@ -469,6 +469,76 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
         assertEquals(Result.UPDATED, argumentCaptor.getValue().getResult());
     }
 
+    @Test
+    public void testExecuteWithValidDynamicHeaders() {
+        doReturn(true).when(connectorAccessControlHelper).validateConnectorAccess(any(Client.class), any(Connector.class));
+
+        MLCreateConnectorInput updateContent = MLCreateConnectorInput
+            .builder()
+            .updateConnector(true)
+            .version("2")
+            .actions(
+                Arrays
+                    .asList(
+                        ConnectorAction
+                            .builder()
+                            .actionType(ConnectorAction.ActionType.PREDICT)
+                            .method("POST")
+                            .url("https://api.openai.com/v1/chat/completions")
+                            .headers(Map.of("X-Custom-Header", "${parameters.custom_value}"))
+                            .requestBody("{ \"model\": \"${parameters.model}\" }")
+                            .build()
+                    )
+            )
+            .build();
+        when(updateRequest.getUpdateContent()).thenReturn(updateContent);
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), isA(ActionListener.class));
+
+        updateConnectorTransportAction.doExecute(task, updateRequest, actionListener);
+        verify(actionListener).onResponse(any(UpdateResponse.class));
+    }
+
+    @Test
+    public void testExecuteWithBlockedDynamicHeaderThrowsException() {
+        doReturn(true).when(connectorAccessControlHelper).validateConnectorAccess(any(Client.class), any(Connector.class));
+
+        MLCreateConnectorInput updateContent = MLCreateConnectorInput
+            .builder()
+            .updateConnector(true)
+            .version("2")
+            .actions(
+                Arrays
+                    .asList(
+                        ConnectorAction
+                            .builder()
+                            .actionType(ConnectorAction.ActionType.PREDICT)
+                            .method("POST")
+                            .url("https://api.openai.com/v1/chat/completions")
+                            .headers(Map.of("Authorization", "${parameters.token}"))
+                            .requestBody("{ \"model\": \"${parameters.model}\" }")
+                            .build()
+                    )
+            )
+            .build();
+        when(updateRequest.getUpdateContent()).thenReturn(updateContent);
+
+        updateConnectorTransportAction.doExecute(task, updateRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertTrue(argumentCaptor.getValue().getMessage().contains("cannot use ${parameters.*} placeholders for security reasons"));
+    }
+
     private SearchResponse noneEmptySearchResponse() throws IOException {
         String modelContent = "{\"name\":\"Remote_Model\",\"algorithm\":\"Remote\",\"version\":1,\"connector_id\":\"test_id\"}";
         SearchHit model = SearchHit.fromXContent(TestHelper.parser(modelContent));

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
@@ -1133,11 +1133,10 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
             + "      \"method\": \"POST\",\n"
             + "      \"url\": \"https://${parameters.endpoint}/post\",\n"
             + "      \"headers\": {\n"
-            + "        \"X-Request-ID\": \"${parameters.request_id}\",\n"
+            + "        \"X-Custom-Request\": \"${parameters.request_id}\",\n"
             + "        \"X-Model\": \"${parameters.model}\"\n"
             + "      },\n"
-            + "      \"request_body\": \"{\\\"input\\\": \\\"${parameters.input}\\\"}\",\n"
-            + "      \"post_process_function\": \"return params.response;\"\n"
+            + "      \"request_body\": \"{\\\"input\\\": \\\"${parameters.input}\\\"}\"\n"
             + "    }\n"
             + "  ]\n"
             + "}";
@@ -1192,21 +1191,20 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
 
         // httpbin returns the headers in the response
         Map headers = (Map) dataAsMap.get("headers");
-        if (headers != null) {
-            // Verify our dynamic headers were substituted correctly
-            String requestId = (String) headers.get("X-Request-Id");
-            String model = (String) headers.get("X-Model");
+        assertNotNull("httpbin response should contain headers", headers);
 
-            // httpbin may lowercase header names
-            if (requestId == null) {
-                requestId = (String) headers.get("x-request-id");
-            }
-            if (model == null) {
-                model = (String) headers.get("x-model");
-            }
+        // Verify our dynamic headers were substituted correctly
+        String requestId = (String) headers.get("X-Custom-Request");
+        String model = (String) headers.get("X-Model");
 
-            assertEquals("req-integration-test-12345", requestId);
-            assertEquals("test-model", model);
+        if (requestId == null) {
+            requestId = (String) headers.get("x-custom-request");
         }
+        if (model == null) {
+            model = (String) headers.get("x-model");
+        }
+
+        assertEquals("req-integration-test-12345", requestId);
+        assertEquals("test-model", model);
     }
 }


### PR DESCRIPTION
### Description
- Fix failing tests for 3.7
- Fix CVE-2026-34477, CVE-2026-34478, CVE-2026-34480
```
% for project in opensearch-ml-algorithms opensearch-ml-client opensearch-ml-common opensearch-ml-memory opensearch-ml-plugin opensearch-ml-search-processors opensearch-ml-spi; do
  echo "=== $project ==="
  ./gradlew :$project:dependencies | grep log4j-core
done
=== opensearch-ml-algorithms ===
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
=== opensearch-ml-client ===
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
=== opensearch-ml-common ===
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
=== opensearch-ml-memory ===
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
=== opensearch-ml-plugin ===
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
+--- org.apache.logging.log4j:log4j-core:2.25.4
+--- org.apache.logging.log4j:log4j-core:2.25.4 (n)
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
+--- org.apache.logging.log4j:log4j-core:2.25.4
|    |    |    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
+--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
+--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    |    +--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4
+--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
+--- org.apache.logging.log4j:log4j-core:2.25.4 (n)
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4
+--- org.apache.logging.log4j:log4j-core:2.25.4 (*)
=== opensearch-ml-search-processors ===
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
=== opensearch-ml-spi ===
     +--- org.apache.logging.log4j:log4j-core:2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
\--- org.apache.logging.log4j:log4j-core:2.25.4
\--- org.apache.logging.log4j:log4j-core:2.25.4 (n)
|    +--- org.apache.logging.log4j:log4j-core:2.25.4
\--- org.apache.logging.log4j:log4j-core:2.25.4
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
