### PR TITLE
[Backport 2.19] Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -6,6 +6,7 @@
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven {url 'https://oss.sonatype.org/content/repositories/snapshots/'}
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -14,6 +14,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/search-processors/build.gradle
+++ b/search-processors/build.gradle
@@ -23,6 +23,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-ml'
 
 include 'client'

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'opensearch.java'
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
 }


### PR DESCRIPTION
### Description
Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins.

### Changes
* `build.gradle` — Add CI mirror before mavenCentral in repositories blocks
* `settings.gradle` — Add `pluginManagement` block with CI mirror

### Testing
Build verification