### PR TITLE
test: Retry integration tests on transient remote-service 5xx errors

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -41,21 +41,25 @@ import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.lucene.search.TotalHits;
+import org.junit.AssumptionViolatedException;
 import org.opensearch.Version;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.WarningsHandler;
 import org.opensearch.cluster.ClusterName;
@@ -201,8 +205,52 @@ public class TestHelper {
         if (entity != null) {
             request.setEntity(entity);
         }
-        return client.performRequest(request);
+        try {
+            return client.performRequest(request);
+        } catch (ResponseException e) {
+            skipIfRemoteServiceUnavailable(e);
+            throw e;
+        }
     }
+
+    /**
+     * Skips the test (assumption violation) when a 503/500 is attributable to remote-service
+     * unavailability (Bedrock/OpenAI/Cohere down or timing out) rather than an ml-commons bug.
+     * All other errors still fail normally.
+     */
+    private static void skipIfRemoteServiceUnavailable(ResponseException e) {
+        int status = e.getResponse().getStatusLine().getStatusCode();
+        if (status != 503 && status != 500) {
+            return;
+        }
+        String body;
+        try {
+            body = EntityUtils.toString(e.getResponse().getEntity());
+        } catch (Exception ignored) {
+            return;
+        }
+        if (body == null) {
+            return;
+        }
+        if (status == 503 && REMOTE_SERVICE_ERROR_PATTERN.matcher(body).find()) {
+            throw new AssumptionViolatedException("Remote service unavailable (503), skipping test: " + body);
+        }
+        if (status == 500 && REMOTE_TIMEOUT_ERROR_PATTERN.matcher(body).find()) {
+            throw new AssumptionViolatedException("Remote service timed out, skipping test: " + body);
+        }
+    }
+
+    // CommonValue.REMOTE_SERVICE_ERROR wrapper plus common upstream 503 phrasings.
+    private static final Pattern REMOTE_SERVICE_ERROR_PATTERN = Pattern
+        .compile("Error from remote service|Service Unavailable|ServiceUnavailable|model.{0,20}not ready", Pattern.CASE_INSENSITIVE);
+
+    // MLSdkAsyncHttpResponseHandler's connectivity wrapper — timeouts/resets only, so genuine
+    // request bugs surfacing as other remote 500s still fail.
+    private static final Pattern REMOTE_TIMEOUT_ERROR_PATTERN = Pattern
+        .compile(
+            "Error communicating with remote model.{0,40}(Read timed out|timed out|Connection reset|Connection refused)",
+            Pattern.CASE_INSENSITIVE
+        );
 
     public static HttpEntity toHttpEntity(ToXContentObject object) throws IOException {
         return new StringEntity(toJsonString(object), APPLICATION_JSON);

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -205,51 +205,73 @@ public class TestHelper {
         if (entity != null) {
             request.setEntity(entity);
         }
-        try {
-            return client.performRequest(request);
-        } catch (ResponseException e) {
-            skipIfRemoteServiceUnavailable(e);
-            throw e;
-        }
+        return performRequestWithRemoteRetry(client, request);
     }
 
-    /**
-     * Skips the test (assumption violation) when a 503/500 is attributable to remote-service
-     * unavailability (Bedrock/OpenAI/Cohere down or timing out) rather than an ml-commons bug.
-     * All other errors still fail normally.
-     */
-    private static void skipIfRemoteServiceUnavailable(ResponseException e) {
+    // Retries transient remote-service 5xx blips (Bedrock/OpenAI/Cohere) so the test still runs and
+    // catches real regressions; only skips if the remote stays down for every attempt.
+    private static Response performRequestWithRemoteRetry(RestClient client, Request request) throws IOException {
+        ResponseException lastTransientError = null;
+        for (int attempt = 0; attempt <= MAX_REMOTE_RETRIES; attempt++) {
+            try {
+                return client.performRequest(request);
+            } catch (ResponseException e) {
+                if (!isTransientRemoteServiceError(e)) {
+                    throw e;
+                }
+                lastTransientError = e;
+                if (attempt < MAX_REMOTE_RETRIES) {
+                    try {
+                        Thread.sleep(REMOTE_RETRY_BACKOFF_MS * (attempt + 1)); // linear backoff
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw e; // interrupted: stop retrying, surface the remote error
+                    }
+                }
+            }
+        }
+        throw new AssumptionViolatedException(
+            "Remote service unavailable after " + (MAX_REMOTE_RETRIES + 1) + " attempts, skipping test: " + lastTransientError.getMessage()
+        );
+    }
+
+    // True only for the two narrow remote-unavailability signatures (503 wrapper, 500 connectivity
+    // timeout/reset); everything else fails normally.
+    private static boolean isTransientRemoteServiceError(ResponseException e) {
         int status = e.getResponse().getStatusLine().getStatusCode();
         if (status != 503 && status != 500) {
-            return;
+            return false;
         }
         String body;
         try {
             body = EntityUtils.toString(e.getResponse().getEntity());
         } catch (Exception ignored) {
-            return;
+            return false;
         }
         if (body == null) {
-            return;
+            return false;
         }
         if (status == 503 && REMOTE_SERVICE_ERROR_PATTERN.matcher(body).find()) {
-            throw new AssumptionViolatedException("Remote service unavailable (503), skipping test: " + body);
+            return true;
         }
-        if (status == 500 && REMOTE_TIMEOUT_ERROR_PATTERN.matcher(body).find()) {
-            throw new AssumptionViolatedException("Remote service timed out, skipping test: " + body);
-        }
+        return status == 500 && REMOTE_TIMEOUT_ERROR_PATTERN.matcher(body).find();
     }
+
+    private static final int MAX_REMOTE_RETRIES = 3;
+    private static final long REMOTE_RETRY_BACKOFF_MS = 3000;
 
     // CommonValue.REMOTE_SERVICE_ERROR wrapper plus common upstream 503 phrasings.
     private static final Pattern REMOTE_SERVICE_ERROR_PATTERN = Pattern
-        .compile("Error from remote service|Service Unavailable|ServiceUnavailable|model.{0,20}not ready", Pattern.CASE_INSENSITIVE);
+        .compile(
+            "Error from remote service|Service Unavailable|ServiceUnavailable|model.{0,20}not ready",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+        );
 
-    // MLSdkAsyncHttpResponseHandler's connectivity wrapper — timeouts/resets only, so genuine
-    // request bugs surfacing as other remote 500s still fail.
+    // MLSdkAsyncHttpResponseHandler connectivity wrapper — timeouts/resets only.
     private static final Pattern REMOTE_TIMEOUT_ERROR_PATTERN = Pattern
         .compile(
             "Error communicating with remote model.{0,40}(Read timed out|timed out|Connection reset|Connection refused)",
-            Pattern.CASE_INSENSITIVE
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL
         );
 
     public static HttpEntity toHttpEntity(ToXContentObject object) throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/TestHelper.java
@@ -52,7 +52,6 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.lucene.search.TotalHits;
-import org.junit.AssumptionViolatedException;
 import org.opensearch.Version;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.ShardSearchFailure;
@@ -208,31 +207,26 @@ public class TestHelper {
         return performRequestWithRemoteRetry(client, request);
     }
 
-    // Retries transient remote-service 5xx blips (Bedrock/OpenAI/Cohere) so the test still runs and
-    // catches real regressions; only skips if the remote stays down for every attempt.
+    // Retries transient remote-service 5xx blips (Bedrock/OpenAI/Cohere) so a momentary outage
+    // doesn't fail CI. If the remote stays unavailable across every attempt, the error is re-thrown
+    // and the test fails normally, so a genuine regression is never masked.
     private static Response performRequestWithRemoteRetry(RestClient client, Request request) throws IOException {
-        ResponseException lastTransientError = null;
         for (int attempt = 0; attempt <= MAX_REMOTE_RETRIES; attempt++) {
             try {
                 return client.performRequest(request);
             } catch (ResponseException e) {
-                if (!isTransientRemoteServiceError(e)) {
+                if (!isTransientRemoteServiceError(e) || attempt == MAX_REMOTE_RETRIES) {
                     throw e;
                 }
-                lastTransientError = e;
-                if (attempt < MAX_REMOTE_RETRIES) {
-                    try {
-                        Thread.sleep(REMOTE_RETRY_BACKOFF_MS * (attempt + 1)); // linear backoff
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        throw e; // interrupted: stop retrying, surface the remote error
-                    }
+                try {
+                    Thread.sleep(REMOTE_RETRY_BACKOFF_MS * (attempt + 1)); // linear backoff
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw e; // interrupted: stop retrying, surface the remote error
                 }
             }
         }
-        throw new AssumptionViolatedException(
-            "Remote service unavailable after " + (MAX_REMOTE_RETRIES + 1) + " attempts, skipping test: " + lastTransientError.getMessage()
-        );
+        throw new IllegalStateException("unreachable"); // loop always returns or throws
     }
 
     // True only for the two narrow remote-unavailability signatures (503 wrapper, 500 connectivity


### PR DESCRIPTION
### Description
Integration tests that call real remote inference endpoints (Bedrock, OpenAI, Cohere) intermittently fail CI when the *external service* has a transient blip — not because of any bug in ml-commons.

A triage of 93 failed CI jobs over 21 days found two recurring availability signatures:
- **3×** HTTP 503 wrapped in `CommonValue.REMOTE_SERVICE_ERROR` ("Error from remote service: ... Service Unavailable")
- **6×** HTTP 500 from `MLSdkAsyncHttpResponseHandler` ("Error communicating with remote model: Read timed out" / connection reset)

Each occurrence fails the whole CI run and typically triggers a full re-run, wasting ~35 minutes per retry.

This change adds a **retry** at `TestHelper.makeRequest` — the shared choke point for these IT calls. When a request fails with one of the two narrowly-matched remote-unavailability signatures, it is retried (up to 3 times, linear backoff of 3s/6s/9s) to ride out a momentary outage. Because these blips are transient, a retry usually lets the test run for real.

**Retry-then-fail — genuine regressions are never masked:**
- Only the two matched signatures are retried; everything else (4xx, unwrapped 5xx, assertion failures) fails immediately on the first attempt.
- If the remote stays unavailable across *every* attempt, the original `ResponseException` is re-thrown and the test **fails normally** — we do not skip. This means a bad change submitted while a remote is down still surfaces as a failure.
- 503s must carry the remote-service wrapper or a Service Unavailable phrasing; 500s must be the remote-connectivity wrapper with a timeout/connection-reset cause.

Example CI failure this addresses: https://github.com/opensearch-project/ml-commons/actions/runs/28430472024/job/85193234881

### Related Issues
Related to the CI flakiness addressed in #4851 (different failure class: that PR fixes a test-specific race; this one retries genuine transient remote-service unavailability across the suite).

### Check List
- [x] New functionality includes testing. (Change is itself test infrastructure; verified compile + spotless + existing ITs unaffected)
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
