### PR TITLE
Fix cross-tenant agent execution bypass in MLAgentExecutor

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutor.java
@@ -257,6 +257,7 @@ public class MLAgentExecutor implements Executable, SettingsChangeListener {
                                                         RestStatus.FORBIDDEN
                                                     )
                                                 );
+                                            return;
                                         }
 
                                         processAgentInput(agentMLInput, mlAgent);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/MLAgentExecutorTest.java
@@ -1979,4 +1979,36 @@ public class MLAgentExecutorTest {
         // MCP check passes (enabled), so execution must reach executeV2Agent
         verify(memory, timeout(5000).atLeastOnce()).getStructuredMessages(any());
     }
+
+    @Test
+    public void test_Execute_CrossTenantAgentExecution_BlockedWithForbidden() throws IOException {
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+        mlAgentExecutor.onMultiTenancyEnabledChanged(true);
+        when(clusterService.state().metadata().hasIndex(anyString())).thenReturn(true);
+
+        MLAgent agentOwnedByTenantA = MLAgent
+            .builder()
+            .name("tenant_a_agent")
+            .type(MLAgentType.CONVERSATIONAL.name())
+            .llm(LLMSpec.builder().modelId("test-model").build())
+            .tenantId("tenant-A")
+            .createdTime(Instant.now())
+            .lastUpdateTime(Instant.now())
+            .build();
+
+        mockSdkClientWithAgent(serializeAgentToGetResponseJson(agentOwnedByTenantA));
+
+        Map<String, String> params = new HashMap<>();
+        params.put(QUESTION, "test question");
+        RemoteInferenceInputDataSet dataset = RemoteInferenceInputDataSet.builder().parameters(params).build();
+        AgentMLInput agentMLInput = new AgentMLInput("test-agent-id", "tenant-B", FunctionName.AGENT, dataset);
+
+        mlAgentExecutor.execute(agentMLInput, listener, channel);
+
+        verify(listener, timeout(5000)).onFailure(exceptionCaptor.capture());
+        Exception exception = exceptionCaptor.getValue();
+        assertTrue(exception instanceof OpenSearchStatusException);
+        assertEquals("You don't have permission to access this resource", exception.getMessage());
+        assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) exception).status());
+    }
 }


### PR DESCRIPTION
### Description
Add missing return statement after listener.onFailure() in the cross-tenant authorization check. Without it, execution falls through to processAgentInput() and the full agent pipeline, allowing a user in one tenant to execute another tenant's agent server-side.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
