### PR TITLE
Fix flaky IT: testChatAgentWithMcpStreamableHttpConnector, add timeout

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
@@ -78,16 +78,18 @@ public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
         assertEquals(200, registerResponse.getStatusLine().getStatusCode());
 
         // MCP per-node tool registration is fire-and-forget, so HTTP 200 doesn't guarantee
-        // the tool is visible yet. Poll /_list until ListIndexTool shows up (15s max).
-        Thread.sleep(500);
-        long deadline = System.currentTimeMillis() + 15_000;
-        while (System.currentTimeMillis() < deadline) {
-            Response listResponse = TestHelper
-                .makeRequest(client(), "GET", "/_plugins/_ml/mcp/tools/_list", null, "", null);
+        // the tool is visible yet. Poll /_list until ListIndexTool shows up (20 x 500ms = 10s max).
+        boolean toolVisible = false;
+        for (int attempt = 0; attempt < 20; attempt++) {
+            Thread.sleep(500);
+            Response listResponse = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/mcp/tools/_list", null, "", null);
             if (TestHelper.httpEntityToString(listResponse.getEntity()).contains("ListIndexTool")) {
+                toolVisible = true;
                 break;
             }
-            Thread.sleep(500);
+        }
+        if (!toolVisible) {
+            throw new AssertionError("ListIndexTool did not become visible in /_plugins/_ml/mcp/tools/_list within 10s");
         }
 
         ingestIrisData(irisIndex);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
@@ -12,12 +12,12 @@ import java.util.Map;
 
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
-import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.opensearch.client.Response;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.utils.TestHelper;
 
@@ -54,7 +54,7 @@ public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
     private String llmModelId;
 
     @Before
-    public void setup() throws IOException, ParseException, InterruptedException {
+    public void setup() throws Exception {
         Assume.assumeNotNull(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY);
 
         RestMLRemoteInferenceIT.disableClusterConnectorAccessControl();
@@ -78,19 +78,15 @@ public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
         assertEquals(200, registerResponse.getStatusLine().getStatusCode());
 
         // MCP per-node tool registration is fire-and-forget, so HTTP 200 doesn't guarantee
-        // the tool is visible yet. Poll /_list until ListIndexTool shows up (20 x 500ms = 10s max).
-        boolean toolVisible = false;
-        for (int attempt = 0; attempt < 20; attempt++) {
-            Thread.sleep(500);
+        // the tool is visible yet. Poll /_list until ListIndexTool shows up; assertBusyWithFixedSleepTime
+        // retries every 500ms up to 15s and throws if the tool never appears.
+        assertBusyWithFixedSleepTime(() -> {
             Response listResponse = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/mcp/tools/_list", null, "", null);
-            if (TestHelper.httpEntityToString(listResponse.getEntity()).contains("ListIndexTool")) {
-                toolVisible = true;
-                break;
-            }
-        }
-        if (!toolVisible) {
-            throw new AssertionError("ListIndexTool did not become visible in /_plugins/_ml/mcp/tools/_list within 10s");
-        }
+            assertTrue(
+                "ListIndexTool did not become visible in /_plugins/_ml/mcp/tools/_list within 15s",
+                TestHelper.httpEntityToString(listResponse.getEntity()).contains("ListIndexTool")
+            );
+        }, TimeValue.timeValueSeconds(15), TimeValue.timeValueMillis(500));
 
         ingestIrisData(irisIndex);
         llmModelId = registerAndDeployBedrockModel();

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
@@ -118,6 +118,10 @@ public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
         String mcpServerUrl = host.getSchemeName() + "://" + host.getHostName() + ":" + host.getPort();
 
         // Step 1 – create the MCP streamable-http connector pointing at this cluster's own MCP server.
+        // The MCP tool call loops back into this same cluster over HTTP. Under CI load (40+ IT classes
+        // share one JVM), the default 30s read timeout is too tight and the loopback call intermittently
+        // times out — the LLM then reports a timeout instead of the index list and the assertion fails.
+        // A generous client_config timeout removes that flake source.
         String connectorBody = "{\n"
             + "  \"name\": \"Self MCP Connector\",\n"
             + "  \"description\": \"MCP streamable-http connector pointing back at the same cluster's MCP server\",\n"
@@ -128,6 +132,10 @@ public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
             + "\",\n"
             + "  \"parameters\": {\n"
             + "    \"endpoint\": \"/_plugins/_ml/mcp\"\n"
+            + "  },\n"
+            + "  \"client_config\": {\n"
+            + "    \"connection_timeout\": 120,\n"
+            + "    \"read_timeout\": 120\n"
             + "  },\n"
             + "  \"credential\": {}\n"
             + "}";

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
@@ -77,6 +77,19 @@ public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
             );
         assertEquals(200, registerResponse.getStatusLine().getStatusCode());
 
+        // MCP per-node tool registration is fire-and-forget, so HTTP 200 doesn't guarantee
+        // the tool is visible yet. Poll /_list until ListIndexTool shows up (15s max).
+        Thread.sleep(500);
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (System.currentTimeMillis() < deadline) {
+            Response listResponse = TestHelper
+                .makeRequest(client(), "GET", "/_plugins/_ml/mcp/tools/_list", null, "", null);
+            if (TestHelper.httpEntityToString(listResponse.getEntity()).contains("ListIndexTool")) {
+                break;
+            }
+            Thread.sleep(500);
+        }
+
         ingestIrisData(irisIndex);
         llmModelId = registerAndDeployBedrockModel();
     }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
@@ -77,16 +77,36 @@ public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
             );
         assertEquals(200, registerResponse.getStatusLine().getStatusCode());
 
-        // MCP per-node tool registration is fire-and-forget, so HTTP 200 doesn't guarantee
-        // the tool is visible yet. Poll /_list until ListIndexTool shows up; assertBusyWithFixedSleepTime
-        // retries every 500ms up to 15s and throws if the tool never appears.
+        // MCP per-node tool registration is fire-and-forget, so HTTP 200 doesn't guarantee the
+        // tool is servable yet. Note /_plugins/_ml/mcp/tools/_list reads the system index, NOT the
+        // per-node in-memory MCP server that actually answers tools/list — the two can lag apart
+        // (a background job syncs index -> memory every 10s). Poll the real MCP endpoint with a
+        // JSON-RPC tools/list call, which is exactly what the agent's MCP client will invoke; if
+        // the tool isn't servable, the agent sends Bedrock an empty toolConfig and gets a 400.
+        String toolsListRequest = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}";
         assertBusyWithFixedSleepTime(() -> {
-            Response listResponse = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/mcp/tools/_list", null, "", null);
+            String toolsListBody;
+            try {
+                Response listResponse = TestHelper
+                    .makeRequest(
+                        client(),
+                        "POST",
+                        "/_plugins/_ml/mcp",
+                        null,
+                        toolsListRequest,
+                        ImmutableList.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
+                    );
+                toolsListBody = TestHelper.httpEntityToString(listResponse.getEntity());
+            } catch (Exception e) {
+                // assertBusy only retries on AssertionError; surface transient failures (e.g. MCP
+                // server still initializing) as assertion failures so polling continues.
+                throw new AssertionError("MCP tools/list request failed: " + e.getMessage(), e);
+            }
             assertTrue(
-                "ListIndexTool did not become visible in /_plugins/_ml/mcp/tools/_list within 15s",
-                TestHelper.httpEntityToString(listResponse.getEntity()).contains("ListIndexTool")
+                "ListIndexTool did not become servable via MCP tools/list within 30s, got: " + toolsListBody,
+                toolsListBody.contains("ListIndexTool")
             );
-        }, TimeValue.timeValueSeconds(15), TimeValue.timeValueMillis(500));
+        }, TimeValue.timeValueSeconds(30), TimeValue.timeValueMillis(500));
 
         ingestIrisData(irisIndex);
         llmModelId = registerAndDeployBedrockModel();

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
@@ -77,12 +77,9 @@ public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
             );
         assertEquals(200, registerResponse.getStatusLine().getStatusCode());
 
-        // MCP per-node tool registration is fire-and-forget, so HTTP 200 doesn't guarantee the
-        // tool is servable yet. Note /_plugins/_ml/mcp/tools/_list reads the system index, NOT the
-        // per-node in-memory MCP server that actually answers tools/list — the two can lag apart
-        // (a background job syncs index -> memory every 10s). Poll the real MCP endpoint with a
-        // JSON-RPC tools/list call, which is exactly what the agent's MCP client will invoke; if
-        // the tool isn't servable, the agent sends Bedrock an empty toolConfig and gets a 400.
+        // Registration is fire-and-forget and /_list reads the system index, not the per-node
+        // in-memory registry that serves tools/list (synced every 10s). Poll the MCP endpoint
+        // itself — the same call the agent's MCP client makes — until the tool is servable.
         String toolsListRequest = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}";
         assertBusyWithFixedSleepTime(() -> {
             String toolsListBody;
@@ -98,8 +95,7 @@ public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
                     );
                 toolsListBody = TestHelper.httpEntityToString(listResponse.getEntity());
             } catch (Exception e) {
-                // assertBusy only retries on AssertionError; surface transient failures (e.g. MCP
-                // server still initializing) as assertion failures so polling continues.
+                // assertBusy only retries on AssertionError
                 throw new AssertionError("MCP tools/list request failed: " + e.getMessage(), e);
             }
             assertTrue(
@@ -137,11 +133,9 @@ public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
         HttpHost host = getClusterHosts().get(0);
         String mcpServerUrl = host.getSchemeName() + "://" + host.getHostName() + ":" + host.getPort();
 
-        // Step 1 – create the MCP streamable-http connector pointing at this cluster's own MCP server.
-        // The MCP tool call loops back into this same cluster over HTTP. Under CI load (40+ IT classes
-        // share one JVM), the default 30s read timeout is too tight and the loopback call intermittently
-        // times out — the LLM then reports a timeout instead of the index list and the assertion fails.
-        // A generous client_config timeout removes that flake source.
+        // Step 1 – create the MCP streamable-http connector pointing at this cluster's own MCP
+        // server. Generous client_config timeouts because the default 30s intermittently trips
+        // on the loopback tool call under CI load.
         String connectorBody = "{\n"
             + "  \"name\": \"Self MCP Connector\",\n"
             + "  \"description\": \"MCP streamable-http connector pointing back at the same cluster's MCP server\",\n"


### PR DESCRIPTION
## Summary
- Fix flaky `RestChatAgentWithMcpConnectorIT.testChatAgentWithMcpStreamableHttpConnector` (two independent flake sources)

**Flake 1 — Bedrock 400 "The provided request is not valid" (registration race)**
- `TransportMcpToolsRegisterOnNodesAction.registerToolsOnNode` uses `Flux...subscribe()` (fire-and-forget) and returns success before the reactive `addTool` Mono completes, so HTTP 200 from `/_plugins/_ml/mcp/tools/_register` does not guarantee the tool is servable
- Worse, `/_plugins/_ml/mcp/tools/_list` reads the `.plugins-ml-mcp-tools` system index, while the MCP server answers `tools/list` from a per-node in-memory registry (synced from the index only every 10s) — so polling `/_list` (earlier commits here) can pass while the tool is still not servable
- The agent's MCP client then discovers zero tools, and `BedrockConverseFunctionCalling` renders `tool_configs` as `, "toolConfig": {"tools": []}` — verified empirically against the Converse API that an empty tools array returns exactly this generic 400 (all other malformed request shapes return specific error messages)
- Fix: poll the real `/_plugins/_ml/mcp` endpoint with a JSON-RPC `tools/list` call (30s timeout, 500ms cadence) — the same call the agent's MCP client makes — before continuing setup

**Flake 2 — LLM answers with a timeout apology instead of the index list**
- The MCP connector loops back into the same cluster over HTTP; under CI load the default 30s read timeout is too tight and the loopback tool call intermittently times out
- Fix: set `client_config` connection/read timeouts to 120s on the MCP connector

## Test plan
- [x] Ran the IT 4 times locally with valid AWS Bedrock creds against the earlier revision — 4/4 pass (1m27s first cold run, ~25s on warm cluster)
- [ ] Confirm the updated poll + timeout pass on CI

## Out of scope (follow-up)
The deeper product fixes: `TransportMcpToolsRegisterOnNodesAction:114-144` should await the Mono before returning success; agents that resolve zero MCP tools silently continue and send Bedrock an empty toolConfig (an opaque 400 for any real user hitting the same race) — should fail loudly or omit `toolConfig`. This PR only stabilizes the IT.