### PR TITLE
[Backport 3.3] Return 429 instead of 500 on connection pool acquire timeout

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
@@ -101,7 +101,17 @@ public class MLSdkAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandle
     @Override
     public void onError(Throwable error) {
         log.error("Received error from remote service: {}", error.getMessage(), error);
-        RestStatus status = (statusCode == null) ? RestStatus.INTERNAL_SERVER_ERROR : RestStatus.fromCode(statusCode);
+        RestStatus status;
+        if (statusCode == null) {
+            if (error.getMessage() != null
+                && error.getMessage().contains("Acquire operation took longer than the configured maximum time")) {
+                status = RestStatus.TOO_MANY_REQUESTS;
+            } else {
+                status = RestStatus.INTERNAL_SERVER_ERROR;
+            }
+        } else {
+            status = RestStatus.fromCode(statusCode);
+        }
         String errorMessage = "Error communicating with remote model: " + error.getMessage();
         actionListener.onFailure(new OpenSearchStatusException(errorMessage, status));
     }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
@@ -28,6 +28,7 @@ import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
 import org.opensearch.ml.common.connector.HttpConnector;
@@ -197,6 +198,19 @@ public class MLSdkAsyncHttpResponseHandlerTest {
     @Test
     public void test_MLSdkAsyncHttpResponseHandler_onError() {
         mlSdkAsyncHttpResponseHandler.onError(new Exception("error"));
+    }
+
+    @Test
+    public void test_onError_connectionPoolAcquireTimeout_returns429() {
+        mlSdkAsyncHttpResponseHandler.onError(new RuntimeException("Acquire operation took longer than the configured maximum time"));
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assert captor.getValue() instanceof OpenSearchStatusException;
+        assertEquals(RestStatus.TOO_MANY_REQUESTS, ((OpenSearchStatusException) captor.getValue()).status());
+        assertEquals(
+            "Error communicating with remote model: Acquire operation took longer than the configured maximum time",
+            captor.getValue().getMessage()
+        );
     }
 
     @Test


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/ml-commons/pull/4852 to 3.3 branch


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
