### PR TITLE
Add LLM judgment connector blueprints

### DIFF
--- a/docs/remote_inference_blueprints/llm_judgment/README.md
+++ b/docs/remote_inference_blueprints/llm_judgment/README.md
@@ -1,0 +1,61 @@
+# LLM model setup for Search Relevance Workbench
+
+Search Relevance Workbench (SRW) generates LLM judgments by calling models registered in the [ml-commons plugin](https://github.com/opensearch-project/ml-commons).
+
+SRW is **provider-agnostic**: on every prediction it sends a neutral parameter set and reads the model's text back through a tolerant parser. It does **not** need to know which provider you use. Each provider's request and response differences are absorbed by the ml-commons **connector blueprint** — specifically its `request_body` template and a `post_process_function` that returns the model text in the neutral `response` field. This is the same mechanism OpenSearch neural search uses to support many embedding providers without provider-specific plugin code.
+
+This directory contains connector blueprints in the same Markdown format as [ml-commons `remote_inference_blueprints`](https://github.com/opensearch-project/ml-commons/tree/main/docs/remote_inference_blueprints): each is a set of copy-paste REST calls (create connector, register and deploy, test). The provider coverage mirrors the chat-model blueprints in ml-commons; embedding-only blueprints are not included because LLM judgment needs a generative model.
+
+| Provider | Blueprint | ml-commons blueprint it corresponds to | Transport |
+|---|---|---|---|
+| OpenAI Chat Completions | [openai_chat_blueprint.md](openai_chat_blueprint.md) | `open_ai_connector_chat_blueprint` | HTTP |
+| Azure OpenAI Chat | [azure_openai_chat_blueprint.md](azure_openai_chat_blueprint.md) | `azure_openai_connector_chat_blueprint` | HTTP |
+| DeepSeek Chat (OpenAI-compatible) | [deepseek_chat_blueprint.md](deepseek_chat_blueprint.md) | `deepseek_connector_chat_blueprint` | HTTP |
+| Ollama / local OpenAI-compatible (vLLM, llama.cpp) | [ollama_chat_blueprint.md](ollama_chat_blueprint.md) | `ollama_connector_chat_blueprint` | HTTP |
+| Google Gemini | [google_gemini_chat_blueprint.md](google_gemini_chat_blueprint.md) | `google_gemini_connector_chat_blueprint` | HTTP |
+| Anthropic Claude (Bedrock) | [anthropic_claude_bedrock_blueprint.md](anthropic_claude_bedrock_blueprint.md) | `bedrock_connector_anthropic_claude*_blueprint` | AWS SigV4 |
+| Amazon Bedrock (Converse, generic) | [bedrock_converse_blueprint.md](bedrock_converse_blueprint.md) | `bedrock_connector_converse_blueprint` | AWS SigV4 |
+
+The **Bedrock Converse** blueprint is generic: the Converse API speaks one wire format for every chat model on Bedrock, so this single blueprint covers Amazon Nova, Anthropic Claude, Meta Llama, Mistral, AI21 Jurassic, Cohere, and OpenAI GPT-OSS on Bedrock. That is why we do not ship a separate blueprint per Bedrock model — use `bedrock_converse_blueprint.md` and set the `model` parameter. The dedicated `anthropic_claude_bedrock_blueprint.md` is kept because it uses Claude's native `invoke` API and documents the response shape behind earlier bug fixes.
+
+Any other provider works too: write a blueprint that maps the neutral parameters to the provider's API and returns the model text in a field SRW can read (see [The neutral contract](#the-neutral-contract) below).
+
+## Workflow
+
+1. Pick the blueprint for the provider you want to use (or adapt one for a new provider).
+2. Run its REST calls in order: create the connector, register and deploy the model, then run the test predict to confirm it returns a `response` field.
+3. Take the `model_id` from the register step and pass it to the SRW judgment API:
+
+```http
+PUT _plugins/_search_relevance/judgments
+{
+  "name": "my-judgment",
+  "type": "LLM_JUDGMENT",
+  "modelId": "<model_id from step 2>",
+  "querySetId": "<query set id>",
+  "searchConfigurationList": ["<search config id>"],
+  "size": 10
+}
+```
+
+There is no `connectorType` field — SRW infers nothing about the provider, because the blueprint already speaks the provider's dialect.
+
+## The neutral contract
+
+SRW sends these parameters to ml-commons on every predict call:
+
+| Parameter | Meaning |
+|---|---|
+| `system_prompt` | The rater system instruction. |
+| `user_prompt` | The search query, hits, and any reference data. |
+| `messages` | Legacy OpenAI-shaped `[{system}, {user}]` array. Emitted so already-deployed OpenAI connectors keep working without changes. |
+| `response_format` | Legacy OpenAI JSON-schema structured-output spec. |
+
+A blueprint references whichever of these it needs in its `request_body`. ml-commons only substitutes parameters the blueprint actually references, so the unused ones are harmless.
+
+For the response, SRW reads the model text from the first shape it recognises:
+
+1. a neutral top-level `response` string — **set this in every blueprint** via a `post_process_function`; this is the shape SRW relies on for all providers,
+2. OpenAI `choices[0].message.content` — a fallback so an already-deployed OpenAI connector with no `post_process_function` keeps working.
+
+If the model text arrives in any other shape (Claude's `content[0].text`, Gemini's `candidates[0].content.parts[0].text`, and so on), the blueprint's `post_process_function` is responsible for copying it into the neutral `response` field. Every blueprint in this directory does so, which is why no provider needs SRW-side code. If a blueprint returns an unrecognised shape, SRW fails that chunk with a clear error naming the keys it actually received.

--- a/docs/remote_inference_blueprints/llm_judgment/anthropic_claude_bedrock_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/anthropic_claude_bedrock_blueprint.md
@@ -58,7 +58,7 @@ POST /_plugins/_ml/connectors/_create
         "service_name": "bedrock",
         "anthropic_version": "bedrock-2023-05-31",
         "max_tokens": 8000,
-        "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        "model": "<INFERENCE_PROFILE_ID>"  // example: us.anthropic.claude-haiku-4-5-20251001-v1:0
     },
     "client_config": {
         "max_retry_times": 3,
@@ -96,7 +96,7 @@ POST /_plugins/_ml/connectors/_create
         "service_name": "bedrock",
         "anthropic_version": "bedrock-2023-05-31",
         "max_tokens": 8000,
-        "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        "model": "<INFERENCE_PROFILE_ID>"  // example: us.anthropic.claude-haiku-4-5-20251001-v1:0
     },
     "client_config": {
         "max_retry_times": 3,

--- a/docs/remote_inference_blueprints/llm_judgment/anthropic_claude_bedrock_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/anthropic_claude_bedrock_blueprint.md
@@ -1,0 +1,200 @@
+# Amazon Bedrock connector blueprint example for Anthropic Claude (LLM judgment)
+
+This blueprint integrates an Anthropic Claude model on Amazon Bedrock (native `invoke` API) for Search Relevance Workbench (SRW) LLM judgments. It maps SRW's neutral `system_prompt` / `user_prompt` parameters into Claude's Messages API shape and adds a `post_process_function` that returns the model text in a neutral `response` field.
+
+For non-Claude Bedrock models, prefer the generic `bedrock_converse_blueprint.md` blueprint.
+
+## Available models
+
+This blueprint works with any Anthropic Claude model on Amazon Bedrock. Set the `model` parameter to the model's **cross-region inference profile ID** (the `us.` / `eu.` / `apac.` prefixed form required for on-demand invocation). Verified examples (US regions):
+
+| Model | Inference profile ID | Notes |
+|---|---|---|
+| Claude Haiku 4.5 | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | Fast and low cost — good default for judging |
+| Claude Sonnet 4.5 | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | Balanced quality and cost |
+| Claude Opus 4.5 | `us.anthropic.claude-opus-4-5-20251101-v1:0` | High capability |
+| Claude Opus 4.6 | `us.anthropic.claude-opus-4-6-v1` | Newer flagship |
+| Claude Opus 4.8 | `us.anthropic.claude-opus-4-8` | Latest flagship |
+
+Note that the exact ID format differs per model — older releases carry a date and a `-v1:0` suffix, while newer ones may carry `-v1` or no suffix at all — so always copy the precise inference profile ID from the model's AWS card rather than guessing. For the complete, current catalog and each model's exact ID and Regional availability, see the [AWS Bedrock Anthropic model catalog](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-anthropic.html), or list what is enabled for your account with:
+
+```bash
+aws bedrock list-inference-profiles --region <region> \
+  --query "inferenceProfileSummaries[?contains(inferenceProfileId,'anthropic')].inferenceProfileId"
+```
+
+## 1. Add connector endpoint to trusted URLs:
+Note: this step is only necessary for OpenSearch versions prior to 2.11.0.
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.trusted_connector_endpoints_regex": [
+            "^https://bedrock-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"
+        ]
+    }
+}
+```
+
+## 2. Create connector for Anthropic Claude:
+
+If you are using self-managed OpenSearch, supply your AWS credentials:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+    "name": "Amazon Bedrock Anthropic Claude",
+    "description": "Anthropic Claude via Bedrock for SRW LLM judgments",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "credential": {
+        "access_key": "<PLEASE ADD YOUR AWS ACCESS KEY HERE>",
+        "secret_key": "<PLEASE ADD YOUR AWS SECRET KEY HERE>",
+        "session_token": "<PLEASE ADD YOUR AWS SECURITY TOKEN HERE>"
+    },
+    "parameters": {
+        "region": "<PLEASE ADD YOUR AWS REGION HERE>",
+        "service_name": "bedrock",
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 8000,
+        "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    },
+    "client_config": {
+        "max_retry_times": 3,
+        "retry_backoff_policy": "exponential_full_jitter"
+    },
+    "actions": [
+        {
+            "action_type": "predict",
+            "method": "POST",
+            "headers": {
+                "content-type": "application/json"
+            },
+            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke",
+            "request_body": "{\"anthropic_version\":\"${parameters.anthropic_version}\",\"max_tokens\":${parameters.max_tokens},\"system\":\"${parameters.system_prompt}\",\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"${parameters.user_prompt}\"}]}]}",
+            "post_process_function": "def text = params.content[0].text; return '{\"name\":\"response\",\"dataAsMap\":{\"response\":\"' + escape(text) + '\"}}'"
+        }
+    ]
+}
+```
+
+If you are using the AWS OpenSearch Service, you can provide an IAM role ARN that allows access to the Bedrock service. Refer to the [AWS documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html).
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+    "name": "Amazon Bedrock Anthropic Claude",
+    "description": "Anthropic Claude via Bedrock for SRW LLM judgments",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "credential": {
+        "roleArn": "<PLEASE ADD YOUR AWS ROLE ARN HERE>"
+    },
+    "parameters": {
+        "region": "<PLEASE ADD YOUR AWS REGION HERE>",
+        "service_name": "bedrock",
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 8000,
+        "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    },
+    "client_config": {
+        "max_retry_times": 3,
+        "retry_backoff_policy": "exponential_full_jitter"
+    },
+    "actions": [
+        {
+            "action_type": "predict",
+            "method": "POST",
+            "headers": {
+                "content-type": "application/json"
+            },
+            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke",
+            "request_body": "{\"anthropic_version\":\"${parameters.anthropic_version}\",\"max_tokens\":${parameters.max_tokens},\"system\":\"${parameters.system_prompt}\",\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"${parameters.user_prompt}\"}]}]}",
+            "post_process_function": "def text = params.content[0].text; return '{\"name\":\"response\",\"dataAsMap\":{\"response\":\"' + escape(text) + '\"}}'"
+        }
+    ]
+}
+```
+
+#### Sample response
+```json
+{
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+## 3. Create model group:
+
+```json
+POST /_plugins/_ml/model_groups/_register
+{
+    "name": "remote_model_group_llm_judgment",
+    "description": "Model group for SRW LLM judgment models"
+}
+```
+
+#### Sample response
+```json
+{
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "status": "CREATED"
+}
+```
+
+## 4. Register model to model group & deploy model:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+    "name": "Anthropic Claude model",
+    "function_name": "remote",
+    "model_group_id": "<MODEL_GROUP_ID>",
+    "description": "Anthropic Claude for SRW LLM judgments",
+    "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+#### Sample response
+```json
+{
+  "task_id": "<TASK_ID>",
+  "status": "CREATED",
+  "model_id": "<MODEL_ID>"
+}
+```
+
+## 5. Test model inference
+
+SRW emits the neutral `system_prompt` and `user_prompt`; this blueprint maps them into Claude's top-level `system` field and the structured `messages` content.
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_predict
+{
+  "parameters": {
+    "system_prompt": "You are a relevance rater. Reply with strict JSON only.",
+    "user_prompt": "Rate the relevance of {\"id\":\"001\",\"text\":\"banana smoothie\"} to query banana on a 0.0-1.0 scale. Return {\"ratings\":[{\"id\":\"001\",\"rating_score\":<num>}]}."
+  }
+}
+```
+
+#### Sample response
+The `post_process_function` copies `content[0].text` into the neutral `response` field that SRW reads.
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": "{\"ratings\":[{\"id\":\"001\",\"rating_score\":0.9}]}"
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```

--- a/docs/remote_inference_blueprints/llm_judgment/azure_openai_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/azure_openai_chat_blueprint.md
@@ -1,6 +1,6 @@
 # Azure OpenAI connector blueprint example for LLM judgment
 
-This blueprint integrates an [Azure OpenAI Chat Completions](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions) deployment for Search Relevance Workbench (SRW) LLM judgments. It adds a `post_process_function` that returns the model text in a neutral `response` field. Azure exposes the same Chat Completions shape as OpenAI; only the endpoint, API version, and `api-key` header differ.
+This blueprint integrates an [Azure OpenAI Chat Completions](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions) deployment for Search Relevance Workbench (SRW) LLM judgments. It maps SRW's neutral `system_prompt` / `user_prompt` parameters into the Chat Completions `messages` shape and adds a `post_process_function` that returns the model text in a neutral `response` field. Azure exposes the same Chat Completions shape as OpenAI; only the endpoint, API version, and `api-key` header differ.
 
 ## Available models
 
@@ -59,7 +59,7 @@ POST /_plugins/_ml/connectors/_create
         "Content-Type": "application/json",
         "api-key": "${credential.openAI_key}"
       },
-      "request_body": "{ \"messages\": ${parameters.messages}, \"response_format\": ${parameters.response_format} }",
+      "request_body": "{\"messages\":[{\"role\":\"system\",\"content\":\"${parameters.system_prompt}\"},{\"role\":\"user\",\"content\":\"${parameters.user_prompt}\"}]}",
       "post_process_function": "def text = params.choices[0].message.content; return '{\"name\":\"response\",\"dataAsMap\":{\"response\":\"' + escape(text) + '\"}}'"
     }
   ]
@@ -115,48 +115,14 @@ POST /_plugins/_ml/models/_register?deploy=true
 
 ## 5. Test model inference
 
-`response_format` (structured output) is supported on recent deployments and API versions; drop it from `request_body` if your deployment does not support it.
+SRW emits the neutral `system_prompt` and `user_prompt`; this blueprint maps them into the Chat Completions `messages` array.
 
 ```json
 POST /_plugins/_ml/models/<MODEL_ID>/_predict
 {
   "parameters": {
-    "messages": [
-      {
-        "role": "system",
-        "content": "You are a relevance rater. Reply with strict JSON only."
-      },
-      {
-        "role": "user",
-        "content": "Rate the relevance of {\"id\":\"001\",\"text\":\"banana smoothie\"} to query banana on a 0.0-1.0 scale."
-      }
-    ],
-    "response_format": {
-      "type": "json_schema",
-      "json_schema": {
-        "name": "rating",
-        "strict": true,
-        "schema": {
-          "type": "object",
-          "properties": {
-            "ratings": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": { "type": "string" },
-                  "rating_score": { "type": "number" }
-                },
-                "required": ["id", "rating_score"],
-                "additionalProperties": false
-              }
-            }
-          },
-          "required": ["ratings"],
-          "additionalProperties": false
-        }
-      }
-    }
+    "system_prompt": "You are a relevance rater. Reply with strict JSON only.",
+    "user_prompt": "Rate the relevance of {\"id\":\"001\",\"text\":\"banana smoothie\"} to query banana on a 0.0-1.0 scale. Return {\"ratings\":[{\"id\":\"001\",\"rating_score\":<num>}]}."
   }
 }
 ```

--- a/docs/remote_inference_blueprints/llm_judgment/azure_openai_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/azure_openai_chat_blueprint.md
@@ -1,0 +1,183 @@
+# Azure OpenAI connector blueprint example for LLM judgment
+
+This blueprint integrates an [Azure OpenAI Chat Completions](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions) deployment for Search Relevance Workbench (SRW) LLM judgments. It adds a `post_process_function` that returns the model text in a neutral `response` field. Azure exposes the same Chat Completions shape as OpenAI; only the endpoint, API version, and `api-key` header differ.
+
+## Available models
+
+Azure routes by your **deployment name** (the `deploy-name` parameter), not a model ID — the underlying model is whatever you deployed in your Azure OpenAI resource. Models you can deploy:
+
+| Model | Deployable model name |
+|---|---|
+| GPT-5 | `gpt-5` |
+| GPT-4.1 | `gpt-4.1` |
+| GPT-4o | `gpt-4o` |
+| GPT-4o mini | `gpt-4o-mini` |
+
+For the models you can deploy and the minimum API version each needs, see [Azure OpenAI models](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models).
+
+## 1. Add connector endpoint to trusted URLs:
+Note: skip this step starting 2.19.0
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.trusted_connector_endpoints_regex": [
+          "^https://.*\\.openai\\.azure\\.com/.*$"
+        ]
+    }
+}
+```
+
+## 2. Create connector for Azure OpenAI Chat:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Azure OpenAI Chat",
+  "description": "Azure OpenAI Chat Completions connector for SRW LLM judgments",
+  "version": "1",
+  "protocol": "http",
+  "parameters": {
+    "endpoint": "<YOUR RESOURCE NAME>.openai.azure.com",
+    "deploy-name": "<YOUR DEPLOYMENT NAME>",
+    "api-version": "2024-08-01-preview"
+  },
+  "credential": {
+    "openAI_key": "<PLEASE ADD YOUR AZURE OPENAI API KEY HERE>"
+  },
+  "client_config": {
+    "max_retry_times": 3,
+    "retry_backoff_policy": "exponential_full_jitter"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://${parameters.endpoint}/openai/deployments/${parameters.deploy-name}/chat/completions?api-version=${parameters.api-version}",
+      "headers": {
+        "Content-Type": "application/json",
+        "api-key": "${credential.openAI_key}"
+      },
+      "request_body": "{ \"messages\": ${parameters.messages}, \"response_format\": ${parameters.response_format} }",
+      "post_process_function": "def text = params.choices[0].message.content; return '{\"name\":\"response\",\"dataAsMap\":{\"response\":\"' + escape(text) + '\"}}'"
+    }
+  ]
+}
+```
+
+#### Sample response
+```json
+{
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+## 3. Create model group:
+
+```json
+POST /_plugins/_ml/model_groups/_register
+{
+    "name": "remote_model_group_llm_judgment",
+    "description": "Model group for SRW LLM judgment models"
+}
+```
+
+#### Sample response
+```json
+{
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "status": "CREATED"
+}
+```
+
+## 4. Register model to model group & deploy model:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "Azure OpenAI Chat model",
+  "function_name": "remote",
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "description": "Azure OpenAI Chat for SRW LLM judgments",
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+#### Sample response
+```json
+{
+  "task_id": "<TASK_ID>",
+  "status": "CREATED",
+  "model_id": "<MODEL_ID>"
+}
+```
+
+## 5. Test model inference
+
+`response_format` (structured output) is supported on recent deployments and API versions; drop it from `request_body` if your deployment does not support it.
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_predict
+{
+  "parameters": {
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a relevance rater. Reply with strict JSON only."
+      },
+      {
+        "role": "user",
+        "content": "Rate the relevance of {\"id\":\"001\",\"text\":\"banana smoothie\"} to query banana on a 0.0-1.0 scale."
+      }
+    ],
+    "response_format": {
+      "type": "json_schema",
+      "json_schema": {
+        "name": "rating",
+        "strict": true,
+        "schema": {
+          "type": "object",
+          "properties": {
+            "ratings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "string" },
+                  "rating_score": { "type": "number" }
+                },
+                "required": ["id", "rating_score"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": ["ratings"],
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}
+```
+
+#### Sample response
+The `post_process_function` copies `choices[0].message.content` into the neutral `response` field that SRW reads.
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": "{\"ratings\":[{\"id\":\"001\",\"rating_score\":0.9}]}"
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```

--- a/docs/remote_inference_blueprints/llm_judgment/bedrock_converse_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/bedrock_converse_blueprint.md
@@ -1,0 +1,196 @@
+# Amazon Bedrock connector blueprint example for Converse (LLM judgment)
+
+This blueprint integrates Amazon Bedrock chat models through the [Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html) for Search Relevance Workbench (SRW) LLM judgments. The Converse API uses one request and response format for every chat model on Bedrock, so this single blueprint works for Anthropic Claude, Amazon Nova, Meta Llama, Mistral, AI21, Cohere, and OpenAI GPT-OSS on Bedrock — just change the `model` parameter.
+
+It maps SRW's neutral `system_prompt` / `user_prompt` parameters into the Converse shape and adds a `post_process_function` that returns the model text in a neutral `response` field.
+
+## Available models
+
+The Converse API works with any chat model on Amazon Bedrock. Set the `model` parameter to the model's **cross-region inference profile ID** (the `us.` / `eu.` / `apac.` prefixed form required for on-demand invocation). Verified examples (US regions):
+
+| Provider | Inference profile IDs |
+|---|---|
+| Anthropic Claude | `us.anthropic.claude-haiku-4-5-20251001-v1:0`, `us.anthropic.claude-sonnet-4-5-20250929-v1:0`, `us.anthropic.claude-opus-4-6-v1`, `us.anthropic.claude-opus-4-8` |
+| Amazon Nova | `us.amazon.nova-pro-v1:0`, `us.amazon.nova-lite-v1:0`, `us.amazon.nova-micro-v1:0` |
+| Meta Llama | `us.meta.llama3-3-70b-instruct-v1:0` |
+
+Converse also supports additional models (Cohere Command, Mistral, AI21, OpenAI GPT-OSS on Bedrock, and more). The exact ID format differs per model, so always copy the precise ID from the model's AWS card rather than guessing. For the complete, current catalog and each model's exact ID and Regional availability, see the [Amazon Bedrock supported models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html), or list what is enabled for your account with:
+
+```bash
+aws bedrock list-inference-profiles --region <region> \
+  --query "inferenceProfileSummaries[].inferenceProfileId"
+```
+
+## 1. Add connector endpoint to trusted URLs:
+Note: this step is only necessary for OpenSearch versions prior to 2.11.0.
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.trusted_connector_endpoints_regex": [
+            "^https://bedrock-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$"
+        ]
+    }
+}
+```
+
+## 2. Create connector for Amazon Bedrock Converse:
+
+If you are using self-managed OpenSearch, supply your AWS credentials:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+    "name": "Amazon Bedrock Converse",
+    "description": "Amazon Bedrock Converse for SRW LLM judgments",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "credential": {
+        "access_key": "<PLEASE ADD YOUR AWS ACCESS KEY HERE>",
+        "secret_key": "<PLEASE ADD YOUR AWS SECRET KEY HERE>",
+        "session_token": "<PLEASE ADD YOUR AWS SECURITY TOKEN HERE>"
+    },
+    "parameters": {
+        "region": "<PLEASE ADD YOUR AWS REGION HERE>",
+        "service_name": "bedrock",
+        "max_tokens": 8000,
+        "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    },
+    "client_config": {
+        "max_retry_times": 3,
+        "retry_backoff_policy": "exponential_full_jitter"
+    },
+    "actions": [
+        {
+            "action_type": "predict",
+            "method": "POST",
+            "headers": {
+                "content-type": "application/json"
+            },
+            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+            "request_body": "{\"system\":[{\"text\":\"${parameters.system_prompt}\"}],\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}],\"inferenceConfig\":{\"maxTokens\":${parameters.max_tokens}}}",
+            "post_process_function": "def text = params.output.message.content[0].text; return '{\"name\":\"response\",\"dataAsMap\":{\"response\":\"' + escape(text) + '\"}}'"
+        }
+    ]
+}
+```
+
+If you are using the AWS OpenSearch Service, you can provide an IAM role ARN that allows access to the Bedrock service. Refer to the [AWS documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ml-amazon-connector.html).
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+    "name": "Amazon Bedrock Converse",
+    "description": "Amazon Bedrock Converse for SRW LLM judgments",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "credential": {
+        "roleArn": "<PLEASE ADD YOUR AWS ROLE ARN HERE>"
+    },
+    "parameters": {
+        "region": "<PLEASE ADD YOUR AWS REGION HERE>",
+        "service_name": "bedrock",
+        "max_tokens": 8000,
+        "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    },
+    "client_config": {
+        "max_retry_times": 3,
+        "retry_backoff_policy": "exponential_full_jitter"
+    },
+    "actions": [
+        {
+            "action_type": "predict",
+            "method": "POST",
+            "headers": {
+                "content-type": "application/json"
+            },
+            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+            "request_body": "{\"system\":[{\"text\":\"${parameters.system_prompt}\"}],\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}],\"inferenceConfig\":{\"maxTokens\":${parameters.max_tokens}}}",
+            "post_process_function": "def text = params.output.message.content[0].text; return '{\"name\":\"response\",\"dataAsMap\":{\"response\":\"' + escape(text) + '\"}}'"
+        }
+    ]
+}
+```
+
+#### Sample response
+```json
+{
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+## 3. Create model group:
+
+```json
+POST /_plugins/_ml/model_groups/_register
+{
+    "name": "remote_model_group_llm_judgment",
+    "description": "Model group for SRW LLM judgment models"
+}
+```
+
+#### Sample response
+```json
+{
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "status": "CREATED"
+}
+```
+
+## 4. Register model to model group & deploy model:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+    "name": "Amazon Bedrock Converse model",
+    "function_name": "remote",
+    "model_group_id": "<MODEL_GROUP_ID>",
+    "description": "Amazon Bedrock Converse for SRW LLM judgments",
+    "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+#### Sample response
+```json
+{
+  "task_id": "<TASK_ID>",
+  "status": "CREATED",
+  "model_id": "<MODEL_ID>"
+}
+```
+
+## 5. Test model inference
+
+SRW emits the neutral `system_prompt` and `user_prompt`; this blueprint maps them into the Converse `system` array and `messages` content.
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_predict
+{
+  "parameters": {
+    "system_prompt": "You are a relevance rater. Reply with strict JSON only.",
+    "user_prompt": "Rate the relevance of {\"id\":\"001\",\"text\":\"banana smoothie\"} to query banana on a 0.0-1.0 scale. Return {\"ratings\":[{\"id\":\"001\",\"rating_score\":<num>}]}."
+  }
+}
+```
+
+#### Sample response
+The `post_process_function` copies `output.message.content[0].text` into the neutral `response` field that SRW reads.
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": "{\"ratings\":[{\"id\":\"001\",\"rating_score\":0.9}]}"
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```

--- a/docs/remote_inference_blueprints/llm_judgment/bedrock_converse_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/bedrock_converse_blueprint.md
@@ -55,7 +55,7 @@ POST /_plugins/_ml/connectors/_create
         "region": "<PLEASE ADD YOUR AWS REGION HERE>",
         "service_name": "bedrock",
         "max_tokens": 8000,
-        "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        "model": "<INFERENCE_PROFILE_ID>"  // example: us.anthropic.claude-haiku-4-5-20251001-v1:0
     },
     "client_config": {
         "max_retry_times": 3,
@@ -92,7 +92,7 @@ POST /_plugins/_ml/connectors/_create
         "region": "<PLEASE ADD YOUR AWS REGION HERE>",
         "service_name": "bedrock",
         "max_tokens": 8000,
-        "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        "model": "<INFERENCE_PROFILE_ID>"  // example: us.anthropic.claude-haiku-4-5-20251001-v1:0
     },
     "client_config": {
         "max_retry_times": 3,

--- a/docs/remote_inference_blueprints/llm_judgment/deepseek_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/deepseek_chat_blueprint.md
@@ -38,7 +38,7 @@ POST /_plugins/_ml/connectors/_create
   "protocol": "http",
   "parameters": {
     "endpoint": "api.deepseek.com",
-    "model": "deepseek-chat"
+    "model": "<MODEL_ID>"  // example: deepseek-chat
   },
   "credential": {
     "deepSeek_key": "<PLEASE ADD YOUR DEEPSEEK API KEY HERE>"

--- a/docs/remote_inference_blueprints/llm_judgment/deepseek_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/deepseek_chat_blueprint.md
@@ -1,0 +1,154 @@
+# DeepSeek connector blueprint example for LLM judgment
+
+This blueprint integrates the [DeepSeek Chat Model](https://api-docs.deepseek.com/api/create-chat-completion) for Search Relevance Workbench (SRW) LLM judgments. It adds a `post_process_function` that returns the model text in a neutral `response` field so SRW can read any provider's output the same way. DeepSeek's API is OpenAI-compatible, so SRW's legacy `messages` parameter is used directly.
+
+## Available models
+
+Set the `model` parameter to a current DeepSeek model:
+
+| Model | Model ID |
+|---|---|
+| DeepSeek-V3 (general chat) | `deepseek-chat` |
+| DeepSeek-R1 (reasoning) | `deepseek-reasoner` |
+
+For the authoritative, current list see the [DeepSeek API docs](https://api-docs.deepseek.com/quick_start/pricing).
+
+## 1. Add connector endpoint to trusted URLs:
+Note: skip this step starting 2.19.0
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.trusted_connector_endpoints_regex": [
+          "^https://api\\.deepseek\\.com/.*$"
+        ]
+    }
+}
+```
+
+## 2. Create connector for DeepSeek Chat:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "DeepSeek Chat",
+  "description": "DeepSeek Chat connector for SRW LLM judgments",
+  "version": "1",
+  "protocol": "http",
+  "parameters": {
+    "endpoint": "api.deepseek.com",
+    "model": "deepseek-chat"
+  },
+  "credential": {
+    "deepSeek_key": "<PLEASE ADD YOUR DEEPSEEK API KEY HERE>"
+  },
+  "client_config": {
+    "max_retry_times": 3,
+    "retry_backoff_policy": "exponential_full_jitter"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://${parameters.endpoint}/v1/chat/completions",
+      "headers": {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer ${credential.deepSeek_key}"
+      },
+      "request_body": "{ \"model\": \"${parameters.model}\", \"messages\": ${parameters.messages} }",
+      "post_process_function": "def text = params.choices[0].message.content; return '{\"name\":\"response\",\"dataAsMap\":{\"response\":\"' + escape(text) + '\"}}'"
+    }
+  ]
+}
+```
+
+#### Sample response
+```json
+{
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+## 3. Create model group:
+
+```json
+POST /_plugins/_ml/model_groups/_register
+{
+    "name": "remote_model_group_llm_judgment",
+    "description": "Model group for SRW LLM judgment models"
+}
+```
+
+#### Sample response
+```json
+{
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "status": "CREATED"
+}
+```
+
+## 4. Register model to model group & deploy model:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "DeepSeek Chat model",
+  "function_name": "remote",
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "description": "DeepSeek Chat for SRW LLM judgments",
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+#### Sample response
+```json
+{
+  "task_id": "<TASK_ID>",
+  "status": "CREATED",
+  "model_id": "<MODEL_ID>"
+}
+```
+
+## 5. Test model inference
+
+SRW emits `messages` (and the neutral `system_prompt` / `user_prompt`) on every call; this blueprint references `messages`.
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_predict
+{
+  "parameters": {
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a relevance rater. Reply with strict JSON only."
+      },
+      {
+        "role": "user",
+        "content": "Rate the relevance of {\"id\":\"001\",\"text\":\"banana smoothie\"} to query banana on a 0.0-1.0 scale. Return {\"ratings\":[{\"id\":\"001\",\"rating_score\":<num>}]}."
+      }
+    ]
+  }
+}
+```
+
+#### Sample response
+The `post_process_function` copies `choices[0].message.content` into the neutral `response` field that SRW reads.
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": "{\"ratings\":[{\"id\":\"001\",\"rating_score\":0.9}]}"
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```

--- a/docs/remote_inference_blueprints/llm_judgment/google_gemini_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/google_gemini_chat_blueprint.md
@@ -40,7 +40,7 @@ POST /_plugins/_ml/connectors/_create
   "version": "1",
   "protocol": "http",
   "parameters": {
-    "model": "gemini-2.5-flash"
+    "model": "<MODEL_ID>"  // example: gemini-2.5-flash
   },
   "credential": {
     "gemini_key": "<PLEASE ADD YOUR GEMINI API KEY HERE>"

--- a/docs/remote_inference_blueprints/llm_judgment/google_gemini_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/google_gemini_chat_blueprint.md
@@ -1,0 +1,148 @@
+# Google Gemini connector blueprint example for LLM judgment
+
+This blueprint integrates a Google Gemini chat model through the [generateContent API](https://ai.google.dev/api/generate-content) for Search Relevance Workbench (SRW) LLM judgments. It maps SRW's neutral `system_prompt` / `user_prompt` parameters into Gemini's `systemInstruction` / `contents` shape and adds a `post_process_function` that returns the model text in a neutral `response` field. Get an API key from [Google AI Studio](https://aistudio.google.com/apikey).
+
+The API key is passed in the `x-goog-api-key` header rather than the URL query string, because ml-commons substitutes `${credential.*}` into headers but not into the URL.
+
+## Available models
+
+Set the `model` parameter to any current Gemini model:
+
+| Model | Model ID |
+|---|---|
+| Gemini 2.5 Pro | `gemini-2.5-pro` |
+| Gemini 2.5 Flash | `gemini-2.5-flash` |
+| Gemini 2.5 Flash-Lite | `gemini-2.5-flash-lite` |
+| Gemini 2.0 Flash | `gemini-2.0-flash` |
+
+For the authoritative, current list see [Gemini API models](https://ai.google.dev/gemini-api/docs/models).
+
+## 1. Add connector endpoint to trusted URLs
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "plugins.ml_commons.trusted_connector_endpoints_regex": [
+      "^https://generativelanguage\\.googleapis\\.com/.*$"
+    ]
+  }
+}
+```
+
+## 2. Create connector for Google Gemini Chat:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Google Gemini Chat",
+  "description": "Google Gemini generateContent connector for SRW LLM judgments",
+  "version": "1",
+  "protocol": "http",
+  "parameters": {
+    "model": "gemini-2.5-flash"
+  },
+  "credential": {
+    "gemini_key": "<PLEASE ADD YOUR GEMINI API KEY HERE>"
+  },
+  "client_config": {
+    "max_retry_times": 3,
+    "retry_backoff_policy": "exponential_full_jitter"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://generativelanguage.googleapis.com/v1beta/models/${parameters.model}:generateContent",
+      "headers": {
+        "Content-Type": "application/json",
+        "x-goog-api-key": "${credential.gemini_key}"
+      },
+      "request_body": "{\"systemInstruction\":{\"parts\":[{\"text\":\"${parameters.system_prompt}\"}]},\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"${parameters.user_prompt}\"}]}]}",
+      "post_process_function": "def text = params.candidates[0].content.parts[0].text; return '{\"name\":\"response\",\"dataAsMap\":{\"response\":\"' + escape(text) + '\"}}'"
+    }
+  ]
+}
+```
+
+#### Sample response
+```json
+{
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+## 3. Create model group:
+
+```json
+POST /_plugins/_ml/model_groups/_register
+{
+    "name": "remote_model_group_llm_judgment",
+    "description": "Model group for SRW LLM judgment models"
+}
+```
+
+#### Sample response
+```json
+{
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "status": "CREATED"
+}
+```
+
+## 4. Register model to model group & deploy model:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "Google Gemini Chat model",
+  "function_name": "remote",
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "description": "Google Gemini for SRW LLM judgments",
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+#### Sample response
+```json
+{
+  "task_id": "<TASK_ID>",
+  "status": "CREATED",
+  "model_id": "<MODEL_ID>"
+}
+```
+
+## 5. Test model inference
+
+SRW emits the neutral `system_prompt` and `user_prompt`; this blueprint maps them into Gemini's `systemInstruction` and `contents`.
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_predict
+{
+  "parameters": {
+    "system_prompt": "You are a relevance rater. Reply with strict JSON only.",
+    "user_prompt": "Rate the relevance of {\"id\":\"001\",\"text\":\"banana smoothie\"} to query banana on a 0.0-1.0 scale. Return {\"ratings\":[{\"id\":\"001\",\"rating_score\":<num>}]}."
+  }
+}
+```
+
+#### Sample response
+The `post_process_function` copies `candidates[0].content.parts[0].text` into the neutral `response` field that SRW reads.
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": "{\"ratings\":[{\"id\":\"001\",\"rating_score\":0.9}]}"
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```

--- a/docs/remote_inference_blueprints/llm_judgment/ollama_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/ollama_chat_blueprint.md
@@ -33,11 +33,14 @@ PUT /_cluster/settings
 
 ## 2. Enable private addresses
 
+A local server uses a private IP, so allow it. Starting in OpenSearch 3.7, private IP access also requires an allowlist regex (`trusted_connector_private_endpoints_regex`); adjust the pattern to your local IP.
+
 ```json
 PUT /_cluster/settings
 {
     "persistent": {
-      "plugins.ml_commons.connector.private_ip_enabled": true
+      "plugins.ml_commons.connector.private_ip_enabled": true,
+      "plugins.ml_commons.trusted_connector_private_endpoints_regex": ["^http://127\\.0\\.0\\.1:11434/.*$"]
     }
 }
 ```

--- a/docs/remote_inference_blueprints/llm_judgment/ollama_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/ollama_chat_blueprint.md
@@ -58,7 +58,7 @@ POST /_plugins/_ml/connectors/_create
   "protocol": "http",
   "parameters": {
     "endpoint": "127.0.0.1:11434",
-    "model": "qwen3:4b"
+    "model": "<MODEL_ID>"  // example: qwen3:4b
   },
   "credential": {
     "openAI_key": "<YOUR API KEY HERE IF NEEDED>"

--- a/docs/remote_inference_blueprints/llm_judgment/ollama_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/ollama_chat_blueprint.md
@@ -68,7 +68,7 @@ POST /_plugins/_ml/connectors/_create
     {
       "action_type": "predict",
       "method": "POST",
-      "url": "https://${parameters.endpoint}/v1/chat/completions",
+      "url": "http://${parameters.endpoint}/v1/chat/completions",
       "headers": {
         "Content-Type": "application/json",
         "Authorization": "Bearer ${credential.openAI_key}"

--- a/docs/remote_inference_blueprints/llm_judgment/ollama_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/ollama_chat_blueprint.md
@@ -1,0 +1,171 @@
+# Ollama (OpenAI compatible) connector blueprint example for LLM judgment
+
+This blueprint integrates a locally hosted, OpenAI-compatible LLM (Ollama, llama.cpp, vLLM, etc.) for Search Relevance Workbench (SRW) LLM judgments. It adds a `post_process_function` that returns the model text in a neutral `response` field. Any server exposing the OpenAI Chat Completions API works.
+
+## Available models
+
+Set the `model` parameter to any model you have pulled on your local server. Common Ollama examples:
+
+| Model | Model ID |
+|---|---|
+| Qwen 3 | `qwen3` |
+| Llama 3.3 | `llama3.3` |
+| Mistral | `mistral` |
+| Phi-4 | `phi4` |
+| Gemma 3 | `gemma3` |
+
+List what you have with `ollama list`, and browse the catalog at [ollama.com/library](https://ollama.com/library). For other servers (vLLM, llama.cpp), use whatever model name they expose.
+
+## 1. Add connector endpoint to trusted URLs
+
+Adjust the regex to your local IP. The following example allows all URLs.
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.trusted_connector_endpoints_regex": [
+            ".*$"
+        ]
+    }
+}
+```
+
+## 2. Enable private addresses
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+      "plugins.ml_commons.connector.private_ip_enabled": true
+    }
+}
+```
+
+## 3. Create connector for the local model
+
+In a local setting `openAI_key` might not be needed; set it to any value, or remove it and the `Authorization` header.
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Local OpenAI-compatible Chat",
+  "description": "Local OpenAI-compatible LLM connector for SRW LLM judgments",
+  "version": "1",
+  "protocol": "http",
+  "parameters": {
+    "endpoint": "127.0.0.1:11434",
+    "model": "qwen3:4b"
+  },
+  "credential": {
+    "openAI_key": "<YOUR API KEY HERE IF NEEDED>"
+  },
+  "client_config": {
+    "max_retry_times": 3,
+    "retry_backoff_policy": "exponential_full_jitter"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://${parameters.endpoint}/v1/chat/completions",
+      "headers": {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer ${credential.openAI_key}"
+      },
+      "request_body": "{ \"model\": \"${parameters.model}\", \"messages\": ${parameters.messages} }",
+      "post_process_function": "def text = params.choices[0].message.content; return '{\"name\":\"response\",\"dataAsMap\":{\"response\":\"' + escape(text) + '\"}}'"
+    }
+  ]
+}
+```
+
+#### Sample response
+```json
+{
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+## 4. Create model group:
+
+```json
+POST /_plugins/_ml/model_groups/_register
+{
+    "name": "remote_model_group_llm_judgment",
+    "description": "Model group for SRW LLM judgment models"
+}
+```
+
+#### Sample response
+```json
+{
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "status": "CREATED"
+}
+```
+
+## 5. Register model to model group & deploy model:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "Local OpenAI-compatible model",
+  "function_name": "remote",
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "description": "Local model for SRW LLM judgments",
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+#### Sample response
+```json
+{
+  "task_id": "<TASK_ID>",
+  "status": "CREATED",
+  "model_id": "<MODEL_ID>"
+}
+```
+
+## 6. Test model inference
+
+`response_format` is not sent because local-server support varies; the system prompt instructs strict JSON and SRW sanitises the response before parsing.
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_predict
+{
+  "parameters": {
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a relevance rater. Reply with strict JSON only."
+      },
+      {
+        "role": "user",
+        "content": "Rate the relevance of {\"id\":\"001\",\"text\":\"banana smoothie\"} to query banana on a 0.0-1.0 scale."
+      }
+    ]
+  }
+}
+```
+
+#### Sample response
+The `post_process_function` copies `choices[0].message.content` into the neutral `response` field that SRW reads.
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": "{\"ratings\":[{\"id\":\"001\",\"rating_score\":0.9}]}"
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```

--- a/docs/remote_inference_blueprints/llm_judgment/openai_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/openai_chat_blueprint.md
@@ -1,0 +1,183 @@
+# OpenAI connector blueprint example for LLM judgment
+
+This blueprint integrates an OpenAI Chat Completions model for Search Relevance Workbench (SRW) LLM judgments. It adds a `post_process_function` that returns the model text in a neutral `response` field. SRW emits the OpenAI-shaped `messages` and `response_format` parameters on every call, so this blueprint works without provider-specific SRW code.
+
+## Available models
+
+Set the `model` parameter to any current OpenAI chat model:
+
+| Model | Model ID |
+|---|---|
+| GPT-5 | `gpt-5` |
+| GPT-5 mini | `gpt-5-mini` |
+| GPT-4.1 | `gpt-4.1` |
+| GPT-4o | `gpt-4o` |
+| GPT-4o mini | `gpt-4o-mini` |
+
+OpenAI also releases newer GPT-5.x models (for example GPT-5.4 / GPT-5.5) regularly. For the authoritative, current list and exact IDs see [OpenAI models](https://platform.openai.com/docs/models). Models that do not support structured output can drop `response_format` from the `request_body`.
+
+## 1. Add connector endpoint to trusted URLs:
+Note: skip this step starting 2.19.0
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.trusted_connector_endpoints_regex": [
+          "^https://api\\.openai\\.com/.*$"
+        ]
+    }
+}
+```
+
+## 2. Create connector for OpenAI Chat:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "OpenAI Chat Completions",
+  "description": "OpenAI Chat Completions connector for SRW LLM judgments",
+  "version": "1",
+  "protocol": "http",
+  "parameters": {
+    "endpoint": "api.openai.com",
+    "model": "gpt-5-mini"
+  },
+  "credential": {
+    "openAI_key": "<PLEASE ADD YOUR OPENAI API KEY HERE>"
+  },
+  "client_config": {
+    "max_retry_times": 3,
+    "retry_backoff_policy": "exponential_full_jitter"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://${parameters.endpoint}/v1/chat/completions",
+      "headers": {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer ${credential.openAI_key}"
+      },
+      "request_body": "{ \"model\": \"${parameters.model}\", \"messages\": ${parameters.messages}, \"response_format\": ${parameters.response_format} }",
+      "post_process_function": "def text = params.choices[0].message.content; return '{\"name\":\"response\",\"dataAsMap\":{\"response\":\"' + escape(text) + '\"}}'"
+    }
+  ]
+}
+```
+
+#### Sample response
+```json
+{
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+## 3. Create model group:
+
+```json
+POST /_plugins/_ml/model_groups/_register
+{
+    "name": "remote_model_group_llm_judgment",
+    "description": "Model group for SRW LLM judgment models"
+}
+```
+
+#### Sample response
+```json
+{
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "status": "CREATED"
+}
+```
+
+## 4. Register model to model group & deploy model:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "OpenAI Chat Completions model",
+  "function_name": "remote",
+  "model_group_id": "<MODEL_GROUP_ID>",
+  "description": "OpenAI Chat Completions for SRW LLM judgments",
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+#### Sample response
+```json
+{
+  "task_id": "<TASK_ID>",
+  "status": "CREATED",
+  "model_id": "<MODEL_ID>"
+}
+```
+
+## 5. Test model inference
+
+SRW emits `messages` and `response_format` (and the neutral `system_prompt` / `user_prompt`) on every call. Models that do not support `response_format` (for example `gpt-3.5-turbo`) can drop it from `request_body`.
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_predict
+{
+  "parameters": {
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a relevance rater. Reply with strict JSON only."
+      },
+      {
+        "role": "user",
+        "content": "Rate the relevance of {\"id\":\"001\",\"text\":\"banana smoothie\"} to query banana on a 0.0-1.0 scale."
+      }
+    ],
+    "response_format": {
+      "type": "json_schema",
+      "json_schema": {
+        "name": "rating",
+        "strict": true,
+        "schema": {
+          "type": "object",
+          "properties": {
+            "ratings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "string" },
+                  "rating_score": { "type": "number" }
+                },
+                "required": ["id", "rating_score"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": ["ratings"],
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}
+```
+
+#### Sample response
+The `post_process_function` copies `choices[0].message.content` into the neutral `response` field that SRW reads.
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": "{\"ratings\":[{\"id\":\"001\",\"rating_score\":0.9}]}"
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```

--- a/docs/remote_inference_blueprints/llm_judgment/openai_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/openai_chat_blueprint.md
@@ -41,7 +41,7 @@ POST /_plugins/_ml/connectors/_create
   "protocol": "http",
   "parameters": {
     "endpoint": "api.openai.com",
-    "model": "gpt-5-mini"
+    "model": "<MODEL_ID>"  // example: gpt-5-mini
   },
   "credential": {
     "openAI_key": "<PLEASE ADD YOUR OPENAI API KEY HERE>"

--- a/docs/remote_inference_blueprints/llm_judgment/openai_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/llm_judgment/openai_chat_blueprint.md
@@ -1,6 +1,6 @@
 # OpenAI connector blueprint example for LLM judgment
 
-This blueprint integrates an OpenAI Chat Completions model for Search Relevance Workbench (SRW) LLM judgments. It adds a `post_process_function` that returns the model text in a neutral `response` field. SRW emits the OpenAI-shaped `messages` and `response_format` parameters on every call, so this blueprint works without provider-specific SRW code.
+This blueprint integrates an OpenAI Chat Completions model for Search Relevance Workbench (SRW) LLM judgments. It maps SRW's neutral `system_prompt` / `user_prompt` parameters into OpenAI's `messages` shape and adds a `post_process_function` that returns the model text in a neutral `response` field.
 
 ## Available models
 
@@ -14,7 +14,7 @@ Set the `model` parameter to any current OpenAI chat model:
 | GPT-4o | `gpt-4o` |
 | GPT-4o mini | `gpt-4o-mini` |
 
-OpenAI also releases newer GPT-5.x models (for example GPT-5.4 / GPT-5.5) regularly. For the authoritative, current list and exact IDs see [OpenAI models](https://platform.openai.com/docs/models). Models that do not support structured output can drop `response_format` from the `request_body`.
+OpenAI also releases newer GPT-5.x models (for example GPT-5.4 / GPT-5.5) regularly. For the authoritative, current list and exact IDs see [OpenAI models](https://platform.openai.com/docs/models).
 
 ## 1. Add connector endpoint to trusted URLs:
 Note: skip this step starting 2.19.0
@@ -59,7 +59,7 @@ POST /_plugins/_ml/connectors/_create
         "Content-Type": "application/json",
         "Authorization": "Bearer ${credential.openAI_key}"
       },
-      "request_body": "{ \"model\": \"${parameters.model}\", \"messages\": ${parameters.messages}, \"response_format\": ${parameters.response_format} }",
+      "request_body": "{\"model\":\"${parameters.model}\",\"messages\":[{\"role\":\"system\",\"content\":\"${parameters.system_prompt}\"},{\"role\":\"user\",\"content\":\"${parameters.user_prompt}\"}]}",
       "post_process_function": "def text = params.choices[0].message.content; return '{\"name\":\"response\",\"dataAsMap\":{\"response\":\"' + escape(text) + '\"}}'"
     }
   ]
@@ -115,48 +115,14 @@ POST /_plugins/_ml/models/_register?deploy=true
 
 ## 5. Test model inference
 
-SRW emits `messages` and `response_format` (and the neutral `system_prompt` / `user_prompt`) on every call. Models that do not support `response_format` (for example `gpt-3.5-turbo`) can drop it from `request_body`.
+SRW emits the neutral `system_prompt` and `user_prompt`; this blueprint maps them into OpenAI's `messages` array.
 
 ```json
 POST /_plugins/_ml/models/<MODEL_ID>/_predict
 {
   "parameters": {
-    "messages": [
-      {
-        "role": "system",
-        "content": "You are a relevance rater. Reply with strict JSON only."
-      },
-      {
-        "role": "user",
-        "content": "Rate the relevance of {\"id\":\"001\",\"text\":\"banana smoothie\"} to query banana on a 0.0-1.0 scale."
-      }
-    ],
-    "response_format": {
-      "type": "json_schema",
-      "json_schema": {
-        "name": "rating",
-        "strict": true,
-        "schema": {
-          "type": "object",
-          "properties": {
-            "ratings": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": { "type": "string" },
-                  "rating_score": { "type": "number" }
-                },
-                "required": ["id", "rating_score"],
-                "additionalProperties": false
-              }
-            }
-          },
-          "required": ["ratings"],
-          "additionalProperties": false
-        }
-      }
-    }
+    "system_prompt": "You are a relevance rater. Reply with strict JSON only.",
+    "user_prompt": "Rate the relevance of {\"id\":\"001\",\"text\":\"banana smoothie\"} to query banana on a 0.0-1.0 scale. Return {\"ratings\":[{\"id\":\"001\",\"rating_score\":<num>}]}."
   }
 }
 ```


### PR DESCRIPTION
### Description
Adds connector blueprints under `docs/remote_inference_blueprints/llm_judgment/` for the Search Relevance Workbench (SRW) LLM-as-a-judge flow, which generates relevance judgments by calling a chat model registered in ml-commons.

SRW is provider-agnostic on the wire: it sends provider-neutral `system_prompt` and `user_prompt` parameters and reads the model text back from a neutral top-level `response` field. Each blueprint absorbs one provider's request/response differences by mapping those neutral parameters into the provider's `request_body` and copying the model text into the `response` field via a `post_process_function`. This is the same connector-blueprint mechanism neural search uses to support many embedding providers without provider-specific plugin code.

Blueprints included:
- `openai_chat_blueprint.md` — OpenAI Chat Completions
- `azure_openai_chat_blueprint.md` — Azure OpenAI Chat
- `deepseek_chat_blueprint.md` — DeepSeek (OpenAI-compatible)
- `ollama_chat_blueprint.md` — Ollama and other local OpenAI-compatible servers (vLLM, llama.cpp)
- `google_gemini_chat_blueprint.md` — Google Gemini `generateContent` (API key passed in the `x-goog-api-key` header, since `${credential.*}` is substituted into headers but not the URL)
- `anthropic_claude_bedrock_blueprint.md` — Anthropic Claude on Amazon Bedrock (native `invoke`)
- `bedrock_converse_blueprint.md` — generic Amazon Bedrock Converse API (one format for any chat model on Bedrock)
- `README.md` — index and the neutral request/response contract

Each blueprint follows the existing `remote_inference_blueprints` format (numbered create-connector / register-and-deploy / test-inference steps with sample responses). Every blueprint's `request_body` and `post_process_function` was validated end-to-end against a local OpenSearch cluster — HTTP providers via a mock endpoint, and Claude (native invoke) and Bedrock Converse against real Amazon Bedrock.

### Related Issues
https://github.com/opensearch-project/search-relevance/issues/509

### Related PR
https://github.com/opensearch-project/search-relevance/pull/515

### Check List
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
