### PR TITLE
Support user-configurable retryable HTTP status codes for remote connectors

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/connector/ConnectorClientConfig.java
+++ b/common/src/main/java/org/opensearch/ml/common/connector/ConnectorClientConfig.java
@@ -8,6 +8,9 @@ package org.opensearch.ml.common.connector;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -37,6 +40,7 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
     public static final String MAX_RETRY_TIMES_FIELD = "max_retry_times";
     public static final String RETRY_BACKOFF_POLICY_FIELD = "retry_backoff_policy";
     public static final String SKIP_SSL_VERIFICATION_FIELD = "skip_ssl_verification";
+    public static final String RETRYABLE_STATUS_CODES_FIELD = "retryable_status_codes";
 
     public static final Integer MAX_CONNECTION_DEFAULT_VALUE = Integer.valueOf(30);
     public static final Integer CONNECTION_TIMEOUT_DEFAULT_VALUE = Integer.valueOf(30);
@@ -47,6 +51,7 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
     public static final RetryBackoffPolicy RETRY_BACKOFF_POLICY_DEFAULT_VALUE = RetryBackoffPolicy.CONSTANT;
     public static final Boolean SKIP_SSL_VERIFICATION_DEFAULT_VALUE = Boolean.FALSE;
     public static final Version MINIMAL_SUPPORTED_VERSION_FOR_RETRY = Version.V_2_15_0;
+    public static final Version MINIMAL_SUPPORTED_VERSION_FOR_RETRYABLE_STATUS_CODES = Version.V_3_7_0;
     private Integer maxConnections;
     private Integer connectionTimeout;
     private Integer readTimeout;
@@ -55,8 +60,8 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
     private Integer maxRetryTimes;
     private RetryBackoffPolicy retryBackoffPolicy;
     private Boolean skipSslVerification;
+    private List<Integer> retryableStatusCodes;
 
-    @Builder(toBuilder = true)
     public ConnectorClientConfig(
         Integer maxConnections,
         Integer connectionTimeout,
@@ -67,6 +72,31 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
         RetryBackoffPolicy retryBackoffPolicy,
         Boolean skipSslVerification
     ) {
+        this(
+            maxConnections,
+            connectionTimeout,
+            readTimeout,
+            retryBackoffMillis,
+            retryTimeoutSeconds,
+            maxRetryTimes,
+            retryBackoffPolicy,
+            skipSslVerification,
+            null
+        );
+    }
+
+    @Builder(toBuilder = true)
+    public ConnectorClientConfig(
+        Integer maxConnections,
+        Integer connectionTimeout,
+        Integer readTimeout,
+        Integer retryBackoffMillis,
+        Integer retryTimeoutSeconds,
+        Integer maxRetryTimes,
+        RetryBackoffPolicy retryBackoffPolicy,
+        Boolean skipSslVerification,
+        List<Integer> retryableStatusCodes
+    ) {
         this.maxConnections = maxConnections;
         this.connectionTimeout = connectionTimeout;
         this.readTimeout = readTimeout;
@@ -75,6 +105,12 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
         this.maxRetryTimes = maxRetryTimes;
         this.retryBackoffPolicy = retryBackoffPolicy;
         this.skipSslVerification = skipSslVerification;
+        this.retryableStatusCodes = retryableStatusCodes != null ? List.copyOf(retryableStatusCodes) : null;
+        if (this.retryableStatusCodes != null && !this.retryableStatusCodes.isEmpty()) {
+            if (this.maxRetryTimes == null || (this.maxRetryTimes <= 0 && this.maxRetryTimes != -1)) {
+                throw new IllegalArgumentException("retryable_status_codes requires max_retry_times to be a positive number or -1 (unlimited)");
+            }
+        }
     }
 
     public ConnectorClientConfig(StreamInput input) throws IOException {
@@ -90,6 +126,12 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
                 this.retryBackoffPolicy = RetryBackoffPolicy.from(input.readString());
             }
             this.skipSslVerification = input.readOptionalBoolean();
+            if (streamInputVersion.onOrAfter(MINIMAL_SUPPORTED_VERSION_FOR_RETRYABLE_STATUS_CODES)) {
+                if (input.readBoolean()) {
+                    int[] codes = input.readVIntArray();
+                    this.retryableStatusCodes = List.of(Arrays.stream(codes).boxed().toArray(Integer[]::new));
+                }
+            }
         }
     }
 
@@ -102,6 +144,7 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
         this.maxRetryTimes = MAX_RETRY_TIMES_DEFAULT_VALUE;
         this.retryBackoffPolicy = RETRY_BACKOFF_POLICY_DEFAULT_VALUE;
         this.skipSslVerification = SKIP_SSL_VERIFICATION_DEFAULT_VALUE;
+        this.retryableStatusCodes = null;
     }
 
     @Override
@@ -121,6 +164,14 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
                 out.writeBoolean(false);
             }
             out.writeOptionalBoolean(skipSslVerification);
+            if (streamOutputVersion.onOrAfter(MINIMAL_SUPPORTED_VERSION_FOR_RETRYABLE_STATUS_CODES)) {
+                if (retryableStatusCodes != null) {
+                    out.writeBoolean(true);
+                    out.writeVIntArray(retryableStatusCodes.stream().mapToInt(Integer::intValue).toArray());
+                } else {
+                    out.writeBoolean(false);
+                }
+            }
         }
     }
 
@@ -151,6 +202,9 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
         if (skipSslVerification != null) {
             builder.field(SKIP_SSL_VERIFICATION_FIELD, skipSslVerification);
         }
+        if (retryableStatusCodes != null) {
+            builder.field(RETRYABLE_STATUS_CODES_FIELD, retryableStatusCodes);
+        }
         return builder.endObject();
     }
 
@@ -168,6 +222,7 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
         Integer maxRetryTimes = MAX_RETRY_TIMES_DEFAULT_VALUE;
         RetryBackoffPolicy retryBackoffPolicy = RETRY_BACKOFF_POLICY_DEFAULT_VALUE;
         Boolean skipSslVerification = SKIP_SSL_VERIFICATION_DEFAULT_VALUE;
+        List<Integer> retryableStatusCodes = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -199,6 +254,14 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
                 case SKIP_SSL_VERIFICATION_FIELD:
                     skipSslVerification = parser.booleanValue();
                     break;
+                case RETRYABLE_STATUS_CODES_FIELD:
+                    List<Integer> parsedCodes = new ArrayList<>();
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        parsedCodes.add(parser.intValue());
+                    }
+                    retryableStatusCodes = List.copyOf(parsedCodes);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -214,6 +277,7 @@ public class ConnectorClientConfig implements ToXContentObject, Writeable {
             .maxRetryTimes(maxRetryTimes)
             .retryBackoffPolicy(retryBackoffPolicy)
             .skipSslVerification(skipSslVerification)
+            .retryableStatusCodes(retryableStatusCodes)
             .build();
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorClientConfigTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorClientConfigTest.java
@@ -1,6 +1,8 @@
 package org.opensearch.ml.common.connector;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.Assert;
@@ -174,6 +176,7 @@ public class ConnectorClientConfigTest {
         Assert.assertNull(config.getRetryTimeoutSeconds());
         Assert.assertNull(config.getMaxRetryTimes());
         Assert.assertNull(config.getRetryBackoffPolicy());
+        Assert.assertNull(config.getRetryableStatusCodes());
     }
 
     @Test
@@ -188,5 +191,181 @@ public class ConnectorClientConfigTest {
         Assert.assertEquals(Integer.valueOf(0), config.getMaxRetryTimes());
         Assert.assertEquals(RetryBackoffPolicy.CONSTANT, config.getRetryBackoffPolicy());
         Assert.assertEquals(Boolean.FALSE, config.getSkipSslVerification());
+        Assert.assertNull(config.getRetryableStatusCodes());
+    }
+
+    @Test
+    public void writeTo_ReadFromStream_withRetryableStatusCodes() throws IOException {
+        ConnectorClientConfig config = ConnectorClientConfig
+            .builder()
+            .maxConnections(10)
+            .connectionTimeout(5000)
+            .readTimeout(3000)
+            .retryBackoffMillis(123)
+            .retryTimeoutSeconds(456)
+            .maxRetryTimes(789)
+            .retryBackoffPolicy(RetryBackoffPolicy.CONSTANT)
+            .retryableStatusCodes(Arrays.asList(429, 503))
+            .build();
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        config.writeTo(output);
+        ConnectorClientConfig readConfig = new ConnectorClientConfig(output.bytes().streamInput());
+
+        Assert.assertEquals(config, readConfig);
+        Assert.assertEquals(Arrays.asList(429, 503), readConfig.getRetryableStatusCodes());
+    }
+
+    @Test
+    public void writeTo_ReadFromStream_nullRetryableStatusCodes() throws IOException {
+        ConnectorClientConfig config = ConnectorClientConfig
+            .builder()
+            .maxConnections(10)
+            .connectionTimeout(5000)
+            .readTimeout(3000)
+            .retryBackoffMillis(123)
+            .retryTimeoutSeconds(456)
+            .maxRetryTimes(789)
+            .retryBackoffPolicy(RetryBackoffPolicy.CONSTANT)
+            .retryableStatusCodes(null)
+            .build();
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        config.writeTo(output);
+        ConnectorClientConfig readConfig = new ConnectorClientConfig(output.bytes().streamInput());
+
+        Assert.assertEquals(config, readConfig);
+        Assert.assertNull(readConfig.getRetryableStatusCodes());
+    }
+
+    @Test
+    public void toXContent_withRetryableStatusCodes() throws IOException {
+        ConnectorClientConfig config = ConnectorClientConfig
+            .builder()
+            .maxConnections(10)
+            .connectionTimeout(5000)
+            .readTimeout(3000)
+            .retryBackoffMillis(123)
+            .retryTimeoutSeconds(456)
+            .maxRetryTimes(789)
+            .retryBackoffPolicy(RetryBackoffPolicy.CONSTANT)
+            .retryableStatusCodes(Arrays.asList(429, 503))
+            .build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        config.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String content = TestHelper.xContentBuilderToString(builder);
+
+        String expectedJson = "{\"max_connection\":10,\"connection_timeout\":5000,\"read_timeout\":3000,"
+            + "\"retry_backoff_millis\":123,\"retry_timeout_seconds\":456,\"max_retry_times\":789,"
+            + "\"retry_backoff_policy\":\"constant\",\"retryable_status_codes\":[429,503]}";
+        Assert.assertEquals(expectedJson, content);
+    }
+
+    @Test
+    public void parse_withRetryableStatusCodes() throws IOException {
+        String jsonStr = "{\"max_connection\":10,\"connection_timeout\":5000,\"read_timeout\":3000,"
+            + "\"retry_backoff_millis\":123,\"retry_timeout_seconds\":456,\"max_retry_times\":789,"
+            + "\"retry_backoff_policy\":\"constant\",\"retryable_status_codes\":[429,503]}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+
+        ConnectorClientConfig config = ConnectorClientConfig.parse(parser);
+
+        Assert.assertEquals(Arrays.asList(429, 503), config.getRetryableStatusCodes());
+    }
+
+    @Test
+    public void writeTo_ReadFromStream_atV2_15_0_excludesRetryableStatusCodes() throws IOException {
+        ConnectorClientConfig config = ConnectorClientConfig
+            .builder()
+            .maxConnections(10)
+            .retryBackoffMillis(500)
+            .retryTimeoutSeconds(30)
+            .maxRetryTimes(3)
+            .retryBackoffPolicy(RetryBackoffPolicy.CONSTANT)
+            .retryableStatusCodes(Arrays.asList(429, 503))
+            .build();
+
+        // write with old version (without retryableStatusCodes)
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(Version.V_2_15_0);
+        config.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        input.setVersion(Version.V_2_15_0);
+        ConnectorClientConfig readConfig = ConnectorClientConfig.fromStream(input);
+
+        Assert.assertEquals(Integer.valueOf(10), readConfig.getMaxConnections());
+        Assert.assertEquals(Integer.valueOf(500), readConfig.getRetryBackoffMillis());
+        Assert.assertEquals(Integer.valueOf(3), readConfig.getMaxRetryTimes());
+        // get null when reading V_2_15_0 data without retryableStatusCodes
+        Assert.assertNull(readConfig.getRetryableStatusCodes());
+    }
+
+    @Test
+    public void constructor_withValidStatusCodes_returnsImmutableList() {
+        ArrayList<Integer> mutableList = new ArrayList<>(Arrays.asList(429, 503));
+        ConnectorClientConfig config = ConnectorClientConfig.builder().maxRetryTimes(3).retryableStatusCodes(mutableList).build();
+
+        mutableList.add(500);
+        Assert.assertEquals(Arrays.asList(429, 503), config.getRetryableStatusCodes());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_retryableStatusCodes_withoutMaxRetryTimes_throwsException() {
+        ConnectorClientConfig.builder().retryableStatusCodes(Arrays.asList(429, 503)).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_retryableStatusCodes_withZeroMaxRetryTimes_throwsException() {
+        ConnectorClientConfig.builder().retryableStatusCodes(Arrays.asList(429, 503)).maxRetryTimes(0).build();
+    }
+
+    @Test
+    public void constructor_retryableStatusCodes_withUnlimitedRetry_succeeds() {
+        ConnectorClientConfig config = ConnectorClientConfig
+            .builder()
+            .retryableStatusCodes(Arrays.asList(429, 503))
+            .maxRetryTimes(-1)
+            .build();
+        Assert.assertEquals(Arrays.asList(429, 503), config.getRetryableStatusCodes());
+        Assert.assertEquals(Integer.valueOf(-1), config.getMaxRetryTimes());
+    }
+
+    @Test
+    public void constructor_nullRetryableStatusCodes_withZeroMaxRetryTimes_succeeds() {
+        ConnectorClientConfig config = ConnectorClientConfig.builder().retryableStatusCodes(null).maxRetryTimes(0).build();
+        Assert.assertNull(config.getRetryableStatusCodes());
+    }
+
+    @Test
+    public void constructor_emptyRetryableStatusCodes_withZeroMaxRetryTimes_succeeds() {
+        ConnectorClientConfig config = ConnectorClientConfig
+            .builder()
+            .retryableStatusCodes(new ArrayList<>())
+            .maxRetryTimes(0)
+            .build();
+        Assert.assertTrue(config.getRetryableStatusCodes().isEmpty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parse_retryableStatusCodes_withDefaultMaxRetryTimes_throwsException() throws IOException {
+        String jsonStr = "{\"retryable_status_codes\":[429,503]}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(
+                new NamedXContentRegistry(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()),
+                null,
+                jsonStr
+            );
+        parser.nextToken();
+        ConnectorClientConfig.parse(parser);
     }
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandler.java
@@ -89,6 +89,10 @@ public class MLSdkAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandle
         if (statusCode < HttpStatus.SC_OK || statusCode > HttpStatus.SC_MULTIPLE_CHOICES) {
             log.error("Received error from remote service with status code {}, response headers: {}", statusCode, sdkResponse.headers());
             handleThrottlingInHeader(sdkResponse);
+            // Skip retryable status code check if exception has already been set in throttling header.
+            if (exceptionHolder.get() == null) {
+                handleRetryableStatusCode(statusCode);
+            }
             // add more handling here for other exceptions in headers
         }
     }
@@ -110,7 +114,7 @@ public class MLSdkAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandle
                 status = RestStatus.INTERNAL_SERVER_ERROR;
             }
         } else {
-            status = RestStatus.fromCode(statusCode);
+            status = safeRestStatus(statusCode);
         }
         String errorMessage = "Error communicating with remote model: " + error.getMessage();
         actionListener.onFailure(new OpenSearchStatusException(errorMessage, status));
@@ -140,7 +144,28 @@ public class MLSdkAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandle
                     REMOTE_SERVICE_ERROR
                         + "The request was denied due to remote server throttling. "
                         + "To change the retry policy and behavior, please update the connector client_config.",
-                    RestStatus.fromCode(statusCode)
+                    safeRestStatus(statusCode)
+                )
+            );
+        }
+    }
+
+    private void handleRetryableStatusCode(int statusCode) {
+        List<Integer> retryableStatusCodes = connector.getConnectorClientConfig() != null
+            ? connector.getConnectorClientConfig().getRetryableStatusCodes() : null;
+        if (retryableStatusCodes == null) {
+            return;
+        }
+        if (retryableStatusCodes.contains(statusCode)) {
+            log.error("Remote server returned retryable status code: {}", statusCode);
+            handleException(
+                new RemoteConnectorRetryableException(
+                    REMOTE_SERVICE_ERROR
+                        + "Remote server returned retryable status code: "
+                        + statusCode
+                        + ". "
+                        + "To change the retry policy and behavior, please update the connector client_config.",
+                    safeRestStatus(statusCode)
                 )
             );
         }
@@ -189,7 +214,7 @@ public class MLSdkAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandle
 
         // Handle error status codes (4xx, 5xx)
         if (statusCode == null || statusCode < HttpStatus.SC_OK || statusCode > HttpStatus.SC_MULTIPLE_CHOICES) {
-            RestStatus status = (statusCode != null) ? RestStatus.fromCode(statusCode) : RestStatus.INTERNAL_SERVER_ERROR;
+            RestStatus status = safeRestStatus(statusCode);
             String errorMsg = Strings.isBlank(body)
                 ? String.format("Remote service returned error status %d with empty body", statusCode)
                 : REMOTE_SERVICE_ERROR + body;
@@ -223,4 +248,22 @@ public class MLSdkAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandle
             actionListener.onFailure(new MLException("Fail to execute " + action + " in aws connector", e));
         }
     }
+
+    /**
+     * Returns a safe RestStatus for the given status code.
+     * If the status code is null or cannot be resolved to a valid RestStatus, returns INTERNAL_SERVER_ERROR.
+     *
+     * @param statusCode the status code
+     * @return the safe RestStatus
+     */
+    private RestStatus safeRestStatus(Integer statusCode) {
+        if (statusCode != null) {
+            RestStatus resolved = RestStatus.fromCode(statusCode);
+            if (resolved != null) {
+                return resolved;
+            }
+        }
+        return RestStatus.INTERNAL_SERVER_ERROR;
+    }
+
 }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -419,7 +419,8 @@ public interface RemoteConnectorExecutor extends AutoCloseable {
         public boolean shouldRetry(Exception e) {
             Throwable cause = ExceptionsHelper.unwrapCause(e);
             Integer maxRetryTimes = args.connectionExecutor.getConnectorClientConfig().getMaxRetryTimes();
-            boolean shouldRetry = cause instanceof RemoteConnectorThrottlingException;
+            boolean shouldRetry = cause instanceof RemoteConnectorThrottlingException
+                || cause instanceof RemoteConnectorRetryableException;
             if (++retryTimes > maxRetryTimes && maxRetryTimes != -1) {
                 shouldRetry = false;
             }

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorRetryableException.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorRetryableException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.engine.algorithms.remote;
+
+import java.io.IOException;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.rest.RestStatus;
+
+public class RemoteConnectorRetryableException extends OpenSearchStatusException {
+    public RemoteConnectorRetryableException(String msg, RestStatus status, Throwable cause, Object... args) {
+        super(msg, status, cause, args);
+    }
+
+    public RemoteConnectorRetryableException(String msg, RestStatus status, Object... args) {
+        this(msg, status, null, args);
+    }
+
+    public RemoteConnectorRetryableException(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/MLSdkAsyncHttpResponseHandlerTest.java
@@ -6,6 +6,8 @@
 package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,6 +33,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.ConnectorAction;
+import org.opensearch.ml.common.connector.ConnectorClientConfig;
 import org.opensearch.ml.common.connector.HttpConnector;
 import org.opensearch.ml.common.connector.MLPostProcessFunction;
 import org.opensearch.ml.common.output.model.ModelTensors;
@@ -462,5 +465,198 @@ public class MLSdkAsyncHttpResponseHandlerTest {
             "The embedding should be a non-empty List containing Float values.",
             exceptionCaptor.getValue().getMessage()
         );
+    }
+
+    @Test
+    public void test_onHeaders_retryableStatusCode_429() {
+        Connector retryConnector = buildConnectorWithRetryableStatusCodes(Arrays.asList(429, 500, 503));
+        MLSdkAsyncHttpResponseHandler handler = new MLSdkAsyncHttpResponseHandler(
+            new ExecutionContext(0),
+            actionListener,
+            parameters,
+            retryConnector,
+            scriptService,
+            null,
+            action
+        );
+        SdkHttpFullResponse response = mock(SdkHttpFullResponse.class);
+        when(response.statusCode()).thenReturn(429);
+        handler.onHeaders(response);
+
+        String body = "{\"error\":\"rate limit\"}";
+        Publisher<ByteBuffer> stream = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(body.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        handler.onStream(stream);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof RemoteConnectorRetryableException);
+        assertTrue(captor.getValue().getMessage().contains("retryable status code: 429"));
+    }
+
+    @Test
+    public void test_onHeaders_nonRetryableStatusCode_400() {
+        Connector retryConnector = buildConnectorWithRetryableStatusCodes(Arrays.asList(429, 500, 503));
+        MLSdkAsyncHttpResponseHandler handler = new MLSdkAsyncHttpResponseHandler(
+            new ExecutionContext(0),
+            actionListener,
+            parameters,
+            retryConnector,
+            scriptService,
+            null,
+            action
+        );
+        SdkHttpFullResponse response = mock(SdkHttpFullResponse.class);
+        when(response.statusCode()).thenReturn(400);
+        handler.onHeaders(response);
+
+        String body = "{\"error\":\"bad request\"}";
+        Publisher<ByteBuffer> stream = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(body.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        handler.onStream(stream);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof OpenSearchStatusException);
+        assertFalse(captor.getValue() instanceof RemoteConnectorRetryableException);
+        assertTrue(captor.getValue().getMessage().contains(REMOTE_SERVICE_ERROR));
+    }
+
+    @Test
+    public void test_onHeaders_retryableStatusCode_awsHeaderTakesPrecedence() {
+        Connector retryConnector = buildConnectorWithRetryableStatusCodes(Arrays.asList(429, 500, 503));
+        MLSdkAsyncHttpResponseHandler handler = new MLSdkAsyncHttpResponseHandler(
+            new ExecutionContext(0),
+            actionListener,
+            parameters,
+            retryConnector,
+            scriptService,
+            null,
+            action
+        );
+        SdkHttpFullResponse response = mock(SdkHttpFullResponse.class);
+        when(response.statusCode()).thenReturn(429);
+        when(response.headers()).thenReturn(Map.of(AMZ_ERROR_HEADER, Arrays.asList("ThrottlingException:request throttled!")));
+        handler.onHeaders(response);
+
+        String body = "{\"error\":\"throttled\"}";
+        Publisher<ByteBuffer> stream = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(body.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        handler.onStream(stream);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof RemoteConnectorThrottlingException);
+        assertTrue(captor.getValue().getMessage().contains("remote server throttling"));
+    }
+
+    @Test
+    public void test_onHeaders_retryableStatusCode_nullConfig() {
+        // connector without ConnectorClientConfig -> retryableStatusCodes is null -> skip retryable check
+        MLSdkAsyncHttpResponseHandler handler = new MLSdkAsyncHttpResponseHandler(
+            new ExecutionContext(0),
+            actionListener,
+            parameters,
+            connector,
+            scriptService,
+            null,
+            action
+        );
+        SdkHttpFullResponse response = mock(SdkHttpFullResponse.class);
+        when(response.statusCode()).thenReturn(429);
+        handler.onHeaders(response);
+
+        String body = "{\"error\":\"rate limit\"}";
+        Publisher<ByteBuffer> stream = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(body.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        handler.onStream(stream);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof OpenSearchStatusException);
+        assertFalse(captor.getValue() instanceof RemoteConnectorRetryableException);
+        assertTrue(captor.getValue().getMessage().contains("rate limit"));
+    }
+
+    @Test
+    public void test_onHeaders_retryableStatusCode_nonStandardCode() {
+        Connector retryConnector = buildConnectorWithRetryableStatusCodes(Arrays.asList(520));
+        MLSdkAsyncHttpResponseHandler handler = new MLSdkAsyncHttpResponseHandler(
+            new ExecutionContext(0),
+            actionListener,
+            parameters,
+            retryConnector,
+            scriptService,
+            null,
+            action
+        );
+        SdkHttpFullResponse response = mock(SdkHttpFullResponse.class);
+        when(response.statusCode()).thenReturn(520);
+        handler.onHeaders(response);
+
+        String body = "{\"error\":\"unknown error\"}";
+        Publisher<ByteBuffer> stream = s -> {
+            try {
+                s.onSubscribe(mock(Subscription.class));
+                s.onNext(ByteBuffer.wrap(body.getBytes()));
+                s.onComplete();
+            } catch (Throwable e) {
+                s.onError(e);
+            }
+        };
+        handler.onStream(stream);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof RemoteConnectorRetryableException);
+        assertTrue(captor.getValue().getMessage().contains("retryable status code: 520"));
+        assertEquals(org.opensearch.core.rest.RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) captor.getValue()).status());
+    }
+
+    private Connector buildConnectorWithRetryableStatusCodes(List<Integer> retryableStatusCodes) {
+        ConnectorAction predictAction = ConnectorAction
+            .builder()
+            .actionType(PREDICT)
+            .method("POST")
+            .url("http://test.com/mock")
+            .requestBody("{\"input\": \"${parameters.input}\"}")
+            .build();
+        ConnectorClientConfig clientConfig = ConnectorClientConfig.builder().maxRetryTimes(3).retryableStatusCodes(retryableStatusCodes).build();
+        return HttpConnector
+            .builder()
+            .name("test connector")
+            .version("1")
+            .protocol("http")
+            .actions(Arrays.asList(predictAction))
+            .connectorClientConfig(clientConfig)
+            .build();
     }
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor_RetryableActionExtensionTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor_RetryableActionExtensionTest.java
@@ -7,9 +7,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.apache.logging.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
@@ -108,7 +110,42 @@ public class RemoteConnectorExecutor_RetryableActionExtensionTest {
         return attempt;
     }
 
+    @Test
+    public void test_ShouldRetry_onRetryableStatusCodeException() {
+        var attempts = retryAttempts(-1, this::createRetryableException);
+
+        assertThat(attempts, equalTo(TEST_ATTEMPT_LIMIT));
+    }
+
+    @Test
+    public void test_ShouldRetry_retryableStatusCodeException_stopAtMaxAttempts() {
+        int maxAttempts = 3;
+        var attempts = retryAttempts(maxAttempts, this::createRetryableException);
+
+        assertThat(attempts, equalTo(maxAttempts));
+    }
+
+    @Test
+    public void test_RetryableException_serializationRoundTrip() throws IOException {
+        RemoteConnectorRetryableException original = new RemoteConnectorRetryableException(
+            "Remote server returned retryable status code: 503",
+            RestStatus.SERVICE_UNAVAILABLE
+        );
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        RemoteConnectorRetryableException deserialized = new RemoteConnectorRetryableException(output.bytes().streamInput());
+
+        assertThat(original.getMessage(), equalTo(deserialized.getMessage()));
+        assertThat(original.status(), equalTo(deserialized.status()));
+    }
+
     private RemoteConnectorThrottlingException createThrottleException() {
         return new RemoteConnectorThrottlingException("Throttle", RestStatus.TOO_MANY_REQUESTS);
+    }
+
+    private RemoteConnectorRetryableException createRetryableException() {
+        return new RemoteConnectorRetryableException("Remote server returned retryable status code: 503", RestStatus.SERVICE_UNAVAILABLE);
     }
 }


### PR DESCRIPTION
### Description
Add a new `retryable_status_codes` field to the connector's `client_config` that allows users to specify which HTTP status codes should trigger automatic retries.

### Related Issues
Resolves #4850 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
