### PR TITLE
Preserve original status code in QueryPlanningTool.onFailure()

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.text.StringSubstitutor;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.admin.cluster.storedscripts.GetStoredScriptRequest;
 import org.opensearch.action.admin.indices.get.GetIndexRequest;
 import org.opensearch.action.admin.indices.get.GetIndexResponse;
@@ -403,6 +404,9 @@ public class QueryPlanningTool implements WithModelTool {
                     if (e instanceof IndexNotFoundException) {
                         log.warn("Index does not exist or is not available");
                         listener.onFailure(new IllegalArgumentException("Index does not exist or is not available", e));
+                    } else if (e instanceof OpenSearchStatusException) {
+                        log.warn("Remote service error during index mapping extraction", e);
+                        listener.onFailure(e);
                     } else {
                         log.warn("Failed to extract index mapping");
                         listener.onFailure(new IllegalStateException("Failed to extract index mapping", e));

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
@@ -915,6 +915,37 @@ public class QueryPlanningToolTests {
     }
 
     @Test
+    public void testRunWithOpenSearchStatusException() throws InterruptedException {
+
+        doAnswer(invocation -> {
+            org.opensearch.core.action.ActionListener<org.opensearch.action.admin.indices.get.GetIndexResponse> listener = invocation
+                .getArgument(1);
+            listener.onFailure(new org.opensearch.OpenSearchStatusException("Forbidden", org.opensearch.core.rest.RestStatus.FORBIDDEN));
+            return null;
+        }).when(indicesAdminClient).getIndex(any(), any());
+
+        QueryPlanningTool tool = new QueryPlanningTool("llmGenerated", queryGenerationTool, client, null, null);
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("question", "help me find some books related to wind");
+        parameters.put("index_name", "forbidden_index");
+
+        tool.run(parameters, listener);
+
+        // Should preserve the original OpenSearchStatusException (and its status code) instead of wrapping it
+        assertTrue(future.isCompletedExceptionally());
+        try {
+            future.get();
+            fail("Expected ExecutionException to be thrown");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof org.opensearch.OpenSearchStatusException);
+            assertEquals(org.opensearch.core.rest.RestStatus.FORBIDDEN, ((org.opensearch.OpenSearchStatusException) e.getCause()).status());
+        }
+    }
+
+    @Test
     @SneakyThrows
     public void testGetSampleDocTruncation() throws ExecutionException, InterruptedException {
         mockGetIndexMapping();


### PR DESCRIPTION
### Description
`QueryPlanningTool.onFailure()` wrapped every non-`IndexNotFoundException` failure in `IllegalStateException("Failed to extract index mapping")`. When the underlying failure was an `OpenSearchStatusException` (e.g. a 4xx returned while fetching index mappings), this wrapping discarded the original HTTP status code, so OpenSearch returned a `500 Internal Server Error` to the caller instead of the real status (403, 404, etc.).

This change adds an `OpenSearchStatusException` check before the catch-all `else` branch so the original exception — and its status code — is preserved and propagated to the caller.

Added a unit test (`testRunWithOpenSearchStatusException`) that mirrors the existing `testRunWithNonExistentIndex` and asserts the cause remains an `OpenSearchStatusException` with `RestStatus.FORBIDDEN`.

### Related Issues
<!-- N/A -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
