### PR TITLE
fix: Retry transient HTTP errors from any remote service

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor.java
@@ -419,7 +419,7 @@ public interface RemoteConnectorExecutor extends AutoCloseable {
         public boolean shouldRetry(Exception e) {
             Throwable cause = ExceptionsHelper.unwrapCause(e);
             Integer maxRetryTimes = args.connectionExecutor.getConnectorClientConfig().getMaxRetryTimes();
-            boolean shouldRetry = cause instanceof RemoteConnectorThrottlingException;
+            boolean shouldRetry = isRetryable(cause);
             if (++retryTimes > maxRetryTimes && maxRetryTimes != -1) {
                 shouldRetry = false;
             }
@@ -429,6 +429,22 @@ public interface RemoteConnectorExecutor extends AutoCloseable {
                     .debug(String.format(Locale.ROOT, "The %d-th retry for invoke remote model", retryTimes), e);
             }
             return shouldRetry;
+        }
+
+        private static boolean isRetryable(Throwable cause) {
+            // AWS header-based throttling.
+            if (cause instanceof RemoteConnectorThrottlingException) {
+                return true;
+            }
+            // Transient HTTP failures from any remote service: 429 and 5xx.
+            if (cause instanceof OpenSearchStatusException) {
+                RestStatus status = ((OpenSearchStatusException) cause).status();
+                if (status == null) {
+                    return false;
+                }
+                return status == RestStatus.TOO_MANY_REQUESTS || status.getStatus() >= 500;
+            }
+            return false;
         }
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor_RetryableActionExtensionTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor_RetryableActionExtensionTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.bulk.BackoffPolicy;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
@@ -106,6 +107,34 @@ public class RemoteConnectorExecutor_RetryableActionExtensionTest {
             shouldRetry = retryableAction.shouldRetry(exception.get());
         } while (shouldRetry && ++attempt < TEST_ATTEMPT_LIMIT);
         return attempt;
+    }
+
+    @Test
+    public void test_ShouldRetry_OnTooManyRequests() {
+        var attempts = retryAttempts(-1, () -> new OpenSearchStatusException("rate limited", RestStatus.TOO_MANY_REQUESTS));
+
+        assertThat(attempts, equalTo(TEST_ATTEMPT_LIMIT));
+    }
+
+    @Test
+    public void test_ShouldRetry_OnServerError() {
+        var attempts = retryAttempts(-1, () -> new OpenSearchStatusException("server error", RestStatus.SERVICE_UNAVAILABLE));
+
+        assertThat(attempts, equalTo(TEST_ATTEMPT_LIMIT));
+    }
+
+    @Test
+    public void test_ShouldNotRetry_OnClientError() {
+        var attempts = retryAttempts(-1, () -> new OpenSearchStatusException("bad request", RestStatus.BAD_REQUEST));
+
+        assertThat(attempts, equalTo(0));
+    }
+
+    @Test
+    public void test_ShouldNotRetry_WhenStatusIsNull() {
+        var attempts = retryAttempts(-1, () -> new OpenSearchStatusException("unknown status", RestStatus.fromCode(799)));
+
+        assertThat(attempts, equalTo(0));
     }
 
     private RemoteConnectorThrottlingException createThrottleException() {


### PR DESCRIPTION
### Description

#### Problem

Currently, connector retries only trigger on `RemoteConnectorThrottlingException`, which is produced solely from AWS's `x-amzn-ErrorType` response header.  However, other providers (OpenAI, Gemini, Cohere, Anthropic, DeepSeek, etc.) signal transient failures with plain HTTP status codes, not that AWS-specific exception, so their throttling and server errors are never retried.

| Provider | Transient failure signal | Retried before? | Retried now? |
|---|---|---|---|
| AWS (Bedrock/SageMaker) | `RemoteConnectorThrottlingException` (header) | ✅ | ✅ |
| OpenAI, Gemini, Cohere, Anthropic, DeepSeek, etc | HTTP `429` | ❌ | ✅ |
| Any remote service | HTTP `5xx` | ❌ | ✅ |

#### Change

The retry decision is extracted into a new `isRetryable(Throwable)` helper method. Instead of only recognizing the AWS-specific `RemoteConnectorThrottlingException`, it now also inspects the HTTP status code on `OpenSearchStatusException` — the common exception type produced by the shared `MLSdkAsyncHttpResponseHandler` that all connectors (AWS and generic HTTP) use.

| Condition | Retried? | Example scenario |
|---|---|---|
| `RemoteConnectorThrottlingException` | ✅ | AWS SageMaker/Bedrock header-based throttling |
| HTTP `429` (Too Many Requests) | ✅ | OpenAI / Gemini / Cohere rate-limiting |
| HTTP `5xx` (Server Error) | ✅ | Transient outage, gateway timeout, connection timeout |

Non-transient failures (`4xx` client errors, unknown status codes) are not retried — the request itself is wrong or unsupported, and repeating it would not help.

Local per-model and per-user rate limiting remains unaffected: those checks throw before the retry wrapper is created, so they never enter the retry path.

#### Testing

Unit tests cover each branch of `isRetryable`: throttling, `429`, `5xx`, non-retryable `4xx`, and `null` status.

### Related Issues
https://github.com/opensearch-project/search-relevance/issues/510

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
