### PR TITLE
Fix system_prompt not reaching Bedrock Converse

### DIFF
--- a/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/GenerativeQAResponseProcessor.java
+++ b/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/GenerativeQAResponseProcessor.java
@@ -162,22 +162,16 @@ public class GenerativeQAResponseProcessor extends AbstractProcessor implements 
         List<String> searchResults = getSearchResults(response, topN);
 
         // See if the prompt is being overridden at the request level.
-        String effectiveSystemPrompt = systemPrompt;
-        String effectiveUserInstructions = userInstructions;
-        if (params.getSystemPrompt() != null) {
-            effectiveSystemPrompt = params.getSystemPrompt();
-        }
-        if (params.getUserInstructions() != null) {
-            effectiveUserInstructions = params.getUserInstructions();
-        }
+        final String effectiveSystemPrompt = params.getSystemPrompt() != null ? params.getSystemPrompt() : systemPrompt;
+        final String effectiveUserInstructions = params.getUserInstructions() != null ? params.getUserInstructions() : userInstructions;
 
         final List<Interaction> chatHistory = new ArrayList<>();
         if (conversationId == null) {
             doChatCompletion(
                 LlmIOUtil
                     .createChatCompletionInput(
-                        systemPrompt,
-                        userInstructions,
+                        effectiveSystemPrompt,
+                        effectiveUserInstructions,
                         llmModel,
                         llmQuestion,
                         chatHistory,
@@ -200,8 +194,8 @@ public class GenerativeQAResponseProcessor extends AbstractProcessor implements 
                 doChatCompletion(
                     LlmIOUtil
                         .createChatCompletionInput(
-                            systemPrompt,
-                            userInstructions,
+                            effectiveSystemPrompt,
+                            effectiveUserInstructions,
                             llmModel,
                             llmQuestion,
                             chatHistory,

--- a/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/llm/DefaultLlmImpl.java
+++ b/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/llm/DefaultLlmImpl.java
@@ -138,6 +138,8 @@ public class DefaultLlmImpl implements Llm {
                 );
         } else if (chatCompletionInput.getModelProvider() == ModelProvider.BEDROCK_CONVERSE) {
             // Bedrock Converse API does not include the system prompt as part of the Messages block.
+            // Instead, it is passed as a separate runtime parameter for the connector to place
+            // in the Converse API's top-level "system" field via ${parameters.system_prompt}.
             String messages = PromptUtil
                 .getChatCompletionPrompt(
                     chatCompletionInput.getModelProvider(),
@@ -149,6 +151,9 @@ public class DefaultLlmImpl implements Llm {
                     chatCompletionInput.getLlmMessages()
                 );
             inputParameters.put(CONNECTOR_INPUT_PARAMETER_MESSAGES, messages);
+            if (chatCompletionInput.getSystemPrompt() != null) {
+                inputParameters.put("system_prompt", chatCompletionInput.getSystemPrompt());
+            }
         } else {
             throw new IllegalArgumentException(
                 "Unknown/unsupported model provider: "

--- a/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/llm/DefaultLlmImpl.java
+++ b/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/llm/DefaultLlmImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
@@ -152,7 +153,7 @@ public class DefaultLlmImpl implements Llm {
                     chatCompletionInput.getLlmMessages()
                 );
             inputParameters.put(CONNECTOR_INPUT_PARAMETER_MESSAGES, messages);
-            if (chatCompletionInput.getSystemPrompt() != null) {
+            if (!Strings.isNullOrEmpty(chatCompletionInput.getSystemPrompt())) {
                 inputParameters.put(CONNECTOR_INPUT_PARAMETER_SYSTEM_PROMPT, chatCompletionInput.getSystemPrompt());
             }
         } else {

--- a/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/llm/DefaultLlmImpl.java
+++ b/search-processors/src/main/java/org/opensearch/searchpipelines/questionanswering/generative/llm/DefaultLlmImpl.java
@@ -47,6 +47,7 @@ public class DefaultLlmImpl implements Llm {
 
     private static final String CONNECTOR_INPUT_PARAMETER_MODEL = "model";
     private static final String CONNECTOR_INPUT_PARAMETER_MESSAGES = "messages";
+    private static final String CONNECTOR_INPUT_PARAMETER_SYSTEM_PROMPT = "system_prompt";
     private static final String CONNECTOR_OUTPUT_CHOICES = "choices";
     private static final String CONNECTOR_OUTPUT_MESSAGE = "message";
     private static final String CONNECTOR_OUTPUT_MESSAGE_ROLE = "role";
@@ -152,7 +153,7 @@ public class DefaultLlmImpl implements Llm {
                 );
             inputParameters.put(CONNECTOR_INPUT_PARAMETER_MESSAGES, messages);
             if (chatCompletionInput.getSystemPrompt() != null) {
-                inputParameters.put("system_prompt", chatCompletionInput.getSystemPrompt());
+                inputParameters.put(CONNECTOR_INPUT_PARAMETER_SYSTEM_PROMPT, chatCompletionInput.getSystemPrompt());
             }
         } else {
             throw new IllegalArgumentException(

--- a/search-processors/src/test/java/org/opensearch/searchpipelines/questionanswering/generative/GenerativeQAResponseProcessorTests.java
+++ b/search-processors/src/test/java/org/opensearch/searchpipelines/questionanswering/generative/GenerativeQAResponseProcessorTests.java
@@ -259,6 +259,108 @@ public class GenerativeQAResponseProcessorTests extends OpenSearchTestCase {
         assertEquals(numHits, passages.size());
     }
 
+    public void testProcessResponseSystemPromptAndUserInstructionsOverride() throws Exception {
+        Client client = mock(Client.class);
+        Map<String, Object> config = new HashMap<>();
+        config.put(GenerativeQAProcessorConstants.CONFIG_NAME_MODEL_ID, "dummy-model");
+        config.put(GenerativeQAProcessorConstants.CONFIG_NAME_CONTEXT_FIELD_LIST, List.of("text"));
+        config.put(GenerativeQAProcessorConstants.CONFIG_NAME_SYSTEM_PROMPT, "processor-level-system-prompt");
+        config.put(GenerativeQAProcessorConstants.CONFIG_NAME_USER_INSTRUCTIONS, "processor-level-user-instructions");
+
+        GenerativeQAResponseProcessor processor = (GenerativeQAResponseProcessor) new GenerativeQAResponseProcessor.Factory(
+            client,
+            mlFeatureEnabledSetting
+        ).create(null, "tag", "desc", true, config, null);
+
+        ConversationalMemoryClient memoryClient = mock(ConversationalMemoryClient.class);
+        List<Interaction> chatHistory = List
+            .of(
+                new Interaction(
+                    "0",
+                    Instant.now(),
+                    Instant.now(),
+                    "1",
+                    "question",
+                    "",
+                    "answer",
+                    "foo",
+                    Collections.singletonMap("meta data", "some meta")
+                )
+            );
+
+        doAnswer(invocation -> {
+            ((ActionListener<List<Interaction>>) invocation.getArguments()[2]).onResponse(chatHistory);
+            return null;
+        }).when(memoryClient).getInteractions(any(), anyInt(), any());
+
+        processor.setMemoryClient(memoryClient);
+
+        // GenerativeQAParameters overrides system_prompt and user_instructions at query time
+        SearchRequest request = new SearchRequest();
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        GenerativeQAParameters params = new GenerativeQAParameters(
+            "12345",
+            "llm_model",
+            "What is the meaning of life?",
+            "query-level-system-prompt",       // overrides processor-level
+            "query-level-user-instructions",   // overrides processor-level
+            null,
+            null,
+            null,
+            null
+        );
+        GenerativeQAParamExtBuilder extBuilder = new GenerativeQAParamExtBuilder();
+        extBuilder.setParams(params);
+        request.source(sourceBuilder);
+        sourceBuilder.ext(List.of(extBuilder));
+
+        int numHits = 3;
+        SearchHit[] hitsArray = new SearchHit[numHits];
+        for (int i = 0; i < numHits; i++) {
+            XContentBuilder sourceContent = JsonXContent
+                .contentBuilder()
+                .startObject()
+                .field("_id", String.valueOf(i))
+                .field("text", "passage" + i)
+                .endObject();
+            hitsArray[i] = new SearchHit(i, "doc" + i, Map.of(), Map.of());
+            hitsArray[i].sourceRef(BytesReference.bytes(sourceContent));
+        }
+
+        SearchHits searchHits = new SearchHits(hitsArray, null, 1.0f);
+        SearchResponseSections internal = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
+        SearchResponse response = new SearchResponse(internal, null, 1, 1, 0, 1, null, null, null);
+
+        Llm llm = mock(Llm.class);
+        ChatCompletionOutput output = mock(ChatCompletionOutput.class);
+        doAnswer(invocation -> {
+            ((ActionListener<ChatCompletionOutput>) invocation.getArguments()[1]).onResponse(output);
+            return null;
+        }).when(llm).doChatCompletion(any(), any());
+        when(output.getAnswers()).thenReturn(List.of("42"));
+
+        processor.setLlm(llm);
+
+        ArgumentCaptor<ChatCompletionInput> captor = ArgumentCaptor.forClass(ChatCompletionInput.class);
+
+        processor
+            .processResponseAsync(
+                request,
+                response,
+                null,
+                ActionListener.wrap(r -> { assertTrue(r instanceof GenerativeSearchResponse); }, e -> {
+                    fail(e.getMessage());
+                })
+            );
+
+        verify(llm).doChatCompletion(captor.capture(), any());
+        ChatCompletionInput input = captor.getValue();
+
+        // Assert that query-level overrides were passed, NOT the processor-level values
+        assertEquals("query-level-system-prompt", input.getSystemPrompt());
+        assertEquals("query-level-user-instructions", input.getUserInstructions());
+    }
+
     public void testProcessResponseWithErrorFromLlm() throws Exception {
         Client client = mock(Client.class);
         Map<String, Object> config = new HashMap<>();

--- a/search-processors/src/test/java/org/opensearch/searchpipelines/questionanswering/generative/GenerativeQAResponseProcessorTests.java
+++ b/search-processors/src/test/java/org/opensearch/searchpipelines/questionanswering/generative/GenerativeQAResponseProcessorTests.java
@@ -295,15 +295,14 @@ public class GenerativeQAResponseProcessorTests extends OpenSearchTestCase {
 
         processor.setMemoryClient(memoryClient);
 
-        // GenerativeQAParameters overrides system_prompt and user_instructions at query time
         SearchRequest request = new SearchRequest();
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
         GenerativeQAParameters params = new GenerativeQAParameters(
             "12345",
             "llm_model",
-            "What is the meaning of life?",
-            "query-level-system-prompt",       // overrides processor-level
-            "query-level-user-instructions",   // overrides processor-level
+            "You are kind.",
+            "query-level-system-prompt",
+            "query-level-user-instructions",
             null,
             null,
             null,
@@ -337,7 +336,7 @@ public class GenerativeQAResponseProcessorTests extends OpenSearchTestCase {
             ((ActionListener<ChatCompletionOutput>) invocation.getArguments()[1]).onResponse(output);
             return null;
         }).when(llm).doChatCompletion(any(), any());
-        when(output.getAnswers()).thenReturn(List.of("42"));
+        when(output.getAnswers()).thenReturn(List.of("foo"));
 
         processor.setLlm(llm);
 
@@ -356,7 +355,6 @@ public class GenerativeQAResponseProcessorTests extends OpenSearchTestCase {
         verify(llm).doChatCompletion(captor.capture(), any());
         ChatCompletionInput input = captor.getValue();
 
-        // Assert that query-level overrides were passed, NOT the processor-level values
         assertEquals("query-level-system-prompt", input.getSystemPrompt());
         assertEquals("query-level-user-instructions", input.getUserInstructions());
     }

--- a/search-processors/src/test/java/org/opensearch/searchpipelines/questionanswering/generative/llm/DefaultLlmImplTests.java
+++ b/search-processors/src/test/java/org/opensearch/searchpipelines/questionanswering/generative/llm/DefaultLlmImplTests.java
@@ -337,6 +337,56 @@ public class DefaultLlmImplTests extends OpenSearchTestCase {
         assertFalse(parameters.containsKey("system_prompt"));
     }
 
+    public void testSystemPromptOmittedWhenEmptyForBedrockConverse() throws Exception {
+        MachineLearningInternalClient mlClient = mock(MachineLearningInternalClient.class);
+        ArgumentCaptor<MLInput> captor = ArgumentCaptor.forClass(MLInput.class);
+        DefaultLlmImpl connector = new DefaultLlmImpl("model_id", client);
+        connector.setMlClient(mlClient);
+
+        Map<String, String> text = Map.of("text", "answer");
+        List<Map> list = List.of(text);
+        Map<String, ?> content = Map.of("content", list);
+        Map<String, ?> message = Map.of("message", content);
+        Map<String, ?> dataAsMap = Map.of("output", message);
+        ModelTensor tensor = new ModelTensor("tensor", new Number[0], new long[0], MLResultDataType.STRING, null, null, dataAsMap);
+        ModelTensorOutput mlOutput = new ModelTensorOutput(List.of(new ModelTensors(List.of(tensor))));
+        ActionFuture<MLOutput> future = mock(ActionFuture.class);
+        when(future.actionGet(anyLong())).thenReturn(mlOutput);
+        when(mlClient.predict(any(), any())).thenReturn(future);
+        ChatCompletionInput input = new ChatCompletionInput(
+            "bedrock-converse/model",
+            "question",
+            Collections.emptyList(),
+            Collections.emptyList(),
+            0,
+            "",
+            "instructions",
+            Llm.ModelProvider.BEDROCK_CONVERSE,
+            null,
+            null
+        );
+        doAnswer(invocation -> {
+            ((ActionListener<MLOutput>) invocation.getArguments()[2]).onResponse(mlOutput);
+            return null;
+        }).when(mlClient).predict(any(), any(), any());
+        connector.doChatCompletion(input, new ActionListener<>() {
+            @Override
+            public void onResponse(ChatCompletionOutput output) {
+                assertEquals("answer", output.getAnswers().get(0));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+
+            }
+        });
+        verify(mlClient, times(1)).predict(any(), captor.capture(), any());
+        MLInput mlInput = captor.getValue();
+        assertTrue(mlInput.getInputDataset() instanceof RemoteInferenceInputDataSet);
+        Map<String, String> parameters = ((RemoteInferenceInputDataSet) mlInput.getInputDataset()).getParameters();
+        assertFalse(parameters.containsKey("system_prompt"));
+    }
+
     public void testChatCompletionApiForCohere() throws Exception {
         MachineLearningInternalClient mlClient = mock(MachineLearningInternalClient.class);
         ArgumentCaptor<MLInput> captor = ArgumentCaptor.forClass(MLInput.class);

--- a/search-processors/src/test/java/org/opensearch/searchpipelines/questionanswering/generative/llm/DefaultLlmImplTests.java
+++ b/search-processors/src/test/java/org/opensearch/searchpipelines/questionanswering/generative/llm/DefaultLlmImplTests.java
@@ -237,6 +237,106 @@ public class DefaultLlmImplTests extends OpenSearchTestCase {
         assertTrue(mlInput.getInputDataset() instanceof RemoteInferenceInputDataSet);
     }
 
+    public void testSystemPromptPassedAsParameterForBedrockConverse() throws Exception {
+        MachineLearningInternalClient mlClient = mock(MachineLearningInternalClient.class);
+        ArgumentCaptor<MLInput> captor = ArgumentCaptor.forClass(MLInput.class);
+        DefaultLlmImpl connector = new DefaultLlmImpl("model_id", client);
+        connector.setMlClient(mlClient);
+
+        Map<String, String> text = Map.of("text", "answer");
+        List<Map> list = List.of(text);
+        Map<String, ?> content = Map.of("content", list);
+        Map<String, ?> message = Map.of("message", content);
+        Map<String, ?> dataAsMap = Map.of("output", message);
+        ModelTensor tensor = new ModelTensor("tensor", new Number[0], new long[0], MLResultDataType.STRING, null, null, dataAsMap);
+        ModelTensorOutput mlOutput = new ModelTensorOutput(List.of(new ModelTensors(List.of(tensor))));
+        ActionFuture<MLOutput> future = mock(ActionFuture.class);
+        when(future.actionGet(anyLong())).thenReturn(mlOutput);
+        when(mlClient.predict(any(), any())).thenReturn(future);
+        ChatCompletionInput input = new ChatCompletionInput(
+            "bedrock-converse/model",
+            "question",
+            Collections.emptyList(),
+            Collections.emptyList(),
+            0,
+            "you are a support professional",
+            "instructions",
+            Llm.ModelProvider.BEDROCK_CONVERSE,
+            null,
+            null
+        );
+        doAnswer(invocation -> {
+            ((ActionListener<MLOutput>) invocation.getArguments()[2]).onResponse(mlOutput);
+            return null;
+        }).when(mlClient).predict(any(), any(), any());
+        connector.doChatCompletion(input, new ActionListener<>() {
+            @Override
+            public void onResponse(ChatCompletionOutput output) {
+                assertEquals("answer", output.getAnswers().get(0));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+
+            }
+        });
+        verify(mlClient, times(1)).predict(any(), captor.capture(), any());
+        MLInput mlInput = captor.getValue();
+        assertTrue(mlInput.getInputDataset() instanceof RemoteInferenceInputDataSet);
+        Map<String, String> parameters = ((RemoteInferenceInputDataSet) mlInput.getInputDataset()).getParameters();
+        assertEquals("you are a support professional", parameters.get("system_prompt"));
+    }
+
+    public void testSystemPromptOmittedWhenNullForBedrockConverse() throws Exception {
+        MachineLearningInternalClient mlClient = mock(MachineLearningInternalClient.class);
+        ArgumentCaptor<MLInput> captor = ArgumentCaptor.forClass(MLInput.class);
+        DefaultLlmImpl connector = new DefaultLlmImpl("model_id", client);
+        connector.setMlClient(mlClient);
+
+        Map<String, String> text = Map.of("text", "answer");
+        List<Map> list = List.of(text);
+        Map<String, ?> content = Map.of("content", list);
+        Map<String, ?> message = Map.of("message", content);
+        Map<String, ?> dataAsMap = Map.of("output", message);
+        ModelTensor tensor = new ModelTensor("tensor", new Number[0], new long[0], MLResultDataType.STRING, null, null, dataAsMap);
+        ModelTensorOutput mlOutput = new ModelTensorOutput(List.of(new ModelTensors(List.of(tensor))));
+        ActionFuture<MLOutput> future = mock(ActionFuture.class);
+        when(future.actionGet(anyLong())).thenReturn(mlOutput);
+        when(mlClient.predict(any(), any())).thenReturn(future);
+        ChatCompletionInput input = new ChatCompletionInput(
+            "bedrock-converse/model",
+            "question",
+            Collections.emptyList(),
+            Collections.emptyList(),
+            0,
+            null,
+            "instructions",
+            Llm.ModelProvider.BEDROCK_CONVERSE,
+            null,
+            null
+        );
+        doAnswer(invocation -> {
+            ((ActionListener<MLOutput>) invocation.getArguments()[2]).onResponse(mlOutput);
+            return null;
+        }).when(mlClient).predict(any(), any(), any());
+        connector.doChatCompletion(input, new ActionListener<>() {
+            @Override
+            public void onResponse(ChatCompletionOutput output) {
+                assertEquals("answer", output.getAnswers().get(0));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+
+            }
+        });
+        verify(mlClient, times(1)).predict(any(), captor.capture(), any());
+        MLInput mlInput = captor.getValue();
+        assertTrue(mlInput.getInputDataset() instanceof RemoteInferenceInputDataSet);
+        Map<String, String> parameters = ((RemoteInferenceInputDataSet) mlInput.getInputDataset()).getParameters();
+        assertFalse(parameters.containsKey("system_prompt"));
+    }
+
     public void testChatCompletionApiForCohere() throws Exception {
         MachineLearningInternalClient mlClient = mock(MachineLearningInternalClient.class);
         ArgumentCaptor<MLInput> captor = ArgumentCaptor.forClass(MLInput.class);


### PR DESCRIPTION
### Description
The `system_prompt` configured on the RAG response processor (or overridden at request time) was not reaching the Bedrock Converse API. Two issues:

1. `DefaultLlmImpl` never added the system prompt to the connector input parameters for the `BEDROCK_CONVERSE` branch, so the connector had nothing to place in the Converse API's top-level `system` field. It now sets a `system_prompt` parameter when a system prompt is present.

2. `GenerativeQAResponseProcessor` computed `effectiveSystemPrompt` / `effectiveUserInstructions` (applying request-level overrides) but passed the raw configured values into `createChatCompletionInput`. Both invocation paths now use the effective values.

Note: the connector blueprint already references `${parameters.system_prompt}` in the Converse `system` field; before this fix the response processor's configured prompt was never forwarded to the Bedrock Converse connector, so the connector's default was used. No tutorial change is required.

### Related Issues
Resolves #3894

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

### Local Verification
Reproduced locally to make sure the fix works: built OpenSearch from the fix branch and ran a RAG query against real Amazon Bedrock Converse.

The setup uses two different `system_prompt` values: the **connector** default forces **English**, while the **pipeline** forces **French**. If the answer comes back in French, the pipeline's `system_prompt` reached Bedrock.

---

#### Step 1 — Connector has a default `system_prompt` (English)

Connector config:
```json
{
    "name": "Amazon Bedrock Converse",
    "version": "1",
    "description": "Connector with a default system_prompt",
    "protocol": "aws_sigv4",
    "parameters": {
        "top_p": "0.9",
        "max_tokens": "512",
        "service_name": "bedrock",
        "temperature": "0.0",
        "model": "us.anthropic.claude-sonnet-4-20250514-v1:0",
        "system_prompt": "You are a helpful assistant. You must respond ONLY in English.",
        "region": "us-west-2"
    },
    "actions": [
        {
            "action_type": "PREDICT",
            "method": "POST",
            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
            "headers": {
                "content-type": "application/json"
            },
            "request_body": "{ \"system\": [{\"text\": \"${parameters.system_prompt}\"}], \"messages\": ${parameters.messages} , \"inferenceConfig\": {\"temperature\": ${parameters.temperature}, \"topP\": ${parameters.top_p}, \"maxTokens\": ${parameters.max_tokens}} }"
        }
    ]
}
```

The connector's `request_body` maps `${parameters.system_prompt}` into Converse's top-level `system` field, and its default value is **English**.

---

#### Step 2 — Pipeline sets a different `system_prompt` (French)

Pipeline config:
```json
{
    "rag-search-pipeline": {
        "response_processors": [
            {
                "retrieval_augmented_generation": {
                    "tag": "RAG pipeline",
                    "description": "pipeline system_prompt should reach the connector",
                    "model_id": "<model_id>",
                    "context_field_list": [
                        "text"
                    ],
                    "system_prompt": "You must respond ONLY in French, regardless of the question language.",
                    "user_instructions": "Answer concisely."
                }
            }
        ]
    }
}
```

---

#### Step 3 — Run RAG; the pipeline's `system_prompt` wins

Query (English question, using the pipeline above):
```json
{
  "query": { "match": { "text": "population" } },
  "ext": { "generative_qa_parameters": {
      "llm_model": "bedrock-converse/us.anthropic.claude-sonnet-4-20250514-v1:0",
      "llm_question": "What was the population change of New York City from 2021 to 2023?",
      "context_size": 5 } } }
```

Response:
```json
{
    "took": 1,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 1,
            "relation": "eq"
        },
        "max_score": 0.13076457,
        "hits": [
            {
                "_index": "qa_demo",
                "_id": "1",
                "_score": 0.13076457,
                "_source": {
                    "text": "New York City population was about 8.47 million in 2021 and about 8.26 million in 2023."
                }
            }
        ]
    },
    "ext": {
        "retrieval_augmented_generation": {
            "answer": "La population de New York a diminué d'environ 210 000 habitants entre 2021 et 2023, passant de 8,47 millions à 8,26 millions d'habitants."
        }
    }
}
```

---

#### Conclusion

- The **document** and **question** are in English.
- The **connector default** `system_prompt` forces English.
- The **pipeline** `system_prompt` forces French.
- The model answered in **French** → the pipeline's `system_prompt` was propagated to the Bedrock Converse request and overrode the connector default.