### PR TITLE
Revert "docs: Add jiapingzeng as maintainer (#4906)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @b4sjoo @dhrubo-os @mingshl @jngz-es @jiapingzeng @model-collapse @rbhavna @ylwu-amzn @zane-neo @Zhangxunmt @austintlee @HenryL27 @sam-herman @xinyual @pyek-bot @rithinpullela @akolarkunnu
+*   @b4sjoo @dhrubo-os @mingshl @jngz-es @model-collapse @rbhavna @ylwu-amzn @zane-neo @Zhangxunmt @austintlee @HenryL27 @sam-herman @xinyual @pyek-bot @rithinpullela @akolarkunnu

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Charlie Yang         | [model-collapse](https://github.com/model-collapse) | Amazon    |
 | Dhrubo Saha          | [dhrubo-os](https://github.com/dhrubo-os)           | Amazon    |
 | Jing Zhang           | [jngz-es](https://github.com/jngz-es)               | Amazon    |
-| Jiaping Zeng         | [jiapingzeng](https://github.com/jiapingzeng)       | Amazon    |
 | Junshen Wu           | [wujunshen](https://github.com/wujunshen)           | Amazon    |
 | Sicheng Song         | [b4sjoo](https://github.com/b4sjoo)                 | Amazon    |
 | Mingshi Liu          | [mingshl](https://github.com/mingshl)               | Amazon    |


### PR DESCRIPTION
This reverts commit 4bcf0439c31a5c578a3986a4fcae8ca61f172be0.

Will raise another PR to wait for LF approval to add jiaping as a maintainer 

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
