### PR TITLE
fix: Use http instead of https for Ollama connector endpoint

### DIFF
--- a/docs/remote_inference_blueprints/ollama_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/ollama_connector_chat_blueprint.md
@@ -52,7 +52,7 @@ POST /_plugins/_ml/connectors/_create
     {
       "action_type": "predict",
       "method": "POST",
-      "url": "https://${parameters.endpoint}/v1/chat/completions",
+      "url": "http://${parameters.endpoint}/v1/chat/completions",
       "supports_structured_output": true,
       "headers": {
         "Authorization": "Bearer ${credential.openAI_key}"

--- a/docs/remote_inference_blueprints/ollama_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/ollama_connector_chat_blueprint.md
@@ -25,7 +25,8 @@ PUT /_cluster/settings
 PUT /_cluster/settings
 {
     "persistent": {
-      "plugins.ml_commons.connector.private_ip_enabled": true
+      "plugins.ml_commons.connector.private_ip_enabled": true,
+      "plugins.ml_commons.trusted_connector_private_endpoints_regex": ["^http://127\\.0\\.0\\.1:11434/.*$"]
     }
 }
 ```

--- a/docs/tutorials/conversational_search/conversational_search_with_Ollama.md
+++ b/docs/tutorials/conversational_search/conversational_search_with_Ollama.md
@@ -52,7 +52,7 @@ POST /_plugins/_ml/connectors/_create
     {
       "action_type": "predict",
       "method": "POST",
-      "url": "https://${parameters.endpoint}/v1/chat/completions",
+      "url": "http://${parameters.endpoint}/v1/chat/completions",
       "headers": {
         "Authorization": "Bearer ${credential.openAI_key}"
       },


### PR DESCRIPTION
### Description
The Ollama connector blueprint and the conversational search tutorial both set `"protocol": "http"` with endpoint `127.0.0.1:11434`, but the action URL used `https://${parameters.endpoint}/v1/chat/completions`. Ollama serves plain HTTP on port 11434 by default (HTTPS requires a separate reverse proxy), so the `https://` scheme fails
the TLS handshake. This switches both files to `http://` to match the declared protocol and Ollama's default.

Reference: [official Ollama documentation](https://docs.ollama.com/api/introduction), the API is served over `http://localhost:11434`.

Additionally, the blueprint now sets `plugins.ml_commons.trusted_connector_private_endpoints_regex` alongside `connector.private_ip_enabled`. Enabling private IPs alone permits connectors to reach *any* private address; scoping it to `^http://127\.0\.0\.1:11434/.*$` restricts access to just the local Ollama endpoint, following the feature added in #4818.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).



