### PR TITLE
Fix unchecked and deprecated API warnings in common and memory test classes

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -82,6 +82,10 @@ jacocoTestCoverageVerification {
 }
 check.dependsOn jacocoTestCoverageVerification
 
+tasks.named('compileTestJava').configure {
+    options.compilerArgs.addAll(['-Xlint:unchecked', '-Xlint:deprecation'])
+}
+
 shadowJar {
     destinationDirectory = file("${project.buildDir}/distributions")
     archiveClassifier.set(null)

--- a/common/src/test/java/org/opensearch/ml/common/MLAgentTypeTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/MLAgentTypeTests.java
@@ -7,15 +7,9 @@ package org.opensearch.ml.common;
 
 import static org.junit.Assert.*;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class MLAgentTypeTests {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void testFromWithValidTypes() {
         // Test all enum values to ensure they return correctly
@@ -43,24 +37,23 @@ public class MLAgentTypeTests {
     @Test
     public void testFromWithInvalidType() {
         // This should throw an IllegalArgumentException
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Wrong Agent type");
-        MLAgentType.from("INVALID_TYPE");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> MLAgentType.from("INVALID_TYPE"));
+        assertEquals("Wrong Agent type", exception.getMessage());
     }
 
     @Test
     public void testFromWithEmptyString() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Wrong Agent type");
-        // This should also throw an IllegalArgumentException
-        MLAgentType.from("");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            // This should also throw an IllegalArgumentException
+            MLAgentType.from("");
+        });
+        assertEquals("Wrong Agent type", exception.getMessage());
     }
 
     @Test
     public void testFromWithNull() {
         // This should also throw an IllegalArgumentException
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Agent type can't be null");
-        MLAgentType.from(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> MLAgentType.from(null));
+        assertEquals("Agent type can't be null", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/MLCommonsClassLoaderTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/MLCommonsClassLoaderTests.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -17,9 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
@@ -49,9 +48,6 @@ public class MLCommonsClassLoaderTests {
     private StreamInput streamInputForInput;
     private Output output;
     private StreamInput streamInputForOutput;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() throws IOException {
@@ -89,11 +85,12 @@ public class MLCommonsClassLoaderTests {
 
     @Test
     public void testClassLoader_WrongType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Can't find class for type TEST");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        SampleAlgoParams mlAlgoParams = MLCommonsClassLoader.initMLInstance(TestEnum.TEST, streamInputForParams, StreamInput.class);
-        assertEquals(params.getSampleParam(), mlAlgoParams.getSampleParam());
+            SampleAlgoParams mlAlgoParams = MLCommonsClassLoader.initMLInstance(TestEnum.TEST, streamInputForParams, StreamInput.class);
+            assertEquals(params.getSampleParam(), mlAlgoParams.getSampleParam());
+        });
+        assertEquals("Can't find class for type TEST", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/MLConfigTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/MLConfigTest.java
@@ -10,9 +10,7 @@ import java.time.Instant;
 import java.util.Collections;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
@@ -25,10 +23,6 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.SearchModule;
 
 public class MLConfigTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void toXContent_Minimal() throws IOException {
         MLConfig config = MLConfig.builder().type("test_type").build();

--- a/common/src/test/java/org/opensearch/ml/common/MLModelGroupTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/MLModelGroupTest.java
@@ -5,14 +5,15 @@
 
 package org.opensearch.ml.common;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
@@ -24,16 +25,13 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.SearchModule;
 
 public class MLModelGroupTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void toXContent_NullName() {
-        exceptionRule.expect(NullPointerException.class);
-        exceptionRule.expectMessage("model group name must not be null");
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> {
 
-        MLModelGroup.builder().build();
+            MLModelGroup.builder().build();
+        });
+        assertEquals("model group name must not be null", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/MockitoTestHelper.java
+++ b/common/src/test/java/org/opensearch/ml/common/MockitoTestHelper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.opensearch.core.action.ActionListener;
+
+/**
+ * Type-safe Mockito helpers for common test patterns.
+ */
+public final class MockitoTestHelper {
+
+    private MockitoTestHelper() {}
+
+    @SuppressWarnings("unchecked") // Mockito mock() cannot preserve ActionListener generic type
+    public static <T> ActionListener<T> mockActionListener() {
+        return mock(ActionListener.class);
+    }
+
+    public static <T> ActionListener<T> anyActionListener() {
+        return ArgumentMatchers.<ActionListener<T>>any();
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" }) // ArgumentCaptor.forClass requires raw Class for generic Map
+    public static <K, V> ArgumentCaptor<Map<K, V>> forMapClass() {
+        return ArgumentCaptor.forClass((Class) java.util.Map.class);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/agent/AgentModelServiceTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/AgentModelServiceTest.java
@@ -12,17 +12,11 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.input.execute.agent.ModelProviderType;
 import org.opensearch.ml.common.transport.register.MLRegisterModelInput;
 
 public class AgentModelServiceTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void testCreateModelFromSpec_Success() {
         // Arrange
@@ -53,11 +47,12 @@ public class AgentModelServiceTest {
     @Test
     public void testCreateModelFromSpec_NullModelSpec() {
         // Arrange & Assert
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Model specification not found");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        AgentModelService.createModelFromSpec(null);
+            // Act
+            AgentModelService.createModelFromSpec(null);
+        });
+        assertEquals("Model specification not found", exception.getMessage());
     }
 
     @Test
@@ -66,11 +61,12 @@ public class AgentModelServiceTest {
         MLAgentModelSpec modelSpec = MLAgentModelSpec.builder().modelId("   ").modelProvider("bedrock/converse").build();
 
         // Assert
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model_id cannot be null or empty");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        AgentModelService.createModelFromSpec(modelSpec);
+            // Act
+            AgentModelService.createModelFromSpec(modelSpec);
+        });
+        assertEquals("model_id cannot be null or empty", exception.getMessage());
     }
 
     @Test
@@ -79,11 +75,12 @@ public class AgentModelServiceTest {
         MLAgentModelSpec modelSpec = MLAgentModelSpec.builder().modelId("test-model-id").modelProvider("  ").build();
 
         // Assert
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model_provider cannot be null or empty");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        AgentModelService.createModelFromSpec(modelSpec);
+            // Act
+            AgentModelService.createModelFromSpec(modelSpec);
+        });
+        assertEquals("model_provider cannot be null or empty", exception.getMessage());
     }
 
     @Test
@@ -96,11 +93,11 @@ public class AgentModelServiceTest {
         String expectedMessage = "Unknown model provider type. Supported types: " + supportedTypes;
 
         // Assert
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(expectedMessage);
-
-        // Act
-        AgentModelService.createModelFromSpec(modelSpec);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> AgentModelService.createModelFromSpec(modelSpec)
+        );
+        assertEquals(expectedMessage, exception.getMessage());
     }
 
     @Test
@@ -118,10 +115,11 @@ public class AgentModelServiceTest {
             .build();
 
         // Assert
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Missing credential");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        AgentModelService.createModelFromSpec(modelSpec);
+            AgentModelService.createModelFromSpec(modelSpec);
+        });
+        assertEquals("Missing credential", exception.getMessage());
     }
 
     @Test
@@ -156,11 +154,12 @@ public class AgentModelServiceTest {
             .modelProvider("bedrock/converse")
             .build();
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Missing credential");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        AgentModelService.createModelFromSpec(modelSpec);
+            // Act
+            AgentModelService.createModelFromSpec(modelSpec);
+        });
+        assertEquals("Missing credential", exception.getMessage());
     }
 
     @Test
@@ -225,11 +224,12 @@ public class AgentModelServiceTest {
             .build();
 
         // Assert
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Missing credential");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        AgentModelService.createModelFromSpec(modelSpec);
+            // Act
+            AgentModelService.createModelFromSpec(modelSpec);
+        });
+        assertEquals("Missing credential", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/agent/BedrockConverseModelProviderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/BedrockConverseModelProviderTest.java
@@ -13,9 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.connector.AwsConnector;
 import org.opensearch.ml.common.connector.Connector;
@@ -32,9 +30,6 @@ import org.opensearch.ml.common.input.execute.agent.VideoContent;
 public class BedrockConverseModelProviderTest {
 
     private BedrockConverseModelProvider provider;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -257,10 +252,11 @@ public class BedrockConverseModelProviderTest {
         modelParameters.put("region", "eu-west-1");
 
         // Arrange & Assert
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Missing credential");
-        // Act
-        provider.createConnector(modelId, null, modelParameters);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            // Act
+            provider.createConnector(modelId, null, modelParameters);
+        });
+        assertEquals("Missing credential", exception.getMessage());
     }
 
     @Test
@@ -271,11 +267,12 @@ public class BedrockConverseModelProviderTest {
         Map<String, String> modelParameters = new HashMap<>();
         modelParameters.put("region", "ap-southeast-1");
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Missing credential");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        provider.createConnector(modelId, credential, modelParameters);
+            // Act
+            provider.createConnector(modelId, credential, modelParameters);
+        });
+        assertEquals("Missing credential", exception.getMessage());
     }
 
     @Test
@@ -283,9 +280,11 @@ public class BedrockConverseModelProviderTest {
         // Arrange
         String modelName = "us.anthropic.claude-3-5-sonnet-20241022-v2:0";
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Missing credential");
-        provider.createConnector(modelName, new HashMap<>(), new HashMap<>());
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> provider.createConnector(modelName, new HashMap<>(), new HashMap<>())
+        );
+        assertEquals("Missing credential", exception.getMessage());
     }
 
     @Test
@@ -975,11 +974,12 @@ public class BedrockConverseModelProviderTest {
         AgentInput agentInput = new AgentInput();
         agentInput.setInput(blocks);
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Input type not supported. Expected String, List<ContentBlock>, or List<Message>");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+            // Act
+            provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+        });
+        assertEquals("Input type not supported. Expected String, List<ContentBlock>, or List<Message>", exception.getMessage());
     }
 
     @Test
@@ -989,11 +989,12 @@ public class BedrockConverseModelProviderTest {
         AgentInput agentInput = new AgentInput();
         agentInput.setInput(messages);
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Input type not supported. Expected String, List<ContentBlock>, or List<Message>");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+            // Act
+            provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+        });
+        assertEquals("Input type not supported. Expected String, List<ContentBlock>, or List<Message>", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/agent/GeminiV1BetaGenerateContentModelProviderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/GeminiV1BetaGenerateContentModelProviderTest.java
@@ -13,9 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.HttpConnector;
@@ -31,9 +29,6 @@ import org.opensearch.ml.common.input.execute.agent.VideoContent;
 public class GeminiV1BetaGenerateContentModelProviderTest {
 
     private GeminiV1BetaGenerateContentModelProvider provider;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -654,11 +649,12 @@ public class GeminiV1BetaGenerateContentModelProviderTest {
         AgentInput agentInput = new AgentInput();
         agentInput.setInput(blocks);
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Input type not supported. Expected String, List<ContentBlock>, or List<Message>");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+            // Act
+            provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+        });
+        assertEquals("Input type not supported. Expected String, List<ContentBlock>, or List<Message>", exception.getMessage());
     }
 
     @Test
@@ -668,11 +664,12 @@ public class GeminiV1BetaGenerateContentModelProviderTest {
         AgentInput agentInput = new AgentInput();
         agentInput.setInput(messages);
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Input type not supported. Expected String, List<ContentBlock>, or List<Message>");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+            // Act
+            provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+        });
+        assertEquals("Input type not supported. Expected String, List<ContentBlock>, or List<Message>", exception.getMessage());
     }
 
     // ==================== Tests for extractMessageFromResponse ====================

--- a/common/src/test/java/org/opensearch/ml/common/agent/LLMSpecTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/LLMSpecTest.java
@@ -7,9 +7,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
@@ -21,16 +19,13 @@ import org.opensearch.ml.common.TestHelper;
 import org.opensearch.search.SearchModule;
 
 public class LLMSpecTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void constructor_NonModelID() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model id is null");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        LLMSpec spec = new LLMSpec(null, Map.of("test_key", "test_value"));
+            LLMSpec spec = new LLMSpec(null, Map.of("test_key", "test_value"));
+        });
+        assertEquals("model id is null", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/agent/MLAgentTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/MLAgentTest.java
@@ -14,9 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -35,10 +33,6 @@ import org.opensearch.ml.common.transport.agent.MLRegisterAgentRequest;
 import org.opensearch.search.SearchModule;
 
 public class MLAgentTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     MLToolSpec mlToolSpec = new MLToolSpec(
         "test",
         "test",
@@ -53,102 +47,106 @@ public class MLAgentTest {
 
     @Test
     public void constructor_NullName() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Agent name can't be null");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        MLAgent agent = new MLAgent(
-            null,
-            MLAgentType.CONVERSATIONAL.name(),
-            "test",
-            new LLMSpec("test_model", Map.of("test_key", "test_value")),
-            null, // MLAgentModelSpec model
-            List.of(mlToolSpec),
-            null,
-            null,
-            Instant.EPOCH,
-            Instant.EPOCH,
-            "test",
-            false,
-            null,
-            null,
-            null,
-            null
-        );
+            MLAgent agent = new MLAgent(
+                null,
+                MLAgentType.CONVERSATIONAL.name(),
+                "test",
+                new LLMSpec("test_model", Map.of("test_key", "test_value")),
+                null, // MLAgentModelSpec model
+                List.of(mlToolSpec),
+                null,
+                null,
+                Instant.EPOCH,
+                Instant.EPOCH,
+                "test",
+                false,
+                null,
+                null,
+                null,
+                null
+            );
+        });
+        assertEquals("Agent name can't be null", exception.getMessage());
     }
 
     @Test
     public void constructor_NullType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Agent type can't be null");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        MLAgent agent = new MLAgent(
-            "test_agent",
-            null,
-            "test",
-            new LLMSpec("test_model", Map.of("test_key", "test_value")),
-            null, // MLAgentModelSpec model
-            List.of(mlToolSpec),
-            null,
-            null,
-            Instant.EPOCH,
-            Instant.EPOCH,
-            "test",
-            false,
-            null,
-            null,
-            null,
-            null
-        );
+            MLAgent agent = new MLAgent(
+                "test_agent",
+                null,
+                "test",
+                new LLMSpec("test_model", Map.of("test_key", "test_value")),
+                null, // MLAgentModelSpec model
+                List.of(mlToolSpec),
+                null,
+                null,
+                Instant.EPOCH,
+                Instant.EPOCH,
+                "test",
+                false,
+                null,
+                null,
+                null,
+                null
+            );
+        });
+        assertEquals("Agent type can't be null", exception.getMessage());
     }
 
     @Test
     public void constructor_NullLLMSpec() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("We need model information for the conversational agent type");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        MLAgent agent = new MLAgent(
-            "test_agent",
-            MLAgentType.CONVERSATIONAL.name(),
-            "test",
-            null,
-            null, // MLAgentModelSpec model
-            List.of(mlToolSpec),
-            null,
-            null,
-            Instant.EPOCH,
-            Instant.EPOCH,
-            "test",
-            false,
-            null,
-            null,
-            null,
-            null
-        );
+            MLAgent agent = new MLAgent(
+                "test_agent",
+                MLAgentType.CONVERSATIONAL.name(),
+                "test",
+                null,
+                null, // MLAgentModelSpec model
+                List.of(mlToolSpec),
+                null,
+                null,
+                Instant.EPOCH,
+                Instant.EPOCH,
+                "test",
+                false,
+                null,
+                null,
+                null,
+                null
+            );
+        });
+        assertEquals("We need model information for the conversational agent type", exception.getMessage());
     }
 
     @Test
     public void constructor_DuplicateTool() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Duplicate tool defined in agent configuration");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        MLAgent agent = new MLAgent(
-            "test_name",
-            MLAgentType.CONVERSATIONAL.name(),
-            "test_description",
-            new LLMSpec("test_model", Map.of("test_key", "test_value")),
-            null, // MLAgentModelSpec model
-            List.of(mlToolSpec, mlToolSpec),
-            null,
-            null,
-            Instant.EPOCH,
-            Instant.EPOCH,
-            "test",
-            false,
-            null,
-            null,
-            null,
-            null
-        );
+            MLAgent agent = new MLAgent(
+                "test_name",
+                MLAgentType.CONVERSATIONAL.name(),
+                "test_description",
+                new LLMSpec("test_model", Map.of("test_key", "test_value")),
+                null, // MLAgentModelSpec model
+                List.of(mlToolSpec, mlToolSpec),
+                null,
+                null,
+                Instant.EPOCH,
+                Instant.EPOCH,
+                "test",
+                false,
+                null,
+                null,
+                null,
+                null
+            );
+        });
+        assertEquals("Duplicate tool defined in agent configuration", exception.getMessage());
     }
 
     @Test
@@ -399,27 +397,28 @@ public class MLAgentTest {
 
     @Test
     public void constructor_InvalidAgentType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Invalid Agent Type");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        new MLAgent(
-            "test_name",
-            "INVALID_TYPE",
-            "test_description",
-            null,
-            null, // MLAgentModelSpec model
-            null,
-            null,
-            null,
-            Instant.EPOCH,
-            Instant.EPOCH,
-            "test",
-            false,
-            null,
-            null,
-            null,
-            null
-        );
+            new MLAgent(
+                "test_name",
+                "INVALID_TYPE",
+                "test_description",
+                null,
+                null, // MLAgentModelSpec model
+                null,
+                null,
+                null,
+                Instant.EPOCH,
+                Instant.EPOCH,
+                "test",
+                false,
+                null,
+                null,
+                null,
+                null
+            );
+        });
+        assertEquals("Invalid Agent Type", exception.getMessage());
     }
 
     @Test
@@ -580,27 +579,28 @@ public class MLAgentTest {
 
     @Test
     public void constructor_ConflictingContextManagement() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Cannot specify both context_management_name and context_management");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        MLAgent agent = new MLAgent(
-            "test_agent",
-            MLAgentType.FLOW.name(),
-            "test description",
-            null,
-            null, // MLAgentModelSpec model
-            null,
-            null,
-            null,
-            Instant.EPOCH,
-            Instant.EPOCH,
-            "test_app",
-            false,
-            "template_name",
-            new ContextManagementTemplate(),
-            null,
-            null
-        );
+            MLAgent agent = new MLAgent(
+                "test_agent",
+                MLAgentType.FLOW.name(),
+                "test description",
+                null,
+                null, // MLAgentModelSpec model
+                null,
+                null,
+                null,
+                Instant.EPOCH,
+                Instant.EPOCH,
+                "test_app",
+                false,
+                "template_name",
+                new ContextManagementTemplate(),
+                null,
+                null
+            );
+        });
+        assertEquals("Cannot specify both context_management_name and context_management", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/agent/OpenaiV1ChatCompletionsModelProviderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/OpenaiV1ChatCompletionsModelProviderTest.java
@@ -13,9 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.MLAgentType;
 import org.opensearch.ml.common.connector.Connector;
 import org.opensearch.ml.common.connector.HttpConnector;
@@ -32,9 +30,6 @@ import org.opensearch.ml.common.input.execute.agent.VideoContent;
 public class OpenaiV1ChatCompletionsModelProviderTest {
 
     private OpenaiV1ChatCompletionsModelProvider provider;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -782,11 +777,12 @@ public class OpenaiV1ChatCompletionsModelProviderTest {
         AgentInput agentInput = new AgentInput();
         agentInput.setInput(blocks);
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Input type not supported. Expected String, List<ContentBlock>, or List<Message>");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+            // Act
+            provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+        });
+        assertEquals("Input type not supported. Expected String, List<ContentBlock>, or List<Message>", exception.getMessage());
     }
 
     @Test
@@ -796,11 +792,12 @@ public class OpenaiV1ChatCompletionsModelProviderTest {
         AgentInput agentInput = new AgentInput();
         agentInput.setInput(messages);
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Input type not supported. Expected String, List<ContentBlock>, or List<Message>");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        // Act
-        provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+            // Act
+            provider.mapAgentInput(agentInput, MLAgentType.CONVERSATIONAL);
+        });
+        assertEquals("Input type not supported. Expected String, List<ContentBlock>, or List<Message>", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/agui/AGUIEventTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agui/AGUIEventTest.java
@@ -58,7 +58,7 @@ public class AGUIEventTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked") // Event.getResult()/getValue() returns Object; cast to Map for assertion
     public void testRunFinishedEvent_Constructor() {
         Map<String, Object> result = new HashMap<>();
         result.put("status", "success");
@@ -397,7 +397,7 @@ public class AGUIEventTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked") // Event.getResult()/getValue() returns Object; cast to Map for assertion
     public void testCustomEvent_Serialization() throws IOException {
         Map<String, Object> value = new HashMap<>();
         value.put("input_tokens", 100);

--- a/common/src/test/java/org/opensearch/ml/common/agui/AGUIInputConverterTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agui/AGUIInputConverterTest.java
@@ -299,7 +299,7 @@ public class AGUIInputConverterTest {
 
         assertNotNull(result.getAgentInput());
         assertTrue(result.getAgentInput().getInput() instanceof List);
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> convertedMessages = (List<Message>) result.getAgentInput().getInput();
         assertNotNull(convertedMessages);
         assertEquals(1, convertedMessages.size());
@@ -335,7 +335,7 @@ public class AGUIInputConverterTest {
 
         AgentMLInput result = AGUIInputConverter.convertFromAGUIInput(gson.toJson(aguiInput), "agent-id", null, false);
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> convertedMessages = (List<Message>) result.getAgentInput().getInput();
         assertEquals(3, convertedMessages.size()); // user, tool, and assistant
         assertEquals("user", convertedMessages.get(0).getRole());
@@ -374,7 +374,7 @@ public class AGUIInputConverterTest {
 
         AgentMLInput result = AGUIInputConverter.convertFromAGUIInput(gson.toJson(aguiInput), "agent-id", null, false);
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> convertedMessages = (List<Message>) result.getAgentInput().getInput();
         assertEquals(3, convertedMessages.size()); // user, assistant with tool calls, and final assistant
         assertEquals("user", convertedMessages.get(0).getRole());
@@ -400,7 +400,7 @@ public class AGUIInputConverterTest {
 
         AgentMLInput result = AGUIInputConverter.convertFromAGUIInput(gson.toJson(aguiInput), "agent-id", null, false);
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> convertedMessages = (List<Message>) result.getAgentInput().getInput();
         ContentBlock content = convertedMessages.get(0).getContent().get(0);
         assertEquals(ContentType.TEXT, content.getType());
@@ -439,7 +439,7 @@ public class AGUIInputConverterTest {
 
         AgentMLInput result = AGUIInputConverter.convertFromAGUIInput(gson.toJson(aguiInput), "agent-id", null, false);
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> convertedMessages = (List<Message>) result.getAgentInput().getInput();
         List<ContentBlock> content = convertedMessages.get(0).getContent();
         assertEquals(2, content.size());
@@ -505,7 +505,7 @@ public class AGUIInputConverterTest {
 
         AgentMLInput result = AGUIInputConverter.convertFromAGUIInput(gson.toJson(aguiInput), "agent-id", null, false);
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> convertedMessages = (List<Message>) result.getAgentInput().getInput();
         ContentBlock imageBlock = convertedMessages.get(0).getContent().get(0);
         assertEquals(ContentType.IMAGE, imageBlock.getType());
@@ -536,7 +536,7 @@ public class AGUIInputConverterTest {
 
         AgentMLInput result = AGUIInputConverter.convertFromAGUIInput(gson.toJson(aguiInput), "agent-id", null, false);
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> convertedMessages = (List<Message>) result.getAgentInput().getInput();
         // Non-image binary content should be skipped
         assertTrue(convertedMessages.get(0).getContent().isEmpty());
@@ -570,7 +570,7 @@ public class AGUIInputConverterTest {
 
         AgentMLInput result = AGUIInputConverter.convertFromAGUIInput(aguiInputJson, "agent-id", null, false);
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> convertedMessages = (List<Message>) result.getAgentInput().getInput();
         assertEquals(1, convertedMessages.size());
         assertEquals("assistant", convertedMessages.get(0).getRole());
@@ -606,7 +606,7 @@ public class AGUIInputConverterTest {
 
         AgentMLInput result = AGUIInputConverter.convertFromAGUIInput(aguiInputJson, "agent-id", null, false);
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> convertedMessages = (List<Message>) result.getAgentInput().getInput();
 
         // Should have: user, assistant with toolCalls, tool, final assistant
@@ -638,7 +638,7 @@ public class AGUIInputConverterTest {
 
         AgentMLInput result = AGUIInputConverter.convertFromAGUIInput(aguiInputJson, "agent-id", null, false);
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> convertedMessages = (List<Message>) result.getAgentInput().getInput();
         assertEquals(1, convertedMessages.size());
         // Context should NOT be embedded in the message content (it's applied later at LLM call time)
@@ -682,7 +682,7 @@ public class AGUIInputConverterTest {
 
         AgentMLInput result = AGUIInputConverter.convertFromAGUIInput(aguiInputJson, "agent-id", null, false);
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> convertedMessages = (List<Message>) result.getAgentInput().getInput();
         assertEquals(1, convertedMessages.size());
         assertEquals(2, convertedMessages.get(0).getToolCalls().size());
@@ -779,7 +779,7 @@ public class AGUIInputConverterTest {
 
         assertEquals(1, result.size());
         // Multiple content blocks should be an array
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Map<String, Object>> content = (List<Map<String, Object>>) result.get(0).get("content");
         assertEquals(2, content.size());
         assertEquals("text", content.get(0).get("type"));
@@ -803,13 +803,13 @@ public class AGUIInputConverterTest {
         List<Map<String, Object>> result = AGUIInputConverter.convertToAGUIFormat(List.of(message));
 
         assertEquals(1, result.size());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Map<String, Object>> toolCalls = (List<Map<String, Object>>) result.get(0).get("toolCalls");
         assertNotNull(toolCalls);
         assertEquals(1, toolCalls.size());
         assertEquals("call-123", toolCalls.get(0).get("id"));
         assertEquals("function", toolCalls.get(0).get("type"));
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         Map<String, String> func = (Map<String, String>) toolCalls.get(0).get("function");
         assertEquals("get_weather", func.get("name"));
         assertEquals("{\"location\":\"NYC\"}", func.get("arguments"));
@@ -870,7 +870,7 @@ public class AGUIInputConverterTest {
             """;
 
         AgentMLInput agentMLInput = AGUIInputConverter.convertFromAGUIInput(aguiInputJson, "agent-id", null, false);
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> messages = (List<Message>) agentMLInput.getAgentInput().getInput();
 
         List<Map<String, Object>> roundTripped = AGUIInputConverter.convertToAGUIFormat(messages);

--- a/common/src/test/java/org/opensearch/ml/common/agui/CustomEventTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agui/CustomEventTest.java
@@ -88,7 +88,7 @@ public class CustomEventTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked") // CustomEvent.getValue() returns Object; cast to Map for assertion
     public void testSerialization_roundTrip() throws IOException {
         Map<String, Object> value = new HashMap<>();
         value.put("inputTokens", 100);

--- a/common/src/test/java/org/opensearch/ml/common/connector/AwsConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/AwsConnectorTest.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.common.connector;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.ml.common.connector.AbstractConnector.ACCESS_KEY_FIELD;
 import static org.opensearch.ml.common.connector.AbstractConnector.SECRET_KEY_FIELD;
 import static org.opensearch.ml.common.connector.AbstractConnector.SESSION_TOKEN_FIELD;
@@ -21,9 +23,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.TriConsumer;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
@@ -37,9 +37,6 @@ import org.opensearch.ml.common.TestHelper;
 import org.opensearch.search.SearchModule;
 
 public class AwsConnectorTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     TriConsumer<List<String>, String, ActionListener<List<String>>> encryptFunction = (s, v, t) -> t
         .onResponse(List.of(s.stream().map(x -> "encrypted: " + x.toLowerCase(Locale.ROOT)).toArray(String[]::new)));
     TriConsumer<List<String>, String, ActionListener<List<String>>> decryptFunction = (s, v, t) -> t
@@ -47,53 +44,58 @@ public class AwsConnectorTest {
 
     @Test
     public void constructor_NullCredential() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Missing credential");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        AwsConnector.awsConnectorBuilder().protocol(ConnectorProtocols.AWS_SIGV4).build();
+            AwsConnector.awsConnectorBuilder().protocol(ConnectorProtocols.AWS_SIGV4).build();
+        });
+        assertEquals("Missing credential", exception.getMessage());
     }
 
     @Test
     public void constructor_NullAccessKey() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Missing credential");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        Map<String, String> credential = new HashMap<>();
-        AwsConnector.awsConnectorBuilder().protocol(ConnectorProtocols.AWS_SIGV4).credential(credential).build();
+            Map<String, String> credential = new HashMap<>();
+            AwsConnector.awsConnectorBuilder().protocol(ConnectorProtocols.AWS_SIGV4).credential(credential).build();
+        });
+        assertEquals("Missing credential", exception.getMessage());
     }
 
     @Test
     public void constructor_NullSecretKey() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Missing credential");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        Map<String, String> credential = new HashMap<>();
-        credential.put(ACCESS_KEY_FIELD, "test_access_key");
-        AwsConnector.awsConnectorBuilder().protocol(ConnectorProtocols.AWS_SIGV4).credential(credential).build();
+            Map<String, String> credential = new HashMap<>();
+            credential.put(ACCESS_KEY_FIELD, "test_access_key");
+            AwsConnector.awsConnectorBuilder().protocol(ConnectorProtocols.AWS_SIGV4).credential(credential).build();
+        });
+        assertEquals("Missing credential", exception.getMessage());
     }
 
     @Test
     public void constructor_NullServiceName() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Missing service name");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        Map<String, String> credential = new HashMap<>();
-        credential.put(ACCESS_KEY_FIELD, "test_access_key");
-        credential.put(SECRET_KEY_FIELD, "test_secret_key");
-        AwsConnector.awsConnectorBuilder().protocol(ConnectorProtocols.AWS_SIGV4).credential(credential).build();
+            Map<String, String> credential = new HashMap<>();
+            credential.put(ACCESS_KEY_FIELD, "test_access_key");
+            credential.put(SECRET_KEY_FIELD, "test_secret_key");
+            AwsConnector.awsConnectorBuilder().protocol(ConnectorProtocols.AWS_SIGV4).credential(credential).build();
+        });
+        assertEquals("Missing service name", exception.getMessage());
     }
 
     @Test
     public void constructor_NullRegion() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Missing region");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        Map<String, String> credential = new HashMap<>();
-        credential.put(ACCESS_KEY_FIELD, "test_access_key");
-        credential.put(SECRET_KEY_FIELD, "test_secret_key");
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put(SERVICE_NAME_FIELD, "test_service");
-        AwsConnector.awsConnectorBuilder().protocol(ConnectorProtocols.AWS_SIGV4).credential(credential).parameters(parameters).build();
+            Map<String, String> credential = new HashMap<>();
+            credential.put(ACCESS_KEY_FIELD, "test_access_key");
+            credential.put(SECRET_KEY_FIELD, "test_secret_key");
+            Map<String, String> parameters = new HashMap<>();
+            parameters.put(SERVICE_NAME_FIELD, "test_service");
+            AwsConnector.awsConnectorBuilder().protocol(ConnectorProtocols.AWS_SIGV4).credential(credential).parameters(parameters).build();
+        });
+        assertEquals("Missing region", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorActionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorActionTest.java
@@ -43,6 +43,7 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -863,7 +864,7 @@ public class ConnectorActionTest {
         private final List<LogEvent> logEvents = new ArrayList<>();
 
         public TestLogAppender(String name) {
-            super(name, null, PatternLayout.createDefaultLayout(), false);
+            super(name, null, PatternLayout.createDefaultLayout(), false, Property.EMPTY_ARRAY);
             start();
         }
 

--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorProtocolsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorProtocolsTest.java
@@ -5,26 +5,27 @@
 
 package org.opensearch.ml.common.connector;
 
-import org.junit.Rule;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ConnectorProtocolsTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void validateProtocol_Null() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Connector protocol is null. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]");
-        ConnectorProtocols.validateProtocol(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> ConnectorProtocols.validateProtocol(null));
+        assertEquals(
+            "Connector protocol is null. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]",
+            exception.getMessage()
+        );
     }
 
     @Test
     public void validateProtocol_WrongValue() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]");
-        ConnectorProtocols.validateProtocol("abc");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> ConnectorProtocols.validateProtocol("abc"));
+        assertEquals(
+            "Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]",
+            exception.getMessage()
+        );
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorTest.java
@@ -1,5 +1,7 @@
 package org.opensearch.ml.common.connector;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.ml.common.connector.HttpConnectorTest.createHttpConnector;
 
 import java.io.IOException;
@@ -7,9 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
@@ -21,9 +21,6 @@ import org.opensearch.ml.common.TestHelper;
 import org.opensearch.search.SearchModule;
 
 public class ConnectorTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void fromStream() throws IOException {
         HttpConnector connector = createHttpConnector();
@@ -65,19 +62,20 @@ public class ConnectorTest {
 
     @Test
     public void validateConnectorURL_Invalid() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Connector URL is not matching the trusted connector endpoint regex");
-        HttpConnector connector = createHttpConnector();
-        connector
-            .validateConnectorURL(
-                Arrays
-                    .asList(
-                        "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
-                        "^https://api\\.openai\\.com/.*$",
-                        "^https://api\\.cohere\\.ai/.*$",
-                        "^https://bedrock-agent-runtime\\\\..*[a-z0-9-]\\\\.amazonaws\\\\.com/.*$"
-                    )
-            );
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            HttpConnector connector = createHttpConnector();
+            connector
+                .validateConnectorURL(
+                    Arrays
+                        .asList(
+                            "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                            "^https://api\\.openai\\.com/.*$",
+                            "^https://api\\.cohere\\.ai/.*$",
+                            "^https://bedrock-agent-runtime\\\\..*[a-z0-9-]\\\\.amazonaws\\\\.com/.*$"
+                        )
+                );
+        });
+        assertEquals("Connector URL is not matching the trusted connector endpoint regex", exception.getMessage());
     }
 
     @Test
@@ -103,37 +101,47 @@ public class ConnectorTest {
 
     @Test
     public void validateResolvedEndpoint_noMatch_rejected() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Connector URL is not matching the trusted connector endpoint regex");
-        HttpConnector connector = createHttpConnector();
-        connector
-            .validateResolvedEndpoint(
-                "https://attacker.example.com/anything?/v1/chat/completions",
-                Arrays.asList("^https://api\\.openai\\.com/.*$")
-            );
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            HttpConnector connector = createHttpConnector();
+            connector
+                .validateResolvedEndpoint(
+                    "https://attacker.example.com/anything?/v1/chat/completions",
+                    Arrays.asList("^https://api\\.openai\\.com/.*$")
+                );
+        });
+        assertEquals("Connector URL is not matching the trusted connector endpoint regex", exception.getMessage());
     }
 
     @Test
     public void validateResolvedEndpoint_emptyAllowlist_rejected() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Trusted connector endpoints regex is not configured");
-        HttpConnector connector = createHttpConnector();
-        connector.validateResolvedEndpoint("https://api.openai.com/v1/chat/completions", Collections.emptyList());
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            HttpConnector connector = createHttpConnector();
+            connector.validateResolvedEndpoint("https://api.openai.com/v1/chat/completions", Collections.emptyList());
+        });
+        assertEquals(
+            "Trusted connector endpoints regex is not configured. Please set plugins.ml_commons.trusted_connector_endpoints_regex.",
+            exception.getMessage()
+        );
     }
 
     @Test
     public void validateResolvedEndpoint_nullAllowlist_rejected() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Trusted connector endpoints regex is not configured");
-        HttpConnector connector = createHttpConnector();
-        connector.validateResolvedEndpoint("https://api.openai.com/v1/chat/completions", null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            HttpConnector connector = createHttpConnector();
+            connector.validateResolvedEndpoint("https://api.openai.com/v1/chat/completions", null);
+        });
+        assertEquals(
+            "Trusted connector endpoints regex is not configured. Please set plugins.ml_commons.trusted_connector_endpoints_regex.",
+            exception.getMessage()
+        );
     }
 
     @Test
     public void validateResolvedEndpoint_nullResolvedUrl_rejected() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Resolved connector URL is null");
-        HttpConnector connector = createHttpConnector();
-        connector.validateResolvedEndpoint(null, Arrays.asList("^https://api\\.openai\\.com/.*$"));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            HttpConnector connector = createHttpConnector();
+            connector.validateResolvedEndpoint(null, Arrays.asList("^https://api\\.openai\\.com/.*$"));
+        });
+        assertEquals("Resolved connector URL is null", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/HttpConnectorTest.java
@@ -5,7 +5,9 @@
 
 package org.opensearch.ml.common.connector;
 
-import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.opensearch.ml.common.MockitoTestHelper.mockActionListener;
 import static org.opensearch.ml.common.connector.ConnectorAction.ActionType.PREDICT;
 
 import java.io.IOException;
@@ -19,9 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.TriConsumer;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
@@ -42,15 +42,12 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 public class HttpConnectorTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     TriConsumer<List<String>, String, ActionListener<List<String>>> encryptFunction = (s, v, t) -> t
         .onResponse(List.of(s.stream().map(x -> "encrypted: " + x.toLowerCase(Locale.ROOT)).toArray(String[]::new)));
     TriConsumer<List<String>, String, ActionListener<List<String>>> decryptFunction = (s, v, t) -> t
         .onResponse(List.of(s.stream().map(x -> "decrypted: " + x.toUpperCase(Locale.ROOT)).toArray(String[]::new)));
 
-    ActionListener<Boolean> listener = mock(ActionListener.class);
+    ActionListener<Boolean> listener = mockActionListener();
 
     String TEST_CONNECTOR_JSON_STRING = "{\"name\":\"test_connector_name\",\"version\":\"1\","
         + "\"description\":\"this is a test connector\",\"protocol\":\"http\","
@@ -66,10 +63,14 @@ public class HttpConnectorTest {
 
     @Test
     public void constructor_InvalidProtocol() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        HttpConnector.builder().protocol("wrong protocol").build();
+            HttpConnector.builder().protocol("wrong protocol").build();
+        });
+        assertEquals(
+            "Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]",
+            exception.getMessage()
+        );
     }
 
     @Test
@@ -171,21 +172,23 @@ public class HttpConnectorTest {
 
     @Test
     public void createPayload_Invalid() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Some parameter placeholder not filled in payload: input");
-        HttpConnector connector = createHttpConnector();
-        String predictPayload = connector.createPayload(PREDICT.name(), null);
-        connector.validatePayload(predictPayload);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            HttpConnector connector = createHttpConnector();
+            String predictPayload = connector.createPayload(PREDICT.name(), null);
+            connector.validatePayload(predictPayload);
+        });
+        assertEquals("Some parameter placeholder not filled in payload: input", exception.getMessage());
     }
 
     @Test
     public void createPayload_InvalidJson() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Invalid payload: {\"input\": ${parameters.input} }");
-        String requestBody = "{\"input\": ${parameters.input} }";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
-        String predictPayload = connector.createPayload(PREDICT.name(), null);
-        connector.validatePayload(predictPayload);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            String requestBody = "{\"input\": ${parameters.input} }";
+            HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+            String predictPayload = connector.createPayload(PREDICT.name(), null);
+            connector.validatePayload(predictPayload);
+        });
+        assertEquals("Invalid payload: {\"input\": ${parameters.input} }", exception.getMessage());
     }
 
     @Test
@@ -218,19 +221,20 @@ public class HttpConnectorTest {
 
     @Test
     public void createPayload_MissingParamsInvalidJson() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule
-            .expectMessage(
-                "Invalid payload: {\"input\": \"test value\", \"parameters\": {\"sparseEmbeddingFormat\": \"WORD\", \"content_type\": ${parameters.content_type} }}"
-            );
-        String requestBody =
-            "{\"input\": \"${parameters.input}\", \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": ${parameters.content_type} }}";
-        HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put("input", "test value");
-        parameters.put("sparseEmbeddingFormat", "WORD");
-        String predictPayload = connector.createPayload(PREDICT.name(), parameters);
-        connector.validatePayload(predictPayload);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            String requestBody =
+                "{\"input\": \"${parameters.input}\", \"parameters\": {\"sparseEmbeddingFormat\": \"${parameters.sparseEmbeddingFormat}\", \"content_type\": ${parameters.content_type} }}";
+            HttpConnector connector = createHttpConnectorWithRequestBody(requestBody);
+            Map<String, String> parameters = new HashMap<>();
+            parameters.put("input", "test value");
+            parameters.put("sparseEmbeddingFormat", "WORD");
+            String predictPayload = connector.createPayload(PREDICT.name(), parameters);
+            connector.validatePayload(predictPayload);
+        });
+        assertEquals(
+            "Invalid payload: {\"input\": \"test value\", \"parameters\": {\"sparseEmbeddingFormat\": \"WORD\", \"content_type\": ${parameters.content_type} }}",
+            exception.getMessage()
+        );
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/MLPostProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/MLPostProcessFunctionTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.common.connector;
 
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.ml.common.connector.MLPostProcessFunction.BEDROCK_EMBEDDING;
 import static org.opensearch.ml.common.connector.MLPostProcessFunction.COHERE_EMBEDDING;
 import static org.opensearch.ml.common.connector.MLPostProcessFunction.DEFAULT_EMBEDDING;
@@ -15,15 +16,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class MLPostProcessFunctionTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void contains() {
         Assert.assertTrue(MLPostProcessFunction.contains(OPENAI_EMBEDDING));
@@ -51,7 +46,6 @@ public class MLPostProcessFunctionTest {
 
     @Test
     public void test_buildModelTensorList_exception() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        MLPostProcessFunction.get(DEFAULT_EMBEDDING).apply(null, null);
+        assertThrows(IllegalArgumentException.class, () -> MLPostProcessFunction.get(DEFAULT_EMBEDDING).apply(null, null));
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/McpConnectorTest.java
@@ -5,7 +5,9 @@
 
 package org.opensearch.ml.common.connector;
 
-import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.opensearch.ml.common.MockitoTestHelper.mockActionListener;
 import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_SSE;
 import static org.opensearch.ml.common.connector.RetryBackoffPolicy.CONSTANT;
 
@@ -18,9 +20,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.TriConsumer;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
@@ -37,24 +37,25 @@ import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
 import org.opensearch.search.SearchModule;
 
 public class McpConnectorTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     TriConsumer<List<String>, String, ActionListener<List<String>>> encryptFunction = (s, v, t) -> t
         .onResponse(List.of(s.stream().map(x -> "encrypted: " + x.toLowerCase(Locale.ROOT)).toArray(String[]::new)));
     TriConsumer<List<String>, String, ActionListener<List<String>>> decryptFunction = (s, v, t) -> t
         .onResponse(List.of(s.stream().map(x -> "decrypted: " + x.toUpperCase(Locale.ROOT)).toArray(String[]::new)));
 
-    private ActionListener<Boolean> actionListener = mock(ActionListener.class);
+    private ActionListener<Boolean> actionListener = mockActionListener();
     String TEST_CONNECTOR_JSON_STRING =
         "{\"name\":\"test_mcp_connector_name\",\"version\":\"1\",\"description\":\"this is a test mcp connector\",\"protocol\":\"mcp_sse\",\"credential\":{\"key\":\"test_key_value\"},\"backend_roles\":[\"role1\",\"role2\"],\"access\":\"public\",\"client_config\":{\"max_connection\":30,\"connection_timeout\":30,\"read_timeout\":30,\"retry_backoff_millis\":10,\"retry_timeout_seconds\":10,\"max_retry_times\":-1,\"retry_backoff_policy\":\"constant\"},\"url\":\"https://test.com\",\"headers\":{\"api_key\":\"${credential.key}\"},\"parameters\":{\"sse_endpoint\":\"/custom/sse\"}}";
 
     @Test
     public void constructor_InvalidProtocol() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        McpConnector.builder().protocol("wrong protocol").build();
+            McpConnector.builder().protocol("wrong protocol").build();
+        });
+        assertEquals(
+            "Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]",
+            exception.getMessage()
+        );
     }
 
     @Test
@@ -158,18 +159,19 @@ public class McpConnectorTest {
             );
 
         // Test invalid URL
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Connector URL is not matching the trusted connector endpoint regex");
-        connector
-            .validateConnectorURL(
-                Arrays
-                    .asList(
-                        "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
-                        "^https://api\\.openai\\.com/.*$",
-                        "^https://api\\.cohere\\.ai/.*$",
-                        "^https://bedrock-agent-runtime\\\\..*[a-z0-9-]\\\\.amazonaws\\\\.com/.*$"
-                    )
-            );
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            connector
+                .validateConnectorURL(
+                    Arrays
+                        .asList(
+                            "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                            "^https://api\\.openai\\.com/.*$",
+                            "^https://api\\.cohere\\.ai/.*$",
+                            "^https://bedrock-agent-runtime\\\\..*[a-z0-9-]\\\\.amazonaws\\\\.com/.*$"
+                        )
+                );
+        });
+        assertEquals("Connector URL is not matching the trusted connector endpoint regex", exception.getMessage());
     }
 
     @Test
@@ -286,9 +288,8 @@ public class McpConnectorTest {
             .updateConnector(true)
             .build();
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("MCP Connector url is blank");
-        connector.update(updateInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> connector.update(updateInput));
+        assertEquals("MCP Connector url is blank", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/McpStreamableHttpConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/McpStreamableHttpConnectorTest.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.common.connector;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.ml.common.connector.ConnectorProtocols.MCP_STREAMABLE_HTTP;
 import static org.opensearch.ml.common.connector.RetryBackoffPolicy.CONSTANT;
 
@@ -17,9 +19,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.TriConsumer;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
@@ -36,9 +36,6 @@ import org.opensearch.ml.common.transport.connector.MLCreateConnectorInput;
 import org.opensearch.search.SearchModule;
 
 public class McpStreamableHttpConnectorTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     TriConsumer<List<String>, String, ActionListener<List<String>>> encryptFunction = (s, v, t) -> t
         .onResponse(List.of(s.stream().map(x -> "encrypted: " + x.toLowerCase(Locale.ROOT)).toArray(String[]::new)));
     TriConsumer<List<String>, String, ActionListener<List<String>>> decryptFunction = (s, v, t) -> t
@@ -49,10 +46,14 @@ public class McpStreamableHttpConnectorTest {
 
     @Test
     public void constructor_InvalidProtocol() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        McpStreamableHttpConnector.builder().protocol("wrong protocol").build();
+            McpStreamableHttpConnector.builder().protocol("wrong protocol").build();
+        });
+        assertEquals(
+            "Unsupported connector protocol. Please use one of [aws_sigv4, http, mcp_sse, mcp_streamable_http]",
+            exception.getMessage()
+        );
     }
 
     @Test
@@ -145,19 +146,20 @@ public class McpStreamableHttpConnectorTest {
 
     @Test
     public void validateConnectorURL_Invalid() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Connector URL is not matching the trusted connector endpoint regex");
-        McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
-        connector
-            .validateConnectorURL(
-                Arrays
-                    .asList(
-                        "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
-                        "^https://api\\.openai\\.com/.*$",
-                        "^https://api\\.cohere\\.ai/.*$",
-                        "^https://bedrock-agent-runtime\\\\..*[a-z0-9-]\\\\.amazonaws\\\\.com/.*$"
-                    )
-            );
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            McpStreamableHttpConnector connector = createMcpStreamableHttpConnector();
+            connector
+                .validateConnectorURL(
+                    Arrays
+                        .asList(
+                            "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                            "^https://api\\.openai\\.com/.*$",
+                            "^https://api\\.cohere\\.ai/.*$",
+                            "^https://bedrock-agent-runtime\\\\..*[a-z0-9-]\\\\.amazonaws\\\\.com/.*$"
+                        )
+                );
+        });
+        assertEquals("Connector URL is not matching the trusted connector endpoint regex", exception.getMessage());
     }
 
     @Test
@@ -261,10 +263,8 @@ public class McpStreamableHttpConnectorTest {
             .updateConnector(true)
             .build();
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("MCP Connector url is blank");
-        connector.update(updateInput);
-        TestHelper.endecryptCredentials(connector, encryptFunction, true);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> connector.update(updateInput));
+        assertEquals("MCP Connector url is blank", exception.getMessage());
     }
 
     public static McpStreamableHttpConnector createMcpStreamableHttpConnector() {

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockBatchJobArnPostProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockBatchJobArnPostProcessFunctionTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.connector.functions.postprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.ml.common.connector.functions.postprocess.BedrockBatchJobArnPostProcessFunction.JOB_ARN;
 import static org.opensearch.ml.common.connector.functions.postprocess.BedrockBatchJobArnPostProcessFunction.PROCESSED_JOB_ARN;
 
@@ -13,16 +14,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.output.model.ModelTensor;
 
 public class BedrockBatchJobArnPostProcessFunctionTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     BedrockBatchJobArnPostProcessFunction function;
 
     @Before
@@ -32,16 +27,17 @@ public class BedrockBatchJobArnPostProcessFunctionTest {
 
     @Test
     public void process_WrongInput_NotMap() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Post process function input is not a Map.");
-        function.apply("abc", null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply("abc", null));
+        assertEquals("Post process function input is not a Map.", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput_NotContainJobArn() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("job arn is missing.");
-        function.apply(Map.of("test", "value"), null);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> function.apply(Map.of("test", "value"), null)
+        );
+        assertEquals("job arn is missing.", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockEmbeddingPostProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockEmbeddingPostProcessFunctionTest.java
@@ -6,20 +6,16 @@
 package org.opensearch.ml.common.connector.functions.postprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.output.model.ModelTensor;
 
 public class BedrockEmbeddingPostProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     BedrockEmbeddingPostProcessFunction function;
 
     @Before
@@ -29,16 +25,14 @@ public class BedrockEmbeddingPostProcessFunctionTest {
 
     @Test
     public void process_WrongInput_NotList() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Post process function input is not a List.");
-        function.apply("abc", null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply("abc", null));
+        assertEquals("Post process function input is not a List.", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput_NotNumberList() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The embedding should be a non-empty List containing Float values.");
-        function.apply(Arrays.asList("abc"), null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(Arrays.asList("abc"), null));
+        assertEquals("The embedding should be a non-empty List containing Float values.", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockRerankPostProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/BedrockRerankPostProcessFunctionTest.java
@@ -6,21 +6,17 @@
 package org.opensearch.ml.common.connector.functions.postprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.output.model.ModelTensor;
 
 public class BedrockRerankPostProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     BedrockRerankPostProcessFunction function;
 
     @Before
@@ -30,58 +26,59 @@ public class BedrockRerankPostProcessFunctionTest {
 
     @Test
     public void process_WrongInput_NotList() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Post process function input is not a List.");
-        function.apply("abc", null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply("abc", null));
+        assertEquals("Post process function input is not a List.", exception.getMessage());
     }
 
     @Test
     public void process_EmptyInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Post process function input is empty.");
-        function.apply(Arrays.asList(), null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(Arrays.asList(), null));
+        assertEquals("Post process function input is empty.", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput_NotCorrectListOfMapsFormat() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Rerank result is not a Map.");
-        function.apply(Arrays.asList("abc"), null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(Arrays.asList("abc"), null));
+        assertEquals("Rerank result is not a Map.", exception.getMessage());
     }
 
     @Test
     public void process_EmptyMapInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Rerank result is empty.");
-        function.apply(Arrays.asList(Map.of()), null);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> function.apply(Arrays.asList(Map.of()), null)
+        );
+        assertEquals("Rerank result is empty.", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput_NotCorrectMap() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Rerank result should have both index and relevanceScore.");
-        List<Map<String, Object>> rerankResults = List
-            .of(
-                Map.of("index", 2, "relevanceScore", 0.7711548805236816),
-                Map.of("index", 0, "relevanceScore", 0.0025114635936915874),
-                Map.of("index", 1, "relevanceScore", 2.4876489987946115e-05),
-                Map.of("test1", "value1")
-            );
-        function.apply(rerankResults, null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            List<Map<String, Object>> rerankResults = List
+                .of(
+                    Map.of("index", 2, "relevanceScore", 0.7711548805236816),
+                    Map.of("index", 0, "relevanceScore", 0.0025114635936915874),
+                    Map.of("index", 1, "relevanceScore", 2.4876489987946115e-05),
+                    Map.of("test1", "value1")
+                );
+            function.apply(rerankResults, null);
+        });
+        assertEquals("Rerank result should have both index and relevanceScore.", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput_NotCorrectRelevanceScore() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("relevanceScore is not BigDecimal or Double.");
-        List<Map<String, Object>> rerankResults = List
-            .of(
-                Map.of("index", 2, "relevanceScore", 0.7711548805236816),
-                Map.of("index", 0, "relevanceScore", 0.0025114635936915874),
-                Map.of("index", 1, "relevanceScore", 2.4876489987946115e-05),
-                Map.of("index", 3, "relevanceScore", "value1")
-            );
-        function.apply(rerankResults, null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            List<Map<String, Object>> rerankResults = List
+                .of(
+                    Map.of("index", 2, "relevanceScore", 0.7711548805236816),
+                    Map.of("index", 0, "relevanceScore", 0.0025114635936915874),
+                    Map.of("index", 1, "relevanceScore", 2.4876489987946115e-05),
+                    Map.of("index", 3, "relevanceScore", "value1")
+                );
+            function.apply(rerankResults, null);
+        });
+        assertEquals("relevanceScore is not BigDecimal or Double.", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/CohereRerankPostProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/CohereRerankPostProcessFunctionTest.java
@@ -6,21 +6,17 @@
 package org.opensearch.ml.common.connector.functions.postprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.output.model.ModelTensor;
 
 public class CohereRerankPostProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     CohereRerankPostProcessFunction function;
 
     @Before
@@ -30,23 +26,23 @@ public class CohereRerankPostProcessFunctionTest {
 
     @Test
     public void process_WrongInput_NotList() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Post process function input is not a List.");
-        function.apply("abc", null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply("abc", null));
+        assertEquals("Post process function input is not a List.", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput_NotCorrectList() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Post process function input is not a List of Map.");
-        function.apply(Arrays.asList("abc"), null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(Arrays.asList("abc"), null));
+        assertEquals("Post process function input is not a List of Map.", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput_NotCorrectMap() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The rerank result should contain index and relevance_score.");
-        function.apply(Arrays.asList(Map.of("test1", "value1")), null);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> function.apply(Arrays.asList(Map.of("test1", "value1")), null)
+        );
+        assertEquals("The rerank result should contain index and relevance_score.", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/EmbeddingPostProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/EmbeddingPostProcessFunctionTest.java
@@ -6,20 +6,16 @@
 package org.opensearch.ml.common.connector.functions.postprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.output.model.ModelTensor;
 
 public class EmbeddingPostProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     EmbeddingPostProcessFunction function;
 
     @Before
@@ -29,23 +25,23 @@ public class EmbeddingPostProcessFunctionTest {
 
     @Test
     public void process_WrongInput_NotList() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Post process function input is not a List.");
-        function.apply("abc", null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply("abc", null));
+        assertEquals("Post process function input is not a List.", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput_NotListOfList() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The embedding should be a non-empty List containing List of Float values.");
-        function.apply(Arrays.asList("abc"), null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(Arrays.asList("abc"), null));
+        assertEquals("The embedding should be a non-empty List containing List of Float values.", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput_NotListOfNumber() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The embedding should be a non-empty List containing Float values.");
-        function.apply(List.of(Arrays.asList("abc")), null);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> function.apply(List.of(Arrays.asList("abc")), null)
+        );
+        assertEquals("The embedding should be a non-empty List containing Float values.", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/RemoteMlCommonsPassthroughPostProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/postprocess/RemoteMlCommonsPassthroughPostProcessFunctionTest.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.connector.functions.postprocess;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.ml.common.output.model.ModelTensors.OUTPUT_FIELD;
 
 import java.util.Arrays;
@@ -14,16 +15,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.output.model.MLResultDataType;
 import org.opensearch.ml.common.output.model.ModelTensor;
 
 public class RemoteMlCommonsPassthroughPostProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     RemoteMlCommonsPassthroughPostProcessFunction function;
 
     @Before
@@ -33,9 +29,8 @@ public class RemoteMlCommonsPassthroughPostProcessFunctionTest {
 
     @Test
     public void process_WrongInput_NotMapOrList() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Post process function input must be a Map or List");
-        function.apply("abc", null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply("abc", null));
+        assertEquals("Post process function input must be a Map or List", exception.getMessage());
     }
 
     /**
@@ -59,7 +54,8 @@ public class RemoteMlCommonsPassthroughPostProcessFunctionTest {
         assertEquals(innerDataAsMap, tensor.getDataAsMap());
 
         // Verify the nested sparse data structure
-        Map<String, Object> dataAsMap = (Map<String, Object>) tensor.getDataAsMap();
+        Map<String, ?> dataAsMap = tensor.getDataAsMap();
+        @SuppressWarnings("unchecked") // Nested response list is parsed from dynamic JSON structure
         List<Map<String, Object>> response = (List<Map<String, Object>>) dataAsMap.get("response");
         assertEquals(1, response.size());
         assertEquals(0.35982144, (Double) response.get(0).get("hello"), 0.0001);

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/AudioEmbeddingPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/AudioEmbeddingPreProcessFunctionTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -14,9 +15,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -24,9 +23,6 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
 public class AudioEmbeddingPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     AudioEmbeddingPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
@@ -51,16 +47,17 @@ public class AudioEmbeddingPreProcessFunctionTest {
 
     @Test
     public void process_NullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support TextDocsInputDataSet");
-        function.apply(textSimilarityInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(textSimilarityInput));
+        assertEquals(
+            "This pre_process_function can only support TextDocsInputDataSet which including a list of string with key 'text_docs'",
+            exception.getMessage()
+        );
     }
 
     @Test
@@ -77,9 +74,8 @@ public class AudioEmbeddingPreProcessFunctionTest {
         when(mockDataSet.getDocs()).thenReturn(Collections.emptyList());
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(mockDataSet).build();
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("No input audio provided");
-        function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(mlInput));
+        assertEquals("No input audio provided", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/BedrockEmbeddingPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/BedrockEmbeddingPreProcessFunctionTest.java
@@ -6,14 +6,13 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -21,9 +20,6 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
 public class BedrockEmbeddingPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     BedrockEmbeddingPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
@@ -48,16 +44,17 @@ public class BedrockEmbeddingPreProcessFunctionTest {
 
     @Test
     public void process_NullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support TextDocsInputDataSet");
-        function.apply(textSimilarityInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(textSimilarityInput));
+        assertEquals(
+            "This pre_process_function can only support TextDocsInputDataSet which including a list of string with key 'text_docs'",
+            exception.getMessage()
+        );
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/BedrockRerankPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/BedrockRerankPreProcessFunctionTest.java
@@ -6,15 +6,14 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 
 import org.json.JSONArray;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -22,9 +21,6 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
 public class BedrockRerankPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     BedrockRerankPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
@@ -39,17 +35,17 @@ public class BedrockRerankPreProcessFunctionTest {
 
     @Test
     public void process_NullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support TextSimilarityInputDataSet");
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
-        function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
+            function.apply(mlInput);
+        });
+        assertEquals("This pre_process_function can only support TextSimilarityInputDataSet", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/CohereEmbeddingPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/CohereEmbeddingPreProcessFunctionTest.java
@@ -6,13 +6,12 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -20,9 +19,6 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
 public class CohereEmbeddingPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     CohereEmbeddingPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
@@ -37,17 +33,20 @@ public class CohereEmbeddingPreProcessFunctionTest {
 
     @Test
     public void process_NullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support TextDocsInputDataSet");
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_SIMILARITY).inputDataset(textSimilarityInputDataSet).build();
-        function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_SIMILARITY).inputDataset(textSimilarityInputDataSet).build();
+            function.apply(mlInput);
+        });
+        assertEquals(
+            "This pre_process_function can only support TextDocsInputDataSet which including a list of string with key 'text_docs'",
+            exception.getMessage()
+        );
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/CohereMultiModalEmbeddingPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/CohereMultiModalEmbeddingPreProcessFunctionTest.java
@@ -6,15 +6,14 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -22,9 +21,6 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
 public class CohereMultiModalEmbeddingPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     CohereMultiModalEmbeddingPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
@@ -49,16 +45,17 @@ public class CohereMultiModalEmbeddingPreProcessFunctionTest {
 
     @Test
     public void testProcess_whenNullInput_expectIllegalArgumentException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void testProcess_whenWrongInput_expectIllegalArgumentException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support TextDocsInputDataSet");
-        function.apply(textSimilarityInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(textSimilarityInput));
+        assertEquals(
+            "This pre_process_function can only support TextDocsInputDataSet which including a list of string with key 'text_docs'",
+            exception.getMessage()
+        );
     }
 
     @Test
@@ -72,13 +69,14 @@ public class CohereMultiModalEmbeddingPreProcessFunctionTest {
 
     @Test
     public void testProcess_whenInputTextIsnull_expectIllegalArgumentException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("No image provided");
-        List<String> docs = new ArrayList<>();
-        docs.add(null);
-        TextDocsInputDataSet textDocsInputDataSet1 = TextDocsInputDataSet.builder().docs(docs).build();
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet1).build();
-        RemoteInferenceInputDataSet dataSet = function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            List<String> docs = new ArrayList<>();
+            docs.add(null);
+            TextDocsInputDataSet textDocsInputDataSet1 = TextDocsInputDataSet.builder().docs(docs).build();
+            MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet1).build();
+            RemoteInferenceInputDataSet dataSet = function.apply(mlInput);
+        });
+        assertEquals("No image provided", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/CohereRerankPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/CohereRerankPreProcessFunctionTest.java
@@ -6,13 +6,12 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -20,9 +19,6 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
 public class CohereRerankPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     CohereRerankPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
@@ -37,17 +33,17 @@ public class CohereRerankPreProcessFunctionTest {
 
     @Test
     public void process_NullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support TextSimilarityInputDataSet");
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
-        function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
+            function.apply(mlInput);
+        });
+        assertEquals("This pre_process_function can only support TextSimilarityInputDataSet", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/DefaultPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/DefaultPreProcessFunctionTest.java
@@ -6,15 +6,14 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.ingest.TestTemplateService;
@@ -25,9 +24,6 @@ import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.script.ScriptService;
 
 public class DefaultPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     DefaultPreProcessFunction functionWithConvertToJsonString;
     DefaultPreProcessFunction functionWithoutConvertToJsonString;
 
@@ -49,27 +45,31 @@ public class DefaultPreProcessFunctionTest {
 
     @Test
     public void process_NullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        functionWithConvertToJsonString.apply(null);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> functionWithConvertToJsonString.apply(null)
+        );
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void process_CorrectInput_WrongProcessedResult() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function output is null");
-        when(scriptService.compile(any(), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(null));
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
-        functionWithConvertToJsonString.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            when(scriptService.compile(any(), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(null));
+            MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
+            functionWithConvertToJsonString.apply(mlInput);
+        });
+        assertEquals("Preprocess function output is null", exception.getMessage());
     }
 
     @Test
     public void process_CorrectInput_WrongProcessedResult_WithoutConvertToJsonString() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function output is null");
-        when(scriptService.compile(any(), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(null));
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
-        functionWithoutConvertToJsonString.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            when(scriptService.compile(any(), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(null));
+            MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
+            functionWithoutConvertToJsonString.apply(mlInput);
+        });
+        assertEquals("Preprocess function output is null", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/ImageEmbeddingPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/ImageEmbeddingPreProcessFunctionTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -14,9 +15,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -24,9 +23,6 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
 public class ImageEmbeddingPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     ImageEmbeddingPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
@@ -51,16 +47,17 @@ public class ImageEmbeddingPreProcessFunctionTest {
 
     @Test
     public void process_NullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support TextDocsInputDataSet");
-        function.apply(textSimilarityInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(textSimilarityInput));
+        assertEquals(
+            "This pre_process_function can only support TextDocsInputDataSet which including a list of string with key 'text_docs'",
+            exception.getMessage()
+        );
     }
 
     @Test
@@ -77,9 +74,8 @@ public class ImageEmbeddingPreProcessFunctionTest {
         when(mockDataSet.getDocs()).thenReturn(Collections.emptyList());
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(mockDataSet).build();
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("No input image provided");
-        function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(mlInput));
+        assertEquals("No input image provided", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/MultiModalConnectorPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/MultiModalConnectorPreProcessFunctionTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,9 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -23,9 +22,6 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
 public class MultiModalConnectorPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     MultiModalConnectorPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
@@ -53,16 +49,17 @@ public class MultiModalConnectorPreProcessFunctionTest {
 
     @Test
     public void testProcess_whenNullInput_expectIllegalArgumentException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void testProcess_whenWrongInput_expectIllegalArgumentException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support TextDocsInputDataSet");
-        function.apply(textSimilarityInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(textSimilarityInput));
+        assertEquals(
+            "This pre_process_function can only support TextDocsInputDataSet which including a list of string with key 'text_docs'",
+            exception.getMessage()
+        );
     }
 
     @Test
@@ -85,13 +82,14 @@ public class MultiModalConnectorPreProcessFunctionTest {
 
     @Test
     public void testProcess_whenInputTextIsnull_expectIllegalArgumentException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("No input text or image provided");
-        List<String> docs = new ArrayList<>();
-        docs.add(null);
-        TextDocsInputDataSet textDocsInputDataSet1 = TextDocsInputDataSet.builder().docs(docs).build();
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet1).build();
-        RemoteInferenceInputDataSet dataSet = function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            List<String> docs = new ArrayList<>();
+            docs.add(null);
+            TextDocsInputDataSet textDocsInputDataSet1 = TextDocsInputDataSet.builder().docs(docs).build();
+            MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet1).build();
+            RemoteInferenceInputDataSet dataSet = function.apply(mlInput);
+        });
+        assertEquals("No input text or image provided", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/NovaMultiModalEmbeddingPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/NovaMultiModalEmbeddingPreProcessFunctionTest.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -15,9 +16,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -25,9 +24,6 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
 public class NovaMultiModalEmbeddingPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     NovaMultiModalEmbeddingPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
@@ -48,16 +44,17 @@ public class NovaMultiModalEmbeddingPreProcessFunctionTest {
 
     @Test
     public void process_NullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support TextDocsInputDataSet");
-        function.apply(textSimilarityInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(textSimilarityInput));
+        assertEquals(
+            "This pre_process_function can only support TextDocsInputDataSet which including a list of string with key 'text_docs'",
+            exception.getMessage()
+        );
     }
 
     @Test
@@ -102,9 +99,8 @@ public class NovaMultiModalEmbeddingPreProcessFunctionTest {
         when(mockDataSet.getDocs()).thenReturn(Collections.emptyList());
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(mockDataSet).build();
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("No input provided");
-        function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(mlInput));
+        assertEquals("No input provided", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/OpenAIEmbeddingPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/OpenAIEmbeddingPreProcessFunctionTest.java
@@ -6,13 +6,12 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -20,9 +19,6 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
 public class OpenAIEmbeddingPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     OpenAIEmbeddingPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
@@ -37,17 +33,20 @@ public class OpenAIEmbeddingPreProcessFunctionTest {
 
     @Test
     public void process_NullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support TextDocsInputDataSet");
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_SIMILARITY).inputDataset(textSimilarityInputDataSet).build();
-        function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_SIMILARITY).inputDataset(textSimilarityInputDataSet).build();
+            function.apply(mlInput);
+        });
+        assertEquals(
+            "This pre_process_function can only support TextDocsInputDataSet which including a list of string with key 'text_docs'",
+            exception.getMessage()
+        );
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/RemoteInferencePreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/RemoteInferencePreProcessFunctionTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -14,9 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.ingest.TestTemplateService;
@@ -27,9 +26,6 @@ import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.script.ScriptService;
 
 public class RemoteInferencePreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     RemoteInferencePreProcessFunction function;
 
     @Mock
@@ -53,26 +49,27 @@ public class RemoteInferencePreProcessFunctionTest {
 
     @Test
     public void process_NullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support RemoteInferenceInputDataSet");
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
-        function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(textDocsInputDataSet).build();
+            function.apply(mlInput);
+        });
+        assertEquals("This pre_process_function can only support RemoteInferenceInputDataSet", exception.getMessage());
     }
 
     @Test
     public void process_CorrectInput_WrongProcessedResult() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function output is null");
-        when(scriptService.compile(any(), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(null));
-        MLInput mlInput = MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(remoteInferenceInputDataSet).build();
-        function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            when(scriptService.compile(any(), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(null));
+            MLInput mlInput = MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(remoteInferenceInputDataSet).build();
+            function.apply(mlInput);
+        });
+        assertEquals("Preprocess function output is null", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/VideoEmbeddingPreProcessFunctionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/functions/preprocess/VideoEmbeddingPreProcessFunctionTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.connector.functions.preprocess;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -14,9 +15,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -24,9 +23,6 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 
 public class VideoEmbeddingPreProcessFunctionTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     VideoEmbeddingPreProcessFunction function;
 
     TextSimilarityInputDataSet textSimilarityInputDataSet;
@@ -51,16 +47,17 @@ public class VideoEmbeddingPreProcessFunctionTest {
 
     @Test
     public void process_NullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Preprocess function input can't be null");
-        function.apply(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(null));
+        assertEquals("Preprocess function input can't be null", exception.getMessage());
     }
 
     @Test
     public void process_WrongInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("This pre_process_function can only support TextDocsInputDataSet");
-        function.apply(textSimilarityInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(textSimilarityInput));
+        assertEquals(
+            "This pre_process_function can only support TextDocsInputDataSet which including a list of string with key 'text_docs'",
+            exception.getMessage()
+        );
     }
 
     @Test
@@ -77,9 +74,8 @@ public class VideoEmbeddingPreProcessFunctionTest {
         when(mockDataSet.getDocs()).thenReturn(Collections.emptyList());
         MLInput mlInput = MLInput.builder().algorithm(FunctionName.TEXT_EMBEDDING).inputDataset(mockDataSet).build();
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("No input video provided");
-        function.apply(mlInput);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> function.apply(mlInput));
+        assertEquals("No input video provided", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/controller/MLControllerTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/controller/MLControllerTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -18,9 +19,7 @@ import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
@@ -42,9 +41,6 @@ public class MLControllerTest {
 
     private final String expectedInputStr = "{\"model_id\":\"testModelId\",\"user_rate_limiter\":"
         + "{\"testUser\":{\"limit\":\"1\",\"unit\":\"MILLISECONDS\"}}}";
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -160,16 +156,17 @@ public class MLControllerTest {
 
     @Test
     public void parseWithNullField() throws Exception {
-        exceptionRule.expect(IllegalStateException.class);
-        final String expectedInputStrWithNullField = "{\"model_id\":null,\"user_rate_limiter\":"
-            + "{\"testUser\":{\"limit\":\"1\",\"unit\":\"MILLISECONDS\"}}}";
+        assertThrows(IllegalStateException.class, () -> {
+            final String expectedInputStrWithNullField = "{\"model_id\":null,\"user_rate_limiter\":"
+                + "{\"testUser\":{\"limit\":\"1\",\"unit\":\"MILLISECONDS\"}}}";
 
-        testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
-            try {
-                assertEquals(expectedInputStr, serializationWithToXContent(parsedInput));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
+                try {
+                    assertEquals(expectedInputStr, serializationWithToXContent(parsedInput));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
         });
     }
 
@@ -192,32 +189,34 @@ public class MLControllerTest {
     // This will throw a ParsingException because MLRateLimiter parser cannot parse
     // null field.
     public void parseWithNullMLRateLimiterInUserRateLimiterFieldWithException() throws Exception {
-        exceptionRule.expect(RuntimeException.class);
-        final String expectedInputStrWithNullField = "{\"model_id\":\"testModelId\",\"user_rate_limiter\":{\"testUser\":null}}";
-        final String expectedOutputStr = "{\"model_id\":\"testModelId\",\"user_rate_limiter\":{\"testUser\":null}}";
+        assertThrows(RuntimeException.class, () -> {
+            final String expectedInputStrWithNullField = "{\"model_id\":\"testModelId\",\"user_rate_limiter\":{\"testUser\":null}}";
+            final String expectedOutputStr = "{\"model_id\":\"testModelId\",\"user_rate_limiter\":{\"testUser\":null}}";
 
-        testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
-            try {
-                assertEquals(expectedOutputStr, serializationWithToXContent(parsedInput));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
+                try {
+                    assertEquals(expectedOutputStr, serializationWithToXContent(parsedInput));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
         });
     }
 
     @Test
     public void parseWithIllegalRateLimiterFieldWithException() throws Exception {
-        exceptionRule.expect(RuntimeException.class);
-        final String expectedInputStrWithIllegalField =
-            "{\"model_id\":\"testModelId\",\"illegal_field\":\"This field need to be skipped.\",\"user_rate_limiter\":"
-                + "{\"testUser\":\"Some illegal content that MLRateLimiter parser cannot parse.\"}}";
+        assertThrows(RuntimeException.class, () -> {
+            final String expectedInputStrWithIllegalField =
+                "{\"model_id\":\"testModelId\",\"illegal_field\":\"This field need to be skipped.\",\"user_rate_limiter\":"
+                    + "{\"testUser\":\"Some illegal content that MLRateLimiter parser cannot parse.\"}}";
 
-        testParseFromJsonString(expectedInputStrWithIllegalField, parsedInput -> {
-            try {
-                assertEquals(expectedInputStr, serializationWithToXContent(parsedInput));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            testParseFromJsonString(expectedInputStrWithIllegalField, parsedInput -> {
+                try {
+                    assertEquals(expectedInputStr, serializationWithToXContent(parsedInput));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
         });
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/controller/MLRateLimiterTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/controller/MLRateLimiterTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -17,9 +18,7 @@ import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
@@ -44,9 +43,6 @@ public class MLRateLimiterTest {
     private MLRateLimiter rateLimiterNull;
 
     private final String expectedInputStr = "{\"limit\":\"1\",\"unit\":\"MILLISECONDS\"}";
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -97,29 +93,32 @@ public class MLRateLimiterTest {
 
     @Test
     public void parseWithIllegalLimit() throws Exception {
-        exceptionRule.expect(OpenSearchParseException.class);
-        String inputStrWithIllegalLimit = "{\"limit\":\"-1\",\"unit\":\"MILLISECONDS\"}";
-        testParseFromJsonString(inputStrWithIllegalLimit, parsedInput -> {});
+        assertThrows(OpenSearchParseException.class, () -> {
+            String inputStrWithIllegalLimit = "{\"limit\":\"-1\",\"unit\":\"MILLISECONDS\"}";
+            testParseFromJsonString(inputStrWithIllegalLimit, parsedInput -> {});
+        });
     }
 
     @Test
     public void parseWithNegativeLimit() throws Exception {
-        exceptionRule.expect(OpenSearchParseException.class);
-        String inputStrWithNegativeLimit = "{\"limit\":\"ILLEGAL\",\"unit\":\"MILLISECONDS\"}";
-        testParseFromJsonString(inputStrWithNegativeLimit, parsedInput -> {});
+        assertThrows(OpenSearchParseException.class, () -> {
+            String inputStrWithNegativeLimit = "{\"limit\":\"ILLEGAL\",\"unit\":\"MILLISECONDS\"}";
+            testParseFromJsonString(inputStrWithNegativeLimit, parsedInput -> {});
+        });
     }
 
     @Test
     public void parseWithNullField() throws Exception {
-        exceptionRule.expect(IllegalStateException.class);
-        final String expectedInputStrWithNullField = "{\"limit\":\"1\",\"unit\":null}";
+        assertThrows(IllegalStateException.class, () -> {
+            final String expectedInputStrWithNullField = "{\"limit\":\"1\",\"unit\":null}";
 
-        testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
-            try {
-                assertEquals(expectedInputStr, serializationWithToXContent(parsedInput));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
+                try {
+                    assertEquals(expectedInputStr, serializationWithToXContent(parsedInput));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
         });
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnTypeTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnTypeTest.java
@@ -5,22 +5,20 @@
 
 package org.opensearch.ml.common.dataframe;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 import java.math.BigDecimal;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ColumnTypeTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void from_WrongType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("unsupported type:java.math.BigDecimal");
-        BigDecimal obj = new BigDecimal("0");
-        ColumnType type = ColumnType.from(obj);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            BigDecimal obj = new BigDecimal("0");
+            ColumnType type = ColumnType.from(obj);
+        });
+        assertEquals("unsupported type:java.math.BigDecimal", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnValueBuilderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnValueBuilderTest.java
@@ -6,18 +6,13 @@
 package org.opensearch.ml.common.dataframe;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.math.BigDecimal;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ColumnValueBuilderTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void build() {
         ColumnValue value = ColumnValueBuilder.build(null);
@@ -58,9 +53,10 @@ public class ColumnValueBuilderTest {
 
     @Test
     public void build_IllegalType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("unsupported type:java.math.BigDecimal");
-        Object obj = new BigDecimal("0");
-        ColumnValueBuilder.build(obj);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            Object obj = new BigDecimal("0");
+            ColumnValueBuilder.build(obj);
+        });
+        assertEquals("unsupported type:java.math.BigDecimal", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnValueTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/ColumnValueTest.java
@@ -5,17 +5,13 @@
 
 package org.opensearch.ml.common.dataframe;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ColumnValueTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void equals_SameObject() {
         ColumnValue value = new IntValue(1);
@@ -24,57 +20,64 @@ public class ColumnValueTest {
 
     @Test
     public void wrongIntValue() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("the value isn't Integer type");
-        ColumnValue value = new DoubleValue(1.0);
-        value.intValue();
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            ColumnValue value = new DoubleValue(1.0);
+            value.intValue();
+        });
+        assertEquals("the value isn't Integer type", exception.getMessage());
     }
 
     @Test
     public void wrongBooleanValue() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("the value isn't Boolean type");
-        ColumnValue value = new DoubleValue(1.0);
-        value.booleanValue();
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            ColumnValue value = new DoubleValue(1.0);
+            value.booleanValue();
+        });
+        assertEquals("the value isn't Boolean type", exception.getMessage());
     }
 
     @Test
     public void wrongStringValue() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("the value isn't String type");
-        ColumnValue value = new DoubleValue(1.0);
-        value.stringValue();
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            ColumnValue value = new DoubleValue(1.0);
+            value.stringValue();
+        });
+        assertEquals("the value isn't String type", exception.getMessage());
     }
 
     @Test
     public void wrongDoubleValue() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("the value isn't Double type");
-        ColumnValue value = new BooleanValue(true);
-        value.doubleValue();
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            ColumnValue value = new BooleanValue(true);
+            value.doubleValue();
+        });
+        assertEquals("the value isn't Double type", exception.getMessage());
     }
 
     @Test
     public void wrongFloatValue() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("the value isn't Float type");
-        ColumnValue value = new IntValue(1);
-        value.floatValue();
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            ColumnValue value = new IntValue(1);
+            value.floatValue();
+        });
+        assertEquals("the value isn't Float type", exception.getMessage());
     }
 
     @Test
     public void wrongShortValue() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("the value isn't Short type");
-        ColumnValue value = new IntValue(1);
-        value.shortValue();
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            ColumnValue value = new IntValue(1);
+            value.shortValue();
+        });
+        assertEquals("the value isn't Short type", exception.getMessage());
     }
 
     @Test
     public void wrongLongValue() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("the value isn't Long type");
-        ColumnValue value = new IntValue(1);
-        value.longValue();
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            ColumnValue value = new IntValue(1);
+            value.longValue();
+        });
+        assertEquals("the value isn't Long type", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/DataFrameBuilderTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/DataFrameBuilderTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.dataframe;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -13,16 +14,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 
 public class DataFrameBuilderTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void emptyDataFrame_Success() {
         ColumnMeta[] columnMetas = new ColumnMeta[] { ColumnMeta.builder().name("k1").columnType(ColumnType.DOUBLE).build() };
@@ -98,37 +93,40 @@ public class DataFrameBuilderTest {
 
     @Test
     public void load_Exception_DifferentColumnsInColumnMetasAndInputMapList() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("input item map size is different in the map");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        Map<String, Object> map = new HashMap<>();
-        map.put("k1", 2.3D);
-        ColumnMeta[] columnMetas = new ColumnMeta[] {
-            ColumnMeta.builder().name("k1").columnType(ColumnType.DOUBLE).build(),
-            ColumnMeta.builder().name("k2").columnType(ColumnType.DOUBLE).build() };
-        DataFrameBuilder.load(columnMetas, Collections.singletonList(map));
+            Map<String, Object> map = new HashMap<>();
+            map.put("k1", 2.3D);
+            ColumnMeta[] columnMetas = new ColumnMeta[] {
+                ColumnMeta.builder().name("k1").columnType(ColumnType.DOUBLE).build(),
+                ColumnMeta.builder().name("k2").columnType(ColumnType.DOUBLE).build() };
+            DataFrameBuilder.load(columnMetas, Collections.singletonList(map));
+        });
+        assertEquals("input item map size is different in the map", exception.getMessage());
     }
 
     @Test
     public void load_Exception_DifferentTypesForSameField() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("the same field has different data type");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        Map<String, Object> map = new HashMap<>();
-        map.put("k1", 2.3D);
-        ColumnMeta[] columnMetas = new ColumnMeta[] { ColumnMeta.builder().name("k1").columnType(ColumnType.INTEGER).build() };
-        DataFrameBuilder.load(columnMetas, Collections.singletonList(map));
+            Map<String, Object> map = new HashMap<>();
+            map.put("k1", 2.3D);
+            ColumnMeta[] columnMetas = new ColumnMeta[] { ColumnMeta.builder().name("k1").columnType(ColumnType.INTEGER).build() };
+            DataFrameBuilder.load(columnMetas, Collections.singletonList(map));
+        });
+        assertEquals("the same field has different data type", exception.getMessage());
     }
 
     @Test
     public void load_Exception_DifferentFields() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("field of input item doesn't exist in columns, filed:k2");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        Map<String, Object> map = new HashMap<>();
-        map.put("k2", 2.3D);
-        ColumnMeta[] columnMetas = new ColumnMeta[] { ColumnMeta.builder().name("k1").columnType(ColumnType.INTEGER).build() };
-        DataFrameBuilder.load(columnMetas, Collections.singletonList(map));
+            Map<String, Object> map = new HashMap<>();
+            map.put("k2", 2.3D);
+            ColumnMeta[] columnMetas = new ColumnMeta[] { ColumnMeta.builder().name("k1").columnType(ColumnType.INTEGER).build() };
+            DataFrameBuilder.load(columnMetas, Collections.singletonList(map));
+        });
+        assertEquals("field of input item doesn't exist in columns, filed:k2", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/DefaultDataFrameTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/DefaultDataFrameTest.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.dataframe;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -15,9 +16,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -30,9 +29,6 @@ public class DefaultDataFrameTest {
 
     DefaultDataFrame defaultDataFrame;
     Function<XContentParser, DefaultDataFrame> function;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -99,10 +95,11 @@ public class DefaultDataFrameTest {
 
     @Test
     public void appendRow_Exception_NullRow() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("input row can't be null");
-        Row row = null;
-        defaultDataFrame.appendRow(row);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            Row row = null;
+            defaultDataFrame.appendRow(row);
+        });
+        assertEquals("input row can't be null", exception.getMessage());
     }
 
     @Test
@@ -125,33 +122,36 @@ public class DefaultDataFrameTest {
 
     @Test
     public void appendRow_Exception_NullValues() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("input values can't be null");
-        Object[] values = null;
-        defaultDataFrame.appendRow(values);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            Object[] values = null;
+            defaultDataFrame.appendRow(values);
+        });
+        assertEquals("input values can't be null", exception.getMessage());
     }
 
     @Test
     public void appendRow_Exception_DifferentColumns() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("the size is different between input row:3 and column size in dataframe:4");
-        Row row = new Row(3);
-        row.setValue(0, new StringValue("string2"));
-        row.setValue(1, new IntValue(2));
-        row.setValue(2, new DoubleValue(3.0D));
-        defaultDataFrame.appendRow(row);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            Row row = new Row(3);
+            row.setValue(0, new StringValue("string2"));
+            row.setValue(1, new IntValue(2));
+            row.setValue(2, new DoubleValue(3.0D));
+            defaultDataFrame.appendRow(row);
+        });
+        assertEquals("the size is different between input row:3 and column size in dataframe:4", exception.getMessage());
     }
 
     @Test
     public void appendRow_Exception_DifferentColumnTypes() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("the column type is different in column meta:BOOLEAN and input row:DOUBLE for " + "index: 3");
-        Row row = new Row(4);
-        row.setValue(0, new StringValue("string2"));
-        row.setValue(1, new IntValue(2));
-        row.setValue(2, new DoubleValue(3.0D));
-        row.setValue(3, new DoubleValue(4.0D));
-        defaultDataFrame.appendRow(row);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            Row row = new Row(4);
+            row.setValue(0, new StringValue("string2"));
+            row.setValue(1, new IntValue(2));
+            row.setValue(2, new DoubleValue(3.0D));
+            row.setValue(3, new DoubleValue(4.0D));
+            defaultDataFrame.appendRow(row);
+        });
+        assertEquals("the column type is different in column meta:BOOLEAN and input row:DOUBLE for index: 3", exception.getMessage());
     }
 
     @Test
@@ -162,25 +162,23 @@ public class DefaultDataFrameTest {
 
     @Test
     public void remove_Exception_InputColumnIndexBiggerThanColumensLength() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("columnIndex can't be negative or bigger than columns length:4");
-        defaultDataFrame.remove(4);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> defaultDataFrame.remove(4));
+        assertEquals("columnIndex can't be negative or bigger than columns length:4", exception.getMessage());
     }
 
     @Test
     public void remove_Exception_InputColumnIndexNegtiveColumensLength() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("columnIndex can't be negative or bigger than columns length:4");
-        defaultDataFrame.remove(-1);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> defaultDataFrame.remove(-1));
+        assertEquals("columnIndex can't be negative or bigger than columns length:4", exception.getMessage());
     }
 
     @Test
     public void remove_EmptyColumnMeta() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("columnIndex can't be negative or bigger than columns length:0");
-        DefaultDataFrame dataFrame = new DefaultDataFrame(new ColumnMeta[0]);
-        DataFrame newDataFrame = dataFrame.remove(0);
-        assertEquals(0, newDataFrame.size());
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new DefaultDataFrame(new ColumnMeta[0]).remove(0)
+        );
+        assertEquals("columnIndex can't be negative or bigger than columns length:0", exception.getMessage());
     }
 
     @Test
@@ -199,16 +197,14 @@ public class DefaultDataFrameTest {
 
     @Test
     public void select_Exception_EmptyInputColumns() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("columns can't be null or empty");
-        defaultDataFrame.select(new int[0]);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> defaultDataFrame.select(new int[0]));
+        assertEquals("columns can't be null or empty", exception.getMessage());
     }
 
     @Test
     public void select_Exception_InvalidColumn() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("columnIndex can't be negative or bigger than columns length");
-        defaultDataFrame.select(new int[] { 5 });
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> defaultDataFrame.select(new int[] { 5 }));
+        assertEquals("columnIndex can't be negative or bigger than columns length", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/dataframe/RowTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataframe/RowTest.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.dataframe;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.opensearch.ml.common.TestHelper.testParse;
 import static org.opensearch.ml.common.TestHelper.testParseFromString;
@@ -17,9 +18,7 @@ import java.util.Iterator;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
@@ -30,9 +29,6 @@ public class RowTest {
     Row row;
 
     Function<XContentParser, Row> function;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setup() {
@@ -106,18 +102,20 @@ public class RowTest {
 
     @Test
     public void remove_WrongIndex() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("removed index can't be negative or bigger than row's values length:0");
-        row = new Row(0);
-        row.remove(0);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            row = new Row(0);
+            row.remove(0);
+        });
+        assertEquals("removed index can't be negative or bigger than row's values length:0", exception.getMessage());
     }
 
     @Test
     public void remove_WrongNegativeIndex() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("removed index can't be negative or bigger than row's values length:0");
-        row = new Row(0);
-        row.remove(-1);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            row = new Row(0);
+            row.remove(-1);
+        });
+        assertEquals("removed index can't be negative or bigger than row's values length:0", exception.getMessage());
     }
 
     @Test
@@ -214,32 +212,34 @@ public class RowTest {
 
     @Test
     public void testParse_WrongColumnTypeField() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("wrong column type, expect column_type field but got column_type_wrong");
-        ColumnValue[] values = new ColumnValue[] {
-            new IntValue(1),
-            new DoubleValue(2.0),
-            new NullValue(),
-            new StringValue("test"),
-            new BooleanValue(true) };
-        Row row = new Row(values);
-        String jsonStr = "{\"values\":[{\"column_type_wrong\":\"INTEGER\",\"value\":1}]}";
-        testParseFromString(row, jsonStr, function);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            ColumnValue[] values = new ColumnValue[] {
+                new IntValue(1),
+                new DoubleValue(2.0),
+                new NullValue(),
+                new StringValue("test"),
+                new BooleanValue(true) };
+            Row row = new Row(values);
+            String jsonStr = "{\"values\":[{\"column_type_wrong\":\"INTEGER\",\"value\":1}]}";
+            testParseFromString(row, jsonStr, function);
+        });
+        assertEquals("wrong column type, expect column_type field but got column_type_wrong", exception.getMessage());
     }
 
     @Test
     public void testParse_WrongValueField() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("wrong column value, expect value field but got value_wrong");
-        ColumnValue[] values = new ColumnValue[] {
-            new IntValue(1),
-            new DoubleValue(2.0),
-            new NullValue(),
-            new StringValue("test"),
-            new BooleanValue(true) };
-        Row row = new Row(values);
-        String jsonStr = "{\"values\":[{\"column_type\":\"INTEGER\",\"value_wrong\":1}]}";
-        testParseFromString(row, jsonStr, function);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            ColumnValue[] values = new ColumnValue[] {
+                new IntValue(1),
+                new DoubleValue(2.0),
+                new NullValue(),
+                new StringValue("test"),
+                new BooleanValue(true) };
+            Row row = new Row(values);
+            String jsonStr = "{\"values\":[{\"column_type\":\"INTEGER\",\"value_wrong\":1}]}";
+            testParseFromString(row, jsonStr, function);
+        });
+        assertEquals("wrong column value, expect value field but got value_wrong", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/dataset/AsymmetricTextEmbeddingParametersTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataset/AsymmetricTextEmbeddingParametersTest.java
@@ -2,6 +2,7 @@ package org.opensearch.ml.common.dataset;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.ml.common.TestHelper.contentObjectToString;
 import static org.opensearch.ml.common.TestHelper.testParseFromString;
 
@@ -9,9 +10,7 @@ import java.io.IOException;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -22,10 +21,6 @@ import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbe
 import org.opensearch.ml.common.input.parameter.textembedding.SparseEmbeddingFormat;
 
 public class AsymmetricTextEmbeddingParametersTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     AsymmetricTextEmbeddingParameters params;
     private Function<XContentParser, AsymmetricTextEmbeddingParameters> function = parser -> {
         try {
@@ -53,13 +48,14 @@ public class AsymmetricTextEmbeddingParametersTest {
 
     @Test
     public void parse_AsymmetricTextEmbeddingParameters_Invalid() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule
-            .expectMessage(
-                "No enum constant org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters.EmbeddingContentType.FU"
-            );
-        String paramsStr = contentObjectToString(params);
-        testParseFromString(params, paramsStr.replace("QUERY", "fu"), function);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            String paramsStr = contentObjectToString(params);
+            testParseFromString(params, paramsStr.replace("QUERY", "fu"), function);
+        });
+        assertEquals(
+            "No enum constant org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters.EmbeddingContentType.FU",
+            exception.getMessage()
+        );
     }
 
     @Test
@@ -108,11 +104,14 @@ public class AsymmetricTextEmbeddingParametersTest {
 
     @Test
     public void parse_AsymmetricTextEmbeddingParameters_SparseEmbeddingFormat_Invalid() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule
-            .expectMessage("No enum constant org.opensearch.ml.common.input.parameter.textembedding.SparseEmbeddingFormat.INVALID");
-        String jsonWithInvalidFormat = "{\"content_type\": \"QUERY\", \"sparse_embedding_format\": \"INVALID\"}";
-        testParseFromString(params, jsonWithInvalidFormat, function);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            String jsonWithInvalidFormat = "{\"content_type\": \"QUERY\", \"sparse_embedding_format\": \"INVALID\"}";
+            testParseFromString(params, jsonWithInvalidFormat, function);
+        });
+        assertEquals(
+            "No enum constant org.opensearch.ml.common.input.parameter.textembedding.SparseEmbeddingFormat.INVALID",
+            exception.getMessage()
+        );
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/dataset/SearchQueryInputDatasetTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataset/SearchQueryInputDatasetTest.java
@@ -6,24 +6,19 @@
 package org.opensearch.ml.common.dataset;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 public class SearchQueryInputDatasetTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void writeTo_Success() throws IOException {
         SearchQueryInputDataset searchQueryInputDataset = SearchQueryInputDataset
@@ -44,8 +39,14 @@ public class SearchQueryInputDatasetTest {
 
     @Test
     public void init_EmptyIndices() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("indices can't be empty");
-        SearchQueryInputDataset.builder().indices(new ArrayList<>()).searchSourceBuilder(new SearchSourceBuilder().size(1)).build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> SearchQueryInputDataset
+                .builder()
+                .indices(new ArrayList<>())
+                .searchSourceBuilder(new SearchSourceBuilder().size(1))
+                .build()
+        );
+        assertEquals("indices can't be empty", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/dataset/TextDocsInputDataSetTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataset/TextDocsInputDataSetTest.java
@@ -10,17 +10,11 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.util.Arrays;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 
 public class TextDocsInputDataSetTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void writeTo_Success() throws IOException {
         TextDocsInputDataSet inputDataSet = TextDocsInputDataSet.builder().docs(Arrays.asList("doc1", "doc2")).build();

--- a/common/src/test/java/org/opensearch/ml/common/httpclient/MLValidatableAsyncHttpClientTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/httpclient/MLValidatableAsyncHttpClientTests.java
@@ -15,9 +15,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 
@@ -34,9 +32,6 @@ public class MLValidatableAsyncHttpClientTests {
         Collections.emptyList(),
         Collections.emptyList()
     );
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void test_invalidIP_localHost_privateIPDisabled() {
@@ -163,23 +158,29 @@ public class MLValidatableAsyncHttpClientTests {
     }
 
     @Test
-    public void test_validateSchemaAndPort_notAllowedSchema_throwException() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        validatingHttpClient.validate("ftp://api.openai.com", "ftp", TEST_HOST, 80, PRIVATE_IP_DISABLED);
+    public void test_validateSchemaAndPort_notAllowedSchema_throwException() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validatingHttpClient.validate("ftp://api.openai.com", "ftp", TEST_HOST, 80, PRIVATE_IP_DISABLED)
+        );
     }
 
     @Test
-    public void test_validateSchemaAndPort_portNotInRange1_throwException() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Port out of range: 65537");
-        validatingHttpClient.validate("https://api.openai.com", HTTPS, TEST_HOST, 65537, PRIVATE_IP_DISABLED);
+    public void test_validateSchemaAndPort_portNotInRange1_throwException() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> validatingHttpClient.validate("https://api.openai.com", HTTPS, TEST_HOST, 65537, PRIVATE_IP_DISABLED)
+        );
+        assertEquals("Port out of range: 65537", exception.getMessage());
     }
 
     @Test
-    public void test_validateSchemaAndPort_portNotInRange2_throwException() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Port out of range: -10");
-        validatingHttpClient.validate("http://api.openai.com", HTTP, TEST_HOST, -10, PRIVATE_IP_DISABLED);
+    public void test_validateSchemaAndPort_portNotInRange2_throwException() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> validatingHttpClient.validate("http://api.openai.com", HTTP, TEST_HOST, -10, PRIVATE_IP_DISABLED)
+        );
+        assertEquals("Port out of range: -10", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/AbstractIndexInsightTaskTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/AbstractIndexInsightTaskTests.java
@@ -13,6 +13,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.opensearch.ml.common.CommonValue.INDEX_INSIGHT_GENERATING_TIMEOUT;
 import static org.opensearch.ml.common.CommonValue.INDEX_INSIGHT_UPDATE_INTERVAL;
+import static org.opensearch.ml.common.MockitoTestHelper.anyActionListener;
+import static org.opensearch.ml.common.MockitoTestHelper.forMapClass;
+import static org.opensearch.ml.common.MockitoTestHelper.mockActionListener;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.*;
 
 import java.io.IOException;
@@ -106,10 +109,10 @@ public class AbstractIndexInsightTaskTests {
     @Test
     public void testGetInsightContentFromContainer() {
         mockGetSuccess(sdkClient, "{\"key\": \"value\"}");
-        ActionListener<Map<String, Object>> listener = mock(ActionListener.class);
+        ActionListener<Map<String, Object>> listener = mockActionListener();
         task.getInsightContentFromContainer(MLIndexInsightType.STATISTICAL_DATA, "", listener);
 
-        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass((Class) Map.class);
+        ArgumentCaptor<Map<String, Object>> captor = forMapClass();
         verify(listener).onResponse(captor.capture());
         assertEquals("value", captor.getValue().get("key"));
     }
@@ -117,10 +120,10 @@ public class AbstractIndexInsightTaskTests {
     @Test
     public void testGetInsightContentFromContainer_NotExists() {
         mockGetSuccess(sdkClient, "");
-        ActionListener<Map<String, Object>> listener = mock(ActionListener.class);
+        ActionListener<Map<String, Object>> listener = mockActionListener();
         task.getInsightContentFromContainer(MLIndexInsightType.STATISTICAL_DATA, "", listener);
 
-        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass((Class) Map.class);
+        ArgumentCaptor<Map<String, Object>> captor = forMapClass();
         verify(listener).onResponse(captor.capture());
         assertNull(captor.getValue());
     }
@@ -128,7 +131,7 @@ public class AbstractIndexInsightTaskTests {
     @Test
     public void testSaveResult() {
         mockUpdateSuccess(sdkClient);
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.saveResult("test content", "test-tenant", listener);
 
         ArgumentCaptor<IndexInsight> captor = ArgumentCaptor.forClass(IndexInsight.class);
@@ -144,7 +147,7 @@ public class AbstractIndexInsightTaskTests {
         failedFuture.completeExceptionally(new Exception("SDK Client update failed"));
         when(sdkClient.putDataObjectAsync(any())).thenReturn(failedFuture);
 
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.saveResult("test content", "test-storage", listener);
 
         verify(listener).onFailure(any());
@@ -153,7 +156,7 @@ public class AbstractIndexInsightTaskTests {
     @Test
     public void testSaveFailedStatus() {
         mockUpdateSuccess(sdkClient);
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.saveFailedStatus("", new RuntimeException("test error"), listener);
         ArgumentCaptor<PutDataObjectRequest> captor = ArgumentCaptor.forClass(PutDataObjectRequest.class);
 
@@ -175,7 +178,7 @@ public class AbstractIndexInsightTaskTests {
         source.put(IndexInsight.TASK_TYPE_FIELD, "STATISTICAL_DATA");
         source.put(IndexInsight.CONTENT_FIELD, "test content");
 
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.handleExistingDoc(source, "test-tenant", listener);
 
         ArgumentCaptor<IndexInsight> captor = ArgumentCaptor.forClass(IndexInsight.class);
@@ -193,7 +196,7 @@ public class AbstractIndexInsightTaskTests {
         source.put(IndexInsight.CONTENT_FIELD, "test content");
 
         mockFullFlowExecution(sdkClient);
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.handleExistingDoc(source, "test-tenant", listener);
 
         // Verify prerequisite task execution: 5 threadPool calls indicate both prerequisite and main task ran
@@ -207,7 +210,7 @@ public class AbstractIndexInsightTaskTests {
         source.put(IndexInsight.STATUS_FIELD, "GENERATING");
         source.put(IndexInsight.LAST_UPDATE_FIELD, Instant.now().toEpochMilli());
 
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.handleExistingDoc(source, "test-tenant", listener);
 
         ArgumentCaptor<OpenSearchStatusException> captor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
@@ -223,7 +226,7 @@ public class AbstractIndexInsightTaskTests {
         source.put(IndexInsight.LAST_UPDATE_FIELD, Instant.now().toEpochMilli() - INDEX_INSIGHT_GENERATING_TIMEOUT - 3600);
 
         mockFullFlowExecution(sdkClient);
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.handleExistingDoc(source, "test-tenant", listener);
 
         verify(client, times(5)).threadPool();
@@ -237,7 +240,7 @@ public class AbstractIndexInsightTaskTests {
         source.put(IndexInsight.LAST_UPDATE_FIELD, Instant.now().toEpochMilli());
 
         mockFullFlowExecution(sdkClient);
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.handleExistingDoc(source, "test-tenant", listener);
 
         verify(client, times(5)).threadPool();
@@ -247,7 +250,7 @@ public class AbstractIndexInsightTaskTests {
     @Test
     public void testRunWithPrerequisites_Success() throws IOException {
         mockFullFlowExecution(sdkClient);
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.runWithPrerequisites("test-tenant", listener);
 
         verify(listener).onResponse(any(IndexInsight.class));
@@ -260,7 +263,7 @@ public class AbstractIndexInsightTaskTests {
         failedFuture.completeExceptionally(new Exception("Prerequisite failed"));
         when(sdkClient.getDataObjectAsync(any())).thenReturn(failedFuture);
 
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.runWithPrerequisites("test-tenant", listener);
 
         verify(listener).onFailure(any());
@@ -278,7 +281,7 @@ public class AbstractIndexInsightTaskTests {
 
         mockGetSuccess(sdkClient, prereqSource);
         mockUpdateSuccess(sdkClient);
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.runWithPrerequisites("test-tenant", listener);
 
         verify(client, times(2)).threadPool();
@@ -305,7 +308,7 @@ public class AbstractIndexInsightTaskTests {
         SearchHit[] hits = new SearchHit[] { patternHit };
         mockSearchWithPatternHit(sdkClient, hits);
 
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.execute("test-tenant", listener);
 
         ArgumentCaptor<IndexInsight> captor = ArgumentCaptor.forClass(IndexInsight.class);
@@ -319,7 +322,7 @@ public class AbstractIndexInsightTaskTests {
     @Test
     public void testGetAgentIdToRun_Success() {
         Client client = mock(Client.class);
-        ActionListener<String> actionListener = mock(ActionListener.class);
+        ActionListener<String> actionListener = mockActionListener();
         String tenantId = "test-tenant";
         String expectedAgentId = "test-agent-id";
 
@@ -331,7 +334,7 @@ public class AbstractIndexInsightTaskTests {
             ActionListener<MLConfigGetResponse> listener = invocation.getArgument(2);
             listener.onResponse(response);
             return null;
-        }).when(client).execute(any(), any(MLConfigGetRequest.class), any(ActionListener.class));
+        }).when(client).execute(any(), any(MLConfigGetRequest.class), anyActionListener());
 
         AbstractIndexInsightTask.getAgentIdToRun(client, tenantId, actionListener);
 
@@ -341,7 +344,7 @@ public class AbstractIndexInsightTaskTests {
     @Test
     public void testGetAgentIdToRun_Failure() {
         Client client = mock(Client.class);
-        ActionListener<String> actionListener = mock(ActionListener.class);
+        ActionListener<String> actionListener = mockActionListener();
         String tenantId = "test-tenant";
         Exception expectedException = new RuntimeException("Test error");
 
@@ -349,7 +352,7 @@ public class AbstractIndexInsightTaskTests {
             ActionListener<MLConfigGetResponse> listener = invocation.getArgument(2);
             listener.onFailure(expectedException);
             return null;
-        }).when(client).execute(any(), any(MLConfigGetRequest.class), any(ActionListener.class));
+        }).when(client).execute(any(), any(MLConfigGetRequest.class), anyActionListener());
 
         AbstractIndexInsightTask.getAgentIdToRun(client, tenantId, actionListener);
 
@@ -435,7 +438,7 @@ public class AbstractIndexInsightTaskTests {
     @Test
     public void testCallLLMWithAgent_SuccessWithJson() {
         Client client = mock(Client.class);
-        ActionListener<String> listener = mock(ActionListener.class);
+        ActionListener<String> listener = mockActionListener();
         String agentId = "test-agent";
         String prompt = "test prompt";
         String sourceIndex = "test-index";
@@ -457,7 +460,7 @@ public class AbstractIndexInsightTaskTests {
             ActionListener<MLExecuteTaskResponse> responseListener = invocation.getArgument(2);
             responseListener.onResponse(response);
             return null;
-        }).when(client).execute(any(), any(MLExecuteTaskRequest.class), any(ActionListener.class));
+        }).when(client).execute(any(), any(MLExecuteTaskRequest.class), anyActionListener());
 
         AbstractIndexInsightTask.callLLMWithAgent(client, agentId, prompt, sourceIndex, listener);
 
@@ -467,7 +470,7 @@ public class AbstractIndexInsightTaskTests {
     @Test
     public void testCallLLMWithAgent_SuccessWithPlainText() {
         Client client = mock(Client.class);
-        ActionListener<String> listener = mock(ActionListener.class);
+        ActionListener<String> listener = mockActionListener();
         String agentId = "test-agent";
         String prompt = "test prompt";
         String sourceIndex = "test-index";
@@ -489,7 +492,7 @@ public class AbstractIndexInsightTaskTests {
             ActionListener<MLExecuteTaskResponse> responseListener = invocation.getArgument(2);
             responseListener.onResponse(response);
             return null;
-        }).when(client).execute(any(), any(MLExecuteTaskRequest.class), any(ActionListener.class));
+        }).when(client).execute(any(), any(MLExecuteTaskRequest.class), anyActionListener());
 
         AbstractIndexInsightTask.callLLMWithAgent(client, agentId, prompt, sourceIndex, listener);
 
@@ -499,7 +502,7 @@ public class AbstractIndexInsightTaskTests {
     @Test
     public void testCallLLMWithAgent_Failure() {
         Client client = mock(Client.class);
-        ActionListener<String> listener = mock(ActionListener.class);
+        ActionListener<String> listener = mockActionListener();
         String agentId = "test-agent";
         String prompt = "test prompt";
         String sourceIndex = "test-index";
@@ -509,7 +512,7 @@ public class AbstractIndexInsightTaskTests {
             ActionListener<MLExecuteTaskResponse> responseListener = invocation.getArgument(2);
             responseListener.onFailure(expectedException);
             return null;
-        }).when(client).execute(any(), any(MLExecuteTaskRequest.class), any(ActionListener.class));
+        }).when(client).execute(any(), any(MLExecuteTaskRequest.class), anyActionListener());
 
         AbstractIndexInsightTask.callLLMWithAgent(client, agentId, prompt, sourceIndex, listener);
 

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/FieldDescriptionTaskTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/FieldDescriptionTaskTests.java
@@ -6,10 +6,13 @@
 package org.opensearch.ml.common.indexInsight;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.opensearch.ml.common.MockitoTestHelper.anyActionListener;
+import static org.opensearch.ml.common.MockitoTestHelper.mockActionListener;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockGetSuccess;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockMLConfigFailure;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockMLConfigSuccess;
@@ -22,9 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
@@ -40,10 +41,6 @@ import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.IndicesAdminClient;
 
 public class FieldDescriptionTaskTests {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     private Client client;
     private SdkClient sdkClient;
     private FieldDescriptionTask task;
@@ -56,7 +53,7 @@ public class FieldDescriptionTaskTests {
         client = mock(Client.class);
         sdkClient = mock(SdkClient.class);
         task = new FieldDescriptionTask("test-index", client, sdkClient);
-        listener = mock(ActionListener.class);
+        listener = mockActionListener();
         threadPool = mock(ThreadPool.class);
         Settings settings = Settings.builder().build();
         threadContext = new ThreadContext(settings);
@@ -97,9 +94,8 @@ public class FieldDescriptionTaskTests {
     @Test
     public void testCreatePrerequisiteTask_UnsupportedType() {
         MLIndexInsightType unsupportedType = MLIndexInsightType.LOG_RELATED_INDEX_CHECK;
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("Unsupported prerequisite type: " + unsupportedType);
-        task.createPrerequisiteTask(unsupportedType);
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> task.createPrerequisiteTask(unsupportedType));
+        assertEquals("Unsupported prerequisite type: " + unsupportedType, exception.getMessage());
     }
 
     @Test
@@ -119,7 +115,7 @@ public class FieldDescriptionTaskTests {
 
         task.runTask("tenant-id", listener);
 
-        verify(client, times(2)).execute(eq(MLExecuteTaskAction.INSTANCE), any(MLExecuteTaskRequest.class), any(ActionListener.class));
+        verify(client, times(2)).execute(eq(MLExecuteTaskAction.INSTANCE), any(MLExecuteTaskRequest.class), anyActionListener());
     }
 
     @Test
@@ -266,7 +262,7 @@ public class FieldDescriptionTaskTests {
             return null;
         }).when(indicesClient).getMappings(any(), any());
 
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.handlePatternResult(patternSource, "tenant-id", listener);
 
         ArgumentCaptor<IndexInsight> captor = ArgumentCaptor.forClass(IndexInsight.class);

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/IndexInsightAccessControllerHelperTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/IndexInsightAccessControllerHelperTests.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.MockitoTestHelper.anyActionListener;
+import static org.opensearch.ml.common.MockitoTestHelper.mockActionListener;
 
 import java.util.Map;
 
@@ -48,7 +50,7 @@ public class IndexInsightAccessControllerHelperTests {
         when(client.admin()).thenReturn(adminClient);
         when(adminClient.indices()).thenReturn(indicesAdminClient);
 
-        ActionListener<Boolean> actionListener = mock(ActionListener.class);
+        ActionListener<Boolean> actionListener = mockActionListener();
         String sourceIndex = "test-index";
 
         GetMappingsResponse getMappingsResponse = mock(GetMappingsResponse.class);
@@ -59,14 +61,14 @@ public class IndexInsightAccessControllerHelperTests {
             ActionListener<GetMappingsResponse> listener = invocation.getArgument(1);
             listener.onResponse(getMappingsResponse);
             return null;
-        }).when(indicesAdminClient).getMappings(any(GetMappingsRequest.class), any(ActionListener.class));
+        }).when(indicesAdminClient).getMappings(any(GetMappingsRequest.class), anyActionListener());
 
         SearchResponse searchResponse = mock(SearchResponse.class);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onResponse(searchResponse);
             return null;
-        }).when(client).search(any(SearchRequest.class), any(ActionListener.class));
+        }).when(client).search(any(SearchRequest.class), anyActionListener());
 
         IndexInsightAccessControllerHelper.verifyAccessController(client, actionListener, sourceIndex);
 
@@ -82,7 +84,7 @@ public class IndexInsightAccessControllerHelperTests {
         when(client.admin()).thenReturn(adminClient);
         when(adminClient.indices()).thenReturn(indicesAdminClient);
 
-        ActionListener<Boolean> actionListener = mock(ActionListener.class);
+        ActionListener<Boolean> actionListener = mockActionListener();
         String sourceIndex = "test-index";
 
         GetMappingsResponse getMappingsResponse = mock(GetMappingsResponse.class);
@@ -93,13 +95,13 @@ public class IndexInsightAccessControllerHelperTests {
             ActionListener<GetMappingsResponse> listener = invocation.getArgument(1);
             listener.onResponse(getMappingsResponse);
             return null;
-        }).when(indicesAdminClient).getMappings(any(GetMappingsRequest.class), any(ActionListener.class));
+        }).when(indicesAdminClient).getMappings(any(GetMappingsRequest.class), anyActionListener());
 
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onFailure(new RuntimeException("no permissions"));
             return null;
-        }).when(client).search(any(SearchRequest.class), any(ActionListener.class));
+        }).when(client).search(any(SearchRequest.class), anyActionListener());
 
         IndexInsightAccessControllerHelper.verifyAccessController(client, actionListener, sourceIndex);
 
@@ -117,7 +119,7 @@ public class IndexInsightAccessControllerHelperTests {
         when(client.admin()).thenReturn(adminClient);
         when(adminClient.indices()).thenReturn(indicesAdminClient);
 
-        ActionListener<Boolean> actionListener = mock(ActionListener.class);
+        ActionListener<Boolean> actionListener = mockActionListener();
         String sourceIndex = "abc*";
 
         GetMappingsResponse getMappingsResponse = mock(GetMappingsResponse.class);
@@ -127,7 +129,7 @@ public class IndexInsightAccessControllerHelperTests {
             ActionListener<GetMappingsResponse> listener = invocation.getArgument(1);
             listener.onResponse(getMappingsResponse);
             return null;
-        }).when(indicesAdminClient).getMappings(any(GetMappingsRequest.class), any(ActionListener.class));
+        }).when(indicesAdminClient).getMappings(any(GetMappingsRequest.class), anyActionListener());
 
         IndexInsightAccessControllerHelper.verifyAccessController(client, actionListener, sourceIndex);
 

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/IndexInsightTaskStatusTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/IndexInsightTaskStatusTests.java
@@ -6,16 +6,11 @@
 package org.opensearch.ml.common.indexInsight;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class IndexInsightTaskStatusTests {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void testValidStatuses() {
         assertEquals(IndexInsightTaskStatus.GENERATING, IndexInsightTaskStatus.fromString("GENERATING"));
@@ -25,15 +20,16 @@ public class IndexInsightTaskStatusTests {
 
     @Test
     public void testNullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Index insight task status can't be null");
-        IndexInsightTaskStatus.fromString(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> IndexInsightTaskStatus.fromString(null));
+        assertEquals("Index insight task status can't be null", exception.getMessage());
     }
 
     @Test
     public void testInvalidStatus() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Wrong index insight task status");
-        IndexInsightTaskStatus.fromString("INVALID_STATUS");
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> IndexInsightTaskStatus.fromString("INVALID_STATUS")
+        );
+        assertEquals("Wrong index insight task status", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/IndexInsightTestHelper.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/IndexInsightTestHelper.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
 import static org.opensearch.ml.common.MLTaskState.COMPLETED;
+import static org.opensearch.ml.common.MockitoTestHelper.anyActionListener;
 import static org.opensearch.ml.common.indexInsight.IndexInsight.CONTENT_FIELD;
 import static org.opensearch.ml.common.indexInsight.IndexInsight.INDEX_NAME_FIELD;
 import static org.opensearch.ml.common.indexInsight.IndexInsight.LAST_UPDATE_FIELD;
@@ -64,7 +65,7 @@ public class IndexInsightTestHelper {
             MLConfig config = MLConfig.builder().type("test").configuration(Configuration.builder().agentId("agent-id").build()).build();
             configListener.onResponse(new MLConfigGetResponse(config));
             return null;
-        }).when(client).execute(eq(MLConfigGetAction.INSTANCE), any(MLConfigGetRequest.class), any(ActionListener.class));
+        }).when(client).execute(eq(MLConfigGetAction.INSTANCE), any(MLConfigGetRequest.class), anyActionListener());
     }
 
     public static void mockMLConfigFailure(Client client, String errorMessage) {
@@ -72,7 +73,7 @@ public class IndexInsightTestHelper {
             ActionListener<MLConfigGetResponse> configListener = invocation.getArgument(2);
             configListener.onFailure(new IllegalStateException(errorMessage));
             return null;
-        }).when(client).execute(eq(MLConfigGetAction.INSTANCE), any(MLConfigGetRequest.class), any(ActionListener.class));
+        }).when(client).execute(eq(MLConfigGetAction.INSTANCE), any(MLConfigGetRequest.class), anyActionListener());
     }
 
     public static void mockMLExecuteSuccess(Client client, String response) {
@@ -83,7 +84,7 @@ public class IndexInsightTestHelper {
             ModelTensorOutput output = ModelTensorOutput.builder().mlModelOutputs(List.of(tensors)).build();
             executeListener.onResponse(MLExecuteTaskResponse.builder().functionName(FunctionName.AGENT).output(output).build());
             return null;
-        }).when(client).execute(eq(MLExecuteTaskAction.INSTANCE), any(MLExecuteTaskRequest.class), any(ActionListener.class));
+        }).when(client).execute(eq(MLExecuteTaskAction.INSTANCE), any(MLExecuteTaskRequest.class), anyActionListener());
     }
 
     public static void mockMLExecuteFailure(Client client, String errorMessage) {
@@ -91,7 +92,7 @@ public class IndexInsightTestHelper {
             ActionListener<MLExecuteTaskResponse> executeListener = invocation.getArgument(2);
             executeListener.onFailure(new RuntimeException(errorMessage));
             return null;
-        }).when(client).execute(eq(MLExecuteTaskAction.INSTANCE), any(MLExecuteTaskRequest.class), any(ActionListener.class));
+        }).when(client).execute(eq(MLExecuteTaskAction.INSTANCE), any(MLExecuteTaskRequest.class), anyActionListener());
     }
 
     public static void mockUpdateSuccess(SdkClient sdkClient) {

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/LogRelatedIndexCheckTaskTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/LogRelatedIndexCheckTaskTests.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.mock;
+import static org.opensearch.ml.common.MockitoTestHelper.anyActionListener;
+import static org.opensearch.ml.common.MockitoTestHelper.mockActionListener;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockMLConfigFailure;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockMLConfigSuccess;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockMLExecuteFailure;
@@ -16,9 +18,7 @@ import java.util.Map;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.TotalHits.Relation;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -32,10 +32,6 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
 public class LogRelatedIndexCheckTaskTests {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     private Client client;
     private SdkClient sdkClient;
     private LogRelatedIndexCheckTask task;
@@ -64,11 +60,11 @@ public class LogRelatedIndexCheckTaskTests {
             when(resp.getHits()).thenReturn(hits);
             listener.onResponse(resp);
             return null;
-        }).when(client).search(any(), any(ActionListener.class));
+        }).when(client).search(any(), anyActionListener());
     }
 
     // parseCheckResponse declared method
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked") // reflection invoke returns Object; cast to Map for assertions
     private Map<String, Object> invokeParse(LogRelatedIndexCheckTask t, String resp) {
         try {
             Method method = LogRelatedIndexCheckTask.class.getDeclaredMethod("parseCheckResponse", String.class);
@@ -126,8 +122,7 @@ public class LogRelatedIndexCheckTaskTests {
             return null;
         }).when(client).search(any(SearchRequest.class), any());
 
-        @SuppressWarnings("unchecked")
-        ActionListener<String> listener = mock(ActionListener.class);
+        ActionListener<String> listener = mockActionListener();
 
         invokeCollect(task, listener);
 
@@ -142,8 +137,7 @@ public class LogRelatedIndexCheckTaskTests {
             return null;
         }).when(client).search(any(SearchRequest.class), any());
 
-        @SuppressWarnings("unchecked")
-        ActionListener<String> listener = mock(ActionListener.class);
+        ActionListener<String> listener = mockActionListener();
 
         invokeCollect(task, listener);
 
@@ -187,8 +181,7 @@ public class LogRelatedIndexCheckTaskTests {
             return null;
         }).when(client).search(any(SearchRequest.class), any());
 
-        @SuppressWarnings("unchecked")
-        ActionListener<String> listener = mock(ActionListener.class);
+        ActionListener<String> listener = mockActionListener();
 
         invokeCollect(task, listener);
 
@@ -208,8 +201,7 @@ public class LogRelatedIndexCheckTaskTests {
             return null;
         }).when(client).search(any(SearchRequest.class), any());
 
-        @SuppressWarnings("unchecked")
-        ActionListener<String> listener = mock(ActionListener.class);
+        ActionListener<String> listener = mockActionListener();
 
         invokeCollect(task, listener);
 
@@ -230,8 +222,7 @@ public class LogRelatedIndexCheckTaskTests {
             return null;
         }).when(client).search(any(SearchRequest.class), any());
 
-        @SuppressWarnings("unchecked")
-        ActionListener<String> listener = mock(ActionListener.class);
+        ActionListener<String> listener = mockActionListener();
 
         invokeCollect(task, listener);
 
@@ -245,9 +236,11 @@ public class LogRelatedIndexCheckTaskTests {
 
     @Test
     public void testCreatePrerequisiteTask_ThrowsException() {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("LogRelatedIndexCheckTask has no prerequisites");
-        task.createPrerequisiteTask(MLIndexInsightType.STATISTICAL_DATA);
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> task.createPrerequisiteTask(MLIndexInsightType.STATISTICAL_DATA)
+        );
+        assertEquals("LogRelatedIndexCheckTask has no prerequisites", exception.getMessage());
     }
 
     @Test
@@ -262,7 +255,7 @@ public class LogRelatedIndexCheckTaskTests {
         // Mock update call for saveResult
         mockUpdateSuccess(sdkClient);
 
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.runTask("tenant-id", listener);
 
         ArgumentCaptor<IndexInsight> captor = ArgumentCaptor.forClass(IndexInsight.class);
@@ -278,7 +271,7 @@ public class LogRelatedIndexCheckTaskTests {
         // Mock getAgentIdToRun
         mockMLConfigFailure(client, "Config not found");
 
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.runTask("tenant-id", listener);
 
         ArgumentCaptor<IllegalStateException> captor = ArgumentCaptor.forClass(IllegalStateException.class);
@@ -296,7 +289,7 @@ public class LogRelatedIndexCheckTaskTests {
         mockUpdateSuccess(sdkClient);
         mockMLExecuteFailure(client, "ML execution failed");
 
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
         task.runTask("tenant-id", listener);
 
         ArgumentCaptor<RuntimeException> captor = ArgumentCaptor.forClass(RuntimeException.class);

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/MLIndexInsightTypeTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/MLIndexInsightTypeTests.java
@@ -6,16 +6,11 @@
 package org.opensearch.ml.common.indexInsight;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class MLIndexInsightTypeTests {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void testValidTypes() {
         assertEquals(MLIndexInsightType.STATISTICAL_DATA, MLIndexInsightType.fromString("STATISTICAL_DATA"));
@@ -26,15 +21,16 @@ public class MLIndexInsightTypeTests {
 
     @Test
     public void testNullInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("ML index insight type can't be null");
-        MLIndexInsightType.fromString(null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> MLIndexInsightType.fromString(null));
+        assertEquals("ML index insight type can't be null", exception.getMessage());
     }
 
     @Test
     public void testInvalidType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Wrong index insight type");
-        MLIndexInsightType.fromString("INVALID_TYPE");
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> MLIndexInsightType.fromString("INVALID_TYPE")
+        );
+        assertEquals("Wrong index insight type", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/StatisticalDataTaskTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/StatisticalDataTaskTests.java
@@ -7,9 +7,11 @@ package org.opensearch.ml.common.indexInsight;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.opensearch.ml.common.MockitoTestHelper.mockActionListener;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockGetSuccess;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockMLConfigSuccess;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockMLExecuteSuccess;
@@ -26,11 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.swing.*;
-
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsRequest;
@@ -56,11 +54,9 @@ import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.IndicesAdminClient;
 
+import com.google.gson.reflect.TypeToken;
+
 public class StatisticalDataTaskTests {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Mock
     public SdkClient sdkClient;
 
@@ -139,9 +135,11 @@ public class StatisticalDataTaskTests {
         Client client = mock(Client.class);
         StatisticalDataTask task = new StatisticalDataTask("test-index", client, sdkClient);
 
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("StatisticalDataTask has no prerequisites");
-        task.createPrerequisiteTask(MLIndexInsightType.FIELD_DESCRIPTION);
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> task.createPrerequisiteTask(MLIndexInsightType.FIELD_DESCRIPTION)
+        );
+        assertEquals("StatisticalDataTask has no prerequisites", exception.getMessage());
     }
 
     @Test
@@ -169,7 +167,7 @@ public class StatisticalDataTaskTests {
         doAnswer(invocation -> { return null; }).when(indicesAdminClient).getMappings(any(GetMappingsRequest.class), any());
 
         StatisticalDataTask task = new StatisticalDataTask("test-index", client, sdkClient);
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
 
         task.runTask("tenant-id", listener);
 
@@ -180,7 +178,7 @@ public class StatisticalDataTaskTests {
     public void testRunTask_WithEmptyMappings() {
         Client client = setupBasicClientMocks();
         GetMappingsResponse getMappingsResponse = mock(GetMappingsResponse.class);
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
 
         when(getMappingsResponse.getMappings()).thenReturn(new HashMap<>());
         setupGetMappingsCall(client, getMappingsResponse);
@@ -195,7 +193,7 @@ public class StatisticalDataTaskTests {
     public void testRunTask_WithSearchFailure() {
         Client client = setupBasicClientMocks();
         GetMappingsResponse getMappingsResponse = setupMappingResponse();
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
 
         setupGetMappingsCall(client, getMappingsResponse);
 
@@ -220,7 +218,7 @@ public class StatisticalDataTaskTests {
     public void testHandlePatternMatchedDoc_RunWithoutStoring() {
         Client client = setupBasicClientMocks();
         GetMappingsResponse getMappingsResponse = setupMappingResponse();
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
 
         Map<String, Object> patternSource = new HashMap<>();
         patternSource.put(IndexInsight.STATUS_FIELD, "COMPLETED");
@@ -242,6 +240,7 @@ public class StatisticalDataTaskTests {
     }
 
     @Test
+    @SuppressWarnings("unchecked") // Private package methods are invoked via reflection in tests
     public void testParseSearchResult_WithEmptyAggregations() throws Exception {
         Client client = mock(Client.class);
         StatisticalDataTask task = new StatisticalDataTask("test-index", client, sdkClient);
@@ -266,6 +265,7 @@ public class StatisticalDataTaskTests {
     }
 
     @Test
+    @SuppressWarnings("unchecked") // Private package methods are invoked via reflection in tests
     public void testFilterColumns_WithFiltersAggregation() throws Exception {
         Client client = mock(Client.class);
         StatisticalDataTask task = new StatisticalDataTask("test-index", client, sdkClient);
@@ -315,7 +315,7 @@ public class StatisticalDataTaskTests {
         mockMLConfigSuccess(client);
         mockMLExecuteSuccess(client, "");
         GetMappingsResponse getMappingsResponse = setupMappingResponse();
-        ActionListener<IndexInsight> listener = mock(ActionListener.class);
+        ActionListener<IndexInsight> listener = mockActionListener();
 
         setupGetMappingsCall(client, getMappingsResponse);
         StatisticalDataTask task = new StatisticalDataTask("test-index", client, sdkClient);
@@ -392,8 +392,10 @@ public class StatisticalDataTaskTests {
         Map<String, Object> expectedContent = gson
             .fromJson(
                 "{\"example_docs\":[{\"index_name\":\"test-*\"}],\"important_column_and_distribution\":{\"field1\":{\"type\":\"text\",\"unique_count\":\"demo2\",\"unique_terms\":[\"demo\"],\"max_value\":\"demo2\"}}}",
-                Map.class
+                new TypeToken<Map<String, Object>>() {
+                }.getType()
             );
-        assertEquals(expectedContent, gson.fromJson(response.getContent(), Map.class));
+        assertEquals(expectedContent, gson.fromJson(response.getContent(), new TypeToken<Map<String, Object>>() {
+        }.getType()));
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/input/MLInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/MLInputTest.java
@@ -17,9 +17,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
@@ -50,10 +48,6 @@ import lombok.NonNull;
 public class MLInputTest {
 
     MLInput input;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     private final FunctionName algorithm = FunctionName.LINEAR_REGRESSION;
 
     private Function<XContentParser, MLInput> function = parser -> {
@@ -82,9 +76,8 @@ public class MLInputTest {
 
     @Test
     public void constructor_NullAlgorithm() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("algorithm can't be null");
-        MLInput.builder().build();
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> MLInput.builder().build());
+        assertEquals("algorithm can't be null", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/input/execute/agent/AgentInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/execute/agent/AgentInputTest.java
@@ -186,7 +186,7 @@ public class AgentInputTest {
 
         // Assert
         assertEquals(InputType.CONTENT_BLOCKS, deserializedInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<ContentBlock> deserializedBlocks = (List<ContentBlock>) deserializedInput.getInput();
         assertEquals(2, deserializedBlocks.size());
         assertEquals(ContentType.TEXT, deserializedBlocks.get(0).getType());
@@ -222,7 +222,7 @@ public class AgentInputTest {
 
         // Assert
         assertEquals(InputType.MESSAGES, deserializedInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> deserializedMessages = (List<Message>) deserializedInput.getInput();
         assertEquals(1, deserializedMessages.size());
         assertEquals("user", deserializedMessages.get(0).getRole());
@@ -251,7 +251,7 @@ public class AgentInputTest {
         AgentInput deserializedInput = new AgentInput(input);
 
         // Assert
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<ContentBlock> deserializedBlocks = (List<ContentBlock>) deserializedInput.getInput();
         assertEquals(1, deserializedBlocks.size());
         assertEquals(ContentType.VIDEO, deserializedBlocks.get(0).getType());
@@ -281,7 +281,7 @@ public class AgentInputTest {
         AgentInput deserializedInput = new AgentInput(input);
 
         // Assert
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<ContentBlock> deserializedBlocks = (List<ContentBlock>) deserializedInput.getInput();
         assertEquals(1, deserializedBlocks.size());
         assertEquals(ContentType.DOCUMENT, deserializedBlocks.get(0).getType());
@@ -348,7 +348,7 @@ public class AgentInputTest {
         // Assert
         assertNotNull(agentInput.getInput());
         assertEquals(InputType.CONTENT_BLOCKS, agentInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<ContentBlock> blocks = (List<ContentBlock>) agentInput.getInput();
         assertEquals(1, blocks.size());
         assertEquals(ContentType.TEXT, blocks.get(0).getType());
@@ -370,7 +370,7 @@ public class AgentInputTest {
         // Assert
         assertNotNull(agentInput.getInput());
         assertEquals(InputType.MESSAGES, agentInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> messages = (List<Message>) agentInput.getInput();
         assertEquals(1, messages.size());
         assertEquals("user", messages.get(0).getRole());
@@ -392,7 +392,7 @@ public class AgentInputTest {
 
         // Assert
         assertNotNull(agentInput.getInput());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<ContentBlock> blocks = (List<ContentBlock>) agentInput.getInput();
         assertEquals(1, blocks.size());
         assertEquals(ContentType.IMAGE, blocks.get(0).getType());
@@ -417,7 +417,7 @@ public class AgentInputTest {
 
         // Assert
         assertNotNull(agentInput.getInput());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<ContentBlock> blocks = (List<ContentBlock>) agentInput.getInput();
         assertEquals(1, blocks.size());
         assertEquals(ContentType.VIDEO, blocks.get(0).getType());
@@ -440,7 +440,7 @@ public class AgentInputTest {
 
         // Assert
         assertNotNull(agentInput.getInput());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<ContentBlock> blocks = (List<ContentBlock>) agentInput.getInput();
         assertEquals(1, blocks.size());
         assertEquals(ContentType.DOCUMENT, blocks.get(0).getType());
@@ -544,7 +544,7 @@ public class AgentInputTest {
 
         // Assert
         assertEquals(InputType.MESSAGES, deserializedInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> deserializedMessages = (List<Message>) deserializedInput.getInput();
         assertEquals(1, deserializedMessages.size());
         assertEquals(2, deserializedMessages.get(0).getContent().size());
@@ -597,7 +597,7 @@ public class AgentInputTest {
 
         // Assert
         assertEquals(InputType.MESSAGES, deserializedInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> deserializedMessages = (List<Message>) deserializedInput.getInput();
         assertEquals(2, deserializedMessages.size());
         assertEquals("user", deserializedMessages.get(0).getRole());
@@ -630,7 +630,7 @@ public class AgentInputTest {
 
         // Assert
         assertEquals(InputType.MESSAGES, agentInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> resultMessages = (List<Message>) agentInput.getInput();
         assertEquals(1, resultMessages.size());
         assertNotNull(resultMessages.get(0).getToolCalls());
@@ -659,7 +659,7 @@ public class AgentInputTest {
 
         // Assert
         assertEquals(InputType.MESSAGES, agentInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> resultMessages = (List<Message>) agentInput.getInput();
         assertEquals(1, resultMessages.size());
         assertEquals("tool", resultMessages.get(0).getRole());
@@ -702,7 +702,7 @@ public class AgentInputTest {
 
         // Assert
         assertEquals(InputType.MESSAGES, deserializedInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> deserializedMessages = (List<Message>) deserializedInput.getInput();
         assertEquals(1, deserializedMessages.size());
         assertEquals("assistant", deserializedMessages.get(0).getRole());
@@ -742,7 +742,7 @@ public class AgentInputTest {
 
         // Assert
         assertEquals(InputType.MESSAGES, deserializedInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> deserializedMessages = (List<Message>) deserializedInput.getInput();
         assertEquals(1, deserializedMessages.size());
         assertEquals("tool", deserializedMessages.get(0).getRole());
@@ -777,7 +777,7 @@ public class AgentInputTest {
 
         // Assert
         assertEquals(InputType.MESSAGES, agentInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> messages = (List<Message>) agentInput.getInput();
         assertEquals(1, messages.size());
         assertEquals("assistant", messages.get(0).getRole());
@@ -807,7 +807,7 @@ public class AgentInputTest {
 
         // Assert
         assertEquals(InputType.MESSAGES, agentInput.getInputType());
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> messages = (List<Message>) agentInput.getInput();
         assertEquals(1, messages.size());
         assertEquals("tool", messages.get(0).getRole());
@@ -865,7 +865,7 @@ public class AgentInputTest {
         AgentInput deserializedInput = new AgentInput(input);
 
         // Assert
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // AgentInput.getInput() returns Object; cast to typed list for assertion
         List<Message> deserializedMessages = (List<Message>) deserializedInput.getInput();
         assertEquals(4, deserializedMessages.size());
 

--- a/common/src/test/java/org/opensearch/ml/common/input/execute/metricscorrelation/MetricsCorrelationInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/execute/metricscorrelation/MetricsCorrelationInputTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.input.execute.metricscorrelation;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -13,9 +14,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.XContentParser;
@@ -33,9 +32,6 @@ public class MetricsCorrelationInputTest {
         }
     };
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Before
     public void setUp() {
         List<float[]> inputData = new ArrayList<>();
@@ -47,20 +43,20 @@ public class MetricsCorrelationInputTest {
 
     @Test
     public void constructor_NullOperation() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("empty input data");
-        MetricsCorrelationInput.builder().build();
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> MetricsCorrelationInput.builder().build());
+        assertEquals("empty input data", exception.getMessage());
     }
 
     @Test
     public void constructor_variableLengthInput() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("All the input metrics sizes should be same");
-        List<float[]> inputData = new ArrayList<>();
-        inputData.add(new float[] { 1.0f, 2.0f, 3.0f, 4.0f });
-        inputData.add(new float[] { 1.0f, 2.0f, 3.0f });
-        inputData.add(new float[] { 1.0f, 2.0f, 3.0f, 4.0f });
-        MetricsCorrelationInput.builder().inputData(inputData).build();
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            List<float[]> inputData = new ArrayList<>();
+            inputData.add(new float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+            inputData.add(new float[] { 1.0f, 2.0f, 3.0f });
+            inputData.add(new float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+            MetricsCorrelationInput.builder().inputData(inputData).build();
+        });
+        assertEquals("All the input metrics sizes should be same", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/input/execute/samplecalculator/LocalSampleCalculatorInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/execute/samplecalculator/LocalSampleCalculatorInputTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.input.execute.samplecalculator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -13,9 +14,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.XContentParser;
@@ -33,9 +32,6 @@ public class LocalSampleCalculatorInputTest {
         }
     };
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Before
     public void setUp() {
         List<Double> inputData = new ArrayList<>();
@@ -47,9 +43,11 @@ public class LocalSampleCalculatorInputTest {
 
     @Test
     public void constructor_NullOperation() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("wrong operation");
-        LocalSampleCalculatorInput.builder().build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> LocalSampleCalculatorInput.builder().build()
+        );
+        assertEquals("wrong operation", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/input/nlp/TextDocsMLInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/nlp/TextDocsMLInputTest.java
@@ -12,9 +12,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
@@ -33,10 +31,6 @@ import org.opensearch.search.SearchModule;
 public class TextDocsMLInputTest {
 
     MLInput input;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     private final FunctionName algorithm = FunctionName.TEXT_EMBEDDING;
 
     @Before

--- a/common/src/test/java/org/opensearch/ml/common/input/parameter/clustering/KMeansParamsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/parameter/clustering/KMeansParamsTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.input.parameter.clustering;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.ml.common.TestHelper.contentObjectToString;
 import static org.opensearch.ml.common.TestHelper.testParseFromString;
 
@@ -13,18 +14,13 @@ import java.io.IOException;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.TestHelper;
 
 public class KMeansParamsTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     KMeansParams params;
     private Function<XContentParser, KMeansParams> function = parser -> {
         try {
@@ -46,18 +42,20 @@ public class KMeansParamsTest {
 
     @Test
     public void parse_KMeansParams_InvalidDoubleValue() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("10.01 cannot be converted to Integer without data loss");
-        String paramsStr = contentObjectToString(params);
-        testParseFromString(params, paramsStr.replace("\"iterations\":10,", "\"iterations\":10.01,"), function);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            String paramsStr = contentObjectToString(params);
+            testParseFromString(params, paramsStr.replace("\"iterations\":10,", "\"iterations\":10.01,"), function);
+        });
+        assertEquals("10.01 cannot be converted to Integer without data loss", exception.getMessage());
     }
 
     @Test
     public void parse_KMeansParams_InvalidDoubleString() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Integer value passed as String");
-        String paramsStr = contentObjectToString(params);
-        testParseFromString(params, paramsStr.replace("\"iterations\":10,", "\"iterations\":\"10.01\","), function);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            String paramsStr = contentObjectToString(params);
+            testParseFromString(params, paramsStr.replace("\"iterations\":10,", "\"iterations\":\"10.01\","), function);
+        });
+        assertEquals("Integer value passed as String", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/input/parameter/clustering/RCFSummarizeParamsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/parameter/clustering/RCFSummarizeParamsTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.input.parameter.clustering;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.ml.common.TestHelper.contentObjectToString;
 import static org.opensearch.ml.common.TestHelper.testParseFromString;
 
@@ -13,18 +14,13 @@ import java.io.IOException;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.TestHelper;
 
 public class RCFSummarizeParamsTest {
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     RCFSummarizeParams params;
     private Function<XContentParser, RCFSummarizeParams> function = parser -> {
         try {
@@ -46,18 +42,20 @@ public class RCFSummarizeParamsTest {
 
     @Test
     public void parseRCFSummarizeParamsExceptionOnInvalidDoubleValue() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("2.01 cannot be converted to Integer without data loss");
-        String paramsStr = contentObjectToString(params);
-        testParseFromString(params, paramsStr.replace("\"max_k\":2,", "\"max_k\":2.01,"), function);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            String paramsStr = contentObjectToString(params);
+            testParseFromString(params, paramsStr.replace("\"max_k\":2,", "\"max_k\":2.01,"), function);
+        });
+        assertEquals("2.01 cannot be converted to Integer without data loss", exception.getMessage());
     }
 
     @Test
     public void parseRCFSummarizeParamsExceptionOnInvalidDoubleString() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Integer value passed as String");
-        String paramsStr = contentObjectToString(params);
-        testParseFromString(params, paramsStr.replace("\"max_k\":2,", "\"max_k\":\"2.01\","), function);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            String paramsStr = contentObjectToString(params);
+            testParseFromString(params, paramsStr.replace("\"max_k\":2,", "\"max_k\":\"2.01\","), function);
+        });
+        assertEquals("Integer value passed as String", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/input/parameter/regression/LinearRegressionParamsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/parameter/regression/LinearRegressionParamsTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.input.parameter.regression;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.ml.common.TestHelper.contentObjectToString;
 import static org.opensearch.ml.common.TestHelper.testParseFromString;
 
@@ -13,19 +14,13 @@ import java.io.IOException;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.TestHelper;
 
 public class LinearRegressionParamsTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     private Function<XContentParser, LinearRegressionParams> function = parser -> {
         try {
             return (LinearRegressionParams) LinearRegressionParams.parse(parser);
@@ -90,10 +85,11 @@ public class LinearRegressionParamsTest {
 
     @Test
     public void parse_InvalidParam_InvalidDoubleValue() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Double value passed as String");
-        String paramsStr = contentObjectToString(params);
-        testParseFromString(params, paramsStr.replace("\"epsilon\":0.3,", "\"epsilon\":\"0.3\","), function);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            String paramsStr = contentObjectToString(params);
+            testParseFromString(params, paramsStr.replace("\"epsilon\":0.3,", "\"epsilon\":\"0.3\","), function);
+        });
+        assertEquals("Double value passed as String", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/input/parameter/regression/LogisticRegressionParamsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/parameter/regression/LogisticRegressionParamsTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.input.parameter.regression;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.ml.common.TestHelper.contentObjectToString;
 import static org.opensearch.ml.common.TestHelper.testParseFromString;
 import static org.opensearch.ml.common.input.parameter.regression.LogisticRegressionParams.PARSE_FIELD_NAME;
@@ -14,19 +15,13 @@ import java.io.IOException;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.TestHelper;
 
 public class LogisticRegressionParamsTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     private Function<XContentParser, LogisticRegressionParams> function = parser -> {
         try {
             return (LogisticRegressionParams) LogisticRegressionParams.parse(parser);
@@ -75,10 +70,11 @@ public class LogisticRegressionParamsTest {
 
     @Test
     public void parse_InvalidParam_InvalidDoubleValue() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Double value passed as String");
-        String paramsStr = contentObjectToString(logisticRegressionParams);
-        testParseFromString(logisticRegressionParams, paramsStr.replace("\"epsilon\":0.3,", "\"epsilon\":\"0.3\","), function);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            String paramsStr = contentObjectToString(logisticRegressionParams);
+            testParseFromString(logisticRegressionParams, paramsStr.replace("\"epsilon\":0.3,", "\"epsilon\":\"0.3\","), function);
+        });
+        assertEquals("Double value passed as String", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
@@ -296,7 +296,7 @@ public class MLLongTermMemoryTest {
     @Test
     public void testToIndexMap() {
         Map<String, Object> indexMap = memoryWithAllFields.toIndexMap();
-        Map<String, String> namespace = (Map<String, String>) indexMap.get("namespace");
+        Map<String, String> namespace = castToStringMap(indexMap.get("namespace"));
         assertEquals("session-123", namespace.get(SESSION_ID_FIELD));
         assertEquals("This is a test memory content", indexMap.get("memory"));
         assertEquals("SEMANTIC", indexMap.get("strategy_type"));
@@ -311,7 +311,7 @@ public class MLLongTermMemoryTest {
     @Test
     public void testToIndexMapMinimal() {
         Map<String, Object> indexMap = memoryMinimal.toIndexMap();
-        Map<String, String> namespace = (Map<String, String>) indexMap.get("namespace");
+        Map<String, String> namespace = castToStringMap(indexMap.get("namespace"));
         assertEquals("session-minimal", namespace.get("session_id"));
         assertEquals("Minimal memory", indexMap.get("memory"));
         assertEquals("SEMANTIC", indexMap.get("strategy_type"));
@@ -423,5 +423,10 @@ public class MLLongTermMemoryTest {
         assertEquals(specialMemory.getNamespace().get(SESSION_ID_FIELD), parsed.getNamespace().get(SESSION_ID_FIELD));
         assertEquals(specialMemory.getMemory(), parsed.getMemory());
         assertEquals(specialMemory.getTags(), parsed.getTags());
+    }
+
+    @SuppressWarnings("unchecked") // Index map values are deserialized from generic Object maps
+    private static Map<String, String> castToStringMap(Object value) {
+        return (Map<String, String>) value;
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/model/BaseModelConfigTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/BaseModelConfigTests.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.opensearch.ml.common.CommonValue.VERSION_3_0_0;
 import static org.opensearch.ml.common.CommonValue.VERSION_3_1_0;
@@ -17,9 +18,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -31,8 +30,6 @@ public class BaseModelConfigTests {
 
     BaseModelConfig config;
     Function<XContentParser, BaseModelConfig> function;
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -73,9 +70,11 @@ public class BaseModelConfigTests {
 
     @Test
     public void nullFields_ModelType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model type is null");
-        config = BaseModelConfig.baseModelConfigBuilder().build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> config = BaseModelConfig.baseModelConfigBuilder().build()
+        );
+        assertEquals("model type is null", exception.getMessage());
     }
 
     @Test
@@ -129,12 +128,18 @@ public class BaseModelConfigTests {
 
     @Test
     public void duplicateKeys() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Duplicate keys found in both all_config and additional_config: key1");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        String allConfig = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
-        Map<String, Object> additionalConfig = Map.of("key1", "value3");
+            String allConfig = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
+            Map<String, Object> additionalConfig = Map.of("key1", "value3");
 
-        BaseModelConfig.baseModelConfigBuilder().allConfig(allConfig).modelType("testModelType").additionalConfig(additionalConfig).build();
+            BaseModelConfig
+                .baseModelConfigBuilder()
+                .allConfig(allConfig)
+                .modelType("testModelType")
+                .additionalConfig(additionalConfig)
+                .build();
+        });
+        assertEquals("Duplicate keys found in both all_config and additional_config: key1", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/model/MLDeployingSettingTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/MLDeployingSettingTests.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -14,9 +15,7 @@ import java.util.Collections;
 import java.util.function.Consumer;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
@@ -37,9 +36,6 @@ public class MLDeployingSettingTests {
     private MLDeploySetting deploySettingNull;
 
     private final String expectedInputStr = "{\"is_auto_deploy_enabled\":true,\"model_ttl_minutes\":-1}";
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -75,29 +71,31 @@ public class MLDeployingSettingTests {
 
     @Test
     public void parseWithIllegalArgumentNull() throws Exception {
-        exceptionRule.expect(JsonParseException.class);
-        final String expectedInputStrWithNullField = "{\"is_auto_deploy_enabled\":null}";
+        assertThrows(JsonParseException.class, () -> {
+            final String expectedInputStrWithNullField = "{\"is_auto_deploy_enabled\":null}";
 
-        testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
-            try {
-                assertEquals("{}", serializationWithToXContent(parsedInput));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
+                try {
+                    assertEquals("{}", serializationWithToXContent(parsedInput));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
         });
     }
 
     @Test
     public void parseWithIllegalArgumentInteger() throws Exception {
-        exceptionRule.expect(JsonParseException.class);
-        final String expectedInputStrWithNullField = "{\"is_auto_deploy_enabled\":364}";
+        assertThrows(JsonParseException.class, () -> {
+            final String expectedInputStrWithNullField = "{\"is_auto_deploy_enabled\":364}";
 
-        testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
-            try {
-                assertEquals("{}", serializationWithToXContent(parsedInput));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
+                try {
+                    assertEquals("{}", serializationWithToXContent(parsedInput));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
         });
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/model/MLModelFormatTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/MLModelFormatTests.java
@@ -6,16 +6,11 @@
 package org.opensearch.ml.common.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class MLModelFormatTests {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void from() {
         MLModelFormat modelFormat = MLModelFormat.from("TORCH_SCRIPT");
@@ -24,8 +19,7 @@ public class MLModelFormatTests {
 
     @Test
     public void from_wrongValue() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Wrong model format");
-        MLModelFormat.from("test_wrong_value");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> MLModelFormat.from("test_wrong_value"));
+        assertEquals("Wrong model format", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/model/MLModelStateTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/MLModelStateTests.java
@@ -6,16 +6,11 @@
 package org.opensearch.ml.common.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class MLModelStateTests {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void from() {
         MLModelState modelState = MLModelState.from("REGISTERED");
@@ -24,9 +19,8 @@ public class MLModelStateTests {
 
     @Test
     public void from_wrongValue() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Wrong model state");
-        MLModelState.from("test_wrong_value");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> MLModelState.from("test_wrong_value"));
+        assertEquals("Wrong model state", exception.getMessage());
     }
 
 }

--- a/common/src/test/java/org/opensearch/ml/common/model/MetricsCorrelationModelConfigTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/MetricsCorrelationModelConfigTests.java
@@ -6,15 +6,14 @@
 package org.opensearch.ml.common.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 
 import java.io.IOException;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -26,8 +25,6 @@ public class MetricsCorrelationModelConfigTests {
 
     MetricsCorrelationModelConfig config;
     Function<XContentParser, MetricsCorrelationModelConfig> function;
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -58,9 +55,11 @@ public class MetricsCorrelationModelConfigTests {
 
     @Test
     public void nullFields_ModelType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model type is null");
-        config = MetricsCorrelationModelConfig.builder().build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> config = MetricsCorrelationModelConfig.builder().build()
+        );
+        assertEquals("model type is null", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/model/QuestionAnsweringModelConfigTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/QuestionAnsweringModelConfigTests.java
@@ -6,15 +6,14 @@
 package org.opensearch.ml.common.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 
 import java.io.IOException;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -26,8 +25,6 @@ public class QuestionAnsweringModelConfigTests {
 
     QuestionAnsweringModelConfig config;
     Function<XContentParser, QuestionAnsweringModelConfig> function;
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -60,16 +57,20 @@ public class QuestionAnsweringModelConfigTests {
 
     @Test
     public void nullFields_ModelType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model type is null");
-        config = QuestionAnsweringModelConfig.builder().build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> config = QuestionAnsweringModelConfig.builder().build()
+        );
+        assertEquals("model type is null", exception.getMessage());
     }
 
     @Test
     public void nullFields_FrameworkType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("framework type is null");
-        config = QuestionAnsweringModelConfig.builder().modelType("testModelType").build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> config = QuestionAnsweringModelConfig.builder().modelType("testModelType").build()
+        );
+        assertEquals("framework type is null", exception.getMessage());
     }
 
     @Test
@@ -81,9 +82,11 @@ public class QuestionAnsweringModelConfigTests {
 
     @Test
     public void frameworkType_wrongValue() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Wrong framework type");
-        QuestionAnsweringModelConfig.FrameworkType.from("test_wrong_value");
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> QuestionAnsweringModelConfig.FrameworkType.from("test_wrong_value")
+        );
+        assertEquals("Wrong framework type", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/model/RemoteModelConfigTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/RemoteModelConfigTests.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 
 import java.io.IOException;
@@ -15,9 +16,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
@@ -30,8 +29,6 @@ public class RemoteModelConfigTests {
 
     RemoteModelConfig config;
     Function<XContentParser, RemoteModelConfig> function;
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -77,35 +74,42 @@ public class RemoteModelConfigTests {
 
     @Test
     public void nullFields_ModelType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model type is null");
-        config = RemoteModelConfig.builder().build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> config = RemoteModelConfig.builder().build()
+        );
+        assertEquals("model type is null", exception.getMessage());
     }
 
     @Test
     public void textEmbedding_MissingEmbeddingDimension() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Embedding dimension must be provided for remote text embedding model");
-        RemoteModelConfig.builder().modelType("text_embedding").additionalConfig(Map.of("space_type", "l2")).build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> RemoteModelConfig.builder().modelType("text_embedding").additionalConfig(Map.of("space_type", "l2")).build()
+        );
+        assertEquals("Embedding dimension must be provided for remote text embedding model", exception.getMessage());
     }
 
     @Test
     public void textEmbedding_MissingFrameworkType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Framework type must be provided for remote text embedding model");
-        RemoteModelConfig.builder().modelType("text_embedding").embeddingDimension(100).build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> RemoteModelConfig.builder().modelType("text_embedding").embeddingDimension(100).build()
+        );
+        assertEquals("Framework type must be provided for remote text embedding model", exception.getMessage());
     }
 
     @Test
     public void textEmbedding_MissingSpaceType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Space type must be provided in additional_config for remote text embedding model");
-        RemoteModelConfig
-            .builder()
-            .modelType("text_embedding")
-            .embeddingDimension(100)
-            .frameworkType(RemoteModelConfig.FrameworkType.SENTENCE_TRANSFORMERS)
-            .build();
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            RemoteModelConfig
+                .builder()
+                .modelType("text_embedding")
+                .embeddingDimension(100)
+                .frameworkType(RemoteModelConfig.FrameworkType.SENTENCE_TRANSFORMERS)
+                .build();
+        });
+        assertEquals("Space type must be provided in additional_config for remote text embedding model", exception.getMessage());
     }
 
     @Test
@@ -140,16 +144,20 @@ public class RemoteModelConfigTests {
 
     @Test
     public void frameworkType_wrongValue() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Wrong framework type");
-        RemoteModelConfig.FrameworkType.from("test_wrong_value");
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> RemoteModelConfig.FrameworkType.from("test_wrong_value")
+        );
+        assertEquals("Wrong framework type", exception.getMessage());
     }
 
     @Test
     public void poolingMode_wrongValue() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Wrong pooling method");
-        RemoteModelConfig.PoolingMode.from("test_wrong_value");
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> RemoteModelConfig.PoolingMode.from("test_wrong_value")
+        );
+        assertEquals("Wrong pooling method", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/model/TextEmbeddingModelConfigTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/TextEmbeddingModelConfigTests.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 
 import java.io.IOException;
@@ -15,9 +16,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
@@ -30,8 +29,6 @@ public class TextEmbeddingModelConfigTests {
 
     TextEmbeddingModelConfig config;
     Function<XContentParser, TextEmbeddingModelConfig> function;
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -70,23 +67,29 @@ public class TextEmbeddingModelConfigTests {
 
     @Test
     public void nullFields_ModelType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model type is null");
-        config = TextEmbeddingModelConfig.builder().build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> config = TextEmbeddingModelConfig.builder().build()
+        );
+        assertEquals("model type is null", exception.getMessage());
     }
 
     @Test
     public void nullFields_EmbeddingDimension() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("embedding dimension is null");
-        config = TextEmbeddingModelConfig.builder().modelType("testModelType").build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> config = TextEmbeddingModelConfig.builder().modelType("testModelType").build()
+        );
+        assertEquals("embedding dimension is null", exception.getMessage());
     }
 
     @Test
     public void nullFields_FrameworkType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("framework type is null");
-        config = TextEmbeddingModelConfig.builder().modelType("testModelType").embeddingDimension(100).build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> config = TextEmbeddingModelConfig.builder().modelType("testModelType").embeddingDimension(100).build()
+        );
+        assertEquals("framework type is null", exception.getMessage());
     }
 
     @Test
@@ -98,9 +101,11 @@ public class TextEmbeddingModelConfigTests {
 
     @Test
     public void frameworkType_wrongValue() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Wrong framework type");
-        TextEmbeddingModelConfig.FrameworkType.from("test_wrong_value");
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> TextEmbeddingModelConfig.FrameworkType.from("test_wrong_value")
+        );
+        assertEquals("Wrong framework type", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/output/execute/metricscorrelation/MCorrModelTensorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/output/execute/metricscorrelation/MCorrModelTensorTest.java
@@ -11,9 +11,7 @@ import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 import java.io.IOException;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -22,10 +20,6 @@ import org.opensearch.ml.common.TestHelper;
 import org.opensearch.ml.common.output.execute.metrics_correlation.MCorrModelTensor;
 
 public class MCorrModelTensorTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     private MCorrModelTensor mCorrModelTensor;
 
     @Before

--- a/common/src/test/java/org/opensearch/ml/common/output/execute/metricscorrelation/MCorrModelTensorsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/output/execute/metricscorrelation/MCorrModelTensorsTest.java
@@ -12,9 +12,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -25,9 +23,6 @@ import org.opensearch.ml.common.output.execute.metrics_correlation.MCorrModelTen
 import org.opensearch.ml.common.output.model.ModelResultFilter;
 
 public class MCorrModelTensorsTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
     private MCorrModelTensors mcorrModelTensors;
     private ModelResultFilter modelResultFilter;
 

--- a/common/src/test/java/org/opensearch/ml/common/output/model/ModelTensorOutputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/output/model/ModelTensorOutputTest.java
@@ -3,6 +3,7 @@ package org.opensearch.ml.common.output.model;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -15,9 +16,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
@@ -32,8 +31,6 @@ public class ModelTensorOutputTest {
 
     Float[] value;
     ModelTensorOutput modelTensorOutput;
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -190,10 +187,11 @@ public class ModelTensorOutputTest {
         ModelTensorOutput spyTensor = spy(modelTensorOutput);
         doThrow(new IOException("Mock IOException")).when(spyTensor).toXContent(any(XContentBuilder.class), any());
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Can't convert ModelTensorOutput to string");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        spyTensor.toString();
+            spyTensor.toString();
+        });
+        assertEquals("Can't convert ModelTensorOutput to string", exception.getMessage());
     }
 
     private void readInputStream(ModelTensorOutput input, Consumer<ModelTensorOutput> verify) throws IOException {

--- a/common/src/test/java/org/opensearch/ml/common/output/model/ModelTensorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/output/model/ModelTensorTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.output.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -17,9 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -27,10 +26,6 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.TestHelper;
 
 public class ModelTensorTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     private ModelTensor modelTensor;
 
     @Before
@@ -99,31 +94,33 @@ public class ModelTensorTest {
 
     @Test
     public void test_UnknownDataType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("data type is null");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        ModelTensor
-            .builder()
-            .name("null_data")
-            .data(new Number[] { 1, 2, 3 })
-            .shape(null)
-            .dataType(MLResultDataType.UNKNOWN)
-            .byteBuffer(ByteBuffer.wrap(new byte[] { 0, 1, 0, 1 }))
-            .build();
+            ModelTensor
+                .builder()
+                .name("null_data")
+                .data(new Number[] { 1, 2, 3 })
+                .shape(null)
+                .dataType(MLResultDataType.UNKNOWN)
+                .byteBuffer(ByteBuffer.wrap(new byte[] { 0, 1, 0, 1 }))
+                .build();
+        });
+        assertEquals("data type is null", exception.getMessage());
     }
 
     @Test
     public void test_NullDataType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("data type is null");
-        ModelTensor
-            .builder()
-            .name("null_data")
-            .data(new Number[] { 1, 2, 3 })
-            .shape(null)
-            .dataType(null)
-            .byteBuffer(ByteBuffer.wrap(new byte[] { 0, 1, 0, 1 }))
-            .build();
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            ModelTensor
+                .builder()
+                .name("null_data")
+                .data(new Number[] { 1, 2, 3 })
+                .shape(null)
+                .dataType(null)
+                .byteBuffer(ByteBuffer.wrap(new byte[] { 0, 1, 0, 1 }))
+                .build();
+        });
+        assertEquals("data type is null", exception.getMessage());
     }
 
     @Test
@@ -139,9 +136,10 @@ public class ModelTensorTest {
         ModelTensor spyTensor = spy(modelTensor);
         doThrow(new IOException("Mock IOException")).when(spyTensor).toXContent(any(XContentBuilder.class), any());
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Can't convert ModelTensor to string");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        spyTensor.toString();
+            spyTensor.toString();
+        });
+        assertEquals("Can't convert ModelTensor to string", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/output/model/ModelTensorsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/output/model/ModelTensorsTest.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.output.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -18,9 +19,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
@@ -31,9 +30,6 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.TestHelper;
 
 public class ModelTensorsTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
     private ModelTensors modelTensors;
     private ModelResultFilter modelResultFilter;
     private Number[] testData;
@@ -291,9 +287,10 @@ public class ModelTensorsTest {
         ModelTensors spyTensors = spy(modelTensors);
         doThrow(new IOException("Mock IOException")).when(spyTensors).toXContent(any(XContentBuilder.class), any());
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Can't convert ModelTensors to string");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        spyTensors.toString();
+            spyTensors.toString();
+        });
+        assertEquals("Can't convert ModelTensors to string", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/agent/MLRegisterAgentRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/agent/MLRegisterAgentRequestTest.java
@@ -16,9 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -31,8 +29,6 @@ import org.opensearch.ml.common.contextmanager.ContextManagerConfig;
 public class MLRegisterAgentRequestTest {
 
     MLAgent mlAgent;
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -101,21 +97,22 @@ public class MLRegisterAgentRequestTest {
 
     @Test
     public void fromActionRequest_Exception() {
-        exceptionRule.expect(UncheckedIOException.class);
-        exceptionRule.expectMessage("Failed to parse ActionRequest into MLRegisterAgentRequest");
-        MLRegisterAgentRequest registerAgentRequest = new MLRegisterAgentRequest(mlAgent);
-        ActionRequest actionRequest = new ActionRequest() {
-            @Override
-            public ActionRequestValidationException validate() {
-                return null;
-            }
+        UncheckedIOException exception = assertThrows(UncheckedIOException.class, () -> {
+            MLRegisterAgentRequest registerAgentRequest = new MLRegisterAgentRequest(mlAgent);
+            ActionRequest actionRequest = new ActionRequest() {
+                @Override
+                public ActionRequestValidationException validate() {
+                    return null;
+                }
 
-            @Override
-            public void writeTo(StreamOutput out) throws IOException {
-                throw new IOException();
-            }
-        };
-        MLRegisterAgentRequest.fromActionRequest(actionRequest);
+                @Override
+                public void writeTo(StreamOutput out) throws IOException {
+                    throw new IOException();
+                }
+            };
+            MLRegisterAgentRequest.fromActionRequest(actionRequest);
+        });
+        assertEquals("Failed to parse ActionRequest into MLRegisterAgentRequest", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/agent/MLRegisterAgentResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/agent/MLRegisterAgentResponseTest.java
@@ -11,9 +11,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionResponse;
@@ -24,8 +22,6 @@ import org.opensearch.core.xcontent.XContentBuilder;
 
 public class MLRegisterAgentResponseTest {
     String agentId;
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -81,17 +77,18 @@ public class MLRegisterAgentResponseTest {
 
     @Test
     public void fromActionResponse_Exception() {
-        exceptionRule.expect(UncheckedIOException.class);
-        exceptionRule.expectMessage("Failed to parse ActionResponse into MLRegisterAgentResponse");
-        MLRegisterAgentResponse registerAgentResponse = new MLRegisterAgentResponse(agentId);
-        ActionResponse actionResponse = new ActionResponse() {
+        UncheckedIOException exception = assertThrows(UncheckedIOException.class, () -> {
+            MLRegisterAgentResponse registerAgentResponse = new MLRegisterAgentResponse(agentId);
+            ActionResponse actionResponse = new ActionResponse() {
 
-            @Override
-            public void writeTo(StreamOutput out) throws IOException {
-                throw new IOException();
-            }
-        };
-        MLRegisterAgentResponse.fromActionResponse(actionResponse);
+                @Override
+                public void writeTo(StreamOutput out) throws IOException {
+                    throw new IOException();
+                }
+            };
+            MLRegisterAgentResponse.fromActionResponse(actionResponse);
+        });
+        assertEquals("Failed to parse ActionResponse into MLRegisterAgentResponse", exception.getMessage());
     }
 
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInputTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/batch/MLBatchIngestionInputTests.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.transport.batch;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -16,9 +17,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
@@ -36,9 +35,6 @@ public class MLBatchIngestionInputTests {
     private MLBatchIngestionInput mlBatchIngestionInput;
 
     private Map<String, Object> dataSource;
-
-    @Rule
-    public final ExpectedException exceptionRule = ExpectedException.none();
 
     private final String expectedInputStr = "{"
         + "\"index_name\":\"test index\","
@@ -74,18 +70,23 @@ public class MLBatchIngestionInputTests {
 
     @Test
     public void constructorMLBatchIngestionInput_NullName() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The index name for data ingestion is missing. Please provide a valid index name to proceed.");
-
-        MLBatchIngestionInput.builder().indexName(null).dataSources(dataSource).build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> MLBatchIngestionInput.builder().indexName(null).dataSources(dataSource).build()
+        );
+        assertEquals("The index name for data ingestion is missing. Please provide a valid index name to proceed.", exception.getMessage());
     }
 
     @Test
     public void constructorMLBatchIngestionInput_NullSource() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule
-            .expectMessage("No data sources were provided for ingestion. Please specify at least one valid data source to proceed.");
-        MLBatchIngestionInput.builder().indexName("test index").dataSources(null).build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> MLBatchIngestionInput.builder().indexName("test index").dataSources(null).build()
+        );
+        assertEquals(
+            "No data sources were provided for ingestion. Please specify at least one valid data source to proceed.",
+            exception.getMessage()
+        );
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/controller/MLDeployControllerNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/controller/MLDeployControllerNodeResponseTest.java
@@ -16,9 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -32,9 +30,6 @@ public class MLDeployControllerNodeResponseTest {
 
     @Mock
     private DiscoveryNode localNode;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {

--- a/common/src/test/java/org/opensearch/ml/common/transport/controller/MLUndeployControllerNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/controller/MLUndeployControllerNodeResponseTest.java
@@ -16,9 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -32,9 +30,6 @@ public class MLUndeployControllerNodeResponseTest {
 
     @Mock
     private DiscoveryNode localNode;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {

--- a/common/src/test/java/org/opensearch/ml/common/transport/execute/MLExecuteTaskRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/execute/MLExecuteTaskRequestTest.java
@@ -7,9 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.ml.common.FunctionName;
@@ -19,8 +17,6 @@ import org.opensearch.ml.common.input.execute.metricscorrelation.MetricsCorrelat
 public class MLExecuteTaskRequestTest {
     private Input exInput;
     private List<float[]> inputData;
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -54,11 +50,12 @@ public class MLExecuteTaskRequestTest {
 
     @Test
     public void validate_Exception_NullFunctionNane() {
-        exceptionRule.expect(NullPointerException.class);
-        exceptionRule.expectMessage("functionName is marked non-null but is null");
-        MLExecuteTaskRequest request = MLExecuteTaskRequest.builder().build();
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> {
+            MLExecuteTaskRequest request = MLExecuteTaskRequest.builder().build();
 
-        request.validate();
+            request.validate();
+        });
+        assertEquals("functionName is marked non-null but is null", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/mcpserver/requests/register/RegisterMcpToolTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/mcpserver/requests/register/RegisterMcpToolTest.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.transport.mcpserver.requests.register;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -17,9 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
@@ -33,10 +32,6 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.SearchModule;
 
 public class RegisterMcpToolTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     private McpToolRegisterInput mcptool;
     private final String toolName = "weather_tool";
     private final String description = "Fetch weather data";
@@ -97,9 +92,8 @@ public class RegisterMcpToolTest {
             );
         parser.nextToken();
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("type field required");
-        McpToolRegisterInput.parse(parser);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> McpToolRegisterInput.parse(parser));
+        assertEquals("type field required", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MessageInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MessageInputTest.java
@@ -15,9 +15,7 @@ import static org.opensearch.ml.common.TestHelper.createTestContent;
 import java.io.IOException;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
@@ -31,8 +29,6 @@ import org.opensearch.ml.common.TestHelper;
 public class MessageInputTest {
 
     private MessageInput messageWithRole;
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -48,9 +44,11 @@ public class MessageInputTest {
 
     @Test
     public void testBuilderWithoutRole() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Message must have role and content");
-        MessageInput.builder().content(createTestContent("Hello, how are you?")).build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> MessageInput.builder().content(createTestContent("Hello, how are you?")).build()
+        );
+        assertEquals("Message must have role and content", exception.getMessage());
     }
 
     @Test
@@ -71,9 +69,11 @@ public class MessageInputTest {
 
     @Test
     public void testConstructorWithEmptyContent() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Message must have role and content");
-        MessageInput.builder().role("user").content(null).build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> MessageInput.builder().role("user").content(null).build()
+        );
+        assertEquals("Message must have role and content", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/model/MLUpdateModelInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/model/MLUpdateModelInputTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
 
@@ -21,9 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
@@ -82,9 +81,6 @@ public class MLUpdateModelInputTest {
         "{\"model_id\":\"test-model-id\",\"name\":\"name\",\"description\":\"description\",\"model_group_id\":"
             + "\"modelGroupId\",\"model_config\":"
             + "{\"model_type\":\"sparse_encoding\",\"additional_config\":{\"space_type\":\"l2\"}}}";
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -180,19 +176,20 @@ public class MLUpdateModelInputTest {
 
     @Test
     public void parseWithNullFieldWithoutModel() throws Exception {
-        exceptionRule.expect(IllegalStateException.class);
-        String expectedInputStrWithNullField =
-            "{\"model_id\":\"test-model_id\",\"name\":null,\"description\":\"description\",\"model_version\":"
-                + "\"2\",\"model_group_id\":\"modelGroupId\",\"is_enabled\":false,\"rate_limiter\":"
-                + "{\"limit\":\"1\",\"unit\":\"MILLISECONDS\"},\"model_config\":"
-                + "{\"model_type\":\"testModelType\",\"embedding_dimension\":100,\"framework_type\":\"SENTENCE_TRANSFORMERS\",\"all_config\":\""
-                + "{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\"}\"},\"connector_id\":\"test-connector_id\"}";
-        testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
-            try {
-                assertEquals(expectedOutputStr, serializationWithToXContent(parsedInput));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+        assertThrows(IllegalStateException.class, () -> {
+            String expectedInputStrWithNullField =
+                "{\"model_id\":\"test-model_id\",\"name\":null,\"description\":\"description\",\"model_version\":"
+                    + "\"2\",\"model_group_id\":\"modelGroupId\",\"is_enabled\":false,\"rate_limiter\":"
+                    + "{\"limit\":\"1\",\"unit\":\"MILLISECONDS\"},\"model_config\":"
+                    + "{\"model_type\":\"testModelType\",\"embedding_dimension\":100,\"framework_type\":\"SENTENCE_TRANSFORMERS\",\"all_config\":\""
+                    + "{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\"}\"},\"connector_id\":\"test-connector_id\"}";
+            testParseFromJsonString(expectedInputStrWithNullField, parsedInput -> {
+                try {
+                    assertEquals(expectedOutputStr, serializationWithToXContent(parsedInput));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
         });
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelInputTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;
 import static org.opensearch.ml.common.CommonValue.VERSION_3_5_0;
@@ -16,9 +17,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -49,9 +48,6 @@ public class MLRegisterModelInputTest {
     @Mock
     MLModelConfig config;
     MLRegisterModelInput input;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
     private final String expectedInputStr = "{\"function_name\":\"TEXT_EMBEDDING\",\"name\":\"modelName\","
         + "\"version\":\"version\",\"model_group_id\":\"modelGroupId\",\"description\":\"test description\","
         + "\"url\":\"url\",\"model_content_hash_value\":\"hash_value_test\",\"model_format\":\"ONNX\","
@@ -107,47 +103,50 @@ public class MLRegisterModelInputTest {
 
     @Test
     public void constructor_NullModel() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model name is null");
-        MLRegisterModelInput.builder().build();
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> MLRegisterModelInput.builder().build());
+        assertEquals("model name is null", exception.getMessage());
     }
 
     @Test
     public void constructor_NullModelName() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model name is null");
-        MLRegisterModelInput.builder().functionName(functionName).modelGroupId(modelGroupId).modelName(null).build();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> MLRegisterModelInput.builder().functionName(functionName).modelGroupId(modelGroupId).modelName(null).build()
+        );
+        assertEquals("model name is null", exception.getMessage());
     }
 
     @Test
     public void constructor_NullModelFormat() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model format is null");
-        MLRegisterModelInput
-            .builder()
-            .functionName(functionName)
-            .modelName(modelName)
-            .version(version)
-            .modelGroupId(modelGroupId)
-            .modelFormat(null)
-            .url(url)
-            .build();
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLRegisterModelInput
+                .builder()
+                .functionName(functionName)
+                .modelName(modelName)
+                .version(version)
+                .modelGroupId(modelGroupId)
+                .modelFormat(null)
+                .url(url)
+                .build();
+        });
+        assertEquals("model format is null", exception.getMessage());
     }
 
     @Test
     public void constructor_NullModelConfig() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("model config is null");
-        MLRegisterModelInput
-            .builder()
-            .functionName(functionName)
-            .modelName(modelName)
-            .version(version)
-            .modelGroupId(modelGroupId)
-            .modelFormat(MLModelFormat.ONNX)
-            .modelConfig(null)
-            .url(url)
-            .build();
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            MLRegisterModelInput
+                .builder()
+                .functionName(functionName)
+                .modelName(modelName)
+                .version(version)
+                .modelGroupId(modelGroupId)
+                .modelFormat(MLModelFormat.ONNX)
+                .modelConfig(null)
+                .url(url)
+                .build();
+        });
+        assertEquals("model config is null", exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelsResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelsResponseTest.java
@@ -18,9 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.opensearch.Version;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.cluster.ClusterName;
@@ -37,8 +35,6 @@ import org.opensearch.core.xcontent.XContentBuilder;
 public class MLUndeployModelsResponseTest {
 
     MLUndeployModelNodesResponse undeployModelNodesResponse;
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -107,15 +103,16 @@ public class MLUndeployModelsResponseTest {
 
     @Test
     public void fromActionResponse_Exception() {
-        exceptionRule.expect(UncheckedIOException.class);
-        exceptionRule.expectMessage("Failed to parse ActionResponse into MLUndeployModelsResponse");
-        MLUndeployModelsResponse undeployModelsResponse = new MLUndeployModelsResponse(undeployModelNodesResponse);
-        ActionResponse actionResponse = new ActionResponse() {
-            @Override
-            public void writeTo(StreamOutput out) throws IOException {
-                throw new IOException();
-            }
-        };
-        MLUndeployModelsResponse.fromActionResponse(actionResponse);
+        UncheckedIOException exception = assertThrows(UncheckedIOException.class, () -> {
+            MLUndeployModelsResponse undeployModelsResponse = new MLUndeployModelsResponse(undeployModelNodesResponse);
+            ActionResponse actionResponse = new ActionResponse() {
+                @Override
+                public void writeTo(StreamOutput out) throws IOException {
+                    throw new IOException();
+                }
+            };
+            MLUndeployModelsResponse.fromActionResponse(actionResponse);
+        });
+        assertEquals("Failed to parse ActionResponse into MLUndeployModelsResponse", exception.getMessage());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/update_cache/MLUpdateModelCacheNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/update_cache/MLUpdateModelCacheNodeResponseTest.java
@@ -16,9 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -32,9 +30,6 @@ public class MLUpdateModelCacheNodeResponseTest {
 
     @Mock
     private DiscoveryNode localNode;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {

--- a/common/src/test/java/org/opensearch/ml/common/utils/MLTaskUtilsTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/MLTaskUtilsTests.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
+import static org.opensearch.ml.common.MockitoTestHelper.mockActionListener;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -53,28 +54,28 @@ public class MLTaskUtilsTests {
 
     @Test
     public void testUpdateMLTaskDirectly_NullFields() {
-        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> listener = mockActionListener();
         MLTaskUtils.updateMLTaskDirectly("task_id", null, null, client, sdkClient, listener);
         verify(listener).onFailure(any(IllegalArgumentException.class));
     }
 
     @Test
     public void testUpdateMLTaskDirectly_EmptyFields() {
-        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> listener = mockActionListener();
         MLTaskUtils.updateMLTaskDirectly("task_id", null, new HashMap<>(), client, sdkClient, listener);
         verify(listener).onFailure(any(IllegalArgumentException.class));
     }
 
     @Test
     public void testUpdateMLTaskDirectly_NullTaskId() {
-        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> listener = mockActionListener();
         MLTaskUtils.updateMLTaskDirectly(null, null, new HashMap<>(), client, sdkClient, listener);
         verify(listener).onFailure(any(IllegalArgumentException.class));
     }
 
     @Test
     public void testUpdateMLTaskDirectly_EmptyTaskId() {
-        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> listener = mockActionListener();
         MLTaskUtils.updateMLTaskDirectly("", null, new HashMap<>(), client, sdkClient, listener);
         verify(listener).onFailure(any(IllegalArgumentException.class));
     }
@@ -92,7 +93,7 @@ public class MLTaskUtilsTests {
         CompletableFuture<UpdateDataObjectResponse> future = CompletableFuture.completedFuture(sdkResponse);
         when(sdkClient.updateDataObjectAsync(any(UpdateDataObjectRequest.class))).thenReturn(future);
 
-        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> listener = mockActionListener();
         MLTaskUtils.updateMLTaskDirectly("task_id", "tenant1", updatedFields, client, sdkClient, listener);
         verify(listener).onResponse(any(UpdateResponse.class));
     }
@@ -102,7 +103,7 @@ public class MLTaskUtilsTests {
         Map<String, Object> updatedFields = new HashMap<>();
         updatedFields.put("state", "INVALID_STATE");
 
-        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> listener = mockActionListener();
         MLTaskUtils.updateMLTaskDirectly("task_id", null, updatedFields, client, sdkClient, listener);
         verify(listener).onFailure(any(IllegalArgumentException.class));
     }
@@ -120,7 +121,7 @@ public class MLTaskUtilsTests {
         CompletableFuture<UpdateDataObjectResponse> future = CompletableFuture.completedFuture(sdkResponse);
         when(sdkClient.updateDataObjectAsync(any(UpdateDataObjectRequest.class))).thenReturn(future);
 
-        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> listener = mockActionListener();
         MLTaskUtils.updateMLTaskDirectly("task_id", "tenant1", updatedFields, client, sdkClient, listener);
         verify(listener).onResponse(any(UpdateResponse.class));
     }
@@ -134,7 +135,7 @@ public class MLTaskUtilsTests {
         future.completeExceptionally(new RuntimeException("Test exception"));
         when(sdkClient.updateDataObjectAsync(any(UpdateDataObjectRequest.class))).thenReturn(future);
 
-        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> listener = mockActionListener();
         MLTaskUtils.updateMLTaskDirectly("task_id", "tenant1", updatedFields, client, sdkClient, listener);
         verify(listener).onFailure(any(Exception.class));
     }

--- a/common/src/test/java/org/opensearch/ml/common/utils/ModelInterfaceUtilsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/ModelInterfaceUtilsTest.java
@@ -29,9 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Spy;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.connector.ConnectorAction;
@@ -52,9 +50,6 @@ public class ModelInterfaceUtilsTest {
     public ConnectorAction connectorActionWithPostProcessFunction;
 
     public ConnectorAction connectorActionWithoutPostProcessFunction;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {

--- a/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/StringUtilsTest.java
@@ -189,9 +189,9 @@ public class StringUtilsTest {
             .fromJson("{\"key\": {\"nested_key\": \"nested_value\", \"nested_array\": [1, \"a\"]}}", "response");
         assertEquals(1, response.size());
         assertTrue(response.get("key") instanceof Map);
-        Map nestedMap = (Map) response.get("key");
+        Map<String, Object> nestedMap = castToMap(response.get("key"));
         assertEquals("nested_value", nestedMap.get("nested_key"));
-        List list = (List) nestedMap.get("nested_array");
+        List<Object> list = castToList(nestedMap.get("nested_array"));
         assertEquals(2, list.size());
         assertEquals(1, list.get(0));
         assertEquals("a", list.get(1));
@@ -202,7 +202,7 @@ public class StringUtilsTest {
         Map<String, Object> response = StringUtils.fromJson("[1, \"a\"]", "response");
         assertEquals(1, response.size());
         assertTrue(response.get("response") instanceof List);
-        List list = (List) response.get("response");
+        List<Object> list = castToList(response.get("response"));
         assertEquals(1, list.get(0));
         assertEquals("a", list.get(1));
     }
@@ -212,7 +212,7 @@ public class StringUtilsTest {
         Map<String, Object> response = StringUtils.fromJson("[1, \"a\", [2, 3], {\"key\": \"value\"}]", "response");
         assertEquals(1, response.size());
         assertTrue(response.get("response") instanceof List);
-        List list = (List) response.get("response");
+        List<Object> list = castToList(response.get("response"));
         assertEquals(1, list.get(0));
         assertEquals("a", list.get(1));
         assertTrue(list.get(2) instanceof List);
@@ -224,7 +224,7 @@ public class StringUtilsTest {
         Map<String, Object> response = StringUtils.fromJsonWithWrappingKey("{\"key\": \"value\"}", "wrapper");
         assertEquals(1, response.size());
         assertTrue(response.get("wrapper") instanceof Map);
-        Map wrappedMap = (Map) response.get("wrapper");
+        Map<String, Object> wrappedMap = castToMap(response.get("wrapper"));
         assertEquals("value", wrappedMap.get("key"));
     }
 
@@ -234,11 +234,11 @@ public class StringUtilsTest {
             .fromJsonWithWrappingKey("{\"key\": {\"nested_key\": \"nested_value\", \"nested_array\": [1, \"a\"]}}", "wrapper");
         assertEquals(1, response.size());
         assertTrue(response.get("wrapper") instanceof Map);
-        Map wrappedMap = (Map) response.get("wrapper");
+        Map<String, Object> wrappedMap = castToMap(response.get("wrapper"));
         assertTrue(wrappedMap.get("key") instanceof Map);
-        Map nestedMap = (Map) wrappedMap.get("key");
+        Map<String, Object> nestedMap = castToMap(wrappedMap.get("key"));
         assertEquals("nested_value", nestedMap.get("nested_key"));
-        List list = (List) nestedMap.get("nested_array");
+        List<Object> list = castToList(nestedMap.get("nested_array"));
         assertEquals(2, list.size());
         assertEquals(1.0, list.get(0));
         assertEquals("a", list.get(1));
@@ -249,7 +249,7 @@ public class StringUtilsTest {
         Map<String, Object> response = StringUtils.fromJsonWithWrappingKey("[1, \"a\"]", "wrapper");
         assertEquals(1, response.size());
         assertTrue(response.get("wrapper") instanceof List);
-        List list = (List) response.get("wrapper");
+        List<Object> list = castToList(response.get("wrapper"));
         assertEquals(1.0, list.get(0));
         assertEquals("a", list.get(1));
     }
@@ -259,7 +259,7 @@ public class StringUtilsTest {
         Map<String, Object> response = StringUtils.fromJsonWithWrappingKey("[1, \"a\", [2, 3], {\"key\": \"value\"}]", "wrapper");
         assertEquals(1, response.size());
         assertTrue(response.get("wrapper") instanceof List);
-        List list = (List) response.get("wrapper");
+        List<Object> list = castToList(response.get("wrapper"));
         assertEquals(1.0, list.get(0));
         assertEquals("a", list.get(1));
         assertTrue(list.get(2) instanceof List);
@@ -271,7 +271,7 @@ public class StringUtilsTest {
         Map<String, Object> response = StringUtils.fromJsonWithWrappingKey("{}", "wrapper");
         assertEquals(1, response.size());
         assertTrue(response.get("wrapper") instanceof Map);
-        Map wrappedMap = (Map) response.get("wrapper");
+        Map<String, Object> wrappedMap = castToMap(response.get("wrapper"));
         assertTrue(wrappedMap.isEmpty());
     }
 
@@ -280,7 +280,7 @@ public class StringUtilsTest {
         Map<String, Object> response = StringUtils.fromJsonWithWrappingKey("[]", "wrapper");
         assertEquals(1, response.size());
         assertTrue(response.get("wrapper") instanceof List);
-        List list = (List) response.get("wrapper");
+        List<Object> list = castToList(response.get("wrapper"));
         assertTrue(list.isEmpty());
     }
 
@@ -837,9 +837,9 @@ public class StringUtilsTest {
         Object result = StringUtils.prepareNestedStructures(jsonObject, "a.b.c");
 
         assertTrue(jsonObject.get("a") instanceof Map);
-        Map<String, Object> aMap = (Map<String, Object>) jsonObject.get("a");
+        Map<String, Object> aMap = castToMap(jsonObject.get("a"));
         assertTrue(aMap.get("b") instanceof Map);
-        Map<String, Object> bMap = (Map<String, Object>) aMap.get("b");
+        Map<String, Object> bMap = castToMap(aMap.get("b"));
         assertTrue(bMap.containsKey("c"));
     }
 
@@ -853,10 +853,10 @@ public class StringUtilsTest {
         Object result = StringUtils.prepareNestedStructures(jsonObject, "a[1].b");
 
         assertTrue(jsonObject.get("a") instanceof List);
-        List<Object> aList = (List<Object>) jsonObject.get("a");
+        List<Object> aList = castToList(jsonObject.get("a"));
         assertEquals(2, aList.size());
         assertTrue(aList.get(1) instanceof Map);
-        Map<String, Object> aMap = (Map<String, Object>) aList.get(1);
+        Map<String, Object> aMap = castToMap(aList.get(1));
         assertTrue(aMap.containsKey("b"));
     }
 
@@ -871,7 +871,7 @@ public class StringUtilsTest {
 
         assertEquals(jsonObject, result);
         assertTrue(jsonObject.get("a") instanceof List);
-        List<Object> aList = (List<Object>) jsonObject.get("a");
+        List<Object> aList = castToList(jsonObject.get("a"));
         assertEquals("not a map", aList.get(0));
     }
 
@@ -892,13 +892,13 @@ public class StringUtilsTest {
         Object result = StringUtils.prepareNestedStructures(jsonObject, "a[0].b[1].c");
 
         assertTrue(jsonObject.get("a") instanceof List);
-        List<Object> aList = (List<Object>) jsonObject.get("a");
+        List<Object> aList = castToList(jsonObject.get("a"));
         assertTrue(aList.get(0) instanceof Map);
-        Map<String, Object> aMap = (Map<String, Object>) aList.get(0);
+        Map<String, Object> aMap = castToMap(aList.get(0));
         assertTrue(aMap.get("b") instanceof List);
-        List<Object> bList = (List<Object>) aMap.get("b");
+        List<Object> bList = castToList(aMap.get("b"));
         assertTrue(bList.get(1) instanceof Map);
-        Map<String, Object> bMap = (Map<String, Object>) bList.get(1);
+        Map<String, Object> bMap = castToMap(bList.get(1));
         assertTrue(bMap.containsKey("c"));
     }
 
@@ -1189,6 +1189,7 @@ public class StringUtilsTest {
     }
 
     // reflect method for PlainDoubleAdapter
+    @SuppressWarnings("unchecked") // PlainDoubleAdapter is package-private and must be loaded via reflection
     private static TypeAdapter<Double> createPlainDoubleAdapter() {
         try {
             Class<?> clazz = Class.forName("org.opensearch.ml.common.utils.StringUtils$PlainDoubleAdapter");
@@ -1415,5 +1416,15 @@ public class StringUtilsTest {
             () -> StringUtils.fromJson(jsonWithNestedDuplicates, "response")
         );
         assertTrue(exception.getMessage().contains("Invalid JSON format"));
+    }
+
+    @SuppressWarnings("unchecked") // JSON parsing returns nested Map structures as Object values
+    private static Map<String, Object> castToMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    @SuppressWarnings("unchecked") // JSON parsing returns nested List structures as Object values
+    private static List<Object> castToList(Object value) {
+        return (List<Object>) value;
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/utils/ToolUtilsTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/ToolUtilsTest.java
@@ -391,7 +391,7 @@ public class ToolUtilsTest {
         assertEquals(outputKey, result.getName());
         // JSON object should be wrapped with "output" key using fromJsonWithWrappingKey
         assertTrue(result.getDataAsMap().containsKey(ToolUtils.TOOL_OUTPUT_KEY));
-        Map<String, Object> wrappedOutput = (Map<String, Object>) result.getDataAsMap().get(ToolUtils.TOOL_OUTPUT_KEY);
+        Map<String, Object> wrappedOutput = castToMap(result.getDataAsMap().get(ToolUtils.TOOL_OUTPUT_KEY));
         assertEquals("value1", wrappedOutput.get("key1"));
         assertEquals("value2", wrappedOutput.get("key2"));
     }
@@ -406,7 +406,7 @@ public class ToolUtilsTest {
         assertEquals(outputKey, result.getName());
         // JSON array should be wrapped with "output" key using fromJsonWithWrappingKey
         assertTrue(result.getDataAsMap().containsKey(ToolUtils.TOOL_OUTPUT_KEY));
-        List<String> wrappedOutput = (List<String>) result.getDataAsMap().get(ToolUtils.TOOL_OUTPUT_KEY);
+        List<String> wrappedOutput = castToStringList(result.getDataAsMap().get(ToolUtils.TOOL_OUTPUT_KEY));
         assertEquals(3, wrappedOutput.size());
         assertEquals("item1", wrappedOutput.get(0));
         assertEquals("item2", wrappedOutput.get(1));
@@ -461,15 +461,15 @@ public class ToolUtilsTest {
 
         assertEquals(outputKey, result.getName());
         assertTrue(result.getDataAsMap().containsKey(ToolUtils.TOOL_OUTPUT_KEY));
-        Map<String, Object> wrappedOutput = (Map<String, Object>) result.getDataAsMap().get(ToolUtils.TOOL_OUTPUT_KEY);
+        Map<String, Object> wrappedOutput = castToMap(result.getDataAsMap().get(ToolUtils.TOOL_OUTPUT_KEY));
         assertTrue(wrappedOutput.containsKey("user"));
         assertTrue(wrappedOutput.containsKey("items"));
 
-        Map<String, Object> user = (Map<String, Object>) wrappedOutput.get("user");
+        Map<String, Object> user = castToMap(wrappedOutput.get("user"));
         assertEquals("John", user.get("name"));
         assertEquals(30.0, user.get("age")); // Gson parses numbers as Double
 
-        List<String> items = (List<String>) wrappedOutput.get("items");
+        List<String> items = castToStringList(wrappedOutput.get("items"));
         assertEquals(2, items.size());
         assertEquals("a", items.get(0));
         assertEquals("b", items.get(1));
@@ -513,5 +513,15 @@ public class ToolUtilsTest {
         expectedMap.put(ToolUtils.TOOL_OUTPUT_KEY, null);
         assertEquals(expectedMap, result.getDataAsMap());
         assertEquals(null, result.getDataAsMap().get(ToolUtils.TOOL_OUTPUT_KEY));
+    }
+
+    @SuppressWarnings("unchecked") // ModelTensor dataAsMap values are dynamically typed tool outputs
+    private static Map<String, Object> castToMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    @SuppressWarnings("unchecked") // ModelTensor dataAsMap values are dynamically typed tool outputs
+    private static List<String> castToStringList(Object value) {
+        return (List<String>) value;
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/utils/mergeMetaDataUtils/MergeRuleHelperTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/mergeMetaDataUtils/MergeRuleHelperTests.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
 public class MergeRuleHelperTests {
 
@@ -26,7 +27,8 @@ public class MergeRuleHelperTests {
             }
 
             """;
-        Map<String, Object> tmpMap = gson.fromJson(mapBlock, Map.class);
+        Map<String, Object> tmpMap = gson.fromJson(mapBlock, new TypeToken<Map<String, Object>>() {
+        }.getType());
         return tmpMap;
     }
 
@@ -43,7 +45,8 @@ public class MergeRuleHelperTests {
             }
 
             """;
-        Map<String, Object> tmpMap = gson.fromJson(mapBlock, Map.class);
+        Map<String, Object> tmpMap = gson.fromJson(mapBlock, new TypeToken<Map<String, Object>>() {
+        }.getType());
         return tmpMap;
     }
 
@@ -64,7 +67,8 @@ public class MergeRuleHelperTests {
             }
 
             """;
-        Map<String, Object> tmpMap = gson.fromJson(mapBlock, Map.class);
+        Map<String, Object> tmpMap = gson.fromJson(mapBlock, new TypeToken<Map<String, Object>>() {
+        }.getType());
         return tmpMap;
     }
 
@@ -84,7 +88,8 @@ public class MergeRuleHelperTests {
             }
 
             """;
-        Map<String, Object> tmpMap = gson.fromJson(mapBlock, Map.class);
+        Map<String, Object> tmpMap = gson.fromJson(mapBlock, new TypeToken<Map<String, Object>>() {
+        }.getType());
         return tmpMap;
     }
 
@@ -202,7 +207,8 @@ public class MergeRuleHelperTests {
             }
 
             """;
-        Map<String, Object> tmpMap = gson.fromJson(mapBlock, Map.class);
+        Map<String, Object> tmpMap = gson.fromJson(mapBlock, new TypeToken<Map<String, Object>>() {
+        }.getType());
         return tmpMap;
     }
 
@@ -226,7 +232,8 @@ public class MergeRuleHelperTests {
             }
 
             """;
-        Map<String, Object> tmpMap = gson.fromJson(mapBlock, Map.class);
+        Map<String, Object> tmpMap = gson.fromJson(mapBlock, new TypeToken<Map<String, Object>>() {
+        }.getType());
         return tmpMap;
     }
 }

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -80,3 +80,7 @@ jacocoTestCoverageVerification {
     dependsOn jacocoTestReport
 }
 check.dependsOn jacocoTestCoverageVerification
+
+tasks.named('compileTestJava').configure {
+    options.compilerArgs.addAll(['-Xlint:unchecked', '-Xlint:deprecation'])
+}

--- a/memory/src/test/java/org/opensearch/ml/memory/MockitoTestHelper.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/MockitoTestHelper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Aryn, Inc 2023
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.memory;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.Map;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.opensearch.core.action.ActionListener;
+
+public final class MockitoTestHelper {
+
+    private MockitoTestHelper() {}
+
+    @SuppressWarnings("unchecked") // Mockito mock() cannot preserve ActionListener generic type
+    public static <T> ActionListener<T> mockActionListener() {
+        return mock(ActionListener.class);
+    }
+
+    public static <T> ActionListener<T> anyActionListener() {
+        return ArgumentMatchers.<ActionListener<T>>any();
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" }) // ArgumentCaptor.forClass requires raw Class for generic Map
+    public static <K, V> ArgumentCaptor<Map<K, V>> forMapClass() {
+        return ArgumentCaptor.forClass((Class) Map.class);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" }) // ArgumentCaptor.forClass requires raw Class for generic List
+    public static <T> ArgumentCaptor<List<T>> forListClass() {
+        return ArgumentCaptor.forClass((Class) java.util.List.class);
+    }
+
+    public static Map<String, Object> anyStringKeyMap() {
+        return ArgumentMatchers.any();
+    }
+}

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateConversationRequestTests.java
@@ -25,8 +25,6 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
@@ -44,9 +42,6 @@ import org.opensearch.test.rest.FakeRestRequest;
 import com.google.gson.Gson;
 
 public class CreateConversationRequestTests extends OpenSearchTestCase {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
     Gson gson;
 
     @Before

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateConversationTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateConversationTransportActionTests.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_DISABLED_MESSAGE;
+import static org.opensearch.ml.memory.MockitoTestHelper.anyActionListener;
+import static org.opensearch.ml.memory.MockitoTestHelper.mockActionListener;
 
 import java.io.IOException;
 import java.util.Set;
@@ -90,8 +92,7 @@ public class CreateConversationTransportActionTests extends OpenSearchTestCase {
         this.xContentRegistry = Mockito.mock(NamedXContentRegistry.class);
         this.transportService = Mockito.mock(TransportService.class);
         this.actionFilters = Mockito.mock(ActionFilters.class);
-        @SuppressWarnings("unchecked")
-        ActionListener<CreateConversationResponse> al = (ActionListener<CreateConversationResponse>) Mockito.mock(ActionListener.class);
+        ActionListener<CreateConversationResponse> al = mockActionListener();
         this.actionListener = al;
         this.cmHandler = Mockito.mock(OpenSearchConversationalMemoryHandler.class);
 
@@ -126,7 +127,7 @@ public class CreateConversationTransportActionTests extends OpenSearchTestCase {
             ActionListener<String> listener = invocation.getArgument(0);
             listener.onResponse("testID-2");
             return null;
-        }).when(cmHandler).createConversation(any(ActionListener.class));
+        }).when(cmHandler).createConversation(anyActionListener());
         String nullstr = null;
         this.request = new CreateConversationRequest(nullstr);
         action.doExecute(null, request, actionListener);

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateInteractionTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/CreateInteractionTransportActionTests.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_DISABLED_MESSAGE;
+import static org.opensearch.ml.memory.MockitoTestHelper.mockActionListener;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -95,8 +96,7 @@ public class CreateInteractionTransportActionTests extends OpenSearchTestCase {
         this.xContentRegistry = Mockito.mock(NamedXContentRegistry.class);
         this.transportService = Mockito.mock(TransportService.class);
         this.actionFilters = Mockito.mock(ActionFilters.class);
-        @SuppressWarnings("unchecked")
-        ActionListener<CreateInteractionResponse> al = (ActionListener<CreateInteractionResponse>) Mockito.mock(ActionListener.class);
+        ActionListener<CreateInteractionResponse> al = mockActionListener();
         this.actionListener = al;
         this.cmHandler = Mockito.mock(OpenSearchConversationalMemoryHandler.class);
 

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/DeleteConversationTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/DeleteConversationTransportActionTests.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_DISABLED_MESSAGE;
+import static org.opensearch.ml.memory.MockitoTestHelper.mockActionListener;
 
 import java.io.IOException;
 import java.util.Set;
@@ -90,8 +91,7 @@ public class DeleteConversationTransportActionTests extends OpenSearchTestCase {
         this.xContentRegistry = Mockito.mock(NamedXContentRegistry.class);
         this.transportService = Mockito.mock(TransportService.class);
         this.actionFilters = Mockito.mock(ActionFilters.class);
-        @SuppressWarnings("unchecked")
-        ActionListener<DeleteConversationResponse> al = (ActionListener<DeleteConversationResponse>) Mockito.mock(ActionListener.class);
+        ActionListener<DeleteConversationResponse> al = mockActionListener();
         this.actionListener = al;
         this.cmHandler = Mockito.mock(OpenSearchConversationalMemoryHandler.class);
 

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationTransportActionTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_DISABLED_MESSAGE;
+import static org.opensearch.ml.memory.MockitoTestHelper.mockActionListener;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -88,8 +89,7 @@ public class GetConversationTransportActionTests extends OpenSearchTestCase {
         this.xContentRegistry = Mockito.mock(NamedXContentRegistry.class);
         this.transportService = Mockito.mock(TransportService.class);
         this.actionFilters = Mockito.mock(ActionFilters.class);
-        @SuppressWarnings("unchecked")
-        ActionListener<GetConversationResponse> al = (ActionListener<GetConversationResponse>) Mockito.mock(ActionListener.class);
+        ActionListener<GetConversationResponse> al = mockActionListener();
         this.actionListener = al;
         this.cmHandler = Mockito.mock(OpenSearchConversationalMemoryHandler.class);
 

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsTransportActionTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_DISABLED_MESSAGE;
+import static org.opensearch.ml.memory.MockitoTestHelper.mockActionListener;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -92,8 +93,7 @@ public class GetConversationsTransportActionTests extends OpenSearchTestCase {
         this.xContentRegistry = Mockito.mock(NamedXContentRegistry.class);
         this.transportService = Mockito.mock(TransportService.class);
         this.actionFilters = Mockito.mock(ActionFilters.class);
-        @SuppressWarnings("unchecked")
-        ActionListener<GetConversationsResponse> al = (ActionListener<GetConversationsResponse>) Mockito.mock(ActionListener.class);
+        ActionListener<GetConversationsResponse> al = mockActionListener();
         this.actionListener = al;
         this.cmHandler = Mockito.mock(OpenSearchConversationalMemoryHandler.class);
 
@@ -154,8 +154,7 @@ public class GetConversationsTransportActionTests extends OpenSearchTestCase {
         assert (argCaptor.getValue().hasMorePages());
         assert (argCaptor.getValue().getNextToken() == 2);
 
-        @SuppressWarnings("unchecked")
-        ActionListener<GetConversationsResponse> al1 = (ActionListener<GetConversationsResponse>) Mockito.mock(ActionListener.class);
+        ActionListener<GetConversationsResponse> al1 = mockActionListener();
         GetConversationsRequest r1 = new GetConversationsRequest(2, 2);
         action.doExecute(null, r1, al1);
         argCaptor = ArgumentCaptor.forClass(GetConversationsResponse.class);
@@ -164,8 +163,7 @@ public class GetConversationsTransportActionTests extends OpenSearchTestCase {
         assert (argCaptor.getValue().hasMorePages());
         assert (argCaptor.getValue().getNextToken() == 4);
 
-        @SuppressWarnings("unchecked")
-        ActionListener<GetConversationsResponse> al2 = (ActionListener<GetConversationsResponse>) Mockito.mock(ActionListener.class);
+        ActionListener<GetConversationsResponse> al2 = mockActionListener();
         GetConversationsRequest r2 = new GetConversationsRequest(20, 4);
         action.doExecute(null, r2, al2);
         argCaptor = ArgumentCaptor.forClass(GetConversationsResponse.class);

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetInteractionTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetInteractionTransportActionTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_DISABLED_MESSAGE;
+import static org.opensearch.ml.memory.MockitoTestHelper.mockActionListener;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -88,8 +89,7 @@ public class GetInteractionTransportActionTests extends OpenSearchTestCase {
         this.xContentRegistry = Mockito.mock(NamedXContentRegistry.class);
         this.transportService = Mockito.mock(TransportService.class);
         this.actionFilters = Mockito.mock(ActionFilters.class);
-        @SuppressWarnings("unchecked")
-        ActionListener<GetInteractionResponse> al = (ActionListener<GetInteractionResponse>) Mockito.mock(ActionListener.class);
+        ActionListener<GetInteractionResponse> al = mockActionListener();
         this.actionListener = al;
         this.cmHandler = Mockito.mock(OpenSearchConversationalMemoryHandler.class);
 

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetInteractionsTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetInteractionsTransportActionTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.ML_COMMONS_MEMORY_FEATURE_DISABLED_MESSAGE;
+import static org.opensearch.ml.memory.MockitoTestHelper.mockActionListener;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -93,8 +94,7 @@ public class GetInteractionsTransportActionTests extends OpenSearchTestCase {
         this.xContentRegistry = Mockito.mock(NamedXContentRegistry.class);
         this.transportService = Mockito.mock(TransportService.class);
         this.actionFilters = Mockito.mock(ActionFilters.class);
-        @SuppressWarnings("unchecked")
-        ActionListener<GetInteractionsResponse> al = (ActionListener<GetInteractionsResponse>) Mockito.mock(ActionListener.class);
+        ActionListener<GetInteractionsResponse> al = mockActionListener();
         this.actionListener = al;
         this.cmHandler = Mockito.mock(OpenSearchConversationalMemoryHandler.class);
 

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetTracesTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetTracesTransportActionTests.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.memory.MockitoTestHelper.mockActionListener;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -65,8 +66,7 @@ public class GetTracesTransportActionTests extends OpenSearchTestCase {
     public void setup() throws IOException {
         MockitoAnnotations.openMocks(this);
 
-        @SuppressWarnings("unchecked")
-        ActionListener<GetTracesResponse> al = (ActionListener<GetTracesResponse>) Mockito.mock(ActionListener.class);
+        ActionListener<GetTracesResponse> al = mockActionListener();
         this.actionListener = al;
         this.cmHandler = Mockito.mock(OpenSearchConversationalMemoryHandler.class);
 

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/UpdateInteractionTransportActionTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/UpdateInteractionTransportActionTests.java
@@ -6,13 +6,15 @@
 package org.opensearch.ml.memory.action.conversation;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_ADDITIONAL_INFO_FIELD;
 import static org.opensearch.ml.common.conversation.ConversationalIndexConstants.INTERACTIONS_RESPONSE_FIELD;
+import static org.opensearch.ml.memory.MockitoTestHelper.anyActionListener;
+import static org.opensearch.ml.memory.MockitoTestHelper.anyStringKeyMap;
+import static org.opensearch.ml.memory.MockitoTestHelper.forMapClass;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -114,12 +116,12 @@ public class UpdateInteractionTransportActionTests extends OpenSearchTestCase {
             ActionListener<UpdateResponse> listener = invocation.getArgument(2);
             listener.onResponse(updateResponse);
             return null;
-        }).when(cmHandler).updateInteraction(any(String.class), any(Map.class), isA(ActionListener.class));
+        }).when(cmHandler).updateInteraction(any(String.class), anyStringKeyMap(), anyActionListener());
 
         updateInteractionTransportAction.doExecute(task, updateRequest, actionListener);
 
-        ArgumentCaptor<Map<String, Object>> updateContentCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(cmHandler).updateInteraction(any(String.class), updateContentCaptor.capture(), isA(ActionListener.class));
+        ArgumentCaptor<Map<String, Object>> updateContentCaptor = forMapClass();
+        verify(cmHandler).updateInteraction(any(String.class), updateContentCaptor.capture(), anyActionListener());
         Map<String, Object> capturedUpdateContent = updateContentCaptor.getValue();
         assertTrue(capturedUpdateContent.containsKey("updated_time"));
         verify(actionListener).onResponse(updateResponse);
@@ -130,7 +132,7 @@ public class UpdateInteractionTransportActionTests extends OpenSearchTestCase {
             ActionListener<UpdateResponse> listener = invocation.getArgument(2);
             listener.onFailure(new RuntimeException("Error in Update Request"));
             return null;
-        }).when(cmHandler).updateInteraction(any(String.class), any(Map.class), isA(ActionListener.class));
+        }).when(cmHandler).updateInteraction(any(String.class), anyStringKeyMap(), anyActionListener());
 
         updateInteractionTransportAction.doExecute(task, updateRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);
@@ -144,7 +146,7 @@ public class UpdateInteractionTransportActionTests extends OpenSearchTestCase {
             ActionListener<UpdateResponse> listener = invocation.getArgument(2);
             listener.onResponse(updateResponse);
             return null;
-        }).when(cmHandler).updateInteraction(any(String.class), any(Map.class), isA(ActionListener.class));
+        }).when(cmHandler).updateInteraction(any(String.class), anyStringKeyMap(), anyActionListener());
 
         updateInteractionTransportAction.doExecute(task, updateRequest, actionListener);
         verify(actionListener).onResponse(updateResponse);
@@ -153,7 +155,7 @@ public class UpdateInteractionTransportActionTests extends OpenSearchTestCase {
     public void test_execute_ThrowException() {
         doThrow(new RuntimeException("Error in Update Request"))
             .when(cmHandler)
-            .updateInteraction(any(String.class), any(Map.class), isA(ActionListener.class));
+            .updateInteraction(any(String.class), anyStringKeyMap(), anyActionListener());
 
         updateInteractionTransportAction.doExecute(task, updateRequest, actionListener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(RuntimeException.class);

--- a/memory/src/test/java/org/opensearch/ml/memory/index/ConversationMetaIndexTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/index/ConversationMetaIndexTests.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.opensearch.ml.memory.MockitoTestHelper.forListClass;
+import static org.opensearch.ml.memory.MockitoTestHelper.mockActionListener;
 
 import java.util.List;
 
@@ -151,8 +153,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
 
     public void testInit_DoesNotCreateIndex() {
         setupDoesNotMakeIndex();
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         conversationMetaIndex.initConversationMetaIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(createIndexListener, times(1)).onResponse(argCaptor.capture());
@@ -166,8 +167,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Test Error"));
             return null;
         }).when(indicesAdminClient).create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         conversationMetaIndex.initConversationMetaIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createIndexListener, times(1)).onFailure(argCaptor.capture());
@@ -181,8 +181,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onFailure(new SendRequestTransportException(null, "action", new Exception("some other exception")));
             return null;
         }).when(indicesAdminClient).create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         conversationMetaIndex.initConversationMetaIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createIndexListener, times(1)).onFailure(argCaptor.capture());
@@ -193,8 +192,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
     public void testInit_ClientFails_WithResourceExists_ThenOK() {
         doReturn(false).when(metadata).hasIndex(anyString());
         doThrow(new ResourceAlreadyExistsException("Test index exists")).when(indicesAdminClient).create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         conversationMetaIndex.initConversationMetaIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(createIndexListener, times(1)).onResponse(argCaptor.capture());
@@ -206,8 +204,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
         doThrow(new SendRequestTransportException(null, "action", new ResourceAlreadyExistsException("Test index exists")))
             .when(indicesAdminClient)
             .create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         conversationMetaIndex.initConversationMetaIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(createIndexListener, times(1)).onResponse(argCaptor.capture());
@@ -219,8 +216,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
         doThrow(new SendRequestTransportException(null, "action", new Exception("Some other exception")))
             .when(indicesAdminClient)
             .create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         conversationMetaIndex.initConversationMetaIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createIndexListener, times(1)).onFailure(argCaptor.capture());
@@ -231,8 +227,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
     public void testInit_ClientFails_ThenFail() {
         doReturn(false).when(metadata).hasIndex(anyString());
         doThrow(new RuntimeException("Test Client Failure")).when(indicesAdminClient).create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         conversationMetaIndex.initConversationMetaIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createIndexListener, times(1)).onFailure(argCaptor.capture());
@@ -241,8 +236,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
 
     public void testCreate_DoesntMakeIndex_ThenFail() {
         setupDoesNotMakeIndex();
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createConversationListener = mock(ActionListener.class);
+        ActionListener<String> createConversationListener = mockActionListener();
         conversationMetaIndex.createConversation(createConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -258,8 +252,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onResponse(response);
             return null;
         }).when(client).index(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createConversationListener = mock(ActionListener.class);
+        ActionListener<String> createConversationListener = mockActionListener();
         conversationMetaIndex.createConversation(createConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -273,8 +266,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Test Failure"));
             return null;
         }).when(client).index(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createConversationListener = mock(ActionListener.class);
+        ActionListener<String> createConversationListener = mockActionListener();
         conversationMetaIndex.createConversation(createConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -284,8 +276,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
     public void testCreate_ClientFails_ThenFail() {
         doReturn(true).when(metadata).hasIndex(anyString());
         doThrow(new RuntimeException("Test Failure")).when(client).index(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createConversationListener = mock(ActionListener.class);
+        ActionListener<String> createConversationListener = mockActionListener();
         conversationMetaIndex.createConversation(createConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -295,8 +286,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
     public void testCreate_InitFails_ThenFail() {
         doReturn(false).when(metadata).hasIndex(anyString());
         doThrow(new RuntimeException("Test Init Client Failure")).when(indicesAdminClient).create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createConversationListener = mock(ActionListener.class);
+        ActionListener<String> createConversationListener = mockActionListener();
         conversationMetaIndex.createConversation(createConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -305,11 +295,9 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
 
     public void testGet_NoIndex_ThenEmpty() {
         doReturn(false).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<ConversationMeta>> getConversationsListener = mock(ActionListener.class);
+        ActionListener<List<ConversationMeta>> getConversationsListener = mockActionListener();
         conversationMetaIndex.getConversations(10, getConversationsListener);
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<List<ConversationMeta>> argCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<ConversationMeta>> argCaptor = forListClass();
         verify(getConversationsListener, times(1)).onResponse(argCaptor.capture());
         assert (argCaptor.getValue().size() == 0);
     }
@@ -322,8 +310,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Test Exception"));
             return null;
         }).when(client).search(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<ConversationMeta>> getConversationsListener = mock(ActionListener.class);
+        ActionListener<List<ConversationMeta>> getConversationsListener = mockActionListener();
         conversationMetaIndex.getConversations(10, getConversationsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getConversationsListener, times(1)).onFailure(argCaptor.capture());
@@ -337,8 +324,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Refresh Exception"));
             return null;
         }).when(indicesAdminClient).refresh(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<ConversationMeta>> getConversationsListener = mock(ActionListener.class);
+        ActionListener<List<ConversationMeta>> getConversationsListener = mockActionListener();
         conversationMetaIndex.getConversations(10, getConversationsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getConversationsListener, times(1)).onFailure(argCaptor.capture());
@@ -348,8 +334,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
     public void testGet_ClientFails_ThenFail() {
         doReturn(true).when(metadata).hasIndex(anyString());
         doThrow(new RuntimeException("Refresh Client Failure")).when(indicesAdminClient).refresh(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<ConversationMeta>> getConversationsListener = mock(ActionListener.class);
+        ActionListener<List<ConversationMeta>> getConversationsListener = mockActionListener();
         conversationMetaIndex.getConversations(10, getConversationsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getConversationsListener, times(1)).onFailure(argCaptor.capture());
@@ -358,8 +343,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
 
     public void testDelete_NoIndex_ThenReturnTrue() {
         doReturn(false).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         conversationMetaIndex.deleteConversation("test-id", deleteConversationListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(deleteConversationListener, times(1)).onResponse(argCaptor.capture());
@@ -376,8 +360,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onResponse(response);
             return null;
         }).when(client).delete(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         conversationMetaIndex.deleteConversation("test-id", deleteConversationListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(deleteConversationListener, times(1)).onResponse(argCaptor.capture());
@@ -393,8 +376,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onResponse(response);
             return null;
         }).when(client).delete(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         conversationMetaIndex.deleteConversation("test-id", deleteConversationListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(deleteConversationListener, times(1)).onResponse(argCaptor.capture());
@@ -409,8 +391,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Test Fail in Delete"));
             return null;
         }).when(client).delete(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         conversationMetaIndex.deleteConversation("test-id", deleteConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(deleteConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -421,8 +402,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
         doReturn(true).when(metadata).hasIndex(anyString());
         blanketGrantAccess();
         doThrow(new RuntimeException("Client Fail in Delete")).when(client).delete(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         conversationMetaIndex.deleteConversation("test-id", deleteConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(deleteConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -440,8 +420,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onResponse(response);
             return null;
         }).when(client).get(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> accessListener = mock(ActionListener.class);
+        ActionListener<Boolean> accessListener = mockActionListener();
         conversationMetaIndex.checkAccess("test id", accessListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(accessListener, times(1)).onFailure(argCaptor.capture());
@@ -461,8 +440,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onResponse(response);
             return null;
         }).when(client).get(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> accessListener = mock(ActionListener.class);
+        ActionListener<Boolean> accessListener = mockActionListener();
         conversationMetaIndex.checkAccess("test id", accessListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(accessListener, times(1)).onFailure(argCaptor.capture());
@@ -479,8 +457,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Test Fail"));
             return null;
         }).when(client).get(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> accessListener = mock(ActionListener.class);
+        ActionListener<Boolean> accessListener = mockActionListener();
         conversationMetaIndex.checkAccess("test id", accessListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(accessListener, times(1)).onFailure(argCaptor.capture());
@@ -492,8 +469,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
         setupRefreshSuccess();
         doReturn(true).when(metadata).hasIndex(anyString());
         doThrow(new RuntimeException("Client Test Fail")).when(client).admin();
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> accessListener = mock(ActionListener.class);
+        ActionListener<Boolean> accessListener = mockActionListener();
         conversationMetaIndex.checkAccess("test id", accessListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(accessListener, times(1)).onFailure(argCaptor.capture());
@@ -513,8 +489,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             listener.onResponse(dummyGetResponse);
             return null;
         }).when(client).get(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> accessListener = mock(ActionListener.class);
+        ActionListener<Boolean> accessListener = mockActionListener();
         conversationMetaIndex.checkAccess(id, accessListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(accessListener, times(1)).onResponse(argCaptor.capture());
@@ -529,8 +504,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Refresh Exception"));
             return null;
         }).when(indicesAdminClient).refresh(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> accessListener = mock(ActionListener.class);
+        ActionListener<Boolean> accessListener = mockActionListener();
         conversationMetaIndex.checkAccess("test id", accessListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(accessListener, times(1)).onFailure(argCaptor.capture());
@@ -544,8 +518,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Refresh Exception"));
             return null;
         }).when(indicesAdminClient).refresh(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<SearchResponse> searchConversationsListener = mock(ActionListener.class);
+        ActionListener<SearchResponse> searchConversationsListener = mockActionListener();
         conversationMetaIndex.searchConversations(request, searchConversationsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(searchConversationsListener, times(1)).onFailure(argCaptor.capture());
@@ -556,8 +529,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
         SearchRequest request = dummyRequest();
         doReturn(true).when(metadata).hasIndex(anyString());
         doThrow(new RuntimeException("Client Test Fail")).when(client).admin();
-        @SuppressWarnings("unchecked")
-        ActionListener<SearchResponse> accessListener = mock(ActionListener.class);
+        ActionListener<SearchResponse> accessListener = mockActionListener();
         conversationMetaIndex.searchConversations(request, accessListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(accessListener, times(1)).onFailure(argCaptor.capture());
@@ -566,8 +538,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
 
     public void testGetConversation_NoIndex_ThenFail() {
         doReturn(false).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<ConversationMeta> getListener = mock(ActionListener.class);
+        ActionListener<ConversationMeta> getListener = mockActionListener();
         conversationMetaIndex.getConversation("tester_id", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -587,8 +558,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onResponse(response);
             return null;
         }).when(client).get(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<ConversationMeta> getListener = mock(ActionListener.class);
+        ActionListener<ConversationMeta> getListener = mockActionListener();
         conversationMetaIndex.getConversation("tester_id", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -606,8 +576,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onResponse(response);
             return null;
         }).when(client).get(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<ConversationMeta> getListener = mock(ActionListener.class);
+        ActionListener<ConversationMeta> getListener = mockActionListener();
         conversationMetaIndex.getConversation("tester_id", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -621,8 +590,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Refresh Exception"));
             return null;
         }).when(indicesAdminClient).refresh(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<ConversationMeta> getListener = mock(ActionListener.class);
+        ActionListener<ConversationMeta> getListener = mockActionListener();
         conversationMetaIndex.getConversation("tester_id", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -632,8 +600,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
     public void testGetConversation_ClientFails_ThenFail() {
         doReturn(true).when(metadata).hasIndex(anyString());
         doThrow(new RuntimeException("Client Failure")).when(client).admin();
-        @SuppressWarnings("unchecked")
-        ActionListener<ConversationMeta> getListener = mock(ActionListener.class);
+        ActionListener<ConversationMeta> getListener = mockActionListener();
         conversationMetaIndex.getConversation("tester_id", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -642,8 +609,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
 
     public void testUpdateConversation_NoIndex_ThenFail() {
         doReturn(false).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<UpdateResponse> getListener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> getListener = mockActionListener();
         conversationMetaIndex.updateConversation("tester_id", new UpdateRequest(), getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -665,8 +631,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             return null;
         }).when(client).get(any(), any());
         doReturn(true).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<UpdateResponse> getListener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> getListener = mockActionListener();
 
         doAnswer(invocation -> {
             ShardId shardId = new ShardId(new Index("indexName", "uuid"), 1);
@@ -692,8 +657,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             return null;
         }).when(client).get(any(), any());
         doReturn(true).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<UpdateResponse> getListener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> getListener = mockActionListener();
 
         doThrow(new RuntimeException("Client Failure")).when(client).update(any(), any());
         conversationMetaIndex.updateConversation("test_id", new UpdateRequest(), getListener);
@@ -710,7 +674,7 @@ public class ConversationMetaIndexTests extends OpenSearchTestCase {
             return null;
         }).when(conversationMetaIndex).checkAccess(anyString(), any());
 
-        ActionListener<UpdateResponse> updateListener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> updateListener = mockActionListener();
         conversationMetaIndex.updateConversation("conversationId", new UpdateRequest(), updateListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(updateListener, times(1)).onFailure(argCaptor.capture());

--- a/memory/src/test/java/org/opensearch/ml/memory/index/InteractionsIndexTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/index/InteractionsIndexTests.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.opensearch.ml.memory.MockitoTestHelper.forListClass;
+import static org.opensearch.ml.memory.MockitoTestHelper.mockActionListener;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -187,8 +189,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
 
     public void testInit_DoesNotCreateIndex_ThenReturnFalse() {
         setupDoesNotMakeIndex();
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         interactionsIndex.initInteractionsIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(createIndexListener, times(1)).onResponse(argCaptor.capture());
@@ -202,8 +203,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Test Error"));
             return null;
         }).when(indicesAdminClient).create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         interactionsIndex.initInteractionsIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createIndexListener, times(1)).onFailure(argCaptor.capture());
@@ -217,8 +217,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onFailure(new SendRequestTransportException(null, "action", new Exception("some other exception")));
             return null;
         }).when(indicesAdminClient).create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         interactionsIndex.initInteractionsIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createIndexListener, times(1)).onFailure(argCaptor.capture());
@@ -229,8 +228,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
     public void testInit_ClientFails_WithResourceExists_ThenOK() {
         doReturn(false).when(metadata).hasIndex(anyString());
         doThrow(new ResourceAlreadyExistsException("Test index exists")).when(indicesAdminClient).create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         interactionsIndex.initInteractionsIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(createIndexListener, times(1)).onResponse(argCaptor.capture());
@@ -242,8 +240,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         doThrow(new SendRequestTransportException(null, "action", new ResourceAlreadyExistsException("Test index exists")))
             .when(indicesAdminClient)
             .create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         interactionsIndex.initInteractionsIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(createIndexListener, times(1)).onResponse(argCaptor.capture());
@@ -255,8 +252,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         doThrow(new SendRequestTransportException(null, "action", new Exception("Some other exception")))
             .when(indicesAdminClient)
             .create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         interactionsIndex.initInteractionsIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createIndexListener, times(1)).onFailure(argCaptor.capture());
@@ -267,8 +263,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
     public void testInit_ClientFails_ThenFail() {
         doReturn(false).when(metadata).hasIndex(anyString());
         doThrow(new RuntimeException("Test Client Failure")).when(indicesAdminClient).create(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> createIndexListener = mock(ActionListener.class);
+        ActionListener<Boolean> createIndexListener = mockActionListener();
         interactionsIndex.initInteractionsIndexIfAbsent(createIndexListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(createIndexListener, times(1)).onFailure(argCaptor.capture());
@@ -277,8 +272,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
 
     public void testCreate_NoIndex_ThenFail() {
         setupDoesNotMakeIndex();
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createInteractionListener = mock(ActionListener.class);
+        ActionListener<String> createInteractionListener = mockActionListener();
         interactionsIndex
             .createInteraction("cid", "inp", "pt", "rsp", "ogn", Collections.singletonMap("meta", "some meta"), createInteractionListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -296,8 +290,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onResponse(response);
             return null;
         }).when(client).index(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createInteractionListener = mock(ActionListener.class);
+        ActionListener<String> createInteractionListener = mockActionListener();
         interactionsIndex
             .createInteraction("cid", "inp", "pt", "rsp", "ogn", Collections.singletonMap("meta", "some meta"), createInteractionListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -313,8 +306,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Test Failure"));
             return null;
         }).when(client).index(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createInteractionListener = mock(ActionListener.class);
+        ActionListener<String> createInteractionListener = mockActionListener();
         interactionsIndex
             .createInteraction("cid", "inp", "pt", "rsp", "ogn", Collections.singletonMap("meta", "some meta"), createInteractionListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -326,8 +318,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         doReturn(true).when(metadata).hasIndex(anyString());
         setupGrantAccess();
         doThrow(new RuntimeException("Test Client Failure")).when(client).index(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createInteractionListener = mock(ActionListener.class);
+        ActionListener<String> createInteractionListener = mockActionListener();
         interactionsIndex
             .createInteraction("cid", "inp", "pt", "rsp", "ogn", Collections.singletonMap("meta", "some meta"), createInteractionListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -339,8 +330,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         doReturn(true).when(metadata).hasIndex(anyString());
         setupDenyAccess(null);
         doThrow(new RuntimeException("Test Client Failure")).when(client).index(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createInteractionListener = mock(ActionListener.class);
+        ActionListener<String> createInteractionListener = mockActionListener();
         interactionsIndex
             .createInteraction("cid", "inp", "pt", "rsp", "ogn", Collections.singletonMap("meta", "some meta"), createInteractionListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -355,8 +345,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         doReturn(true).when(metadata).hasIndex(anyString());
         setupDenyAccess("user");
         doThrow(new RuntimeException("Test Client Failure")).when(client).index(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createInteractionListener = mock(ActionListener.class);
+        ActionListener<String> createInteractionListener = mockActionListener();
         interactionsIndex
             .createInteraction("cid", "inp", "pt", "rsp", "ogn", Collections.singletonMap("meta", "some meta"), createInteractionListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -370,8 +359,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Fail in Index Creation"));
             return null;
         }).when(interactionsIndex).initInteractionsIndexIfAbsent(any());
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createInteractionListener = mock(ActionListener.class);
+        ActionListener<String> createInteractionListener = mockActionListener();
         interactionsIndex
             .createInteraction("cid", "inp", "pt", "rsp", "ogn", Collections.singletonMap("meta", "some meta"), createInteractionListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -381,11 +369,9 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
 
     public void testGet_NoIndex_ThenEmpty() {
         doReturn(false).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<Interaction>> getInteractionsListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getInteractionsListener = mockActionListener();
         interactionsIndex.getInteractions("cid", 0, 10, getInteractionsListener);
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<List<Interaction>> argCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<Interaction>> argCaptor = forListClass();
         verify(getInteractionsListener, times(1)).onResponse(argCaptor.capture());
         assert (argCaptor.getValue().size() == 0);
     }
@@ -399,8 +385,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Failure in Search"));
             return null;
         }).when(client).search(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<Interaction>> getInteractionsListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getInteractionsListener = mockActionListener();
         interactionsIndex.getInteractions("cid", 0, 10, getInteractionsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getInteractionsListener, times(1)).onFailure(argCaptor.capture());
@@ -415,8 +400,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Failed to Refresh"));
             return null;
         }).when(indicesAdminClient).refresh(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<Interaction>> getInteractionsListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getInteractionsListener = mockActionListener();
         interactionsIndex.getInteractions("cid", 0, 10, getInteractionsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getInteractionsListener, times(1)).onFailure(argCaptor.capture());
@@ -427,8 +411,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         doReturn(true).when(metadata).hasIndex(anyString());
         setupGrantAccess();
         doThrow(new RuntimeException("Client Failure")).when(indicesAdminClient).refresh(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<Interaction>> getInteractionsListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getInteractionsListener = mockActionListener();
         interactionsIndex.getInteractions("cid", 0, 10, getInteractionsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getInteractionsListener, times(1)).onFailure(argCaptor.capture());
@@ -438,8 +421,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
     public void testGet_NoAccessNoUser_ThenFail() {
         doReturn(true).when(metadata).hasIndex(anyString());
         setupDenyAccess(null);
-        @SuppressWarnings("unchecked")
-        ActionListener<List<Interaction>> getInteractionsListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getInteractionsListener = mockActionListener();
         interactionsIndex.getInteractions("cid", 0, 10, getInteractionsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getInteractionsListener, times(1)).onFailure(argCaptor.capture());
@@ -451,11 +433,9 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
 
     public void testGetTraces_NoIndex_ThenEmpty() {
         doReturn(false).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<Interaction>> getTracesListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getTracesListener = mockActionListener();
         interactionsIndex.getTraces("cid", 0, 10, getTracesListener);
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<List<Interaction>> argCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<Interaction>> argCaptor = forListClass();
         verify(getTracesListener, times(1)).onResponse(argCaptor.capture());
         assert (argCaptor.getValue().size() == 0);
     }
@@ -463,11 +443,9 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
     public void testInnerGetTraces_success() {
         setUpSearchTraceResponse();
         doReturn(true).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<Interaction>> getTracesListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getTracesListener = mockActionListener();
         interactionsIndex.innerGetTraces("cid", 0, 10, getTracesListener);
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<List<Interaction>> argCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<Interaction>> argCaptor = forListClass();
         verify(getTracesListener, times(1)).onResponse(argCaptor.capture());
         assert (argCaptor.getValue().size() == 1);
     }
@@ -485,11 +463,9 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         }).when(client).get(any(), any());
         setUpSearchTraceResponse();
         doReturn(true).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<Interaction>> getTracesListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getTracesListener = mockActionListener();
         interactionsIndex.getTraces("iid", 0, 10, getTracesListener);
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<List<Interaction>> argCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<Interaction>> argCaptor = forListClass();
         verify(getTracesListener, times(1)).onResponse(argCaptor.capture());
         assert (argCaptor.getValue().size() == 1);
     }
@@ -497,7 +473,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
     public void testGetTraces_clientFail() {
         doReturn(true).when(metadata).hasIndex(anyString());
         doThrow(new RuntimeException("Client Failure")).when(client).search(any(), any());
-        ActionListener<List<Interaction>> getTracesListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getTracesListener = mockActionListener();
         interactionsIndex.innerGetTraces("cid", 0, 10, getTracesListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getTracesListener, times(1)).onFailure(argCaptor.capture());
@@ -505,8 +481,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
     }
 
     public void testGetAll_BadMaxResults_ThenFail() {
-        @SuppressWarnings("unchecked")
-        ActionListener<List<Interaction>> getInteractionsListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getInteractionsListener = mockActionListener();
         interactionsIndex.nextGetListener("cid", 0, 0, getInteractionsListener, List.of());
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getInteractionsListener, times(1)).onFailure(argCaptor.capture());
@@ -576,11 +551,9 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onResponse(List.of());
             return null;
         }).when(interactionsIndex).innerGetInteractions(anyString(), eq(4), anyInt(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<Interaction>> getInteractionsListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getInteractionsListener = mockActionListener();
         interactionsIndex.getAllInteractions("cid", 2, getInteractionsListener);
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<List<Interaction>> argCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<Interaction>> argCaptor = forListClass();
         verify(getInteractionsListener, times(1)).onResponse(argCaptor.capture());
         List<Interaction> result = argCaptor.getValue();
         assert (result.size() == 4);
@@ -596,8 +569,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Failure in Get"));
             return null;
         }).when(interactionsIndex).innerGetInteractions(anyString(), anyInt(), anyInt(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<List<Interaction>> getInteractionsListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getInteractionsListener = mockActionListener();
         interactionsIndex.getAllInteractions("cid", 2, getInteractionsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getInteractionsListener, times(1)).onFailure(argCaptor.capture());
@@ -606,8 +578,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
 
     public void testDelete_NoIndex_ThenReturnTrue() {
         doReturn(false).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         interactionsIndex.deleteConversation("cid", deleteConversationListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(deleteConversationListener, times(1)).onResponse(argCaptor.capture());
@@ -629,8 +600,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onResponse(List.of(interaction));
             return null;
         }).when(interactionsIndex).getAllInteractions(anyString(), anyInt(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         interactionsIndex.deleteConversation("cid", deleteConversationListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(deleteConversationListener, times(1)).onResponse(argCaptor.capture());
@@ -650,8 +620,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onResponse(List.of(interaction));
             return null;
         }).when(interactionsIndex).getAllInteractions(anyString(), anyInt(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         interactionsIndex.deleteConversation("cid", deleteConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(deleteConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -666,8 +635,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Failure during GetAllInteractions"));
             return null;
         }).when(interactionsIndex).getAllInteractions(anyString(), anyInt(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         interactionsIndex.deleteConversation("cid", deleteConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(deleteConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -682,8 +650,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onResponse(List.of());
             return null;
         }).when(interactionsIndex).getAllInteractions(anyString(), anyInt(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         interactionsIndex.deleteConversation("cid", deleteConversationListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(deleteConversationListener, times(1)).onResponse(argCaptor.capture());
@@ -693,8 +660,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
     public void testDelete_NoAccessNoUser_ThenFail() {
         doReturn(true).when(metadata).hasIndex(anyString());
         setupDenyAccess(null);
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         interactionsIndex.deleteConversation("cid", deleteConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(deleteConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -707,8 +673,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
     public void testDelete_NoAccessWithUser_ThenFail() {
         doReturn(true).when(metadata).hasIndex(anyString());
         setupDenyAccess("user");
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         interactionsIndex.deleteConversation("cid", deleteConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(deleteConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -722,8 +687,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Access Failure"));
             return null;
         }).when(conversationMetaIndex).checkAccess(anyString(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         interactionsIndex.deleteConversation("cid", deleteConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(deleteConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -733,8 +697,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
     public void testDelete_MainFailure_ThenFail() {
         doReturn(true).when(metadata).hasIndex(anyString());
         doThrow(new RuntimeException("Test Failure")).when(conversationMetaIndex).checkAccess(anyString(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteConversationListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteConversationListener = mockActionListener();
         interactionsIndex.deleteConversation("cid", deleteConversationListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(deleteConversationListener, times(1)).onFailure(argCaptor.capture());
@@ -750,8 +713,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Failed during Search Refresh"));
             return null;
         }).when(indicesAdminClient).refresh(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<SearchResponse> searchInteractionsListener = mock(ActionListener.class);
+        ActionListener<SearchResponse> searchInteractionsListener = mockActionListener();
         interactionsIndex.searchInteractions(cid, request, searchInteractionsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(searchInteractionsListener, times(1)).onFailure(argCaptor.capture());
@@ -763,8 +725,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         SearchRequest request = dummyRequest();
         final String cid = "test_cid";
         doThrow(new RuntimeException("Client Failure in Search Interactions")).when(client).admin();
-        @SuppressWarnings("unchecked")
-        ActionListener<SearchResponse> searchInteractionsListener = mock(ActionListener.class);
+        ActionListener<SearchResponse> searchInteractionsListener = mockActionListener();
         interactionsIndex.searchInteractions(cid, request, searchInteractionsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(searchInteractionsListener, times(1)).onFailure(argCaptor.capture());
@@ -776,8 +737,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         setupDenyAccess("user");
         SearchRequest request = dummyRequest();
         final String cid = "test_cid";
-        @SuppressWarnings("unchecked")
-        ActionListener<SearchResponse> searchInteractionsListener = mock(ActionListener.class);
+        ActionListener<SearchResponse> searchInteractionsListener = mockActionListener();
         interactionsIndex.searchInteractions(cid, request, searchInteractionsListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(searchInteractionsListener, times(1)).onFailure(argCaptor.capture());
@@ -786,8 +746,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
 
     public void testGetSg_NoIndex_ThenFail() {
         doReturn(false).when(metadata).hasIndex(anyString());
-        @SuppressWarnings("unchecked")
-        ActionListener<Interaction> getListener = mock(ActionListener.class);
+        ActionListener<Interaction> getListener = mockActionListener();
         interactionsIndex.getInteraction("iid", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -808,8 +767,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             listener.onResponse(response);
             return null;
         }).when(client).get(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Interaction> getListener = mock(ActionListener.class);
+        ActionListener<Interaction> getListener = mockActionListener();
         interactionsIndex.getInteraction("iid", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -828,8 +786,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             listener.onResponse(response);
             return null;
         }).when(client).get(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Interaction> getListener = mock(ActionListener.class);
+        ActionListener<Interaction> getListener = mockActionListener();
         interactionsIndex.getInteraction("iid", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -844,8 +801,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             al.onFailure(new Exception("Failed during Sg Get Refresh"));
             return null;
         }).when(indicesAdminClient).refresh(any(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Interaction> getListener = mock(ActionListener.class);
+        ActionListener<Interaction> getListener = mockActionListener();
         interactionsIndex.getInteraction("iid", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -856,8 +812,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
         doReturn(true).when(metadata).hasIndex(anyString());
         setupGrantAccess();
         doThrow(new RuntimeException("Client Failure in Sg Get")).when(client).admin();
-        @SuppressWarnings("unchecked")
-        ActionListener<Interaction> getListener = mock(ActionListener.class);
+        ActionListener<Interaction> getListener = mockActionListener();
         interactionsIndex.getInteraction("iid", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -874,7 +829,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             listener.onResponse(response);
             return null;
         }).when(client).get(any(), any());
-        ActionListener<Interaction> getListener = mock(ActionListener.class);
+        ActionListener<Interaction> getListener = mockActionListener();
         interactionsIndex.getInteraction("iid", getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -891,7 +846,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             listener.onResponse(response);
             return null;
         }).when(client).get(any(), any());
-        ActionListener<Interaction> getListener = mock(ActionListener.class);
+        ActionListener<Interaction> getListener = mockActionListener();
         interactionsIndex.getInteraction("iid", getListener);
         ArgumentCaptor<Interaction> argCaptor = ArgumentCaptor.forClass(Interaction.class);
         verify(getListener, times(1)).onResponse(argCaptor.capture());
@@ -910,7 +865,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             return null;
         }).when(client).get(any(), any());
 
-        ActionListener<List<Interaction>> getListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getListener = mockActionListener();
         interactionsIndex.getTraces("iid", 0, 10, getListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(getListener, times(1)).onFailure(argCaptor.capture());
@@ -928,7 +883,7 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             return null;
         }).when(client).get(any(), any());
 
-        ActionListener<UpdateResponse> updateListener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> updateListener = mockActionListener();
         interactionsIndex.updateInteraction("iid", new UpdateRequest(), updateListener);
         ArgumentCaptor<Exception> argCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(updateListener, times(1)).onFailure(argCaptor.capture());
@@ -954,14 +909,13 @@ public class InteractionsIndexTests extends OpenSearchTestCase {
             return null;
         }).when(client).update(any(), any());
 
-        ActionListener<UpdateResponse> updateListener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> updateListener = mockActionListener();
         interactionsIndex.updateInteraction("iid", new UpdateRequest(), updateListener);
         ArgumentCaptor<UpdateResponse> argCaptor = ArgumentCaptor.forClass(UpdateResponse.class);
         verify(updateListener, times(1)).onResponse(argCaptor.capture());
     }
 
     private GetResponse setUpInteractionResponse(String interactionId) {
-        @SuppressWarnings("unchecked")
         GetResponse response = mock(GetResponse.class);
         doReturn(true).when(response).isExists();
         doReturn(interactionId).when(response).getId();

--- a/memory/src/test/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandlerTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/index/OpenSearchConversationalMemoryHandlerTests.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.opensearch.ml.memory.MockitoTestHelper.forListClass;
+import static org.opensearch.ml.memory.MockitoTestHelper.mockActionListener;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -123,8 +125,7 @@ public class OpenSearchConversationalMemoryHandlerTests extends OpenSearchTestCa
             .response("rsp")
             .promptTemplate("pt")
             .additionalInfo(Collections.singletonMap("meta", "some meta"));
-        @SuppressWarnings("unchecked")
-        ActionListener<String> createInteractionListener = mock(ActionListener.class);
+        ActionListener<String> createInteractionListener = mockActionListener();
         cmHandler.createInteraction(builder, createInteractionListener);
         ArgumentCaptor<String> argCaptor = ArgumentCaptor.forClass(String.class);
         verify(createInteractionListener, times(1)).onResponse(argCaptor.capture());
@@ -185,9 +186,9 @@ public class OpenSearchConversationalMemoryHandlerTests extends OpenSearchTestCa
             al.onResponse(List.of());
             return null;
         }).when(interactionsIndex).getTraces(any(), anyInt(), anyInt(), any());
-        ActionListener<List<Interaction>> getTracesListener = mock(ActionListener.class);
+        ActionListener<List<Interaction>> getTracesListener = mockActionListener();
         cmHandler.getTraces("iId", 0, 10, getTracesListener);
-        ArgumentCaptor<List<Interaction>> argCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<Interaction>> argCaptor = forListClass();
         verify(getTracesListener, times(1)).onResponse(argCaptor.capture());
         assert (argCaptor.getValue().size() == 0);
     }
@@ -201,7 +202,7 @@ public class OpenSearchConversationalMemoryHandlerTests extends OpenSearchTestCa
             return null;
         }).when(conversationMetaIndex).updateConversation(any(), any(), any());
 
-        ActionListener<UpdateResponse> updateConversationListener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> updateConversationListener = mockActionListener();
         cmHandler.updateConversation("cId", new HashMap<>(), updateConversationListener);
         ArgumentCaptor<UpdateResponse> argCaptor = ArgumentCaptor.forClass(UpdateResponse.class);
         verify(updateConversationListener, times(1)).onResponse(argCaptor.capture());
@@ -213,8 +214,7 @@ public class OpenSearchConversationalMemoryHandlerTests extends OpenSearchTestCa
             al.onResponse(false);
             return null;
         }).when(conversationMetaIndex).checkAccess(anyString(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteListener = mockActionListener();
         cmHandler.deleteConversation("cid", deleteListener);
         ArgumentCaptor<OpenSearchStatusException> argCaptor = ArgumentCaptor.forClass(OpenSearchStatusException.class);
         verify(deleteListener).onFailure(argCaptor.capture());
@@ -237,8 +237,7 @@ public class OpenSearchConversationalMemoryHandlerTests extends OpenSearchTestCa
             al.onResponse(true);
             return null;
         }).when(interactionsIndex).deleteConversation(anyString(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteListener = mockActionListener();
         cmHandler.deleteConversation("cid", deleteListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(deleteListener, times(1)).onResponse(argCaptor.capture());
@@ -261,8 +260,7 @@ public class OpenSearchConversationalMemoryHandlerTests extends OpenSearchTestCa
             al.onResponse(false);
             return null;
         }).when(interactionsIndex).deleteConversation(anyString(), any());
-        @SuppressWarnings("unchecked")
-        ActionListener<Boolean> deleteListener = mock(ActionListener.class);
+        ActionListener<Boolean> deleteListener = mockActionListener();
         cmHandler.deleteConversation("cid", deleteListener);
         ArgumentCaptor<Boolean> argCaptor = ArgumentCaptor.forClass(Boolean.class);
         verify(deleteListener, times(1)).onResponse(argCaptor.capture());
@@ -355,7 +353,7 @@ public class OpenSearchConversationalMemoryHandlerTests extends OpenSearchTestCa
             return null;
         }).when(interactionsIndex).updateInteraction(any(), any(), any());
 
-        ActionListener<UpdateResponse> updateInteractionListener = mock(ActionListener.class);
+        ActionListener<UpdateResponse> updateInteractionListener = mockActionListener();
         cmHandler.updateInteraction("iId", new HashMap<>(), updateInteractionListener);
         ArgumentCaptor<UpdateResponse> argCaptor = ArgumentCaptor.forClass(UpdateResponse.class);
         verify(updateInteractionListener, times(1)).onResponse(argCaptor.capture());


### PR DESCRIPTION
## Description

This change eliminates unchecked/unsafe operation warnings and deprecated API usage warnings in test sources under `common/src/test/**` and `memory/src/test/**`.

The goal of this refactor is to reduce compiler warning noise in CI, improve type safety in tests, and prevent future warnings from masking real issues.

### Changes

#### Unchecked/Unsafe Operation Cleanup

* Replaced raw collection types with parameterized generics.
* Removed unnecessary unchecked casts where possible.
* Added typed helper methods for Mockito APIs that expose raw generic interfaces.
* Replaced raw `ArgumentCaptor` and `ActionListener` usages with type-safe alternatives.
* Migrated Gson deserialization patterns to use typed `TypeToken` implementations where applicable.
* Added narrowly scoped `@SuppressWarnings` annotations only where type safety cannot be expressed due to framework limitations.

#### Deprecated API Cleanup

* Migrated JUnit `ExpectedException` usage to `assertThrows`.
* Replaced deprecated Log4j appender constructor usage with the supported API.
* Updated deprecated test utilities and APIs while preserving existing test behavior.

#### Refactoring Improvements

* Added reusable `MockitoTestHelper` utilities in both `common` and `memory` test modules.
* Removed redundant `@SuppressWarnings` annotations.
* Removed unused helper methods introduced during refactoring.
* Applied formatting and import cleanup across all modified files.


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
