### PR TITLE
Add RetentionRule data model and retention_policy field to MemoryConf... (PR1/PR5)

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -110,6 +110,7 @@ public class CommonValue {
     public static final Version VERSION_3_4_0 = Version.fromString("3.4.0");
     public static final Version VERSION_3_5_0 = Version.fromString("3.5.0");
     public static final Version VERSION_3_7_0 = Version.fromString("3.7.0");
+    public static final Version VERSION_3_8_0 = Version.fromString("3.8.0");
 
     // Connector Constants
     public static final String NAME_FIELD = "name";

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_AGENTIC_MEMORY_SYSTEM_INDEX_PREFIX;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DEFAULT_MEMORY_INDEX_PREFIX;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DIMENSION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DISABLE_HISTORY_FIELD;
@@ -64,7 +65,6 @@ import lombok.extern.log4j.Log4j2;
  */
 @Getter
 @Setter
-@Builder
 @EqualsAndHashCode
 @Log4j2
 public class MemoryConfiguration implements ToXContentObject, Writeable {
@@ -73,22 +73,18 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     private String embeddingModelId;
     private String llmId;
     private Integer dimension;
-    @Builder.Default
-    private Integer maxInferSize = MAX_INFER_SIZE_DEFAULT_VALUE;
+    private Integer maxInferSize;
     private List<MemoryStrategy> strategies;
-    @Builder.Default
-    private Map<String, Map<String, Object>> indexSettings = new HashMap<>();
-    @Builder.Default
-    private Map<String, Object> parameters = new HashMap<>();
-    @Builder.Default
-    private boolean disableHistory = false;
-    @Builder.Default
-    private boolean disableSession = false;
-    @Builder.Default
-    private boolean useSystemIndex = true;
+    private Map<String, Map<String, Object>> indexSettings;
+    private Map<String, Object> parameters;
+    private boolean disableHistory;
+    private boolean disableSession;
+    private boolean useSystemIndex;
     private String tenantId;
     private Map<MemoryType, RetentionRule> retentionPolicy;
+    private transient boolean retentionPolicyExplicitlyNull = false;
 
+    @Builder
     public MemoryConfiguration(
         String indexPrefix,
         FunctionName embeddingModelType,
@@ -99,17 +95,23 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         List<MemoryStrategy> strategies,
         Map<String, Map<String, Object>> indexSettings,
         Map<String, Object> parameters,
-        boolean disableHistory,
-        boolean disableSession,
-        boolean useSystemIndex,
+        Boolean disableHistory,
+        Boolean disableSession,
+        Boolean useSystemIndex,
         String tenantId,
         Map<MemoryType, RetentionRule> retentionPolicy
     ) {
+        // Apply defaults for Boolean parameters
+        boolean effectiveUseSystemIndex = (useSystemIndex != null) ? useSystemIndex : true;
+        boolean effectiveDisableHistory = (disableHistory != null) ? disableHistory : false;
+        boolean effectiveDisableSession = (disableSession != null) ? disableSession : false;
+
         // Validate first
         validateInputs(embeddingModelType, embeddingModelId, dimension, maxInferSize);
+        validateRetentionPolicy(retentionPolicy);
 
         // Assign values after validation
-        this.indexPrefix = buildIndexPrefix(indexPrefix, useSystemIndex);
+        this.indexPrefix = buildIndexPrefix(indexPrefix, effectiveUseSystemIndex);
         this.embeddingModelType = embeddingModelType;
         this.embeddingModelId = embeddingModelId;
         this.llmId = llmId;
@@ -127,9 +129,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         if (parameters != null && !parameters.isEmpty()) {
             this.parameters.putAll(parameters);
         }
-        this.disableHistory = disableHistory;
-        this.disableSession = disableSession;
-        this.useSystemIndex = useSystemIndex;
+        this.disableHistory = effectiveDisableHistory;
+        this.disableSession = effectiveDisableSession;
+        this.useSystemIndex = effectiveUseSystemIndex;
         this.tenantId = tenantId;
         this.retentionPolicy = retentionPolicy;
     }
@@ -173,13 +175,15 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = input.readBoolean();
         this.useSystemIndex = input.readBoolean();
         this.tenantId = input.readOptionalString();
-        if (input.readBoolean()) {
-            int size = input.readVInt();
-            this.retentionPolicy = new EnumMap<>(MemoryType.class);
-            for (int i = 0; i < size; i++) {
-                MemoryType key = input.readEnum(MemoryType.class);
-                RetentionRule value = new RetentionRule(input);
-                this.retentionPolicy.put(key, value);
+        if (input.getVersion().onOrAfter(VERSION_3_7_0)) {
+            if (input.readBoolean()) {
+                int size = input.readVInt();
+                this.retentionPolicy = new EnumMap<>(MemoryType.class);
+                for (int i = 0; i < size; i++) {
+                    MemoryType key = input.readEnum(MemoryType.class);
+                    RetentionRule value = new RetentionRule(input);
+                    this.retentionPolicy.put(key, value);
+                }
             }
         }
     }
@@ -214,15 +218,17 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         out.writeBoolean(disableSession);
         out.writeBoolean(useSystemIndex);
         out.writeOptionalString(tenantId);
-        if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
-            out.writeBoolean(true);
-            out.writeVInt(retentionPolicy.size());
-            for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
-                out.writeEnum(entry.getKey());
-                entry.getValue().writeTo(out);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
+                out.writeBoolean(true);
+                out.writeVInt(retentionPolicy.size());
+                for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
+                    out.writeEnum(entry.getKey());
+                    entry.getValue().writeTo(out);
+                }
+            } else {
+                out.writeBoolean(false);
             }
-        } else {
-            out.writeBoolean(false);
         }
     }
 
@@ -301,6 +307,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         boolean useSystemIndex = true;
         String tenantId = null;
         Map<MemoryType, RetentionRule> retentionPolicy = null;
+        boolean retentionPolicyIsExplicitlyNull = false;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -355,6 +362,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 case RETENTION_POLICY_FIELD:
                     if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                         retentionPolicy = null;
+                        retentionPolicyIsExplicitlyNull = true;
                     } else {
                         retentionPolicy = parseRetentionPolicy(parser);
                     }
@@ -366,7 +374,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         }
 
         // Note: validation is already called in the constructor
-        return MemoryConfiguration
+        MemoryConfiguration config = MemoryConfiguration
             .builder()
             .indexPrefix(indexPrefix)
             .embeddingModelType(embeddingModelType)
@@ -383,6 +391,8 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             .tenantId(tenantId)
             .retentionPolicy(retentionPolicy)
             .build();
+        config.setRetentionPolicyExplicitlyNull(retentionPolicyIsExplicitlyNull);
+        return config;
     }
 
     private static Map<MemoryType, RetentionRule> parseRetentionPolicy(XContentParser parser) throws IOException {
@@ -488,6 +498,29 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     private static void validateInputs(FunctionName embeddingModelType, String embeddingModelId, Integer dimension, Integer maxInferSize) {
         validateEmbeddingConfiguration(embeddingModelType, embeddingModelId, dimension);
         validateMaxInferSize(maxInferSize);
+    }
+
+    /**
+     * Validates retention policy constraints.
+     * Ensures WORKING memory type is not configured directly and HISTORY does not have retention_days.
+     *
+     * @param retentionPolicy the retention policy map to validate
+     * @throws IllegalArgumentException if the policy violates constraints
+     */
+    private static void validateRetentionPolicy(Map<MemoryType, RetentionRule> retentionPolicy) {
+        if (retentionPolicy == null || retentionPolicy.isEmpty()) {
+            return;
+        }
+        if (retentionPolicy.containsKey(MemoryType.WORKING)) {
+            throw new IllegalArgumentException(
+                "Working memory retention cannot be configured directly. Working memory is deleted when its parent session expires."
+                    + " To control message lifetime, configure retention on \"sessions\" instead."
+            );
+        }
+        RetentionRule historyRule = retentionPolicy.get(MemoryType.HISTORY);
+        if (historyRule != null && historyRule.getRetentionDays() != null) {
+            throw new IllegalArgumentException("retention_days is not supported for history memory type");
+        }
     }
 
     /**
@@ -609,24 +642,15 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             this.dimension = updateContent.getDimension();
         }
         // Merge retention policy
-        if (updateContent.getRetentionPolicy() != null) {
+        if (updateContent.isRetentionPolicyExplicitlyNull()) {
+            this.retentionPolicy = null;
+        } else if (updateContent.getRetentionPolicy() != null) {
+            validateRetentionPolicy(updateContent.getRetentionPolicy());
             if (this.retentionPolicy == null) {
                 this.retentionPolicy = new EnumMap<>(MemoryType.class);
             }
             for (Map.Entry<MemoryType, RetentionRule> entry : updateContent.getRetentionPolicy().entrySet()) {
-                MemoryType type = entry.getKey();
-                RetentionRule incomingRule = entry.getValue();
-                RetentionRule existingRule = this.retentionPolicy.get(type);
-
-                if (existingRule == null) {
-                    this.retentionPolicy.put(type, incomingRule);
-                } else {
-                    Integer mergedDays = incomingRule.getRetentionDays() != null
-                        ? incomingRule.getRetentionDays()
-                        : existingRule.getRetentionDays();
-                    Integer mergedCount = incomingRule.getMaxCount() != null ? incomingRule.getMaxCount() : existingRule.getMaxCount();
-                    this.retentionPolicy.put(type, new RetentionRule(mergedDays, mergedCount));
-                }
+                this.retentionPolicy.put(entry.getKey(), entry.getValue());
             }
         }
         // Note: indexPrefix and other structural fields are intentionally not updated

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -28,10 +28,12 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SPARSE_ENCODING_DIMENSION_NOT_ALLOWED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRATEGIES_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TEXT_EMBEDDING_DIMENSION_REQUIRED_ERROR;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.USE_SYSTEM_INDEX_FIELD;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +87,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     @Builder.Default
     private boolean useSystemIndex = true;
     private String tenantId;
+    private Map<MemoryType, RetentionRule> retentionPolicy;
 
     public MemoryConfiguration(
         String indexPrefix,
@@ -99,7 +102,8 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         boolean disableHistory,
         boolean disableSession,
         boolean useSystemIndex,
-        String tenantId
+        String tenantId,
+        Map<MemoryType, RetentionRule> retentionPolicy
     ) {
         // Validate first
         validateInputs(embeddingModelType, embeddingModelId, dimension, maxInferSize);
@@ -127,6 +131,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = disableSession;
         this.useSystemIndex = useSystemIndex;
         this.tenantId = tenantId;
+        this.retentionPolicy = retentionPolicy;
     }
 
     private String buildIndexPrefix(String indexPrefix, boolean useSystemIndex) {
@@ -168,6 +173,15 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = input.readBoolean();
         this.useSystemIndex = input.readBoolean();
         this.tenantId = input.readOptionalString();
+        if (input.readBoolean()) {
+            int size = input.readVInt();
+            this.retentionPolicy = new EnumMap<>(MemoryType.class);
+            for (int i = 0; i < size; i++) {
+                MemoryType key = input.readEnum(MemoryType.class);
+                RetentionRule value = new RetentionRule(input);
+                this.retentionPolicy.put(key, value);
+            }
+        }
     }
 
     @Override
@@ -200,6 +214,16 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         out.writeBoolean(disableSession);
         out.writeBoolean(useSystemIndex);
         out.writeOptionalString(tenantId);
+        if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
+            out.writeBoolean(true);
+            out.writeVInt(retentionPolicy.size());
+            for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
+                out.writeEnum(entry.getKey());
+                entry.getValue().writeTo(out);
+            }
+        } else {
+            out.writeBoolean(false);
+        }
     }
 
     @Override
@@ -250,6 +274,14 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         if (tenantId != null) {
             builder.field(TENANT_ID_FIELD, tenantId);
         }
+        if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
+            builder.startObject(RETENTION_POLICY_FIELD);
+            for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
+                builder.field(entry.getKey().getValue());
+                entry.getValue().toXContent(builder, params);
+            }
+            builder.endObject();
+        }
         builder.endObject();
         return builder;
     }
@@ -268,6 +300,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         boolean disableSession = false;
         boolean useSystemIndex = true;
         String tenantId = null;
+        Map<MemoryType, RetentionRule> retentionPolicy = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -319,6 +352,13 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 case USE_SYSTEM_INDEX_FIELD:
                     useSystemIndex = parser.booleanValue();
                     break;
+                case RETENTION_POLICY_FIELD:
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        retentionPolicy = null;
+                    } else {
+                        retentionPolicy = parseRetentionPolicy(parser);
+                    }
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -341,7 +381,40 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             .disableSession(disableSession)
             .useSystemIndex(useSystemIndex)
             .tenantId(tenantId)
+            .retentionPolicy(retentionPolicy)
             .build();
+    }
+
+    private static Map<MemoryType, RetentionRule> parseRetentionPolicy(XContentParser parser) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        Map<MemoryType, RetentionRule> policy = new EnumMap<>(MemoryType.class);
+
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String key = parser.currentName();
+            parser.nextToken();
+
+            if (key.equals(MemoryType.WORKING.getValue())) {
+                throw new IllegalArgumentException(
+                    "Working memory retention cannot be configured directly. Working memory is deleted when its parent session expires."
+                        + " To control message lifetime, configure retention on \"sessions\" instead."
+                );
+            }
+
+            if (!MemoryType.isValid(key)) {
+                throw new IllegalArgumentException("unknown memory type: " + key);
+            }
+
+            MemoryType memoryType = MemoryType.fromString(key);
+            RetentionRule rule = RetentionRule.parse(parser);
+
+            if (memoryType == MemoryType.HISTORY && rule.getRetentionDays() != null) {
+                throw new IllegalArgumentException("retention_days is not supported for history memory type");
+            }
+
+            policy.put(memoryType, rule);
+        }
+
+        return policy;
     }
 
     public String getFinalMemoryIndexPrefix() {
@@ -534,6 +607,27 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         } else if (updateContent.getDimension() != null) {
             // Only update dimension for TEXT_EMBEDDING if provided
             this.dimension = updateContent.getDimension();
+        }
+        // Merge retention policy
+        if (updateContent.getRetentionPolicy() != null) {
+            if (this.retentionPolicy == null) {
+                this.retentionPolicy = new EnumMap<>(MemoryType.class);
+            }
+            for (Map.Entry<MemoryType, RetentionRule> entry : updateContent.getRetentionPolicy().entrySet()) {
+                MemoryType type = entry.getKey();
+                RetentionRule incomingRule = entry.getValue();
+                RetentionRule existingRule = this.retentionPolicy.get(type);
+
+                if (existingRule == null) {
+                    this.retentionPolicy.put(type, incomingRule);
+                } else {
+                    Integer mergedDays = incomingRule.getRetentionDays() != null
+                        ? incomingRule.getRetentionDays()
+                        : existingRule.getRetentionDays();
+                    Integer mergedCount = incomingRule.getMaxCount() != null ? incomingRule.getMaxCount() : existingRule.getMaxCount();
+                    this.retentionPolicy.put(type, new RetentionRule(mergedDays, mergedCount));
+                }
+            }
         }
         // Note: indexPrefix and other structural fields are intentionally not updated
         // as they would require index recreation

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -23,12 +23,12 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MAX_INFER_SIZE_LIMIT_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_INDEX_PREFIX_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETERS_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SEMANTIC_STORAGE_EMBEDDING_MODEL_ID_REQUIRED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SEMANTIC_STORAGE_EMBEDDING_MODEL_TYPE_REQUIRED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SPARSE_ENCODING_DIMENSION_NOT_ALLOWED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRATEGIES_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TEXT_EMBEDDING_DIMENSION_REQUIRED_ERROR;
-import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.USE_SYSTEM_INDEX_FIELD;
 
 import java.io.IOException;

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -8,7 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_AGENTIC_MEMORY_SYSTEM_INDEX_PREFIX;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DEFAULT_MEMORY_INDEX_PREFIX;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DIMENSION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DISABLE_HISTORY_FIELD;
@@ -175,7 +175,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = input.readBoolean();
         this.useSystemIndex = input.readBoolean();
         this.tenantId = input.readOptionalString();
-        if (input.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (input.getVersion().onOrAfter(VERSION_3_8_0)) {
             if (input.readBoolean()) {
                 int size = input.readVInt();
                 this.retentionPolicy = new EnumMap<>(MemoryType.class);
@@ -218,7 +218,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         out.writeBoolean(disableSession);
         out.writeBoolean(useSystemIndex);
         out.writeOptionalString(tenantId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
                 out.writeBoolean(true);
                 out.writeVInt(retentionPolicy.size());

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -74,9 +74,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     private String llmId;
     private Integer dimension;
     private Integer maxInferSize;
-    private List<MemoryStrategy> strategies;
-    private Map<String, Map<String, Object>> indexSettings;
-    private Map<String, Object> parameters;
+    private List<MemoryStrategy> strategies = new ArrayList<>();
+    private Map<String, Map<String, Object>> indexSettings = new HashMap<>();
+    private Map<String, Object> parameters = new HashMap<>();
     private boolean disableHistory;
     private boolean disableSession;
     private boolean useSystemIndex;

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -148,6 +148,11 @@ public class MemoryContainerConstants {
         "Backend role contains invalid characters. Only alphanumeric characters and :+=,.@-_/ are allowed: %s";
     public static final String BACKEND_ROLE_EMPTY_ERROR = "Backend role cannot be empty or blank";
 
+    // Retention policy field names
+    public static final String RETENTION_POLICY_FIELD = "retention_policy";
+    public static final String RETENTION_DAYS_FIELD = "retention_days";
+    public static final String MAX_COUNT_FIELD = "max_count";
+
     // Model validation error messages
     public static final String LLM_MODEL_NOT_FOUND_ERROR = "LLM model with ID %s not found";
     public static final String LLM_MODEL_NOT_REMOTE_ERROR = "LLM model must be a REMOTE model, found: %s";

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MAX_COUNT_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_DAYS_FIELD;
+
+import java.io.IOException;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@Builder
+@EqualsAndHashCode
+public class RetentionRule implements ToXContentObject, Writeable {
+
+    private final Integer retentionDays;
+    private final Integer maxCount;
+
+    public RetentionRule(Integer retentionDays, Integer maxCount) {
+        if (retentionDays != null && retentionDays <= 0) {
+            throw new IllegalArgumentException("retention_days must be a positive integer or null");
+        }
+        if (maxCount != null && maxCount <= 0) {
+            throw new IllegalArgumentException("max_count must be a positive integer or null");
+        }
+        this.retentionDays = retentionDays;
+        this.maxCount = maxCount;
+    }
+
+    public RetentionRule(StreamInput in) throws IOException {
+        this.retentionDays = in.readOptionalInt();
+        this.maxCount = in.readOptionalInt();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalInt(retentionDays);
+        out.writeOptionalInt(maxCount);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        if (retentionDays != null) {
+            builder.field(RETENTION_DAYS_FIELD, retentionDays);
+        }
+        if (maxCount != null) {
+            builder.field(MAX_COUNT_FIELD, maxCount);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static RetentionRule parse(XContentParser parser) throws IOException {
+        Integer retentionDays = null;
+        Integer maxCount = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case RETENTION_DAYS_FIELD:
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        retentionDays = null;
+                    } else {
+                        retentionDays = parser.intValue();
+                    }
+                    break;
+                case MAX_COUNT_FIELD:
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        maxCount = null;
+                    } else {
+                        maxCount = parser.intValue();
+                    }
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+
+        return new RetentionRule(retentionDays, maxCount);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
@@ -24,13 +24,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
-@Builder
 @EqualsAndHashCode
 public class RetentionRule implements ToXContentObject, Writeable {
 
     private final Integer retentionDays;
     private final Integer maxCount;
 
+    @Builder
     public RetentionRule(Integer retentionDays, Integer maxCount) {
         if (retentionDays != null && retentionDays <= 0) {
             throw new IllegalArgumentException("retention_days must be a positive integer or null");

--- a/common/src/main/resources/index-mappings/ml_memory_container.json
+++ b/common/src/main/resources/index-mappings/ml_memory_container.json
@@ -75,6 +75,31 @@
         },
         "index_settings": {
           "type": "flat_object"
+        },
+        "retention_policy": {
+          "type": "object",
+          "properties": {
+            "sessions": {
+              "type": "object",
+              "properties": {
+                "retention_days": { "type": "integer" },
+                "max_count": { "type": "integer" }
+              }
+            },
+            "long-term": {
+              "type": "object",
+              "properties": {
+                "retention_days": { "type": "integer" },
+                "max_count": { "type": "integer" }
+              }
+            },
+            "history": {
+              "type": "object",
+              "properties": {
+                "max_count": { "type": "integer" }
+              }
+            }
+          }
         }
       }
     },

--- a/common/src/main/resources/index-mappings/ml_memory_container.json
+++ b/common/src/main/resources/index-mappings/ml_memory_container.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "schema_version": 1
+    "schema_version": 2
   },
   "properties": {
     "name": {

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.memorycontainer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -1251,26 +1252,26 @@ public class MemoryConfigurationTests {
     }
 
     @Test
-    public void testUpdate_RetentionPolicy_MergeSemanticsPartialUpdate() {
+    public void testUpdate_RetentionPolicy_TypeLevelReplacement() {
         Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
         existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
         existingPolicy.put(MemoryType.LONG_TERM, new RetentionRule(90, 500));
 
         MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
 
-        // Update only sessions max_count, leaving retention_days unchanged
+        // Update sessions with only max_count — full replacement at type level
         Map<MemoryType, RetentionRule> updatePolicy = new java.util.EnumMap<>(MemoryType.class);
         updatePolicy.put(MemoryType.SESSIONS, new RetentionRule(null, 200));
 
         MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(updatePolicy).build();
         config.update(updateContent);
 
-        // Sessions: retentionDays preserved from existing, maxCount updated
+        // Sessions: fully replaced — retentionDays is now null (not preserved)
         RetentionRule sessionsRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
-        assertEquals(Integer.valueOf(30), sessionsRule.getRetentionDays());
+        assertNull(sessionsRule.getRetentionDays());
         assertEquals(Integer.valueOf(200), sessionsRule.getMaxCount());
 
-        // Long-term: untouched
+        // Long-term: untouched (type not in update)
         RetentionRule longTermRule = config.getRetentionPolicy().get(MemoryType.LONG_TERM);
         assertEquals(Integer.valueOf(90), longTermRule.getRetentionDays());
         assertEquals(Integer.valueOf(500), longTermRule.getMaxCount());
@@ -1328,5 +1329,87 @@ public class MemoryConfigurationTests {
         assertNotNull(historyRule);
         assertNull(historyRule.getRetentionDays());
         assertEquals(Integer.valueOf(500), historyRule.getMaxCount());
+    }
+
+    @Test
+    public void testRetentionPolicy_ConstructorValidation_RejectsWorkingKey() {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.WORKING, new RetentionRule(null, 10));
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build()
+        );
+        assertTrue(e.getMessage().contains("Working memory retention cannot be configured directly"));
+    }
+
+    @Test
+    public void testRetentionPolicy_ConstructorValidation_RejectsHistoryRetentionDays() {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.HISTORY, new RetentionRule(30, null));
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build()
+        );
+        assertTrue(e.getMessage().contains("retention_days is not supported for history memory type"));
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_ExplicitNullWipesPolicy() throws Exception {
+        // Setup: config with existing policy
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Simulate parsing an update with "retention_policy": null
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":null}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        // Verify the flag is set
+        assertTrue(updateContent.isRetentionPolicyExplicitlyNull());
+
+        // Apply update
+        config.update(updateContent);
+
+        // Policy should be wiped
+        assertNull(config.getRetentionPolicy());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_AbsentDoesNotWipe() throws Exception {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Parse an update WITHOUT retention_policy field
+        String json = "{\"index_prefix\":\"test\"}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        // Flag should NOT be set
+        assertFalse(updateContent.isRetentionPolicyExplicitlyNull());
+
+        // Apply update
+        config.update(updateContent);
+
+        // Policy should still be there
+        assertNotNull(config.getRetentionPolicy());
+        assertEquals(1, config.getRetentionPolicy().size());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration.EmbeddingConfig;
 
@@ -1097,5 +1098,238 @@ public class MemoryConfigurationTests {
     public void testBuildIndexPrefix_AcceptsHyphenAndUnderscore() {
         MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("valid_prefix-with-chars").build();
         assertEquals("valid_prefix-with-chars", config.getIndexPrefix());
+    }
+
+    // ==================== Retention Policy Tests ====================
+
+    @Test
+    public void testParse_WithRetentionPolicy() throws Exception {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"sessions\":{\"retention_days\":30,\"max_count\":100},"
+            + "\"long-term\":{\"retention_days\":90,\"max_count\":500}}}";
+
+        XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration config = MemoryConfiguration.parse(parser);
+
+        assertNotNull(config.getRetentionPolicy());
+        assertEquals(2, config.getRetentionPolicy().size());
+
+        RetentionRule sessionsRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
+        assertNotNull(sessionsRule);
+        assertEquals(Integer.valueOf(30), sessionsRule.getRetentionDays());
+        assertEquals(Integer.valueOf(100), sessionsRule.getMaxCount());
+
+        RetentionRule longTermRule = config.getRetentionPolicy().get(MemoryType.LONG_TERM);
+        assertNotNull(longTermRule);
+        assertEquals(Integer.valueOf(90), longTermRule.getRetentionDays());
+        assertEquals(Integer.valueOf(500), longTermRule.getMaxCount());
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_WorkingKeyRejected() {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"working\":{\"max_count\":10}}}";
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+                .xContent()
+                .createParser(
+                    org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                    org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                    json
+                );
+            parser.nextToken();
+            MemoryConfiguration.parse(parser);
+        });
+        assertTrue(e.getMessage().contains("Working memory retention cannot be configured directly"));
+        assertTrue(e.getMessage().contains("sessions"));
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_HistoryWithRetentionDaysRejected() {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"history\":{\"retention_days\":30}}}";
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+                .xContent()
+                .createParser(
+                    org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                    org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                    json
+                );
+            parser.nextToken();
+            MemoryConfiguration.parse(parser);
+        });
+        assertTrue(e.getMessage().contains("retention_days is not supported for history memory type"));
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_UnknownKeyRejected() {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"unknown_type\":{\"max_count\":10}}}";
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+                .xContent()
+                .createParser(
+                    org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                    org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                    json
+                );
+            parser.nextToken();
+            MemoryConfiguration.parse(parser);
+        });
+        assertTrue(e.getMessage().contains("unknown memory type: unknown_type"));
+    }
+
+    @Test
+    public void testRetentionPolicy_XContentRoundTrip() throws Exception {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        policy.put(MemoryType.LONG_TERM, new RetentionRule(90, null));
+        policy.put(MemoryType.HISTORY, new RetentionRule(null, 1000));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build();
+
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.core.xcontent.MediaTypeRegistry
+            .contentBuilder(org.opensearch.common.xcontent.XContentType.JSON);
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String json = org.opensearch.ml.common.TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration parsed = MemoryConfiguration.parse(parser);
+
+        assertNotNull(parsed.getRetentionPolicy());
+        assertEquals(3, parsed.getRetentionPolicy().size());
+        assertEquals(config.getRetentionPolicy().get(MemoryType.SESSIONS), parsed.getRetentionPolicy().get(MemoryType.SESSIONS));
+        assertEquals(config.getRetentionPolicy().get(MemoryType.LONG_TERM), parsed.getRetentionPolicy().get(MemoryType.LONG_TERM));
+        assertEquals(config.getRetentionPolicy().get(MemoryType.HISTORY), parsed.getRetentionPolicy().get(MemoryType.HISTORY));
+    }
+
+    @Test
+    public void testRetentionPolicy_StreamRoundTrip() throws Exception {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.SESSIONS, new RetentionRule(7, 50));
+        policy.put(MemoryType.LONG_TERM, new RetentionRule(365, 10000));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build();
+
+        org.opensearch.common.io.stream.BytesStreamOutput output = new org.opensearch.common.io.stream.BytesStreamOutput();
+        config.writeTo(output);
+
+        org.opensearch.core.common.io.stream.StreamInput input = output.bytes().streamInput();
+        MemoryConfiguration deserialized = new MemoryConfiguration(input);
+
+        assertNotNull(deserialized.getRetentionPolicy());
+        assertEquals(2, deserialized.getRetentionPolicy().size());
+        assertEquals(config.getRetentionPolicy().get(MemoryType.SESSIONS), deserialized.getRetentionPolicy().get(MemoryType.SESSIONS));
+        assertEquals(
+            config.getRetentionPolicy().get(MemoryType.LONG_TERM),
+            deserialized.getRetentionPolicy().get(MemoryType.LONG_TERM)
+        );
+    }
+
+    @Test
+    public void testRetentionPolicy_StreamRoundTrip_NullPolicy() throws Exception {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
+
+        org.opensearch.common.io.stream.BytesStreamOutput output = new org.opensearch.common.io.stream.BytesStreamOutput();
+        config.writeTo(output);
+
+        org.opensearch.core.common.io.stream.StreamInput input = output.bytes().streamInput();
+        MemoryConfiguration deserialized = new MemoryConfiguration(input);
+
+        assertNull(deserialized.getRetentionPolicy());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_MergeSemanticsPartialUpdate() {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        existingPolicy.put(MemoryType.LONG_TERM, new RetentionRule(90, 500));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Update only sessions max_count, leaving retention_days unchanged
+        Map<MemoryType, RetentionRule> updatePolicy = new java.util.EnumMap<>(MemoryType.class);
+        updatePolicy.put(MemoryType.SESSIONS, new RetentionRule(null, 200));
+
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(updatePolicy).build();
+        config.update(updateContent);
+
+        // Sessions: retentionDays preserved from existing, maxCount updated
+        RetentionRule sessionsRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
+        assertEquals(Integer.valueOf(30), sessionsRule.getRetentionDays());
+        assertEquals(Integer.valueOf(200), sessionsRule.getMaxCount());
+
+        // Long-term: untouched
+        RetentionRule longTermRule = config.getRetentionPolicy().get(MemoryType.LONG_TERM);
+        assertEquals(Integer.valueOf(90), longTermRule.getRetentionDays());
+        assertEquals(Integer.valueOf(500), longTermRule.getMaxCount());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_AddNewType() {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        Map<MemoryType, RetentionRule> updatePolicy = new java.util.EnumMap<>(MemoryType.class);
+        updatePolicy.put(MemoryType.HISTORY, new RetentionRule(null, 1000));
+
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(updatePolicy).build();
+        config.update(updateContent);
+
+        assertEquals(2, config.getRetentionPolicy().size());
+        assertNotNull(config.getRetentionPolicy().get(MemoryType.SESSIONS));
+        assertEquals(Integer.valueOf(1000), config.getRetentionPolicy().get(MemoryType.HISTORY).getMaxCount());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_NullIncomingDoesNotRemove() {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Update without retention_policy field — should not touch existing
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().llmId("new-llm").build();
+        config.update(updateContent);
+
+        assertNotNull(config.getRetentionPolicy());
+        assertEquals(1, config.getRetentionPolicy().size());
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_HistoryWithMaxCountOnly() throws Exception {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"history\":{\"max_count\":500}}}";
+
+        XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration config = MemoryConfiguration.parse(parser);
+
+        assertNotNull(config.getRetentionPolicy());
+        RetentionRule historyRule = config.getRetentionPolicy().get(MemoryType.HISTORY);
+        assertNotNull(historyRule);
+        assertNull(historyRule.getRetentionDays());
+        assertEquals(Integer.valueOf(500), historyRule.getMaxCount());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1234,10 +1234,7 @@ public class MemoryConfigurationTests {
         assertNotNull(deserialized.getRetentionPolicy());
         assertEquals(2, deserialized.getRetentionPolicy().size());
         assertEquals(config.getRetentionPolicy().get(MemoryType.SESSIONS), deserialized.getRetentionPolicy().get(MemoryType.SESSIONS));
-        assertEquals(
-            config.getRetentionPolicy().get(MemoryType.LONG_TERM),
-            deserialized.getRetentionPolicy().get(MemoryType.LONG_TERM)
-        );
+        assertEquals(config.getRetentionPolicy().get(MemoryType.LONG_TERM), deserialized.getRetentionPolicy().get(MemoryType.LONG_TERM));
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
@@ -14,14 +14,14 @@ import java.io.IOException;
 
 import org.junit.Test;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.common.xcontent.LoggingDeprecationHandler;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.TestHelper;
 
 public class RetentionRuleTests {

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.TestHelper;
+
+public class RetentionRuleTests {
+
+    @Test
+    public void testBothFieldsSet() {
+        RetentionRule rule = new RetentionRule(30, 100);
+        assertEquals(Integer.valueOf(30), rule.getRetentionDays());
+        assertEquals(Integer.valueOf(100), rule.getMaxCount());
+    }
+
+    @Test
+    public void testOnlyRetentionDaysSet() {
+        RetentionRule rule = new RetentionRule(7, null);
+        assertEquals(Integer.valueOf(7), rule.getRetentionDays());
+        assertNull(rule.getMaxCount());
+    }
+
+    @Test
+    public void testOnlyMaxCountSet() {
+        RetentionRule rule = new RetentionRule(null, 50);
+        assertNull(rule.getRetentionDays());
+        assertEquals(Integer.valueOf(50), rule.getMaxCount());
+    }
+
+    @Test
+    public void testBothNull() {
+        RetentionRule rule = new RetentionRule(null, null);
+        assertNull(rule.getRetentionDays());
+        assertNull(rule.getMaxCount());
+    }
+
+    @Test
+    public void testNegativeRetentionDaysThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(-1, null));
+        assertEquals("retention_days must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testZeroRetentionDaysThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(0, null));
+        assertEquals("retention_days must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testNegativeMaxCountThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(null, -5));
+        assertEquals("max_count must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testZeroMaxCountThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(null, 0));
+        assertEquals("max_count must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testXContentRoundTrip_BothFields() throws IOException {
+        RetentionRule original = new RetentionRule(30, 100);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testXContentRoundTrip_OnlyRetentionDays() throws IOException {
+        RetentionRule original = new RetentionRule(14, null);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testXContentRoundTrip_OnlyMaxCount() throws IOException {
+        RetentionRule original = new RetentionRule(null, 200);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testXContentRoundTrip_BothNull() throws IOException {
+        RetentionRule original = new RetentionRule(null, null);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testStreamRoundTrip_BothFields() throws IOException {
+        RetentionRule original = new RetentionRule(30, 100);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testStreamRoundTrip_OnlyRetentionDays() throws IOException {
+        RetentionRule original = new RetentionRule(7, null);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testStreamRoundTrip_OnlyMaxCount() throws IOException {
+        RetentionRule original = new RetentionRule(null, 50);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testStreamRoundTrip_BothNull() throws IOException {
+        RetentionRule original = new RetentionRule(null, null);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testParseFromJsonString() throws IOException {
+        String json = "{\"retention_days\":60,\"max_count\":500}";
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertNotNull(parsed);
+        assertEquals(Integer.valueOf(60), parsed.getRetentionDays());
+        assertEquals(Integer.valueOf(500), parsed.getMaxCount());
+    }
+
+    @Test
+    public void testParseFromJsonString_UnknownFieldsIgnored() throws IOException {
+        String json = "{\"retention_days\":10,\"max_count\":20,\"unknown_field\":\"ignored\"}";
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(Integer.valueOf(10), parsed.getRetentionDays());
+        assertEquals(Integer.valueOf(20), parsed.getMaxCount());
+    }
+
+    @Test
+    public void testBuilder() {
+        RetentionRule rule = RetentionRule.builder().retentionDays(14).maxCount(50).build();
+        assertEquals(Integer.valueOf(14), rule.getRetentionDays());
+        assertEquals(Integer.valueOf(50), rule.getMaxCount());
+    }
+
+    @Test
+    public void testEquality() {
+        RetentionRule rule1 = new RetentionRule(30, 100);
+        RetentionRule rule2 = new RetentionRule(30, 100);
+        assertEquals(rule1, rule2);
+        assertEquals(rule1.hashCode(), rule2.hashCode());
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
@@ -241,4 +241,22 @@ public class RetentionRuleTests {
         assertEquals(rule1, rule2);
         assertEquals(rule1.hashCode(), rule2.hashCode());
     }
+
+    @Test
+    public void testBuilder_NegativeRetentionDaysThrows() {
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> RetentionRule.builder().retentionDays(-1).maxCount(10).build()
+        );
+        assertEquals("retention_days must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testBuilder_ZeroMaxCountThrows() {
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> RetentionRule.builder().retentionDays(5).maxCount(0).build()
+        );
+        assertEquals("max_count must be a positive integer or null", e.getMessage());
+    }
 }


### PR DESCRIPTION
Title: Add RetentionRule data model for memory retention lifecycle

### Description
Introduces the `RetentionRule` data model class and integrates
  `retention_policy`
  into `MemoryConfiguration` for the memory retention lifecycle feature.

  - Adds `RetentionRule` with fields: `session_ttl`, `history_ttl`,
  `working_memory_ttl`, `max_sessions`
  - Adds `retention_policy` field to `MemoryConfiguration` with full
  serialization/deserialization
  - Updates `ml_memory_container` index mapping to include retention
  policy fields
  - Unit tests for RetentionRule and updated MemoryConfiguration tests

### Related Issues
Related to RFC #4727
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
