### PR TITLE
Follow up for feat: Add structured output (constrained decoding) support for agentic memory fact extraction #4824

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java
@@ -244,6 +244,7 @@ public class ConnectorAction implements ToXContentObject, Writeable {
                     supportsStructuredOutput = parser.booleanValue();
                     break;
                 default:
+                    logger.debug("Skipping unknown connector action field: {}", fieldName);
                     parser.skipChildren();
                     break;
             }

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -440,7 +440,10 @@ public class HttpConnector extends AbstractConnector {
             JsonObject target = body.has(fieldName) && body.get(fieldName).isJsonObject()
                 ? body.getAsJsonObject(fieldName)
                 : new JsonObject();
-            additions.entrySet().forEach(e -> { if (!target.has(e.getKey())) target.add(e.getKey(), e.getValue()); });
+            additions.entrySet().forEach(e -> {
+                if (!target.has(e.getKey()))
+                    target.add(e.getKey(), e.getValue());
+            });
             body.add(fieldName, target);
             modified = true;
         }

--- a/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/HttpConnector.java
@@ -68,6 +68,8 @@ public class HttpConnector extends AbstractConnector {
     // Allowlist of top-level JSON fields that _<field>_json / _<field>_additions_json parameters may inject.
     // Restricts injection to structured-output fields only; prevents callers from overriding
     // provider control fields such as "model", "stream", or "max_tokens".
+    // Each entry corresponds to a FACTS_EXTRACTION_* constant in MemoryContainerConstants.
+    // Any new field added here must have a matching constant wired into MemoryContainerHelper.schemaForUrl.
     static final Set<String> STRUCTURED_OUTPUT_ALLOWED_FIELDS = Set
         .of(
             "response_format",  // OpenAI, Azure OpenAI, DeepSeek, Ollama, Cohere
@@ -406,6 +408,8 @@ public class HttpConnector extends AbstractConnector {
     // (b) a non-empty, allowlisted field name, and (c) a valid JSON object value string.
     // Replacements (_X_json) are applied before merges (_X_additions_json) so behaviour is
     // deterministic when both are present for the same field.
+    // Collision semantics: keys already present in the target object are preserved — the operation
+    // is strictly additive. Use _<field>_json (full replacement) to override existing keys.
     // Note: matched parameters are read but not removed from the map.
     private String injectStructuredOutputParams(Map<String, String> parameters, String payload) {
         JsonElement parsed = JsonParser.parseString(payload);
@@ -415,6 +419,7 @@ public class HttpConnector extends AbstractConnector {
         boolean modified = false;
 
         // Pass 1: _<field>_json — inject or replace a top-level field
+        // Without this skip, allowlist still prevents Pass 1 from processing *_additions_json keys, but explicit is safer.
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
             if (entry.getKey().endsWith("_additions_json"))
                 continue;
@@ -435,7 +440,7 @@ public class HttpConnector extends AbstractConnector {
             JsonObject target = body.has(fieldName) && body.get(fieldName).isJsonObject()
                 ? body.getAsJsonObject(fieldName)
                 : new JsonObject();
-            additions.entrySet().forEach(e -> target.add(e.getKey(), e.getValue()));
+            additions.entrySet().forEach(e -> { if (!target.has(e.getKey())) target.add(e.getKey(), e.getValue()); });
             body.add(fieldName, target);
             modified = true;
         }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -208,6 +208,9 @@ public class MemoryContainerConstants {
     // Each constant is the value for the corresponding _xxx_json injection parameter in HttpConnector.
     // The full MemoryContainerHelper.getStructuredOutputParameters() implementation selects the right
     // constant and parameter name based on the model's connector URL.
+    // Reminder: Keep in sync with HttpConnector.STRUCTURED_OUTPUT_ALLOWED_FIELDS: the top-level field name
+    // embedded in each constant (_response_format_json → "response_format", etc.) must appear in
+    // that allowlist, otherwise the injection parameter is silently dropped at the wire layer.
 
     // OpenAI, Azure OpenAI, Ollama (OpenAI-compatible), DeepSeek — value for _response_format_json
     public static final String FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON = """

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -882,6 +882,58 @@ public class HttpConnectorTest {
     }
 
     @Test
+    public void createPayload_StructuredOutputDisabled_ParameterNotInjected() {
+        // Gate check: when supports_structured_output is false, _response_format_json in the
+        // parameters map must be ignored even though it has the correct naming convention.
+        String requestBody = "{\"messages\":[{\"role\":\"user\",\"content\":\"${parameters.input}\"}]}";
+        ConnectorAction action = ConnectorAction
+            .builder()
+            .actionType(ConnectorAction.ActionType.PREDICT)
+            .method("POST")
+            .url("https://api.openai.com/v1/chat/completions")
+            .headers(Map.of("api_key", "${credential.key}"))
+            .requestBody(requestBody)
+            .supportsStructuredOutput(false)
+            .build();
+        HttpConnector connector = buildConnector(action);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "Hello");
+        parameters.put("_response_format_json", "{\"type\":\"json_schema\"}");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
+        Assert.assertFalse(
+            "response_format must NOT be injected when supports_structured_output is false",
+            json.has("response_format")
+        );
+    }
+
+    @Test
+    public void createPayload_AdditionsJson_DoesNotOverrideExistingKey() {
+        // _additions_json is strictly additive: keys already present in the target object are
+        // preserved. Use _<field>_json for a full replacement when overriding existing keys.
+        String requestBody = "{\"generationConfig\":{\"temperature\":0.5,\"responseMimeType\":\"text/plain\"},"
+            + "\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"${parameters.input}\"}]}]}";
+        HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("input", "test");
+        parameters.put("_generationConfig_additions_json", "{\"responseMimeType\":\"application/json\",\"responseSchema\":{\"type\":\"OBJECT\"}}");
+
+        String payload = connector.createPayload(PREDICT.name(), parameters);
+
+        JsonObject genConfig = JsonParser.parseString(payload).getAsJsonObject().getAsJsonObject("generationConfig");
+        Assert.assertNotNull("generationConfig must be present", genConfig);
+        Assert.assertEquals("non-colliding key temperature must be preserved", "0.5", genConfig.get("temperature").getAsString());
+        Assert.assertEquals(
+            "colliding key responseMimeType: existing value must be preserved, not overwritten",
+            "text/plain",
+            genConfig.get("responseMimeType").getAsString()
+        );
+        Assert.assertTrue("new key responseSchema from additions must be added", genConfig.has("responseSchema"));
+    }
+
+    @Test
     public void testFindAction_MultipleActionsWithSameType() {
         ConnectorAction action1 = new ConnectorAction(
             PREDICT,

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -903,10 +903,7 @@ public class HttpConnectorTest {
         String payload = connector.createPayload(PREDICT.name(), parameters);
 
         JsonObject json = JsonParser.parseString(payload).getAsJsonObject();
-        Assert.assertFalse(
-            "response_format must NOT be injected when supports_structured_output is false",
-            json.has("response_format")
-        );
+        Assert.assertFalse("response_format must NOT be injected when supports_structured_output is false", json.has("response_format"));
     }
 
     @Test
@@ -918,18 +915,23 @@ public class HttpConnectorTest {
         HttpConnector connector = createHttpConnectorWithStructuredOutputEnabled(requestBody);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("input", "test");
-        parameters.put("_generationConfig_additions_json", "{\"responseMimeType\":\"application/json\",\"responseSchema\":{\"type\":\"OBJECT\"}}");
+        parameters
+            .put(
+                "_generationConfig_additions_json",
+                "{\"responseMimeType\":\"application/json\",\"responseSchema\":{\"type\":\"OBJECT\"}}"
+            );
 
         String payload = connector.createPayload(PREDICT.name(), parameters);
 
         JsonObject genConfig = JsonParser.parseString(payload).getAsJsonObject().getAsJsonObject("generationConfig");
         Assert.assertNotNull("generationConfig must be present", genConfig);
         Assert.assertEquals("non-colliding key temperature must be preserved", "0.5", genConfig.get("temperature").getAsString());
-        Assert.assertEquals(
-            "colliding key responseMimeType: existing value must be preserved, not overwritten",
-            "text/plain",
-            genConfig.get("responseMimeType").getAsString()
-        );
+        Assert
+            .assertEquals(
+                "colliding key responseMimeType: existing value must be preserved, not overwritten",
+                "text/plain",
+                genConfig.get("responseMimeType").getAsString()
+            );
         Assert.assertTrue("new key responseSchema from additions must be added", genConfig.has("responseSchema"));
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
@@ -95,12 +95,19 @@ public class MemoryContainerHelper {
     private static final String URL_TOKEN_GOOGLEAPIS = "googleapis";
     private static final String URL_TOKEN_COHERE = "cohere";
     private static final String URL_TOKEN_V2_PATH_SEGMENT = "v2";
+    private static final String URL_TOKEN_CHAT_SEGMENT = "chat";
+    // URL_TOKEN_OPENAI is used only for Azure path matching (/openai/deployments/...).
+    // Direct OpenAI API calls use URL_HOST_OPENAI_API equality to prevent openai.attacker.com
+    // from matching via label-based host segment checks.
     private static final String URL_TOKEN_OPENAI = "openai";
-    private static final String URL_TOKEN_DEEPSEEK = "deepseek";
     // Multi-segment path — used with path.contains() on a query-stripped path, which is safe.
     private static final String URL_TOKEN_OPENAI_COMPAT_PATH = "/v1/chat/completions";
     private static final String URL_TOKEN_AMAZONAWS = "amazonaws";
     private static final String URL_TOKEN_CONVERSE_SEGMENT = "converse";
+    // Exact hostnames for public providers — full equality prevents label-confusion attacks
+    // (e.g. openai.attacker.com contains "openai" as a label but does not equal "api.openai.com").
+    private static final String URL_HOST_OPENAI_API = "api.openai.com";
+    private static final String URL_HOST_DEEPSEEK_API = "api.deepseek.com";
 
     // Captures (1) host and (2) path from a URL, stopping before '?' or '#'.
     // Handles connector template URLs such as https://${parameters.endpoint}/openai/...
@@ -570,7 +577,9 @@ public class MemoryContainerHelper {
         if (connector.getActions() == null) {
             return Map.of();
         }
-        // first matching PREDICT action wins; assumes one PREDICT per connector for fact extraction
+        // TODO: extend to support multi-action connectors — currently only the first PREDICT action
+        //       with supports_structured_output=true is used; connectors with multiple PREDICT actions
+        //       each targeting different providers would need per-action URL routing.
         return connector
             .getActions()
             .stream()
@@ -611,22 +620,24 @@ public class MemoryContainerHelper {
         }
         // Cohere structured output (json_schema type) requires the v2 Chat API (/v2/chat).
         // The legacy /v1/chat endpoint only supports json_object and ignores json_schema.
-        if (hostHasSegment(host, URL_TOKEN_COHERE) && pathHasSegment(path, URL_TOKEN_V2_PATH_SEGMENT)) {
+        // Both "v2" and "chat" segments are required to avoid matching /v2/embed or /v2/rerank.
+        if (hostHasSegment(host, URL_TOKEN_COHERE)
+            && pathHasSegment(path, URL_TOKEN_V2_PATH_SEGMENT)
+            && pathHasSegment(path, URL_TOKEN_CHAT_SEGMENT)) {
             return Map.of("_response_format_json", FACTS_EXTRACTION_COHERE_RESPONSE_FORMAT_JSON);
         }
-        // hostHasSegment(host, URL_TOKEN_OPENAI) catches api.openai.com and similar.
-        // pathHasSegment(path, URL_TOKEN_OPENAI) is specifically for Azure, whose connector URL uses
+        // host.equals(URL_HOST_OPENAI_API) matches the canonical OpenAI API endpoint exactly.
+        // Full equality closes the openai.attacker.com label-confusion attack: that host has
+        // "openai" as an exact segment but does not equal "api.openai.com".
+        // pathHasSegment(path, URL_TOKEN_OPENAI) handles Azure OpenAI, whose connector URL uses
         // a template host (${parameters.endpoint}), so "openai" only appears in the path
         // (/openai/deployments/...) rather than the host.
+        // host.equals(URL_HOST_DEEPSEEK_API) applies the same exact-equality defence for DeepSeek.
         // URL_TOKEN_OPENAI_COMPAT_PATH ("/v1/chat/completions") catches Ollama, vLLM, LM Studio,
-        // and other OpenAI-compatible servers whose hostnames contain neither "openai" nor "deepseek".
-        // supports_structured_output must be explicitly set to true on the connector action
-        // (requires admin access), so an unintended match only results in an extra response_format
-        // field being sent. Note: if the upstream provider rejects the extra field with a 4xx,
-        // that surfaces as a failed predict call, not a silent fallback.
-        if (hostHasSegment(host, URL_TOKEN_OPENAI)
+        // and other OpenAI-compatible servers regardless of hostname.
+        if (host.equals(URL_HOST_OPENAI_API)
             || pathHasSegment(path, URL_TOKEN_OPENAI)
-            || hostHasSegment(host, URL_TOKEN_DEEPSEEK)
+            || host.equals(URL_HOST_DEEPSEEK_API)
             || path.contains(URL_TOKEN_OPENAI_COMPAT_PATH)) {
             return Map.of("_response_format_json", FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON);
         }

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
@@ -578,8 +578,8 @@ public class MemoryContainerHelper {
             return Map.of();
         }
         // TODO: extend to support multi-action connectors — currently only the first PREDICT action
-        //       with supports_structured_output=true is used; connectors with multiple PREDICT actions
-        //       each targeting different providers would need per-action URL routing.
+        // with supports_structured_output=true is used; connectors with multiple PREDICT actions
+        // each targeting different providers would need per-action URL routing.
         return connector
             .getActions()
             .stream()

--- a/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/helper/MemoryContainerHelperTests.java
@@ -936,9 +936,27 @@ public class MemoryContainerHelperTests extends OpenSearchTestCase {
         assertEquals(FACTS_EXTRACTION_OPENAI_RESPONSE_FORMAT_JSON, captor.getValue().get("_response_format_json"));
     }
 
+    public void testGetStructuredOutputParameters_OpenAILabelInAttackerHost_ReturnsEmptyMap() {
+        // openai.attacker.com has "openai" as an exact host label. Previously this would have
+        // matched via hostHasSegment; now host.equals("api.openai.com") closes that vector.
+        Connector connector = mock(Connector.class);
+        ConnectorAction attackerAction = mockPredictAction(true, "https://openai.attacker.com/api/chat");
+        when(connector.getActions()).thenReturn(Arrays.asList(attackerAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
     public void testGetStructuredOutputParameters_SubstringInHostLabel_ReturnsEmptyMap() {
-        // "my-openai-proxy" is a single host label — it does not equal the "openai" token,
-        // so token-based matching must not mis-route it.
+        // "my-openai-proxy" is a single host label — it does not equal "api.openai.com",
+        // so it must not be mis-routed.
         Connector connector = mock(Connector.class);
         ConnectorAction proxyAction = mockPredictAction(true, "https://my-openai-proxy.internal/api/chat");
         when(connector.getActions()).thenReturn(Arrays.asList(proxyAction));
@@ -1095,6 +1113,63 @@ public class MemoryContainerHelperTests extends OpenSearchTestCase {
         ConnectorAction executeAction = mock(ConnectorAction.class);
         when(executeAction.getActionType()).thenReturn(ConnectorAction.ActionType.EXECUTE);
         when(connector.getActions()).thenReturn(Arrays.asList(executeAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_CohereV2Embed_ReturnsEmptyMap() {
+        // Cohere /v2/embed is not a chat endpoint; the json_schema structured-output
+        // constraint is only valid for /v2/chat. Matching on "v2" alone would incorrectly
+        // route embedding requests, so both "v2" and "chat" path segments are required.
+        Connector connector = mock(Connector.class);
+        ConnectorAction cohereEmbedAction = mockPredictAction(true, "https://api.cohere.com/v2/embed");
+        when(connector.getActions()).thenReturn(Arrays.asList(cohereEmbedAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_CohereV2Rerank_ReturnsEmptyMap() {
+        Connector connector = mock(Connector.class);
+        ConnectorAction cohereRerankAction = mockPredictAction(true, "https://api.cohere.com/v2/rerank");
+        when(connector.getActions()).thenReturn(Arrays.asList(cohereRerankAction));
+        MLModel model = mock(MLModel.class);
+        when(model.getConnector()).thenReturn(connector);
+        stubModelWithEmbeddedConnector(model);
+
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+        helper.getStructuredOutputParameters("m1", listener);
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isEmpty());
+    }
+
+    public void testGetStructuredOutputParameters_ProviderTokenInUserinfo_ReturnsEmptyMap() {
+        // URL_PARTS captures the full authority (userinfo + host) in group 1. A provider token
+        // that appears only in the userinfo (e.g. "openai" in "user:openai@attacker.example.com")
+        // must not trigger a match. After splitting group 1 on '.', the userinfo segment is
+        // "user:openai@attacker" — which does not equal the bare token "openai" — so the host
+        // confusion attack is blocked. This test pins that behaviour so a future regex change
+        // does not accidentally introduce a host-confusion vulnerability.
+        Connector connector = mock(Connector.class);
+        ConnectorAction action = mockPredictAction(true, "https://user:openai@attacker.example.com/path");
+        when(connector.getActions()).thenReturn(Arrays.asList(action));
         MLModel model = mock(MLModel.class);
         when(model.getConnector()).thenReturn(connector);
         stubModelWithEmbeddedConnector(model);

--- a/release-notes/opensearch-ml-commons.release-notes-3.7.0.0.md
+++ b/release-notes/opensearch-ml-commons.release-notes-3.7.0.0.md
@@ -12,6 +12,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.7.0
 
 * Add private IP security controls and ReDoS protection for ML connectors ([#4818](https://github.com/opensearch-project/ml-commons/pull/4818))
 * Add structured output (constrained decoding) support for agentic memory fact extraction ([#4824](https://github.com/opensearch-project/ml-commons/pull/4824))
+* **Downgrade note**: rolling back to 3.6 silently clears `supports_structured_output` on connector actions; structured output injection falls back to prompt enforcement until the cluster is upgraded again ([#4824](https://github.com/opensearch-project/ml-commons/pull/4824))
 * Strengthen enforcement of `trusted_connector_endpoints_regex` across all outbound connector request paths ([#4826](https://github.com/opensearch-project/ml-commons/pull/4826))
 * Simplify USER_PREFERENCE extraction prompt to produce plain sentences, fixing silent JSON parse failures with smaller LLMs ([#4798](https://github.com/opensearch-project/ml-commons/pull/4798))
 


### PR DESCRIPTION
### Description
Applies follow up feedback comments on #4799 which was merged into OpenSearch 3.7

- High-priority — downgrade BWC: the new field is silently dropped on XContent parse by 3.6 nodes.
- Reminder comments to keep all of these schema constant variables defined in lockstep (URL predicate, injection-parameter name, schema constant, allowlisted field)
- Test that verifies a connector with the flag set to false ignores _response_format_json even when present in parameters
- Addresses: _<field>_additions_json "merge" overwrites existing keys; the JavaDoc says "merge into" which is ambiguous. Update test createPayload_AdditionsJson_DoesNotOverrideExistingKey
- Update testGetStructuredOutputParameters_ProviderTokenInUserinfo_ReturnsEmptyMap to test that URL_PARTS regex excludes userInfo for security
- Add TODO to update schemaForConnector return if multi-action connectors is implemented
- Tighten schemaForUrl cohere path check to require both v2 and chat segments, or check for the literal substring /v2/chat
- Tighten schemaForUrl openai host matching to: host.equals("api.openai.com") for security

### Related Issues
Original issue: [[FEATURE] Support structured output / constrained decoding for agentic memory fact extraction #4799](https://github.com/opensearch-project/ml-commons/issues/4799)

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
