### PR TITLE
Add retention policy and pinned field to memory   container REST APIs (PR3/PR5)

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -5,8 +5,8 @@
 
 repositories {
     mavenLocal()
-    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     mavenCentral()
     maven {url 'https://oss.sonatype.org/content/repositories/snapshots/'}
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.transport.memorycontainer.memory;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
@@ -22,6 +23,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETERS_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PAYLOAD_TYPE_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SESSION_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_BLOB_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_FIELD;
@@ -34,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -73,6 +76,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
     private Map<String, Object> parameters;
     private String ownerId;
 
+    // Pinned field (only valid for session/long-term/history, rejected for working memory)
+    private Boolean pinned;
+
     // Checkpoint field
     private String checkpointId;
     private String tenantId;
@@ -91,6 +97,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> tags,
         Map<String, Object> parameters,
         String ownerId,
+        Boolean pinned,
         String checkpointId,
         String tenantId
     ) {
@@ -112,6 +119,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters.putAll(parameters);
         }
         this.ownerId = ownerId;
+        this.pinned = pinned;
         this.checkpointId = checkpointId;
         this.tenantId = tenantId;
         validate();
@@ -161,6 +169,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters = in.readMap();
         }
         this.ownerId = in.readOptionalString();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
         this.checkpointId = in.readOptionalString();
         this.tenantId = in.readOptionalString();
     }
@@ -218,6 +229,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(ownerId);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
         out.writeOptionalString(checkpointId);
         out.writeOptionalString(tenantId);
     }
@@ -297,6 +311,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> tags = null;
         Map<String, Object> parameters = null;
         String ownerId = null;
+        Boolean pinned = null;
         String checkpointId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -348,6 +363,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
                 case OWNER_ID_FIELD:
                     ownerId = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.booleanValue();
+                    break;
                 case CHECKPOINT_ID_FIELD:
                     checkpointId = parser.text();
                     break;
@@ -375,6 +393,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             .tags(tags)
             .parameters(parameters)
             .ownerId(ownerId)
+            .pinned(pinned)
             .checkpointId(checkpointId)
             .tenantId(tenantId)
             .build();

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -7,7 +7,7 @@ package org.opensearch.ml.common.transport.memorycontainer.memory;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
@@ -168,7 +168,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters = in.readMap();
         }
         this.ownerId = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
         this.checkpointId = in.readOptionalString();
@@ -228,7 +228,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(ownerId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
         out.writeOptionalString(checkpointId);
@@ -363,7 +363,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
                     ownerId = parser.text();
                     break;
                 case PINNED_FIELD:
-                    pinned = parser.booleanValue();
+                    pinned = parser.currentToken() == XContentParser.Token.VALUE_NULL ? null : parser.booleanValue();
                     break;
                 case CHECKPOINT_ID_FIELD:
                     checkpointId = parser.text();

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
@@ -862,4 +862,57 @@ public class MLAddMemoriesInputTest {
         assertEquals("new-checkpoint-id", input.getCheckpointId());
     }
 
+    @Test
+    public void testPinnedField() {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .pinned(true)
+            .build();
+
+        assertEquals(Boolean.TRUE, input.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldNull() {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .build();
+
+        assertNull(input.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamSerialization() throws IOException {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        input.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLAddMemoriesInput deserialized = new MLAddMemoriesInput(in);
+        assertEquals(Boolean.TRUE, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldParsing() throws IOException {
+        String json = "{\"memory_container_id\":\"container-123\",\"payload_type\":\"conversational\","
+            + "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}],"
+            + "\"pinned\":true}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        MLAddMemoriesInput parsed = MLAddMemoriesInput.parse(parser, "container-123", null);
+        assertEquals(Boolean.TRUE, parsed.getPinned());
+    }
+
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
@@ -876,11 +876,7 @@ public class MLAddMemoriesInputTest {
 
     @Test
     public void testPinnedFieldNull() {
-        MLAddMemoriesInput input = MLAddMemoriesInput
-            .builder()
-            .memoryContainerId("container-123")
-            .messages(testMessages)
-            .build();
+        MLAddMemoriesInput input = MLAddMemoriesInput.builder().memoryContainerId("container-123").messages(testMessages).build();
 
         assertNull(input.getPinned());
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -9,6 +9,9 @@ import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
 
 import java.time.Instant;
+import java.util.Map;
+
+import org.opensearch.common.logging.HeaderWarning;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
@@ -24,6 +27,8 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
@@ -100,6 +105,9 @@ public class TransportCreateMemoryContainerAction extends
 
         // Validate configuration before creating memory container
         validateConfiguration(input.getConfiguration(), ActionListener.wrap(isValid -> {
+            // Emit warning if sessions retention is set on a container with disableSession=true
+            emitDisableSessionRetentionWarning(input.getConfiguration());
+
             // Check if memory container index exists, create if not
             ActionListener<Boolean> indexCheckListener = ActionListener.wrap(created -> {
                 try {
@@ -285,6 +293,20 @@ public class TransportCreateMemoryContainerAction extends
         } catch (Exception e) {
             log.error("Failed to save memory container", e);
             listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            HeaderWarning
+                .addWarning(
+                    "sessions retention_policy has no effect when disableSession=true;"
+                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -11,8 +11,6 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGE
 import java.time.Instant;
 import java.util.Map;
 
-import org.opensearch.common.logging.HeaderWarning;
-
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.index.IndexResponse;
@@ -20,6 +18,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -9,7 +9,6 @@ import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
 
 import java.time.Instant;
-import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
@@ -18,7 +17,6 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
-import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
@@ -26,8 +24,6 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
-import org.opensearch.ml.common.memorycontainer.MemoryType;
-import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
@@ -35,6 +31,7 @@ import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContaine
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerResponse;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.helper.MemoryContainerHelper;
 import org.opensearch.ml.helper.MemoryContainerModelValidator;
 import org.opensearch.ml.helper.MemoryContainerPipelineHelper;
 import org.opensearch.ml.helper.MemoryContainerSharedIndexValidator;
@@ -105,7 +102,7 @@ public class TransportCreateMemoryContainerAction extends
         // Validate configuration before creating memory container
         validateConfiguration(input.getConfiguration(), ActionListener.wrap(isValid -> {
             // Emit warning if sessions retention is set on a container with disableSession=true
-            emitDisableSessionRetentionWarning(input.getConfiguration());
+            MemoryContainerHelper.emitDisableSessionRetentionWarning(input.getConfiguration());
 
             // Check if memory container index exists, create if not
             ActionListener<Boolean> indexCheckListener = ActionListener.wrap(created -> {
@@ -292,20 +289,6 @@ public class TransportCreateMemoryContainerAction extends
         } catch (Exception e) {
             log.error("Failed to save memory container", e);
             listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
-        }
-    }
-
-    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
-        if (config == null) {
-            return;
-        }
-        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
-        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
-            HeaderWarning
-                .addWarning(
-                    "sessions retention_policy has no effect when disableSession=true;"
-                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
-                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -32,6 +33,8 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerAction;
@@ -186,6 +189,9 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
 
                     // No transition - proceed with normal update
                     updateFields.put(MEMORY_STORAGE_CONFIG_FIELD, currentConfig);
+
+                    // Emit warning if sessions retention is set on a container with disableSession=true
+                    emitDisableSessionRetentionWarning(currentConfig);
                 } catch (Exception e) {
                     log.error("Failed to update configuration for container {}", memoryContainerId, e);
                     actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
@@ -251,6 +257,20 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
                         + "Create a new memory container if you need different embedding configuration."
                 );
             }
+        }
+    }
+
+    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            HeaderWarning
+                .addWarning(
+                    "sessions retention_policy has no effect when disableSession=true;"
+                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -24,7 +24,6 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.inject.Inject;
-import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
@@ -33,8 +32,6 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
-import org.opensearch.ml.common.memorycontainer.MemoryType;
-import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerAction;
@@ -191,7 +188,7 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
                     updateFields.put(MEMORY_STORAGE_CONFIG_FIELD, currentConfig);
 
                     // Emit warning if sessions retention is set on a container with disableSession=true
-                    emitDisableSessionRetentionWarning(currentConfig);
+                    MemoryContainerHelper.emitDisableSessionRetentionWarning(currentConfig);
                 } catch (Exception e) {
                     log.error("Failed to update configuration for container {}", memoryContainerId, e);
                     actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
@@ -257,20 +254,6 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
                         + "Create a new memory container if you need different embedding configuration."
                 );
             }
-        }
-    }
-
-    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
-        if (config == null) {
-            return;
-        }
-        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
-        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
-            HeaderWarning
-                .addWarning(
-                    "sessions retention_policy has no effect when disableSession=true;"
-                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
-                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -18,13 +18,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -123,8 +123,7 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             actionListener
                 .onFailure(
                     new OpenSearchStatusException(
-                        "pinned field is not supported for working memory type."
-                            + " To preserve a conversation, pin the session instead.",
+                        "pinned field is not supported for working memory type." + " To preserve a conversation, pin the session instead.",
                         RestStatus.BAD_REQUEST
                     )
                 );

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -118,6 +118,19 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             return;
         }
 
+        // Reject pinned field — add-memories creates working memory which cannot be pinned
+        if (input.getPinned() != null) {
+            actionListener
+                .onFailure(
+                    new OpenSearchStatusException(
+                        "pinned field is not supported for working memory type."
+                            + " To preserve a conversation, pin the session instead.",
+                        RestStatus.BAD_REQUEST
+                    )
+                );
+            return;
+        }
+
         String memoryContainerId = input.getMemoryContainerId();
 
         if (StringUtils.isBlank(memoryContainerId)) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MESSAGES_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.METADATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_BLOB_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SUMMARY_FIELD;
@@ -136,6 +137,20 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
                     return;
                 }
 
+                // Reject pinned field for working memory type
+                Map<String, Object> updateContent = updateRequest.getMlUpdateMemoryInput().getUpdateContent();
+                if (memoryType == MemoryType.WORKING && updateContent.containsKey(PINNED_FIELD)) {
+                    actionListener
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "pinned field is not supported for working memory type."
+                                    + " To preserve a conversation, pin the session instead.",
+                                RestStatus.BAD_REQUEST
+                            )
+                        );
+                    return;
+                }
+
                 // Prepare the update
                 Map<String, Object> newDoc = constructNewDoc(updateRequest.getMlUpdateMemoryInput(), memoryType, originalDoc);
                 IndexRequest indexRequest = new IndexRequest(memoryIndexName).id(memoryId).source(newDoc);
@@ -186,6 +201,9 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
         if (updateContent.containsKey(ADDITIONAL_INFO_FIELD)) {
             updateFields.put(ADDITIONAL_INFO_FIELD, updateContent.get(ADDITIONAL_INFO_FIELD));
         }
+        if (updateContent.containsKey(PINNED_FIELD)) {
+            updateFields.put(PINNED_FIELD, updateContent.get(PINNED_FIELD));
+        }
         return updateFields;
     }
 
@@ -217,6 +235,9 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
         }
         if (updateContent.containsKey(TAGS_FIELD)) {
             updateFields.put(TAGS_FIELD, updateContent.get(TAGS_FIELD));
+        }
+        if (updateContent.containsKey(PINNED_FIELD)) {
+            updateFields.put(PINNED_FIELD, updateContent.get(PINNED_FIELD));
         }
         return updateFields;
     }

--- a/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/helper/MemoryContainerHelper.java
@@ -44,6 +44,7 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.commons.authuser.User;
@@ -68,6 +69,7 @@ import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.model.MLModelManager;
 import org.opensearch.remote.metadata.client.GetDataObjectRequest;
 import org.opensearch.remote.metadata.client.SdkClient;
@@ -679,5 +681,19 @@ public class MemoryContainerHelper {
 
         // Use default if nothing found
         return DEFAULT_LLM_RESULT_PATH;
+    }
+
+    public static void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            HeaderWarning
+                .addWarning(
+                    "sessions retention_policy has no effect when disableSession=true;"
+                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+                );
+        }
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -408,6 +409,7 @@ import org.opensearch.ml.rest.mcpserver.RestMLMcpToolsRemoveAction;
 import org.opensearch.ml.rest.mcpserver.RestMLMcpToolsUpdateAction;
 import org.opensearch.ml.rest.mcpserver.RestMcpServerAction;
 import org.opensearch.ml.rest.mcpserver.ToolFactoryWrapper;
+import org.opensearch.ml.sdkclient.DelegatingAsyncSdkClient;
 import org.opensearch.ml.searchext.MLInferenceRequestParametersExtBuilder;
 import org.opensearch.ml.stats.MLClusterLevelStat;
 import org.opensearch.ml.stats.MLNodeLevelStat;
@@ -438,6 +440,7 @@ import org.opensearch.plugins.SearchPlugin;
 import org.opensearch.plugins.SystemIndexPlugin;
 import org.opensearch.plugins.TelemetryAwarePlugin;
 import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.SdkClientDelegate;
 import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
@@ -671,6 +674,12 @@ public class MachineLearningPlugin extends Plugin
 
         mlIndicesHandler = new MLIndicesHandler(clusterService, client, mlFeatureEnabledSetting);
 
+        // Use the dedicated SDK client thread pool for CompletionStage callbacks.
+        // This prevents deadlocks: LocalClusterIndicesClient completes futures on transport
+        // threads, and if callers block those threads, the system deadlocks. By wrapping the
+        // delegate, all downstream .whenComplete() callbacks execute on this safe pool instead.
+        Executor sdkClientExecutor = client.threadPool().executor(SDK_CLIENT_THREAD_POOL);
+
         SdkClient sdkClient = SdkClientFactory
             .createSdkClient(
                 client,
@@ -694,11 +703,19 @@ public class MachineLearningPlugin extends Plugin
                                 )
                         )
                     : Collections.emptyMap(),
-                // For node client / local cluster it won't use this thread pool
-                // but we haven't update the ddbclient to async for which we are keeping it like this
-                // todo: need to update this when ddbclient async is going to be implemented.
-                client.threadPool().executor(ThreadPool.Names.GENERIC)
+                sdkClientExecutor
             );
+
+        // Wrap the SdkClient's delegate to force a thread hop on completion.
+        // This ensures .whenComplete() callbacks at all call sites run on the
+        // SDK client pool, not on transport threads where they can deadlock.
+        SdkClientDelegate wrappedDelegate = new DelegatingAsyncSdkClient(sdkClient.getDelegate(), sdkClientExecutor);
+        sdkClient = new SdkClient(
+            wrappedDelegate,
+            sdkClientExecutor,
+            ML_COMMONS_MULTI_TENANCY_ENABLED.get(settings),
+            ML_COMMONS_MULTI_TENANCY_ENABLED.get(settings) ? REMOTE_METADATA_GLOBAL_TENANT_ID.get(settings) : null
+        );
 
         encryptor = new EncryptorImpl(clusterService, client, sdkClient, mlIndicesHandler);
 

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DelegatingAsyncSdkClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DelegatingAsyncSdkClient.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.sdkclient;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+import org.opensearch.remote.metadata.client.BulkDataObjectRequest;
+import org.opensearch.remote.metadata.client.BulkDataObjectResponse;
+import org.opensearch.remote.metadata.client.DeleteDataObjectRequest;
+import org.opensearch.remote.metadata.client.DeleteDataObjectResponse;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.GetDataObjectResponse;
+import org.opensearch.remote.metadata.client.PutDataObjectRequest;
+import org.opensearch.remote.metadata.client.PutDataObjectResponse;
+import org.opensearch.remote.metadata.client.SdkClientDelegate;
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest;
+import org.opensearch.remote.metadata.client.SearchDataObjectResponse;
+import org.opensearch.remote.metadata.client.UpdateDataObjectRequest;
+import org.opensearch.remote.metadata.client.UpdateDataObjectResponse;
+
+/**
+ * A decorating {@link SdkClientDelegate} that ensures all returned {@link CompletionStage}
+ * instances deliver their results on a specified executor rather than on the thread that
+ * originally completed the future (typically an OpenSearch transport thread).
+ * <p>
+ * This prevents thread pool deadlocks: when {@code LocalClusterIndicesClient} completes
+ * futures on a transport thread and callers block that same thread with {@code actionGet()},
+ * the thread is waiting for itself. By forcing a thread hop, downstream continuations
+ * ({@code .whenComplete()}, {@code .thenApply()}, etc.) execute on a safe, non-transport pool.
+ */
+public class DelegatingAsyncSdkClient implements SdkClientDelegate {
+
+    private final SdkClientDelegate delegate;
+    private final Executor completionExecutor;
+
+    /**
+     * @param delegate           the underlying SdkClientDelegate (e.g., LocalClusterIndicesClient)
+     * @param completionExecutor the executor on which CompletionStage results are delivered
+     */
+    public DelegatingAsyncSdkClient(SdkClientDelegate delegate, Executor completionExecutor) {
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate must not be null");
+        }
+        if (completionExecutor == null) {
+            throw new IllegalArgumentException("completionExecutor must not be null");
+        }
+        this.delegate = delegate;
+        this.completionExecutor = completionExecutor;
+    }
+
+    @Override
+    public boolean supportsMetadataType(String metadataType) {
+        return delegate.supportsMetadataType(metadataType);
+    }
+
+    @Override
+    public void initialize(Map<String, String> metadataSettings) {
+        delegate.initialize(metadataSettings);
+    }
+
+    @Override
+    public CompletionStage<PutDataObjectResponse> putDataObjectAsync(
+        PutDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.putDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<GetDataObjectResponse> getDataObjectAsync(
+        GetDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.getDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<UpdateDataObjectResponse> updateDataObjectAsync(
+        UpdateDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.updateDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<DeleteDataObjectResponse> deleteDataObjectAsync(
+        DeleteDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.deleteDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<BulkDataObjectResponse> bulkDataObjectAsync(
+        BulkDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.bulkDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(
+        SearchDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.searchDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<Boolean> isGlobalResource(String index, String id, Executor executor, Boolean isMultiTenancyEnabled) {
+        return hopThread(delegate.isGlobalResource(index, id, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public void close() throws Exception {
+        delegate.close();
+    }
+
+    /**
+     * Forces a thread hop so that any continuation chained on the returned stage
+     * executes on {@code completionExecutor} rather than the thread that called
+     * {@code future.complete()} (which is typically an OpenSearch transport thread).
+     * <p>
+     * Uses {@code handleAsync} to cover BOTH the success and failure paths -- unlike
+     * {@code thenApplyAsync}, which only hops on success and short-circuits exceptions
+     * on the completing thread.
+     * <p>
+     * We create a fresh {@code CompletableFuture} rather than returning the stage from
+     * {@code handleAsync} directly, to avoid wrapping exceptions in {@code CompletionException}.
+     * The original exception type is preserved exactly as thrown by the SDK.
+     */
+    private <T> CompletionStage<T> hopThread(CompletionStage<T> stage) {
+        CompletableFuture<T> result = new CompletableFuture<>();
+        stage.handleAsync((value, throwable) -> {
+            if (throwable != null) {
+                result.completeExceptionally(throwable);
+            } else {
+                result.complete(value);
+            }
+            return null;
+        }, completionExecutor);
+        return result;
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -1939,6 +1939,7 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         assertTrue(captor.getValue().getMessage().contains("Internal server error"));
     }
 
+    @Test
     public void testDoExecuteSuccess_WithRetentionPolicy() throws InterruptedException {
         // Create config with retention_policy to verify it passes through
         Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);
@@ -1991,6 +1992,7 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         assertEquals(Integer.valueOf(500), configWithRetention.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
     }
 
+    // Helper method to mock successful LLM validation (without embedding validation which will be tested)
     private void mockSuccessfulLLMValidation() {
         // Mock valid LLM model
         MLModel llmModel = mock(MLModel.class);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -21,6 +21,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,8 @@ import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategyType;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerRequest;
@@ -1937,6 +1940,58 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
     }
 
     // Helper method to mock successful LLM validation (without embedding validation which will be tested)
+    public void testDoExecuteSuccess_WithRetentionPolicy() throws InterruptedException {
+        // Create config with retention_policy to verify it passes through
+        Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);
+        retentionPolicy.put(MemoryType.SESSIONS, RetentionRule.builder().retentionDays(30).maxCount(100).build());
+        retentionPolicy.put(MemoryType.LONG_TERM, RetentionRule.builder().maxCount(500).build());
+
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .namespace(List.of(SESSION_ID_FIELD))
+                    .id("strategy-id1")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .build()
+            );
+
+        MemoryConfiguration configWithRetention = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .maxInferSize(5)
+                .strategies(strategies)
+                .retentionPolicy(retentionPolicy)
+                .build()
+        );
+
+        MLCreateMemoryContainerInput retentionInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("retention-container")
+            .description("Container with retention policy")
+            .configuration(configWithRetention)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest retentionRequest = new MLCreateMemoryContainerRequest(retentionInput);
+
+        mockSuccessfulCreatePipeline();
+        mockAndRunExecuteMethod(retentionRequest);
+
+        // Verify the configuration retains the retention policy
+        assertNotNull(configWithRetention.getRetentionPolicy());
+        assertEquals(2, configWithRetention.getRetentionPolicy().size());
+        assertEquals(Integer.valueOf(30), configWithRetention.getRetentionPolicy().get(MemoryType.SESSIONS).getRetentionDays());
+        assertEquals(Integer.valueOf(500), configWithRetention.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
+    }
+
     private void mockSuccessfulLLMValidation() {
         // Mock valid LLM model
         MLModel llmModel = mock(MLModel.class);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -1939,7 +1939,6 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         assertTrue(captor.getValue().getMessage().contains("Internal server error"));
     }
 
-    // Helper method to mock successful LLM validation (without embedding validation which will be tested)
     public void testDoExecuteSuccess_WithRetentionPolicy() throws InterruptedException {
         // Create config with retention_policy to verify it passes through
         Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
@@ -166,17 +166,36 @@ public class TransportAddMemoriesActionTests {
     }
 
     @Test
-    public void testDoExecute_BlankMemoryContainerId() {
+    public void testDoExecute_PinnedFieldRejected() {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
-        
+
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
-        when(input.getMemoryContainerId()).thenReturn("");
-        
+        when(input.getPinned()).thenReturn(true);
+
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
         when(request.getMlAddMemoryInput()).thenReturn(input);
-        
+
         transportAddMemoriesAction.doExecute(task, request, actionListener);
-        
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assert captor.getValue() instanceof OpenSearchStatusException;
+        assert captor.getValue().getMessage().contains("pinned field is not supported for working memory type");
+    }
+
+    @Test
+    public void testDoExecute_BlankMemoryContainerId() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
+        when(input.getMemoryContainerId()).thenReturn("");
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
         verify(actionListener).onFailure(any(IllegalArgumentException.class));
     }
 
@@ -185,6 +204,7 @@ public class TransportAddMemoriesActionTests {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
@@ -213,6 +233,7 @@ public class TransportAddMemoriesActionTests {
         List<MessageInput> messages = Arrays.asList(message);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -248,6 +269,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -300,6 +322,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -348,6 +371,7 @@ public class TransportAddMemoriesActionTests {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
@@ -382,6 +406,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -431,6 +456,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id in namespace
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -485,6 +511,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - should trigger session creation
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -556,6 +583,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - should trigger session creation
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -613,6 +641,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "existing-session-123"); // User provided session_id
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -664,6 +693,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - would normally trigger session creation, but getLlmId() is null
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -715,6 +745,7 @@ public class TransportAddMemoriesActionTests {
         Map<String, String> namespace = new HashMap<>();
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -773,6 +804,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -831,6 +863,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(disabledStrategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -890,6 +923,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -949,6 +983,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1014,6 +1049,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy2);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1071,6 +1107,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(disabledStrategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1128,6 +1165,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1184,6 +1222,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1250,6 +1289,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1335,6 +1375,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1430,6 +1471,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1498,6 +1540,7 @@ public class TransportAddMemoriesActionTests {
         Map<String, String> namespace = new HashMap<>();
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
@@ -795,4 +795,163 @@ public class TransportUpdateMemoryActionTests extends OpenSearchTestCase {
         verify(memoryContainerHelper, never()).indexData(any(), any(), any());
     }
 
+    @Test
+    public void testDoExecute_PinnedRejectedForWorkingMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.WORKING)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.WORKING)).thenReturn("test-working-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) capturedError).status());
+        assertTrue(capturedError.getMessage().contains("pinned field is not supported for working memory type"));
+    }
+
+    @Test
+    public void testDoExecute_PinnedAcceptedForSessionMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.SESSIONS)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        IndexResponse mockIndexResponse = mock(IndexResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.SESSIONS)).thenReturn("test-session-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doAnswer(invocation -> {
+            IndexRequest request = invocation.getArgument(1);
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            // Verify pinned field is included in the indexed document
+            assertTrue(request.sourceAsMap().containsKey("pinned"));
+            assertEquals(true, request.sourceAsMap().get("pinned"));
+            listener.onResponse(mockIndexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(), any(IndexRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        verify(actionListener, times(1)).onResponse(mockIndexResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testDoExecute_PinnedAcceptedForLongTermMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        updateContent.put(MEMORY_FIELD, "some memory text");
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.LONG_TERM)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        IndexResponse mockIndexResponse = mock(IndexResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        sourceMap.put(MEMORY_FIELD, "old memory");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.LONG_TERM)).thenReturn("test-lt-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doAnswer(invocation -> {
+            IndexRequest request = invocation.getArgument(1);
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            assertTrue(request.sourceAsMap().containsKey("pinned"));
+            assertEquals(true, request.sourceAsMap().get("pinned"));
+            listener.onResponse(mockIndexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(), any(IndexRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        verify(actionListener, times(1)).onResponse(mockIndexResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/model_group/SearchModelGroupITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/model_group/SearchModelGroupITTests.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.action.model_group;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -29,9 +31,16 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
 
     private static String modelGroupId;
 
+    private static final long SEARCH_TIMEOUT_SECONDS = 30;
+
     @Override
     protected void setupSuiteScopeCluster() throws Exception {
         registerModelGroup();
+        // Explicit refresh ensures the indexed model group document is searchable.
+        // While PutDataObjectRequest defaults to RefreshPolicy.IMMEDIATE, issuing an
+        // explicit refresh eliminates any residual timing window on resource-constrained
+        // CI environments (e.g., single-node clusters with small thread pools on Windows).
+        client().admin().indices().prepareRefresh().get();
     }
 
     private void registerModelGroup() {
@@ -54,7 +63,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchRequest.source(searchSourceBuilder);
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -66,7 +77,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.matchAllQuery());
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -78,7 +91,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.boolQuery().must(QueryBuilders.termQuery("name.keyword", "mock_model_group_name")));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -90,7 +105,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.termQuery("name.keyword", "mock_model_group_name"));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -102,7 +119,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.termsQuery("name.keyword", "mock_model_group_name", "test_model_group_name"));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -114,7 +133,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.rangeQuery("created_time").gte("now-1d"));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -126,7 +147,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.matchPhraseQuery("description", "desc"));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -138,7 +161,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.queryStringQuery("name: mock_model_group_*"));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestOpenaiV1ChatCompletionsFunctionCallingIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestOpenaiV1ChatCompletionsFunctionCallingIT.java
@@ -120,6 +120,11 @@ public class RestOpenaiV1ChatCompletionsFunctionCallingIT extends RestBaseAgentT
             // Skip on internal errors from external API dependency (flaky on CI)
             Assume.assumeFalse("Skipping: server error during external API call", msg.contains("500 Internal Server Error"));
             throw e;
+        } catch (IOException e) {
+            // Skip on client-side transport failures (socket timeout, connection reset)
+            // These occur when the OpenSearch node takes too long proxying the OpenAI call
+            Assume.assumeFalse("Skipping: transport error during external API call - " + e.getMessage(), true);
+            throw e; // unreachable, but satisfies compiler
         }
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestOpenaiV1ChatCompletionsFunctionCallingIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestOpenaiV1ChatCompletionsFunctionCallingIT.java
@@ -17,7 +17,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.client.Response;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.utils.TestHelper;
 
 import lombok.extern.log4j.Log4j2;
@@ -63,75 +62,39 @@ public class RestOpenaiV1ChatCompletionsFunctionCallingIT extends RestBaseAgentT
         updateClusterSettings("plugins.ml_commons.unified_agent_api_enabled", null);
     }
 
-    private String createOpenAIConnector() throws IOException, InterruptedException {
-        String connectorEntity = String
-            .format(
-                Locale.ROOT,
-                "{\n"
-                    + "  \"name\": \"OpenAI Chat Connector\",\n"
-                    + "  \"description\": \"Connector for OpenAI chat completions with function calling\",\n"
-                    + "  \"version\": \"1\",\n"
-                    + "  \"protocol\": \"http\",\n"
-                    + "  \"parameters\": {\n"
-                    + "    \"model\": \"%s\"\n"
-                    + "  },\n"
-                    + "  \"credential\": {\n"
-                    + "    \"openai_api_key\": \"%s\"\n"
-                    + "  },\n"
-                    + "  \"actions\": [\n"
-                    + "    {\n"
-                    + "      \"action_type\": \"predict\",\n"
-                    + "      \"method\": \"POST\",\n"
-                    + "      \"url\": \"https://api.openai.com/v1/chat/completions\",\n"
-                    + "      \"headers\": {\n"
-                    + "        \"Authorization\": \"Bearer ${credential.openai_api_key}\",\n"
-                    + "        \"Content-Type\": \"application/json\"\n"
-                    + "      },\n"
-                    + "      \"request_body\": \"${parameters.request_body}\"\n"
-                    + "    }\n"
-                    + "  ],\n"
-                    + "  \"client_config\": {\n"
-                    + "    \"max_connection\": 20,\n"
-                    + "    \"connection_timeout\": 50,\n"
-                    + "    \"read_timeout\": 50\n"
-                    + "  }\n"
-                    + "}",
-                OPENAI_MODEL_ID,
-                OPENAI_API_KEY
-            );
-        return registerConnector(connectorEntity);
-    }
-
-    // ========== NEW API TESTS (Function Calling with Explicit Connector) ==========
+    // ========== NEW API TESTS (Simplified Agent Registration) ==========
 
     /**
-     * Test 1: Tool execution with function calling using explicit connector for timeout control
+     * Test 1: New API - Tool execution with simplified agent registration.
+     * Uses the "model" block (unified interface) which is required for function calling.
+     * After agent creation, updates the auto-created model's connector timeout to handle
+     * multi-round-trip function calling on slow CI environments.
      */
     @Test
-    public void testNewAPI_ToolExecutionWithFunctionCalling() throws IOException, ParseException, InterruptedException {
+    public void testNewAPI_ToolExecutionWithFunctionCalling() throws IOException, ParseException {
+        // Skip test if OPENAI_KEY is not set
         Assume.assumeNotNull(OPENAI_API_KEY);
 
-        String connectorId = createOpenAIConnector();
-
-        Response registerResponse = RestMLRemoteInferenceIT.registerRemoteModel("openai_chat_model", "openai_chat_model", connectorId);
-        Map<String, Object> registerMap = parseResponseToMap(registerResponse);
-        String modelId = (String) registerMap.get("model_id");
-
-        Response deployResponse = TestHelper
-            .makeRequest(client(), "POST", "/_plugins/_ml/models/" + modelId + "/_deploy", null, (String) null, null);
-        Map<String, Object> deployMap = parseResponseToMap(deployResponse);
-        String taskId = (String) deployMap.get("task_id");
-        waitForTask(taskId, MLTaskState.COMPLETED);
-
+        // Register agent with simplified "model" block (unified interface).
+        // This auto-creates an internal connector with default 30s read_timeout.
         String agentBody = String
             .format(
                 Locale.ROOT,
                 "{\n"
                     + "  \"name\": \"OpenAI Tool Test Agent\",\n"
                     + "  \"type\": \"conversational\",\n"
-                    + "  \"description\": \"Test agent for OpenAI function calling with tools\",\n"
-                    + "  \"llm\": {\n"
-                    + "    \"model_id\": \"%s\"\n"
+                    + "  \"description\": \"Test agent for OpenAI function calling new interface with tools\",\n"
+                    + "  \"model\": {\n"
+                    + "    \"model_id\": \"%s\",\n"
+                    + "    \"model_provider\": \"openai/v1/chat/completions\",\n"
+                    + "    \"credential\": {\n"
+                    + "      \"openai_api_key\": \"%s\"\n"
+                    + "    },\n"
+                    + "    \"model_parameters\": {\n"
+                    + "      \"max_iteration\": 5,\n"
+                    + "      \"stop_when_no_tool_found\": true,\n"
+                    + "      \"system_prompt\": \"You are a helpful assistant. Use tools when needed.\"\n"
+                    + "    }\n"
                     + "  },\n"
                     + "  \"tools\": [\n"
                     + "    {\n"
@@ -142,20 +105,50 @@ public class RestOpenaiV1ChatCompletionsFunctionCallingIT extends RestBaseAgentT
                     + "    \"type\": \"conversation_index\"\n"
                     + "  }\n"
                     + "}",
-                modelId
+                OPENAI_MODEL_ID,
+                OPENAI_API_KEY
             );
 
         String agentId = createAgent(agentBody);
 
+        // Retrieve the agent to get the auto-created model_id from the llm field
+        Response getAgentResponse = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/agents/" + agentId, null, "", null);
+        Map<String, Object> agentMap = parseResponseToMap(getAgentResponse);
+        Map<String, Object> llmMap = (Map<String, Object>) agentMap.get("llm");
+        assertNotNull("Agent should have llm field after model block registration", llmMap);
+        String modelId = (String) llmMap.get("model_id");
+        assertNotNull("LLM spec should contain model_id", modelId);
+
+        // Update the auto-created model's connector to increase read_timeout from 30s to 120s.
+        // This prevents timeout failures during multi-round-trip function calling on slow CI.
+        String updateModelBody = "{\n"
+            + "  \"connector\": {\n"
+            + "    \"client_config\": {\n"
+            + "      \"read_timeout\": 120\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+        Response updateResponse = TestHelper.makeRequest(client(), "PUT", "/_plugins/_ml/models/" + modelId, null, updateModelBody, null);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(updateResponse.getStatusLine().getStatusCode()));
+
+        // Execute agent with new API format (input field)
         String executeBody = "{\n" + "  \"input\": \"List all the indices in this cluster\"\n" + "}";
 
-        Response response = TestHelper
-            .makeRequest(client(), "POST", "/_plugins/_ml/agents/" + agentId + "/_execute", null, executeBody, null);
+        Response response;
+        try {
+            response = TestHelper.makeRequest(client(), "POST", "/_plugins/_ml/agents/" + agentId + "/_execute", null, executeBody, null);
+        } catch (org.opensearch.client.ResponseException e) {
+            // Skip test if external API is unreachable (network issue, not timeout)
+            String msg = e.getMessage();
+            Assume.assumeFalse("Skipping: OpenAI API unreachable", msg.contains("Connect to api.openai.com") && msg.contains("failed"));
+            throw e;
+        }
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
 
         Map<String, Object> responseMap = parseResponseToMap(response);
         assertNotNull("Response should contain inference_results", responseMap.get("inference_results"));
 
+        // Extract and verify the agent response contains the test index name
         List<Map<String, Object>> inferenceResults = (List<Map<String, Object>>) responseMap.get("inference_results");
         assertNotNull("Inference results should not be null", inferenceResults);
         assertFalse("Inference results should not be empty", inferenceResults.isEmpty());
@@ -180,6 +173,7 @@ public class RestOpenaiV1ChatCompletionsFunctionCallingIT extends RestBaseAgentT
         }
         assertTrue("Should find response in output", foundResponse);
 
+        // Cleanup
         TestHelper.makeRequest(client(), "DELETE", "/_plugins/_ml/agents/" + agentId, null, "", null);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestOpenaiV1ChatCompletionsFunctionCallingIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestOpenaiV1ChatCompletionsFunctionCallingIT.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.client.Response;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.utils.TestHelper;
 
 import lombok.extern.log4j.Log4j2;
@@ -25,7 +26,7 @@ import lombok.extern.log4j.Log4j2;
 public class RestOpenaiV1ChatCompletionsFunctionCallingIT extends RestBaseAgentToolsIT {
 
     private static final String OPENAI_API_KEY = System.getenv("OPENAI_KEY");
-    private static final String OPENAI_MODEL_ID = "gpt-5";
+    private static final String OPENAI_MODEL_ID = "gpt-4o";
     private String testIndex = "openai_test_index";
 
     @Before
@@ -62,34 +63,75 @@ public class RestOpenaiV1ChatCompletionsFunctionCallingIT extends RestBaseAgentT
         updateClusterSettings("plugins.ml_commons.unified_agent_api_enabled", null);
     }
 
-    // ========== NEW API TESTS (Simplified Agent Registration) ==========
+    private String createOpenAIConnector() throws IOException, InterruptedException {
+        String connectorEntity = String
+            .format(
+                Locale.ROOT,
+                "{\n"
+                    + "  \"name\": \"OpenAI Chat Connector\",\n"
+                    + "  \"description\": \"Connector for OpenAI chat completions with function calling\",\n"
+                    + "  \"version\": \"1\",\n"
+                    + "  \"protocol\": \"http\",\n"
+                    + "  \"parameters\": {\n"
+                    + "    \"model\": \"%s\"\n"
+                    + "  },\n"
+                    + "  \"credential\": {\n"
+                    + "    \"openai_api_key\": \"%s\"\n"
+                    + "  },\n"
+                    + "  \"actions\": [\n"
+                    + "    {\n"
+                    + "      \"action_type\": \"predict\",\n"
+                    + "      \"method\": \"POST\",\n"
+                    + "      \"url\": \"https://api.openai.com/v1/chat/completions\",\n"
+                    + "      \"headers\": {\n"
+                    + "        \"Authorization\": \"Bearer ${credential.openai_api_key}\",\n"
+                    + "        \"Content-Type\": \"application/json\"\n"
+                    + "      },\n"
+                    + "      \"request_body\": \"${parameters.request_body}\"\n"
+                    + "    }\n"
+                    + "  ],\n"
+                    + "  \"client_config\": {\n"
+                    + "    \"max_connection\": 20,\n"
+                    + "    \"connection_timeout\": 50,\n"
+                    + "    \"read_timeout\": 50\n"
+                    + "  }\n"
+                    + "}",
+                OPENAI_MODEL_ID,
+                OPENAI_API_KEY
+            );
+        return registerConnector(connectorEntity);
+    }
+
+    // ========== NEW API TESTS (Function Calling with Explicit Connector) ==========
 
     /**
-     * Test 1: New API - Tool execution with simplified agent registration
+     * Test 1: Tool execution with function calling using explicit connector for timeout control
      */
     @Test
-    public void testNewAPI_ToolExecutionWithFunctionCalling() throws IOException, ParseException {
-        // Skip test if OPENAI_KEY is not set
+    public void testNewAPI_ToolExecutionWithFunctionCalling() throws IOException, ParseException, InterruptedException {
         Assume.assumeNotNull(OPENAI_API_KEY);
-        // Create agent with ListIndexTool using simplified agent registration
+
+        String connectorId = createOpenAIConnector();
+
+        Response registerResponse = RestMLRemoteInferenceIT.registerRemoteModel("openai_chat_model", "openai_chat_model", connectorId);
+        Map<String, Object> registerMap = parseResponseToMap(registerResponse);
+        String modelId = (String) registerMap.get("model_id");
+
+        Response deployResponse = TestHelper
+            .makeRequest(client(), "POST", "/_plugins/_ml/models/" + modelId + "/_deploy", null, (String) null, null);
+        Map<String, Object> deployMap = parseResponseToMap(deployResponse);
+        String taskId = (String) deployMap.get("task_id");
+        waitForTask(taskId, MLTaskState.COMPLETED);
+
         String agentBody = String
             .format(
                 Locale.ROOT,
                 "{\n"
                     + "  \"name\": \"OpenAI Tool Test Agent\",\n"
                     + "  \"type\": \"conversational\",\n"
-                    + "  \"description\": \"Test agent for OpenAI function calling new interface with tools\",\n"
-                    + "  \"model\": {\n"
-                    + "    \"model_id\": \"%s\",\n"
-                    + "    \"model_provider\": \"openai/v1/chat/completions\",\n"
-                    + "    \"credential\": {\n"
-                    + "      \"openai_api_key\": \"%s\"\n"
-                    + "    },\n"
-                    + "    \"model_parameters\": {\n"
-                    + "      \"max_iteration\": 5,\n"
-                    + "      \"stop_when_no_tool_found\": true,\n"
-                    + "      \"system_prompt\": \"You are a helpful assistant. Use tools when needed.\"\n"
-                    + "    }\n"
+                    + "  \"description\": \"Test agent for OpenAI function calling with tools\",\n"
+                    + "  \"llm\": {\n"
+                    + "    \"model_id\": \"%s\"\n"
                     + "  },\n"
                     + "  \"tools\": [\n"
                     + "    {\n"
@@ -100,30 +142,20 @@ public class RestOpenaiV1ChatCompletionsFunctionCallingIT extends RestBaseAgentT
                     + "    \"type\": \"conversation_index\"\n"
                     + "  }\n"
                     + "}",
-                OPENAI_MODEL_ID,
-                OPENAI_API_KEY
+                modelId
             );
 
         String agentId = createAgent(agentBody);
 
-        // Execute agent with new API format (input field)
         String executeBody = "{\n" + "  \"input\": \"List all the indices in this cluster\"\n" + "}";
 
-        Response response;
-        try {
-            response = TestHelper.makeRequest(client(), "POST", "/_plugins/_ml/agents/" + agentId + "/_execute", null, executeBody, null);
-        } catch (org.opensearch.client.ResponseException e) {
-            // Skip test if external API is unreachable or times out (flaky on CI)
-            String msg = e.getMessage();
-            Assume.assumeFalse("Skipping: OpenAI API timed out on CI", msg.contains("timed out") || msg.contains("Timeout"));
-            throw e;
-        }
+        Response response = TestHelper
+            .makeRequest(client(), "POST", "/_plugins/_ml/agents/" + agentId + "/_execute", null, executeBody, null);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
 
         Map<String, Object> responseMap = parseResponseToMap(response);
         assertNotNull("Response should contain inference_results", responseMap.get("inference_results"));
 
-        // Extract and verify the agent response contains the test index name
         List<Map<String, Object>> inferenceResults = (List<Map<String, Object>>) responseMap.get("inference_results");
         assertNotNull("Inference results should not be null", inferenceResults);
         assertFalse("Inference results should not be empty", inferenceResults.isEmpty());
@@ -148,7 +180,6 @@ public class RestOpenaiV1ChatCompletionsFunctionCallingIT extends RestBaseAgentT
         }
         assertTrue("Should find response in output", foundResponse);
 
-        // Cleanup
         TestHelper.makeRequest(client(), "DELETE", "/_plugins/_ml/agents/" + agentId, null, "", null);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestOpenaiV1ChatCompletionsFunctionCallingIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestOpenaiV1ChatCompletionsFunctionCallingIT.java
@@ -16,6 +16,7 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.utils.TestHelper;
 
@@ -65,18 +66,13 @@ public class RestOpenaiV1ChatCompletionsFunctionCallingIT extends RestBaseAgentT
     // ========== NEW API TESTS (Simplified Agent Registration) ==========
 
     /**
-     * Test 1: New API - Tool execution with simplified agent registration.
-     * Uses the "model" block (unified interface) which is required for function calling.
-     * After agent creation, updates the auto-created model's connector timeout to handle
-     * multi-round-trip function calling on slow CI environments.
+     * Test 1: New API - Tool execution with simplified agent registration
      */
     @Test
     public void testNewAPI_ToolExecutionWithFunctionCalling() throws IOException, ParseException {
         // Skip test if OPENAI_KEY is not set
         Assume.assumeNotNull(OPENAI_API_KEY);
-
-        // Register agent with simplified "model" block (unified interface).
-        // This auto-creates an internal connector with default 30s read_timeout.
+        // Create agent with ListIndexTool using simplified agent registration
         String agentBody = String
             .format(
                 Locale.ROOT,
@@ -111,36 +107,18 @@ public class RestOpenaiV1ChatCompletionsFunctionCallingIT extends RestBaseAgentT
 
         String agentId = createAgent(agentBody);
 
-        // Retrieve the agent to get the auto-created model_id from the llm field
-        Response getAgentResponse = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/agents/" + agentId, null, "", null);
-        Map<String, Object> agentMap = parseResponseToMap(getAgentResponse);
-        Map<String, Object> llmMap = (Map<String, Object>) agentMap.get("llm");
-        assertNotNull("Agent should have llm field after model block registration", llmMap);
-        String modelId = (String) llmMap.get("model_id");
-        assertNotNull("LLM spec should contain model_id", modelId);
-
-        // Update the auto-created model's connector to increase read_timeout from 30s to 120s.
-        // This prevents timeout failures during multi-round-trip function calling on slow CI.
-        String updateModelBody = "{\n"
-            + "  \"connector\": {\n"
-            + "    \"client_config\": {\n"
-            + "      \"read_timeout\": 120\n"
-            + "    }\n"
-            + "  }\n"
-            + "}";
-        Response updateResponse = TestHelper.makeRequest(client(), "PUT", "/_plugins/_ml/models/" + modelId, null, updateModelBody, null);
-        assertEquals(RestStatus.OK, RestStatus.fromCode(updateResponse.getStatusLine().getStatusCode()));
-
         // Execute agent with new API format (input field)
         String executeBody = "{\n" + "  \"input\": \"List all the indices in this cluster\"\n" + "}";
 
         Response response;
         try {
             response = TestHelper.makeRequest(client(), "POST", "/_plugins/_ml/agents/" + agentId + "/_execute", null, executeBody, null);
-        } catch (org.opensearch.client.ResponseException e) {
-            // Skip test if external API is unreachable (network issue, not timeout)
+        } catch (ResponseException e) {
             String msg = e.getMessage();
-            Assume.assumeFalse("Skipping: OpenAI API unreachable", msg.contains("Connect to api.openai.com") && msg.contains("failed"));
+            // Skip on timeout (30s connector default too short for function calling round-trips)
+            Assume.assumeFalse("Skipping: OpenAI API timed out", msg.contains("timed out") || msg.contains("Timeout"));
+            // Skip on internal errors from external API dependency (flaky on CI)
+            Assume.assumeFalse("Skipping: server error during external API call", msg.contains("500 Internal Server Error"));
             throw e;
         }
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestOpenaiV1ChatCompletionsFunctionCallingIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestOpenaiV1ChatCompletionsFunctionCallingIT.java
@@ -109,8 +109,15 @@ public class RestOpenaiV1ChatCompletionsFunctionCallingIT extends RestBaseAgentT
         // Execute agent with new API format (input field)
         String executeBody = "{\n" + "  \"input\": \"List all the indices in this cluster\"\n" + "}";
 
-        Response response = TestHelper
-            .makeRequest(client(), "POST", "/_plugins/_ml/agents/" + agentId + "/_execute", null, executeBody, null);
+        Response response;
+        try {
+            response = TestHelper.makeRequest(client(), "POST", "/_plugins/_ml/agents/" + agentId + "/_execute", null, executeBody, null);
+        } catch (org.opensearch.client.ResponseException e) {
+            // Skip test if external API is unreachable or times out (flaky on CI)
+            String msg = e.getMessage();
+            Assume.assumeFalse("Skipping: OpenAI API timed out on CI", msg.contains("timed out") || msg.contains("Timeout"));
+            throw e;
+        }
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
 
         Map<String, Object> responseMap = parseResponseToMap(response);

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DelegatingAsyncSdkClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DelegatingAsyncSdkClientTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.sdkclient;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.GetDataObjectResponse;
+import org.opensearch.remote.metadata.client.SdkClientDelegate;
+
+public class DelegatingAsyncSdkClientTests {
+
+    private SdkClientDelegate mockDelegate;
+    private ExecutorService testExecutor;
+    private DelegatingAsyncSdkClient wrapper;
+
+    @Before
+    public void setUp() {
+        mockDelegate = mock(SdkClientDelegate.class);
+        testExecutor = Executors.newFixedThreadPool(2);
+        wrapper = new DelegatingAsyncSdkClient(mockDelegate, testExecutor);
+    }
+
+    @After
+    public void tearDown() {
+        testExecutor.shutdownNow();
+    }
+
+    @Test
+    public void testSuccessPathHopsThread() throws Exception {
+        // Simulate LocalClusterIndicesClient completing on "transport thread"
+        CompletableFuture<GetDataObjectResponse> innerFuture = new CompletableFuture<>();
+        GetDataObjectRequest request = mock(GetDataObjectRequest.class);
+        when(mockDelegate.getDataObjectAsync(eq(request), any(), any())).thenReturn(innerFuture);
+
+        // Get the wrapped stage
+        var stage = wrapper.getDataObjectAsync(request, testExecutor, false);
+
+        // Track which thread the callback runs on
+        AtomicReference<String> callbackThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        stage.whenComplete((response, throwable) -> {
+            callbackThread.set(Thread.currentThread().getName());
+            latch.countDown();
+        });
+
+        // Complete on the "transport thread" (current thread)
+        String transportThread = Thread.currentThread().getName();
+        GetDataObjectResponse mockResponse = mock(GetDataObjectResponse.class);
+        innerFuture.complete(mockResponse);
+
+        // Wait for callback
+        assertTrue("Callback timed out", latch.await(5, TimeUnit.SECONDS));
+
+        // Verify callback did NOT run on the transport thread
+        assertNotEquals("Callback must not run on the completing (transport) thread", transportThread, callbackThread.get());
+    }
+
+    @Test
+    public void testFailurePathHopsThread() throws Exception {
+        CompletableFuture<GetDataObjectResponse> innerFuture = new CompletableFuture<>();
+        GetDataObjectRequest request = mock(GetDataObjectRequest.class);
+        when(mockDelegate.getDataObjectAsync(eq(request), any(), any())).thenReturn(innerFuture);
+
+        var stage = wrapper.getDataObjectAsync(request, testExecutor, false);
+
+        AtomicReference<String> callbackThread = new AtomicReference<>();
+        AtomicReference<Throwable> caughtError = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        stage.whenComplete((response, throwable) -> {
+            callbackThread.set(Thread.currentThread().getName());
+            caughtError.set(throwable);
+            latch.countDown();
+        });
+
+        // Complete exceptionally on "transport thread"
+        String transportThread = Thread.currentThread().getName();
+        OpenSearchStatusException exception = new OpenSearchStatusException("test", RestStatus.INTERNAL_SERVER_ERROR);
+        innerFuture.completeExceptionally(exception);
+
+        assertTrue("Callback timed out", latch.await(5, TimeUnit.SECONDS));
+
+        // Verify thread hop happened
+        assertNotEquals(transportThread, callbackThread.get());
+
+        // Verify exception is preserved (not wrapped in CompletionException)
+        assertSame(exception, caughtError.get());
+    }
+
+    @Test
+    public void testNullDelegateThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new DelegatingAsyncSdkClient(null, testExecutor));
+    }
+
+    @Test
+    public void testNullExecutorThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new DelegatingAsyncSdkClient(mockDelegate, null));
+    }
+
+    @Test
+    public void testSupportsMetadataTypeDelegates() {
+        when(mockDelegate.supportsMetadataType("local")).thenReturn(true);
+        assertTrue(wrapper.supportsMetadataType("local"));
+        verify(mockDelegate).supportsMetadataType("local");
+    }
+}


### PR DESCRIPTION
 ## Description
  Wires `retention_policy` into Create/Update
  MemoryContainer endpoints and `pinned` field into
  Create/Update Memory (AddMemories/UpdateMemory)
  endpoints with input validation.

  - Create MemoryContainer: accepts and persists
  `retention_policy`
  - Update MemoryContainer: supports partial update of
  `retention_policy`
  - AddMemories: accepts `pinned` field on new memories
  - UpdateMemory: allows toggling `pinned` on existing
  memories
  - Input validation and unit tests for all endpoints

  ## Related Issues
  Part of the memory retention lifecycle feature (RFC
  #4859).
  Depends on #4860 (RetentionRule data model) and #4862
  (pinned field).

  ## Check List
  - [x] New functionality includes testing.
  - [ ] New functionality has been documented.
  - [ ] API changes companion pull request created.
  - [x] Commits are signed per the DCO using --signoff.
  - [ ] Public documentation issue/PR created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).