### PR TITLE
Add Gemini embedding connector blueprint

### DIFF
--- a/docs/remote_inference_blueprints/google_gemini_connector_chat_blueprint.md
+++ b/docs/remote_inference_blueprints/google_gemini_connector_chat_blueprint.md
@@ -21,6 +21,8 @@ PUT /_cluster/settings
 
 The Gemini API uses `contents` (not `messages`) with `role` and `parts`. `generationConfig` is optional and can be passed per-request if needed.
 
+> **Note:** The API key must be sent as the `x-goog-api-key` header rather than a `?key=` query parameter. `${credential.*}` substitution is only applied to headers, not to the action `url`, so a credential placeholder left in the URL will not be resolved at request time.
+
 ```json
 POST /_plugins/_ml/connectors/_create
 {

--- a/docs/remote_inference_blueprints/google_gemini_connector_embedding_blueprint.md
+++ b/docs/remote_inference_blueprints/google_gemini_connector_embedding_blueprint.md
@@ -1,0 +1,105 @@
+# Google Gemini Connector Blueprint for Embedding
+
+This blueprint connects a Google Gemini text embedding model to your OpenSearch cluster using the [Gemini embedContent API](https://ai.google.dev/api/embeddings). You will need a Gemini API key from [Google AI Studio](https://aistudio.google.com/apikey).
+
+## 1. Add connector endpoint to trusted URLs
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "plugins.ml_commons.trusted_connector_endpoints_regex": [
+      "^https://generativelanguage\\.googleapis\\.com/.*$"
+    ]
+  }
+}
+```
+
+## 2. Create connector
+
+The Gemini API uses `content.parts[].text` for the input text and returns the embedding as `embedding.values`. The `response_filter` extracts the values array directly.
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Google Gemini Embedding",
+  "description": "Connector to Google Gemini embedContent API",
+  "version": "1",
+  "protocol": "http",
+  "credential": {
+    "gemini_key": "<ENTER_GEMINI_API_KEY_HERE>"
+  },
+  "parameters": {
+    "model": "gemini-embedding-001",
+    "response_filter": "$.embedding.values"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://generativelanguage.googleapis.com/v1beta/models/${parameters.model}:embedContent",
+      "headers": {
+        "Content-Type": "application/json",
+        "x-goog-api-key": "${credential.gemini_key}"
+      },
+      "request_body": "{ \"model\": \"models/${parameters.model}\", \"content\": { \"parts\": [{ \"text\": \"${parameters.text}\" }] } }"
+    }
+  ]
+}
+```
+
+> **Note:** This blueprint calls `embedContent` for one input at a time via the `text` parameter. Gemini's `batchEmbedContents` endpoint can be used instead if you need to embed multiple documents per request; adjust `request_body` and `response_filter` accordingly.
+
+## 3. Register and deploy model
+
+```json
+POST /_plugins/_ml/models/_register
+{
+  "name": "Google Gemini Embedding",
+  "function_name": "remote",
+  "description": "Google Gemini text embedding model",
+  "connector_id": "<CONNECTOR_ID>"
+}
+```
+
+Poll the returned `task_id` until `status` is `COMPLETED`, then deploy:
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_deploy
+```
+
+## 4. Test model
+
+```json
+POST /_plugins/_ml/models/<MODEL_ID>/_predict
+{
+  "parameters": {
+    "text": "What is OpenSearch?"
+  }
+}
+```
+
+Sample response:
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": [
+              -0.011785943,
+              0.023027036,
+              0.0034649687,
+              ...
+            ]
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```

--- a/docs/remote_inference_blueprints/standard_blueprints/README.md
+++ b/docs/remote_inference_blueprints/standard_blueprints/README.md
@@ -48,7 +48,11 @@ These blueprints include pre- and post-processing functions, suitable when you n
 
 - OpenAI: 
   - [text-embedding-ada-002](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/openai_connector_embedding_blueprint.md)
-  
+
+- Google Gemini
+  - chat: [gemini-2.0-flash](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/google_gemini_connector_chat_blueprint.md)
+  - text embedding: [gemini-embedding-001](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/google_gemini_connector_embedding_blueprint.md)
+
 - VertexAI
   - [embedding](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/gcp_vertexai_connector_embedding_blueprint.md)
 


### PR DESCRIPTION
## Summary

- Adds a pre-configured blueprint for Gemini text embeddings using the `embedContent` API.
- Lists the Gemini chat and embedding blueprints in the standard blueprints index.
- Documents that Gemini API keys are passed through the `x-goog-api-key` header.

The chat connector authentication fix originally included in this PR was merged separately in #4874. This branch has been rebased onto `main`, so that implementation is no longer duplicated here.

## Sources

- Gemini embeddings API: https://ai.google.dev/api/embeddings
- Gemini embeddings guide: https://ai.google.dev/gemini-api/docs/embeddings
- Gemini API authentication: https://ai.google.dev/gemini-api/docs/api-key

## Test plan

- [x] Rebased onto current `main` and verified the diff contains no duplicate auth implementation from #4874.
- [x] `git diff --check`
- [x] `./gradlew spotlessCheck`
- [ ] Manually create the embedding connector with a real Gemini API key and confirm `_predict` returns a float vector through `response_filter`.

Docs-only change; no production code is modified.
