### PR TITLE
Disable fail-fast on CI matrix so Java 21 and 25 jobs run independently

### DIFF
--- a/.github/workflows/CI-workflow.yml
+++ b/.github/workflows/CI-workflow.yml
@@ -41,6 +41,7 @@ jobs:
   Build-ml-linux:
     needs: [Get-Require-Approval, Get-CI-Image-Tag, spotless]
     strategy:
+      fail-fast: false
       matrix:
         java: [21, 25]
 
@@ -107,6 +108,7 @@ jobs:
   Test-ml-linux-docker:
     needs: [Get-Require-Approval, Build-ml-linux, spotless]
     strategy:
+      fail-fast: false
       matrix:
         java: [21, 25]
 
@@ -203,6 +205,7 @@ jobs:
 
   Build-ml-windows:
     strategy:
+      fail-fast: false
       matrix:
         java: [21, 25]
     name: Build and Test MLCommons Plugin on Windows


### PR DESCRIPTION
### Description

GitHub Actions matrix strategies default to `fail-fast: true`, which cancels all in-progress sibling matrix jobs as soon as one fails. In our CI, `Build-ml-linux`, `Test-ml-linux-docker`, and `Build-ml-windows` all run a `java: [21, 25]` matrix — so a single flaky test failure on Java 21 cancels the Java 25 run (and vice versa), and we lose all signal for the cancelled JDK version.

This change adds `fail-fast: false` to all three matrix strategy blocks so both JDK versions always run to completion independently.

**What this changes:**
- A failure on one JDK no longer cancels the other — every CI run produces real pass/fail results for both Java 21 and Java 25
- Makes it possible to distinguish "broken on both JDKs" from "broken only on one" (or just a flake) in a single run
- Maintainers can re-run only the failed matrix leg instead of the whole workflow

**What this does NOT change:**
- Merge gating is unchanged — the workflow still fails if either JDK version fails
- No change to build logic, tests, or what runs

This matches the existing convention in this repo (`maven-publish.yml` already uses `fail-fast: false`) and in sibling plugin repos (security, flow-framework, anomaly-detection).

### Related Issues

N/A — CI-only improvement

### Check List

- [x] New functionality includes testing (N/A — CI config only)
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I agree that my contribution will be licensed under the Apache 2.0 License.
