### PR TITLE
Feature memory retention (PR4/PR5)

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -5,8 +5,8 @@
 
 repositories {
     mavenLocal()
-    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     mavenCentral()
     maven {url 'https://oss.sonatype.org/content/repositories/snapshots/'}
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
@@ -102,7 +103,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = in.readOptionalString();
         this.memoryContainerId = in.readOptionalString();
         this.strategyId = in.readOptionalString();
-        this.pinned = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 
@@ -127,7 +130,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         out.writeOptionalString(ownerId);
         out.writeOptionalString(memoryContainerId);
         out.writeOptionalString(strategyId);
-        out.writeOptionalBoolean(pinned);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
@@ -6,7 +6,7 @@
 package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
@@ -103,7 +103,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = in.readOptionalString();
         this.memoryContainerId = in.readOptionalString();
         this.strategyId = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
@@ -130,7 +130,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         out.writeOptionalString(ownerId);
         out.writeOptionalString(memoryContainerId);
         out.writeOptionalString(strategyId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
@@ -15,6 +15,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_SIZE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRATEGY_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TAGS_FIELD;
 
@@ -58,6 +59,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
     private String ownerId;
     private String memoryContainerId;
     private String strategyId;
+    private Boolean pinned;
 
     @Builder
     public MLLongTermMemory(
@@ -70,7 +72,8 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         Object memoryEmbedding,
         String ownerId,
         String memoryContainerId,
-        String strategyId
+        String strategyId,
+        Boolean pinned
     ) {
         this.memory = memory;
         this.strategyType = strategyType;
@@ -82,6 +85,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = ownerId;
         this.memoryContainerId = memoryContainerId;
         this.strategyId = strategyId;
+        this.pinned = pinned;
     }
 
     public MLLongTermMemory(StreamInput in) throws IOException {
@@ -98,6 +102,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = in.readOptionalString();
         this.memoryContainerId = in.readOptionalString();
         this.strategyId = in.readOptionalString();
+        this.pinned = in.readOptionalBoolean();
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 
@@ -122,6 +127,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         out.writeOptionalString(ownerId);
         out.writeOptionalString(memoryContainerId);
         out.writeOptionalString(strategyId);
+        out.writeOptionalBoolean(pinned);
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 
@@ -151,6 +157,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         if (strategyId != null) {
             builder.field(STRATEGY_ID_FIELD, strategyId);
         }
+        if (pinned != null) {
+            builder.field(PINNED_FIELD, pinned);
+        }
 
         builder.endObject();
         return builder;
@@ -167,6 +176,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         String ownerId = null;
         String memoryContainerId = null;
         String strategyId = null;
+        Boolean pinned = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -211,6 +221,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
                 case STRATEGY_ID_FIELD:
                     strategyId = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.currentToken() == XContentParser.Token.VALUE_NULL ? null : parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -229,6 +242,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
             .ownerId(ownerId)
             .memoryContainerId(memoryContainerId)
             .strategyId(strategyId)
+            .pinned(pinned)
             .build();
     }
 
@@ -269,6 +283,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         }
         if (strategyId != null) {
             result.put(STRATEGY_ID_FIELD, strategyId);
+        }
+        if (pinned != null) {
+            result.put(PINNED_FIELD, pinned);
         }
         return result;
     }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ERROR_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_ACTION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_AFTER_FIELD;
@@ -110,7 +111,9 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         this.tenantId = in.readOptionalString();
         this.error = in.readOptionalString();
-        this.pinned = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
     }
 
     @Override
@@ -136,6 +139,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
+        out.writeOptionalInstant(createdTime);
         if (namespace != null && !namespace.isEmpty()) {
             out.writeBoolean(true);
             out.writeMap(namespace, StreamOutput::writeString, StreamOutput::writeString);
@@ -148,10 +152,11 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
-        out.writeOptionalInstant(createdTime);
         out.writeOptionalString(tenantId);
         out.writeOptionalString(error);
-        out.writeOptionalBoolean(pinned);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
     }
 
     @Override

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
@@ -8,7 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ERROR_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_ACTION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_AFTER_FIELD;
@@ -111,7 +111,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         this.tenantId = in.readOptionalString();
         this.error = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
     }
@@ -154,7 +154,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         out.writeOptionalString(tenantId);
         out.writeOptionalString(error);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
     }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
@@ -17,6 +17,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_SIZE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TAGS_FIELD;
 
 import java.io.IOException;
@@ -57,6 +58,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
     private Instant createdTime;
     private String tenantId;
     private String error;
+    private Boolean pinned;
 
     public MLMemoryHistory(
         String ownerId,
@@ -69,7 +71,8 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         Map<String, String> tags,
         Instant createdTime,
         String tenantId,
-        String error
+        String error,
+        Boolean pinned
     ) {
         this.ownerId = ownerId;
         this.memoryContainerId = memoryContainerId;
@@ -82,6 +85,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         this.createdTime = createdTime;
         this.tenantId = tenantId;
         this.error = error;
+        this.pinned = pinned;
     }
 
     public MLMemoryHistory(StreamInput in) throws IOException {
@@ -106,6 +110,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         this.tenantId = in.readOptionalString();
         this.error = in.readOptionalString();
+        this.pinned = in.readOptionalBoolean();
     }
 
     @Override
@@ -146,6 +151,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         out.writeOptionalInstant(createdTime);
         out.writeOptionalString(tenantId);
         out.writeOptionalString(error);
+        out.writeOptionalBoolean(pinned);
     }
 
     @Override
@@ -185,6 +191,9 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         if (error != null) {
             builder.field(ERROR_FIELD, error);
         }
+        if (pinned != null) {
+            builder.field(PINNED_FIELD, pinned);
+        }
         builder.endObject();
         return builder;
     }
@@ -201,6 +210,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         Instant createdTime = null;
         String tenantId = null;
         String error = null;
+        Boolean pinned = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -241,6 +251,9 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
                 case ERROR_FIELD:
                     error = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.currentToken() == XContentParser.Token.VALUE_NULL ? null : parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -260,6 +273,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
             .createdTime(createdTime)
             .tenantId(tenantId)
             .error(error)
+            .pinned(pinned)
             .build();
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.conversation.ActionConstants.ADDITIONAL_INFO_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENTS_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
@@ -100,7 +101,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             this.namespace = in.readMap(StreamInput::readString, StreamInput::readString);
         }
         this.tenantId = in.readOptionalString();
-        this.pinned = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
     }
 
     @Override
@@ -136,7 +139,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(tenantId);
-        out.writeOptionalBoolean(pinned);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
     }
 
     @Override

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
@@ -7,7 +7,7 @@ package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.conversation.ActionConstants.ADDITIONAL_INFO_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENTS_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
@@ -101,7 +101,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             this.namespace = in.readMap(StreamInput::readString, StreamInput::readString);
         }
         this.tenantId = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
     }
@@ -139,7 +139,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(tenantId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
     }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
@@ -15,6 +15,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.METADATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SUMMARY_FIELD;
 
 import java.io.IOException;
@@ -52,6 +53,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
     private Map<String, Object> additionalInfo;
     private Map<String, String> namespace;
     private String tenantId;
+    private Boolean pinned;
 
     public MLMemorySession(
         String ownerId,
@@ -63,7 +65,8 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         Map<String, Object> agents,
         Map<String, Object> additionalInfo,
         Map<String, String> namespace,
-        String tenantId
+        String tenantId,
+        Boolean pinned
     ) {
         this.ownerId = ownerId;
         this.memoryContainerId = memoryContainerId;
@@ -75,6 +78,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         this.additionalInfo = additionalInfo;
         this.namespace = namespace;
         this.tenantId = tenantId;
+        this.pinned = pinned;
     }
 
     public MLMemorySession(StreamInput in) throws IOException {
@@ -96,6 +100,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             this.namespace = in.readMap(StreamInput::readString, StreamInput::readString);
         }
         this.tenantId = in.readOptionalString();
+        this.pinned = in.readOptionalBoolean();
     }
 
     @Override
@@ -131,6 +136,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(tenantId);
+        out.writeOptionalBoolean(pinned);
     }
 
     @Override
@@ -166,6 +172,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         if (tenantId != null) {
             builder.field(TENANT_ID_FIELD, tenantId);
         }
+        if (pinned != null) {
+            builder.field(PINNED_FIELD, pinned);
+        }
         builder.endObject();
         return builder;
     }
@@ -181,6 +190,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         Map<String, Object> additionalInfo = null;
         Map<String, String> namespace = null;
         String tenantId = null;
+        Boolean pinned = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -218,6 +228,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
                 case TENANT_ID_FIELD:
                     tenantId = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.currentToken() == XContentParser.Token.VALUE_NULL ? null : parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -236,6 +249,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             .additionalInfo(additionalInfo)
             .namespace(namespace)
             .tenantId(tenantId)
+            .pinned(pinned)
             .build();
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_AGENTIC_MEMORY_SYSTEM_INDEX_PREFIX;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DEFAULT_MEMORY_INDEX_PREFIX;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DIMENSION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DISABLE_HISTORY_FIELD;
@@ -64,7 +65,6 @@ import lombok.extern.log4j.Log4j2;
  */
 @Getter
 @Setter
-@Builder
 @EqualsAndHashCode
 @Log4j2
 public class MemoryConfiguration implements ToXContentObject, Writeable {
@@ -73,22 +73,18 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     private String embeddingModelId;
     private String llmId;
     private Integer dimension;
-    @Builder.Default
-    private Integer maxInferSize = MAX_INFER_SIZE_DEFAULT_VALUE;
+    private Integer maxInferSize;
     private List<MemoryStrategy> strategies;
-    @Builder.Default
-    private Map<String, Map<String, Object>> indexSettings = new HashMap<>();
-    @Builder.Default
-    private Map<String, Object> parameters = new HashMap<>();
-    @Builder.Default
-    private boolean disableHistory = false;
-    @Builder.Default
-    private boolean disableSession = false;
-    @Builder.Default
-    private boolean useSystemIndex = true;
+    private Map<String, Map<String, Object>> indexSettings;
+    private Map<String, Object> parameters;
+    private boolean disableHistory;
+    private boolean disableSession;
+    private boolean useSystemIndex;
     private String tenantId;
     private Map<MemoryType, RetentionRule> retentionPolicy;
+    private transient boolean retentionPolicyExplicitlyNull = false;
 
+    @Builder
     public MemoryConfiguration(
         String indexPrefix,
         FunctionName embeddingModelType,
@@ -99,17 +95,23 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         List<MemoryStrategy> strategies,
         Map<String, Map<String, Object>> indexSettings,
         Map<String, Object> parameters,
-        boolean disableHistory,
-        boolean disableSession,
-        boolean useSystemIndex,
+        Boolean disableHistory,
+        Boolean disableSession,
+        Boolean useSystemIndex,
         String tenantId,
         Map<MemoryType, RetentionRule> retentionPolicy
     ) {
+        // Apply defaults for Boolean parameters
+        boolean effectiveUseSystemIndex = (useSystemIndex != null) ? useSystemIndex : true;
+        boolean effectiveDisableHistory = (disableHistory != null) ? disableHistory : false;
+        boolean effectiveDisableSession = (disableSession != null) ? disableSession : false;
+
         // Validate first
         validateInputs(embeddingModelType, embeddingModelId, dimension, maxInferSize);
+        validateRetentionPolicy(retentionPolicy);
 
         // Assign values after validation
-        this.indexPrefix = buildIndexPrefix(indexPrefix, useSystemIndex);
+        this.indexPrefix = buildIndexPrefix(indexPrefix, effectiveUseSystemIndex);
         this.embeddingModelType = embeddingModelType;
         this.embeddingModelId = embeddingModelId;
         this.llmId = llmId;
@@ -127,9 +129,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         if (parameters != null && !parameters.isEmpty()) {
             this.parameters.putAll(parameters);
         }
-        this.disableHistory = disableHistory;
-        this.disableSession = disableSession;
-        this.useSystemIndex = useSystemIndex;
+        this.disableHistory = effectiveDisableHistory;
+        this.disableSession = effectiveDisableSession;
+        this.useSystemIndex = effectiveUseSystemIndex;
         this.tenantId = tenantId;
         this.retentionPolicy = retentionPolicy;
     }
@@ -173,13 +175,15 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = input.readBoolean();
         this.useSystemIndex = input.readBoolean();
         this.tenantId = input.readOptionalString();
-        if (input.readBoolean()) {
-            int size = input.readVInt();
-            this.retentionPolicy = new EnumMap<>(MemoryType.class);
-            for (int i = 0; i < size; i++) {
-                MemoryType key = input.readEnum(MemoryType.class);
-                RetentionRule value = new RetentionRule(input);
-                this.retentionPolicy.put(key, value);
+        if (input.getVersion().onOrAfter(VERSION_3_7_0)) {
+            if (input.readBoolean()) {
+                int size = input.readVInt();
+                this.retentionPolicy = new EnumMap<>(MemoryType.class);
+                for (int i = 0; i < size; i++) {
+                    MemoryType key = input.readEnum(MemoryType.class);
+                    RetentionRule value = new RetentionRule(input);
+                    this.retentionPolicy.put(key, value);
+                }
             }
         }
     }
@@ -214,15 +218,17 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         out.writeBoolean(disableSession);
         out.writeBoolean(useSystemIndex);
         out.writeOptionalString(tenantId);
-        if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
-            out.writeBoolean(true);
-            out.writeVInt(retentionPolicy.size());
-            for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
-                out.writeEnum(entry.getKey());
-                entry.getValue().writeTo(out);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
+                out.writeBoolean(true);
+                out.writeVInt(retentionPolicy.size());
+                for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
+                    out.writeEnum(entry.getKey());
+                    entry.getValue().writeTo(out);
+                }
+            } else {
+                out.writeBoolean(false);
             }
-        } else {
-            out.writeBoolean(false);
         }
     }
 
@@ -301,6 +307,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         boolean useSystemIndex = true;
         String tenantId = null;
         Map<MemoryType, RetentionRule> retentionPolicy = null;
+        boolean retentionPolicyIsExplicitlyNull = false;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -355,6 +362,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 case RETENTION_POLICY_FIELD:
                     if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                         retentionPolicy = null;
+                        retentionPolicyIsExplicitlyNull = true;
                     } else {
                         retentionPolicy = parseRetentionPolicy(parser);
                     }
@@ -366,7 +374,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         }
 
         // Note: validation is already called in the constructor
-        return MemoryConfiguration
+        MemoryConfiguration config = MemoryConfiguration
             .builder()
             .indexPrefix(indexPrefix)
             .embeddingModelType(embeddingModelType)
@@ -383,6 +391,8 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             .tenantId(tenantId)
             .retentionPolicy(retentionPolicy)
             .build();
+        config.setRetentionPolicyExplicitlyNull(retentionPolicyIsExplicitlyNull);
+        return config;
     }
 
     private static Map<MemoryType, RetentionRule> parseRetentionPolicy(XContentParser parser) throws IOException {
@@ -488,6 +498,29 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     private static void validateInputs(FunctionName embeddingModelType, String embeddingModelId, Integer dimension, Integer maxInferSize) {
         validateEmbeddingConfiguration(embeddingModelType, embeddingModelId, dimension);
         validateMaxInferSize(maxInferSize);
+    }
+
+    /**
+     * Validates retention policy constraints.
+     * Ensures WORKING memory type is not configured directly and HISTORY does not have retention_days.
+     *
+     * @param retentionPolicy the retention policy map to validate
+     * @throws IllegalArgumentException if the policy violates constraints
+     */
+    private static void validateRetentionPolicy(Map<MemoryType, RetentionRule> retentionPolicy) {
+        if (retentionPolicy == null || retentionPolicy.isEmpty()) {
+            return;
+        }
+        if (retentionPolicy.containsKey(MemoryType.WORKING)) {
+            throw new IllegalArgumentException(
+                "Working memory retention cannot be configured directly. Working memory is deleted when its parent session expires."
+                    + " To control message lifetime, configure retention on \"sessions\" instead."
+            );
+        }
+        RetentionRule historyRule = retentionPolicy.get(MemoryType.HISTORY);
+        if (historyRule != null && historyRule.getRetentionDays() != null) {
+            throw new IllegalArgumentException("retention_days is not supported for history memory type");
+        }
     }
 
     /**
@@ -609,24 +642,15 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             this.dimension = updateContent.getDimension();
         }
         // Merge retention policy
-        if (updateContent.getRetentionPolicy() != null) {
+        if (updateContent.isRetentionPolicyExplicitlyNull()) {
+            this.retentionPolicy = null;
+        } else if (updateContent.getRetentionPolicy() != null) {
+            validateRetentionPolicy(updateContent.getRetentionPolicy());
             if (this.retentionPolicy == null) {
                 this.retentionPolicy = new EnumMap<>(MemoryType.class);
             }
             for (Map.Entry<MemoryType, RetentionRule> entry : updateContent.getRetentionPolicy().entrySet()) {
-                MemoryType type = entry.getKey();
-                RetentionRule incomingRule = entry.getValue();
-                RetentionRule existingRule = this.retentionPolicy.get(type);
-
-                if (existingRule == null) {
-                    this.retentionPolicy.put(type, incomingRule);
-                } else {
-                    Integer mergedDays = incomingRule.getRetentionDays() != null
-                        ? incomingRule.getRetentionDays()
-                        : existingRule.getRetentionDays();
-                    Integer mergedCount = incomingRule.getMaxCount() != null ? incomingRule.getMaxCount() : existingRule.getMaxCount();
-                    this.retentionPolicy.put(type, new RetentionRule(mergedDays, mergedCount));
-                }
+                this.retentionPolicy.put(entry.getKey(), entry.getValue());
             }
         }
         // Note: indexPrefix and other structural fields are intentionally not updated

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -28,10 +28,12 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SPARSE_ENCODING_DIMENSION_NOT_ALLOWED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRATEGIES_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TEXT_EMBEDDING_DIMENSION_REQUIRED_ERROR;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.USE_SYSTEM_INDEX_FIELD;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +87,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     @Builder.Default
     private boolean useSystemIndex = true;
     private String tenantId;
+    private Map<MemoryType, RetentionRule> retentionPolicy;
 
     public MemoryConfiguration(
         String indexPrefix,
@@ -99,7 +102,8 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         boolean disableHistory,
         boolean disableSession,
         boolean useSystemIndex,
-        String tenantId
+        String tenantId,
+        Map<MemoryType, RetentionRule> retentionPolicy
     ) {
         // Validate first
         validateInputs(embeddingModelType, embeddingModelId, dimension, maxInferSize);
@@ -127,6 +131,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = disableSession;
         this.useSystemIndex = useSystemIndex;
         this.tenantId = tenantId;
+        this.retentionPolicy = retentionPolicy;
     }
 
     private String buildIndexPrefix(String indexPrefix, boolean useSystemIndex) {
@@ -168,6 +173,15 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = input.readBoolean();
         this.useSystemIndex = input.readBoolean();
         this.tenantId = input.readOptionalString();
+        if (input.readBoolean()) {
+            int size = input.readVInt();
+            this.retentionPolicy = new EnumMap<>(MemoryType.class);
+            for (int i = 0; i < size; i++) {
+                MemoryType key = input.readEnum(MemoryType.class);
+                RetentionRule value = new RetentionRule(input);
+                this.retentionPolicy.put(key, value);
+            }
+        }
     }
 
     @Override
@@ -200,6 +214,16 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         out.writeBoolean(disableSession);
         out.writeBoolean(useSystemIndex);
         out.writeOptionalString(tenantId);
+        if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
+            out.writeBoolean(true);
+            out.writeVInt(retentionPolicy.size());
+            for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
+                out.writeEnum(entry.getKey());
+                entry.getValue().writeTo(out);
+            }
+        } else {
+            out.writeBoolean(false);
+        }
     }
 
     @Override
@@ -250,6 +274,14 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         if (tenantId != null) {
             builder.field(TENANT_ID_FIELD, tenantId);
         }
+        if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
+            builder.startObject(RETENTION_POLICY_FIELD);
+            for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
+                builder.field(entry.getKey().getValue());
+                entry.getValue().toXContent(builder, params);
+            }
+            builder.endObject();
+        }
         builder.endObject();
         return builder;
     }
@@ -268,6 +300,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         boolean disableSession = false;
         boolean useSystemIndex = true;
         String tenantId = null;
+        Map<MemoryType, RetentionRule> retentionPolicy = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -319,6 +352,13 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 case USE_SYSTEM_INDEX_FIELD:
                     useSystemIndex = parser.booleanValue();
                     break;
+                case RETENTION_POLICY_FIELD:
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        retentionPolicy = null;
+                    } else {
+                        retentionPolicy = parseRetentionPolicy(parser);
+                    }
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -341,7 +381,40 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             .disableSession(disableSession)
             .useSystemIndex(useSystemIndex)
             .tenantId(tenantId)
+            .retentionPolicy(retentionPolicy)
             .build();
+    }
+
+    private static Map<MemoryType, RetentionRule> parseRetentionPolicy(XContentParser parser) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        Map<MemoryType, RetentionRule> policy = new EnumMap<>(MemoryType.class);
+
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String key = parser.currentName();
+            parser.nextToken();
+
+            if (key.equals(MemoryType.WORKING.getValue())) {
+                throw new IllegalArgumentException(
+                    "Working memory retention cannot be configured directly. Working memory is deleted when its parent session expires."
+                        + " To control message lifetime, configure retention on \"sessions\" instead."
+                );
+            }
+
+            if (!MemoryType.isValid(key)) {
+                throw new IllegalArgumentException("unknown memory type: " + key);
+            }
+
+            MemoryType memoryType = MemoryType.fromString(key);
+            RetentionRule rule = RetentionRule.parse(parser);
+
+            if (memoryType == MemoryType.HISTORY && rule.getRetentionDays() != null) {
+                throw new IllegalArgumentException("retention_days is not supported for history memory type");
+            }
+
+            policy.put(memoryType, rule);
+        }
+
+        return policy;
     }
 
     public String getFinalMemoryIndexPrefix() {
@@ -534,6 +607,27 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         } else if (updateContent.getDimension() != null) {
             // Only update dimension for TEXT_EMBEDDING if provided
             this.dimension = updateContent.getDimension();
+        }
+        // Merge retention policy
+        if (updateContent.getRetentionPolicy() != null) {
+            if (this.retentionPolicy == null) {
+                this.retentionPolicy = new EnumMap<>(MemoryType.class);
+            }
+            for (Map.Entry<MemoryType, RetentionRule> entry : updateContent.getRetentionPolicy().entrySet()) {
+                MemoryType type = entry.getKey();
+                RetentionRule incomingRule = entry.getValue();
+                RetentionRule existingRule = this.retentionPolicy.get(type);
+
+                if (existingRule == null) {
+                    this.retentionPolicy.put(type, incomingRule);
+                } else {
+                    Integer mergedDays = incomingRule.getRetentionDays() != null
+                        ? incomingRule.getRetentionDays()
+                        : existingRule.getRetentionDays();
+                    Integer mergedCount = incomingRule.getMaxCount() != null ? incomingRule.getMaxCount() : existingRule.getMaxCount();
+                    this.retentionPolicy.put(type, new RetentionRule(mergedDays, mergedCount));
+                }
+            }
         }
         // Note: indexPrefix and other structural fields are intentionally not updated
         // as they would require index recreation

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -23,12 +23,12 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MAX_INFER_SIZE_LIMIT_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_INDEX_PREFIX_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETERS_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SEMANTIC_STORAGE_EMBEDDING_MODEL_ID_REQUIRED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SEMANTIC_STORAGE_EMBEDDING_MODEL_TYPE_REQUIRED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SPARSE_ENCODING_DIMENSION_NOT_ALLOWED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRATEGIES_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TEXT_EMBEDDING_DIMENSION_REQUIRED_ERROR;
-import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.USE_SYSTEM_INDEX_FIELD;
 
 import java.io.IOException;

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -148,6 +148,9 @@ public class MemoryContainerConstants {
         "Backend role contains invalid characters. Only alphanumeric characters and :+=,.@-_/ are allowed: %s";
     public static final String BACKEND_ROLE_EMPTY_ERROR = "Backend role cannot be empty or blank";
 
+    // Pinned field
+    public static final String PINNED_FIELD = "pinned";
+
     // Retention policy field names
     public static final String RETENTION_POLICY_FIELD = "retention_policy";
     public static final String RETENTION_DAYS_FIELD = "retention_days";

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -148,6 +148,11 @@ public class MemoryContainerConstants {
         "Backend role contains invalid characters. Only alphanumeric characters and :+=,.@-_/ are allowed: %s";
     public static final String BACKEND_ROLE_EMPTY_ERROR = "Backend role cannot be empty or blank";
 
+    // Retention policy field names
+    public static final String RETENTION_POLICY_FIELD = "retention_policy";
+    public static final String RETENTION_DAYS_FIELD = "retention_days";
+    public static final String MAX_COUNT_FIELD = "max_count";
+
     // Model validation error messages
     public static final String LLM_MODEL_NOT_FOUND_ERROR = "LLM model with ID %s not found";
     public static final String LLM_MODEL_NOT_REMOTE_ERROR = "LLM model must be a REMOTE model, found: %s";

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MAX_COUNT_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_DAYS_FIELD;
+
+import java.io.IOException;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@Builder
+@EqualsAndHashCode
+public class RetentionRule implements ToXContentObject, Writeable {
+
+    private final Integer retentionDays;
+    private final Integer maxCount;
+
+    public RetentionRule(Integer retentionDays, Integer maxCount) {
+        if (retentionDays != null && retentionDays <= 0) {
+            throw new IllegalArgumentException("retention_days must be a positive integer or null");
+        }
+        if (maxCount != null && maxCount <= 0) {
+            throw new IllegalArgumentException("max_count must be a positive integer or null");
+        }
+        this.retentionDays = retentionDays;
+        this.maxCount = maxCount;
+    }
+
+    public RetentionRule(StreamInput in) throws IOException {
+        this.retentionDays = in.readOptionalInt();
+        this.maxCount = in.readOptionalInt();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalInt(retentionDays);
+        out.writeOptionalInt(maxCount);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        if (retentionDays != null) {
+            builder.field(RETENTION_DAYS_FIELD, retentionDays);
+        }
+        if (maxCount != null) {
+            builder.field(MAX_COUNT_FIELD, maxCount);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static RetentionRule parse(XContentParser parser) throws IOException {
+        Integer retentionDays = null;
+        Integer maxCount = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case RETENTION_DAYS_FIELD:
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        retentionDays = null;
+                    } else {
+                        retentionDays = parser.intValue();
+                    }
+                    break;
+                case MAX_COUNT_FIELD:
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        maxCount = null;
+                    } else {
+                        maxCount = parser.intValue();
+                    }
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+
+        return new RetentionRule(retentionDays, maxCount);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
@@ -24,13 +24,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
-@Builder
 @EqualsAndHashCode
 public class RetentionRule implements ToXContentObject, Writeable {
 
     private final Integer retentionDays;
     private final Integer maxCount;
 
+    @Builder
     public RetentionRule(Integer retentionDays, Integer maxCount) {
         if (retentionDays != null && retentionDays <= 0) {
             throw new IllegalArgumentException("retention_days must be a positive integer or null");

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -584,6 +584,40 @@ public final class MLCommonsSettings {
     public static final String ML_COMMONS_AG_UI_DISABLED_MESSAGE =
         "The AG-UI agent feature is not enabled. To enable, please update the setting " + ML_COMMONS_AG_UI_ENABLED.getKey();
 
+    // Memory retention job settings
+    public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
+            24,
+            1,
+            168,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_throttle_seconds",
+            5,
+            1,
+            60,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS = Setting
+        .intSetting(ML_PLUGIN_SETTING_PREFIX + "memory.orphan_ttl_days", 7, 1, 365, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.working_memory_ttl_days",
+            30,
+            1,
+            365,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
     private static void validateRegexSafety(String regex) {
         // Reject nested quantifiers or backreferences
         if (regex.matches(".*\\([^)]*[*+?]\\)[*+?{].*") || regex.matches(".*\\\\[1-9].*")) {

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.transport.memorycontainer.memory;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
@@ -22,6 +23,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETERS_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PAYLOAD_TYPE_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SESSION_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_BLOB_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_FIELD;
@@ -34,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -73,6 +76,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
     private Map<String, Object> parameters;
     private String ownerId;
 
+    // Pinned field (only valid for session/long-term/history, rejected for working memory)
+    private Boolean pinned;
+
     // Checkpoint field
     private String checkpointId;
     private String tenantId;
@@ -91,6 +97,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> tags,
         Map<String, Object> parameters,
         String ownerId,
+        Boolean pinned,
         String checkpointId,
         String tenantId
     ) {
@@ -112,6 +119,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters.putAll(parameters);
         }
         this.ownerId = ownerId;
+        this.pinned = pinned;
         this.checkpointId = checkpointId;
         this.tenantId = tenantId;
         validate();
@@ -161,6 +169,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters = in.readMap();
         }
         this.ownerId = in.readOptionalString();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
         this.checkpointId = in.readOptionalString();
         this.tenantId = in.readOptionalString();
     }
@@ -218,6 +229,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(ownerId);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
         out.writeOptionalString(checkpointId);
         out.writeOptionalString(tenantId);
     }
@@ -297,6 +311,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> tags = null;
         Map<String, Object> parameters = null;
         String ownerId = null;
+        Boolean pinned = null;
         String checkpointId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -348,6 +363,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
                 case OWNER_ID_FIELD:
                     ownerId = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.booleanValue();
+                    break;
                 case CHECKPOINT_ID_FIELD:
                     checkpointId = parser.text();
                     break;
@@ -375,6 +393,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             .tags(tags)
             .parameters(parameters)
             .ownerId(ownerId)
+            .pinned(pinned)
             .checkpointId(checkpointId)
             .tenantId(tenantId)
             .build();

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -7,7 +7,7 @@ package org.opensearch.ml.common.transport.memorycontainer.memory;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
@@ -168,7 +168,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters = in.readMap();
         }
         this.ownerId = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
         this.checkpointId = in.readOptionalString();
@@ -228,7 +228,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(ownerId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
         out.writeOptionalString(checkpointId);

--- a/common/src/main/resources/index-mappings/ml_memory_container.json
+++ b/common/src/main/resources/index-mappings/ml_memory_container.json
@@ -75,6 +75,31 @@
         },
         "index_settings": {
           "type": "flat_object"
+        },
+        "retention_policy": {
+          "type": "object",
+          "properties": {
+            "sessions": {
+              "type": "object",
+              "properties": {
+                "retention_days": { "type": "integer" },
+                "max_count": { "type": "integer" }
+              }
+            },
+            "long-term": {
+              "type": "object",
+              "properties": {
+                "retention_days": { "type": "integer" },
+                "max_count": { "type": "integer" }
+              }
+            },
+            "history": {
+              "type": "object",
+              "properties": {
+                "max_count": { "type": "integer" }
+              }
+            }
+          }
         }
       }
     },

--- a/common/src/main/resources/index-mappings/ml_memory_long_term.json
+++ b/common/src/main/resources/index-mappings/ml_memory_long_term.json
@@ -34,6 +34,9 @@
     "last_updated_time": {
       "type": "date",
       "format": "strict_date_time||epoch_millis"
+    },
+    "pinned": {
+      "type": "boolean"
     }
   }
 }

--- a/common/src/main/resources/index-mappings/ml_memory_long_term_history.json
+++ b/common/src/main/resources/index-mappings/ml_memory_long_term_history.json
@@ -39,6 +39,9 @@
     },
     "tenant_id": {
       "type": "keyword"
+    },
+    "pinned": {
+      "type": "boolean"
     }
   }
 }

--- a/common/src/main/resources/index-mappings/ml_memory_sessions.json
+++ b/common/src/main/resources/index-mappings/ml_memory_sessions.json
@@ -38,6 +38,9 @@
     "owner": USER_MAPPING_PLACEHOLDER,
     "tenant_id": {
       "type": "keyword"
+    },
+    "pinned": {
+      "type": "boolean"
     }
   }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
@@ -27,6 +27,7 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.TestHelper;
 
 public class MLLongTermMemoryTest {
@@ -540,6 +541,31 @@ public class MLLongTermMemoryTest {
         StreamInput in = out.bytes().streamInput();
         MLLongTermMemory deserialized = new MLLongTermMemory(in);
 
+        assertNull(deserialized.getPinned());
+    }
+
+    @Test
+    public void testBackwardCompatStreamFromOldNode() throws IOException {
+        MLLongTermMemory memory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Test memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(CommonValue.VERSION_3_5_0);
+        memory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(CommonValue.VERSION_3_5_0);
+        MLLongTermMemory deserialized = new MLLongTermMemory(in);
+
+        assertEquals("Test memory", deserialized.getMemory());
+        assertEquals(MemoryStrategyType.SEMANTIC, deserialized.getStrategyType());
         assertNull(deserialized.getPinned());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
@@ -424,4 +424,122 @@ public class MLLongTermMemoryTest {
         assertEquals(specialMemory.getMemory(), parsed.getMemory());
         assertEquals(specialMemory.getTags(), parsed.getTags());
     }
+
+    @Test
+    public void testPinnedFieldXContentRoundTrip() throws IOException {
+        MLLongTermMemory pinnedMemory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Pinned memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(true)
+            .build();
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        pinnedMemory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assertTrue(jsonString.contains("\"pinned\":true"));
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLLongTermMemory parsed = MLLongTermMemory.parse(parser);
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTrip() throws IOException {
+        MLLongTermMemory pinnedMemory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Pinned memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        pinnedMemory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLLongTermMemory deserialized = new MLLongTermMemory(in);
+
+        assertEquals(true, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldDefaultIsNull() throws IOException {
+        String jsonString = "{"
+            + "\"namespace\":{\"session_id\":\"session-123\"},"
+            + "\"memory\":\"No pinned field\","
+            + "\"strategy_type\":\"SEMANTIC\","
+            + "\"created_time\":"
+            + testCreatedTime.toEpochMilli()
+            + ","
+            + "\"last_updated_time\":"
+            + testUpdatedTime.toEpochMilli()
+            + "}";
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLLongTermMemory parsed = MLLongTermMemory.parse(parser);
+        assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldFalse() throws IOException {
+        MLLongTermMemory unpinnedMemory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Unpinned memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(false)
+            .build();
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        unpinnedMemory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assertTrue(jsonString.contains("\"pinned\":false"));
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLLongTermMemory parsed = MLLongTermMemory.parse(parser);
+        assertEquals(false, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTripNull() throws IOException {
+        MLLongTermMemory memory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("No pinned")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(null)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        memory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLLongTermMemory deserialized = new MLLongTermMemory(in);
+
+        assertNull(deserialized.getPinned());
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.TestHelper;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MemoryEvent;
+
+public class MLMemoryHistoryTest {
+
+    private MLMemoryHistory historyWithAllFields;
+    private MLMemoryHistory historyWithNullFields;
+    private Instant testCreatedTime;
+    private Map<String, Object> testBefore;
+    private Map<String, Object> testAfter;
+    private Map<String, String> testNamespace;
+    private Map<String, String> testTags;
+
+    @Before
+    public void setUp() {
+        testCreatedTime = Instant.ofEpochMilli(1640995200000L);
+
+        testBefore = new HashMap<>();
+        testBefore.put("memory", "old fact");
+
+        testAfter = new HashMap<>();
+        testAfter.put("memory", "new fact");
+
+        testNamespace = new HashMap<>();
+        testNamespace.put("project", "ml-project");
+
+        testTags = new HashMap<>();
+        testTags.put("topic", "testing");
+
+        historyWithAllFields = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryContainerId("container-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.UPDATE)
+            .before(testBefore)
+            .after(testAfter)
+            .namespace(testNamespace)
+            .tags(testTags)
+            .createdTime(testCreatedTime)
+            .tenantId("tenant-789")
+            .error(null)
+            .pinned(true)
+            .build();
+
+        historyWithNullFields = MLMemoryHistory
+            .builder()
+            .ownerId(null)
+            .memoryContainerId(null)
+            .memoryId(null)
+            .action(null)
+            .before(null)
+            .after(null)
+            .namespace(null)
+            .tags(null)
+            .createdTime(null)
+            .tenantId(null)
+            .error(null)
+            .pinned(null)
+            .build();
+    }
+
+    @Test
+    public void testBuilderWithAllFields() {
+        assertNotNull(historyWithAllFields);
+        assertEquals("owner-123", historyWithAllFields.getOwnerId());
+        assertEquals("container-123", historyWithAllFields.getMemoryContainerId());
+        assertEquals("memory-456", historyWithAllFields.getMemoryId());
+        assertEquals(MemoryEvent.UPDATE, historyWithAllFields.getAction());
+        assertEquals(testBefore, historyWithAllFields.getBefore());
+        assertEquals(testAfter, historyWithAllFields.getAfter());
+        assertEquals(testNamespace, historyWithAllFields.getNamespace());
+        assertEquals(testTags, historyWithAllFields.getTags());
+        assertEquals(testCreatedTime, historyWithAllFields.getCreatedTime());
+        assertEquals("tenant-789", historyWithAllFields.getTenantId());
+        assertEquals(true, historyWithAllFields.getPinned());
+    }
+
+    @Test
+    public void testBuilderWithNullFields() {
+        assertNotNull(historyWithNullFields);
+        assertNull(historyWithNullFields.getOwnerId());
+        assertNull(historyWithNullFields.getMemoryContainerId());
+        assertNull(historyWithNullFields.getMemoryId());
+        assertNull(historyWithNullFields.getAction());
+        assertNull(historyWithNullFields.getBefore());
+        assertNull(historyWithNullFields.getAfter());
+        assertNull(historyWithNullFields.getNamespace());
+        assertNull(historyWithNullFields.getTags());
+        assertNull(historyWithNullFields.getCreatedTime());
+        assertNull(historyWithNullFields.getTenantId());
+        assertNull(historyWithNullFields.getPinned());
+    }
+
+    // Note: Stream round-trip tests are omitted for MLMemoryHistory because the original writeTo/StreamInput
+    // constructor has a pre-existing serialization order mismatch (writeTo writes namespace/tags before
+    // createdTime, but the StreamInput constructor reads createdTime before namespace/tags).
+    // The pinned field is tested via XContent round-trip instead.
+
+    @Test
+    public void testToXContentWithAllFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        historyWithAllFields.toXContent(builder, EMPTY_PARAMS);
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        assertNotNull(jsonString);
+
+        assert jsonString.contains("\"owner_id\":\"owner-123\"");
+        assert jsonString.contains("\"memory_container_id\":\"container-123\"");
+        assert jsonString.contains("\"memory_id\":\"memory-456\"");
+        assert jsonString.contains("\"pinned\":true");
+    }
+
+    @Test
+    public void testToXContentWithNullFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        historyWithNullFields.toXContent(builder, EMPTY_PARAMS);
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        assertEquals("{}", jsonString);
+    }
+
+    @Test
+    public void testParseWithAllFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.field("memory_container_id", "container-123");
+        builder.field("memory_id", "memory-456");
+        builder.field("action", "UPDATE");
+        builder.field("before", testBefore);
+        builder.field("after", testAfter);
+        builder.field("namespace", testNamespace);
+        builder.field("tags", testTags);
+        builder.field("created_time", testCreatedTime.toEpochMilli());
+        builder.field("tenant_id", "tenant-789");
+        builder.field("pinned", true);
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+
+        assertEquals("owner-123", parsed.getOwnerId());
+        assertEquals("container-123", parsed.getMemoryContainerId());
+        assertEquals("memory-456", parsed.getMemoryId());
+        assertEquals(MemoryEvent.UPDATE, parsed.getAction());
+        assertEquals(testBefore, parsed.getBefore());
+        assertEquals(testAfter, parsed.getAfter());
+        assertEquals(testNamespace, parsed.getNamespace());
+        assertEquals(testTags, parsed.getTags());
+        assertEquals(testCreatedTime, parsed.getCreatedTime());
+        assertEquals("tenant-789", parsed.getTenantId());
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldXContentRoundTrip() throws IOException {
+        MLMemoryHistory pinnedHistory = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(true)
+            .build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        pinnedHistory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":true");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldDefaultIsNull() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.field("action", "ADD");
+        builder.field("created_time", testCreatedTime.toEpochMilli());
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+        assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldFalse() throws IOException {
+        MLMemoryHistory unpinnedHistory = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(false)
+            .build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        unpinnedHistory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":false");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+        assertEquals(false, parsed.getPinned());
+    }
+
+    @Test
+    public void testParseWithUnknownFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.field("unknown_field", "unknown_value");
+        builder.field("action", "ADD");
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+
+        assertEquals("owner-123", parsed.getOwnerId());
+        assertEquals(MemoryEvent.ADD, parsed.getAction());
+        assertNull(parsed.getPinned());
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
@@ -17,11 +17,14 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.TestHelper;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MemoryEvent;
 
@@ -116,10 +119,82 @@ public class MLMemoryHistoryTest {
         assertNull(historyWithNullFields.getPinned());
     }
 
-    // Note: Stream round-trip tests are omitted for MLMemoryHistory because the original writeTo/StreamInput
-    // constructor has a pre-existing serialization order mismatch (writeTo writes namespace/tags before
-    // createdTime, but the StreamInput constructor reads createdTime before namespace/tags).
-    // The pinned field is tested via XContent round-trip instead.
+    @Test
+    public void testStreamInputOutputWithAllFields() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        historyWithAllFields.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertEquals(historyWithAllFields.getOwnerId(), deserialized.getOwnerId());
+        assertEquals(historyWithAllFields.getMemoryContainerId(), deserialized.getMemoryContainerId());
+        assertEquals(historyWithAllFields.getMemoryId(), deserialized.getMemoryId());
+        assertEquals(historyWithAllFields.getAction(), deserialized.getAction());
+        assertEquals(historyWithAllFields.getBefore(), deserialized.getBefore());
+        assertEquals(historyWithAllFields.getAfter(), deserialized.getAfter());
+        assertEquals(historyWithAllFields.getCreatedTime(), deserialized.getCreatedTime());
+        assertEquals(historyWithAllFields.getTenantId(), deserialized.getTenantId());
+        assertEquals(historyWithAllFields.getPinned(), deserialized.getPinned());
+    }
+
+    @Test
+    public void testStreamInputOutputWithNullFields() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        historyWithNullFields.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertNull(deserialized.getOwnerId());
+        assertNull(deserialized.getMemoryContainerId());
+        assertNull(deserialized.getMemoryId());
+        assertNull(deserialized.getAction());
+        assertNull(deserialized.getBefore());
+        assertNull(deserialized.getAfter());
+        assertNull(deserialized.getCreatedTime());
+        assertNull(deserialized.getTenantId());
+        assertNull(deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTrip() throws IOException {
+        MLMemoryHistory pinnedHistory = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        pinnedHistory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertEquals(true, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTripNull() throws IOException {
+        MLMemoryHistory history = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(null)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        history.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertNull(deserialized.getPinned());
+    }
 
     @Test
     public void testToXContentWithAllFields() throws IOException {
@@ -272,5 +347,31 @@ public class MLMemoryHistoryTest {
         assertEquals("owner-123", parsed.getOwnerId());
         assertEquals(MemoryEvent.ADD, parsed.getAction());
         assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testBackwardCompatStreamFromOldNode() throws IOException {
+        MLMemoryHistory history = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.UPDATE)
+            .createdTime(testCreatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(CommonValue.VERSION_3_5_0);
+        history.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(CommonValue.VERSION_3_5_0);
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertEquals("owner-123", deserialized.getOwnerId());
+        assertEquals("memory-456", deserialized.getMemoryId());
+        assertEquals(MemoryEvent.UPDATE, deserialized.getAction());
+        assertEquals(testCreatedTime, deserialized.getCreatedTime());
+        assertNull(deserialized.getPinned());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
@@ -126,7 +126,8 @@ public class MLMemorySessionTest {
             testAgents,
             testAdditionalInfo,
             testNamespace,
-            "tenant-456"
+            "tenant-456",
+            true
         );
 
         assertEquals("owner-123", session.getOwnerId());
@@ -138,11 +139,12 @@ public class MLMemorySessionTest {
         assertEquals(testAdditionalInfo, session.getAdditionalInfo());
         assertEquals(testNamespace, session.getNamespace());
         assertEquals("tenant-456", session.getTenantId());
+        assertEquals(true, session.getPinned());
     }
 
     @Test
     public void testConstructorWithNullFields() {
-        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null);
+        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null, null);
 
         assertNull(session.getOwnerId());
         assertNull(session.getSummary());
@@ -153,6 +155,7 @@ public class MLMemorySessionTest {
         assertNull(session.getAdditionalInfo());
         assertNull(session.getNamespace());
         assertNull(session.getTenantId());
+        assertNull(session.getPinned());
     }
 
     @Test
@@ -330,7 +333,7 @@ public class MLMemorySessionTest {
 
     @Test
     public void testSettersAndGetters() {
-        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null);
+        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null, null);
 
         // Test setters
         session.setOwnerId("new-owner");
@@ -720,5 +723,87 @@ public class MLMemorySessionTest {
         assertNull(emptySession.getAdditionalInfo());
         assertNull(emptySession.getNamespace());
         assertNull(emptySession.getTenantId());
+        assertNull(emptySession.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldXContentRoundTrip() throws IOException {
+        MLMemorySession pinnedSession = MLMemorySession.builder().ownerId("owner-123").pinned(true).build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        pinnedSession.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":true");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemorySession parsed = MLMemorySession.parse(parser);
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTrip() throws IOException {
+        MLMemorySession pinnedSession = MLMemorySession.builder().ownerId("owner-123").pinned(true).build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        pinnedSession.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemorySession deserialized = new MLMemorySession(in);
+
+        assertEquals(true, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldDefaultIsNull() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemorySession parsed = MLMemorySession.parse(parser);
+        assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldFalse() throws IOException {
+        MLMemorySession unpinnedSession = MLMemorySession.builder().ownerId("owner-123").pinned(false).build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        unpinnedSession.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":false");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemorySession parsed = MLMemorySession.parse(parser);
+        assertEquals(false, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTripNull() throws IOException {
+        MLMemorySession session = MLMemorySession.builder().ownerId("owner-123").pinned(null).build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        session.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemorySession deserialized = new MLMemorySession(in);
+
+        assertNull(deserialized.getPinned());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
@@ -24,6 +24,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.TestHelper;
 
 public class MLMemorySessionTest {
@@ -189,6 +190,7 @@ public class MLMemorySessionTest {
         assertEquals(sessionWithoutNamespace.getAdditionalInfo(), deserialized.getAdditionalInfo());
         assertEquals(sessionWithoutNamespace.getNamespace(), deserialized.getNamespace());
         assertEquals(sessionWithoutNamespace.getTenantId(), deserialized.getTenantId());
+        assertNull(deserialized.getPinned());
     }
 
     @Test
@@ -804,6 +806,22 @@ public class MLMemorySessionTest {
         StreamInput in = out.bytes().streamInput();
         MLMemorySession deserialized = new MLMemorySession(in);
 
+        assertNull(deserialized.getPinned());
+    }
+
+    @Test
+    public void testBackwardCompatStreamFromOldNode() throws IOException {
+        MLMemorySession session = MLMemorySession.builder().ownerId("owner-123").pinned(true).build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(CommonValue.VERSION_3_5_0);
+        session.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(CommonValue.VERSION_3_5_0);
+        MLMemorySession deserialized = new MLMemorySession(in);
+
+        assertEquals("owner-123", deserialized.getOwnerId());
         assertNull(deserialized.getPinned());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.memorycontainer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -1251,26 +1252,26 @@ public class MemoryConfigurationTests {
     }
 
     @Test
-    public void testUpdate_RetentionPolicy_MergeSemanticsPartialUpdate() {
+    public void testUpdate_RetentionPolicy_TypeLevelReplacement() {
         Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
         existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
         existingPolicy.put(MemoryType.LONG_TERM, new RetentionRule(90, 500));
 
         MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
 
-        // Update only sessions max_count, leaving retention_days unchanged
+        // Update sessions with only max_count — full replacement at type level
         Map<MemoryType, RetentionRule> updatePolicy = new java.util.EnumMap<>(MemoryType.class);
         updatePolicy.put(MemoryType.SESSIONS, new RetentionRule(null, 200));
 
         MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(updatePolicy).build();
         config.update(updateContent);
 
-        // Sessions: retentionDays preserved from existing, maxCount updated
+        // Sessions: fully replaced — retentionDays is now null (not preserved)
         RetentionRule sessionsRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
-        assertEquals(Integer.valueOf(30), sessionsRule.getRetentionDays());
+        assertNull(sessionsRule.getRetentionDays());
         assertEquals(Integer.valueOf(200), sessionsRule.getMaxCount());
 
-        // Long-term: untouched
+        // Long-term: untouched (type not in update)
         RetentionRule longTermRule = config.getRetentionPolicy().get(MemoryType.LONG_TERM);
         assertEquals(Integer.valueOf(90), longTermRule.getRetentionDays());
         assertEquals(Integer.valueOf(500), longTermRule.getMaxCount());
@@ -1328,5 +1329,87 @@ public class MemoryConfigurationTests {
         assertNotNull(historyRule);
         assertNull(historyRule.getRetentionDays());
         assertEquals(Integer.valueOf(500), historyRule.getMaxCount());
+    }
+
+    @Test
+    public void testRetentionPolicy_ConstructorValidation_RejectsWorkingKey() {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.WORKING, new RetentionRule(null, 10));
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build()
+        );
+        assertTrue(e.getMessage().contains("Working memory retention cannot be configured directly"));
+    }
+
+    @Test
+    public void testRetentionPolicy_ConstructorValidation_RejectsHistoryRetentionDays() {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.HISTORY, new RetentionRule(30, null));
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build()
+        );
+        assertTrue(e.getMessage().contains("retention_days is not supported for history memory type"));
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_ExplicitNullWipesPolicy() throws Exception {
+        // Setup: config with existing policy
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Simulate parsing an update with "retention_policy": null
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":null}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        // Verify the flag is set
+        assertTrue(updateContent.isRetentionPolicyExplicitlyNull());
+
+        // Apply update
+        config.update(updateContent);
+
+        // Policy should be wiped
+        assertNull(config.getRetentionPolicy());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_AbsentDoesNotWipe() throws Exception {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Parse an update WITHOUT retention_policy field
+        String json = "{\"index_prefix\":\"test\"}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        // Flag should NOT be set
+        assertFalse(updateContent.isRetentionPolicyExplicitlyNull());
+
+        // Apply update
+        config.update(updateContent);
+
+        // Policy should still be there
+        assertNotNull(config.getRetentionPolicy());
+        assertEquals(1, config.getRetentionPolicy().size());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration.EmbeddingConfig;
 
@@ -1097,5 +1098,238 @@ public class MemoryConfigurationTests {
     public void testBuildIndexPrefix_AcceptsHyphenAndUnderscore() {
         MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("valid_prefix-with-chars").build();
         assertEquals("valid_prefix-with-chars", config.getIndexPrefix());
+    }
+
+    // ==================== Retention Policy Tests ====================
+
+    @Test
+    public void testParse_WithRetentionPolicy() throws Exception {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"sessions\":{\"retention_days\":30,\"max_count\":100},"
+            + "\"long-term\":{\"retention_days\":90,\"max_count\":500}}}";
+
+        XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration config = MemoryConfiguration.parse(parser);
+
+        assertNotNull(config.getRetentionPolicy());
+        assertEquals(2, config.getRetentionPolicy().size());
+
+        RetentionRule sessionsRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
+        assertNotNull(sessionsRule);
+        assertEquals(Integer.valueOf(30), sessionsRule.getRetentionDays());
+        assertEquals(Integer.valueOf(100), sessionsRule.getMaxCount());
+
+        RetentionRule longTermRule = config.getRetentionPolicy().get(MemoryType.LONG_TERM);
+        assertNotNull(longTermRule);
+        assertEquals(Integer.valueOf(90), longTermRule.getRetentionDays());
+        assertEquals(Integer.valueOf(500), longTermRule.getMaxCount());
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_WorkingKeyRejected() {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"working\":{\"max_count\":10}}}";
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+                .xContent()
+                .createParser(
+                    org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                    org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                    json
+                );
+            parser.nextToken();
+            MemoryConfiguration.parse(parser);
+        });
+        assertTrue(e.getMessage().contains("Working memory retention cannot be configured directly"));
+        assertTrue(e.getMessage().contains("sessions"));
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_HistoryWithRetentionDaysRejected() {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"history\":{\"retention_days\":30}}}";
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+                .xContent()
+                .createParser(
+                    org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                    org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                    json
+                );
+            parser.nextToken();
+            MemoryConfiguration.parse(parser);
+        });
+        assertTrue(e.getMessage().contains("retention_days is not supported for history memory type"));
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_UnknownKeyRejected() {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"unknown_type\":{\"max_count\":10}}}";
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+                .xContent()
+                .createParser(
+                    org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                    org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                    json
+                );
+            parser.nextToken();
+            MemoryConfiguration.parse(parser);
+        });
+        assertTrue(e.getMessage().contains("unknown memory type: unknown_type"));
+    }
+
+    @Test
+    public void testRetentionPolicy_XContentRoundTrip() throws Exception {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        policy.put(MemoryType.LONG_TERM, new RetentionRule(90, null));
+        policy.put(MemoryType.HISTORY, new RetentionRule(null, 1000));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build();
+
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.core.xcontent.MediaTypeRegistry
+            .contentBuilder(org.opensearch.common.xcontent.XContentType.JSON);
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String json = org.opensearch.ml.common.TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration parsed = MemoryConfiguration.parse(parser);
+
+        assertNotNull(parsed.getRetentionPolicy());
+        assertEquals(3, parsed.getRetentionPolicy().size());
+        assertEquals(config.getRetentionPolicy().get(MemoryType.SESSIONS), parsed.getRetentionPolicy().get(MemoryType.SESSIONS));
+        assertEquals(config.getRetentionPolicy().get(MemoryType.LONG_TERM), parsed.getRetentionPolicy().get(MemoryType.LONG_TERM));
+        assertEquals(config.getRetentionPolicy().get(MemoryType.HISTORY), parsed.getRetentionPolicy().get(MemoryType.HISTORY));
+    }
+
+    @Test
+    public void testRetentionPolicy_StreamRoundTrip() throws Exception {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.SESSIONS, new RetentionRule(7, 50));
+        policy.put(MemoryType.LONG_TERM, new RetentionRule(365, 10000));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build();
+
+        org.opensearch.common.io.stream.BytesStreamOutput output = new org.opensearch.common.io.stream.BytesStreamOutput();
+        config.writeTo(output);
+
+        org.opensearch.core.common.io.stream.StreamInput input = output.bytes().streamInput();
+        MemoryConfiguration deserialized = new MemoryConfiguration(input);
+
+        assertNotNull(deserialized.getRetentionPolicy());
+        assertEquals(2, deserialized.getRetentionPolicy().size());
+        assertEquals(config.getRetentionPolicy().get(MemoryType.SESSIONS), deserialized.getRetentionPolicy().get(MemoryType.SESSIONS));
+        assertEquals(
+            config.getRetentionPolicy().get(MemoryType.LONG_TERM),
+            deserialized.getRetentionPolicy().get(MemoryType.LONG_TERM)
+        );
+    }
+
+    @Test
+    public void testRetentionPolicy_StreamRoundTrip_NullPolicy() throws Exception {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
+
+        org.opensearch.common.io.stream.BytesStreamOutput output = new org.opensearch.common.io.stream.BytesStreamOutput();
+        config.writeTo(output);
+
+        org.opensearch.core.common.io.stream.StreamInput input = output.bytes().streamInput();
+        MemoryConfiguration deserialized = new MemoryConfiguration(input);
+
+        assertNull(deserialized.getRetentionPolicy());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_MergeSemanticsPartialUpdate() {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        existingPolicy.put(MemoryType.LONG_TERM, new RetentionRule(90, 500));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Update only sessions max_count, leaving retention_days unchanged
+        Map<MemoryType, RetentionRule> updatePolicy = new java.util.EnumMap<>(MemoryType.class);
+        updatePolicy.put(MemoryType.SESSIONS, new RetentionRule(null, 200));
+
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(updatePolicy).build();
+        config.update(updateContent);
+
+        // Sessions: retentionDays preserved from existing, maxCount updated
+        RetentionRule sessionsRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
+        assertEquals(Integer.valueOf(30), sessionsRule.getRetentionDays());
+        assertEquals(Integer.valueOf(200), sessionsRule.getMaxCount());
+
+        // Long-term: untouched
+        RetentionRule longTermRule = config.getRetentionPolicy().get(MemoryType.LONG_TERM);
+        assertEquals(Integer.valueOf(90), longTermRule.getRetentionDays());
+        assertEquals(Integer.valueOf(500), longTermRule.getMaxCount());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_AddNewType() {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        Map<MemoryType, RetentionRule> updatePolicy = new java.util.EnumMap<>(MemoryType.class);
+        updatePolicy.put(MemoryType.HISTORY, new RetentionRule(null, 1000));
+
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(updatePolicy).build();
+        config.update(updateContent);
+
+        assertEquals(2, config.getRetentionPolicy().size());
+        assertNotNull(config.getRetentionPolicy().get(MemoryType.SESSIONS));
+        assertEquals(Integer.valueOf(1000), config.getRetentionPolicy().get(MemoryType.HISTORY).getMaxCount());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_NullIncomingDoesNotRemove() {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Update without retention_policy field — should not touch existing
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().llmId("new-llm").build();
+        config.update(updateContent);
+
+        assertNotNull(config.getRetentionPolicy());
+        assertEquals(1, config.getRetentionPolicy().size());
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_HistoryWithMaxCountOnly() throws Exception {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"history\":{\"max_count\":500}}}";
+
+        XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration config = MemoryConfiguration.parse(parser);
+
+        assertNotNull(config.getRetentionPolicy());
+        RetentionRule historyRule = config.getRetentionPolicy().get(MemoryType.HISTORY);
+        assertNotNull(historyRule);
+        assertNull(historyRule.getRetentionDays());
+        assertEquals(Integer.valueOf(500), historyRule.getMaxCount());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1234,10 +1234,7 @@ public class MemoryConfigurationTests {
         assertNotNull(deserialized.getRetentionPolicy());
         assertEquals(2, deserialized.getRetentionPolicy().size());
         assertEquals(config.getRetentionPolicy().get(MemoryType.SESSIONS), deserialized.getRetentionPolicy().get(MemoryType.SESSIONS));
-        assertEquals(
-            config.getRetentionPolicy().get(MemoryType.LONG_TERM),
-            deserialized.getRetentionPolicy().get(MemoryType.LONG_TERM)
-        );
+        assertEquals(config.getRetentionPolicy().get(MemoryType.LONG_TERM), deserialized.getRetentionPolicy().get(MemoryType.LONG_TERM));
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
@@ -14,14 +14,14 @@ import java.io.IOException;
 
 import org.junit.Test;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.common.xcontent.LoggingDeprecationHandler;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.TestHelper;
 
 public class RetentionRuleTests {

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.TestHelper;
+
+public class RetentionRuleTests {
+
+    @Test
+    public void testBothFieldsSet() {
+        RetentionRule rule = new RetentionRule(30, 100);
+        assertEquals(Integer.valueOf(30), rule.getRetentionDays());
+        assertEquals(Integer.valueOf(100), rule.getMaxCount());
+    }
+
+    @Test
+    public void testOnlyRetentionDaysSet() {
+        RetentionRule rule = new RetentionRule(7, null);
+        assertEquals(Integer.valueOf(7), rule.getRetentionDays());
+        assertNull(rule.getMaxCount());
+    }
+
+    @Test
+    public void testOnlyMaxCountSet() {
+        RetentionRule rule = new RetentionRule(null, 50);
+        assertNull(rule.getRetentionDays());
+        assertEquals(Integer.valueOf(50), rule.getMaxCount());
+    }
+
+    @Test
+    public void testBothNull() {
+        RetentionRule rule = new RetentionRule(null, null);
+        assertNull(rule.getRetentionDays());
+        assertNull(rule.getMaxCount());
+    }
+
+    @Test
+    public void testNegativeRetentionDaysThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(-1, null));
+        assertEquals("retention_days must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testZeroRetentionDaysThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(0, null));
+        assertEquals("retention_days must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testNegativeMaxCountThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(null, -5));
+        assertEquals("max_count must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testZeroMaxCountThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(null, 0));
+        assertEquals("max_count must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testXContentRoundTrip_BothFields() throws IOException {
+        RetentionRule original = new RetentionRule(30, 100);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testXContentRoundTrip_OnlyRetentionDays() throws IOException {
+        RetentionRule original = new RetentionRule(14, null);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testXContentRoundTrip_OnlyMaxCount() throws IOException {
+        RetentionRule original = new RetentionRule(null, 200);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testXContentRoundTrip_BothNull() throws IOException {
+        RetentionRule original = new RetentionRule(null, null);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testStreamRoundTrip_BothFields() throws IOException {
+        RetentionRule original = new RetentionRule(30, 100);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testStreamRoundTrip_OnlyRetentionDays() throws IOException {
+        RetentionRule original = new RetentionRule(7, null);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testStreamRoundTrip_OnlyMaxCount() throws IOException {
+        RetentionRule original = new RetentionRule(null, 50);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testStreamRoundTrip_BothNull() throws IOException {
+        RetentionRule original = new RetentionRule(null, null);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testParseFromJsonString() throws IOException {
+        String json = "{\"retention_days\":60,\"max_count\":500}";
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertNotNull(parsed);
+        assertEquals(Integer.valueOf(60), parsed.getRetentionDays());
+        assertEquals(Integer.valueOf(500), parsed.getMaxCount());
+    }
+
+    @Test
+    public void testParseFromJsonString_UnknownFieldsIgnored() throws IOException {
+        String json = "{\"retention_days\":10,\"max_count\":20,\"unknown_field\":\"ignored\"}";
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(Integer.valueOf(10), parsed.getRetentionDays());
+        assertEquals(Integer.valueOf(20), parsed.getMaxCount());
+    }
+
+    @Test
+    public void testBuilder() {
+        RetentionRule rule = RetentionRule.builder().retentionDays(14).maxCount(50).build();
+        assertEquals(Integer.valueOf(14), rule.getRetentionDays());
+        assertEquals(Integer.valueOf(50), rule.getMaxCount());
+    }
+
+    @Test
+    public void testEquality() {
+        RetentionRule rule1 = new RetentionRule(30, 100);
+        RetentionRule rule2 = new RetentionRule(30, 100);
+        assertEquals(rule1, rule2);
+        assertEquals(rule1.hashCode(), rule2.hashCode());
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
@@ -241,4 +241,22 @@ public class RetentionRuleTests {
         assertEquals(rule1, rule2);
         assertEquals(rule1.hashCode(), rule2.hashCode());
     }
+
+    @Test
+    public void testBuilder_NegativeRetentionDaysThrows() {
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> RetentionRule.builder().retentionDays(-1).maxCount(10).build()
+        );
+        assertEquals("retention_days must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testBuilder_ZeroMaxCountThrows() {
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> RetentionRule.builder().retentionDays(5).maxCount(0).build()
+        );
+        assertEquals("max_count must be a positive integer or null", e.getMessage());
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
@@ -862,4 +862,57 @@ public class MLAddMemoriesInputTest {
         assertEquals("new-checkpoint-id", input.getCheckpointId());
     }
 
+    @Test
+    public void testPinnedField() {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .pinned(true)
+            .build();
+
+        assertEquals(Boolean.TRUE, input.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldNull() {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .build();
+
+        assertNull(input.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamSerialization() throws IOException {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        input.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLAddMemoriesInput deserialized = new MLAddMemoriesInput(in);
+        assertEquals(Boolean.TRUE, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldParsing() throws IOException {
+        String json = "{\"memory_container_id\":\"container-123\",\"payload_type\":\"conversational\","
+            + "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}],"
+            + "\"pinned\":true}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        MLAddMemoriesInput parsed = MLAddMemoriesInput.parse(parser, "container-123", null);
+        assertEquals(Boolean.TRUE, parsed.getPinned());
+    }
+
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
@@ -876,11 +876,7 @@ public class MLAddMemoriesInputTest {
 
     @Test
     public void testPinnedFieldNull() {
-        MLAddMemoriesInput input = MLAddMemoriesInput
-            .builder()
-            .memoryContainerId("container-123")
-            .messages(testMessages)
-            .build();
+        MLAddMemoriesInput input = MLAddMemoriesInput.builder().memoryContainerId("container-123").messages(testMessages).build();
 
         assertNull(input.getPinned());
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -9,6 +9,9 @@ import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
 
 import java.time.Instant;
+import java.util.Map;
+
+import org.opensearch.common.logging.HeaderWarning;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
@@ -24,6 +27,8 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
@@ -100,6 +105,9 @@ public class TransportCreateMemoryContainerAction extends
 
         // Validate configuration before creating memory container
         validateConfiguration(input.getConfiguration(), ActionListener.wrap(isValid -> {
+            // Emit warning if sessions retention is set on a container with disableSession=true
+            emitDisableSessionRetentionWarning(input.getConfiguration());
+
             // Check if memory container index exists, create if not
             ActionListener<Boolean> indexCheckListener = ActionListener.wrap(created -> {
                 try {
@@ -285,6 +293,20 @@ public class TransportCreateMemoryContainerAction extends
         } catch (Exception e) {
             log.error("Failed to save memory container", e);
             listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            HeaderWarning
+                .addWarning(
+                    "sessions retention_policy has no effect when disableSession=true;"
+                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -11,8 +11,6 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGE
 import java.time.Instant;
 import java.util.Map;
 
-import org.opensearch.common.logging.HeaderWarning;
-
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.index.IndexResponse;
@@ -20,6 +18,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -32,6 +33,8 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerAction;
@@ -186,6 +189,9 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
 
                     // No transition - proceed with normal update
                     updateFields.put(MEMORY_STORAGE_CONFIG_FIELD, currentConfig);
+
+                    // Emit warning if sessions retention is set on a container with disableSession=true
+                    emitDisableSessionRetentionWarning(currentConfig);
                 } catch (Exception e) {
                     log.error("Failed to update configuration for container {}", memoryContainerId, e);
                     actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
@@ -251,6 +257,20 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
                         + "Create a new memory container if you need different embedding configuration."
                 );
             }
+        }
+    }
+
+    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            HeaderWarning
+                .addWarning(
+                    "sessions retention_policy has no effect when disableSession=true;"
+                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -18,13 +18,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -123,8 +123,7 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             actionListener
                 .onFailure(
                     new OpenSearchStatusException(
-                        "pinned field is not supported for working memory type."
-                            + " To preserve a conversation, pin the session instead.",
+                        "pinned field is not supported for working memory type." + " To preserve a conversation, pin the session instead.",
                         RestStatus.BAD_REQUEST
                     )
                 );

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -118,6 +118,19 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             return;
         }
 
+        // Reject pinned field — add-memories creates working memory which cannot be pinned
+        if (input.getPinned() != null) {
+            actionListener
+                .onFailure(
+                    new OpenSearchStatusException(
+                        "pinned field is not supported for working memory type."
+                            + " To preserve a conversation, pin the session instead.",
+                        RestStatus.BAD_REQUEST
+                    )
+                );
+            return;
+        }
+
         String memoryContainerId = input.getMemoryContainerId();
 
         if (StringUtils.isBlank(memoryContainerId)) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MESSAGES_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.METADATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_BLOB_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SUMMARY_FIELD;
@@ -136,6 +137,20 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
                     return;
                 }
 
+                // Reject pinned field for working memory type
+                Map<String, Object> updateContent = updateRequest.getMlUpdateMemoryInput().getUpdateContent();
+                if (memoryType == MemoryType.WORKING && updateContent.containsKey(PINNED_FIELD)) {
+                    actionListener
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "pinned field is not supported for working memory type."
+                                    + " To preserve a conversation, pin the session instead.",
+                                RestStatus.BAD_REQUEST
+                            )
+                        );
+                    return;
+                }
+
                 // Prepare the update
                 Map<String, Object> newDoc = constructNewDoc(updateRequest.getMlUpdateMemoryInput(), memoryType, originalDoc);
                 IndexRequest indexRequest = new IndexRequest(memoryIndexName).id(memoryId).source(newDoc);
@@ -186,6 +201,9 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
         if (updateContent.containsKey(ADDITIONAL_INFO_FIELD)) {
             updateFields.put(ADDITIONAL_INFO_FIELD, updateContent.get(ADDITIONAL_INFO_FIELD));
         }
+        if (updateContent.containsKey(PINNED_FIELD)) {
+            updateFields.put(PINNED_FIELD, updateContent.get(PINNED_FIELD));
+        }
         return updateFields;
     }
 
@@ -217,6 +235,9 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
         }
         if (updateContent.containsKey(TAGS_FIELD)) {
             updateFields.put(TAGS_FIELD, updateContent.get(TAGS_FIELD));
+        }
+        if (updateContent.containsKey(PINNED_FIELD)) {
+            updateFields.put(PINNED_FIELD, updateContent.get(PINNED_FIELD));
         }
         return updateFields;
     }

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -105,7 +105,8 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                 if (mlFeatureEnabledSetting.isAgenticMemoryEnabled()
                     && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
                     && !this.startedMemoryRetentionJob) {
-                    mlTaskManager.indexMemoryRetentionJob();
+                    int intervalHours = MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.get(clusterService.getSettings());
+                    mlTaskManager.indexMemoryRetentionJob(intervalHours);
                     this.startedMemoryRetentionJob = true;
                 }
 

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -21,6 +21,7 @@ import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.autoredeploy.MLModelAutoReDeployer;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
@@ -40,6 +41,7 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
     private final Client client;
     private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
     private boolean startedStatsJob;
+    private boolean startedMemoryRetentionJob;
 
     public MLCommonsClusterEventListener(
         ClusterService clusterService,
@@ -98,6 +100,13 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                     mlTaskManager.indexStatsCollectorJob(true);
                     // using this variable in case if same node has a cluster state change event and the state is not updated yet
                     this.startedStatsJob = true;
+                }
+
+                if (mlFeatureEnabledSetting.isAgenticMemoryEnabled()
+                    && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
+                    && !this.startedMemoryRetentionJob) {
+                    mlTaskManager.indexMemoryRetentionJob();
+                    this.startedMemoryRetentionJob = true;
                 }
 
                 break;

--- a/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
@@ -13,6 +13,7 @@ import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.jobs.processors.MLBatchTaskUpdateProcessor;
 import org.opensearch.ml.jobs.processors.MLStatsJobProcessor;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
@@ -105,6 +106,9 @@ public class MLJobRunner implements ScheduledJobRunner {
                 break;
             case BATCH_TASK_UPDATE:
                 MLBatchTaskUpdateProcessor.getInstance(clusterService, client, threadPool).process(jobParameter, jobExecutionContext);
+                break;
+            case MEMORY_RETENTION:
+                MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool).process(jobParameter, jobExecutionContext);
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported job type " + jobParameter.getJobType());

--- a/plugin/src/main/java/org/opensearch/ml/jobs/MLJobType.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/MLJobType.java
@@ -7,7 +7,8 @@ package org.opensearch.ml.jobs;
 
 public enum MLJobType {
     STATS_COLLECTOR("Job to collect static metrics and push to Metrics Registry"),
-    BATCH_TASK_UPDATE("Job to poll and update status of running batch prediction tasks for remote models");
+    BATCH_TASK_UPDATE("Job to poll and update status of running batch prediction tasks for remote models"),
+    MEMORY_RETENTION("Job to enforce retention policies on agentic memory containers");
 
     private final String description;
 

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.jobs.processors;
+
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class MemoryRetentionJobProcessor extends MLJobProcessor {
+
+    private static final Logger log = LogManager.getLogger(MemoryRetentionJobProcessor.class);
+
+    private static MemoryRetentionJobProcessor instance;
+
+    public static MemoryRetentionJobProcessor getInstance(ClusterService clusterService, Client client, ThreadPool threadPool) {
+        if (instance != null) {
+            return instance;
+        }
+
+        synchronized (MemoryRetentionJobProcessor.class) {
+            if (instance != null) {
+                return instance;
+            }
+
+            instance = new MemoryRetentionJobProcessor(clusterService, client, threadPool);
+            return instance;
+        }
+    }
+
+    @VisibleForTesting
+    public static synchronized void reset() {
+        instance = null;
+    }
+
+    public MemoryRetentionJobProcessor(ClusterService clusterService, Client client, ThreadPool threadPool) {
+        super(clusterService, client, threadPool);
+    }
+
+    @Override
+    public void run() {
+        if (ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())) {
+            log.warn("Memory retention job skipped: multi-tenancy is enabled and native client lacks tenant routing");
+            return;
+        }
+
+        log.info("Memory retention job triggered");
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1436,7 +1436,11 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_MAX_JSON_SIZE,
                 MLCommonsSettings.ML_COMMONS_UNIFIED_AGENT_API_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
-                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED
+                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED,
+                MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -571,7 +571,7 @@ public class MLTaskManager implements SettingsChangeListener {
         }
     }
 
-    public void indexMemoryRetentionJob() {
+    public void indexMemoryRetentionJob(int intervalHours) {
         if (this.memoryRetentionJobStarted) {
             log.debug("Memory retention job already started");
             return;
@@ -580,7 +580,7 @@ public class MLTaskManager implements SettingsChangeListener {
         try {
             MLJobParameter jobParameter = new MLJobParameter(
                 MLJobType.MEMORY_RETENTION.name(),
-                new IntervalSchedule(Instant.now(), 24, ChronoUnit.HOURS),
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
                 120L,
                 null,
                 MLJobType.MEMORY_RETENTION,

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -84,6 +84,7 @@ public class MLTaskManager implements SettingsChangeListener {
     private final Map<MLTaskType, AtomicInteger> runningTasksCount;
     private boolean taskPollingJobStarted;
     private boolean statsCollectorJobStarted;
+    private boolean memoryRetentionJobStarted;
     public static final ImmutableSet<MLTaskState> TASK_DONE_STATES = ImmutableSet
         .of(MLTaskState.COMPLETED, MLTaskState.COMPLETED_WITH_ERROR, MLTaskState.FAILED, MLTaskState.CANCELLED);
 
@@ -567,6 +568,37 @@ public class MLTaskManager implements SettingsChangeListener {
             indexJob(indexRequest, MLJobType.BATCH_TASK_UPDATE, () -> this.taskPollingJobStarted = true);
         } catch (IOException e) {
             log.error("Failed to index task polling job", e);
+        }
+    }
+
+    public void indexMemoryRetentionJob() {
+        if (this.memoryRetentionJobStarted) {
+            log.debug("Memory retention job already started");
+            return;
+        }
+
+        try {
+            MLJobParameter jobParameter = new MLJobParameter(
+                MLJobType.MEMORY_RETENTION.name(),
+                new IntervalSchedule(Instant.now(), 24, ChronoUnit.HOURS),
+                120L,
+                null,
+                MLJobType.MEMORY_RETENTION,
+                true
+            );
+
+            IndexRequest indexRequest = new IndexRequest()
+                .index(CommonValue.ML_JOBS_INDEX)
+                .id(MLJobType.MEMORY_RETENTION.name())
+                .source(jobParameter.toXContent(JsonXContent.contentBuilder(), null))
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+            indexJob(indexRequest, MLJobType.MEMORY_RETENTION, () -> {
+                this.memoryRetentionJobStarted = true;
+                log.debug("Memory retention job started successfully");
+            });
+        } catch (IOException e) {
+            log.error("Failed to index memory retention job", e);
         }
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -21,6 +21,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,8 @@ import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategyType;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerRequest;
@@ -1937,6 +1940,58 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
     }
 
     // Helper method to mock successful LLM validation (without embedding validation which will be tested)
+    public void testDoExecuteSuccess_WithRetentionPolicy() throws InterruptedException {
+        // Create config with retention_policy to verify it passes through
+        Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);
+        retentionPolicy.put(MemoryType.SESSIONS, RetentionRule.builder().retentionDays(30).maxCount(100).build());
+        retentionPolicy.put(MemoryType.LONG_TERM, RetentionRule.builder().maxCount(500).build());
+
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .namespace(List.of(SESSION_ID_FIELD))
+                    .id("strategy-id1")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .build()
+            );
+
+        MemoryConfiguration configWithRetention = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .maxInferSize(5)
+                .strategies(strategies)
+                .retentionPolicy(retentionPolicy)
+                .build()
+        );
+
+        MLCreateMemoryContainerInput retentionInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("retention-container")
+            .description("Container with retention policy")
+            .configuration(configWithRetention)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest retentionRequest = new MLCreateMemoryContainerRequest(retentionInput);
+
+        mockSuccessfulCreatePipeline();
+        mockAndRunExecuteMethod(retentionRequest);
+
+        // Verify the configuration retains the retention policy
+        assertNotNull(configWithRetention.getRetentionPolicy());
+        assertEquals(2, configWithRetention.getRetentionPolicy().size());
+        assertEquals(Integer.valueOf(30), configWithRetention.getRetentionPolicy().get(MemoryType.SESSIONS).getRetentionDays());
+        assertEquals(Integer.valueOf(500), configWithRetention.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
+    }
+
     private void mockSuccessfulLLMValidation() {
         // Mock valid LLM model
         MLModel llmModel = mock(MLModel.class);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
@@ -166,17 +166,36 @@ public class TransportAddMemoriesActionTests {
     }
 
     @Test
-    public void testDoExecute_BlankMemoryContainerId() {
+    public void testDoExecute_PinnedFieldRejected() {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
-        
+
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
-        when(input.getMemoryContainerId()).thenReturn("");
-        
+        when(input.getPinned()).thenReturn(true);
+
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
         when(request.getMlAddMemoryInput()).thenReturn(input);
-        
+
         transportAddMemoriesAction.doExecute(task, request, actionListener);
-        
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assert captor.getValue() instanceof OpenSearchStatusException;
+        assert captor.getValue().getMessage().contains("pinned field is not supported for working memory type");
+    }
+
+    @Test
+    public void testDoExecute_BlankMemoryContainerId() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
+        when(input.getMemoryContainerId()).thenReturn("");
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
         verify(actionListener).onFailure(any(IllegalArgumentException.class));
     }
 
@@ -185,6 +204,7 @@ public class TransportAddMemoriesActionTests {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
@@ -213,6 +233,7 @@ public class TransportAddMemoriesActionTests {
         List<MessageInput> messages = Arrays.asList(message);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -248,6 +269,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -300,6 +322,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -348,6 +371,7 @@ public class TransportAddMemoriesActionTests {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
@@ -382,6 +406,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -431,6 +456,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id in namespace
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -485,6 +511,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - should trigger session creation
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -556,6 +583,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - should trigger session creation
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -613,6 +641,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "existing-session-123"); // User provided session_id
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -664,6 +693,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - would normally trigger session creation, but getLlmId() is null
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -715,6 +745,7 @@ public class TransportAddMemoriesActionTests {
         Map<String, String> namespace = new HashMap<>();
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -773,6 +804,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -831,6 +863,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(disabledStrategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -890,6 +923,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -949,6 +983,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1014,6 +1049,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy2);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1071,6 +1107,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(disabledStrategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1128,6 +1165,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1184,6 +1222,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1250,6 +1289,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1335,6 +1375,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1430,6 +1471,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1498,6 +1540,7 @@ public class TransportAddMemoriesActionTests {
         Map<String, String> namespace = new HashMap<>();
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
@@ -795,4 +795,163 @@ public class TransportUpdateMemoryActionTests extends OpenSearchTestCase {
         verify(memoryContainerHelper, never()).indexData(any(), any(), any());
     }
 
+    @Test
+    public void testDoExecute_PinnedRejectedForWorkingMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.WORKING)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.WORKING)).thenReturn("test-working-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) capturedError).status());
+        assertTrue(capturedError.getMessage().contains("pinned field is not supported for working memory type"));
+    }
+
+    @Test
+    public void testDoExecute_PinnedAcceptedForSessionMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.SESSIONS)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        IndexResponse mockIndexResponse = mock(IndexResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.SESSIONS)).thenReturn("test-session-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doAnswer(invocation -> {
+            IndexRequest request = invocation.getArgument(1);
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            // Verify pinned field is included in the indexed document
+            assertTrue(request.sourceAsMap().containsKey("pinned"));
+            assertEquals(true, request.sourceAsMap().get("pinned"));
+            listener.onResponse(mockIndexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(), any(IndexRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        verify(actionListener, times(1)).onResponse(mockIndexResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testDoExecute_PinnedAcceptedForLongTermMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        updateContent.put(MEMORY_FIELD, "some memory text");
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.LONG_TERM)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        IndexResponse mockIndexResponse = mock(IndexResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        sourceMap.put(MEMORY_FIELD, "old memory");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.LONG_TERM)).thenReturn("test-lt-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doAnswer(invocation -> {
+            IndexRequest request = invocation.getArgument(1);
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            assertTrue(request.sourceAsMap().containsKey("pinned"));
+            assertEquals(true, request.sourceAsMap().get("pinned"));
+            listener.onResponse(mockIndexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(), any(IndexRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        verify(actionListener, times(1)).onResponse(mockIndexResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
 }

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.cluster;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -129,7 +130,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager).indexMemoryRetentionJob();
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {
@@ -142,7 +143,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenAgenticMemoryDisabled() {
@@ -154,7 +155,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
     }
 
     private DiscoveryNode createDataNode(Version version) {

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -120,6 +120,43 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager, never()).indexStatsCollectorJob(anyBoolean());
     }
 
+    public void testClusterChanged_MemoryRetentionJobStarted() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager).indexMemoryRetentionJob();
+    }
+
+    public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings())
+            .thenReturn(org.opensearch.common.settings.Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build());
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+    }
+
+    public void testClusterChanged_MemoryRetentionJobNotStarted_WhenAgenticMemoryDisabled() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+    }
+
     private DiscoveryNode createDataNode(Version version) {
         return new DiscoveryNode(
             "dataNode",

--- a/plugin/src/test/java/org/opensearch/ml/jobs/MLJobRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/MLJobRunnerTests.java
@@ -6,16 +6,22 @@
 package org.opensearch.ml.jobs;
 
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutorService;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
+import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
@@ -78,6 +84,22 @@ public class MLJobRunnerTests {
     public void testRunJobWithDisabledJob() {
         when(jobParameter.isEnabled()).thenReturn(false);
         when(jobParameter.getJobType()).thenReturn(MLJobType.STATS_COLLECTOR);
+        jobRunner.runJob(jobParameter, jobExecutionContext);
+    }
+
+    @Test
+    public void testRunJobWithMemoryRetentionType() {
+        MemoryRetentionJobProcessor.reset();
+        when(jobParameter.isEnabled()).thenReturn(true);
+        when(jobParameter.getJobType()).thenReturn(MLJobType.MEMORY_RETENTION);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+
+        LockService lockService = mock(LockService.class);
+        when(jobExecutionContext.getLockService()).thenReturn(lockService);
+
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(threadPool.generic()).thenReturn(executorService);
+
         jobRunner.runJob(jobParameter, jobExecutionContext);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.jobs.processors;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+public class MemoryRetentionJobProcessorTests {
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private Client client;
+
+    private MemoryRetentionJobProcessor processor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        MemoryRetentionJobProcessor.reset();
+        processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+    }
+
+    @Test
+    public void testGetInstance() {
+        MemoryRetentionJobProcessor instance1 = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+        MemoryRetentionJobProcessor instance2 = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+        assertSame(instance1, instance2);
+    }
+
+    @Test
+    public void testRunSkipsWhenMultiTenancyEnabled() {
+        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        processor.run();
+
+        // No exception thrown, method returns early with warning log
+    }
+
+    @Test
+    public void testRunExecutesWhenMultiTenancyDisabled() {
+        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", false).build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        processor.run();
+
+        // No exception thrown, logs "Memory retention job triggered"
+    }
+
+    @Test
+    public void testRunExecutesWithDefaultSettings() {
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+
+        processor.run();
+
+        // Default multi_tenancy_enabled is false, so job should execute
+    }
+}


### PR DESCRIPTION
## Description

Adds the background job infrastructure for memory retention lifecycle processing. Registers the retention job with the ML Commons job scheduler, adds cluster settings for job configuration, and provides a skeleton processor that will be filled in by subsequent PRs.

- Registers `MEMORY_RETENTION` job type in `MLJobType`
- Adds cluster settings: `retention_job_interval`, `retention_job_throttle`, `orphan_ttl_days`, `working_memory_ttl_days`
- Implements `MemoryRetentionJobProcessor` skeleton
- Integrates with `MLCommonsClusterEventListener` for job scheduling
- Unit tests for job registration and processor

## Related Issues

Part of the memory retention lifecycle feature (RFC #4859). Depends on #4860 (data model), #4862 (pinned field), and #4866 (API integration).

## Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request created.
- [x] Commits are signed per the DCO using --signoff.
- [ ] Public documentation issue/PR created.
