### PR TITLE
Fix thread pool deadlock causing SearchModelGroupITTests to hang on Windows CI

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -408,6 +409,7 @@ import org.opensearch.ml.rest.mcpserver.RestMLMcpToolsRemoveAction;
 import org.opensearch.ml.rest.mcpserver.RestMLMcpToolsUpdateAction;
 import org.opensearch.ml.rest.mcpserver.RestMcpServerAction;
 import org.opensearch.ml.rest.mcpserver.ToolFactoryWrapper;
+import org.opensearch.ml.sdkclient.DelegatingAsyncSdkClient;
 import org.opensearch.ml.searchext.MLInferenceRequestParametersExtBuilder;
 import org.opensearch.ml.stats.MLClusterLevelStat;
 import org.opensearch.ml.stats.MLNodeLevelStat;
@@ -438,6 +440,7 @@ import org.opensearch.plugins.SearchPlugin;
 import org.opensearch.plugins.SystemIndexPlugin;
 import org.opensearch.plugins.TelemetryAwarePlugin;
 import org.opensearch.remote.metadata.client.SdkClient;
+import org.opensearch.remote.metadata.client.SdkClientDelegate;
 import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
@@ -671,6 +674,12 @@ public class MachineLearningPlugin extends Plugin
 
         mlIndicesHandler = new MLIndicesHandler(clusterService, client, mlFeatureEnabledSetting);
 
+        // Use the dedicated SDK client thread pool for CompletionStage callbacks.
+        // This prevents deadlocks: LocalClusterIndicesClient completes futures on transport
+        // threads, and if callers block those threads, the system deadlocks. By wrapping the
+        // delegate, all downstream .whenComplete() callbacks execute on this safe pool instead.
+        Executor sdkClientExecutor = client.threadPool().executor(SDK_CLIENT_THREAD_POOL);
+
         SdkClient sdkClient = SdkClientFactory
             .createSdkClient(
                 client,
@@ -694,11 +703,19 @@ public class MachineLearningPlugin extends Plugin
                                 )
                         )
                     : Collections.emptyMap(),
-                // For node client / local cluster it won't use this thread pool
-                // but we haven't update the ddbclient to async for which we are keeping it like this
-                // todo: need to update this when ddbclient async is going to be implemented.
-                client.threadPool().executor(ThreadPool.Names.GENERIC)
+                sdkClientExecutor
             );
+
+        // Wrap the SdkClient's delegate to force a thread hop on completion.
+        // This ensures .whenComplete() callbacks at all call sites run on the
+        // SDK client pool, not on transport threads where they can deadlock.
+        SdkClientDelegate wrappedDelegate = new DelegatingAsyncSdkClient(sdkClient.getDelegate(), sdkClientExecutor);
+        sdkClient = new SdkClient(
+            wrappedDelegate,
+            sdkClientExecutor,
+            ML_COMMONS_MULTI_TENANCY_ENABLED.get(settings),
+            ML_COMMONS_MULTI_TENANCY_ENABLED.get(settings) ? REMOTE_METADATA_GLOBAL_TENANT_ID.get(settings) : null
+        );
 
         encryptor = new EncryptorImpl(clusterService, client, sdkClient, mlIndicesHandler);
 

--- a/plugin/src/main/java/org/opensearch/ml/sdkclient/DelegatingAsyncSdkClient.java
+++ b/plugin/src/main/java/org/opensearch/ml/sdkclient/DelegatingAsyncSdkClient.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.sdkclient;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+import org.opensearch.remote.metadata.client.BulkDataObjectRequest;
+import org.opensearch.remote.metadata.client.BulkDataObjectResponse;
+import org.opensearch.remote.metadata.client.DeleteDataObjectRequest;
+import org.opensearch.remote.metadata.client.DeleteDataObjectResponse;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.GetDataObjectResponse;
+import org.opensearch.remote.metadata.client.PutDataObjectRequest;
+import org.opensearch.remote.metadata.client.PutDataObjectResponse;
+import org.opensearch.remote.metadata.client.SdkClientDelegate;
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest;
+import org.opensearch.remote.metadata.client.SearchDataObjectResponse;
+import org.opensearch.remote.metadata.client.UpdateDataObjectRequest;
+import org.opensearch.remote.metadata.client.UpdateDataObjectResponse;
+
+/**
+ * A decorating {@link SdkClientDelegate} that ensures all returned {@link CompletionStage}
+ * instances deliver their results on a specified executor rather than on the thread that
+ * originally completed the future (typically an OpenSearch transport thread).
+ * <p>
+ * This prevents thread pool deadlocks: when {@code LocalClusterIndicesClient} completes
+ * futures on a transport thread and callers block that same thread with {@code actionGet()},
+ * the thread is waiting for itself. By forcing a thread hop, downstream continuations
+ * ({@code .whenComplete()}, {@code .thenApply()}, etc.) execute on a safe, non-transport pool.
+ */
+public class DelegatingAsyncSdkClient implements SdkClientDelegate {
+
+    private final SdkClientDelegate delegate;
+    private final Executor completionExecutor;
+
+    /**
+     * @param delegate           the underlying SdkClientDelegate (e.g., LocalClusterIndicesClient)
+     * @param completionExecutor the executor on which CompletionStage results are delivered
+     */
+    public DelegatingAsyncSdkClient(SdkClientDelegate delegate, Executor completionExecutor) {
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate must not be null");
+        }
+        if (completionExecutor == null) {
+            throw new IllegalArgumentException("completionExecutor must not be null");
+        }
+        this.delegate = delegate;
+        this.completionExecutor = completionExecutor;
+    }
+
+    @Override
+    public boolean supportsMetadataType(String metadataType) {
+        return delegate.supportsMetadataType(metadataType);
+    }
+
+    @Override
+    public void initialize(Map<String, String> metadataSettings) {
+        delegate.initialize(metadataSettings);
+    }
+
+    @Override
+    public CompletionStage<PutDataObjectResponse> putDataObjectAsync(
+        PutDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.putDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<GetDataObjectResponse> getDataObjectAsync(
+        GetDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.getDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<UpdateDataObjectResponse> updateDataObjectAsync(
+        UpdateDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.updateDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<DeleteDataObjectResponse> deleteDataObjectAsync(
+        DeleteDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.deleteDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<BulkDataObjectResponse> bulkDataObjectAsync(
+        BulkDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.bulkDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(
+        SearchDataObjectRequest request,
+        Executor executor,
+        Boolean isMultiTenancyEnabled
+    ) {
+        return hopThread(delegate.searchDataObjectAsync(request, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public CompletionStage<Boolean> isGlobalResource(String index, String id, Executor executor, Boolean isMultiTenancyEnabled) {
+        return hopThread(delegate.isGlobalResource(index, id, executor, isMultiTenancyEnabled));
+    }
+
+    @Override
+    public void close() throws Exception {
+        delegate.close();
+    }
+
+    /**
+     * Forces a thread hop so that any continuation chained on the returned stage
+     * executes on {@code completionExecutor} rather than the thread that called
+     * {@code future.complete()} (which is typically an OpenSearch transport thread).
+     * <p>
+     * Uses {@code handleAsync} to cover BOTH the success and failure paths -- unlike
+     * {@code thenApplyAsync}, which only hops on success and short-circuits exceptions
+     * on the completing thread.
+     * <p>
+     * We create a fresh {@code CompletableFuture} rather than returning the stage from
+     * {@code handleAsync} directly, to avoid wrapping exceptions in {@code CompletionException}.
+     * The original exception type is preserved exactly as thrown by the SDK.
+     */
+    private <T> CompletionStage<T> hopThread(CompletionStage<T> stage) {
+        CompletableFuture<T> result = new CompletableFuture<>();
+        stage.handleAsync((value, throwable) -> {
+            if (throwable != null) {
+                result.completeExceptionally(throwable);
+            } else {
+                result.complete(value);
+            }
+            return null;
+        }, completionExecutor);
+        return result;
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/model_group/SearchModelGroupITTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/model_group/SearchModelGroupITTests.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.action.model_group;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -29,9 +31,16 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
 
     private static String modelGroupId;
 
+    private static final long SEARCH_TIMEOUT_SECONDS = 30;
+
     @Override
     protected void setupSuiteScopeCluster() throws Exception {
         registerModelGroup();
+        // Explicit refresh ensures the indexed model group document is searchable.
+        // While PutDataObjectRequest defaults to RefreshPolicy.IMMEDIATE, issuing an
+        // explicit refresh eliminates any residual timing window on resource-constrained
+        // CI environments (e.g., single-node clusters with small thread pools on Windows).
+        client().admin().indices().prepareRefresh().get();
     }
 
     private void registerModelGroup() {
@@ -54,7 +63,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchRequest.source(searchSourceBuilder);
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -66,7 +77,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.matchAllQuery());
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -78,7 +91,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.boolQuery().must(QueryBuilders.termQuery("name.keyword", "mock_model_group_name")));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -90,7 +105,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.termQuery("name.keyword", "mock_model_group_name"));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -102,7 +119,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.termsQuery("name.keyword", "mock_model_group_name", "test_model_group_name"));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -114,7 +133,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.rangeQuery("created_time").gte("now-1d"));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -126,7 +147,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.matchPhraseQuery("description", "desc"));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }
@@ -138,7 +161,9 @@ public class SearchModelGroupITTests extends MLCommonsIntegTestCase {
         searchRequest.source(searchSourceBuilder);
         searchRequest.source().query(QueryBuilders.queryStringQuery("name: mock_model_group_*"));
         MLSearchActionRequest mlSearchActionRequest = new MLSearchActionRequest(searchRequest, null);
-        SearchResponse response = client().execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest).actionGet();
+        SearchResponse response = client()
+            .execute(MLModelGroupSearchAction.INSTANCE, mlSearchActionRequest)
+            .actionGet(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertEquals(1, response.getHits().getTotalHits().value());
         assertEquals(modelGroupId, response.getHits().getHits()[0].getId());
     }

--- a/plugin/src/test/java/org/opensearch/ml/sdkclient/DelegatingAsyncSdkClientTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/sdkclient/DelegatingAsyncSdkClientTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.sdkclient;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.remote.metadata.client.GetDataObjectRequest;
+import org.opensearch.remote.metadata.client.GetDataObjectResponse;
+import org.opensearch.remote.metadata.client.SdkClientDelegate;
+
+public class DelegatingAsyncSdkClientTests {
+
+    private SdkClientDelegate mockDelegate;
+    private ExecutorService testExecutor;
+    private DelegatingAsyncSdkClient wrapper;
+
+    @Before
+    public void setUp() {
+        mockDelegate = mock(SdkClientDelegate.class);
+        testExecutor = Executors.newFixedThreadPool(2);
+        wrapper = new DelegatingAsyncSdkClient(mockDelegate, testExecutor);
+    }
+
+    @After
+    public void tearDown() {
+        testExecutor.shutdownNow();
+    }
+
+    @Test
+    public void testSuccessPathHopsThread() throws Exception {
+        // Simulate LocalClusterIndicesClient completing on "transport thread"
+        CompletableFuture<GetDataObjectResponse> innerFuture = new CompletableFuture<>();
+        GetDataObjectRequest request = mock(GetDataObjectRequest.class);
+        when(mockDelegate.getDataObjectAsync(eq(request), any(), any())).thenReturn(innerFuture);
+
+        // Get the wrapped stage
+        var stage = wrapper.getDataObjectAsync(request, testExecutor, false);
+
+        // Track which thread the callback runs on
+        AtomicReference<String> callbackThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        stage.whenComplete((response, throwable) -> {
+            callbackThread.set(Thread.currentThread().getName());
+            latch.countDown();
+        });
+
+        // Complete on the "transport thread" (current thread)
+        String transportThread = Thread.currentThread().getName();
+        GetDataObjectResponse mockResponse = mock(GetDataObjectResponse.class);
+        innerFuture.complete(mockResponse);
+
+        // Wait for callback
+        assertTrue("Callback timed out", latch.await(5, TimeUnit.SECONDS));
+
+        // Verify callback did NOT run on the transport thread
+        assertNotEquals("Callback must not run on the completing (transport) thread", transportThread, callbackThread.get());
+    }
+
+    @Test
+    public void testFailurePathHopsThread() throws Exception {
+        CompletableFuture<GetDataObjectResponse> innerFuture = new CompletableFuture<>();
+        GetDataObjectRequest request = mock(GetDataObjectRequest.class);
+        when(mockDelegate.getDataObjectAsync(eq(request), any(), any())).thenReturn(innerFuture);
+
+        var stage = wrapper.getDataObjectAsync(request, testExecutor, false);
+
+        AtomicReference<String> callbackThread = new AtomicReference<>();
+        AtomicReference<Throwable> caughtError = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        stage.whenComplete((response, throwable) -> {
+            callbackThread.set(Thread.currentThread().getName());
+            caughtError.set(throwable);
+            latch.countDown();
+        });
+
+        // Complete exceptionally on "transport thread"
+        String transportThread = Thread.currentThread().getName();
+        OpenSearchStatusException exception = new OpenSearchStatusException("test", RestStatus.INTERNAL_SERVER_ERROR);
+        innerFuture.completeExceptionally(exception);
+
+        assertTrue("Callback timed out", latch.await(5, TimeUnit.SECONDS));
+
+        // Verify thread hop happened
+        assertNotEquals(transportThread, callbackThread.get());
+
+        // Verify exception is preserved (not wrapped in CompletionException)
+        assertSame(exception, caughtError.get());
+    }
+
+    @Test
+    public void testNullDelegateThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new DelegatingAsyncSdkClient(null, testExecutor));
+    }
+
+    @Test
+    public void testNullExecutorThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new DelegatingAsyncSdkClient(mockDelegate, null));
+    }
+
+    @Test
+    public void testSupportsMetadataTypeDelegates() {
+        when(mockDelegate.supportsMetadataType("local")).thenReturn(true);
+        assertTrue(wrapper.supportsMetadataType("local"));
+        verify(mockDelegate).supportsMetadataType("local");
+    }
+}


### PR DESCRIPTION
### Description

Fixes a thread pool deadlock that causes `SearchModelGroupITTests` to hang indefinitely (30-minute timeout) on Windows CI.

**Root cause:** `LocalClusterIndicesClient` (from `opensearch-remote-metadata-sdk`) completes `CompletableFuture` instances on transport threads via `ActionListener` callbacks. All 67 `.whenComplete()` call sites in ml-commons chain callbacks on those same transport threads. When a caller blocks with `actionGet()`, the transport thread is occupied — but the `CompletableFuture.whenComplete()` callback needs that same thread to fire. On single-node test clusters with small thread pools (Windows CI has fewer cores → `generic` pool = `4 * cores`), this deadlocks.

**Fix:** Add a `DelegatingAsyncSdkClient` decorator that wraps the SDK delegate and forces a thread hop via `handleAsync` on every returned `CompletionStage`. All downstream `.whenComplete()` callbacks now execute on the dedicated `SDK_CLIENT_THREAD_POOL` (32 threads, 10k queue) instead of transport threads. Thread context is automatically preserved via `OpenSearchThreadPoolExecutor.wrapRunnable()`.

Also adds bounded `actionGet(30, TimeUnit.SECONDS)` + explicit index refresh in `SearchModelGroupITTests` as defense-in-depth.

### Changes

| File | Change |
|------|--------|
| `plugin/src/main/java/org/opensearch/ml/sdkclient/DelegatingAsyncSdkClient.java` (NEW) | Decorator implementing `SdkClientDelegate` — intercepts all async methods and applies `handleAsync` thread hop covering both success and failure paths |
| `plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java` | Wraps SDK client delegate with `DelegatingAsyncSdkClient` using `SDK_CLIENT_THREAD_POOL`; switches executor from `GENERIC` to the dedicated pool |
| `plugin/src/test/java/org/opensearch/ml/action/model_group/SearchModelGroupITTests.java` | Bounded `actionGet(30s)` + explicit refresh in setup as defense-in-depth |
| `plugin/src/test/java/org/opensearch/ml/sdkclient/DelegatingAsyncSdkClientTests.java` (NEW) | Unit tests verifying thread hop on success/failure, exception type preservation, null guards, delegation |

### Related Issues

Resolves flaky CI: `SearchModelGroupITTests.test_matchPhrase_search` hanging on Windows with seed `4D16264BE4B77BC4`


### Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
