### PR TITLE
feat: Support inline template_body in QueryPlanningTool search_templates

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
@@ -82,6 +82,7 @@ public class QueryPlanningTool implements WithModelTool {
     public static final String QUESTION_FIELD = "question";
     private static final String TEMPLATE_ID_FIELD = "template_id";
     private static final String TEMPLATE_DESCRIPTION_FIELD = "template_description";
+    private static final String TEMPLATE_BODY_FIELD = "template_body";
     public static final String INDEX_NAME_FIELD = "index_name";
     private static final int MAX_TRUNCATE_CHARS = 250;
     private static final String TRUNC_PREFIX = "[truncated]";
@@ -213,14 +214,22 @@ public class QueryPlanningTool implements WithModelTool {
                     if (templateId == null || templateId.isBlank() || templateId.equals("null")) {
                         executeQueryPlanning(parameters, listener);
                     } else {
-                        // Retrieve search template by ID
-                        GetStoredScriptRequest getStoredScriptRequest = new GetStoredScriptRequest(templateId);
-                        client.admin().cluster().getStoredScript(getStoredScriptRequest, ActionListener.wrap(getStoredScriptResponse -> {
-                            if (getStoredScriptResponse.getSource() != null) {
-                                parameters.put(TEMPLATE_FIELD, gson.toJson(getStoredScriptResponse.getSource().getSource()));
-                            }
+                        String inlineBody = findInlineTemplateBody(templateId);
+                        if (inlineBody != null) {
+                            parameters.put(TEMPLATE_FIELD, gson.toJson(inlineBody));
                             executeQueryPlanning(parameters, listener);
-                        }, e -> { listener.onFailure(e); }));
+                        } else {
+                            GetStoredScriptRequest getStoredScriptRequest = new GetStoredScriptRequest(templateId);
+                            client
+                                .admin()
+                                .cluster()
+                                .getStoredScript(getStoredScriptRequest, ActionListener.wrap(getStoredScriptResponse -> {
+                                    if (getStoredScriptResponse.getSource() != null) {
+                                        parameters.put(TEMPLATE_FIELD, gson.toJson(getStoredScriptResponse.getSource().getSource()));
+                                    }
+                                    executeQueryPlanning(parameters, listener);
+                                }, e -> { listener.onFailure(e); }));
+                        }
                     }
                 } catch (Exception e) {
                     IllegalArgumentException parsingException = new IllegalArgumentException(
@@ -415,6 +424,27 @@ public class QueryPlanningTool implements WithModelTool {
         }
     }
 
+    private String findInlineTemplateBody(String templateId) {
+        if (searchTemplates == null || templateId == null) {
+            return null;
+        }
+        List<Map<String, String>> templates = gson.fromJson(
+            gson.fromJson(searchTemplates, String.class),
+            new TypeToken<List<Map<String, String>>>() {
+            }.getType()
+        );
+        for (Map<String, String> template : templates) {
+            if (templateId.equals(template.get(TEMPLATE_ID_FIELD))) {
+                String body = template.get(TEMPLATE_BODY_FIELD);
+                if (body != null && !body.isBlank()) {
+                    return body;
+                }
+                return null;
+            }
+        }
+        return null;
+    }
+
     @Override
     public String getType() {
         return TYPE;
@@ -549,6 +579,19 @@ public class QueryPlanningTool implements WithModelTool {
             String templateDescription = template.get(TEMPLATE_DESCRIPTION_FIELD);
             if (templateDescription == null || templateDescription.isBlank()) {
                 throw new IllegalArgumentException("search_templates field entries must have a template_description");
+            }
+
+            // Validate templateBody if present — must be parseable JSON
+            String templateBody = template.get(TEMPLATE_BODY_FIELD);
+            if (templateBody != null && !templateBody.isBlank()) {
+                try {
+                    gson.fromJson(templateBody, Object.class);
+                } catch (Exception e) {
+                    throw new IllegalArgumentException(
+                        "search_templates field entry template_body must be valid JSON for template_id: " + templateId,
+                        e
+                    );
+                }
             }
         }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningTool.java
@@ -428,11 +428,9 @@ public class QueryPlanningTool implements WithModelTool {
         if (searchTemplates == null || templateId == null) {
             return null;
         }
-        List<Map<String, String>> templates = gson.fromJson(
-            gson.fromJson(searchTemplates, String.class),
-            new TypeToken<List<Map<String, String>>>() {
-            }.getType()
-        );
+        List<Map<String, String>> templates = gson
+            .fromJson(gson.fromJson(searchTemplates, String.class), new TypeToken<List<Map<String, String>>>() {
+            }.getType());
         for (Map<String, String> template : templates) {
             if (templateId.equals(template.get(TEMPLATE_ID_FIELD))) {
                 String body = template.get(TEMPLATE_BODY_FIELD);

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
@@ -1871,4 +1871,146 @@ public class QueryPlanningToolTests {
         assertNull(tool.getFallbackQuery());
     }
 
+    // --- inline template_body tests ---
+
+    @Test
+    public void testFactory_CreateWithInlineTemplateBody() {
+        String searchTemplatesJson =
+            "[{\"template_id\":\"t1\",\"template_description\":\"desc1\",\"template_body\":\"{\\\"query\\\":{\\\"match_all\\\":{}}}\"}]";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(MODEL_ID_FIELD, "test-model-id");
+        params.put(GENERATION_TYPE_FIELD, USER_SEARCH_TEMPLATES_TYPE_FIELD);
+        params.put(SEARCH_TEMPLATES_FIELD, searchTemplatesJson);
+
+        QueryPlanningTool tool = factory.create(params);
+        assertNotNull(tool);
+        assertEquals(USER_SEARCH_TEMPLATES_TYPE_FIELD, tool.getGenerationType());
+    }
+
+    @Test
+    public void testFactory_CreateWithInvalidTemplateBodyJson() {
+        String searchTemplatesJson =
+            "[{\"template_id\":\"t1\",\"template_description\":\"desc1\",\"template_body\":\"not valid json\"}]";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(MODEL_ID_FIELD, "test-model-id");
+        params.put(GENERATION_TYPE_FIELD, USER_SEARCH_TEMPLATES_TYPE_FIELD);
+        params.put(SEARCH_TEMPLATES_FIELD, searchTemplatesJson);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> factory.create(params));
+        assertTrue(exception.getMessage().contains("template_body must be valid JSON"));
+    }
+
+    @SneakyThrows
+    @Test
+    public void testRunWithInlineTemplateBody_SkipsGetStoredScript() throws ExecutionException, InterruptedException {
+        mockSampleDoc();
+        mockGetIndexMapping();
+        String matchQueryString = "{\"query\":{\"match\":{\"title\":\"wind\"}}}";
+        String templateBody = "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"category\":\"{{category}}\"}}]}}}";
+        String searchTemplatesJson =
+            "[{\"template_id\":\"inline_tpl\",\"template_description\":\"filters by category\",\"template_body\":\""
+                + templateBody.replace("\"", "\\\"")
+                + "\"}]";
+
+        // Stub: first call = template selection (returns template_id), second call = query generation
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(1);
+            listener.onResponse("inline_tpl");
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(1);
+            listener.onResponse(matchQueryString);
+            return null;
+        }).when(queryGenerationTool).run(any(), any());
+
+        QueryPlanningTool tool = new QueryPlanningTool(
+            USER_SEARCH_TEMPLATES_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            gson.toJson(searchTemplatesJson),
+            null
+        );
+
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
+
+        validParams.put(QUESTION_FIELD, "find electronics items");
+        validParams.put(INDEX_NAME_FIELD, "testIndex");
+        tool.run(validParams, listener);
+
+        actionListenerCaptor.getValue().onResponse(getIndexResponse);
+
+        String result = future.get();
+        assertEquals(matchQueryString, result);
+
+        // Verify: GetStoredScript is never called when template_body is provided
+        verify(clusterAdminClient, times(0)).getStoredScript(any(), any());
+
+        // Verify: inline body reaches the query-generation call via TEMPLATE_FIELD
+        // Index 0 = template selection call, index 1 = query generation call
+        ArgumentCaptor<Map<String, String>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(queryGenerationTool, times(2)).run(paramsCaptor.capture(), any());
+        String templateFieldValue = paramsCaptor.getAllValues().get(1).get(TEMPLATE_FIELD);
+        assertEquals(gson.toJson(templateBody), templateFieldValue);
+    }
+
+    @SneakyThrows
+    @Test
+    public void testRunWithMixedTemplates_NonInlineFallsBackToStoredScript() throws ExecutionException, InterruptedException {
+        mockSampleDoc();
+        mockGetIndexMapping();
+        String matchQueryString = "{\"query\":{\"match\":{\"title\":\"wind\"}}}";
+        // First entry has inline body, second does not
+        String searchTemplatesJson = "[{\"template_id\":\"inline_tpl\",\"template_description\":\"has body\","
+            + "\"template_body\":\"{\\\"query\\\":{\\\"match_all\\\":{}}}\"},"
+            + "{\"template_id\":\"stored_tpl\",\"template_description\":\"no body\"}]";
+
+        // Mock stored script retrieval for the non-inline template
+        doAnswer(invocation -> {
+            ActionListener<GetStoredScriptResponse> actionListener = invocation.getArgument(1);
+            GetStoredScriptResponse getStoredScriptResponse = mock(GetStoredScriptResponse.class);
+            StoredScriptSource storedScriptSource = mock(StoredScriptSource.class);
+            when(getStoredScriptResponse.getSource()).thenReturn(storedScriptSource);
+            when(storedScriptSource.getSource()).thenReturn("{\"query\":{\"term\":{\"status\":\"active\"}}}");
+            actionListener.onResponse(getStoredScriptResponse);
+            return null;
+        }).when(clusterAdminClient).getStoredScript(any(), any());
+
+        // LLM selects the non-inline template, then generates query
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(1);
+            listener.onResponse("stored_tpl");
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(1);
+            listener.onResponse(matchQueryString);
+            return null;
+        }).when(queryGenerationTool).run(any(), any());
+
+        QueryPlanningTool tool = new QueryPlanningTool(
+            USER_SEARCH_TEMPLATES_TYPE_FIELD,
+            queryGenerationTool,
+            client,
+            gson.toJson(searchTemplatesJson),
+            null
+        );
+
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        ActionListener<String> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
+
+        validParams.put(QUESTION_FIELD, "find active items");
+        validParams.put(INDEX_NAME_FIELD, "testIndex");
+        tool.run(validParams, listener);
+
+        actionListenerCaptor.getValue().onResponse(getIndexResponse);
+
+        String result = future.get();
+        assertEquals(matchQueryString, result);
+
+        // Verify: GetStoredScript IS called when the selected template has no inline body
+        verify(clusterAdminClient, times(1)).getStoredScript(any(), any());
+    }
+
 }

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/QueryPlanningToolTests.java
@@ -1890,8 +1890,7 @@ public class QueryPlanningToolTests {
 
     @Test
     public void testFactory_CreateWithInvalidTemplateBodyJson() {
-        String searchTemplatesJson =
-            "[{\"template_id\":\"t1\",\"template_description\":\"desc1\",\"template_body\":\"not valid json\"}]";
+        String searchTemplatesJson = "[{\"template_id\":\"t1\",\"template_description\":\"desc1\",\"template_body\":\"not valid json\"}]";
 
         Map<String, Object> params = new HashMap<>();
         params.put(MODEL_ID_FIELD, "test-model-id");


### PR DESCRIPTION
### Description

#### Problem

The `user_templates` generation mode ([PR #4154](https://github.com/opensearch-project/ml-commons/pull/4154)) retrieves template sources via `GET _scripts/{template_id}` after LLM-based template selection. In environments where the Stored Scripts API is unavailable — Amazon OpenSearch Serverless being a notable example — this call fails (404), breaking the `user_templates` flow.

OpenSearch's Search Template API already supports inline template sources (`POST /_search/template` with `"source": {...}`), but QueryPlanningTool has no equivalent inline path.

#### Change

Added an optional `template_body` field to `search_templates` entries. When present, the inline body is passed directly to the query-generation LLM call without calling `GetStoredScript`. Entries without `template_body` continue to use the stored-script path.

| Path | Behavior |
|------|----------|
| `template_body` present | Use inline body directly (no `_scripts` call) |
| `template_body` absent | Retrieve from `_scripts` as before |

Changes in `QueryPlanningTool.java`:
- `findInlineTemplateBody()`: looks up inline body by template_id from the registered search_templates
- Template selection listener: checks for inline body before falling back to `GetStoredScript`
- `validateTemplateFields()`: validates `template_body` is parseable JSON when present

#### Usage

Register a flow agent with inline template body (no `_scripts` registration required):

```json
POST /_plugins/_ml/agents/_register
{
  "name": "Agentic Search with inline templates",
  "type": "flow",
  "tools": [
    {
      "type": "QueryPlanningTool",
      "parameters": {
        "model_id": "your_model_id",
        "generation_type": "user_templates",
        "search_templates": [
          {
            "template_id": "category_filter",
            "template_description": "Filter products by category and price range using bool filter",
            "template_body": "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"category\":\"{{category}}\"}},{\"range\":{\"price\":{\"lte\":{{max_price}}}}}]}}}"
          },
          {
            "template_id": "text_search",
            "template_description": "Full-text search on title and description"
          }
        ]
      }
    }
  ]
}
```

In this example, `category_filter` uses the inline body directly, while `text_search` (no `template_body`) falls back to `GET _scripts/text_search`.

### Related Issues

Resolves #4901

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
