### PR TITLE
Fix CVE-2026-40542: bump httpclient5 to 5.6.1

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -412,7 +412,7 @@ configurations.all {
     resolutionStrategy.force "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     resolutionStrategy.force "org.apache.httpcomponents.core5:httpcore5:5.3.1"
     resolutionStrategy.force "org.apache.httpcomponents.core5:httpcore5-h2:5.3.1"
-    resolutionStrategy.force "org.apache.httpcomponents.client5:httpclient5:5.4.3"
+    resolutionStrategy.force "org.apache.httpcomponents.client5:httpclient5:5.6.1"
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${versions.jackson_databind}"
     resolutionStrategy.force "org.apache.logging.log4j:log4j-api:${versions.log4j}"


### PR DESCRIPTION
## Summary

- Bump `org.apache.httpcomponents.client5:httpclient5` from 5.4.3 to 5.6.1 to fix CVE-2026-40542 (HIGH, GHSA-v468-qcjx-r72w)

## Test plan

- [ ] Verify build compiles successfully with updated httpclient5
- [ ] Run existing test suite to confirm no regressions