### PR TITLE
fix: Pass Gemini API key via header instead of URL in blueprint

### DIFF
--- a/docs/remote_inference_blueprints/google_gemini_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/google_gemini_connector_chat_blueprint.md
@@ -38,10 +38,11 @@ POST /_plugins/_ml/connectors/_create
     {
       "action_type": "predict",
       "method": "POST",
-      "url": "https://generativelanguage.googleapis.com/v1beta/models/${parameters.model}:generateContent?key=${credential.gemini_key}",
+      "url": "https://generativelanguage.googleapis.com/v1beta/models/${parameters.model}:generateContent",
       "supports_structured_output": true,
       "headers": {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "x-goog-api-key": "${credential.gemini_key}"
       },
       "request_body": "{ \"contents\": ${parameters.contents} }"
     }


### PR DESCRIPTION
### Description
The `google_gemini_connector_chat_blueprint.md` puts the API key in the connector url using a `${credential.*} `placeholder, which is not workable:
```
"url": "https://generativelanguage.googleapis.com/v1beta/models/${parameters.model}:generateContent?key=${credential.gemini_key}"
```

In ml-commons, URL substitution only resolves `${parameters.*}`, never `${credential.*}`, so the literal text `${credential.gemini_key} `is left in the URL and the key never reaches Gemini.

`AbstractConnector.getActionEndpoint()` builds the URL with a substitutor whose prefix is hardcoded to `${parameters.`:

```
StringSubstitutor substitutor = new StringSubstitutor(parameters, "${parameters.", "}");
predictEndpoint = substitutor.replace(predictEndpoint);
```
Credentials are only resolved on the header path, via a separate `${credential.`-prefixed substitutor in `AbstractConnector.createDecryptedHeaders()`. The decrypted credential is never merged into the parameters map either, so it is unreachable from the URL (the same applies to request_body).

As written, the unresolved placeholder also leaves {/} in the URL, which are illegal URI characters; `ConnectorUtils.buildSdkRequest()` calls URI.create(endpoint), so the request fails at URI construction before any call is made.

This is the only blueprint in `docs/remote_inference_blueprints/` that references a credential from the url field — every other HTTP-key blueprint `(OpenAI, Azure OpenAI, Cohere, DeepSeek, Ollama, Aleph Alpha, Vertex AI, Yandex) `injects the key via a header.

### Fix
Move the key to the `x-goog-api-key` header (officially supported by the Gemini API) and drop `?key=...` from the URL:

```
"url": "https://generativelanguage.googleapis.com/v1beta/models/${parameters.model}:generateContent",
"headers": {
  "Content-Type": "application/json",
  "x-goog-api-key": "${credential.gemini_key}"
}
```
The header value is resolved by `createDecryptedHeaders()` and sent on the request, so the connector now authenticates correctly.



### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
