### PR TITLE
Ignore flaky model-based guardrail IT with non-deterministic GPT-3.5 decision

### DIFF
--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGuardrailsIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGuardrailsIT.java
@@ -275,6 +275,7 @@ public class RestMLGuardrailsIT extends MLCommonsRestTestCase {
         assertFalse(((String) responseMap.get("text")).isEmpty());
     }
 
+    @Ignore
     public void testPredictRemoteModelFailedWithModelGuardrail() throws IOException, InterruptedException {
         // Skip test if key is null
         Assume.assumeNotNull(OPENAI_KEY);


### PR DESCRIPTION
### Description

`RestMLGuardrailsIT.testPredictRemoteModelFailedWithModelGuardrail` is flaky and intermittently breaks CI.

**Why it fails:** the test registers a predict model protected by a *model-based guardrail*. Unlike a local regex guardrail, this guardrail decides accept/reject by making a live GPT-3.5 call that classifies the user input. That classification is non-deterministic — for the same borderline input the guardrail model sometimes returns `reject` and sometimes does not. When it does not reject, the final predict call succeeds instead of being blocked, so the expected `guardrails triggered for user input` exception is never thrown and the test fails with `failDueToMissingException`. Because the result depends on a live LLM response we do not control, the test cannot be made reliably deterministic.

**Fix:** mark the test `@Ignore`. 
Its sibling `testPredictRemoteModelSuccessWithModelGuardrail` — which exercises the exact same model-based guardrail for the accept case — is already `@Ignore`d for the same reason(https://github.com/opensearch-project/ml-commons/pull/3465); this test `testPredictRemoteModelFailedWithModelGuardrail`was simply missed. **Ignoring it makes the two consistent.**

### Related CI failure

https://github.com/opensearch-project/ml-commons/actions/runs/28921972998/job/85801137745?pr=4874

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request created.
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR created.

By submitting this pull request, I confirm that my contribution is made under the
terms of the Apache 2.0 license.
