### PR TITLE
Add pinned field to memory models for retention policy eviction exemption (PR2/PR5)

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -110,6 +110,7 @@ public class CommonValue {
     public static final Version VERSION_3_4_0 = Version.fromString("3.4.0");
     public static final Version VERSION_3_5_0 = Version.fromString("3.5.0");
     public static final Version VERSION_3_7_0 = Version.fromString("3.7.0");
+    public static final Version VERSION_3_8_0 = Version.fromString("3.8.0");
 
     // Connector Constants
     public static final String NAME_FIELD = "name";

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
@@ -102,7 +103,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = in.readOptionalString();
         this.memoryContainerId = in.readOptionalString();
         this.strategyId = in.readOptionalString();
-        this.pinned = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 
@@ -127,7 +130,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         out.writeOptionalString(ownerId);
         out.writeOptionalString(memoryContainerId);
         out.writeOptionalString(strategyId);
-        out.writeOptionalBoolean(pinned);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
@@ -6,7 +6,7 @@
 package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
@@ -103,7 +103,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = in.readOptionalString();
         this.memoryContainerId = in.readOptionalString();
         this.strategyId = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
@@ -130,7 +130,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         out.writeOptionalString(ownerId);
         out.writeOptionalString(memoryContainerId);
         out.writeOptionalString(strategyId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
@@ -15,6 +15,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_SIZE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRATEGY_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TAGS_FIELD;
 
@@ -58,6 +59,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
     private String ownerId;
     private String memoryContainerId;
     private String strategyId;
+    private Boolean pinned;
 
     @Builder
     public MLLongTermMemory(
@@ -70,7 +72,8 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         Object memoryEmbedding,
         String ownerId,
         String memoryContainerId,
-        String strategyId
+        String strategyId,
+        Boolean pinned
     ) {
         this.memory = memory;
         this.strategyType = strategyType;
@@ -82,6 +85,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = ownerId;
         this.memoryContainerId = memoryContainerId;
         this.strategyId = strategyId;
+        this.pinned = pinned;
     }
 
     public MLLongTermMemory(StreamInput in) throws IOException {
@@ -98,6 +102,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = in.readOptionalString();
         this.memoryContainerId = in.readOptionalString();
         this.strategyId = in.readOptionalString();
+        this.pinned = in.readOptionalBoolean();
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 
@@ -122,6 +127,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         out.writeOptionalString(ownerId);
         out.writeOptionalString(memoryContainerId);
         out.writeOptionalString(strategyId);
+        out.writeOptionalBoolean(pinned);
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 
@@ -151,6 +157,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         if (strategyId != null) {
             builder.field(STRATEGY_ID_FIELD, strategyId);
         }
+        if (pinned != null) {
+            builder.field(PINNED_FIELD, pinned);
+        }
 
         builder.endObject();
         return builder;
@@ -167,6 +176,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         String ownerId = null;
         String memoryContainerId = null;
         String strategyId = null;
+        Boolean pinned = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -211,6 +221,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
                 case STRATEGY_ID_FIELD:
                     strategyId = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.currentToken() == XContentParser.Token.VALUE_NULL ? null : parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -229,6 +242,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
             .ownerId(ownerId)
             .memoryContainerId(memoryContainerId)
             .strategyId(strategyId)
+            .pinned(pinned)
             .build();
     }
 
@@ -269,6 +283,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         }
         if (strategyId != null) {
             result.put(STRATEGY_ID_FIELD, strategyId);
+        }
+        if (pinned != null) {
+            result.put(PINNED_FIELD, pinned);
         }
         return result;
     }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
@@ -102,13 +102,13 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         if (in.readBoolean()) {
             this.after = in.readMap();
         }
-        this.createdTime = in.readOptionalInstant();
         if (in.readBoolean()) {
             namespace = in.readMap(StreamInput::readString, StreamInput::readString);
         }
         if (in.readBoolean()) {
             this.tags = in.readMap(StreamInput::readString, StreamInput::readString);
         }
+        this.createdTime = in.readOptionalInstant();
         this.tenantId = in.readOptionalString();
         this.error = in.readOptionalString();
         if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
@@ -139,7 +139,6 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
-        out.writeOptionalInstant(createdTime);
         if (namespace != null && !namespace.isEmpty()) {
             out.writeBoolean(true);
             out.writeMap(namespace, StreamOutput::writeString, StreamOutput::writeString);
@@ -152,6 +151,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
+        out.writeOptionalInstant(createdTime);
         out.writeOptionalString(tenantId);
         out.writeOptionalString(error);
         if (out.getVersion().onOrAfter(VERSION_3_8_0)) {

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ERROR_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_ACTION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_AFTER_FIELD;
@@ -110,7 +111,9 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         this.tenantId = in.readOptionalString();
         this.error = in.readOptionalString();
-        this.pinned = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
     }
 
     @Override
@@ -136,6 +139,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
+        out.writeOptionalInstant(createdTime);
         if (namespace != null && !namespace.isEmpty()) {
             out.writeBoolean(true);
             out.writeMap(namespace, StreamOutput::writeString, StreamOutput::writeString);
@@ -148,10 +152,11 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
-        out.writeOptionalInstant(createdTime);
         out.writeOptionalString(tenantId);
         out.writeOptionalString(error);
-        out.writeOptionalBoolean(pinned);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
     }
 
     @Override

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
@@ -8,7 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ERROR_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_ACTION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_AFTER_FIELD;
@@ -111,7 +111,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         this.tenantId = in.readOptionalString();
         this.error = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
     }
@@ -154,7 +154,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         out.writeOptionalString(tenantId);
         out.writeOptionalString(error);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
     }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
@@ -17,6 +17,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_SIZE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TAGS_FIELD;
 
 import java.io.IOException;
@@ -57,6 +58,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
     private Instant createdTime;
     private String tenantId;
     private String error;
+    private Boolean pinned;
 
     public MLMemoryHistory(
         String ownerId,
@@ -69,7 +71,8 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         Map<String, String> tags,
         Instant createdTime,
         String tenantId,
-        String error
+        String error,
+        Boolean pinned
     ) {
         this.ownerId = ownerId;
         this.memoryContainerId = memoryContainerId;
@@ -82,6 +85,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         this.createdTime = createdTime;
         this.tenantId = tenantId;
         this.error = error;
+        this.pinned = pinned;
     }
 
     public MLMemoryHistory(StreamInput in) throws IOException {
@@ -106,6 +110,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         this.tenantId = in.readOptionalString();
         this.error = in.readOptionalString();
+        this.pinned = in.readOptionalBoolean();
     }
 
     @Override
@@ -146,6 +151,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         out.writeOptionalInstant(createdTime);
         out.writeOptionalString(tenantId);
         out.writeOptionalString(error);
+        out.writeOptionalBoolean(pinned);
     }
 
     @Override
@@ -185,6 +191,9 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         if (error != null) {
             builder.field(ERROR_FIELD, error);
         }
+        if (pinned != null) {
+            builder.field(PINNED_FIELD, pinned);
+        }
         builder.endObject();
         return builder;
     }
@@ -201,6 +210,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         Instant createdTime = null;
         String tenantId = null;
         String error = null;
+        Boolean pinned = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -241,6 +251,9 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
                 case ERROR_FIELD:
                     error = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.currentToken() == XContentParser.Token.VALUE_NULL ? null : parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -260,6 +273,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
             .createdTime(createdTime)
             .tenantId(tenantId)
             .error(error)
+            .pinned(pinned)
             .build();
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.conversation.ActionConstants.ADDITIONAL_INFO_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENTS_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
@@ -100,7 +101,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             this.namespace = in.readMap(StreamInput::readString, StreamInput::readString);
         }
         this.tenantId = in.readOptionalString();
-        this.pinned = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
     }
 
     @Override
@@ -136,7 +139,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(tenantId);
-        out.writeOptionalBoolean(pinned);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
     }
 
     @Override

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
@@ -7,7 +7,7 @@ package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.conversation.ActionConstants.ADDITIONAL_INFO_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENTS_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
@@ -101,7 +101,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             this.namespace = in.readMap(StreamInput::readString, StreamInput::readString);
         }
         this.tenantId = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
     }
@@ -139,7 +139,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(tenantId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
     }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
@@ -15,6 +15,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.METADATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SUMMARY_FIELD;
 
 import java.io.IOException;
@@ -52,6 +53,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
     private Map<String, Object> additionalInfo;
     private Map<String, String> namespace;
     private String tenantId;
+    private Boolean pinned;
 
     public MLMemorySession(
         String ownerId,
@@ -63,7 +65,8 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         Map<String, Object> agents,
         Map<String, Object> additionalInfo,
         Map<String, String> namespace,
-        String tenantId
+        String tenantId,
+        Boolean pinned
     ) {
         this.ownerId = ownerId;
         this.memoryContainerId = memoryContainerId;
@@ -75,6 +78,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         this.additionalInfo = additionalInfo;
         this.namespace = namespace;
         this.tenantId = tenantId;
+        this.pinned = pinned;
     }
 
     public MLMemorySession(StreamInput in) throws IOException {
@@ -96,6 +100,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             this.namespace = in.readMap(StreamInput::readString, StreamInput::readString);
         }
         this.tenantId = in.readOptionalString();
+        this.pinned = in.readOptionalBoolean();
     }
 
     @Override
@@ -131,6 +136,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(tenantId);
+        out.writeOptionalBoolean(pinned);
     }
 
     @Override
@@ -166,6 +172,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         if (tenantId != null) {
             builder.field(TENANT_ID_FIELD, tenantId);
         }
+        if (pinned != null) {
+            builder.field(PINNED_FIELD, pinned);
+        }
         builder.endObject();
         return builder;
     }
@@ -181,6 +190,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         Map<String, Object> additionalInfo = null;
         Map<String, String> namespace = null;
         String tenantId = null;
+        Boolean pinned = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -218,6 +228,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
                 case TENANT_ID_FIELD:
                     tenantId = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.currentToken() == XContentParser.Token.VALUE_NULL ? null : parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -236,6 +249,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             .additionalInfo(additionalInfo)
             .namespace(namespace)
             .tenantId(tenantId)
+            .pinned(pinned)
             .build();
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -148,7 +148,6 @@ public class MemoryContainerConstants {
         "Backend role contains invalid characters. Only alphanumeric characters and :+=,.@-_/ are allowed: %s";
     public static final String BACKEND_ROLE_EMPTY_ERROR = "Backend role cannot be empty or blank";
 
-
     // Pinned field
     public static final String PINNED_FIELD = "pinned";
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -148,6 +148,15 @@ public class MemoryContainerConstants {
         "Backend role contains invalid characters. Only alphanumeric characters and :+=,.@-_/ are allowed: %s";
     public static final String BACKEND_ROLE_EMPTY_ERROR = "Backend role cannot be empty or blank";
 
+
+    // Pinned field
+    public static final String PINNED_FIELD = "pinned";
+
+    // Retention policy field names
+    public static final String RETENTION_POLICY_FIELD = "retention_policy";
+    public static final String RETENTION_DAYS_FIELD = "retention_days";
+    public static final String MAX_COUNT_FIELD = "max_count";
+
     // Model validation error messages
     public static final String LLM_MODEL_NOT_FOUND_ERROR = "LLM model with ID %s not found";
     public static final String LLM_MODEL_NOT_REMOTE_ERROR = "LLM model must be a REMOTE model, found: %s";

--- a/common/src/main/resources/index-mappings/ml_memory_long_term.json
+++ b/common/src/main/resources/index-mappings/ml_memory_long_term.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "schema_version": 1
+    "schema_version": 2
   },
   "properties": {
     "owner_id": {

--- a/common/src/main/resources/index-mappings/ml_memory_long_term.json
+++ b/common/src/main/resources/index-mappings/ml_memory_long_term.json
@@ -34,6 +34,9 @@
     "last_updated_time": {
       "type": "date",
       "format": "strict_date_time||epoch_millis"
+    },
+    "pinned": {
+      "type": "boolean"
     }
   }
 }

--- a/common/src/main/resources/index-mappings/ml_memory_long_term_history.json
+++ b/common/src/main/resources/index-mappings/ml_memory_long_term_history.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "schema_version": 1
+    "schema_version": 2
   },
   "properties": {
     "owner_id": {

--- a/common/src/main/resources/index-mappings/ml_memory_long_term_history.json
+++ b/common/src/main/resources/index-mappings/ml_memory_long_term_history.json
@@ -39,6 +39,9 @@
     },
     "tenant_id": {
       "type": "keyword"
+    },
+    "pinned": {
+      "type": "boolean"
     }
   }
 }

--- a/common/src/main/resources/index-mappings/ml_memory_sessions.json
+++ b/common/src/main/resources/index-mappings/ml_memory_sessions.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "schema_version": 1
+    "schema_version": 2
   },
   "properties": {
     "owner_id": {

--- a/common/src/main/resources/index-mappings/ml_memory_sessions.json
+++ b/common/src/main/resources/index-mappings/ml_memory_sessions.json
@@ -38,6 +38,9 @@
     "owner": USER_MAPPING_PLACEHOLDER,
     "tenant_id": {
       "type": "keyword"
+    },
+    "pinned": {
+      "type": "boolean"
     }
   }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
@@ -27,6 +27,7 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.TestHelper;
 
 public class MLLongTermMemoryTest {
@@ -540,6 +541,31 @@ public class MLLongTermMemoryTest {
         StreamInput in = out.bytes().streamInput();
         MLLongTermMemory deserialized = new MLLongTermMemory(in);
 
+        assertNull(deserialized.getPinned());
+    }
+
+    @Test
+    public void testBackwardCompatStreamFromOldNode() throws IOException {
+        MLLongTermMemory memory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Test memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(CommonValue.VERSION_3_5_0);
+        memory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(CommonValue.VERSION_3_5_0);
+        MLLongTermMemory deserialized = new MLLongTermMemory(in);
+
+        assertEquals("Test memory", deserialized.getMemory());
+        assertEquals(MemoryStrategyType.SEMANTIC, deserialized.getStrategyType());
         assertNull(deserialized.getPinned());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
@@ -424,4 +424,122 @@ public class MLLongTermMemoryTest {
         assertEquals(specialMemory.getMemory(), parsed.getMemory());
         assertEquals(specialMemory.getTags(), parsed.getTags());
     }
+
+    @Test
+    public void testPinnedFieldXContentRoundTrip() throws IOException {
+        MLLongTermMemory pinnedMemory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Pinned memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(true)
+            .build();
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        pinnedMemory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assertTrue(jsonString.contains("\"pinned\":true"));
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLLongTermMemory parsed = MLLongTermMemory.parse(parser);
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTrip() throws IOException {
+        MLLongTermMemory pinnedMemory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Pinned memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        pinnedMemory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLLongTermMemory deserialized = new MLLongTermMemory(in);
+
+        assertEquals(true, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldDefaultIsNull() throws IOException {
+        String jsonString = "{"
+            + "\"namespace\":{\"session_id\":\"session-123\"},"
+            + "\"memory\":\"No pinned field\","
+            + "\"strategy_type\":\"SEMANTIC\","
+            + "\"created_time\":"
+            + testCreatedTime.toEpochMilli()
+            + ","
+            + "\"last_updated_time\":"
+            + testUpdatedTime.toEpochMilli()
+            + "}";
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLLongTermMemory parsed = MLLongTermMemory.parse(parser);
+        assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldFalse() throws IOException {
+        MLLongTermMemory unpinnedMemory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Unpinned memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(false)
+            .build();
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        unpinnedMemory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assertTrue(jsonString.contains("\"pinned\":false"));
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLLongTermMemory parsed = MLLongTermMemory.parse(parser);
+        assertEquals(false, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTripNull() throws IOException {
+        MLLongTermMemory memory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("No pinned")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(null)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        memory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLLongTermMemory deserialized = new MLLongTermMemory(in);
+
+        assertNull(deserialized.getPinned());
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.TestHelper;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MemoryEvent;
+
+public class MLMemoryHistoryTest {
+
+    private MLMemoryHistory historyWithAllFields;
+    private MLMemoryHistory historyWithNullFields;
+    private Instant testCreatedTime;
+    private Map<String, Object> testBefore;
+    private Map<String, Object> testAfter;
+    private Map<String, String> testNamespace;
+    private Map<String, String> testTags;
+
+    @Before
+    public void setUp() {
+        testCreatedTime = Instant.ofEpochMilli(1640995200000L);
+
+        testBefore = new HashMap<>();
+        testBefore.put("memory", "old fact");
+
+        testAfter = new HashMap<>();
+        testAfter.put("memory", "new fact");
+
+        testNamespace = new HashMap<>();
+        testNamespace.put("project", "ml-project");
+
+        testTags = new HashMap<>();
+        testTags.put("topic", "testing");
+
+        historyWithAllFields = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryContainerId("container-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.UPDATE)
+            .before(testBefore)
+            .after(testAfter)
+            .namespace(testNamespace)
+            .tags(testTags)
+            .createdTime(testCreatedTime)
+            .tenantId("tenant-789")
+            .error(null)
+            .pinned(true)
+            .build();
+
+        historyWithNullFields = MLMemoryHistory
+            .builder()
+            .ownerId(null)
+            .memoryContainerId(null)
+            .memoryId(null)
+            .action(null)
+            .before(null)
+            .after(null)
+            .namespace(null)
+            .tags(null)
+            .createdTime(null)
+            .tenantId(null)
+            .error(null)
+            .pinned(null)
+            .build();
+    }
+
+    @Test
+    public void testBuilderWithAllFields() {
+        assertNotNull(historyWithAllFields);
+        assertEquals("owner-123", historyWithAllFields.getOwnerId());
+        assertEquals("container-123", historyWithAllFields.getMemoryContainerId());
+        assertEquals("memory-456", historyWithAllFields.getMemoryId());
+        assertEquals(MemoryEvent.UPDATE, historyWithAllFields.getAction());
+        assertEquals(testBefore, historyWithAllFields.getBefore());
+        assertEquals(testAfter, historyWithAllFields.getAfter());
+        assertEquals(testNamespace, historyWithAllFields.getNamespace());
+        assertEquals(testTags, historyWithAllFields.getTags());
+        assertEquals(testCreatedTime, historyWithAllFields.getCreatedTime());
+        assertEquals("tenant-789", historyWithAllFields.getTenantId());
+        assertEquals(true, historyWithAllFields.getPinned());
+    }
+
+    @Test
+    public void testBuilderWithNullFields() {
+        assertNotNull(historyWithNullFields);
+        assertNull(historyWithNullFields.getOwnerId());
+        assertNull(historyWithNullFields.getMemoryContainerId());
+        assertNull(historyWithNullFields.getMemoryId());
+        assertNull(historyWithNullFields.getAction());
+        assertNull(historyWithNullFields.getBefore());
+        assertNull(historyWithNullFields.getAfter());
+        assertNull(historyWithNullFields.getNamespace());
+        assertNull(historyWithNullFields.getTags());
+        assertNull(historyWithNullFields.getCreatedTime());
+        assertNull(historyWithNullFields.getTenantId());
+        assertNull(historyWithNullFields.getPinned());
+    }
+
+    // Note: Stream round-trip tests are omitted for MLMemoryHistory because the original writeTo/StreamInput
+    // constructor has a pre-existing serialization order mismatch (writeTo writes namespace/tags before
+    // createdTime, but the StreamInput constructor reads createdTime before namespace/tags).
+    // The pinned field is tested via XContent round-trip instead.
+
+    @Test
+    public void testToXContentWithAllFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        historyWithAllFields.toXContent(builder, EMPTY_PARAMS);
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        assertNotNull(jsonString);
+
+        assert jsonString.contains("\"owner_id\":\"owner-123\"");
+        assert jsonString.contains("\"memory_container_id\":\"container-123\"");
+        assert jsonString.contains("\"memory_id\":\"memory-456\"");
+        assert jsonString.contains("\"pinned\":true");
+    }
+
+    @Test
+    public void testToXContentWithNullFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        historyWithNullFields.toXContent(builder, EMPTY_PARAMS);
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        assertEquals("{}", jsonString);
+    }
+
+    @Test
+    public void testParseWithAllFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.field("memory_container_id", "container-123");
+        builder.field("memory_id", "memory-456");
+        builder.field("action", "UPDATE");
+        builder.field("before", testBefore);
+        builder.field("after", testAfter);
+        builder.field("namespace", testNamespace);
+        builder.field("tags", testTags);
+        builder.field("created_time", testCreatedTime.toEpochMilli());
+        builder.field("tenant_id", "tenant-789");
+        builder.field("pinned", true);
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+
+        assertEquals("owner-123", parsed.getOwnerId());
+        assertEquals("container-123", parsed.getMemoryContainerId());
+        assertEquals("memory-456", parsed.getMemoryId());
+        assertEquals(MemoryEvent.UPDATE, parsed.getAction());
+        assertEquals(testBefore, parsed.getBefore());
+        assertEquals(testAfter, parsed.getAfter());
+        assertEquals(testNamespace, parsed.getNamespace());
+        assertEquals(testTags, parsed.getTags());
+        assertEquals(testCreatedTime, parsed.getCreatedTime());
+        assertEquals("tenant-789", parsed.getTenantId());
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldXContentRoundTrip() throws IOException {
+        MLMemoryHistory pinnedHistory = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(true)
+            .build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        pinnedHistory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":true");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldDefaultIsNull() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.field("action", "ADD");
+        builder.field("created_time", testCreatedTime.toEpochMilli());
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+        assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldFalse() throws IOException {
+        MLMemoryHistory unpinnedHistory = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(false)
+            .build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        unpinnedHistory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":false");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+        assertEquals(false, parsed.getPinned());
+    }
+
+    @Test
+    public void testParseWithUnknownFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.field("unknown_field", "unknown_value");
+        builder.field("action", "ADD");
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+
+        assertEquals("owner-123", parsed.getOwnerId());
+        assertEquals(MemoryEvent.ADD, parsed.getAction());
+        assertNull(parsed.getPinned());
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
@@ -17,11 +17,14 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.TestHelper;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MemoryEvent;
 
@@ -116,10 +119,82 @@ public class MLMemoryHistoryTest {
         assertNull(historyWithNullFields.getPinned());
     }
 
-    // Note: Stream round-trip tests are omitted for MLMemoryHistory because the original writeTo/StreamInput
-    // constructor has a pre-existing serialization order mismatch (writeTo writes namespace/tags before
-    // createdTime, but the StreamInput constructor reads createdTime before namespace/tags).
-    // The pinned field is tested via XContent round-trip instead.
+    @Test
+    public void testStreamInputOutputWithAllFields() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        historyWithAllFields.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertEquals(historyWithAllFields.getOwnerId(), deserialized.getOwnerId());
+        assertEquals(historyWithAllFields.getMemoryContainerId(), deserialized.getMemoryContainerId());
+        assertEquals(historyWithAllFields.getMemoryId(), deserialized.getMemoryId());
+        assertEquals(historyWithAllFields.getAction(), deserialized.getAction());
+        assertEquals(historyWithAllFields.getBefore(), deserialized.getBefore());
+        assertEquals(historyWithAllFields.getAfter(), deserialized.getAfter());
+        assertEquals(historyWithAllFields.getCreatedTime(), deserialized.getCreatedTime());
+        assertEquals(historyWithAllFields.getTenantId(), deserialized.getTenantId());
+        assertEquals(historyWithAllFields.getPinned(), deserialized.getPinned());
+    }
+
+    @Test
+    public void testStreamInputOutputWithNullFields() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        historyWithNullFields.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertNull(deserialized.getOwnerId());
+        assertNull(deserialized.getMemoryContainerId());
+        assertNull(deserialized.getMemoryId());
+        assertNull(deserialized.getAction());
+        assertNull(deserialized.getBefore());
+        assertNull(deserialized.getAfter());
+        assertNull(deserialized.getCreatedTime());
+        assertNull(deserialized.getTenantId());
+        assertNull(deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTrip() throws IOException {
+        MLMemoryHistory pinnedHistory = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        pinnedHistory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertEquals(true, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTripNull() throws IOException {
+        MLMemoryHistory history = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(null)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        history.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertNull(deserialized.getPinned());
+    }
 
     @Test
     public void testToXContentWithAllFields() throws IOException {
@@ -272,5 +347,31 @@ public class MLMemoryHistoryTest {
         assertEquals("owner-123", parsed.getOwnerId());
         assertEquals(MemoryEvent.ADD, parsed.getAction());
         assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testBackwardCompatStreamFromOldNode() throws IOException {
+        MLMemoryHistory history = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.UPDATE)
+            .createdTime(testCreatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(CommonValue.VERSION_3_5_0);
+        history.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(CommonValue.VERSION_3_5_0);
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertEquals("owner-123", deserialized.getOwnerId());
+        assertEquals("memory-456", deserialized.getMemoryId());
+        assertEquals(MemoryEvent.UPDATE, deserialized.getAction());
+        assertEquals(testCreatedTime, deserialized.getCreatedTime());
+        assertNull(deserialized.getPinned());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
@@ -126,7 +126,8 @@ public class MLMemorySessionTest {
             testAgents,
             testAdditionalInfo,
             testNamespace,
-            "tenant-456"
+            "tenant-456",
+            true
         );
 
         assertEquals("owner-123", session.getOwnerId());
@@ -138,11 +139,12 @@ public class MLMemorySessionTest {
         assertEquals(testAdditionalInfo, session.getAdditionalInfo());
         assertEquals(testNamespace, session.getNamespace());
         assertEquals("tenant-456", session.getTenantId());
+        assertEquals(true, session.getPinned());
     }
 
     @Test
     public void testConstructorWithNullFields() {
-        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null);
+        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null, null);
 
         assertNull(session.getOwnerId());
         assertNull(session.getSummary());
@@ -153,6 +155,7 @@ public class MLMemorySessionTest {
         assertNull(session.getAdditionalInfo());
         assertNull(session.getNamespace());
         assertNull(session.getTenantId());
+        assertNull(session.getPinned());
     }
 
     @Test
@@ -330,7 +333,7 @@ public class MLMemorySessionTest {
 
     @Test
     public void testSettersAndGetters() {
-        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null);
+        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null, null);
 
         // Test setters
         session.setOwnerId("new-owner");
@@ -720,5 +723,87 @@ public class MLMemorySessionTest {
         assertNull(emptySession.getAdditionalInfo());
         assertNull(emptySession.getNamespace());
         assertNull(emptySession.getTenantId());
+        assertNull(emptySession.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldXContentRoundTrip() throws IOException {
+        MLMemorySession pinnedSession = MLMemorySession.builder().ownerId("owner-123").pinned(true).build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        pinnedSession.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":true");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemorySession parsed = MLMemorySession.parse(parser);
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTrip() throws IOException {
+        MLMemorySession pinnedSession = MLMemorySession.builder().ownerId("owner-123").pinned(true).build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        pinnedSession.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemorySession deserialized = new MLMemorySession(in);
+
+        assertEquals(true, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldDefaultIsNull() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemorySession parsed = MLMemorySession.parse(parser);
+        assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldFalse() throws IOException {
+        MLMemorySession unpinnedSession = MLMemorySession.builder().ownerId("owner-123").pinned(false).build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        unpinnedSession.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":false");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemorySession parsed = MLMemorySession.parse(parser);
+        assertEquals(false, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTripNull() throws IOException {
+        MLMemorySession session = MLMemorySession.builder().ownerId("owner-123").pinned(null).build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        session.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemorySession deserialized = new MLMemorySession(in);
+
+        assertNull(deserialized.getPinned());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
@@ -24,6 +24,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.TestHelper;
 
 public class MLMemorySessionTest {
@@ -189,6 +190,7 @@ public class MLMemorySessionTest {
         assertEquals(sessionWithoutNamespace.getAdditionalInfo(), deserialized.getAdditionalInfo());
         assertEquals(sessionWithoutNamespace.getNamespace(), deserialized.getNamespace());
         assertEquals(sessionWithoutNamespace.getTenantId(), deserialized.getTenantId());
+        assertNull(deserialized.getPinned());
     }
 
     @Test
@@ -804,6 +806,22 @@ public class MLMemorySessionTest {
         StreamInput in = out.bytes().streamInput();
         MLMemorySession deserialized = new MLMemorySession(in);
 
+        assertNull(deserialized.getPinned());
+    }
+
+    @Test
+    public void testBackwardCompatStreamFromOldNode() throws IOException {
+        MLMemorySession session = MLMemorySession.builder().ownerId("owner-123").pinned(true).build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(CommonValue.VERSION_3_5_0);
+        session.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(CommonValue.VERSION_3_5_0);
+        MLMemorySession deserialized = new MLMemorySession(in);
+
+        assertEquals("owner-123", deserialized.getOwnerId());
         assertNull(deserialized.getPinned());
     }
 }


### PR DESCRIPTION
### Description
Adds a boolean `pinned` field to `MLMemorySession`,`MLLongTermMemory`, and `MLMemoryHistory` models. Pinned memories are exempt from retention policy eviction, allowing users to protect important memories from automatic cleanup.
- Adds pinned field (default null, treated as unpinned by eviction logic) to all three memory model classes
  - Full serialization/deserialization support (XContent and StreamInput/StreamOutput)
  - Updates index mappings for `ml_memory_sessions`, `ml_memory_long_term`, and `ml_memory_long_term_history`
  - Unit tests for pinned field behavior across all models
  
### Related Issues
Part of the memory retention lifecycle feature (RFC #4727). 
Depends on #4860 (RetentionRule data model).

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
