### PR TITLE
Memory Retention

### DIFF
--- a/AUDIT_FIXES.md
+++ b/AUDIT_FIXES.md
@@ -1,0 +1,385 @@
+# Memory Retention RFC — Audit Fixes
+
+These are the confirmed issues from a 20-agent adversarial audit of the
+`feature/memory-retention/rfc-implementation` branch that should be fixed
+before ship.
+
+---
+
+## 1. RetentionRule explicit-null field removal doesn't persist
+
+**Problem:**
+
+When a user sends an update to remove a retention limit (e.g.,
+`{"retention_policy": {"sessions": {"max_count": null}}}`), the in-memory
+merge correctly sets `max_count` to null. But `RetentionRule.toXContent()`
+only emits non-null fields, so the serialized update doc omits `max_count`
+entirely. OpenSearch's partial-update merge then preserves the stored value,
+and the retention job keeps enforcing a cap the user explicitly removed.
+
+**Solution:**
+
+In `RetentionRule.toXContent()`, emit explicit null fields when the field was
+explicitly cleared. We need to propagate the `retentionDaysExplicitlySet` and
+`maxCountExplicitlySet` flags through the merge (or alternatively, always
+replace the entire `retention_policy` object in the update doc rather than
+relying on recursive partial merge).
+
+The simplest fix: after the merge in `MemoryConfiguration.update()`, when
+constructing the merged RetentionRule, preserve the "explicitly set" flags so
+`toXContent()` can emit `builder.nullField(...)` for cleared fields. The
+pattern already exists in the same file for the whole-policy opt-out:
+
+```java
+} else if (retentionPolicyExplicitlyNull) {
+    builder.nullField(RETENTION_POLICY_FIELD);
+}
+```
+
+Apply the same pattern per-field inside `RetentionRule.toXContent()`.
+
+**Files to modify:**
+- `common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java`
+  - Add logic to `toXContent()` to emit `nullField` when explicitly cleared
+  - May need to carry the explicitlySet flags through the merge
+- `common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java`
+  - In the retention policy merge (around line 685), ensure the constructed
+    merged RetentionRule preserves explicit-set metadata
+
+---
+
+## 2. ModelGuardrail timeout: set back to 5 seconds
+
+**Problem:**
+
+`ML_GUARDRAIL_TIMEOUT_IN_SECONDS` was raised from 5s to 60s. Combined with
+fail-closed semantics (`isAccepted` defaults to false), a hung guardrail model
+pins every ML predict thread for 60s then rejects — causing thread-pool
+starvation of the `opensearch_ml_predict_remote` pool under moderate load.
+
+**Solution:**
+
+Change the constant back to 5 seconds:
+
+```java
+public static final long ML_GUARDRAIL_TIMEOUT_IN_SECONDS = 5;
+```
+
+**File to modify:**
+- `common/src/main/java/org/opensearch/ml/common/model/ModelGuardrail.java` (line 56)
+
+---
+
+## 3. Session max_count eviction: add count short-circuit
+
+**Problem:**
+
+`identifyCountBasedExpiredSessions` → `identifyCountBasedPage` enumerates ALL
+non-pinned sessions at 100/page (sorted created_time DESC), counting until it
+passes `maxCount`. A container with 100k sessions and max_count=100k issues
+1,000 sequential search requests per run to delete nothing.
+
+The long-term (`executeLongTermMaxCount`) and history paths already have a
+`size(0)/trackTotalHits` pre-count that short-circuits when total <= maxCount.
+The session path is missing this.
+
+**Solution:**
+
+Mirror the pattern from `executeLongTermMaxCount` (line 870):
+
+1. First: do a `size(0), trackTotalHits(true)` count query for non-pinned
+   sessions in this container
+2. If `totalCount <= maxCount`: return empty set immediately (no excess)
+3. If `totalCount > maxCount`: compute `excess = totalCount - maxCount`, then
+   use `collectOldestDocIds(sessionIndex, containerId, CREATED_TIME_FIELD, excess, ...)`
+   to fetch only the excess oldest session IDs
+
+This replaces the current `identifyCountBasedPage` approach entirely for
+sessions, making it consistent with LT and history.
+
+**Files to modify:**
+- `plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java`
+  - Replace `identifyCountBasedExpiredSessions` / `identifyCountBasedPage`
+    with the count-first pattern
+
+---
+
+## 4. Orphan sweep: O(total docs) enumeration → O(unique sessions)
+
+**Problem:**
+
+`enumerateSessionIdsFromWorkingMemory()` pages through every working-memory
+document in the container (at 1000 docs/page) to extract distinct
+`namespace.session_id` values. For 5M working-memory messages across 2,000
+sessions, this is 5,000 sequential search requests.
+
+The `namespace` field is mapped as `flat_object` in `ml_memory_working.json`
+(line 42-44). `flat_object` does NOT support terms aggregations or field
+collapsing, so we cannot simply do `collapse("namespace.session_id")` or a
+composite aggregation.
+
+**Solution — add a top-level `session_id` keyword field:**
+
+The cleanest fix is to denormalize `session_id` into a top-level keyword field
+on working-memory documents, enabling efficient aggregation/collapse.
+
+### Step 1: Add field to index mapping
+
+In `common/src/main/resources/index-mappings/ml_memory_working.json`:
+
+```json
+"session_id": {
+  "type": "keyword"
+}
+```
+
+### Step 2: Populate on write
+
+In `TransportAddMemoriesAction.java`, where working memory documents are
+indexed, the session_id is already available from
+`input.getNamespace().get(SESSION_ID_FIELD)`. Add it as a top-level field in
+the index request source alongside `namespace`.
+
+### Step 3: Use composite/terms aggregation in orphan sweep
+
+Replace `enumerateSessionIdsFromWorkingMemory()` with a composite aggregation:
+
+```java
+CompositeAggregationBuilder agg = new CompositeAggregationBuilder("session_ids",
+    List.of(new TermsValuesSourceBuilder("sid").field("session_id")))
+    .size(ORPHAN_SESSION_BATCH_SIZE);
+```
+
+Page through the composite aggregation using `after_key` — each page returns
+up to 1000 unique session IDs directly, with cost proportional to unique
+sessions, not total documents.
+
+### Step 4: Update queries
+
+The orphan sweep queries (`cascadeDeleteWorkingMemory`,
+`deleteOrphanedWorkingMemory`, etc.) currently filter on
+`namespace.session_id`. Update them to use the top-level `session_id` field
+for better performance (keyword vs flat_object subpath).
+
+### Backward compatibility note
+
+Existing working-memory documents won't have the new `session_id` field. The
+orphan sweep should fall back to the current `namespace.session_id` exists
+query for documents missing the top-level field, or run a one-time backfill.
+Alternatively, accept that pre-upgrade orphans use the old (slower) path until
+they're naturally cleaned up.
+
+**Files to modify:**
+- `common/src/main/resources/index-mappings/ml_memory_working.json`
+- `plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java`
+- `plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java`
+  (enumerateSessionIdsFromWorkingMemory, cascadeDeleteWorkingMemory,
+  deleteOrphanedWorkingMemory)
+
+---
+
+## 5. Orphan sweep: ORPHAN_SESSION_ID_CAP never advances across runs
+
+**Problem:**
+
+The orphan enumeration always starts from `searchAfter=null` sorted `_id ASC`
+and stops at 50k unique session IDs. If the first 50k in _id order are all
+live sessions, orphaned working memory beyond the cap is never examined on any
+subsequent run.
+
+**Solution:**
+
+Randomize the sort key so each run starts from a different position in the
+keyspace. Over multiple runs, all regions are probabilistically covered.
+
+Replace:
+```java
+.sort("_id", SortOrder.ASC)
+```
+
+With a random score sort (or rotate based on run count):
+```java
+.sort(SortBuilders.scriptSort(
+    new Script(ScriptType.INLINE, "painless",
+        "doc['_id'].value.hashCode() ^ params.seed", Map.of("seed", System.currentTimeMillis())),
+    ScriptSortBuilder.ScriptSortType.NUMBER))
+```
+
+Alternatively (simpler): use a hash of (container_id + run_timestamp) as a
+prefix filter or sort tiebreaker so each run covers a different slice.
+
+Also update the log message from "Remaining orphans will be caught on next
+run" to "Remaining orphans will be covered in future runs" since coverage is
+now probabilistic rather than guaranteed-next-run.
+
+If the fix in #4 above (composite aggregation on top-level session_id) is
+implemented, this cap becomes much less likely to be hit since enumeration
+cost drops by orders of magnitude and the cap could be raised significantly.
+
+**Files to modify:**
+- `plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java`
+  (enumerateSessionIdsFromWorkingMemory)
+
+---
+
+## 6. Unconditional 5s throttle between containers → throttle only after deletions
+
+**Problem:**
+
+`scheduleNext()` delays 5 seconds after EVERY container, including containers
+that needed zero work. At 10k containers × 5s = ~14 hours of pure sleep per
+run, potentially exceeding the 24h job interval.
+
+**Solution:**
+
+Only throttle after containers where deletions actually occurred. Containers
+that were skipped (opt-out, no policy, no expired data, backfill-only) should
+proceed immediately to the next container.
+
+Change `processContainer` to track whether any deletions happened and pass
+that to the chain:
+
+```java
+private void processContainer(SearchHit hit, ActionListener<Boolean> listener) {
+    // ... existing logic ...
+    // listener.onResponse(true) when deletions occurred
+    // listener.onResponse(false) when no deletions (skip, opt-out, etc.)
+}
+
+private void processContainerChain(SearchHit[] hits, int index, Object[] nextPageSortValues) {
+    if (index >= hits.length) { ... }
+
+    processContainer(hits[index], ActionListener.wrap(hadDeletions -> {
+        if (hadDeletions) {
+            scheduleNext(hits, index + 1, nextPageSortValues);
+        } else {
+            // No deletions — proceed immediately
+            processContainerChain(hits, index + 1, nextPageSortValues);
+        }
+    }, e -> {
+        log.error(...);
+        processContainerChain(hits, index + 1, nextPageSortValues);
+    }));
+}
+```
+
+This means a run over 10k containers where only 50 have expired data takes
+~250s of throttle instead of ~14 hours.
+
+**Files to modify:**
+- `plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java`
+  (processContainer, processContainerChain, executeRetentionPipeline)
+
+---
+
+## 7. Test coverage gaps (6 items)
+
+These are the critical test gaps that leave data-safety paths unprotected
+against regressions. Each can be a separate test method.
+
+### 7a. applyDefaultRetentionPolicy — painless backfill script
+
+Test that:
+- When cluster defaults are configured (>0) and container has no policy, the
+  conditional script update is issued
+- When the script returns NOOP (user set policy concurrently), the container
+  is skipped (no deletions run)
+- When the script succeeds, executeRetentionPipeline runs with the backfilled
+  policy
+- When all defaults are -1, no update is issued
+
+### 7b. Epoch-second normalization
+
+Test that:
+- A session with `last_updated_time` in epoch seconds (e.g., 1752400000) that
+  is newer than the retention cutoff when normalized is NOT deleted
+- A session with `last_updated_time` in epoch millis that IS older than the
+  cutoff IS deleted
+- A session with missing/unparseable last_updated_time is SKIPPED (not deleted)
+
+### 7c. buildEpochAwareCutoffQuery structure
+
+Assert that the delete-by-query for long-term and working-memory includes both
+range clauses (gte threshold + lt cutoff; lt secondsScaleCutoff) and
+minimumShouldMatch=1. A mutation to plain lt(cutoffMillis) should fail the
+test.
+
+### 7d. retention_policy:null opt-out in processor
+
+Test that a container with `"retention_policy": null` in source triggers no
+searches, no deletes, and no default-policy backfill update.
+
+### 7e. Non-content updates don't bump last_updated_time
+
+Test that updating only `pinned`, `tags`, `metadata`, or `additional_info` on
+a session does NOT include `last_updated_time` in the indexed doc. A mutation
+making `shouldBumpLastUpdatedTime` always return true should fail.
+
+### 7f. Session last_updated_time bump on add-memories
+
+Test that:
+- Adding a message to an existing session issues a client.update with
+  LAST_UPDATED_TIME_FIELD
+- Adding a message to a newly created session does NOT issue the bump (session
+  was just created with current time)
+- The bump failure does not fail the add-memories response
+
+**Files to modify:**
+- `plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java`
+- `plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java`
+- `plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java`
+
+---
+
+## 8. Add document IDs to retention job logs at DEBUG level
+
+**Decision context:**
+
+Retention deletions are recorded in job logs only (no audit index, no records
+written into the agent's history index — that would pollute the prompt
+pipeline and create recursive-retention problems). The existing INFO-level
+aggregate counts stay unchanged. We're adding DEBUG-level lines that show
+WHICH documents were deleted, so an operator investigating "what disappeared"
+can raise the log level and trace specific IDs.
+
+**Rules:**
+
+- INFO lines (aggregate counts) stay exactly as they are
+- NO memory content in logs at any level — IDs and criteria only (content may
+  contain PII/credentials)
+- Guard each new line with `if (log.isDebugEnabled())` (or rely on log4j2
+  parameterized-message laziness for cheap args; use the explicit guard where
+  building the message involves collection formatting)
+- Do NOT add extra search requests just to obtain IDs for logging. Log IDs
+  where the code already holds them; log the deletion criteria where it
+  doesn't (delete-by-query paths).
+
+**Where to add DEBUG lines in `MemoryRetentionJobProcessor.java`:**
+
+ID-based paths (we already hold the exact IDs — log them):
+- `deleteSessionBatch` / session deletion: log the expired session IDs per
+  batch, e.g. `container={} deleting session ids={}`
+- `deleteDocumentsBatchRecursive` (used by long-term max_count and history
+  max_count): log the doc IDs per batch with the index name
+
+Delete-by-query paths driven by known session-ID batches (log the batch):
+- `cascadeDeleteBatch` (working memory cascade): log the session-ID batch
+  driving the DBQ
+- `deleteOrphanBatch` (orphaned working memory): log the orphan session-ID
+  batch
+
+Pure criteria-based delete-by-query paths (no IDs available — log criteria,
+do NOT pre-fetch IDs):
+- `executeLongTermRetentionDays`: log index + cutoffMillis
+- `executeWorkingMemoryTTL`: log index + cutoffMillis
+- `deleteEmptyNamespaceWorkingMemory`: log index + cutoffMillis
+
+Log quantity is not a concern; do not truncate the ID lists.
+
+**Test:** add one test asserting a DEBUG deletion-IDs line is emitted for the
+session-deletion path (e.g., via a log appender capture), and that the INFO
+aggregate line is unchanged.
+
+**Files to modify:**
+- `plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java`
+- `plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java`

--- a/DESIGN_DOC.md
+++ b/DESIGN_DOC.md
@@ -127,7 +127,7 @@ There is no deletion job, no TTL field, and no retention configuration anywhere 
 │    5. History   → delete over-count only, skip pinned               │
 │    6. WM TTL    → (disableSession only) delete old working memory   │
 │    7. Orphan    → sweep orphaned working memory (once per job run)  │
-│    8. Throttle  → pause 5s before next container                    │
+│    8. Throttle  → pause 5s before next container (only if deleted)  │
 │                                                                     │
 │  Deletion: _delete_by_query (throttled, idempotent)                 │
 └─────────────────────────────────────────────────────────────────────┘
@@ -356,6 +356,8 @@ When a customer updates a retention policy via the PUT API, **field-level merge*
 Example: current policy is `"sessions": {"retention_days": 60, "max_count": 500}`. Customer sends `{"sessions": {"max_count": 350}}`. Result is `"sessions": {"retention_days": 60, "max_count": 350}` — `retention_days` is unchanged because it was not in the request.
 
 To remove `retention_days`: send `{"sessions": {"retention_days": null, "max_count": 350}}`.
+
+**Implementation detail:** When a field is explicitly set to null, `RetentionRule.toXContent()` emits `builder.nullField(fieldName)` so the partial-update merge correctly removes the stored value. Without this, omitting a field from the serialized update document would leave the old value intact (OpenSearch's partial merge preserves unmentioned fields). The `retentionDaysExplicitlySet` and `maxCountExplicitlySet` flags track whether the null was explicit (user intent to remove) vs. simply absent (user didn't mention the field — preserve current value).
 
 Types not included in the update request are left unchanged. The PUT response **always returns the full resulting retention_policy** so the developer can verify the final state.
 
@@ -705,9 +707,10 @@ FOR each memory container WHERE retention_policy IS NOT NULL:
     IF expired_session_ids is not empty:
         _delete_by_query working_index WHERE:
             memory_container_id = {id}
-            AND namespace.session_id IN [expired_session_ids]
+            AND (session_id IN [expired_session_ids]    // top-level keyword
+                 OR namespace.session_id IN [expired_session_ids])  // legacy flat_object
         // No pinned check — working memory does not support pinning
-        // NOTE: namespace is a flat_object; use termQuery("namespace.session_id", id)
+        // Uses buildSessionIdMatchQuery(): should(terms(session_id), terms(namespace.session_id)) minimumShouldMatch(1)
     
     // Phase 3: Delete the session documents themselves
     IF expired_session_ids is not empty:
@@ -747,7 +750,10 @@ FOR each memory container WHERE retention_policy IS NOT NULL:
         // working_memory_ttl_days is a cluster setting (default 30d), always present
     
     LOG deletion counts per type (including cascade working memory count)
-    PAUSE {throttle_interval} seconds (use threadPool.schedule(), not Thread.sleep())
+    IF any deletions occurred in this container:
+        PAUSE {throttle_interval} seconds (use threadPool.schedule(), not Thread.sleep())
+    ELSE:
+        Proceed immediately to next container (no throttle for no-op containers)
     // Then invoke next container via recursive callback (see note below)
 
 // Phase 7: Orphan Sweep (runs once per full job, not per-container)
@@ -756,22 +762,31 @@ FOR each memory container WHERE disableSession = false:
     sessions_index = container.configuration.getIndexName(MemoryType.SESSIONS)
     
     // Find working memory pointing to non-existent sessions.
-    // NOTE: namespace is a flat_object. Composite aggregation on flat_object sub-fields
-    // may not work reliably. Use paginated scroll search instead:
-    SCROLL SEARCH working_index WHERE memory_container_id = {id}
-        → extract distinct namespace.session_id values (deduplicate in memory)
-    MULTI-GET those session IDs against sessions_index (batched, 1000 per request)
+    // Uses a paged composite aggregation on the top-level session_id keyword field
+    // (namespace is flat_object and cannot be aggregated). Enumeration starts at a
+    // random keyspace position each run and wraps around, so the 50K cap truncates
+    // a different slice each run for probabilistic full coverage.
+    start_key = randomEnumerationStartKey()
+    COMPOSITE AGGREGATION on session_id field, starting at start_key, wrap around
+        → collect distinct session_id values (up to ORPHAN_SESSION_ID_CAP = 50,000)
+    // Legacy fallback: for pre-upgrade docs without top-level session_id:
+    SEARCH_AFTER on docs WHERE namespace.session_id EXISTS AND session_id NOT EXISTS
+        → extract namespace.session_id values, same random-start wrap-around pattern
+    
+    CHECK session existence via batched termsQuery("_id", batch) (1000 per request)
     orphan_ids = session IDs that returned NOT FOUND
     IF orphan_ids is not empty:
         _delete_by_query working_index WHERE:
             memory_container_id = {id}
-            AND namespace.session_id IN [orphan_ids]
+            AND (session_id IN [orphan_ids] OR namespace.session_id IN [orphan_ids])
     
     // Find working memory with no session_id at all (shouldn't exist, but can
     // from partial writes — grace period allows incomplete writes to be finished)
     _delete_by_query working_index WHERE:
         memory_container_id = {id}
-        AND (namespace.session_id IS NULL OR namespace IS NULL)
+        AND session_id NOT EXISTS
+        AND namespace.session_id NOT EXISTS
+        AND namespace.user_id NOT EXISTS AND namespace.agent_id NOT EXISTS
         AND created_time < (now - orphan_ttl_days)  // configurable, default 7d
         // 7-day grace: gives partially-written documents time to have session_id
         // set in a subsequent update before being treated as orphans
@@ -779,13 +794,13 @@ FOR each memory container WHERE disableSession = false:
 RELEASE lock (note: due to async execution, lock is actually released before work completes — see §6.4.1)
 ```
 
-**Implementation note (post-coding):** The orphan sweep uses `search_after` pagination (NOT scroll API) to enumerate distinct `namespace.session_id` values from working memory. Scroll was rejected due to memory pressure at scale — it holds open a search context for the duration. A 50,000 session_id cap prevents OOM on pathological containers; remaining orphans are caught on subsequent job runs.
+**Implementation note (post-coding):** The orphan sweep uses a paged composite aggregation on the top-level `session_id` keyword field (added to the `ml_memory_working` index mapping) to enumerate distinct session IDs at O(unique sessions) cost. The `namespace` field is `flat_object` and does not support aggregations, which is why the top-level field was denormalized. A legacy fallback enumerates pre-upgrade documents (lacking the top-level field) via `search_after` pagination on `namespace.session_id`. Enumeration starts from a per-run random keyspace position and wraps around so the 50,000 session-ID cap truncates a different slice each run (probabilistic full coverage). Scroll was rejected due to memory pressure at scale — it holds open a search context for the duration.
 
 Session existence checking uses batched `termsQuery("_id", batch)` against the sessions index (NOT MultiGetRequest). This is simpler and uses the same `client.search()` pattern as the rest of the job, avoiding additional API surface imports.
 
 **Note on `max_count` implementation:** `_delete_by_query` does not support "delete the N oldest documents." Instead, the job performs a two-step operation: (1) SEARCH with sort + size to identify the document IDs that exceed the cap, then (2) BULK DELETE those specific IDs. This means a partial failure during step 2 leaves some over-cap documents until the next run (safe — idempotent).
 
-**Note on async container iteration:** Since all OpenSearch operations use async `ActionListener` callbacks, the container loop is NOT a synchronous for-loop. Instead, it uses a recursive continuation-passing pattern: container N's final `ActionListener` success callback invokes `threadPool.schedule(throttleDelay, () -> processContainer(N+1, containerList, ...))`. This ensures the throttle pause actually separates work between containers. The pattern is similar to `StepListener` chaining or `ActionListener.wrap()` used elsewhere in the codebase.
+**Note on async container iteration:** Since all OpenSearch operations use async `ActionListener` callbacks, the container loop is NOT a synchronous for-loop. Instead, it uses a recursive continuation-passing pattern: container N's `processContainer` reports whether deletions occurred via `ActionListener<Boolean>`. If `true`, the callback invokes `threadPool.schedule(throttleDelay, () -> processContainerChain(N+1, ...))`. If `false` (no deletions — opt-out, no policy, no expired data, backfill-only), it recurses immediately without scheduling a delay. This conditional throttle ensures the pause only applies where needed while preserving cluster courtesy.
 
 **Note on cascade batching:** If thousands of sessions expire simultaneously (e.g., first-time policy on a container with years of history), the `terms` query in Phase 2 (cascade) must batch `expired_session_ids` into groups of 500–1000 per `_delete_by_query` request to stay within the max clause count (default 1024).
 
@@ -819,7 +834,7 @@ The orphan sweep (Phase 7) is a safety net that catches any edge cases where wor
 |-----------------|---------|-------|-------------|
 | `plugins.ml_commons.memory.retention_enabled` | `true` | true/false | Master kill switch — when false, the retention job skips execution entirely. Allows emergency disable without code rollback or policy removal. |
 | `plugins.ml_commons.memory.retention_job_interval` | `24h` | 1h–168h | How often the job runs |
-| `plugins.ml_commons.memory.retention_job_throttle` | `5s` | 1s–60s | Pause between processing containers |
+| `plugins.ml_commons.memory.retention_job_throttle` | `5s` | 1s–60s | Pause between containers where deletions occurred (no-op containers proceed immediately) |
 | `plugins.ml_commons.memory.orphan_ttl_days` | `7` | 1–365 | Age threshold for deleting working memory with no `session_id` |
 | `plugins.ml_commons.memory.working_memory_ttl_days` | `30` | 1–365 | TTL for working memory when `disableSession=true` (age-based, using `created_time`) |
 | `plugins.ml_commons.memory.default_session_retention_days` | `90` | 1–3650 | Default `retention_days` for sessions when auto-applying |
@@ -865,7 +880,7 @@ Total run summary at job completion:
 
 #### 6.5.2 Relationship Model
 
-- `MLWorkingMemory` stores a `session_id` in its `namespace` map (a `flat_object` field in the index mapping). Every working memory entry belongs to a session. Queried via `termQuery("namespace.session_id", sessionId)`.
+- `MLWorkingMemory` stores a `session_id` in its `namespace` map (a `flat_object` field in the index mapping) and also in a denormalized top-level `session_id` keyword field (populated on write by `TransportAddMemoriesAction`). Every working memory entry belongs to a session. Queries use a `should` matching both `session_id` (top-level keyword) and `namespace.session_id` (flat_object, for pre-upgrade backward compatibility).
 - `MLLongTermMemory` does not structurally depend on sessions. It is distilled knowledge that outlives sessions.
 - `MLMemoryHistory` is never cascaded.
 
@@ -1241,12 +1256,12 @@ ml-commons routes operations through `SdkClient` — an abstraction that switche
 | **Write latency** | Zero — no write-time eviction, no write-path changes |
 | **Background job** | Throttled by design; runs off-peak; configurable interval |
 | **Cluster resources** | `_delete_by_query` generates merge load; mitigated by inter-container pause and request throttling |
-| **Orphan sweep** | Paginated scroll search + multi-get per container — read-heavy; cost scales with number of distinct session_ids in working memory index. Note: `namespace` is a `flat_object` — composite aggregation may not work on sub-fields, so scroll-based extraction is used instead. |
+| **Orphan sweep** | Paged composite aggregation on top-level `session_id` keyword field + batched existence checks per container. Cost scales with unique session IDs (not total documents). A legacy `search_after` fallback handles pre-upgrade documents lacking the top-level field; its cost shrinks to zero as legacy documents are cleaned up. |
 
 ### 8.2 Scalability
 
 - Job runtime scales linearly with number of containers that have policies
-- With a 5-second throttle between containers, the job can process ~17,000 containers per 24-hour interval. For clusters with fewer than 1,000 containers (expected v1 scale), the job completes well within one interval.
+- With conditional throttling (5 seconds only after containers where deletions occurred), total job runtime is proportional to the number of active-deletion containers, not total containers. A cluster with 10,000 containers where only 50 have expired data takes ~250s of throttle. Expected v1 scale is under 1,000 containers, so the job completes well within one interval.
 - If a run cannot complete within one interval, the next scheduled run either waits for the lock or runs concurrently (safe — all operations are idempotent). The job processes all containers from scratch each run; there is no resumption from a partial run.
 - No index-per-policy — retention metadata lives on container documents
 - `_delete_by_query` is batch-efficient (handles thousands of deletions per sweep)
@@ -1282,8 +1297,10 @@ The system degrades gracefully: if the job stops running entirely, the only cons
 
 ### 8.6 Observability
 
-- **Logging:** Per-container deletion counts at INFO level; errors at WARN/ERROR
-- **Orphan sweep logging:** Logs orphaned working memory counts per container
+- **INFO logging:** Per-container aggregate deletion counts (sessions, cascade WM, long-term, history, orphans). Unchanged across operations — suitable for dashboards and alerting.
+- **DEBUG logging:** Per-batch document IDs for bulk-delete paths (session deletion, max_count eviction); session-ID batches for cascade/orphan delete-by-query paths; index + cutoff criteria for time-based DBQ paths. No memory content at any level — IDs and criteria only. Operators investigating "what disappeared" can raise the log level and trace specific IDs.
+- **WARN logging:** Pinned count exceeds `max_count`; partial delete failures; orphan sweep cap reached.
+- **Orphan sweep logging:** Logs orphaned working memory counts per container.
 - **Metrics (future):** Total documents deleted per run, job duration, containers processed, errors — exposed via ml-commons stats API
 
 ---
@@ -1397,7 +1414,7 @@ Longer-term enhancements not planned for immediate iterations:
 | 10 | Orphan sweep | 2026-06-15 | Ignore orphans vs. active cleanup | Active cleanup | Safety net for edge cases; low cost since it runs once per job |
 | 11 | Dry-run preview | 2026-06-15 | Include vs. defer | Defer (not in v1 scope) | Scope reduction; can be added later without design changes |
 | 12 | `disableSession=true` working memory | 2026-06-15 | Leave forever vs. age-based TTL | Age-based TTL via `created_time` | No session to cascade from — need independent cleanup |
-| 13 | Orphan sweep approach | 2026-06-16 | Composite aggregation vs. scroll search | Scroll search + multi-get | `namespace` is a `flat_object`; composite aggregation on flat_object sub-fields is unreliable. Scroll is simpler and has no codebase precedent gap. |
+| 13 | Orphan sweep approach | 2026-06-16 | Composite aggregation vs. scroll search | **Revised: composite aggregation on denormalized top-level `session_id` keyword field** | Original decision was scroll search because `namespace` is `flat_object`. Final implementation adds a top-level `session_id` keyword field to `ml_memory_working.json` (populated on write), enabling efficient composite aggregation. Legacy fallback via `search_after` handles pre-upgrade docs. Randomized start-key ensures 50K cap covers different keyspace slices across runs. |
 | 14 | Job registration timing | 2026-06-16 | Lazy (on first container) vs. startup | Startup (via MLCommonsClusterEventListener) | Follows STATS_COLLECTOR pattern. Avoids complex first-use registration logic. Job no-ops if no containers have policies. |
 | 15 | Lock and concurrency model | 2026-06-16 | Fix lock duration vs. accept idempotent concurrent execution | Accept idempotent execution | MLJobProcessor releases lock before async work completes. Fixing requires refactoring shared infra. All retention operations are idempotent by design, so concurrent execution is safe. |
 | 16 | Native Client vs. SdkClient | 2026-06-16 | Use SdkClient abstraction vs. native Client | Native Client | SdkClient lacks _delete_by_query, scroll, _mget. Follow MemoryContainerHelper.deleteDataByQuery() pattern. Multi-tenancy explicitly unsupported. |

--- a/DESIGN_DOC.md
+++ b/DESIGN_DOC.md
@@ -1,0 +1,1428 @@
+# Agentic Memory Retention Policy — Design Document
+
+| Field | Value |
+|-------|-------|
+| **Author** | ballewer (Erfan) |
+| **Reviewers** | Nathalie, Mingshi (mentor) |
+| **SDM** | Yaliang |
+| **Status** | In Progress |
+| **Last Updated** | 2026-07-10 |
+| **RFC** | opensearch-project/ml-commons #4859 |
+
+---
+
+## 1. Executive Summary
+
+This project adds a **retention policy** to the OpenSearch ml-commons agentic memory framework. Customers configure per-memory-type rules (`retention_days` and/or `max_count`) on memory containers for sessions and long-term memory, and `max_count` for history. A background Job Scheduler job enforces these rules by periodically deleting expired or over-count memories. Working memory is not independently managed — it is deleted exclusively via cascade when its parent session expires (working memory deleted first, then session — preserving conversation integrity and preventing orphans). An orphan sweep catches working memory that points to non-existent sessions. Individual memories can be marked `pinned: true` to exempt them from eviction.
+
+**Key design decisions:**
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Eviction policy | Option A — Container-Level Retention Policy | Simple, industry-standard time + count. FIFO eviction. ~3–4 weeks. |
+| Deletion mechanism | Option X — Fixed-Interval Job Scheduler | Single background job; zero read/write-path changes. |
+| Query-time filtering | Not included | Staleness window accepted. Reduces complexity. |
+| History | Included — `max_count` only | Bounded storage without compromising audit integrity. |
+| Pinned memories | Day-one feature | Customers need per-document eviction exemption. |
+
+All alternatives evaluated (Options A/B/C × X/Y/Z) are documented in the companion analysis `comparisonofideas.md`.
+
+---
+
+## 2. Background
+
+OpenSearch ml-commons provides an agentic memory framework that enables AI agents to persist and reason over structured information across conversations. Memory is organized into **memory containers**, each storing four memory types:
+
+| Memory Type | Purpose | Lifecycle |
+|-------------|---------|-----------|
+| **Working memory** | Active conversation state (raw messages, tool calls) | Short-lived, tied to a session |
+| **Long-term memory** | Distilled knowledge (user preferences, extracted facts) | Persists across sessions |
+| **Sessions** | Conversation metadata (start time, participants, config) | Medium-lived |
+| **History** | Audit trail of memory operations | Append-only, must be bounded |
+
+---
+
+## 3. Problem Statement
+
+The memory system has no lifecycle management. Consequences:
+
+1. **Unbounded storage growth** — no mechanism to reclaim space from obsolete memories
+2. **Context window pollution** — agents retrieve stale/contradictory information, degrading response quality
+3. **Increased inference cost** — larger context windows from irrelevant memories increase token usage
+4. **Manual intervention required** — operators have no automated cleanup; must delete manually or accept growth
+
+There is no deletion job, no TTL field, and no retention configuration anywhere in the codebase.
+
+---
+
+## 4. Goals and Non-Goals
+
+### 4.1 Goals
+
+- Customers can configure lifecycle rules (`retention_days`, `max_count`) for sessions and long-term memory, and `max_count` for history
+- A background job permanently deletes memories that violate configured policies
+- Session deletion cascades to all associated working memory (working memory deleted first, then session)
+- Working memory is never deleted independently — conversations stay intact until their session expires
+- When sessions are disabled (`disableSession=true`), working memory gets its own age-based TTL
+- Individual memories can be pinned to exempt them from eviction
+- Orphaned working memory (pointing to non-existent sessions) is cleaned up automatically
+- History supports `max_count` only (audit trail does not expire by age)
+- Fully backward compatible — existing containers without a policy get defaults auto-applied (with explicit null opt-out available)
+- Retention is opt-out — new containers automatically receive cluster-default policies unless the user explicitly opts out with `null`
+
+### 4.2 Non-Goals
+
+- **Query-time filtering** — memories may remain visible for up to one job interval after expiration
+- **Write-time eviction** — no enforcement on the write path
+- **Access-based / LRU eviction** — eviction is pure FIFO, not usage-weighted
+- **Per-namespace / per-user max_count** — cap is container-wide
+- **AOSS Serverless / managed service deployment** — self-managed only
+- **Dry-run preview endpoint** — not in scope for v1 (second iteration)
+- **On-demand purge endpoint** — not in scope for v1 (second iteration)
+- **GDPR "right to deletion" compliance** — not a stated goal for v1 (though the infrastructure could support it)
+- **New UI / dashboards** — all interaction via REST API
+- **Cluster-wide retention ceiling** — no admin-enforced maximum (future work)
+
+---
+
+## 5. Design Overview
+
+### 5.1 Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        MEMORY CONTAINER                              │
+│                                                                     │
+│  memory_configuration.retention_policy:                              │
+│    sessions: { retention_days: 90, max_count: 5000 }                │
+│    long-term: { max_count: 2000 }                                   │
+│    history: { max_count: 100000 }                                   │
+│                                                                     │
+│  ┌──────────────┐ ┌──────────────┐ ┌──────────┐ ┌─────────┐       │
+│  │Working Memory│ │Long-Term Mem │ │ Sessions │ │ History │       │
+│  │              │ │              │ │          │ │         │       │
+│  │ (no own      │ │ pinned:true  │ │ pinned   │ │         │       │
+│  │  policy —    │ │ last_updated │ │ last_upd │ │ created │       │
+│  │  cascade     │ │              │ │          │ │         │       │
+│  │  only)       │ │              │ │          │ │         │       │
+│  └──────┬───────┘ └──────────────┘ └────┬─────┘ └─────────┘       │
+│         │                                │                          │
+│         │◄── CASCADE (all working mem  ──┘                          │
+│         │    deleted when session dies)                              │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              │ evaluated by
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│              MEMORY RETENTION JOB (Job Scheduler)                    │
+│                                                                     │
+│  Interval: configurable (default 24h)                               │
+│  Locking: distributed via LockService (single-node execution)       │
+│                                                                     │
+│  For each container with a retention_policy:                        │
+│    1. Identify  → find expired sessions (time/count), skip pinned   │
+│    2. Cascade   → delete ALL working memory for those sessions      │
+│    3. Sessions  → delete the expired session documents              │
+│    4. Long-term → delete expired (time/count), skip pinned          │
+│    5. History   → delete over-count only, skip pinned               │
+│    6. WM TTL    → (disableSession only) delete old working memory   │
+│    7. Orphan    → sweep orphaned working memory (once per job run)  │
+│    8. Throttle  → pause 5s before next container                    │
+│                                                                     │
+│  Deletion: _delete_by_query (throttled, idempotent)                 │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Data Flow
+
+```
+Customer                         OpenSearch                      Job Scheduler
+   │                                │                                │
+   │── POST container/_create ─────▶│                                │
+   │   {retention_policy: {...}}    │── persist policy on container   │
+   │◀── 201 ───────────────────────│                                │
+   │                                │                                │
+   │── POST memories ──────────────▶│                                │
+   │   {content, pinned: true}     │── store memory (no eviction)   │
+   │◀── 200 ───────────────────────│                                │
+   │                                │                                │
+   │── GET/search memories ────────▶│                                │
+   │                                │── return all (including stale) │
+   │◀── results ───────────────────│                                │
+   │                                │                                │
+   │                                │         ┌──── every 24h ──────│
+   │                                │         ▼                     │
+   │                                │── acquire lock                │
+   │                                │── iterate containers          │
+   │                                │── evaluate policies           │
+   │                                │── _delete_by_query (pinned!=true) │
+   │                                │── log counts                  │
+   │                                │── release lock                │
+   │                                │                                │
+   │                                │                                │
+```
+
+### 5.3 Staleness Window
+
+Both `retention_days` and `max_count` have a staleness window of up to one job interval:
+
+```
+TIME ─────────────────────────────────────────────────────────────────▶
+
+Memory expires (violates policy):
+  ┌─────────┐                                              ┌─────────┐
+  │ expired │                                              │ deleted │
+  │         │◀─── still visible in reads (up to 24h) ────▶│         │
+  └─────────┘                                              └─────────┘
+              ▲                                            ▲
+              │                                            │
+         policy violated                              job runs
+```
+
+This is an accepted design decision — see §4.2 Non-Goals.
+
+---
+
+## 6. Detailed Design
+
+### 6.1 Data Model
+
+#### 6.1.1 RetentionRule
+
+A new data class stored in `MemoryConfiguration`:
+
+```java
+public class RetentionRule implements ToXContentObject, Writeable {
+    private final Integer retentionDays;  // nullable — null means disabled
+    private final Integer maxCount;       // nullable — null means disabled
+
+    // Both null is valid — means "no deletion for this type" (entry persisted but job skips it)
+    // retentionDays is rejected (validation error) for HISTORY type
+    // MemoryType.WORKING ("working") is NOT a valid key (deleted only via session cascade)
+    // Negative values are rejected (validation error)
+    // Zero is rejected (validation error) — use null to disable
+}
+```
+
+Container-level storage:
+
+```java
+// In MemoryConfiguration.java
+// Valid keys: SESSIONS, LONG_TERM, HISTORY
+// MemoryType.WORKING is not a valid key — it has no independent policy
+// Serialized as JSON keys via MemoryType.getValue(): "sessions", "long-term", "history"
+private Map<MemoryType, RetentionRule> retentionPolicy;
+```
+
+#### 6.1.2 Pinned Field
+
+A new boolean field on memory document types that are directly subject to retention evaluation (`MLLongTermMemory`, `MLMemorySession`, `MLMemoryHistory`):
+
+```java
+private Boolean pinned;  // default: false
+```
+
+Index mapping addition (three indices — working memory does not need `pinned` since it is never independently evaluated):
+
+```json
+{
+  "pinned": { "type": "boolean" }
+}
+```
+
+Note: Working memory does not have a `pinned` field. It is always deleted atomically with its parent session. If a customer needs to preserve a specific conversation, they pin the **session** — which prevents the session from being evicted and therefore preserves all its working memory.
+
+#### 6.1.3 Serialization
+
+`RetentionRule` implements:
+- `ToXContentObject` — for REST API serialization and index storage
+- `Writeable` — for StreamInput/Output transport serialization
+
+This ensures the policy survives cluster restarts (persisted in the container document) and can be sent across nodes (transport layer).
+
+#### 6.1.4 Index Schema Changes
+
+No new indices are created. Changes to existing memory index mappings:
+
+**Actual index naming pattern:** `.plugins-ml-am-{indexPrefix}-memory-{type}`
+
+Index names are **per-container** and computed dynamically via `MemoryConfiguration.getIndexName(MemoryType)`. For example, a container with the default prefix produces indices like `.plugins-ml-am-memory-container-memory-sessions`. Multiple containers can share the same physical index when they use the same prefix (especially with `useSystemIndex=true`).
+
+| Index (computed per container) | Mapping File to Update | New Field | Type | Default | schema_version |
+|-------------------------------|------------------------|-----------|------|---------|----------------|
+| `...memory-long-term` | `ml_memory_long_term.json` | `pinned` | boolean | `false` | 1 → 2 |
+| `...memory-sessions` | `ml_memory_sessions.json` | `pinned` | boolean | `false` | 1 → 2 |
+| `...memory-history` | `ml_memory_long_term_history.json` | `pinned` | boolean | `false` | 1 → 2 |
+
+Working memory indices are **not** modified — working memory has no `pinned` field and no independent retention policy. It is deleted only via session cascade.
+
+The `retention_policy` field is stored on the container document itself (in the `.plugins-ml-am-memory-container` index, mapping file `ml_memory_container.json`, schema_version 1 → 2) — not on a separate index.
+
+**Shared index safety:** Because multiple containers can share a physical index, **every deletion query in the retention job MUST include a `memory_container_id` term filter** to avoid cross-container data loss.
+
+### 6.2 Default Policy
+
+**Retention is opt-out (defaults auto-applied).** When the cluster setting `plugins.ml_commons.memory.retention_enabled=true` (the default), containers WITHOUT an explicit `retention_policy` get the following defaults auto-applied:
+
+| Memory Type | Default `retention_days` | Default `max_count` | Rationale |
+|-------------|:----------------------------:|:-----------------------:|-----------|
+| Sessions | 90 | 5000 | 30 days is the enterprise consensus minimum (Bedrock, Purview, Dialogflow); 90 provides a generous window. 5000 covers high-throughput deployments. |
+| Long-term memory | null (disabled) | 2000 | Knowledge should persist indefinitely by default; retrieval quality degrades beyond 10-20 items per query (Liu et al. 2023, Mem0 guidance), but generous accumulation allows diverse retrieval across topics. Customers can optionally set `retention_days` if they want time-based expiry. |
+| History | N/A (not supported) | 100000 | Audit trail; count-bounded only. 100K events covers months of heavy usage for compliance investigations. |
+
+These defaults come from tunable cluster settings (so admins can adjust them cluster-wide):
+
+| Cluster Setting | Default | Description |
+|-----------------|---------|-------------|
+| `plugins.ml_commons.memory.default_session_retention_days` | 90 | Default `retention_days` for sessions when auto-applying |
+| `plugins.ml_commons.memory.default_session_max_count` | 5000 | Default `max_count` for sessions when auto-applying |
+| `plugins.ml_commons.memory.default_long_term_max_count` | 2000 | Default `max_count` for long-term when auto-applying |
+| `plugins.ml_commons.memory.default_history_max_count` | 100000 | Default `max_count` for history when auto-applying |
+
+**Auto-application happens in two places:**
+1. **At container creation time** — `TransportCreateMemoryContainerAction` writes the defaults onto the container document if the user did not provide an explicit `retention_policy` in the create request.
+2. **At job execution time (backfill)** — For existing containers that have no `retention_policy` (pre-feature containers), the retention job writes the defaults onto the container document before processing it. This ensures older containers are brought into compliance without requiring manual migration.
+
+**Important:** The backfill does NOT override an explicit null opt-out (see §6.2.2).
+
+Working memory has no entry in `retention_policy` — it is deleted exclusively via session cascade. When a session expires, all its working memory is deleted with it.
+
+**Note on `disableSession=true` containers:** When sessions are disabled, any session retention_policy is stored but the job finds zero sessions and skips that phase — harmless. Working memory in these containers is cleaned up by the cluster-level `working_memory_ttl_days` setting (default 30 days), not by the container's `retention_policy`. If a customer sets `"sessions"` in retention_policy on a `disableSession=true` container, return a warning in the response: `"warning": "sessions retention_policy has no effect when disableSession=true; working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"`.
+
+#### 6.2.1 The "default" Keyword
+
+Users can pass the string `"default"` at any level of the retention policy to reset that level to the current cluster default values:
+
+| Input | Effect |
+|-------|--------|
+| `"retention_policy": "default"` | Reset the entire retention policy to cluster defaults (sessions, long-term, history all get default values) |
+| `"retention_policy": {"sessions": "default"}` | Reset sessions policy only to cluster defaults; other types unchanged |
+| `"retention_policy": {"sessions": {"max_count": "default"}}` | Reset `max_count` for sessions to cluster default; `retention_days` unchanged |
+
+**Resolution behavior:** At parse time, `"default"` is resolved to the actual cluster setting value before persisting. The container document always stores concrete integer values (or null), never the string `"default"`. This means:
+- If an admin later changes the cluster default, previously-created containers are NOT retroactively updated (they already have the resolved value)
+- To pick up new cluster defaults, a user must explicitly send `"default"` again
+
+Example:
+```bash
+# Reset sessions to whatever the cluster defaults are right now
+PUT /_plugins/_ml/memory_containers/{id}
+{
+  "configuration": {
+    "retention_policy": {
+      "sessions": "default"
+    }
+  }
+}
+# If cluster defaults are retention_days=90, max_count=5000:
+# Result: "sessions": { "retention_days": 90, "max_count": 5000 }
+```
+
+#### 6.2.2 Null Opt-Out
+
+Users can explicitly opt out of retention by setting values to `null`:
+
+| Input | Effect |
+|-------|--------|
+| `"retention_policy": null` | Explicitly opt out of ALL retention. The container is persisted with an empty retention policy flag. The job will skip this container. |
+| `"max_count": null` | Remove the `max_count` rule for that type (disable count-based eviction) |
+| `"retention_days": null` | Remove the `retention_days` rule for that type (disable time-based eviction) |
+
+**Critical distinction:** A container with `"retention_policy": null` (explicit opt-out) is different from one that never had a policy set:
+- **Never had a policy:** The backfill mechanism WILL write defaults onto this container at job execution time.
+- **Explicit null opt-out:** The backfill mechanism will NOT override this — the customer's explicit decision to disable retention is preserved.
+
+Implementation: An explicit null opt-out is persisted as an empty object `{}` or a dedicated `retention_policy_opted_out: true` flag on the container document, distinguishing it from the absence of the field.
+
+#### 6.2.3 Update Semantics (Field-Level Merge)
+
+When a customer updates a retention policy via the PUT API, **field-level merge** semantics apply at two levels:
+
+1. **Type-level preservation:** Types not mentioned in the update request are left completely unchanged. Sending `{"sessions": {...}}` does not affect `long-term` or `history`.
+
+2. **Field-level merge within a type:** Only fields explicitly present in the request body for a given type are updated. Omitted fields retain their current value.
+
+3. **Explicit removal requires null:** To REMOVE a field, the user must explicitly send `null` for that field.
+
+Example: current policy is `"sessions": {"retention_days": 60, "max_count": 500}`. Customer sends `{"sessions": {"max_count": 350}}`. Result is `"sessions": {"retention_days": 60, "max_count": 350}` — `retention_days` is unchanged because it was not in the request.
+
+To remove `retention_days`: send `{"sessions": {"retention_days": null, "max_count": 350}}`.
+
+Types not included in the update request are left unchanged. The PUT response **always returns the full resulting retention_policy** so the developer can verify the final state.
+
+**Semantics table:**
+
+| Value | Meaning |
+|-------|---------|
+| `retention_policy` absent from container (never set) | Defaults will be auto-applied (at creation or via backfill) |
+| `"retention_policy": null` | Explicit opt-out — no retention, backfill will not override |
+| `"retention_policy": "default"` | Reset to cluster defaults |
+| `retention_policy` explicitly provided with values | Policy is applied as specified |
+| Field set to a positive integer | Use that value |
+| Field set to `"default"` | Resolve to cluster default value |
+| Field set to `null` | Remove/disable that specific constraint |
+| Field set to `0`, negative, or non-integer (other than `null`/`"default"`) | Validation error |
+
+**Backward compatibility:** Existing containers created before this feature have no `retention_policy` field. The backfill mechanism will auto-apply defaults at the next job run. They can explicitly opt out via `"retention_policy": null` or customize via the update API.
+
+### 6.3 API Surface
+
+#### 6.3.1 Modified Endpoints
+
+| Endpoint | Change | Auth |
+|----------|--------|------|
+| `POST /_plugins/_ml/memory_containers/_create` | Accepts optional `retention_policy` in configuration body | Same as container create |
+| `PUT /_plugins/_ml/memory_containers/{id}` | Accepts `retention_policy` updates | Same as container update |
+| `GET /_plugins/_ml/memory_containers/{id}` | Returns `retention_policy` in response | Same as container read |
+| `POST /_plugins/_ml/memory_containers/{id}/memories` | Accepts optional `pinned` field (for session, long-term, history only — not working memory) | Same as memory write |
+| `PUT /_plugins/_ml/memory_containers/{id}/memories/{type}/{mem_id}` | Accepts `pinned` field update (session, long-term, history only) | Same as memory update |
+
+No new permissions are introduced. Retention policy management uses the same authorization as container update.
+
+#### 6.3.2 Validation Rules
+
+| Rule | Error |
+|------|-------|
+| `"working"` key in retention_policy | `400: Working memory retention cannot be configured directly. Working memory is deleted when its parent session expires. To control message lifetime, configure retention on "sessions" instead.` |
+| `retention_days` set on history type | `400: retention_days is not supported for history memory type` |
+| `retention_days` ≤ 0 | `400: retention_days must be a positive integer or null` |
+| `max_count` ≤ 0 | `400: max_count must be a positive integer or null` |
+| Both fields `null` for a type | Valid — means "no retention policy for this type" (effectively disables retention for that type) |
+| Unknown memory type key | `400: unknown memory type: {key}` |
+
+**Note:** Valid keys use `MemoryType.getValue()` strings: `"sessions"`, `"long-term"`, `"history"`. The key `"working"` is the value to reject (not `"working_memory"`).
+
+#### 6.3.3 Example Flow
+
+```bash
+# 1. Create container with explicit retention policy (overrides defaults)
+POST /_plugins/_ml/memory_containers/_create
+{
+  "name": "customer-support-agent",
+  "configuration": {
+    "retention_policy": {
+      "sessions": { "retention_days": 60, "max_count": 500 },
+      "long-term": { "max_count": 5000 },
+      "history": { "max_count": 50000 }
+    }
+  }
+}
+
+# 2. Pin a critical long-term memory (will never be evicted)
+PUT /_plugins/_ml/memory_containers/{id}/memories/long-term/{mem_id}
+{ "pinned": true }
+
+# 3. Pin a session to preserve the entire conversation
+PUT /_plugins/_ml/memory_containers/{id}/memories/sessions/{session_id}
+{ "pinned": true }
+
+# 4. Opt out of time-based retention for sessions
+PUT /_plugins/_ml/memory_containers/{id}
+{
+  "configuration": {
+    "retention_policy": {
+      "sessions": { "retention_days": null, "max_count": 500 }
+    }
+  }
+}
+
+# 5. Disable all retention for a type (both null = no policy)
+PUT /_plugins/_ml/memory_containers/{id}
+{
+  "configuration": {
+    "retention_policy": {
+      "sessions": { "retention_days": null, "max_count": null }
+    }
+  }
+}
+```
+
+#### 6.3.4 Retention Policy Configuration Combinations & Semantics
+
+##### Do I Need to Configure All Three Memory Types Together?
+
+**No.** Each memory type (`sessions`, `long-term`, `history`) is independently configurable. You can set a policy for one type and leave others unconfigured (no deletion). Omitted types are unaffected.
+
+```bash
+# Only configure long-term memory retention — sessions and history are untouched
+POST /_plugins/_ml/memory_containers/_create
+{
+  "name": "minimal-retention-agent",
+  "configuration": {
+    "retention_policy": {
+      "long-term": { "max_count": 1000 }
+    }
+  }
+}
+```
+
+```bash
+# Only configure sessions — long-term and history grow unbounded
+POST /_plugins/_ml/memory_containers/_create
+{
+  "name": "session-only-agent",
+  "configuration": {
+    "retention_policy": {
+      "sessions": { "retention_days": 30 }
+    }
+  }
+}
+```
+
+```bash
+# Configure all three types with different rules
+POST /_plugins/_ml/memory_containers/_create
+{
+  "name": "fully-managed-agent",
+  "configuration": {
+    "retention_policy": {
+      "sessions": { "retention_days": 90, "max_count": 5000 },
+      "long-term": { "max_count": 2000 },
+      "history": { "max_count": 100000 }
+    }
+  }
+}
+```
+
+##### Updating Policy for a Single Type (Merge Semantics)
+
+Updates use **merge semantics** — only the fields you explicitly include are overwritten. Omitted types retain their current policy.
+
+```bash
+# Add retention to history WITHOUT affecting sessions or long-term
+PUT /_plugins/_ml/memory_containers/{id}
+{
+  "configuration": {
+    "retention_policy": {
+      "history": { "max_count": 20000 }
+    }
+  }
+}
+# Result: sessions and long-term policies are unchanged
+```
+
+```bash
+# Change ONLY retention_days for sessions — max_count stays at its current value
+PUT /_plugins/_ml/memory_containers/{id}
+{
+  "configuration": {
+    "retention_policy": {
+      "sessions": { "retention_days": 90 }
+    }
+  }
+}
+# If sessions previously had { "retention_days": 60, "max_count": 5000 },
+# it is now { "retention_days": 90, "max_count": 5000 }
+```
+
+```bash
+# Update max_count for long-term memory
+PUT /_plugins/_ml/memory_containers/{id}
+{
+  "configuration": {
+    "retention_policy": {
+      "long-term": { "max_count": 500 }
+    }
+  }
+}
+# long-term max_count is now 500
+```
+
+```bash
+# Remove entire retention policy (disables all retention for this container)
+PUT /_plugins/_ml/memory_containers/{id}
+{
+  "configuration": {
+    "retention_policy": null
+  }
+}
+```
+
+##### Multiple Conditions: OR Logic (Not AND)
+
+When both `retention_days` and `max_count` are set for the same memory type, they are evaluated as **OR conditions** — a memory is deleted if it violates **either** constraint.
+
+| `retention_days` | `max_count` | Deletion behavior |
+|:---:|:---:|---|
+| set | null | Delete only if older than `retention_days` |
+| null | set | Delete only if count exceeds `max_count` (oldest first, FIFO) |
+| set | set | Delete if older than `retention_days` **OR** if count exceeds `max_count` — whichever triggers first |
+| null | null | No deletion for this type (policy effectively disabled) |
+
+**Example:** `"sessions": { "retention_days": 30, "max_count": 100 }`
+
+- A session older than 30 days is deleted — even if you only have 50 sessions total
+- The 101st session triggers eviction of the oldest — even if it's only 2 days old
+- A session that is 5 days old with only 50 total sessions → **safe** (neither condition met)
+
+##### What Happens When `max_count` and `retention_days` Trigger Simultaneously?
+
+They **do not conflict**. The job evaluates them sequentially within the same run:
+
+1. **Phase: `retention_days`** — delete all memories older than the threshold (skipping pinned)
+2. **Phase: `max_count`** — count remaining memories (skipping pinned); if still over cap, delete the oldest until at `max_count`
+
+Since `retention_days` runs first, it may already reduce the count below `max_count`, making the second phase a no-op. In the worst case, both phases delete documents — the union of both sets is removed. There is **no conflict or race** because:
+
+- Both phases operate on the same index in a single-threaded job pass
+- Deletion in phase 1 reduces the count seen by phase 2
+- The result is always: retain the most recent `max_count` documents that are younger than `retention_days`
+
+```
+Example scenario:
+  retention_days: 30, max_count: 100
+  Container has 150 memories total, 40 are older than 30 days
+
+  Phase 1 (retention_days): delete 40 expired → 110 remain
+  Phase 2 (max_count): 110 > 100 → delete 10 oldest → 100 remain
+
+  Final state: exactly 100 memories, all younger than 30 days
+```
+
+```
+Edge case: all memories are recent
+  retention_days: 30, max_count: 100
+  Container has 150 memories, none older than 30 days
+
+  Phase 1 (retention_days): 0 deleted (nothing expired)
+  Phase 2 (max_count): 150 > 100 → delete 50 oldest → 100 remain
+
+  Final state: 100 memories (max_count was the binding constraint)
+```
+
+```
+Edge case: few memories but some are old
+  retention_days: 30, max_count: 100
+  Container has 50 memories, 10 are older than 30 days
+
+  Phase 1 (retention_days): delete 10 expired → 40 remain
+  Phase 2 (max_count): 40 < 100 → no-op
+
+  Final state: 40 memories (retention_days was the binding constraint)
+```
+
+##### Complete Configuration Combinations Matrix
+
+| Configuration | Sessions | Long-Term | History | Notes |
+|---|---|---|---|---|
+| Only `retention_days` | Expire old sessions + cascade WM | Expire old long-term memories | **Not supported** (400 error) | History only supports `max_count` |
+| Only `max_count` | Keep N most recent sessions | Keep N most recent long-term memories | Keep N most recent history entries | FIFO — oldest by `created_time` deleted first (all types) |
+| Both | OR — delete if either triggers | OR — delete if either triggers | N/A | Most aggressive — combines time + count caps |
+| Neither (both null) | No deletion | No deletion | No deletion | Same as omitting the type entirely |
+| Type omitted from policy | No deletion | No deletion | No deletion | Equivalent to `{ "retention_days": null, "max_count": null }` |
+
+##### Interaction Between Memory Types
+
+Policies for different memory types are **completely independent** — the job processes each type in isolation. There is no cross-type interaction:
+
+```bash
+# This is valid — each type has its own independent rule
+PUT /_plugins/_ml/memory_containers/{id}
+{
+  "configuration": {
+    "retention_policy": {
+      "sessions": { "retention_days": 30 },
+      "long-term": { "max_count": 2000 },
+      "history": { "max_count": 10000 }
+    }
+  }
+}
+# Sessions: only time-based (no count cap)
+# Long-term: only count-based (no time cap)
+# History: only count-based (time-based not supported)
+# Each evaluated independently — deleting sessions does NOT affect long-term count
+```
+
+The one **implicit cross-type interaction** is session cascade: when a session is deleted (by session retention policy), all working memory associated with that session is also deleted. This is cascade behavior, not a retention policy on working memory itself.
+
+### 6.4 Background Deletion Job
+
+#### 6.4.1 Job Implementation
+
+```
+Class: MemoryRetentionJobProcessor extends MLJobProcessor
+Pattern: singleton (mirrors MLStatsJobProcessor)
+Schedule: IntervalSchedule (default 24h, configurable)
+Locking: distributed via LockService (inherited from MLJobProcessor.process())
+```
+
+**Important lock caveat:** `MLJobProcessor.process()` acquires the lock synchronously, calls `run()`, and releases the lock in a `finally` block. Since OpenSearch Client operations use async `ActionListener` callbacks, `run()` returns immediately while actual work is still in-flight. The lock does NOT protect against concurrent execution for the full duration of the job. **Therefore, all retention logic MUST be idempotent** — if two instances run simultaneously, the results must still be correct. This is acceptable because:
+- Age-based deletion (`retention_days`): same query produces same results; deleting already-deleted docs is a no-op
+- Count-based deletion (`max_count`): uses deterministic sort (oldest first); overlapping deletes on the same document set are safe
+
+#### 6.4.2 Processing Algorithm
+
+```
+ACQUIRE distributed lock (via LockService)
+
+// Step 0: Resolve containers with policies
+// Search the .plugins-ml-am-memory-container index for containers where
+// retention_policy IS NOT NULL. For each container, resolve per-type index
+// names via configuration.getIndexName(MemoryType).
+
+FOR each memory container WHERE retention_policy IS NOT NULL:
+    
+    // Resolve the actual index names for this container
+    sessions_index = container.configuration.getIndexName(MemoryType.SESSIONS)
+    long_term_index = container.configuration.getIndexName(MemoryType.LONG_TERM)
+    history_index = container.configuration.getIndexName(MemoryType.HISTORY)
+    working_index = container.configuration.getIndexName(MemoryType.WORKING)
+    
+    // CRITICAL: All queries below MUST include memory_container_id = {id}
+    // because multiple containers can share the same physical index.
+    
+    // Phase 1: Identify expired sessions (but don't delete them yet)
+    expired_session_ids = []
+    
+    IF session policy has retention_days:
+        SEARCH sessions_index (sort: last_updated_time ASC,
+                filter: memory_container_id = {id}
+                AND pinned != true 
+                AND last_updated_time < now - retention_days)
+        APPEND matching IDs to expired_session_ids
+    
+    IF session policy has max_count:
+        count = COUNT in sessions_index WHERE memory_container_id = {id}
+                AND pinned != true
+        IF count > max_count:
+            SEARCH sessions_index (sort: created_time ASC,
+                    size: count - max_count,
+                    filter: memory_container_id = {id} AND pinned != true)
+            APPEND matching IDs to expired_session_ids (deduplicated)
+    
+    // Phase 2: Delete working memory FIRST (before session documents)
+    // This ensures that if we crash after this step, the next run will still
+    // find the sessions expired and re-cascade. No orphans possible.
+    IF expired_session_ids is not empty:
+        _delete_by_query working_index WHERE:
+            memory_container_id = {id}
+            AND namespace.session_id IN [expired_session_ids]
+        // No pinned check — working memory does not support pinning
+        // NOTE: namespace is a flat_object; use termQuery("namespace.session_id", id)
+    
+    // Phase 3: Delete the session documents themselves
+    IF expired_session_ids is not empty:
+        BULK DELETE from sessions_index by document IDs [expired_session_ids]
+    
+    // Phase 4: Long-Term Memory
+    IF long_term policy has retention_days:
+        _delete_by_query long_term_index WHERE:
+            memory_container_id = {id}
+            AND pinned != true
+            AND last_updated_time < (now - retention_days)
+    
+    IF long_term policy has max_count:
+        count = COUNT in long_term_index WHERE memory_container_id = {id}
+                AND pinned != true
+        IF count > max_count:
+            SEARCH long_term_index (sort: created_time ASC,
+                    size: count - max_count,
+                    filter: memory_container_id = {id} AND pinned != true)
+            BULK DELETE by document IDs [result IDs]
+    
+    // Phase 5: History (max_count only, uses created_time — history has NO last_updated_time)
+    IF history policy has max_count:
+        count = COUNT in history_index WHERE memory_container_id = {id}
+                AND pinned != true
+        IF count > max_count:
+            SEARCH history_index (sort: created_time ASC,
+                    size: count - max_count,
+                    filter: memory_container_id = {id} AND pinned != true)
+            BULK DELETE by document IDs [result IDs]
+    
+    // Phase 6: Working memory TTL (only for disableSession=true containers)
+    IF container has disableSession = true:
+        _delete_by_query working_index WHERE:
+            memory_container_id = {id}
+            AND created_time < (now - working_memory_ttl_days)
+        // working_memory_ttl_days is a cluster setting (default 30d), always present
+    
+    LOG deletion counts per type (including cascade working memory count)
+    PAUSE {throttle_interval} seconds (use threadPool.schedule(), not Thread.sleep())
+    // Then invoke next container via recursive callback (see note below)
+
+// Phase 7: Orphan Sweep (runs once per full job, not per-container)
+FOR each memory container WHERE disableSession = false:
+    working_index = container.configuration.getIndexName(MemoryType.WORKING)
+    sessions_index = container.configuration.getIndexName(MemoryType.SESSIONS)
+    
+    // Find working memory pointing to non-existent sessions.
+    // NOTE: namespace is a flat_object. Composite aggregation on flat_object sub-fields
+    // may not work reliably. Use paginated scroll search instead:
+    SCROLL SEARCH working_index WHERE memory_container_id = {id}
+        → extract distinct namespace.session_id values (deduplicate in memory)
+    MULTI-GET those session IDs against sessions_index (batched, 1000 per request)
+    orphan_ids = session IDs that returned NOT FOUND
+    IF orphan_ids is not empty:
+        _delete_by_query working_index WHERE:
+            memory_container_id = {id}
+            AND namespace.session_id IN [orphan_ids]
+    
+    // Find working memory with no session_id at all (shouldn't exist, but can
+    // from partial writes — grace period allows incomplete writes to be finished)
+    _delete_by_query working_index WHERE:
+        memory_container_id = {id}
+        AND (namespace.session_id IS NULL OR namespace IS NULL)
+        AND created_time < (now - orphan_ttl_days)  // configurable, default 7d
+        // 7-day grace: gives partially-written documents time to have session_id
+        // set in a subsequent update before being treated as orphans
+
+RELEASE lock (note: due to async execution, lock is actually released before work completes — see §6.4.1)
+```
+
+**Implementation note (post-coding):** The orphan sweep uses `search_after` pagination (NOT scroll API) to enumerate distinct `namespace.session_id` values from working memory. Scroll was rejected due to memory pressure at scale — it holds open a search context for the duration. A 50,000 session_id cap prevents OOM on pathological containers; remaining orphans are caught on subsequent job runs.
+
+Session existence checking uses batched `termsQuery("_id", batch)` against the sessions index (NOT MultiGetRequest). This is simpler and uses the same `client.search()` pattern as the rest of the job, avoiding additional API surface imports.
+
+**Note on `max_count` implementation:** `_delete_by_query` does not support "delete the N oldest documents." Instead, the job performs a two-step operation: (1) SEARCH with sort + size to identify the document IDs that exceed the cap, then (2) BULK DELETE those specific IDs. This means a partial failure during step 2 leaves some over-cap documents until the next run (safe — idempotent).
+
+**Note on async container iteration:** Since all OpenSearch operations use async `ActionListener` callbacks, the container loop is NOT a synchronous for-loop. Instead, it uses a recursive continuation-passing pattern: container N's final `ActionListener` success callback invokes `threadPool.schedule(throttleDelay, () -> processContainer(N+1, containerList, ...))`. This ensures the throttle pause actually separates work between containers. The pattern is similar to `StepListener` chaining or `ActionListener.wrap()` used elsewhere in the codebase.
+
+**Note on cascade batching:** If thousands of sessions expire simultaneously (e.g., first-time policy on a container with years of history), the `terms` query in Phase 2 (cascade) must batch `expired_session_ids` into groups of 500–1000 per `_delete_by_query` request to stay within the max clause count (default 1024).
+
+**Note on idempotency with `max_count`:** Because the lock does not protect the full async execution (see §6.4.1), two job instances could theoretically run concurrently. For `max_count`, both instances compute the same "oldest N documents" using a deterministic sort (`created_time ASC` for all types). They produce the same document ID set, so overlapping bulk deletes target the same documents — deleting an already-deleted doc is a no-op. This makes concurrent execution safe without true mutual exclusion.
+
+**Note on `max_count` overshoot:** Between the COUNT query and the BULK DELETE, concurrent writes can push the actual count above `max_count`. This overshoot is proportional to write throughput during job execution and is corrected on the next run. Write-time eviction (§12 Future Work) is the eventual fix for zero-overshoot enforcement.
+
+#### 6.4.3 Processing Order Rationale
+
+**Working memory is deleted BEFORE its parent session.** This ordering prevents orphans:
+1. Identify which sessions are expired (Phase 1)
+2. Delete their working memory first (Phase 2)
+3. Delete the session documents (Phase 3)
+
+If the job crashes between Phase 2 and Phase 3, the next run will re-identify the same expired sessions (they still exist), see they have no working memory left (already deleted), and delete the sessions. No orphans are created.
+
+If the job crashes between Phase 1 and Phase 2 (before any deletes), nothing happened — the next run starts fresh.
+
+The orphan sweep (Phase 7) is a safety net that catches any edge cases where working memory somehow points to a non-existent session (bugs, race conditions, partial writes).
+
+#### 6.4.4 Job Registration
+
+- **At cluster startup:** The job is registered unconditionally via `MLCommonsClusterEventListener` (following the `STATS_COLLECTOR` pattern), not lazily on first container creation. The job no-ops if no containers have retention policies.
+- **Idempotent:** If the job document already exists in the ML jobs index, creation is a no-op. Concurrent startup cannot produce duplicate jobs.
+- **Persistent:** Once registered, the job runs on every interval regardless of whether containers currently have policies. It is never unregistered.
+- **Wiring required:** Add `MEMORY_RETENTION` to `MLJobType` enum, add a dispatch case in `MLJobRunner.runJob()`, instantiate `MemoryRetentionJobProcessor` singleton in the plugin.
+
+#### 6.4.5 Configuration
+
+| Cluster Setting | Default | Range | Description |
+|-----------------|---------|-------|-------------|
+| `plugins.ml_commons.memory.retention_enabled` | `true` | true/false | Master kill switch — when false, the retention job skips execution entirely. Allows emergency disable without code rollback or policy removal. |
+| `plugins.ml_commons.memory.retention_job_interval` | `24h` | 1h–168h | How often the job runs |
+| `plugins.ml_commons.memory.retention_job_throttle` | `5s` | 1s–60s | Pause between processing containers |
+| `plugins.ml_commons.memory.orphan_ttl_days` | `7` | 1–365 | Age threshold for deleting working memory with no `session_id` |
+| `plugins.ml_commons.memory.working_memory_ttl_days` | `30` | 1–365 | TTL for working memory when `disableSession=true` (age-based, using `created_time`) |
+| `plugins.ml_commons.memory.default_session_retention_days` | `90` | 1–3650 | Default `retention_days` for sessions when auto-applying |
+| `plugins.ml_commons.memory.default_session_max_count` | `5000` | 1–1000000 | Default `max_count` for sessions when auto-applying |
+| `plugins.ml_commons.memory.default_long_term_max_count` | `2000` | 1–1000000 | Default `max_count` for long-term when auto-applying |
+| `plugins.ml_commons.memory.default_history_max_count` | `100000` | 1–10000000 | Default `max_count` for history when auto-applying |
+
+#### 6.4.6 Failure Handling
+
+| Failure | Behavior |
+|---------|----------|
+| Job fails mid-run (node crash, OOM) | Next scheduled run re-evaluates all containers from scratch. Idempotent deletes make this safe. |
+| Crash after working memory deleted but before session deleted | Next run re-identifies the same expired sessions (still exist), finds no working memory, deletes sessions. No orphans. |
+| Crash before any deletes (during identification) | No state changed. Next run starts fresh. |
+| Partial bulk delete (some IDs succeed, some fail) | Remaining docs are caught on next run. Idempotent. |
+| Lock cannot be acquired | Job skips this interval. Next interval retries. |
+| Container deleted during job run | `_delete_by_query` on non-existent container_id is a no-op. |
+| Job overlaps with next interval | Due to async lock release (see §6.4.1), concurrent execution is possible. All operations are idempotent by design, so concurrent runs produce correct results. |
+| Orphan sweep finds stale references | Deletes orphaned working memory. Safe — these documents are unreachable by any session. |
+| Index does not exist (empty container never used) | All search and `_delete_by_query` operations use `allowNoIndices=true` and `ignoreUnavailable=true`. Job skips that container with a debug log. Orphan sweep skips containers whose session index does not exist. |
+
+#### 6.4.7 Observability
+
+The job logs at INFO level for each container processed:
+
+```
+[MemoryRetentionJob] container={id} deleted: sessions={n}, cascade_working_memory={n}, 
+  long_term={n}, history={n}, pinned_skipped={n}, elapsed={ms}
+```
+
+Total run summary at job completion:
+
+```
+[MemoryRetentionJob] run complete: containers_processed={n}, total_deleted={n}, 
+  duration={s}, errors={n}
+```
+
+### 6.5 Session Cascade Semantics
+
+#### 6.5.1 Core Principle
+
+**Working memory is never deleted independently.** The unit of deletion for working memory is the entire session — when a session is evicted, all its working memory (messages, tool calls, structured data) is deleted as a unit (working memory first, then session document — two operations, not a transaction, but crash-safe by ordering). This preserves conversation integrity: you never end up with a conversation that has random gaps in the middle.
+
+#### 6.5.2 Relationship Model
+
+- `MLWorkingMemory` stores a `session_id` in its `namespace` map (a `flat_object` field in the index mapping). Every working memory entry belongs to a session. Queried via `termQuery("namespace.session_id", sessionId)`.
+- `MLLongTermMemory` does not structurally depend on sessions. It is distilled knowledge that outlives sessions.
+- `MLMemoryHistory` is never cascaded.
+
+#### 6.5.3 Cascade Rules
+
+| When this is deleted... | Also delete | Not deleted |
+|-------------------------|-------------|-------------|
+| Session | **All** working memory where `namespace.session_id` = deleted session ID | Long-term memory, History |
+| Long-term memory | Nothing | — |
+| History | Nothing | — |
+
+Working memory is not listed as a source of deletion because it is never independently targeted by the retention job.
+
+#### 6.5.4 Why Working Memory Has No Independent Policy
+
+Working memory entries are individual messages in a conversation. Deleting them independently would leave conversations with gaps — a user asks a question, the answer is deleted, then the next message references a now-invisible response. This is confusing and useless. The correct granularity for deletion is the entire conversation (session + all its messages).
+
+If a customer wants working memory to live shorter than sessions, they should set a shorter `retention_days` on sessions. When the session dies, all its messages die with it.
+
+**Exception — `disableSession=true` containers:** When sessions are disabled on a container, there is no parent session to cascade from. In this case, working memory entries are standalone and receive an age-based TTL using their `created_time` field (configurable via `plugins.ml_commons.memory.working_memory_ttl_days`, default 30 days). This is the only scenario where working memory is deleted independently.
+
+#### 6.5.5 Deletion Order (Working Memory First)
+
+When a session is expired by the retention job, the deletion order is:
+1. **Delete working memory** entries where `namespace.session_id` = expired session ID
+2. **Delete the session** document itself
+
+This ordering prevents orphans. If the job crashes after step 1 but before step 2, the next run will re-identify the same session as expired (it still exists), see it has no remaining working memory, and delete it cleanly. The reverse order (session first, then working memory) would create orphans that the job could never find again — because the session is gone, the job would never re-cascade.
+
+The orphan sweep (Phase 7) is a safety net for any edge cases where this ordering is violated.
+
+#### 6.5.6 Session ID Safety (UUID Uniqueness)
+
+Session IDs are OpenSearch document `_id` values — generated as UUIDs by the framework. They are never reused. There is no risk of a cascade accidentally deleting working memory belonging to a different session that happens to share an ID. Once a session ID is deleted, no future session will have the same ID.
+
+#### 6.5.7 Why Long-Term Memory Is Not Cascaded
+
+Long-term memory represents the distilled value of conversations — user preferences, extracted facts, summaries. If "user is allergic to peanuts" (extracted during session X) were deleted when session X expires, the agent loses knowledge it was designed to retain. Long-term memory ages out on its own timeline via its own `retention_days`/`max_count` policy.
+
+#### 6.5.8 Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Working memory with no `session_id` (sessions enabled) | Cleaned up by orphan sweep after `orphan_ttl_days` (default 7 days). These shouldn't exist but can from partial writes. |
+| Working memory pointing to non-existent session | Cleaned up by orphan sweep on next job run. |
+| Working memory in `disableSession=true` container | Deleted by age-based TTL using `created_time` (configurable, default 30 days). |
+| Pinned session | Session is not evicted → its working memory is preserved |
+| Session pinned but past `retention_days` | Not deleted (pinned overrides policy) → working memory safe |
+
+### 6.6 Pinned Memories
+
+#### 6.6.1 Semantics
+
+- `pinned: true` exempts a memory from **all** automated eviction: `retention_days` and `max_count`
+- Supported on: sessions, long-term memory, history
+- **Not supported on working memory** — to preserve a conversation, pin the session
+- Pinning a session protects both the session document and all its working memory (since working memory is only deleted via cascade)
+- Pinned documents are excluded from the count when evaluating `max_count` — they don't consume quota
+- Pinning is a per-document decision, not per-type or per-container
+
+#### 6.6.2 Pinned Count Exceeds max_count
+
+If pinned memories alone exceed `max_count`, the container grows beyond its limit indefinitely. This is intentional — `pinned` is an explicit customer override saying "I accept growth for these memories."
+
+**Observability (v1):** The retention job logs a WARN when pinned count exceeds `max_count` for any type in a container, alerting operators to potential unbounded growth: `[MemoryRetentionJob] container={id} type={type} pinned_count={n} exceeds max_count={n}. Container will grow unbounded until pins are removed.`
+
+#### 6.6.3 Implementation
+
+The deletion job adds `pinned != true` (or `pinned: false OR pinned: null`) to all deletion queries. Since `pinned` defaults to `false` and existing documents won't have the field, the query must handle the absent-field case:
+
+```json
+{
+  "bool": {
+    "must_not": [
+      { "term": { "pinned": true } }
+    ]
+  }
+}
+```
+
+This correctly matches documents where `pinned` is `false`, `null`, or absent.
+
+### 6.7 Retention Per Memory Type Summary
+
+| Memory Type | `retention_days` | `max_count` | Deletion Mechanism | Evaluation Field | Pinning |
+|-------------|:----------------:|:-----------:|-------------------|------------------|---------|
+| **Session** | ✓ | ✓ | Direct (job evaluates policy); working memory deleted first, then session | `retention_days`: `last_updated_time`; `max_count`: `created_time` | ✓ |
+| **Working memory** (sessions enabled) | ✗ | ✗ | Cascade only — deleted when parent session expires | N/A | ✗ (pin the session) |
+| **Working memory** (`disableSession=true`) | ✓ (via cluster setting) | ✗ | Age-based TTL using `created_time` | `created_time` | ✗ |
+| **Long-term memory** | ✓ | ✓ | Direct (job evaluates policy) | `retention_days`: `last_updated_time`; `max_count`: `created_time` | ✓ |
+| **History** | ✗ | ✓ | Direct (job evaluates policy) | `created_time` | ✓ |
+
+**Session liveness:** `last_updated_time` on sessions is automatically bumped when working memory is added to the session (see §6.11). Active conversations extend their session's retention lifetime. Only content-field updates bump the timestamp — organizational changes (tagging, pinning) do not (see §6.10).
+
+### 6.8 Evaluation Field Rationale
+
+#### Why `last_updated_time` for Sessions and Long-Term Memory
+
+The retention job evaluates sessions and long-term memory against `last_updated_time`, not `created_time`. This means a memory's clock resets whenever it is explicitly updated via the API.
+
+**Rationale:**
+- A session created 90 days ago but actively updated yesterday is still "alive" — deleting it based on creation date would destroy active conversations
+- Long-term memories that get refined over time (e.g., "user prefers dark mode" updated to "user prefers dark mode with high contrast") should not expire based on when they were first created
+- `last_updated_time` captures the most recent human or agent interaction with the document, which is the best proxy for "relevance" in a FIFO system
+
+**Note:** `last_updated_time` on sessions is now automatically bumped when working memory is added (see §6.11), and only bumped by content-field updates — not organizational changes like tagging or pinning (see §6.10).
+
+#### Why NOT `created_time` (considered alternative)
+
+Using `created_time` as the evaluation field was considered and would have provided the following benefits:
+
+- **Predictable expiration window** — the operator knows exactly when data expires from the moment of creation. A 30-day policy means every document lives for exactly 30 days, no exceptions, making capacity planning straightforward.
+- **Immune to accidental lifetime extension from system-triggered updates** — no background process, API call, or metadata enrichment can inadvertently keep data alive beyond its intended retention window.
+- **Simpler mental model** — "data lives for exactly N days, period." No need to reason about which operations touch `last_updated_time` and which do not. Operators can predict storage reclamation with certainty.
+
+#### Risks of `last_updated_time`
+
+The following scenarios document specific concerns identified through codebase analysis:
+
+1. **Strategy execution updates an existing long-term memory fact**
+   - *Scenario:* Background LLM inference (strategy execution) decides to UPDATE an existing long-term memory fact with new information from a recent conversation.
+   - *Consequence:* The long-term memory's retention clock resets fully, potentially keeping it alive indefinitely if conversations keep reinforcing the same fact. A user preference extracted on day 1 that gets slightly refined every week would never expire, even if the user has moved on and the preference is stale.
+   - *Likelihood:* High. *Mitigation:* Acceptable trade-off — a fact that is actively being refined by the agent is, by definition, still relevant. If staleness becomes an issue, operators can use `max_count` as a hard cap independent of age.
+
+2. **User pins a session or long-term memory via Update Memory API**
+   - *Scenario:* User sets `pinned=true` on a memory via the Update Memory API.
+   - *Consequence:* The retention clock resets as a side effect of the unconditional `last_updated_time` bump in `constructNewDoc()`. The user intended to mark importance, but got an unintended full retention reset. If pinned items are already exempt from retention, this double-extension is redundant but harmless; if not, pinning becomes an implicit retention override.
+   - *Likelihood:* Medium. *Mitigation:* Since pinned documents are already exempt from eviction (see §6.6), the clock reset is redundant and harmless. No functional impact.
+
+3. **User corrects a typo or modifies tags via Update Memory API**
+   - *Scenario:* User corrects a typo in a long-term memory's text field or adds/removes a tag via Update Memory API.
+   - *Consequence:* Full retention clock reset for what should be a cosmetic/organizational change. A 29-day-old memory that would expire tomorrow gets a full new retention period from a tag rename.
+   - *Likelihood:* Medium. *Mitigation:* Document this behavior clearly in API documentation. For operators who find this unacceptable, a future `created_time`-based eviction mode can be offered as a configuration option (see Final Decision below).
+
+4. **Automated external tooling bulk-updates metadata fields**
+   - *Scenario:* Monitoring scripts, admin dashboards, or migration jobs call the Update Memory API to bulk-update metadata fields across many documents.
+   - *Consequence:* All touched documents get retention clocks reset simultaneously, causing a retention cliff where nothing expires for a full retention period after the migration, followed by mass expiration. This could cause unpredictable storage spikes and sudden bulk deletions.
+   - *Likelihood:* Low. *Mitigation:* Document that bulk metadata updates reset retention clocks. Operators performing migrations should account for this in capacity planning or temporarily increase `max_count`.
+
+5. **Strategy execution ADD creates a near-duplicate instead of UPDATE**
+   - *Scenario:* Strategy execution ADD creates a new long-term memory that is essentially a duplicate or near-duplicate of an existing fact (LLM makes a borderline ADD vs UPDATE decision).
+   - *Consequence:* Instead of updating the existing fact (which would reset one clock), a new document is created with a fresh `created_time` AND `last_updated_time`. The old fact may eventually expire while the near-duplicate survives, leading to fragmented memory state. This is a `last_updated_time` problem only indirectly: the old fact does NOT get its clock reset because the LLM chose ADD instead of UPDATE.
+   - *Likelihood:* Medium. *Mitigation:* This is fundamentally an LLM decision-quality problem, not a retention-field problem. Deduplication logic in the strategy layer is the correct fix. Retention policy will eventually clean up the stale duplicate via normal age-out.
+
+6. **Future system-triggered session metadata updates**
+   - *Scenario:* Future code changes add session-level metadata updates triggered by system events (e.g., auto-updating session summary after N messages, or auto-tagging sessions based on content).
+   - *Consequence:* Would silently extend session retention for any session that receives automated metadata enrichment, creating an invisible retention extension pathway that operators may not anticipate. The current code does NOT do this, but the unconditional `last_updated_time` pattern in `TransportUpdateMemoryAction` makes it trivial to accidentally introduce.
+   - *Likelihood:* Low. *Mitigation:* Code review vigilance. Any future system-triggered update should explicitly document its retention impact. Consider adding a `skip_timestamp_update` internal flag for system-initiated metadata writes that should not affect retention.
+
+#### Final decision
+
+`last_updated_time` was chosen because the cost of prematurely deleting an active conversation (the `created_time` approach) is higher than the cost of a memory living slightly longer than intended (the `last_updated_time` approach). For operators who need strict TTL behavior, `created_time`-based eviction could be added as a future configuration option.
+
+#### Why `created_time` for History
+
+History entries are append-only audit records. They are never updated after creation — there is no `last_updated_time` field on history documents. `created_time` is the only meaningful timestamp.
+
+#### Why `created_time` for Working Memory TTL (disableSession=true)
+
+Working memory in sessionless containers has no update lifecycle. Messages are written once and never modified. `created_time` accurately represents when the document entered the system.
+
+### 6.9 max_count Calculation — Detailed Explanation
+
+`max_count` caps the number of non-pinned documents of a given type within a container. It is evaluated independently per memory type — session count does NOT include working memory documents, and working memory count does NOT include sessions.
+
+#### What max_count counts
+
+| Policy on type | What gets counted | What gets deleted |
+|---------------|-------------------|-------------------|
+| `sessions.max_count: 200` | Non-pinned session documents only | Oldest sessions (by `created_time`) beyond the cap, plus their working memory via cascade |
+| `long-term.max_count: 5000` | Non-pinned long-term memory documents only | Oldest long-term memories (by `created_time`) beyond the cap |
+| `history.max_count: 10000` | Non-pinned history documents only | Oldest history entries (by `created_time`) beyond the cap |
+
+**Key clarification:** A session's `max_count` does NOT factor in how many working memory messages that session contains. A session with 2 messages and a session with 200 messages each count as 1 toward the session cap. Working memory quantity is irrelevant to session eviction — when a session is evicted, ALL its working memory is cascade-deleted regardless of count.
+
+#### Algorithm (step by step)
+
+```
+1. COUNT non-pinned documents of this type in this container
+   Query: { bool: { must: [container_id], must_not: [pinned=true] } }
+   
+2. IF count <= max_count → DONE (nothing to evict)
+
+3. COMPUTE excess = count - max_count
+
+4. SEARCH for the oldest `excess` documents (sorted ASC by evaluation field)
+   - All types (sessions, long-term, history): sort by created_time ASC
+   - Fetch only _id (no source needed)
+
+5. DELETE those document IDs via BulkRequest (batched 1000 per request)
+   - For sessions: cascade-delete working memory FIRST, then delete sessions
+
+6. LOG deletion count
+```
+
+#### Interaction with retention_days (OR logic)
+
+When both `retention_days` and `max_count` are set on the same type, they use **OR logic**: a document is deleted if it violates EITHER constraint.
+
+Example with `{"sessions": {"retention_days": 30, "max_count": 100}}`:
+- 150 sessions exist, 20 are older than 30 days
+- Time-based identifies: 20 expired sessions
+- Count-based identifies: 50 sessions beyond cap (150 - 100 = 50 oldest)
+- Union (deduplicated): some sessions appear in both sets
+- Final deletion set: all unique sessions from either set
+
+A session is only safe if it passes BOTH constraints (newer than 30 days AND within the top 100 by count).
+
+#### Pinned documents and max_count
+
+Pinned documents are **completely excluded** from the count:
+- They are not counted in the total (`must_not: [pinned=true]` in the count query)
+- They are never included in the deletion set
+- They do not consume quota
+
+If a container has 300 sessions where 50 are pinned, and `max_count: 200`:
+- Effective count: 250 (300 - 50 pinned)
+- Excess: 50 (250 - 200)
+- Result: 50 oldest non-pinned sessions evicted
+
+If ALL non-pinned sessions are under the cap, nothing is evicted — even if pinned + non-pinned together exceed max_count. The container can grow beyond max_count via pinning. This is intentional — pinning is an explicit customer override.
+
+#### Container-wide vs Per-Namespace Enforcement
+
+Retention policies are evaluated **container-wide** in v1 — all documents of a given type share the same cap regardless of which namespace (user) they belong to. Per-namespace enforcement was considered and deferred to v2.
+
+**Why container-wide was chosen for v1:**
+
+- **`namespace` is a `flat_object`** — enumerating distinct `namespace.user_id` values requires a full scroll + client-side dedup (composite aggregation does not work reliably on `flat_object` sub-fields). This is the same expensive pattern used by the orphan sweep, and running it per-container per-type per-job-cycle adds significant cost.
+- **Multiplied query count** — per-namespace enforcement turns 3 queries per container (count + search + delete) into `1 + (3 × N)` queries where N is the number of distinct users. For a container with 1000 users, this turns a 3-second operation into a 30+ minute operation.
+- **No standardized namespace key** — containers do not declare which namespace field identifies the "user." Some use `namespace.user_id`, others may use `namespace.tenant_id` or `namespace.agent_id`. The retention job would need a configurable "partition key" per container, adding schema complexity.
+- **`retention_days` is already per-document** — time-based eviction naturally operates per-document. Each user's old sessions age out independently regardless of what other users are doing. Only `max_count` has the shared-cap problem.
+- **v1 scope constraint** — the 11-week internship timeline required a working, tested, shippable feature. Container-wide enforcement delivers the core value (automated lifecycle management) with minimal complexity.
+
+**The trade-off accepted:**
+
+In a multi-user container (like the Olly agent with one shared container and namespace-based user isolation), `max_count` operates as a shared cap:
+- User A has 300 sessions, User B has 50 sessions
+- `max_count: 200` → total is 350, excess is 150
+- The 150 oldest sessions (across BOTH users) are evicted — User A loses more because they have more old sessions
+
+This is acceptable because:
+1. `retention_days` (the primary expected constraint) has no fairness issue
+2. `max_count` is intended as a storage safety valve at generous thresholds, not a per-user quota
+3. Deployments that need strict per-user isolation can use separate containers per user (at the cost of more indices)
+4. Memory cleanup is typically configured as a company/platform-level policy (which matches container-level enforcement) rather than a per-user policy — the platform team decides "conversations expire after 90 days," not individual end users
+
+**Why NOT per-namespace (considered alternative):**
+
+Per-namespace enforcement would provide:
+- **Fair eviction** — each user's memory is capped independently (User A hitting 500 sessions doesn't affect User B's 10 sessions)
+- **Predictable per-user capacity** — operators can guarantee each user gets exactly N memories
+- **Better multi-tenant ergonomics** — no need for separate containers per user
+
+But it would require:
+- Scroll-based enumeration of all distinct namespace values (expensive on `flat_object`)
+- A configurable "partition key" field per container (schema change)
+- N× query multiplication per container (scalability concern)
+- Handling edge cases: documents with no namespace, documents with multiple namespace fields, namespace values changing over time
+
+**v1 workaround:**
+- Use `retention_days` as the primary constraint (naturally per-document, no shared cap)
+- Set `max_count` conservatively high (e.g., 5000–10000) as a storage ceiling, not a per-user quota
+- Deployments requiring strict per-user caps should use separate containers per user
+
+**v2 roadmap:** Per-namespace `max_count` enforcement, requiring a `partition_key` configuration on the retention policy and optimized namespace enumeration (possibly via a cached namespace registry or a terms aggregation on a dedicated keyword sub-field).
+
+### 6.10 last_updated_time Conditional Bump
+
+`TransportUpdateMemoryAction` only bumps `last_updated_time` when **content** changes. Organizational/metadata-only changes do NOT extend retention lifetime:
+
+| Memory Type | Fields that bump `last_updated_time` | Fields that do NOT bump |
+|-------------|--------------------------------------|------------------------|
+| **Sessions** | `summary` | `tags`, `pinned`, `metadata`, `additional_info`, `agents` |
+| **Long-term** | `memory` (the core memory field) | `tags`, `pinned`, `metadata`, `additional_info`, `agents` |
+| **Working** | `messages`, `binary_data`, `structured_data`, `structured_data_blob` | `tags`, `pinned`, `metadata`, `additional_info`, `agents` |
+
+**Rationale:** Prevents organizational changes (tagging, pinning, adding metadata) from artificially extending a memory's retention lifetime. Only changes that indicate the memory is actively being used for its primary purpose (content storage) should reset the retention clock.
+
+**Implementation:** `TransportUpdateMemoryAction.constructNewDoc()` checks whether any content field is present in the update request. If only non-content fields are being updated, `last_updated_time` is left at its current value (not overwritten with `Instant.now()`).
+
+### 6.11 Session Liveness on Message Add
+
+`TransportAddMemoriesAction` now bumps the parent session's `last_updated_time` when adding working memory to an **existing** session. This means active conversations extend their session's retention lifetime.
+
+**Behavior:**
+- When working memory is added to a session that already exists, the session document's `last_updated_time` is updated to `Instant.now()`
+- Uses `retryOnConflict(3)` to handle concurrent message writes to the same session
+- Does NOT bump for newly-created sessions (they already have a fresh timestamp from creation)
+
+**Rationale:** This addresses the known limitation from the original design where a session's `last_updated_time` was only set at creation and not refreshed by conversation activity. Active conversations now naturally extend their session's lifetime, preventing premature eviction of sessions that are still in use.
+
+**Write amplification trade-off:** Each message write now triggers an additional session document update (one extra index operation per message). This was previously deferred to v2 but accepted after team discussion because:
+1. The session index is small (one doc per session) — updates are cheap
+2. The alternative (premature session eviction during active conversations) is worse
+3. `retryOnConflict(3)` handles the common case of concurrent messages without failing
+
+### 6.12 Known Issues Fixed
+
+| Issue | Fix | Impact |
+|-------|-----|--------|
+| Session `created_time` used `Instant.now().getEpochSecond()` (epoch seconds) | Changed to `Instant.now().toEpochMilli()` (epoch milliseconds) | The retention job uses `System.currentTimeMillis()` for comparison, which returns milliseconds. Using epoch seconds would make sessions appear to have been created in January 1970 when compared against millisecond timestamps, causing immediate eviction. All timestamps must use consistent millisecond precision. |
+
+---
+
+## 7. Dependencies
+
+| Dependency | Purpose | Status |
+|------------|---------|--------|
+| OpenSearch Job Scheduler plugin | Background job scheduling + distributed locking | Already used by ml-commons |
+| `last_updated_time` field | Retention evaluation for sessions and long-term memory | Already indexed on both types |
+| `created_time` field | Retention evaluation for history; working memory TTL (disableSession); orphan sweep | Already present on all types |
+| `namespace.session_id` field | Cascade deletion + orphan sweep (links working memory → session). **Note:** `namespace` is a `flat_object` type in the index mapping; query via `termQuery("namespace.session_id", id)` | Already present on `MLWorkingMemory` |
+| `MemoryConfiguration` class | Host for the retention policy field | Existing — new field added |
+| `MLJobProcessor` base class | Job infrastructure (lock acquisition, scheduling) | Existing — new subclass |
+
+No new external service dependencies. All work stays within the ml-commons Java plugin.
+
+### 7.1 Existing Job Scheduler Wiring
+
+`MachineLearningPlugin` already implements `JobSchedulerExtension`:
+
+| Element | Class / Value | Role |
+|---------|---------------|------|
+| Extension | `MachineLearningPlugin implements JobSchedulerExtension` | Registers ml-commons as a Job Scheduler provider |
+| Job type | `ML_COMMONS_JOBS_TYPE` | Identifies ml-commons jobs |
+| Job index | `ML_JOBS_INDEX` | System index for job documents |
+| Runner | `MLJobRunner` (ScheduledJobRunner) | Entry point for Job Scheduler |
+| Parameter | `MLJobParameter` (ScheduledJobParameter) | Job definition + schedule |
+| Base processor | `MLJobProcessor` | Lock acquisition + `run()` dispatch |
+| Existing jobs | `MLStatsJobProcessor`, `MLBatchTaskUpdateProcessor` | Patterns to follow |
+
+**Implementation:** Create `MemoryRetentionJobProcessor extends MLJobProcessor` (singleton), implement `run()` with container iteration + `_delete_by_query` logic, register with a daily `IntervalSchedule`.
+
+### 7.2 OpenSearch APIs Used
+
+| API | Used For | Client |
+|-----|----------|--------|
+| `SearchRequest` + `bool`/`range` query | Identify deletion targets; count documents for `max_count` evaluation | Native Client (via `client.execute()`) |
+| `DeleteByQueryAction.INSTANCE` (throttled) | Time-based deletion, cascade (working memory by session_id), orphan cleanup | Native Client (follows `MemoryContainerHelper.deleteDataByQuery()` pattern) |
+| `SearchRequest` with `sort` + `size` | `max_count` — identify oldest non-pinned document IDs beyond cap | Native Client |
+| `BulkRequest` (delete actions) | Delete specific document IDs for `max_count` enforcement and session removal | Native Client |
+| Scroll search (paginated) | Orphan sweep — enumerate distinct `namespace.session_id` values from flat_object field | Native Client |
+| `MultiGetRequest` | Orphan sweep — batch-check which session IDs still exist | Native Client |
+| Job Scheduler SPI | Background scheduling + distributed locking | — |
+
+**Why native Client, not SdkClient:** `SdkClient` only supports Get, Search, Put, Update, Delete (single doc), and Bulk. It does NOT support `_delete_by_query`, scroll, or `_mget`. The retention job bypasses `SdkClient` entirely and uses the native OpenSearch Client with `ThreadContext.stashContext()` for all operations. This means the retention job **cannot support multi-tenant mode** — if `plugins.ml_commons.multi_tenancy_enabled` is true, the job should log a warning and skip execution.
+
+### 7.3 Scope Limitation: Self-Managed Only
+
+ml-commons routes operations through `SdkClient` — an abstraction that switches between local cluster (self-managed) and remote metadata (serverless/managed). This project targets **self-managed clusters only**:
+
+- Job Scheduler requires persistent nodes — valid for self-managed, not for serverless
+- AOSS Serverless is explicitly out of scope (aligns with project proposal)
+- Multi-tenancy mode is explicitly unsupported — `SdkClient` lacks `_delete_by_query`/scroll/`_mget`, so the retention job must use the native Client which has no tenant-routing. If `multi_tenancy_enabled = true`, the job skips execution with a warning log.
+
+---
+
+## 8. Non-Functional Requirements
+
+### 8.1 Performance
+
+| Dimension | Impact |
+|-----------|--------|
+| **Read latency** | Zero — no query-time filtering, no read-path changes |
+| **Write latency** | Zero — no write-time eviction, no write-path changes |
+| **Background job** | Throttled by design; runs off-peak; configurable interval |
+| **Cluster resources** | `_delete_by_query` generates merge load; mitigated by inter-container pause and request throttling |
+| **Orphan sweep** | Paginated scroll search + multi-get per container — read-heavy; cost scales with number of distinct session_ids in working memory index. Note: `namespace` is a `flat_object` — composite aggregation may not work on sub-fields, so scroll-based extraction is used instead. |
+
+### 8.2 Scalability
+
+- Job runtime scales linearly with number of containers that have policies
+- With a 5-second throttle between containers, the job can process ~17,000 containers per 24-hour interval. For clusters with fewer than 1,000 containers (expected v1 scale), the job completes well within one interval.
+- If a run cannot complete within one interval, the next scheduled run either waits for the lock or runs concurrently (safe — all operations are idempotent). The job processes all containers from scratch each run; there is no resumption from a partial run.
+- No index-per-policy — retention metadata lives on container documents
+- `_delete_by_query` is batch-efficient (handles thousands of deletions per sweep)
+
+### 8.3 Availability and Fault Tolerance
+
+| Component | Failure Mode | Recovery |
+|-----------|-------------|----------|
+| Job fails mid-run | Stale memories persist | Next run cleans up (idempotent) |
+| Node hosting job crashes | Lock expires; another node picks up next interval | Automatic |
+| Lock contention | Job skips interval | Runs on next interval |
+| Memory index unavailable | Job logs error, skips container | Retries next run |
+
+The system degrades gracefully: if the job stops running entirely, the only consequence is storage growth and stale memory visibility. No data corruption, no cascading failures.
+
+### 8.4 Security
+
+- No new permissions introduced — retention policy management uses same authorization as container update
+- No new endpoints exposed outside the cluster (all within `_plugins/_ml/` namespace)
+- The deletion job operates with plugin-level system index access (same privilege model as existing ml-commons background operations)
+- The `pinned` field is user-controlled — no system-level override can forcibly delete a pinned memory
+
+### 8.5 Backward Compatibility
+
+| Scenario | Behavior |
+|----------|----------|
+| Container created before this feature (no `retention_policy` field) | Backfill auto-applies cluster defaults at next job run. Container can explicitly opt out with `"retention_policy": null`. |
+| Container created after this feature without explicit policy | Cluster defaults auto-applied at creation time (see §6.2). |
+| Container with explicit `"retention_policy": null` | Opted out — job skips it. Backfill will not override. |
+| Cluster upgraded with existing containers | Existing containers have no policy field → defaults auto-applied at next job run (backfill). |
+| Cluster downgraded after retention was used | `retention_policy` field ignored by older code; no deletion runs. Memories persist. |
+| New `pinned` field on old documents | Absent field treated as `false` by deletion queries. |
+
+### 8.6 Observability
+
+- **Logging:** Per-container deletion counts at INFO level; errors at WARN/ERROR
+- **Orphan sweep logging:** Logs orphaned working memory counts per container
+- **Metrics (future):** Total documents deleted per run, job duration, containers processed, errors — exposed via ml-commons stats API
+
+---
+
+## 9. Testing Strategy
+
+### 9.1 Unit Tests
+
+- `RetentionRule` serialization (XContent round-trip, StreamInput/StreamOutput round-trip)
+- Validation logic (null handling, history rejects `retention_days`, `"working"` key rejected, negative values rejected)
+- Opt-in semantics (new container without retention_policy has no policy; existing container untouched)
+- Pinned document query construction (correctly excludes `pinned: true` and absent field)
+- `max_count` count calculation (excludes pinned documents from total)
+
+### 9.2 Integration Tests
+
+- End-to-end: create container with session policy → create sessions + messages → run job → verify correct sessions + their working memory deleted
+- Cascade ordering: verify working memory is deleted before session document (crash between → next run completes cleanly)
+- Cascade integrity: delete session → verify ALL associated working memory deleted (no partial conversations remain)
+- Cascade atomicity: session with 100 messages → all 100 deleted, none remain
+- Pinned session: create pinned session older than `retention_days` → run job → verify session AND its working memory survive
+- Pinned long-term memory: pin a memory older than policy → verify it survives
+- Orphan sweep: create working memory pointing to non-existent session → run job → verify orphan deleted
+- Orphan sweep (no session_id): create working memory with null namespace.session_id → wait past `orphan_ttl_days` → verify deleted
+- `disableSession=true` TTL: create container with disabled sessions → write working memory → wait past TTL → verify deleted by age
+- Backward compatibility: container without policy → run job → verify nothing deleted
+- OR logic: session violates `max_count` but not `retention_days` → verify deleted with cascade
+- History: verify `retention_days` rejected, `max_count` evaluated against `created_time`
+- Opt-out: set both constraints to `null` → verify no deletion for that type
+- Idempotency: run job twice → second run is a no-op
+- Working memory key rejected: attempt to set `"working"` in retention_policy → verify 400 error
+
+### 9.3 Edge Cases to Cover
+
+- Pinned count exceeds `max_count` (nothing evicted, no error)
+- Empty container (job skips cleanly)
+- Container deleted while job is running (no-op delete queries)
+- Concurrent container creation (job registration is idempotent)
+- Job interval shorter than job runtime (lock prevents double-execution)
+- Partial bulk delete failure (remaining docs caught on next run)
+- Orphan sweep with thousands of distinct session_ids (scroll-based pagination)
+- `disableSession=true` container with no working_memory_ttl configured (uses default 30d)
+
+---
+
+## 10. Rollout Plan
+
+There is no feature flag. The retention infrastructure ships as part of the next ml-commons release:
+
+| Phase | What Ships | Behavior |
+|-------|-----------|----------|
+| **Code merge** | `RetentionRule`, `MemoryRetentionJobProcessor`, `pinned` field, API changes, orphan sweep | Job registered at cluster startup; auto-applies defaults to containers without policies |
+| **First container created** | Container persisted with default retention_policy (unless user opts out with `null`) | Next job run begins enforcement for that container |
+| **Existing clusters upgrade** | Code deployed | Existing containers without a policy field get defaults auto-applied at next job run (backfill). Explicit `null` opt-out available. |
+
+**Opt-out:** Customers who do not want retention can set `"retention_policy": null` on their containers. This explicit opt-out is preserved across job runs (backfill will not override it).
+
+**Emergency disable:** Set `plugins.ml_commons.memory.retention_enabled` to `false` via cluster settings API to immediately stop all retention enforcement without removing policies from containers.
+
+**Recommended workflow for customizing retention on existing containers:**
+1. Review the auto-applied defaults (see §6.2) to understand what will be enforced
+2. Use `PUT /_plugins/_ml/memory_containers/{id}` to customize the policy or opt out with `null`
+3. Monitor the next job run's logs to verify expected deletion counts
+4. Tighten the policy gradually as needed
+
+---
+
+## 11. Second Iteration (v2)
+
+Features explicitly deferred from v1 to reduce scope. They build on v1 infrastructure with no redesign needed.
+
+| Feature | Description | Why Deferred |
+|---------|-------------|--------------|
+| `_retention_preview` endpoint | `POST /_plugins/_ml/memory_containers/{id}/_retention_preview` — shows per-type counts of what would be deleted under a current or proposed policy | Shares query logic with job but adds new REST/transport action pair |
+| `_purge` endpoint | `POST /_plugins/_ml/memory_containers/{id}/_purge` — triggers retention for a single container immediately | Same deletion logic as job, packaged on-demand. Not critical for initial launch |
+| Retention job metrics via Stats API | Expose `job_last_success_timestamp`, `total_deleted`, `containers_processed`, `job_duration_ms` | Follows `MLStatsJobProcessor` pattern. INFO logs provide basic observability in v1 |
+| Cluster-wide retention ceiling | Admin-enforced `max_retention_days_ceiling` and `max_count_ceiling` cluster settings | Important for multi-tenant but adds complexity |
+| Retention policy change audit trail | Write history entry on policy create/update/remove | Compliance (SOX, HIPAA); reuses existing history-write infrastructure |
+| Separate retention_policy permission | Dedicated permission for changing retention settings | Security hardening; prevents accidental policy weakening |
+| Pinned count visibility | Include `pinned_count` per type in GET container response | Ops visibility into unbounded growth from pin abuse |
+| `max_pinned_per_container` setting | Cluster setting that rejects new pin requests (returns 400) or logs warnings when pinned count per container per type exceeds a threshold | Prevents silent unbounded growth from pin abuse. WARN log in v1 provides visibility; this setting would add enforcement. |
+
+## 12. Future Work (Beyond v2)
+
+Longer-term enhancements not planned for immediate iterations:
+
+| Enhancement | Description | Trigger |
+|-------------|-------------|---------|
+| Query-time filtering | Inject time-based filter on reads for immediate invisibility | If staleness window proves problematic for customers |
+| Write-time eviction for `max_count` | Enforce count limit inline on writes (zero staleness) | If 24h overshoot is unacceptable |
+| Access-based eviction (Option C) | LRU/LFU scoring — keep frequently-used memories longer | If FIFO eviction deletes memories customers still need |
+| Per-namespace `max_count` | Cap per user/session within a container | If multi-tenant fairness is reported as an issue |
+| Importance scoring | Weight eviction by semantic importance | Layerable on top of current FIFO |
+
+---
+
+## Appendix A: Decision Log
+
+| # | Decision | Date | Options Considered | Choice | Rationale |
+|---|----------|------|--------------------|--------|-----------|
+| 1 | Scope target | 2026-06-06 | Self-managed only vs. include AOSS | Self-managed only | Serverless has no persistent Job Scheduler; out of scope per project proposal |
+| 2 | Eviction policy (Layer 1) | 2026-06-15 | A (Container Policy), B (Document TTL), C (Access-Based) | Option A | ~3–4 week implementation. Industry standard. Forward-compatible with C. |
+| 3 | Deletion mechanism (Layer 2) | 2026-06-15 | X (Job Scheduler), Y (Write-Time), Z (Hybrid) | Option X | Zero write-path risk. Single system. Batch-efficient. Upgradeable to Z. |
+| 4 | Query-time filtering | 2026-06-15 | Include (immediate invisibility) vs. exclude (staleness window) | Exclude | Complexity not justified for v1. Staleness acceptable. |
+| 5 | History inclusion | 2026-06-15 | Exclude entirely vs. `max_count` only | `max_count` only | Bounds storage without compromising audit integrity |
+| 6 | Pinned memories | 2026-06-15 | Day-one vs. stretch goal | Day-one | Customers need per-document eviction exemption |
+| 7 | Default behavior for new containers (original) | 2026-06-16 | Defaults applied vs. explicit-only | Explicit-only (opt-in) | Original decision: silent deletion of production data is catastrophic. **Superseded by Decision #24 (2026-07-10).** |
+| 8 | Working memory retention | 2026-06-15 | Independent policy vs. cascade-only | Cascade-only | Deleting individual messages leaves conversations with gaps; the session is the correct unit of deletion |
+| 9 | Cascade ordering | 2026-06-15 | Session first vs. working memory first | Working memory first | Prevents orphans — if crash occurs between steps, next run can still find the session and re-cascade |
+| 10 | Orphan sweep | 2026-06-15 | Ignore orphans vs. active cleanup | Active cleanup | Safety net for edge cases; low cost since it runs once per job |
+| 11 | Dry-run preview | 2026-06-15 | Include vs. defer | Defer (not in v1 scope) | Scope reduction; can be added later without design changes |
+| 12 | `disableSession=true` working memory | 2026-06-15 | Leave forever vs. age-based TTL | Age-based TTL via `created_time` | No session to cascade from — need independent cleanup |
+| 13 | Orphan sweep approach | 2026-06-16 | Composite aggregation vs. scroll search | Scroll search + multi-get | `namespace` is a `flat_object`; composite aggregation on flat_object sub-fields is unreliable. Scroll is simpler and has no codebase precedent gap. |
+| 14 | Job registration timing | 2026-06-16 | Lazy (on first container) vs. startup | Startup (via MLCommonsClusterEventListener) | Follows STATS_COLLECTOR pattern. Avoids complex first-use registration logic. Job no-ops if no containers have policies. |
+| 15 | Lock and concurrency model | 2026-06-16 | Fix lock duration vs. accept idempotent concurrent execution | Accept idempotent execution | MLJobProcessor releases lock before async work completes. Fixing requires refactoring shared infra. All retention operations are idempotent by design, so concurrent execution is safe. |
+| 16 | Native Client vs. SdkClient | 2026-06-16 | Use SdkClient abstraction vs. native Client | Native Client | SdkClient lacks _delete_by_query, scroll, _mget. Follow MemoryContainerHelper.deleteDataByQuery() pattern. Multi-tenancy explicitly unsupported. |
+| 17 | Default retention policy (original) | 2026-06-16 | Opt-in (no defaults) vs. opt-out (45-day default) | Opt-in — no defaults | Original decision: silent deletion of production data is catastrophic. **Superseded by Decision #24 (2026-07-10).** |
+| 18 | Update semantics | 2026-06-16 | Replace per type vs. merge per field | Merge — only explicit fields overwrite | Replace semantics silently drops constraints when developers update one field. Merge is safer and matches MemoryConfiguration.update() pattern. |
+| 19 | Session liveness (original) | 2026-06-16 | Static last_updated_time vs. touch on message write | Keep static (defer touch to second iteration) | Original decision: touching session on every message doubles write operations on the hot path. **Superseded by Decision #25 (2026-07-10).** |
+| 20 | `long-term` key naming | 2026-06-16 | Hyphenated `long-term` vs. snake_case `long_term` | Keep `long-term` (match existing MemoryType.getValue()) | Changing the enum value would affect existing index naming and other code that uses MemoryType. Accept the hyphen as-is since the agentic memory framework already uses it. |
+| 21 | Dry-run preview | 2026-06-16 | Defer to second iteration vs. include in v1 | Defer to second iteration | Reduces scope for 11-week timeline. Customers can start with conservative values and monitor job logs. |
+| 22 | On-demand purge | 2026-06-16 | Defer to second iteration vs. include in v1 | Defer to second iteration | Reduces scope. Customers can adjust job interval setting for faster enforcement. |
+| 23 | max_count sort field | 2026-07-10 | last_updated_time vs created_time | created_time | Batch updates make last_updated_time identical; created_time preserves true insertion order for fair FIFO eviction |
+| 24 | Default retention policy | 2026-07-10 | Opt-in (no defaults) vs opt-out (auto-apply defaults) | Opt-out — auto-apply defaults when retention_enabled=true | Team decision: silent unbounded growth is worse than documented defaults. Defaults come from tunable cluster settings. **Supersedes Decision #17.** |
+| 25 | Session liveness | 2026-07-10 | Static last_updated_time vs touch on message write | Touch on message write | Active conversations should extend session lifetime. Accepted write amplification tradeoff. **Supersedes Decision #19.** |
+| 26 | last_updated_time conditional bump | 2026-07-10 | Unconditional vs content-only | Content-only | Pinning/tagging should not extend retention lifetime — only content changes indicate the memory is actively used |
+
+Full alternatives analysis: `comparisonofideas.md`
+
+---
+
+## Appendix B: Glossary
+
+| Term | Definition |
+|------|------------|
+| **`retention_days`** | Time-based rule — memory deleted when `last_updated_time` (sessions, long-term) is older than now minus this value. Not supported for history (history has no `last_updated_time`). |
+| **`max_count`** | Count-based rule — oldest non-pinned memories beyond this cap are deleted (FIFO) |
+| **OR logic** | When both rules set: memory deleted if it violates *either* constraint |
+| **FIFO** | First-In-First-Out eviction — oldest by `created_time` deleted first for `max_count` ordering (all types); `retention_days` uses `last_updated_time` for sessions and long-term |
+| **Staleness window** | Gap between when a memory violates a policy and when the job physically deletes it (up to one job interval) |
+| **Cascade** | Session deletion automatically deletes ALL associated working memory (by `session_id`) — the only mechanism that deletes working memory |
+| **Pinned** | Per-document flag exempting a memory from all automated eviction |
+| **Orphan sweep** | Job phase that finds and deletes working memory pointing to non-existent sessions |
+| **Memory container** | Top-level grouping that holds all four memory types + configuration including retention policy |
+| **Job Scheduler** | OpenSearch plugin providing cron-like scheduling for background tasks |
+
+---
+
+## Appendix C: References
+
+| Resource | Link |
+|----------|------|
+| RFC #4859 (retention lifecycle) | `opensearch-project/ml-commons` issues |
+| Alternatives analysis | `comparisonofideas.md` (companion document) |
+| Options summary | `retention-options-summary.md` (companion document) |
+| Project proposal | `PROJECT_PROPOSAL.md` |
+| OpenSearch Job Scheduler | `opensearch-project/job-scheduler` |
+| ml-commons plugin | `opensearch-project/ml-commons` |

--- a/DESIGN_DOC.md
+++ b/DESIGN_DOC.md
@@ -6,7 +6,7 @@
 | **Reviewers** | Nathalie, Mingshi (mentor) |
 | **SDM** | Yaliang |
 | **Status** | In Progress |
-| **Last Updated** | 2026-07-10 |
+| **Last Updated** | 2026-07-13 |
 | **RFC** | opensearch-project/ml-commons #4859 |
 
 ---
@@ -196,6 +196,11 @@ public class RetentionRule implements ToXContentObject, Writeable {
     private final Integer retentionDays;  // nullable — null means disabled
     private final Integer maxCount;       // nullable — null means disabled
 
+    // Transient parse-time metadata for field-level merge (NOT serialized via Writeable,
+    // NOT included in equals/hashCode). Only meaningful on the node that parsed the JSON request.
+    private final transient boolean retentionDaysExplicitlySet;  // true when field present in JSON (even if null)
+    private final transient boolean maxCountExplicitlySet;       // true when field present in JSON (even if null)
+
     // Both null is valid — means "no deletion for this type" (entry persisted but job skips it)
     // retentionDays is rejected (validation error) for HISTORY type
     // MemoryType.WORKING ("working") is NOT a valid key (deleted only via session cascade)
@@ -203,6 +208,8 @@ public class RetentionRule implements ToXContentObject, Writeable {
     // Zero is rejected (validation error) — use null to disable
 }
 ```
+
+**Note on transient flags:** The `retentionDaysExplicitlySet` and `maxCountExplicitlySet` flags are NOT serialized via `writeTo()` (StreamInput constructor hardcodes both to `false`). This means field-level merge only works correctly when the merge runs on the same node that parsed the original JSON request. Since `TransportUpdateMemoryContainerAction` performs the merge in its `doExecute()` (before any transport serialization), this is always the case in practice.
 
 Container-level storage:
 
@@ -291,7 +298,9 @@ Working memory has no entry in `retention_policy` — it is deleted exclusively 
 
 #### 6.2.1 The "default" Keyword
 
-Users can pass the string `"default"` at any level of the retention policy to reset that level to the current cluster default values:
+> **⚠️ Implementation Status: NOT YET IMPLEMENTED.** This section documents the planned design for the `"default"` keyword. The parser does not currently accept `"default"` as a value — it will return a validation error. Implementation is deferred to a future iteration (see §11 Second Iteration). The design is documented here for completeness and to guide the future implementation.
+
+Users will be able to pass the string `"default"` at any level of the retention policy to reset that level to the current cluster default values:
 
 | Input | Effect |
 |-------|--------|
@@ -356,10 +365,10 @@ Types not included in the update request are left unchanged. The PUT response **
 |-------|---------|
 | `retention_policy` absent from container (never set) | Defaults will be auto-applied (at creation or via backfill) |
 | `"retention_policy": null` | Explicit opt-out — no retention, backfill will not override |
-| `"retention_policy": "default"` | Reset to cluster defaults |
+| `"retention_policy": "default"` | Reset to cluster defaults *(not yet implemented — see §6.2.1)* |
 | `retention_policy` explicitly provided with values | Policy is applied as specified |
 | Field set to a positive integer | Use that value |
-| Field set to `"default"` | Resolve to cluster default value |
+| Field set to `"default"` | Resolve to cluster default value *(not yet implemented — see §6.2.1)* |
 | Field set to `null` | Remove/disable that specific constraint |
 | Field set to `0`, negative, or non-integer (other than `null`/`"default"`) | Validation error |
 
@@ -953,14 +962,16 @@ This correctly matches documents where `pinned` is `false`, `null`, or absent.
 
 ### 6.8 Evaluation Field Rationale
 
-#### Why `last_updated_time` for Sessions and Long-Term Memory
+#### Why `last_updated_time` for `retention_days` on Sessions and Long-Term Memory
 
-The retention job evaluates sessions and long-term memory against `last_updated_time`, not `created_time`. This means a memory's clock resets whenever it is explicitly updated via the API.
+The retention job evaluates `retention_days` for sessions and long-term memory against `last_updated_time`, not `created_time`. This means a memory's time-based retention clock resets whenever it is explicitly updated (content changes only — see §6.10).
 
-**Rationale:**
+**Note:** `max_count` eviction uses `created_time` for ALL types (see Decision #23 below). Only `retention_days` uses `last_updated_time`.
+
+**Rationale for `last_updated_time` on `retention_days`:**
 - A session created 90 days ago but actively updated yesterday is still "alive" — deleting it based on creation date would destroy active conversations
 - Long-term memories that get refined over time (e.g., "user prefers dark mode" updated to "user prefers dark mode with high contrast") should not expire based on when they were first created
-- `last_updated_time` captures the most recent human or agent interaction with the document, which is the best proxy for "relevance" in a FIFO system
+- `last_updated_time` captures the most recent human or agent interaction with the document, which is the best proxy for "active use"
 
 **Note:** `last_updated_time` on sessions is now automatically bumped when working memory is added (see §6.11), and only bumped by content-field updates — not organizational changes like tagging or pinning (see §6.10).
 
@@ -1042,8 +1053,11 @@ Working memory in sessionless containers has no update lifecycle. Messages are w
 
 3. COMPUTE excess = count - max_count
 
-4. SEARCH for the oldest `excess` documents (sorted ASC by evaluation field)
-   - All types (sessions, long-term, history): sort by created_time ASC
+4. SEARCH for the oldest `excess` documents by created_time
+   - Long-term and history: sort by created_time ASC, size = excess (direct collection)
+   - Sessions: sort by created_time DESC, skip the newest maxCount, collect the rest
+     (equivalent outcome — identifies the same oldest documents — but avoids needing
+      the total count as a separate query since it walks from newest first)
    - Fetch only _id (no source needed)
 
 5. DELETE those document IDs via BulkRequest (batched 1000 per request)
@@ -1128,11 +1142,11 @@ But it would require:
 
 `TransportUpdateMemoryAction` only bumps `last_updated_time` when **content** changes. Organizational/metadata-only changes do NOT extend retention lifetime:
 
-| Memory Type | Fields that bump `last_updated_time` | Fields that do NOT bump |
+| Memory Type | Fields that bump `last_updated_time` | Fields that do NOT bump (accepted but non-content) |
 |-------------|--------------------------------------|------------------------|
-| **Sessions** | `summary` | `tags`, `pinned`, `metadata`, `additional_info`, `agents` |
-| **Long-term** | `memory` (the core memory field) | `tags`, `pinned`, `metadata`, `additional_info`, `agents` |
-| **Working** | `messages`, `binary_data`, `structured_data`, `structured_data_blob` | `tags`, `pinned`, `metadata`, `additional_info`, `agents` |
+| **Sessions** | `summary` | `pinned`, `metadata`, `additional_info`, `agents` |
+| **Long-term** | `memory` (the core memory field) | `tags`, `pinned` |
+| **Working** | `messages`, `binary_data`, `structured_data`, `structured_data_blob` | `metadata`, `tags` (note: `pinned` is rejected with 400 for working memory) |
 
 **Rationale:** Prevents organizational changes (tagging, pinning, adding metadata) from artificially extending a memory's retention lifetime. Only changes that indicate the memory is actively being used for its primary purpose (content storage) should reset the retention clock.
 
@@ -1143,9 +1157,11 @@ But it would require:
 `TransportAddMemoriesAction` now bumps the parent session's `last_updated_time` when adding working memory to an **existing** session. This means active conversations extend their session's retention lifetime.
 
 **Behavior:**
-- When working memory is added to a session that already exists, the session document's `last_updated_time` is updated to `Instant.now()`
+- When working memory is added to a session that already exists, the session document's `last_updated_time` is updated to `Instant.now().toEpochMilli()`
 - Uses `retryOnConflict(3)` to handle concurrent message writes to the same session
 - Does NOT bump for newly-created sessions (they already have a fresh timestamp from creation)
+- Does NOT bump for `disableSession=true` containers (no meaningful session to update)
+- The bump is **best-effort and asynchronous** — it fires after the add-memory response is already returned to the client. A failed bump is logged at DEBUG level and never fails the add-memory request. This avoids add-memory latency impact while still providing session liveness tracking for retention.
 
 **Rationale:** This addresses the known limitation from the original design where a session's `last_updated_time` was only set at creation and not refreshed by conversation activity. Active conversations now naturally extend their session's lifetime, preventing premature eviction of sessions that are still in use.
 
@@ -1158,7 +1174,7 @@ But it would require:
 
 | Issue | Fix | Impact |
 |-------|-----|--------|
-| Session `created_time` used `Instant.now().getEpochSecond()` (epoch seconds) | Changed to `Instant.now().toEpochMilli()` (epoch milliseconds) | The retention job uses `System.currentTimeMillis()` for comparison, which returns milliseconds. Using epoch seconds would make sessions appear to have been created in January 1970 when compared against millisecond timestamps, causing immediate eviction. All timestamps must use consistent millisecond precision. |
+| Session `created_time` and `last_updated_time` used `Instant.now().getEpochSecond()` (epoch seconds) | Changed to `Instant.now().toEpochMilli()` (epoch milliseconds) for both fields | The retention job uses `System.currentTimeMillis()` for comparison, which returns milliseconds. Using epoch seconds would make sessions appear to have been created in January 1970 when compared against millisecond timestamps, causing immediate eviction. All timestamps must use consistent millisecond precision. |
 
 ---
 
@@ -1349,6 +1365,7 @@ Features explicitly deferred from v1 to reduce scope. They build on v1 infrastru
 | Separate retention_policy permission | Dedicated permission for changing retention settings | Security hardening; prevents accidental policy weakening |
 | Pinned count visibility | Include `pinned_count` per type in GET container response | Ops visibility into unbounded growth from pin abuse |
 | `max_pinned_per_container` setting | Cluster setting that rejects new pin requests (returns 400) or logs warnings when pinned count per container per type exceeds a threshold | Prevents silent unbounded growth from pin abuse. WARN log in v1 provides visibility; this setting would add enforcement. |
+| `"default"` keyword in retention_policy | Allow `"default"` string at any level to reset to current cluster defaults (see §6.2.1 for full design) | Parser and resolution logic needed; design is complete but implementation is deferred |
 
 ## 12. Future Work (Beyond v2)
 

--- a/DESIGN_DOC.md
+++ b/DESIGN_DOC.md
@@ -6,7 +6,7 @@
 | **Reviewers** | Nathalie, Mingshi (mentor) |
 | **SDM** | Yaliang |
 | **Status** | In Progress |
-| **Last Updated** | 2026-07-13 |
+| **Last Updated** | 2026-07-16 |
 | **RFC** | opensearch-project/ml-commons #4859 |
 
 ---
@@ -67,8 +67,8 @@ There is no deletion job, no TTL field, and no retention configuration anywhere 
 - Individual memories can be pinned to exempt them from eviction
 - Orphaned working memory (pointing to non-existent sessions) is cleaned up automatically
 - History supports `max_count` only (audit trail does not expire by age)
-- Fully backward compatible — existing containers without a policy get defaults auto-applied (with explicit null opt-out available)
-- Retention is opt-out — new containers automatically receive cluster-default policies unless the user explicitly opts out with `null`
+- Fully backward compatible — existing containers are unaffected unless an admin explicitly configures default retention settings
+- Retention is opt-in — no data is deleted unless a user sets a policy on their container, or a cluster admin explicitly configures default values (all defaults ship as `-1`/disabled). An explicit `"retention_policy": null` prevents even admin defaults from being applied.
 
 ### 4.2 Non-Goals
 
@@ -94,9 +94,9 @@ There is no deletion job, no TTL field, and no retention configuration anywhere 
 │                        MEMORY CONTAINER                              │
 │                                                                     │
 │  memory_configuration.retention_policy:                              │
-│    sessions: { retention_days: 90, max_count: 5000 }                │
-│    long-term: { max_count: 2000 }                                   │
-│    history: { max_count: 100000 }                                   │
+│    sessions: { retention_days: 30, max_count: 100 }   ← user-set   │
+│    long-term: { max_count: 5000 }                     ← user-set   │
+│    history: { max_count: 50000 }                      ← user-set   │
 │                                                                     │
 │  ┌──────────────┐ ┌──────────────┐ ┌──────────┐ ┌─────────┐       │
 │  │Working Memory│ │Long-Term Mem │ │ Sessions │ │ History │       │
@@ -267,28 +267,28 @@ The `retention_policy` field is stored on the container document itself (in the 
 
 **Shared index safety:** Because multiple containers can share a physical index, **every deletion query in the retention job MUST include a `memory_container_id` term filter** to avoid cross-container data loss.
 
-### 6.2 Default Policy
+### 6.2 Default Policy (Opt-In, Admin-Configured)
 
-**Retention is opt-out (defaults auto-applied).** When the cluster setting `plugins.ml_commons.memory.retention_enabled=true` (the default), containers WITHOUT an explicit `retention_policy` get the following defaults auto-applied:
+**Retention is opt-in.** Out of the box, no retention policy exists on any container and no data is ever deleted automatically. Retention enforcement only occurs when:
+1. A user explicitly sets a `retention_policy` on their container, OR
+2. A cluster administrator explicitly configures default retention settings (which are then applied to containers that have no policy of their own).
 
-| Memory Type | Default `retention_days` | Default `max_count` | Rationale |
-|-------------|:----------------------------:|:-----------------------:|-----------|
-| Sessions | 90 | 5000 | 30 days is the enterprise consensus minimum (Bedrock, Purview, Dialogflow); 90 provides a generous window. 5000 covers high-throughput deployments. |
-| Long-term memory | null (disabled) | 2000 | Knowledge should persist indefinitely by default; retrieval quality degrades beyond 10-20 items per query (Liu et al. 2023, Mem0 guidance), but generous accumulation allows diverse retrieval across topics. Customers can optionally set `retention_days` if they want time-based expiry. |
-| History | N/A (not supported) | 100000 | Audit trail; count-bounded only. 100K events covers months of heavy usage for compliance investigations. |
+**All default settings ship as `-1` (disabled):**
 
-These defaults come from tunable cluster settings (so admins can adjust them cluster-wide):
+| Cluster Setting | Default | Range | Effect when set > 0 |
+|-----------------|:-------:|:-----:|---------------------|
+| `plugins.ml_commons.memory.default_session_retention_days` | -1 (off) | -1 to 3650 | Applied as sessions `retention_days` on containers without a policy |
+| `plugins.ml_commons.memory.default_session_max_count` | -1 (off) | -1 to 1,000,000 | Applied as sessions `max_count` on containers without a policy |
+| `plugins.ml_commons.memory.default_long_term_max_count` | -1 (off) | -1 to 1,000,000 | Applied as long-term `max_count` on containers without a policy |
+| `plugins.ml_commons.memory.default_history_max_count` | -1 (off) | -1 to 10,000,000 | Applied as history `max_count` on containers without a policy |
 
-| Cluster Setting | Default | Description |
-|-----------------|---------|-------------|
-| `plugins.ml_commons.memory.default_session_retention_days` | 90 | Default `retention_days` for sessions when auto-applying |
-| `plugins.ml_commons.memory.default_session_max_count` | 5000 | Default `max_count` for sessions when auto-applying |
-| `plugins.ml_commons.memory.default_long_term_max_count` | 2000 | Default `max_count` for long-term when auto-applying |
-| `plugins.ml_commons.memory.default_history_max_count` | 100000 | Default `max_count` for history when auto-applying |
+If none of these settings are set to a value greater than zero, containers without an explicit policy are simply skipped by the retention job. No backfill occurs. No data is touched.
 
-**Auto-application happens in two places:**
-1. **At container creation time** — `TransportCreateMemoryContainerAction` writes the defaults onto the container document if the user did not provide an explicit `retention_policy` in the create request.
-2. **At job execution time (backfill)** — For existing containers that have no `retention_policy` (pre-feature containers), the retention job writes the defaults onto the container document before processing it. This ensures older containers are brought into compliance without requiring manual migration.
+**When an admin does configure defaults (any setting > 0)**, auto-application happens in two places:
+1. **At container creation time** — `TransportCreateMemoryContainerAction` writes the admin-configured defaults onto the container document if the user did not provide an explicit `retention_policy` in the create request.
+2. **At job execution time (backfill)** — For existing containers that have no `retention_policy` (pre-feature containers), the retention job writes the admin-configured defaults onto the container document before processing it.
+
+The backfill only executes if any of the four default settings are greater than zero. If all four are `-1`, no backfill occurs and no containers are modified.
 
 **Important:** The backfill does NOT override an explicit null opt-out (see §6.2.2).
 
@@ -323,7 +323,7 @@ PUT /_plugins/_ml/memory_containers/{id}
     }
   }
 }
-# If cluster defaults are retention_days=90, max_count=5000:
+# If admin has configured default_session_retention_days=90, default_session_max_count=5000:
 # Result: "sessions": { "retention_days": 90, "max_count": 5000 }
 ```
 
@@ -338,8 +338,8 @@ Users can explicitly opt out of retention by setting values to `null`:
 | `"retention_days": null` | Remove the `retention_days` rule for that type (disable time-based eviction) |
 
 **Critical distinction:** A container with `"retention_policy": null` (explicit opt-out) is different from one that never had a policy set:
-- **Never had a policy:** The backfill mechanism WILL write defaults onto this container at job execution time.
-- **Explicit null opt-out:** The backfill mechanism will NOT override this — the customer's explicit decision to disable retention is preserved.
+- **Never had a policy:** If an admin has configured default retention settings (any value > 0), the backfill mechanism will write those admin-configured defaults onto this container at job execution time. If no admin defaults are configured, the container is simply skipped.
+- **Explicit null opt-out:** The backfill mechanism will NOT override this — the customer's explicit decision to disable retention is preserved, regardless of whether admin defaults are configured.
 
 Implementation: An explicit null opt-out is persisted as an empty object `{}` or a dedicated `retention_policy_opted_out: true` flag on the container document, distinguishing it from the absence of the field.
 
@@ -365,7 +365,7 @@ Types not included in the update request are left unchanged. The PUT response **
 
 | Value | Meaning |
 |-------|---------|
-| `retention_policy` absent from container (never set) | Defaults will be auto-applied (at creation or via backfill) |
+| `retention_policy` absent from container (never set) | No retention occurs. If an admin has configured default settings (> 0), those will be applied via backfill on the next job run. Otherwise, the container is skipped. |
 | `"retention_policy": null` | Explicit opt-out — no retention, backfill will not override |
 | `"retention_policy": "default"` | Reset to cluster defaults *(not yet implemented — see §6.2.1)* |
 | `retention_policy` explicitly provided with values | Policy is applied as specified |
@@ -374,7 +374,7 @@ Types not included in the update request are left unchanged. The PUT response **
 | Field set to `null` | Remove/disable that specific constraint |
 | Field set to `0`, negative, or non-integer (other than `null`/`"default"`) | Validation error |
 
-**Backward compatibility:** Existing containers created before this feature have no `retention_policy` field. The backfill mechanism will auto-apply defaults at the next job run. They can explicitly opt out via `"retention_policy": null` or customize via the update API.
+**Backward compatibility:** Existing containers created before this feature have no `retention_policy` field. If a cluster admin has configured default retention settings (any value > 0), the backfill mechanism will apply those admin-configured defaults at the next job run. If no admin defaults are configured, these containers are simply skipped — no data is deleted. Containers can explicitly opt out via `"retention_policy": null` or set a custom policy via the update API.
 
 ### 6.3 API Surface
 
@@ -779,6 +779,8 @@ FOR each memory container WHERE disableSession = false:
         _delete_by_query working_index WHERE:
             memory_container_id = {id}
             AND (session_id IN [orphan_ids] OR namespace.session_id IN [orphan_ids])
+            AND created_time < (now - orphan_ttl_days)  // age guard: prevents deletion of
+            // freshly-written working memory under caller-managed session IDs
     
     // Find working memory with no session_id at all (shouldn't exist, but can
     // from partial writes — grace period allows incomplete writes to be finished)
@@ -837,10 +839,10 @@ The orphan sweep (Phase 7) is a safety net that catches any edge cases where wor
 | `plugins.ml_commons.memory.retention_job_throttle` | `5s` | 1s–60s | Pause between containers where deletions occurred (no-op containers proceed immediately) |
 | `plugins.ml_commons.memory.orphan_ttl_days` | `7` | 1–365 | Age threshold for deleting working memory with no `session_id` |
 | `plugins.ml_commons.memory.working_memory_ttl_days` | `30` | 1–365 | TTL for working memory when `disableSession=true` (age-based, using `created_time`) |
-| `plugins.ml_commons.memory.default_session_retention_days` | `90` | 1–3650 | Default `retention_days` for sessions when auto-applying |
-| `plugins.ml_commons.memory.default_session_max_count` | `5000` | 1–1000000 | Default `max_count` for sessions when auto-applying |
-| `plugins.ml_commons.memory.default_long_term_max_count` | `2000` | 1–1000000 | Default `max_count` for long-term when auto-applying |
-| `plugins.ml_commons.memory.default_history_max_count` | `100000` | 1–10000000 | Default `max_count` for history when auto-applying |
+| `plugins.ml_commons.memory.default_session_retention_days` | `-1` (off) | -1–3650 | Admin-configured default `retention_days` for sessions. Only applied when > 0. |
+| `plugins.ml_commons.memory.default_session_max_count` | `-1` (off) | -1–1000000 | Admin-configured default `max_count` for sessions. Only applied when > 0. |
+| `plugins.ml_commons.memory.default_long_term_max_count` | `-1` (off) | -1–1000000 | Admin-configured default `max_count` for long-term. Only applied when > 0. |
+| `plugins.ml_commons.memory.default_history_max_count` | `-1` (off) | -1–10000000 | Admin-configured default `max_count` for history. Only applied when > 0. |
 
 #### 6.4.6 Failure Handling
 
@@ -925,7 +927,7 @@ Long-term memory represents the distilled value of conversations — user prefer
 | Scenario | Behavior |
 |----------|----------|
 | Working memory with no `session_id` (sessions enabled) | Cleaned up by orphan sweep after `orphan_ttl_days` (default 7 days). These shouldn't exist but can from partial writes. |
-| Working memory pointing to non-existent session | Cleaned up by orphan sweep on next job run. |
+| Working memory pointing to non-existent session | Cleaned up by orphan sweep on next job run, subject to `orphan_ttl_days` age guard (default 7 days). Freshly-written working memory under caller-managed session IDs is not deleted until it exceeds this age. |
 | Working memory in `disableSession=true` container | Deleted by age-based TTL using `created_time` (configurable, default 30 days). |
 | Pinned session | Session is not evicted → its working memory is preserved |
 | Session pinned but past `retention_days` | Not deleted (pinned overrides policy) → working memory safe |
@@ -1288,10 +1290,10 @@ The system degrades gracefully: if the job stops running entirely, the only cons
 
 | Scenario | Behavior |
 |----------|----------|
-| Container created before this feature (no `retention_policy` field) | Backfill auto-applies cluster defaults at next job run. Container can explicitly opt out with `"retention_policy": null`. |
-| Container created after this feature without explicit policy | Cluster defaults auto-applied at creation time (see §6.2). |
-| Container with explicit `"retention_policy": null` | Opted out — job skips it. Backfill will not override. |
-| Cluster upgraded with existing containers | Existing containers have no policy field → defaults auto-applied at next job run (backfill). |
+| Container created before this feature (no `retention_policy` field) | No retention occurs. If an admin has configured default settings (> 0), backfill applies those at the next job run. Otherwise, the container is skipped. Container can explicitly opt out with `"retention_policy": null`. |
+| Container created after this feature without explicit policy | If admin defaults are configured (> 0), they are applied at creation time. Otherwise, no retention occurs (see §6.2). |
+| Container with explicit `"retention_policy": null` | Opted out — job skips it. Backfill will not override, even if admin defaults are configured. |
+| Cluster upgraded with existing containers | Existing containers have no policy field → no retention occurs unless an admin explicitly configures default settings. |
 | Cluster downgraded after retention was used | `retention_policy` field ignored by older code; no deletion runs. Memories persist. |
 | New `pinned` field on old documents | Absent field treated as `false` by deletion queries. |
 
@@ -1311,7 +1313,7 @@ The system degrades gracefully: if the job stops running entirely, the only cons
 
 - `RetentionRule` serialization (XContent round-trip, StreamInput/StreamOutput round-trip)
 - Validation logic (null handling, history rejects `retention_days`, `"working"` key rejected, negative values rejected)
-- Opt-in semantics (new container without retention_policy has no policy; existing container untouched)
+- Opt-in semantics (new container without retention_policy has no policy unless admin defaults configured; existing container untouched without admin defaults)
 - Pinned document query construction (correctly excludes `pinned: true` and absent field)
 - `max_count` count calculation (excludes pinned documents from total)
 
@@ -1326,7 +1328,7 @@ The system degrades gracefully: if the job stops running entirely, the only cons
 - Orphan sweep: create working memory pointing to non-existent session → run job → verify orphan deleted
 - Orphan sweep (no session_id): create working memory with null namespace.session_id → wait past `orphan_ttl_days` → verify deleted
 - `disableSession=true` TTL: create container with disabled sessions → write working memory → wait past TTL → verify deleted by age
-- Backward compatibility: container without policy → run job → verify nothing deleted
+- Backward compatibility: container without policy (no admin defaults configured) → run job → verify nothing deleted
 - OR logic: session violates `max_count` but not `retention_days` → verify deleted with cascade
 - History: verify `retention_days` rejected, `max_count` evaluated against `created_time`
 - Opt-out: set both constraints to `null` → verify no deletion for that type
@@ -1352,17 +1354,19 @@ There is no feature flag. The retention infrastructure ships as part of the next
 
 | Phase | What Ships | Behavior |
 |-------|-----------|----------|
-| **Code merge** | `RetentionRule`, `MemoryRetentionJobProcessor`, `pinned` field, API changes, orphan sweep | Job registered at cluster startup; auto-applies defaults to containers without policies |
-| **First container created** | Container persisted with default retention_policy (unless user opts out with `null`) | Next job run begins enforcement for that container |
-| **Existing clusters upgrade** | Code deployed | Existing containers without a policy field get defaults auto-applied at next job run (backfill). Explicit `null` opt-out available. |
+| **Code merge** | `RetentionRule`, `MemoryRetentionJobProcessor`, `pinned` field, API changes, orphan sweep | Job registered at cluster startup. Does nothing unless users set policies or admins configure defaults. |
+| **First container with a policy** | Container persisted with user-specified `retention_policy` | Next job run begins enforcement for that container |
+| **Existing clusters upgrade** | Code deployed | No impact on existing containers. No data is deleted unless an admin explicitly configures default retention settings via cluster settings API. |
 
-**Opt-out:** Customers who do not want retention can set `"retention_policy": null` on their containers. This explicit opt-out is preserved across job runs (backfill will not override it).
+**Out of the box:** No retention occurs. All `default_*` settings ship as `-1` (disabled). Users must explicitly set policies on their containers, or an admin must configure cluster-level defaults, before any automated deletion happens.
 
-**Emergency disable:** Set `plugins.ml_commons.memory.retention_enabled` to `false` via cluster settings API to immediately stop all retention enforcement without removing policies from containers.
+**Opt-out (per container):** Customers who do not want retention (even if admin defaults are configured) can set `"retention_policy": null` on their containers. This explicit opt-out is preserved across job runs.
 
-**Recommended workflow for customizing retention on existing containers:**
-1. Review the auto-applied defaults (see §6.2) to understand what will be enforced
-2. Use `PUT /_plugins/_ml/memory_containers/{id}` to customize the policy or opt out with `null`
+**Emergency disable (cluster-wide):** Set `plugins.ml_commons.memory.retention_enabled` to `false` via cluster settings API to immediately stop all retention enforcement without removing policies from containers.
+
+**Recommended workflow for enabling retention on existing containers:**
+1. Decide on retention values appropriate for your organization
+2. Either configure cluster-level defaults (applies to all containers without a policy) or set per-container policies via `PUT /_plugins/_ml/memory_containers/{id}`
 3. Monitor the next job run's logs to verify expected deletion counts
 4. Tighten the policy gradually as needed
 
@@ -1425,7 +1429,7 @@ Longer-term enhancements not planned for immediate iterations:
 | 21 | Dry-run preview | 2026-06-16 | Defer to second iteration vs. include in v1 | Defer to second iteration | Reduces scope for 11-week timeline. Customers can start with conservative values and monitor job logs. |
 | 22 | On-demand purge | 2026-06-16 | Defer to second iteration vs. include in v1 | Defer to second iteration | Reduces scope. Customers can adjust job interval setting for faster enforcement. |
 | 23 | max_count sort field | 2026-07-10 | last_updated_time vs created_time | created_time | Batch updates make last_updated_time identical; created_time preserves true insertion order for fair FIFO eviction |
-| 24 | Default retention policy | 2026-07-10 | Opt-in (no defaults) vs opt-out (auto-apply defaults) | Opt-out — auto-apply defaults when retention_enabled=true | Team decision: silent unbounded growth is worse than documented defaults. Defaults come from tunable cluster settings. **Supersedes Decision #17.** |
+| 24 | Default retention policy | 2026-07-16 | Opt-in (no defaults) vs opt-out (auto-apply defaults) | Opt-in — admin-configured defaults, all shipping as `-1` (disabled) | Final decision: no data is deleted without explicit action. Admins can optionally configure cluster-level defaults; without that, containers have no retention. **Supersedes Decision #17.** |
 | 25 | Session liveness | 2026-07-10 | Static last_updated_time vs touch on message write | Touch on message write | Active conversations should extend session lifetime. Accepted write amplification tradeoff. **Supersedes Decision #19.** |
 | 26 | last_updated_time conditional bump | 2026-07-10 | Unconditional vs content-only | Content-only | Pinning/tagging should not extend retention lifetime — only content changes indicate the memory is actively used |
 

--- a/MEMORY_RETENTION_GUIDE.html
+++ b/MEMORY_RETENTION_GUIDE.html
@@ -1,0 +1,689 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Memory Retention Guide</title>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #fafafa; --surface: #ffffff; --border: #e2e8f0; --border-light: #f1f5f9;
+    --fg: #1e293b; --fg-muted: #64748b; --fg-subtle: #94a3b8;
+    --accent: #6366f1; --accent-light: #eef2ff; --accent-mid: #818cf8;
+    --code-bg: #f8fafc;
+    --shadow-sm: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04);
+    --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.08), 0 2px 4px -2px rgba(0,0,0,0.04);
+    --radius: 10px; --radius-sm: 6px;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body { background: var(--bg); color: var(--fg); font-family: 'Inter', -apple-system, sans-serif; font-size: 15px; line-height: 1.7; }
+  .layout { display: flex; min-height: 100vh; }
+  .sidebar { width: 260px; flex-shrink: 0; background: var(--surface); border-right: 1px solid var(--border); padding: 24px 0; position: sticky; top: 0; height: 100vh; overflow-y: auto; }
+  .sidebar-title { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-subtle); padding: 0 20px 12px; border-bottom: 1px solid var(--border-light); margin-bottom: 12px; }
+  .sidebar nav a { display: block; padding: 5px 20px; font-size: 13px; color: var(--fg-muted); text-decoration: none; border-left: 2px solid transparent; transition: all 0.15s; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .sidebar nav a:hover { color: var(--accent); border-left-color: var(--accent-mid); background: var(--accent-light); }
+  .sidebar nav a.h1 { font-weight: 600; font-size: 13px; color: var(--fg); }
+  .sidebar nav a.h2 { padding-left: 28px; }
+  .sidebar nav a.h3 { padding-left: 36px; font-size: 12px; }
+  .main { flex: 1; min-width: 0; }
+  .hero { background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #a78bfa 100%); padding: 56px 64px 48px; color: white; }
+  .hero h1 { font-size: 2.4em; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 12px; line-height: 1.2; }
+  .hero .subtitle { font-size: 1.1em; opacity: 0.85; font-weight: 400; }
+  .hero .meta { margin-top: 20px; display: flex; gap: 16px; flex-wrap: wrap; }
+  .hero .badge { background: rgba(255,255,255,0.2); border: 1px solid rgba(255,255,255,0.3); border-radius: 20px; padding: 4px 14px; font-size: 12px; font-weight: 500; }
+  .content { padding: 48px 64px 80px; max-width: 900px; }
+  h1, h2, h3, h4 { color: var(--fg); font-weight: 600; line-height: 1.3; letter-spacing: -0.01em; }
+  h1 { font-size: 1.9em; margin: 2em 0 0.6em; padding-bottom: 0.4em; border-bottom: 2px solid var(--border); }
+  h2 { font-size: 1.45em; margin: 1.8em 0 0.5em; padding-bottom: 0.3em; border-bottom: 1px solid var(--border-light); }
+  h3 { font-size: 1.15em; margin: 1.4em 0 0.4em; color: var(--accent); }
+  h4 { font-size: 1em; margin: 1.2em 0 0.3em; color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.05em; font-size: 0.8em; }
+  p { margin: 0.7em 0; color: var(--fg); }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  ul, ol { padding-left: 1.6em; margin: 0.6em 0; }
+  li { margin: 0.25em 0; }
+  li > ul, li > ol { margin: 0.2em 0; }
+  .table-wrap { overflow-x: auto; margin: 1.2em 0; border-radius: var(--radius); box-shadow: var(--shadow-sm); }
+  table { width: 100%; border-collapse: collapse; font-size: 14px; }
+  thead tr { background: linear-gradient(135deg, var(--accent) 0%, #8b5cf6 100%); }
+  thead th { padding: 12px 16px; text-align: left; font-weight: 600; color: white; font-size: 13px; letter-spacing: 0.02em; }
+  thead th:first-child { border-radius: var(--radius) 0 0 0; }
+  thead th:last-child { border-radius: 0 var(--radius) 0 0; }
+  tbody tr { border-bottom: 1px solid var(--border-light); transition: background 0.1s; }
+  tbody tr:last-child { border-bottom: none; }
+  tbody tr:hover { background: var(--accent-light); }
+  tbody tr:nth-child(even) { background: #f8fafc; }
+  tbody tr:nth-child(even):hover { background: var(--accent-light); }
+  td { padding: 10px 16px; vertical-align: top; font-size: 14px; }
+  code { background: var(--code-bg); border: 1px solid var(--border); padding: 0.15em 0.45em; border-radius: var(--radius-sm); font-size: 0.85em; font-family: 'JetBrains Mono', 'SF Mono', monospace; color: #e83e8c; }
+  pre { background: #1e1e2e; border-radius: var(--radius); padding: 20px 24px; overflow-x: auto; margin: 1em 0; box-shadow: var(--shadow-md); position: relative; }
+  pre code { background: none; border: none; padding: 0; color: #cdd6f4; font-size: 13px; line-height: 1.6; }
+  blockquote { border-left: 4px solid var(--accent); background: var(--accent-light); padding: 14px 20px; margin: 1.2em 0; border-radius: 0 var(--radius-sm) var(--radius-sm) 0; color: var(--fg-muted); font-style: italic; }
+  hr { border: none; border-top: 1px solid var(--border); margin: 2.5em 0; }
+  .sidebar::-webkit-scrollbar { width: 4px; }
+  .sidebar::-webkit-scrollbar-track { background: transparent; }
+  .sidebar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+  @media (max-width: 768px) { .sidebar { display: none; } .content { padding: 24px; } .hero { padding: 32px 24px; } }
+</style>
+</head>
+<body>
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-title">Contents</div>
+    <nav id="toc"></nav>
+  </aside>
+  <div class="main">
+    <div class="hero">
+      <h1 id="doc-title">Memory Retention Guide</h1>
+      <div class="subtitle">OpenSearch ML Commons — Agentic Memory Retention Lifecycle</div>
+      <div class="meta">
+        <span class="badge">OpenSearch ML Commons</span>
+        <span class="badge">Retention Lifecycle</span>
+      </div>
+    </div>
+    <div class="content" id="content">Rendering…</div>
+  </div>
+</div>
+<script id="md-source" type="text/markdown"># Memory Retention Policy Guide
+
+This guide explains how to use the memory retention feature in OpenSearch ML Commons to automatically manage the lifecycle of agentic memory. It is written for both human operators and AI agents that interact with the memory container APIs.
+
+---
+
+## Table of Contents
+
+1. [What Is Memory Retention?](#what-is-memory-retention)
+2. [Memory Types at a Glance](#memory-types-at-a-glance)
+3. [Quick Start](#quick-start)
+4. [Retention Policy Structure](#retention-policy-structure)
+5. [Setting a Retention Policy on a Container](#setting-a-retention-policy-on-a-container)
+6. [Updating a Retention Policy](#updating-a-retention-policy)
+7. [Opting Out of Retention](#opting-out-of-retention)
+8. [Pinning Memories](#pinning-memories)
+9. [How the Retention Job Works](#how-the-retention-job-works)
+10. [Cluster-Level Settings (Admin)](#cluster-level-settings-admin)
+11. [Validation Rules and Error Messages](#validation-rules-and-error-messages)
+12. [Worked Examples](#worked-examples)
+13. [FAQ](#faq)
+
+---
+
+## What Is Memory Retention?
+
+When AI agents use memory containers to store conversations (sessions), distilled knowledge (long-term memory), and audit trails (history), that data grows without bound. Without lifecycle management:
+
+- Storage costs increase continuously.
+- Agents retrieve stale or contradictory memories, degrading response quality.
+- Larger context windows drive up inference costs.
+
+The **memory retention policy** solves this by letting you define rules that automatically delete old or excess memories on a schedule. You set the rules; a background job enforces them.
+
+---
+
+## Memory Types at a Glance
+
+A memory container holds four types of memory. Retention rules apply to three of them:
+
+| Memory Type | What It Stores | Supports `retention_days` | Supports `max_count` | Supports `pinned` |
+|---|---|---|---|---|
+| **sessions** | Conversation sessions between a user and an agent | Yes | Yes | Yes |
+| **long-term** | Distilled knowledge extracted from conversations | Yes | Yes | Yes |
+| **history** | Immutable audit trail of all interactions | No | Yes | No |
+| **working** | Individual messages within a session | Not directly configurable | Not directly configurable | No |
+
+**Working memory** cannot have its own retention rule. It is always deleted when its parent session expires. To control how long messages live, configure retention on sessions.
+
+---
+
+## Quick Start
+
+Create a memory container with a retention policy that keeps sessions for 30 days (max 100), long-term memories capped at 5000, and history capped at 50,000:
+
+```json
+POST /_plugins/_ml/memory_containers/_create
+{
+  "name": "my-agent-memory",
+  "configuration": {
+    "retention_policy": {
+      "sessions": {
+        "retention_days": 30,
+        "max_count": 100
+      },
+      "long-term": {
+        "max_count": 5000
+      },
+      "history": {
+        "max_count": 50000
+      }
+    }
+  }
+}
+```
+
+That's it. The background job (runs every 24 hours by default) will enforce these rules automatically.
+
+---
+
+## Retention Policy Structure
+
+A retention policy is a JSON object nested inside `configuration.retention_policy` on the memory container. It contains up to three keys, one per eligible memory type:
+
+```json
+{
+  "configuration": {
+    "retention_policy": {
+      "sessions": {
+        "retention_days": <positive integer or null>,
+        "max_count": <positive integer or null>
+      },
+      "long-term": {
+        "retention_days": <positive integer or null>,
+        "max_count": <positive integer or null>
+      },
+      "history": {
+        "max_count": <positive integer or null>
+      }
+    }
+  }
+}
+```
+
+### Field Reference
+
+| Field | Type | Unit | Description |
+|---|---|---|---|
+| `retention_days` | Integer or null | Days | Delete memories older than this many days. Age is measured from the memory's `last_updated_time`. |
+| `max_count` | Integer or null | Count | Keep at most this many memories. When the count is exceeded, the oldest are deleted first. |
+
+**Both fields are optional and independent.** You can set one, both, or neither for each memory type. When both are set, they operate as an OR condition: a memory is deleted if it violates either rule.
+
+### Constraints
+
+- Both `retention_days` and `max_count` must be positive integers (greater than zero) when provided.
+- `retention_days` is not supported on the `history` type. The API returns a 400 error if you try.
+- The `working` key is not allowed. The API returns a 400 error with guidance to configure sessions instead.
+- You only need to include the memory types you want to manage. Omitted types have no retention enforcement.
+
+---
+
+## Setting a Retention Policy on a Container
+
+### At creation time
+
+Include `retention_policy` in the create request:
+
+```json
+POST /_plugins/_ml/memory_containers/_create
+{
+  "name": "customer-support-agent",
+  "configuration": {
+    "retention_policy": {
+      "sessions": {
+        "retention_days": 60,
+        "max_count": 500
+      },
+      "long-term": {
+        "max_count": 5000
+      }
+    }
+  }
+}
+```
+
+### If you do not provide a policy
+
+When no `retention_policy` is specified on creation, the system checks whether the cluster administrator has configured default retention settings (see [Cluster-Level Settings](#cluster-level-settings-admin)). If defaults are configured, they are automatically applied to the container at creation time. If no defaults exist, no policy is applied and no retention enforcement occurs.
+
+---
+
+## Updating a Retention Policy
+
+Use a PUT request to modify the policy on an existing container:
+
+```json
+PUT /_plugins/_ml/memory_containers/{memory_container_id}
+{
+  "configuration": {
+    "retention_policy": {
+      "sessions": {
+        "max_count": 200
+      }
+    }
+  }
+}
+```
+
+### Merge behavior
+
+Updates use **field-level merge**, which means:
+
+- **Memory types you include** are merged into the existing policy. Fields you specify are updated; fields you omit within that type are unchanged.
+- **Memory types you omit** are left untouched.
+- **To remove a single field**, send it explicitly as `null`:
+  ```json
+  { "configuration": { "retention_policy": { "sessions": { "retention_days": null } } } }
+  ```
+  This removes `retention_days` from sessions while preserving `max_count`.
+- **To remove an entire memory type's rule**, send its value as `null`:
+  ```json
+  { "configuration": { "retention_policy": { "long-term": null } } }
+  ```
+
+### Examples of merge behavior
+
+Starting policy:
+```json
+{
+  "sessions": { "retention_days": 30, "max_count": 100 },
+  "long-term": { "max_count": 5000 }
+}
+```
+
+| Update request | Resulting policy |
+|---|---|
+| `{"sessions": {"max_count": 50}}` | sessions: days=30, count=50; long-term: count=5000 |
+| `{"sessions": {"retention_days": null}}` | sessions: count=100 (days removed); long-term: count=5000 |
+| `{"history": {"max_count": 10000}}` | sessions: days=30, count=100; long-term: count=5000; history: count=10000 |
+
+---
+
+## Opting Out of Retention
+
+To disable all retention enforcement for a container, set the policy to `null`:
+
+```json
+PUT /_plugins/_ml/memory_containers/{memory_container_id}
+{
+  "configuration": {
+    "retention_policy": null
+  }
+}
+```
+
+This is an explicit opt-out. The retention job will skip this container entirely, even if cluster-level defaults are configured. This is distinct from simply not having a policy (which allows defaults to be backfilled).
+
+To opt back in later, provide a new concrete policy in a subsequent update.
+
+---
+
+## Pinning Memories
+
+Pinning a memory exempts it from all retention enforcement. The retention job never deletes a pinned memory, regardless of its age or the current count.
+
+### Pin a session
+
+Pinning a session preserves the entire conversation, including all of its working memory messages.
+
+```json
+PUT /_plugins/_ml/memory_containers/{id}/memories/sessions/{session_id}
+{
+  "update_content": {
+    "pinned": true
+  }
+}
+```
+
+### Pin a long-term memory
+
+```json
+PUT /_plugins/_ml/memory_containers/{id}/memories/long-term/{memory_id}
+{
+  "update_content": {
+    "pinned": true
+  }
+}
+```
+
+### Unpin a memory
+
+Set `pinned` to `false`:
+
+```json
+PUT /_plugins/_ml/memory_containers/{id}/memories/sessions/{session_id}
+{
+  "update_content": {
+    "pinned": false
+  }
+}
+```
+
+### Pinning rules
+
+- **Sessions**: can be pinned. Protects the session and all its working memory from deletion.
+- **Long-term**: can be pinned. Protects that specific memory from deletion.
+- **Working memory**: cannot be pinned. Pin the parent session instead.
+- **History**: cannot be pinned.
+- **Pinned memories do not count toward `max_count`.** If you have `max_count: 100` and 120 sessions where 30 are pinned, the job sees 90 non-pinned sessions and keeps the newest 100 non-pinned ones (no deletions in this case).
+- **Pinning does not reset the memory's age.** Only content changes (adding messages to a session, updating memory content) extend lifetime by bumping `last_updated_time`.
+
+---
+
+## How the Retention Job Works
+
+A background job runs on a schedule (default: every 24 hours) and processes all memory containers. Understanding what it does helps you predict its behavior.
+
+### Execution order
+
+For each container with a retention policy, the job executes these phases in order:
+
+1. **Session retention** (time-based, then count-based)
+2. **Long-term memory retention** (time-based, then count-based)
+3. **History retention** (count-based only)
+4. **Working memory TTL** (only for session-disabled containers)
+5. **Orphan sweep** (runs after all containers are processed)
+
+### Session retention in detail
+
+When `retention_days` is set: sessions whose `last_updated_time` is older than the threshold are deleted. Active conversations (recently messaged) are safe because adding messages bumps `last_updated_time`.
+
+When `max_count` is set: if the number of non-pinned sessions exceeds the cap, the oldest sessions (by `created_time`) are removed until the count is within bounds.
+
+**Cascade behavior:** When a session is deleted, all of its working memory messages are deleted first, then the session document itself. Conversations are never left with gaps.
+
+### Long-term memory retention in detail
+
+Works identically to sessions: time-based deletion on `last_updated_time`, then count-based on `created_time`, oldest first. Pinned memories are excluded from both.
+
+### History retention in detail
+
+Count-based only. Oldest entries (by `created_time`) are deleted when the non-pinned count exceeds `max_count`.
+
+### Working memory TTL
+
+Only applies to containers with `disable_session: true` (session-less containers). In these containers, working memory has no parent session to cascade from, so a cluster-level TTL (`plugins.ml_commons.memory.working_memory_ttl_days`, default 30 days) governs when orphaned messages are cleaned up.
+
+### Orphan sweep
+
+Identifies working-memory documents whose parent session no longer exists (for example, if a session was manually deleted or a caller-managed session ID was used without creating a session document) and removes them after they exceed `plugins.ml_commons.memory.orphan_ttl_days` (default 7 days). This age guard prevents deletion of freshly-written working memory and gives in-flight conversations time to complete. Also removes completely unattributable working-memory documents (no session ID at all) older than the same threshold.
+
+### Staleness window
+
+Because the job runs periodically (not in real time), there is a window between when a memory becomes eligible for deletion and when it is actually removed. This window is at most one job interval (default 24 hours). Expired memories may still appear in queries during this window.
+
+---
+
+## Cluster-Level Settings (Admin)
+
+Cluster administrators can configure retention behavior using dynamic cluster settings. All settings use the prefix `plugins.ml_commons.memory.` and can be updated at runtime without a restart.
+
+### Master switch
+
+| Setting | Default | Description |
+|---|---|---|
+| `retention_enabled` | `true` | Enables or disables the retention job cluster-wide. Set to `false` to stop all enforcement without modifying individual container policies. |
+
+### Job schedule and throttling
+
+| Setting | Default | Range | Description |
+|---|---|---|---|
+| `retention_job_interval_hours` | 24 | 1 - 168 | How often the retention job runs, in hours. |
+| `retention_job_throttle_seconds` | 5 | 1 - 60 | Pause between containers during job execution to reduce cluster load. |
+
+### Cleanup TTLs
+
+| Setting | Default | Range | Description |
+|---|---|---|---|
+| `working_memory_ttl_days` | 30 | 1 - 365 | TTL for working memory in session-disabled containers. |
+| `orphan_ttl_days` | 7 | 1 - 365 | TTL for unattributable orphaned working-memory documents. |
+
+### Default retention policy (template for new containers)
+
+These defaults are applied to containers that do not specify their own policy and have not explicitly opted out. Values of `-1` mean "no default" (the type is left unconfigured).
+
+| Setting | Default | Range | Applies To |
+|---|---|---|---|
+| `default_session_retention_days` | -1 (disabled) | -1 - 3650 | sessions `retention_days` |
+| `default_session_max_count` | -1 (disabled) | -1 - 1,000,000 | sessions `max_count` |
+| `default_long_term_max_count` | -1 (disabled) | -1 - 1,000,000 | long-term `max_count` |
+| `default_history_max_count` | -1 (disabled) | -1 - 10,000,000 | history `max_count` |
+
+### Setting cluster defaults
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "plugins.ml_commons.memory.default_session_retention_days": 90,
+    "plugins.ml_commons.memory.default_session_max_count": 5000,
+    "plugins.ml_commons.memory.default_long_term_max_count": 2000,
+    "plugins.ml_commons.memory.default_history_max_count": 100000
+  }
+}
+```
+
+Once set, all newly created containers (that do not specify their own policy) will inherit these values. Existing containers without a policy will receive them on the next job run via backfill.
+
+**Important:** Defaults are baked into the container at the time they are applied. If you change cluster defaults later, previously created containers are not retroactively updated. To change a specific container's policy, use the update API.
+
+---
+
+## Validation Rules and Error Messages
+
+| Condition | HTTP Status | Error Message |
+|---|---|---|
+| `retention_days` set to 0 or negative | 400 | `retention_days must be a positive integer or null` |
+| `max_count` set to 0 or negative | 400 | `max_count must be a positive integer or null` |
+| `retention_days` specified for history | 400 | `retention_days is not supported for history memory type` |
+| `working` key included in the policy | 400 | `Working memory retention cannot be configured directly. Working memory is deleted when its parent session expires. To control message lifetime, configure retention on "sessions" instead.` |
+| Unrecognized memory type key | 400 | `unknown memory type: <key>` |
+| `pinned` set when adding working memory | 400 | `pinned field is not supported for working memory type. To preserve a conversation, pin the session instead.` |
+
+---
+
+## Worked Examples
+
+### Example 1: Customer support agent with aggressive cleanup
+
+A high-volume support agent that processes thousands of conversations daily. You want to keep only recent sessions and a moderate knowledge base.
+
+```json
+POST /_plugins/_ml/memory_containers/_create
+{
+  "name": "high-volume-support-agent",
+  "configuration": {
+    "retention_policy": {
+      "sessions": {
+        "retention_days": 7,
+        "max_count": 1000
+      },
+      "long-term": {
+        "retention_days": 180,
+        "max_count": 10000
+      },
+      "history": {
+        "max_count": 100000
+      }
+    }
+  }
+}
+```
+
+**What happens:** Sessions older than 7 days are deleted. If more than 1000 non-pinned sessions exist before 7 days have passed, the oldest are evicted early. Long-term memories are kept for 6 months or until 10,000 accumulate. History keeps the most recent 100,000 entries.
+
+### Example 2: Research assistant with long memory
+
+A knowledge-heavy agent where long-term memory is critical and conversations are secondary.
+
+```json
+POST /_plugins/_ml/memory_containers/_create
+{
+  "name": "research-assistant",
+  "configuration": {
+    "retention_policy": {
+      "sessions": {
+        "retention_days": 14,
+        "max_count": 200
+      },
+      "long-term": {
+        "max_count": 50000
+      }
+    }
+  }
+}
+```
+
+**What happens:** Sessions expire after 2 weeks. Long-term memory grows up to 50,000 entries with no time-based expiry (knowledge is only evicted when the count is exceeded, oldest first). History has no policy, so no history cleanup occurs.
+
+### Example 3: Protecting important conversations
+
+Pin a session that contains an important troubleshooting thread so it is never deleted, regardless of retention rules:
+
+```json
+PUT /_plugins/_ml/memory_containers/{id}/memories/sessions/{session_id}
+{
+  "update_content": {
+    "pinned": true
+  }
+}
+```
+
+The pinned session and all its messages will persist indefinitely. It does not count against `max_count`, so it will not block other sessions from being kept.
+
+### Example 4: Understanding OR logic between retention_days and max_count
+
+Container has: `sessions: { retention_days: 30, max_count: 100 }`
+
+Scenario A: You have 50 sessions. One is 31 days old.
+- Result: The 31-day-old session is deleted (violates `retention_days`). The other 49 remain.
+
+Scenario B: You have 110 sessions, all less than 30 days old.
+- Result: The 10 oldest sessions are deleted (violates `max_count`). 100 remain.
+
+Scenario C: You have 80 sessions, all less than 30 days old.
+- Result: No deletions. Neither rule is violated.
+
+### Example 5: Disabling just time-based retention
+
+You want count-based limits only, with no time-based expiry:
+
+```json
+{
+  "configuration": {
+    "retention_policy": {
+      "sessions": {
+        "retention_days": null,
+        "max_count": 500
+      },
+      "long-term": {
+        "retention_days": null,
+        "max_count": 10000
+      }
+    }
+  }
+}
+```
+
+### Example 6: Completely opting out
+
+```json
+PUT /_plugins/_ml/memory_containers/{memory_container_id}
+{
+  "configuration": {
+    "retention_policy": null
+  }
+}
+```
+
+No retention enforcement of any kind will apply to this container, even if cluster defaults are configured.
+
+---
+
+## FAQ
+
+### Does the retention job delete data immediately when a rule is violated?
+
+No. The job runs on a schedule (default every 24 hours). There is a staleness window of up to one job interval where expired memories may still be visible in query results.
+
+### What happens to working memory when a session is deleted?
+
+All working memory (messages) belonging to that session are deleted first, then the session itself is removed. Conversations are never left in a partial state.
+
+### Can I set retention rules on working memory directly?
+
+No. Working memory lifecycle is tied to its parent session. Configure `sessions` retention to control how long messages live.
+
+### Does pinning a session reset its age?
+
+No. Pinning is a metadata operation and does not change `last_updated_time`. Only adding messages to a session extends its lifetime. However, this does not matter for retention because pinned sessions are never deleted regardless of age.
+
+### What if I have more pinned sessions than max_count?
+
+The job will never delete pinned items. It logs a warning that the container is growing beyond the cap due to pins, but enforcement only applies to non-pinned items. To bring the container back under control, review and unpin sessions that no longer need protection.
+
+### Do cluster default changes affect existing containers?
+
+No. Defaults are applied to a container once (at creation time or on first backfill). Changing cluster defaults later does not update containers that already have a policy. Use the update API to modify individual containers.
+
+### What is the difference between "no policy" and "opted out"?
+
+- **No policy** (field absent): The container may receive cluster defaults via backfill on the next job run.
+- **Opted out** (`"retention_policy": null`): The container is permanently skipped by the retention job. Defaults are never backfilled. This is an active choice.
+
+### Can I trigger the retention job on demand?
+
+Not in this version. The job runs on its configured interval. You can reduce the interval to 1 hour for faster enforcement if needed:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "plugins.ml_commons.memory.retention_job_interval_hours": 1
+  }
+}
+```
+
+### What OpenSearch version is required?
+
+Memory retention policies require OpenSearch 3.8.0 or later.
+
+### Does this work with multi-tenancy?
+
+Not in this version. The retention job is disabled when multi-tenancy is active. Multi-tenant support is planned for a future release.
+
+---
+
+## API Reference Summary
+
+| Operation | Method | Endpoint | Body |
+|---|---|---|---|
+| Create container with policy | POST | `/_plugins/_ml/memory_containers/_create` | `{"configuration": {"retention_policy": {...}}}` |
+| Update container policy | PUT | `/_plugins/_ml/memory_containers/{id}` | `{"configuration": {"retention_policy": {...}}}` |
+| Opt out of retention | PUT | `/_plugins/_ml/memory_containers/{id}` | `{"configuration": {"retention_policy": null}}` |
+| Pin a session | PUT | `/_plugins/_ml/memory_containers/{id}/memories/sessions/{session_id}` | `{"update_content": {"pinned": true}}` |
+| Unpin a session | PUT | `/_plugins/_ml/memory_containers/{id}/memories/sessions/{session_id}` | `{"update_content": {"pinned": false}}` |
+| Pin a long-term memory | PUT | `/_plugins/_ml/memory_containers/{id}/memories/long-term/{memory_id}` | `{"update_content": {"pinned": true}}` |
+| Set cluster defaults | PUT | `/_cluster/settings` | `{"persistent": {"plugins.ml_commons.memory.default_session_retention_days": 90, ...}}` |
+| Disable retention cluster-wide | PUT | `/_cluster/settings` | `{"persistent": {"plugins.ml_commons.memory.retention_enabled": false}}` |
+</script>
+<script>
+function render() {
+  if (!window.marked) { return setTimeout(render, 50); }
+  const src = document.getElementById('md-source').textContent;
+  const renderer = new marked.Renderer();
+  renderer.table = function(header, body) {
+    return '<div class="table-wrap"><table><thead>' + header + '</thead><tbody>' + body + '</tbody></table></div>';
+  };
+  marked.setOptions({ gfm: true, breaks: false, renderer });
+  const contentEl = document.getElementById('content');
+  contentEl.innerHTML = marked.parse(src);
+  const firstH1 = contentEl.querySelector('h1');
+  if (firstH1) { document.getElementById('doc-title').textContent = firstH1.textContent; firstH1.remove(); }
+  const headings = contentEl.querySelectorAll('h1, h2, h3');
+  const toc = document.getElementById('toc');
+  headings.forEach((h, i) => {
+    const id = 'heading-' + i;
+    h.id = id;
+    const a = document.createElement('a');
+    a.href = '#' + id;
+    a.textContent = h.textContent;
+    a.className = h.tagName.toLowerCase();
+    toc.appendChild(a);
+  });
+}
+render();
+</script>
+</body>
+</html>

--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -110,6 +110,7 @@ public class CommonValue {
     public static final Version VERSION_3_4_0 = Version.fromString("3.4.0");
     public static final Version VERSION_3_5_0 = Version.fromString("3.5.0");
     public static final Version VERSION_3_7_0 = Version.fromString("3.7.0");
+    public static final Version VERSION_3_8_0 = Version.fromString("3.8.0");
 
     // Connector Constants
     public static final String NAME_FIELD = "name";

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
@@ -102,7 +103,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = in.readOptionalString();
         this.memoryContainerId = in.readOptionalString();
         this.strategyId = in.readOptionalString();
-        this.pinned = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 
@@ -127,7 +130,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         out.writeOptionalString(ownerId);
         out.writeOptionalString(memoryContainerId);
         out.writeOptionalString(strategyId);
-        out.writeOptionalBoolean(pinned);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
@@ -6,7 +6,7 @@
 package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
@@ -103,7 +103,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = in.readOptionalString();
         this.memoryContainerId = in.readOptionalString();
         this.strategyId = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
@@ -130,7 +130,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         out.writeOptionalString(ownerId);
         out.writeOptionalString(memoryContainerId);
         out.writeOptionalString(strategyId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemory.java
@@ -15,6 +15,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_SIZE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRATEGY_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TAGS_FIELD;
 
@@ -58,6 +59,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
     private String ownerId;
     private String memoryContainerId;
     private String strategyId;
+    private Boolean pinned;
 
     @Builder
     public MLLongTermMemory(
@@ -70,7 +72,8 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         Object memoryEmbedding,
         String ownerId,
         String memoryContainerId,
-        String strategyId
+        String strategyId,
+        Boolean pinned
     ) {
         this.memory = memory;
         this.strategyType = strategyType;
@@ -82,6 +85,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = ownerId;
         this.memoryContainerId = memoryContainerId;
         this.strategyId = strategyId;
+        this.pinned = pinned;
     }
 
     public MLLongTermMemory(StreamInput in) throws IOException {
@@ -98,6 +102,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         this.ownerId = in.readOptionalString();
         this.memoryContainerId = in.readOptionalString();
         this.strategyId = in.readOptionalString();
+        this.pinned = in.readOptionalBoolean();
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 
@@ -122,6 +127,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         out.writeOptionalString(ownerId);
         out.writeOptionalString(memoryContainerId);
         out.writeOptionalString(strategyId);
+        out.writeOptionalBoolean(pinned);
         // Note: memoryEmbedding is not serialized in StreamInput/Output as it's typically handled separately
     }
 
@@ -151,6 +157,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         if (strategyId != null) {
             builder.field(STRATEGY_ID_FIELD, strategyId);
         }
+        if (pinned != null) {
+            builder.field(PINNED_FIELD, pinned);
+        }
 
         builder.endObject();
         return builder;
@@ -167,6 +176,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         String ownerId = null;
         String memoryContainerId = null;
         String strategyId = null;
+        Boolean pinned = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -211,6 +221,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
                 case STRATEGY_ID_FIELD:
                     strategyId = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.currentToken() == XContentParser.Token.VALUE_NULL ? null : parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -229,6 +242,7 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
             .ownerId(ownerId)
             .memoryContainerId(memoryContainerId)
             .strategyId(strategyId)
+            .pinned(pinned)
             .build();
     }
 
@@ -269,6 +283,9 @@ public class MLLongTermMemory implements ToXContentObject, Writeable {
         }
         if (strategyId != null) {
             result.put(STRATEGY_ID_FIELD, strategyId);
+        }
+        if (pinned != null) {
+            result.put(PINNED_FIELD, pinned);
         }
         return result;
     }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
@@ -102,13 +102,13 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         if (in.readBoolean()) {
             this.after = in.readMap();
         }
-        this.createdTime = in.readOptionalInstant();
         if (in.readBoolean()) {
             namespace = in.readMap(StreamInput::readString, StreamInput::readString);
         }
         if (in.readBoolean()) {
             this.tags = in.readMap(StreamInput::readString, StreamInput::readString);
         }
+        this.createdTime = in.readOptionalInstant();
         this.tenantId = in.readOptionalString();
         this.error = in.readOptionalString();
         if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
@@ -139,7 +139,6 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
-        out.writeOptionalInstant(createdTime);
         if (namespace != null && !namespace.isEmpty()) {
             out.writeBoolean(true);
             out.writeMap(namespace, StreamOutput::writeString, StreamOutput::writeString);
@@ -152,6 +151,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
+        out.writeOptionalInstant(createdTime);
         out.writeOptionalString(tenantId);
         out.writeOptionalString(error);
         if (out.getVersion().onOrAfter(VERSION_3_8_0)) {

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ERROR_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_ACTION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_AFTER_FIELD;
@@ -110,7 +111,9 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         this.tenantId = in.readOptionalString();
         this.error = in.readOptionalString();
-        this.pinned = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
     }
 
     @Override
@@ -136,6 +139,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
+        out.writeOptionalInstant(createdTime);
         if (namespace != null && !namespace.isEmpty()) {
             out.writeBoolean(true);
             out.writeMap(namespace, StreamOutput::writeString, StreamOutput::writeString);
@@ -148,10 +152,11 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
-        out.writeOptionalInstant(createdTime);
         out.writeOptionalString(tenantId);
         out.writeOptionalString(error);
-        out.writeOptionalBoolean(pinned);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
     }
 
     @Override

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
@@ -8,7 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ERROR_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_ACTION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_AFTER_FIELD;
@@ -111,7 +111,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         this.tenantId = in.readOptionalString();
         this.error = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
     }
@@ -154,7 +154,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         out.writeOptionalString(tenantId);
         out.writeOptionalString(error);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
     }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistory.java
@@ -17,6 +17,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_SIZE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TAGS_FIELD;
 
 import java.io.IOException;
@@ -57,6 +58,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
     private Instant createdTime;
     private String tenantId;
     private String error;
+    private Boolean pinned;
 
     public MLMemoryHistory(
         String ownerId,
@@ -69,7 +71,8 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         Map<String, String> tags,
         Instant createdTime,
         String tenantId,
-        String error
+        String error,
+        Boolean pinned
     ) {
         this.ownerId = ownerId;
         this.memoryContainerId = memoryContainerId;
@@ -82,6 +85,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         this.createdTime = createdTime;
         this.tenantId = tenantId;
         this.error = error;
+        this.pinned = pinned;
     }
 
     public MLMemoryHistory(StreamInput in) throws IOException {
@@ -106,6 +110,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         }
         this.tenantId = in.readOptionalString();
         this.error = in.readOptionalString();
+        this.pinned = in.readOptionalBoolean();
     }
 
     @Override
@@ -146,6 +151,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         out.writeOptionalInstant(createdTime);
         out.writeOptionalString(tenantId);
         out.writeOptionalString(error);
+        out.writeOptionalBoolean(pinned);
     }
 
     @Override
@@ -185,6 +191,9 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         if (error != null) {
             builder.field(ERROR_FIELD, error);
         }
+        if (pinned != null) {
+            builder.field(PINNED_FIELD, pinned);
+        }
         builder.endObject();
         return builder;
     }
@@ -201,6 +210,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
         Instant createdTime = null;
         String tenantId = null;
         String error = null;
+        Boolean pinned = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -241,6 +251,9 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
                 case ERROR_FIELD:
                     error = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.currentToken() == XContentParser.Token.VALUE_NULL ? null : parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -260,6 +273,7 @@ public class MLMemoryHistory implements ToXContentObject, Writeable {
             .createdTime(createdTime)
             .tenantId(tenantId)
             .error(error)
+            .pinned(pinned)
             .build();
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.conversation.ActionConstants.ADDITIONAL_INFO_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENTS_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
@@ -100,7 +101,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             this.namespace = in.readMap(StreamInput::readString, StreamInput::readString);
         }
         this.tenantId = in.readOptionalString();
-        this.pinned = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
     }
 
     @Override
@@ -136,7 +139,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(tenantId);
-        out.writeOptionalBoolean(pinned);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
     }
 
     @Override

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
@@ -7,7 +7,7 @@ package org.opensearch.ml.common.memorycontainer;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.conversation.ActionConstants.ADDITIONAL_INFO_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENTS_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
@@ -101,7 +101,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             this.namespace = in.readMap(StreamInput::readString, StreamInput::readString);
         }
         this.tenantId = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
     }
@@ -139,7 +139,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(tenantId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
     }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MLMemorySession.java
@@ -15,6 +15,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.METADATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SUMMARY_FIELD;
 
 import java.io.IOException;
@@ -52,6 +53,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
     private Map<String, Object> additionalInfo;
     private Map<String, String> namespace;
     private String tenantId;
+    private Boolean pinned;
 
     public MLMemorySession(
         String ownerId,
@@ -63,7 +65,8 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         Map<String, Object> agents,
         Map<String, Object> additionalInfo,
         Map<String, String> namespace,
-        String tenantId
+        String tenantId,
+        Boolean pinned
     ) {
         this.ownerId = ownerId;
         this.memoryContainerId = memoryContainerId;
@@ -75,6 +78,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         this.additionalInfo = additionalInfo;
         this.namespace = namespace;
         this.tenantId = tenantId;
+        this.pinned = pinned;
     }
 
     public MLMemorySession(StreamInput in) throws IOException {
@@ -96,6 +100,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             this.namespace = in.readMap(StreamInput::readString, StreamInput::readString);
         }
         this.tenantId = in.readOptionalString();
+        this.pinned = in.readOptionalBoolean();
     }
 
     @Override
@@ -131,6 +136,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(tenantId);
+        out.writeOptionalBoolean(pinned);
     }
 
     @Override
@@ -166,6 +172,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         if (tenantId != null) {
             builder.field(TENANT_ID_FIELD, tenantId);
         }
+        if (pinned != null) {
+            builder.field(PINNED_FIELD, pinned);
+        }
         builder.endObject();
         return builder;
     }
@@ -181,6 +190,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
         Map<String, Object> additionalInfo = null;
         Map<String, String> namespace = null;
         String tenantId = null;
+        Boolean pinned = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -218,6 +228,9 @@ public class MLMemorySession implements ToXContentObject, Writeable {
                 case TENANT_ID_FIELD:
                     tenantId = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.currentToken() == XContentParser.Token.VALUE_NULL ? null : parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -236,6 +249,7 @@ public class MLMemorySession implements ToXContentObject, Writeable {
             .additionalInfo(additionalInfo)
             .namespace(namespace)
             .tenantId(tenantId)
+            .pinned(pinned)
             .build();
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_AGENTIC_MEMORY_SYSTEM_INDEX_PREFIX;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DEFAULT_MEMORY_INDEX_PREFIX;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DIMENSION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DISABLE_HISTORY_FIELD;
@@ -64,7 +65,6 @@ import lombok.extern.log4j.Log4j2;
  */
 @Getter
 @Setter
-@Builder
 @EqualsAndHashCode
 @Log4j2
 public class MemoryConfiguration implements ToXContentObject, Writeable {
@@ -73,22 +73,18 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     private String embeddingModelId;
     private String llmId;
     private Integer dimension;
-    @Builder.Default
-    private Integer maxInferSize = MAX_INFER_SIZE_DEFAULT_VALUE;
+    private Integer maxInferSize;
     private List<MemoryStrategy> strategies;
-    @Builder.Default
-    private Map<String, Map<String, Object>> indexSettings = new HashMap<>();
-    @Builder.Default
-    private Map<String, Object> parameters = new HashMap<>();
-    @Builder.Default
-    private boolean disableHistory = false;
-    @Builder.Default
-    private boolean disableSession = false;
-    @Builder.Default
-    private boolean useSystemIndex = true;
+    private Map<String, Map<String, Object>> indexSettings;
+    private Map<String, Object> parameters;
+    private boolean disableHistory;
+    private boolean disableSession;
+    private boolean useSystemIndex;
     private String tenantId;
     private Map<MemoryType, RetentionRule> retentionPolicy;
+    private transient boolean retentionPolicyExplicitlyNull = false;
 
+    @Builder
     public MemoryConfiguration(
         String indexPrefix,
         FunctionName embeddingModelType,
@@ -99,17 +95,23 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         List<MemoryStrategy> strategies,
         Map<String, Map<String, Object>> indexSettings,
         Map<String, Object> parameters,
-        boolean disableHistory,
-        boolean disableSession,
-        boolean useSystemIndex,
+        Boolean disableHistory,
+        Boolean disableSession,
+        Boolean useSystemIndex,
         String tenantId,
         Map<MemoryType, RetentionRule> retentionPolicy
     ) {
+        // Apply defaults for Boolean parameters
+        boolean effectiveUseSystemIndex = (useSystemIndex != null) ? useSystemIndex : true;
+        boolean effectiveDisableHistory = (disableHistory != null) ? disableHistory : false;
+        boolean effectiveDisableSession = (disableSession != null) ? disableSession : false;
+
         // Validate first
         validateInputs(embeddingModelType, embeddingModelId, dimension, maxInferSize);
+        validateRetentionPolicy(retentionPolicy);
 
         // Assign values after validation
-        this.indexPrefix = buildIndexPrefix(indexPrefix, useSystemIndex);
+        this.indexPrefix = buildIndexPrefix(indexPrefix, effectiveUseSystemIndex);
         this.embeddingModelType = embeddingModelType;
         this.embeddingModelId = embeddingModelId;
         this.llmId = llmId;
@@ -127,9 +129,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         if (parameters != null && !parameters.isEmpty()) {
             this.parameters.putAll(parameters);
         }
-        this.disableHistory = disableHistory;
-        this.disableSession = disableSession;
-        this.useSystemIndex = useSystemIndex;
+        this.disableHistory = effectiveDisableHistory;
+        this.disableSession = effectiveDisableSession;
+        this.useSystemIndex = effectiveUseSystemIndex;
         this.tenantId = tenantId;
         this.retentionPolicy = retentionPolicy;
     }
@@ -173,13 +175,15 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = input.readBoolean();
         this.useSystemIndex = input.readBoolean();
         this.tenantId = input.readOptionalString();
-        if (input.readBoolean()) {
-            int size = input.readVInt();
-            this.retentionPolicy = new EnumMap<>(MemoryType.class);
-            for (int i = 0; i < size; i++) {
-                MemoryType key = input.readEnum(MemoryType.class);
-                RetentionRule value = new RetentionRule(input);
-                this.retentionPolicy.put(key, value);
+        if (input.getVersion().onOrAfter(VERSION_3_7_0)) {
+            if (input.readBoolean()) {
+                int size = input.readVInt();
+                this.retentionPolicy = new EnumMap<>(MemoryType.class);
+                for (int i = 0; i < size; i++) {
+                    MemoryType key = input.readEnum(MemoryType.class);
+                    RetentionRule value = new RetentionRule(input);
+                    this.retentionPolicy.put(key, value);
+                }
             }
         }
     }
@@ -214,15 +218,17 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         out.writeBoolean(disableSession);
         out.writeBoolean(useSystemIndex);
         out.writeOptionalString(tenantId);
-        if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
-            out.writeBoolean(true);
-            out.writeVInt(retentionPolicy.size());
-            for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
-                out.writeEnum(entry.getKey());
-                entry.getValue().writeTo(out);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
+                out.writeBoolean(true);
+                out.writeVInt(retentionPolicy.size());
+                for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
+                    out.writeEnum(entry.getKey());
+                    entry.getValue().writeTo(out);
+                }
+            } else {
+                out.writeBoolean(false);
             }
-        } else {
-            out.writeBoolean(false);
         }
     }
 
@@ -301,6 +307,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         boolean useSystemIndex = true;
         String tenantId = null;
         Map<MemoryType, RetentionRule> retentionPolicy = null;
+        boolean retentionPolicyIsExplicitlyNull = false;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -355,6 +362,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 case RETENTION_POLICY_FIELD:
                     if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                         retentionPolicy = null;
+                        retentionPolicyIsExplicitlyNull = true;
                     } else {
                         retentionPolicy = parseRetentionPolicy(parser);
                     }
@@ -366,7 +374,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         }
 
         // Note: validation is already called in the constructor
-        return MemoryConfiguration
+        MemoryConfiguration config = MemoryConfiguration
             .builder()
             .indexPrefix(indexPrefix)
             .embeddingModelType(embeddingModelType)
@@ -383,6 +391,8 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             .tenantId(tenantId)
             .retentionPolicy(retentionPolicy)
             .build();
+        config.setRetentionPolicyExplicitlyNull(retentionPolicyIsExplicitlyNull);
+        return config;
     }
 
     private static Map<MemoryType, RetentionRule> parseRetentionPolicy(XContentParser parser) throws IOException {
@@ -488,6 +498,29 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     private static void validateInputs(FunctionName embeddingModelType, String embeddingModelId, Integer dimension, Integer maxInferSize) {
         validateEmbeddingConfiguration(embeddingModelType, embeddingModelId, dimension);
         validateMaxInferSize(maxInferSize);
+    }
+
+    /**
+     * Validates retention policy constraints.
+     * Ensures WORKING memory type is not configured directly and HISTORY does not have retention_days.
+     *
+     * @param retentionPolicy the retention policy map to validate
+     * @throws IllegalArgumentException if the policy violates constraints
+     */
+    private static void validateRetentionPolicy(Map<MemoryType, RetentionRule> retentionPolicy) {
+        if (retentionPolicy == null || retentionPolicy.isEmpty()) {
+            return;
+        }
+        if (retentionPolicy.containsKey(MemoryType.WORKING)) {
+            throw new IllegalArgumentException(
+                "Working memory retention cannot be configured directly. Working memory is deleted when its parent session expires."
+                    + " To control message lifetime, configure retention on \"sessions\" instead."
+            );
+        }
+        RetentionRule historyRule = retentionPolicy.get(MemoryType.HISTORY);
+        if (historyRule != null && historyRule.getRetentionDays() != null) {
+            throw new IllegalArgumentException("retention_days is not supported for history memory type");
+        }
     }
 
     /**
@@ -609,24 +642,15 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             this.dimension = updateContent.getDimension();
         }
         // Merge retention policy
-        if (updateContent.getRetentionPolicy() != null) {
+        if (updateContent.isRetentionPolicyExplicitlyNull()) {
+            this.retentionPolicy = null;
+        } else if (updateContent.getRetentionPolicy() != null) {
+            validateRetentionPolicy(updateContent.getRetentionPolicy());
             if (this.retentionPolicy == null) {
                 this.retentionPolicy = new EnumMap<>(MemoryType.class);
             }
             for (Map.Entry<MemoryType, RetentionRule> entry : updateContent.getRetentionPolicy().entrySet()) {
-                MemoryType type = entry.getKey();
-                RetentionRule incomingRule = entry.getValue();
-                RetentionRule existingRule = this.retentionPolicy.get(type);
-
-                if (existingRule == null) {
-                    this.retentionPolicy.put(type, incomingRule);
-                } else {
-                    Integer mergedDays = incomingRule.getRetentionDays() != null
-                        ? incomingRule.getRetentionDays()
-                        : existingRule.getRetentionDays();
-                    Integer mergedCount = incomingRule.getMaxCount() != null ? incomingRule.getMaxCount() : existingRule.getMaxCount();
-                    this.retentionPolicy.put(type, new RetentionRule(mergedDays, mergedCount));
-                }
+                this.retentionPolicy.put(entry.getKey(), entry.getValue());
             }
         }
         // Note: indexPrefix and other structural fields are intentionally not updated

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -28,10 +28,12 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SPARSE_ENCODING_DIMENSION_NOT_ALLOWED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRATEGIES_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TEXT_EMBEDDING_DIMENSION_REQUIRED_ERROR;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.USE_SYSTEM_INDEX_FIELD;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +87,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     @Builder.Default
     private boolean useSystemIndex = true;
     private String tenantId;
+    private Map<MemoryType, RetentionRule> retentionPolicy;
 
     public MemoryConfiguration(
         String indexPrefix,
@@ -99,7 +102,8 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         boolean disableHistory,
         boolean disableSession,
         boolean useSystemIndex,
-        String tenantId
+        String tenantId,
+        Map<MemoryType, RetentionRule> retentionPolicy
     ) {
         // Validate first
         validateInputs(embeddingModelType, embeddingModelId, dimension, maxInferSize);
@@ -127,6 +131,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = disableSession;
         this.useSystemIndex = useSystemIndex;
         this.tenantId = tenantId;
+        this.retentionPolicy = retentionPolicy;
     }
 
     private String buildIndexPrefix(String indexPrefix, boolean useSystemIndex) {
@@ -168,6 +173,15 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = input.readBoolean();
         this.useSystemIndex = input.readBoolean();
         this.tenantId = input.readOptionalString();
+        if (input.readBoolean()) {
+            int size = input.readVInt();
+            this.retentionPolicy = new EnumMap<>(MemoryType.class);
+            for (int i = 0; i < size; i++) {
+                MemoryType key = input.readEnum(MemoryType.class);
+                RetentionRule value = new RetentionRule(input);
+                this.retentionPolicy.put(key, value);
+            }
+        }
     }
 
     @Override
@@ -200,6 +214,16 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         out.writeBoolean(disableSession);
         out.writeBoolean(useSystemIndex);
         out.writeOptionalString(tenantId);
+        if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
+            out.writeBoolean(true);
+            out.writeVInt(retentionPolicy.size());
+            for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
+                out.writeEnum(entry.getKey());
+                entry.getValue().writeTo(out);
+            }
+        } else {
+            out.writeBoolean(false);
+        }
     }
 
     @Override
@@ -250,6 +274,14 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         if (tenantId != null) {
             builder.field(TENANT_ID_FIELD, tenantId);
         }
+        if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
+            builder.startObject(RETENTION_POLICY_FIELD);
+            for (Map.Entry<MemoryType, RetentionRule> entry : retentionPolicy.entrySet()) {
+                builder.field(entry.getKey().getValue());
+                entry.getValue().toXContent(builder, params);
+            }
+            builder.endObject();
+        }
         builder.endObject();
         return builder;
     }
@@ -268,6 +300,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         boolean disableSession = false;
         boolean useSystemIndex = true;
         String tenantId = null;
+        Map<MemoryType, RetentionRule> retentionPolicy = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -319,6 +352,13 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 case USE_SYSTEM_INDEX_FIELD:
                     useSystemIndex = parser.booleanValue();
                     break;
+                case RETENTION_POLICY_FIELD:
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        retentionPolicy = null;
+                    } else {
+                        retentionPolicy = parseRetentionPolicy(parser);
+                    }
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -341,7 +381,40 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             .disableSession(disableSession)
             .useSystemIndex(useSystemIndex)
             .tenantId(tenantId)
+            .retentionPolicy(retentionPolicy)
             .build();
+    }
+
+    private static Map<MemoryType, RetentionRule> parseRetentionPolicy(XContentParser parser) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        Map<MemoryType, RetentionRule> policy = new EnumMap<>(MemoryType.class);
+
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String key = parser.currentName();
+            parser.nextToken();
+
+            if (key.equals(MemoryType.WORKING.getValue())) {
+                throw new IllegalArgumentException(
+                    "Working memory retention cannot be configured directly. Working memory is deleted when its parent session expires."
+                        + " To control message lifetime, configure retention on \"sessions\" instead."
+                );
+            }
+
+            if (!MemoryType.isValid(key)) {
+                throw new IllegalArgumentException("unknown memory type: " + key);
+            }
+
+            MemoryType memoryType = MemoryType.fromString(key);
+            RetentionRule rule = RetentionRule.parse(parser);
+
+            if (memoryType == MemoryType.HISTORY && rule.getRetentionDays() != null) {
+                throw new IllegalArgumentException("retention_days is not supported for history memory type");
+            }
+
+            policy.put(memoryType, rule);
+        }
+
+        return policy;
     }
 
     public String getFinalMemoryIndexPrefix() {
@@ -534,6 +607,27 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         } else if (updateContent.getDimension() != null) {
             // Only update dimension for TEXT_EMBEDDING if provided
             this.dimension = updateContent.getDimension();
+        }
+        // Merge retention policy
+        if (updateContent.getRetentionPolicy() != null) {
+            if (this.retentionPolicy == null) {
+                this.retentionPolicy = new EnumMap<>(MemoryType.class);
+            }
+            for (Map.Entry<MemoryType, RetentionRule> entry : updateContent.getRetentionPolicy().entrySet()) {
+                MemoryType type = entry.getKey();
+                RetentionRule incomingRule = entry.getValue();
+                RetentionRule existingRule = this.retentionPolicy.get(type);
+
+                if (existingRule == null) {
+                    this.retentionPolicy.put(type, incomingRule);
+                } else {
+                    Integer mergedDays = incomingRule.getRetentionDays() != null
+                        ? incomingRule.getRetentionDays()
+                        : existingRule.getRetentionDays();
+                    Integer mergedCount = incomingRule.getMaxCount() != null ? incomingRule.getMaxCount() : existingRule.getMaxCount();
+                    this.retentionPolicy.put(type, new RetentionRule(mergedDays, mergedCount));
+                }
+            }
         }
         // Note: indexPrefix and other structural fields are intentionally not updated
         // as they would require index recreation

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -685,7 +685,13 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                         ? incoming.getRetentionDays()
                         : existing.getRetentionDays();
                     Integer mergedCount = incoming.isMaxCountExplicitlySet() ? incoming.getMaxCount() : existing.getMaxCount();
-                    this.retentionPolicy.put(type, new RetentionRule(mergedDays, mergedCount));
+                    // Carry the explicit-set flags through the merge so toXContent() emits
+                    // explicit nulls for cleared fields and the partial-update doc merge
+                    // removes them from storage
+                    boolean mergedDaysExplicitlySet = incoming.isRetentionDaysExplicitlySet() || existing.isRetentionDaysExplicitlySet();
+                    boolean mergedCountExplicitlySet = incoming.isMaxCountExplicitlySet() || existing.isMaxCountExplicitlySet();
+                    this.retentionPolicy
+                        .put(type, new RetentionRule(mergedDays, mergedCount, mergedDaysExplicitlySet, mergedCountExplicitlySet));
                 }
             }
         }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -23,12 +23,12 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MAX_INFER_SIZE_LIMIT_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_INDEX_PREFIX_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETERS_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SEMANTIC_STORAGE_EMBEDDING_MODEL_ID_REQUIRED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SEMANTIC_STORAGE_EMBEDDING_MODEL_TYPE_REQUIRED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SPARSE_ENCODING_DIMENSION_NOT_ALLOWED_ERROR;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRATEGIES_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.TEXT_EMBEDDING_DIMENSION_REQUIRED_ERROR;
-import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.USE_SYSTEM_INDEX_FIELD;
 
 import java.io.IOException;

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -8,7 +8,7 @@ package org.opensearch.ml.common.memorycontainer;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.ML_AGENTIC_MEMORY_SYSTEM_INDEX_PREFIX;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DEFAULT_MEMORY_INDEX_PREFIX;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DIMENSION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DISABLE_HISTORY_FIELD;
@@ -82,7 +82,12 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     private boolean useSystemIndex;
     private String tenantId;
     private Map<MemoryType, RetentionRule> retentionPolicy;
-    private transient boolean retentionPolicyExplicitlyNull = false;
+    /**
+     * True when the user explicitly set "retention_policy": null (opt-out of retention).
+     * Persisted as an explicit null field in toXContent() so the opt-out round-trips through
+     * the container index and survives partial-update merges; distinct from field absence.
+     */
+    private boolean retentionPolicyExplicitlyNull = false;
 
     @Builder
     public MemoryConfiguration(
@@ -175,7 +180,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         this.disableSession = input.readBoolean();
         this.useSystemIndex = input.readBoolean();
         this.tenantId = input.readOptionalString();
-        if (input.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (input.getVersion().onOrAfter(VERSION_3_8_0)) {
             if (input.readBoolean()) {
                 int size = input.readVInt();
                 this.retentionPolicy = new EnumMap<>(MemoryType.class);
@@ -185,6 +190,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                     this.retentionPolicy.put(key, value);
                 }
             }
+        }
+        if (input.getVersion().onOrAfter(VERSION_3_8_0)) {
+            this.retentionPolicyExplicitlyNull = input.readBoolean();
         }
     }
 
@@ -218,7 +226,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         out.writeBoolean(disableSession);
         out.writeBoolean(useSystemIndex);
         out.writeOptionalString(tenantId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             if (retentionPolicy != null && !retentionPolicy.isEmpty()) {
                 out.writeBoolean(true);
                 out.writeVInt(retentionPolicy.size());
@@ -229,6 +237,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             } else {
                 out.writeBoolean(false);
             }
+        }
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
+            out.writeBoolean(retentionPolicyExplicitlyNull);
         }
     }
 
@@ -287,6 +298,11 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 entry.getValue().toXContent(builder, params);
             }
             builder.endObject();
+        } else if (retentionPolicyExplicitlyNull) {
+            // Persist the explicit opt-out as "retention_policy": null so it (a) round-trips
+            // through the container index (parse() maps VALUE_NULL back to this flag) and
+            // (b) removes any previously stored policy during partial-update merges.
+            builder.nullField(RETENTION_POLICY_FIELD);
         }
         builder.endObject();
         return builder;
@@ -644,7 +660,13 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         // Merge retention policy with field-level semantics within each type
         if (updateContent.isRetentionPolicyExplicitlyNull()) {
             this.retentionPolicy = null;
+            // Propagate the opt-out so toXContent() persists "retention_policy": null,
+            // which removes the stored policy during the partial-update merge and lets
+            // the retention job distinguish opt-out from "never configured"
+            this.retentionPolicyExplicitlyNull = true;
         } else if (updateContent.getRetentionPolicy() != null) {
+            // Providing a concrete policy opts back in
+            this.retentionPolicyExplicitlyNull = false;
             validateRetentionPolicy(updateContent.getRetentionPolicy());
             if (this.retentionPolicy == null) {
                 this.retentionPolicy = new EnumMap<>(MemoryType.class);

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -641,7 +641,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             // Only update dimension for TEXT_EMBEDDING if provided
             this.dimension = updateContent.getDimension();
         }
-        // Merge retention policy
+        // Merge retention policy with field-level semantics within each type
         if (updateContent.isRetentionPolicyExplicitlyNull()) {
             this.retentionPolicy = null;
         } else if (updateContent.getRetentionPolicy() != null) {
@@ -650,7 +650,21 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 this.retentionPolicy = new EnumMap<>(MemoryType.class);
             }
             for (Map.Entry<MemoryType, RetentionRule> entry : updateContent.getRetentionPolicy().entrySet()) {
-                this.retentionPolicy.put(entry.getKey(), entry.getValue());
+                MemoryType type = entry.getKey();
+                RetentionRule incoming = entry.getValue();
+                RetentionRule existing = this.retentionPolicy.get(type);
+
+                if (existing == null) {
+                    // No existing rule for this type: use incoming as-is
+                    this.retentionPolicy.put(type, incoming);
+                } else {
+                    // Field-level merge: only override fields that were explicitly set in the request
+                    Integer mergedDays = incoming.isRetentionDaysExplicitlySet()
+                        ? incoming.getRetentionDays()
+                        : existing.getRetentionDays();
+                    Integer mergedCount = incoming.isMaxCountExplicitlySet() ? incoming.getMaxCount() : existing.getMaxCount();
+                    this.retentionPolicy.put(type, new RetentionRule(mergedDays, mergedCount));
+                }
             }
         }
         // Note: indexPrefix and other structural fields are intentionally not updated

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -148,6 +148,9 @@ public class MemoryContainerConstants {
         "Backend role contains invalid characters. Only alphanumeric characters and :+=,.@-_/ are allowed: %s";
     public static final String BACKEND_ROLE_EMPTY_ERROR = "Backend role cannot be empty or blank";
 
+    // Pinned field
+    public static final String PINNED_FIELD = "pinned";
+
     // Retention policy field names
     public static final String RETENTION_POLICY_FIELD = "retention_policy";
     public static final String RETENTION_DAYS_FIELD = "retention_days";

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -148,6 +148,11 @@ public class MemoryContainerConstants {
         "Backend role contains invalid characters. Only alphanumeric characters and :+=,.@-_/ are allowed: %s";
     public static final String BACKEND_ROLE_EMPTY_ERROR = "Backend role cannot be empty or blank";
 
+    // Retention policy field names
+    public static final String RETENTION_POLICY_FIELD = "retention_policy";
+    public static final String RETENTION_DAYS_FIELD = "retention_days";
+    public static final String MAX_COUNT_FIELD = "max_count";
+
     // Model validation error messages
     public static final String LLM_MODEL_NOT_FOUND_ERROR = "LLM model with ID %s not found";
     public static final String LLM_MODEL_NOT_REMOTE_ERROR = "LLM model must be a REMOTE model, found: %s";

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
@@ -30,8 +30,26 @@ public class RetentionRule implements ToXContentObject, Writeable {
     private final Integer retentionDays;
     private final Integer maxCount;
 
+    /**
+     * Transient parse-time metadata: true when retention_days was explicitly present in the
+     * parsed JSON (even if value was null, meaning "remove it"). Not serialized.
+     */
+    @EqualsAndHashCode.Exclude
+    private final transient boolean retentionDaysExplicitlySet;
+
+    /**
+     * Transient parse-time metadata: true when max_count was explicitly present in the
+     * parsed JSON (even if value was null, meaning "remove it"). Not serialized.
+     */
+    @EqualsAndHashCode.Exclude
+    private final transient boolean maxCountExplicitlySet;
+
     @Builder
     public RetentionRule(Integer retentionDays, Integer maxCount) {
+        this(retentionDays, maxCount, false, false);
+    }
+
+    public RetentionRule(Integer retentionDays, Integer maxCount, boolean retentionDaysExplicitlySet, boolean maxCountExplicitlySet) {
         if (retentionDays != null && retentionDays <= 0) {
             throw new IllegalArgumentException("retention_days must be a positive integer or null");
         }
@@ -40,11 +58,15 @@ public class RetentionRule implements ToXContentObject, Writeable {
         }
         this.retentionDays = retentionDays;
         this.maxCount = maxCount;
+        this.retentionDaysExplicitlySet = retentionDaysExplicitlySet;
+        this.maxCountExplicitlySet = maxCountExplicitlySet;
     }
 
     public RetentionRule(StreamInput in) throws IOException {
         this.retentionDays = in.readOptionalInt();
         this.maxCount = in.readOptionalInt();
+        this.retentionDaysExplicitlySet = false;
+        this.maxCountExplicitlySet = false;
     }
 
     @Override
@@ -69,6 +91,8 @@ public class RetentionRule implements ToXContentObject, Writeable {
     public static RetentionRule parse(XContentParser parser) throws IOException {
         Integer retentionDays = null;
         Integer maxCount = null;
+        boolean retentionDaysExplicitlySet = false;
+        boolean maxCountExplicitlySet = false;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -77,6 +101,7 @@ public class RetentionRule implements ToXContentObject, Writeable {
 
             switch (fieldName) {
                 case RETENTION_DAYS_FIELD:
+                    retentionDaysExplicitlySet = true;
                     if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                         retentionDays = null;
                     } else {
@@ -84,6 +109,7 @@ public class RetentionRule implements ToXContentObject, Writeable {
                     }
                     break;
                 case MAX_COUNT_FIELD:
+                    maxCountExplicitlySet = true;
                     if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                         maxCount = null;
                     } else {
@@ -96,6 +122,6 @@ public class RetentionRule implements ToXContentObject, Writeable {
             }
         }
 
-        return new RetentionRule(retentionDays, maxCount);
+        return new RetentionRule(retentionDays, maxCount, retentionDaysExplicitlySet, maxCountExplicitlySet);
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
@@ -80,9 +80,14 @@ public class RetentionRule implements ToXContentObject, Writeable {
         builder.startObject();
         if (retentionDays != null) {
             builder.field(RETENTION_DAYS_FIELD, retentionDays);
+        } else if (retentionDaysExplicitlySet) {
+            // Persist the explicit null so the partial-update doc merge removes the stored value
+            builder.nullField(RETENTION_DAYS_FIELD);
         }
         if (maxCount != null) {
             builder.field(MAX_COUNT_FIELD, maxCount);
+        } else if (maxCountExplicitlySet) {
+            builder.nullField(MAX_COUNT_FIELD);
         }
         builder.endObject();
         return builder;

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MAX_COUNT_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_DAYS_FIELD;
+
+import java.io.IOException;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@Builder
+@EqualsAndHashCode
+public class RetentionRule implements ToXContentObject, Writeable {
+
+    private final Integer retentionDays;
+    private final Integer maxCount;
+
+    public RetentionRule(Integer retentionDays, Integer maxCount) {
+        if (retentionDays != null && retentionDays <= 0) {
+            throw new IllegalArgumentException("retention_days must be a positive integer or null");
+        }
+        if (maxCount != null && maxCount <= 0) {
+            throw new IllegalArgumentException("max_count must be a positive integer or null");
+        }
+        this.retentionDays = retentionDays;
+        this.maxCount = maxCount;
+    }
+
+    public RetentionRule(StreamInput in) throws IOException {
+        this.retentionDays = in.readOptionalInt();
+        this.maxCount = in.readOptionalInt();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalInt(retentionDays);
+        out.writeOptionalInt(maxCount);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        if (retentionDays != null) {
+            builder.field(RETENTION_DAYS_FIELD, retentionDays);
+        }
+        if (maxCount != null) {
+            builder.field(MAX_COUNT_FIELD, maxCount);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static RetentionRule parse(XContentParser parser) throws IOException {
+        Integer retentionDays = null;
+        Integer maxCount = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case RETENTION_DAYS_FIELD:
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        retentionDays = null;
+                    } else {
+                        retentionDays = parser.intValue();
+                    }
+                    break;
+                case MAX_COUNT_FIELD:
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        maxCount = null;
+                    } else {
+                        maxCount = parser.intValue();
+                    }
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+
+        return new RetentionRule(retentionDays, maxCount);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
@@ -24,13 +24,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
-@Builder
 @EqualsAndHashCode
 public class RetentionRule implements ToXContentObject, Writeable {
 
     private final Integer retentionDays;
     private final Integer maxCount;
 
+    @Builder
     public RetentionRule(Integer retentionDays, Integer maxCount) {
         if (retentionDays != null && retentionDays <= 0) {
             throw new IllegalArgumentException("retention_days must be a positive integer or null");

--- a/common/src/main/java/org/opensearch/ml/common/model/ModelGuardrail.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/ModelGuardrail.java
@@ -53,7 +53,7 @@ public class ModelGuardrail extends Guardrail {
     public static final String MODEL_ID_FIELD = "model_id";
     public static final String RESPONSE_FILTER_FIELD = "response_filter";
     public static final String RESPONSE_VALIDATION_REGEX_FIELD = "response_validation_regex";
-    public static final long ML_GUARDRAIL_TIMEOUT_IN_SECONDS = 60;
+    public static final long ML_GUARDRAIL_TIMEOUT_IN_SECONDS = 5;
 
     private String modelId;
     private String responseFilter;

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -584,6 +584,40 @@ public final class MLCommonsSettings {
     public static final String ML_COMMONS_AG_UI_DISABLED_MESSAGE =
         "The AG-UI agent feature is not enabled. To enable, please update the setting " + ML_COMMONS_AG_UI_ENABLED.getKey();
 
+    // Memory retention job settings
+    public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
+            24,
+            1,
+            168,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_throttle_seconds",
+            5,
+            1,
+            60,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS = Setting
+        .intSetting(ML_PLUGIN_SETTING_PREFIX + "memory.orphan_ttl_days", 7, 1, 365, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.working_memory_ttl_days",
+            30,
+            1,
+            365,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
     private static void validateRegexSafety(String regex) {
         // Reject nested quantifiers or backreferences
         if (regex.matches(".*\\([^)]*[*+?]\\)[*+?{].*") || regex.matches(".*\\\\[1-9].*")) {

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -585,6 +585,14 @@ public final class MLCommonsSettings {
         "The AG-UI agent feature is not enabled. To enable, please update the setting " + ML_COMMONS_AG_UI_ENABLED.getKey();
 
     // Memory retention job settings
+    public static final Setting<Boolean> ML_COMMONS_MEMORY_RETENTION_ENABLED = Setting
+        .boolSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.retention_enabled",
+            true,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
     public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
@@ -614,6 +622,46 @@ public final class MLCommonsSettings {
             30,
             1,
             365,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.default_session_retention_days",
+            90,
+            1,
+            3650,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.default_session_max_count",
+            5000,
+            1,
+            1000000,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.default_long_term_max_count",
+            2000,
+            1,
+            1000000,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.default_history_max_count",
+            100000,
+            1,
+            10000000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -591,7 +591,7 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
-            2, // DEMO: default 2 minutes (was 24 hours)
+            24,
             1,
             168,
             Setting.Property.NodeScope,

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -588,7 +588,7 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
-            24,
+            2, // DEMO: default 2 minutes (was 24 hours)
             1,
             168,
             Setting.Property.NodeScope,

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -586,12 +586,7 @@ public final class MLCommonsSettings {
 
     // Memory retention job settings
     public static final Setting<Boolean> ML_COMMONS_MEMORY_RETENTION_ENABLED = Setting
-        .boolSetting(
-            ML_PLUGIN_SETTING_PREFIX + "memory.retention_enabled",
-            true,
-            Setting.Property.NodeScope,
-            Setting.Property.Dynamic
-        );
+        .boolSetting(ML_PLUGIN_SETTING_PREFIX + "memory.retention_enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
         .intSetting(
@@ -629,8 +624,8 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.default_session_retention_days",
-            90,
-            1,
+            -1,
+            -1,
             3650,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
@@ -639,8 +634,8 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.default_session_max_count",
-            5000,
-            1,
+            -1,
+            -1,
             1000000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
@@ -649,8 +644,8 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.default_long_term_max_count",
-            2000,
-            1,
+            -1,
+            -1,
             1000000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
@@ -659,8 +654,8 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.default_history_max_count",
-            100000,
-            1,
+            -1,
+            -1,
             10000000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.transport.memorycontainer.memory;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
@@ -22,6 +23,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETERS_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PAYLOAD_TYPE_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SESSION_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_BLOB_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_FIELD;
@@ -34,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -73,6 +76,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
     private Map<String, Object> parameters;
     private String ownerId;
 
+    // Pinned field (only valid for session/long-term/history, rejected for working memory)
+    private Boolean pinned;
+
     // Checkpoint field
     private String checkpointId;
     private String tenantId;
@@ -91,6 +97,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> tags,
         Map<String, Object> parameters,
         String ownerId,
+        Boolean pinned,
         String checkpointId,
         String tenantId
     ) {
@@ -112,6 +119,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters.putAll(parameters);
         }
         this.ownerId = ownerId;
+        this.pinned = pinned;
         this.checkpointId = checkpointId;
         this.tenantId = tenantId;
         validate();
@@ -161,6 +169,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters = in.readMap();
         }
         this.ownerId = in.readOptionalString();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
         this.checkpointId = in.readOptionalString();
         this.tenantId = in.readOptionalString();
     }
@@ -218,6 +229,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(ownerId);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
         out.writeOptionalString(checkpointId);
         out.writeOptionalString(tenantId);
     }
@@ -297,6 +311,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> tags = null;
         Map<String, Object> parameters = null;
         String ownerId = null;
+        Boolean pinned = null;
         String checkpointId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -348,6 +363,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
                 case OWNER_ID_FIELD:
                     ownerId = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.booleanValue();
+                    break;
                 case CHECKPOINT_ID_FIELD:
                     checkpointId = parser.text();
                     break;
@@ -375,6 +393,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             .tags(tags)
             .parameters(parameters)
             .ownerId(ownerId)
+            .pinned(pinned)
             .checkpointId(checkpointId)
             .tenantId(tenantId)
             .build();

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -7,7 +7,7 @@ package org.opensearch.ml.common.transport.memorycontainer.memory;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
@@ -168,7 +168,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters = in.readMap();
         }
         this.ownerId = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
         this.checkpointId = in.readOptionalString();
@@ -228,7 +228,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(ownerId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
         out.writeOptionalString(checkpointId);

--- a/common/src/main/resources/index-mappings/ml_memory_container.json
+++ b/common/src/main/resources/index-mappings/ml_memory_container.json
@@ -75,6 +75,31 @@
         },
         "index_settings": {
           "type": "flat_object"
+        },
+        "retention_policy": {
+          "type": "object",
+          "properties": {
+            "sessions": {
+              "type": "object",
+              "properties": {
+                "retention_days": { "type": "integer" },
+                "max_count": { "type": "integer" }
+              }
+            },
+            "long-term": {
+              "type": "object",
+              "properties": {
+                "retention_days": { "type": "integer" },
+                "max_count": { "type": "integer" }
+              }
+            },
+            "history": {
+              "type": "object",
+              "properties": {
+                "max_count": { "type": "integer" }
+              }
+            }
+          }
         }
       }
     },

--- a/common/src/main/resources/index-mappings/ml_memory_long_term.json
+++ b/common/src/main/resources/index-mappings/ml_memory_long_term.json
@@ -34,6 +34,9 @@
     "last_updated_time": {
       "type": "date",
       "format": "strict_date_time||epoch_millis"
+    },
+    "pinned": {
+      "type": "boolean"
     }
   }
 }

--- a/common/src/main/resources/index-mappings/ml_memory_long_term_history.json
+++ b/common/src/main/resources/index-mappings/ml_memory_long_term_history.json
@@ -39,6 +39,9 @@
     },
     "tenant_id": {
       "type": "keyword"
+    },
+    "pinned": {
+      "type": "boolean"
     }
   }
 }

--- a/common/src/main/resources/index-mappings/ml_memory_sessions.json
+++ b/common/src/main/resources/index-mappings/ml_memory_sessions.json
@@ -38,6 +38,9 @@
     "owner": USER_MAPPING_PLACEHOLDER,
     "tenant_id": {
       "type": "keyword"
+    },
+    "pinned": {
+      "type": "boolean"
     }
   }
 }

--- a/common/src/main/resources/index-mappings/ml_memory_working.json
+++ b/common/src/main/resources/index-mappings/ml_memory_working.json
@@ -1,9 +1,12 @@
 {
   "_meta": {
-    "schema_version": 2
+    "schema_version": 3
   },
   "properties": {
     "owner_id": {
+      "type": "keyword"
+    },
+    "session_id": {
       "type": "keyword"
     },
     "memory_container_id": {

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
@@ -27,6 +27,7 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.TestHelper;
 
 public class MLLongTermMemoryTest {
@@ -540,6 +541,31 @@ public class MLLongTermMemoryTest {
         StreamInput in = out.bytes().streamInput();
         MLLongTermMemory deserialized = new MLLongTermMemory(in);
 
+        assertNull(deserialized.getPinned());
+    }
+
+    @Test
+    public void testBackwardCompatStreamFromOldNode() throws IOException {
+        MLLongTermMemory memory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Test memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(CommonValue.VERSION_3_5_0);
+        memory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(CommonValue.VERSION_3_5_0);
+        MLLongTermMemory deserialized = new MLLongTermMemory(in);
+
+        assertEquals("Test memory", deserialized.getMemory());
+        assertEquals(MemoryStrategyType.SEMANTIC, deserialized.getStrategyType());
         assertNull(deserialized.getPinned());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLLongTermMemoryTest.java
@@ -424,4 +424,122 @@ public class MLLongTermMemoryTest {
         assertEquals(specialMemory.getMemory(), parsed.getMemory());
         assertEquals(specialMemory.getTags(), parsed.getTags());
     }
+
+    @Test
+    public void testPinnedFieldXContentRoundTrip() throws IOException {
+        MLLongTermMemory pinnedMemory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Pinned memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(true)
+            .build();
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        pinnedMemory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assertTrue(jsonString.contains("\"pinned\":true"));
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLLongTermMemory parsed = MLLongTermMemory.parse(parser);
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTrip() throws IOException {
+        MLLongTermMemory pinnedMemory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Pinned memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        pinnedMemory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLLongTermMemory deserialized = new MLLongTermMemory(in);
+
+        assertEquals(true, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldDefaultIsNull() throws IOException {
+        String jsonString = "{"
+            + "\"namespace\":{\"session_id\":\"session-123\"},"
+            + "\"memory\":\"No pinned field\","
+            + "\"strategy_type\":\"SEMANTIC\","
+            + "\"created_time\":"
+            + testCreatedTime.toEpochMilli()
+            + ","
+            + "\"last_updated_time\":"
+            + testUpdatedTime.toEpochMilli()
+            + "}";
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLLongTermMemory parsed = MLLongTermMemory.parse(parser);
+        assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldFalse() throws IOException {
+        MLLongTermMemory unpinnedMemory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("Unpinned memory")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(false)
+            .build();
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        unpinnedMemory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assertTrue(jsonString.contains("\"pinned\":false"));
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLLongTermMemory parsed = MLLongTermMemory.parse(parser);
+        assertEquals(false, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTripNull() throws IOException {
+        MLLongTermMemory memory = MLLongTermMemory
+            .builder()
+            .namespace(Map.of(SESSION_ID_FIELD, "session-123"))
+            .memory("No pinned")
+            .strategyType(MemoryStrategyType.SEMANTIC)
+            .createdTime(testCreatedTime)
+            .lastUpdatedTime(testUpdatedTime)
+            .pinned(null)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        memory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLLongTermMemory deserialized = new MLLongTermMemory(in);
+
+        assertNull(deserialized.getPinned());
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.TestHelper;
+import org.opensearch.ml.common.transport.memorycontainer.memory.MemoryEvent;
+
+public class MLMemoryHistoryTest {
+
+    private MLMemoryHistory historyWithAllFields;
+    private MLMemoryHistory historyWithNullFields;
+    private Instant testCreatedTime;
+    private Map<String, Object> testBefore;
+    private Map<String, Object> testAfter;
+    private Map<String, String> testNamespace;
+    private Map<String, String> testTags;
+
+    @Before
+    public void setUp() {
+        testCreatedTime = Instant.ofEpochMilli(1640995200000L);
+
+        testBefore = new HashMap<>();
+        testBefore.put("memory", "old fact");
+
+        testAfter = new HashMap<>();
+        testAfter.put("memory", "new fact");
+
+        testNamespace = new HashMap<>();
+        testNamespace.put("project", "ml-project");
+
+        testTags = new HashMap<>();
+        testTags.put("topic", "testing");
+
+        historyWithAllFields = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryContainerId("container-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.UPDATE)
+            .before(testBefore)
+            .after(testAfter)
+            .namespace(testNamespace)
+            .tags(testTags)
+            .createdTime(testCreatedTime)
+            .tenantId("tenant-789")
+            .error(null)
+            .pinned(true)
+            .build();
+
+        historyWithNullFields = MLMemoryHistory
+            .builder()
+            .ownerId(null)
+            .memoryContainerId(null)
+            .memoryId(null)
+            .action(null)
+            .before(null)
+            .after(null)
+            .namespace(null)
+            .tags(null)
+            .createdTime(null)
+            .tenantId(null)
+            .error(null)
+            .pinned(null)
+            .build();
+    }
+
+    @Test
+    public void testBuilderWithAllFields() {
+        assertNotNull(historyWithAllFields);
+        assertEquals("owner-123", historyWithAllFields.getOwnerId());
+        assertEquals("container-123", historyWithAllFields.getMemoryContainerId());
+        assertEquals("memory-456", historyWithAllFields.getMemoryId());
+        assertEquals(MemoryEvent.UPDATE, historyWithAllFields.getAction());
+        assertEquals(testBefore, historyWithAllFields.getBefore());
+        assertEquals(testAfter, historyWithAllFields.getAfter());
+        assertEquals(testNamespace, historyWithAllFields.getNamespace());
+        assertEquals(testTags, historyWithAllFields.getTags());
+        assertEquals(testCreatedTime, historyWithAllFields.getCreatedTime());
+        assertEquals("tenant-789", historyWithAllFields.getTenantId());
+        assertEquals(true, historyWithAllFields.getPinned());
+    }
+
+    @Test
+    public void testBuilderWithNullFields() {
+        assertNotNull(historyWithNullFields);
+        assertNull(historyWithNullFields.getOwnerId());
+        assertNull(historyWithNullFields.getMemoryContainerId());
+        assertNull(historyWithNullFields.getMemoryId());
+        assertNull(historyWithNullFields.getAction());
+        assertNull(historyWithNullFields.getBefore());
+        assertNull(historyWithNullFields.getAfter());
+        assertNull(historyWithNullFields.getNamespace());
+        assertNull(historyWithNullFields.getTags());
+        assertNull(historyWithNullFields.getCreatedTime());
+        assertNull(historyWithNullFields.getTenantId());
+        assertNull(historyWithNullFields.getPinned());
+    }
+
+    // Note: Stream round-trip tests are omitted for MLMemoryHistory because the original writeTo/StreamInput
+    // constructor has a pre-existing serialization order mismatch (writeTo writes namespace/tags before
+    // createdTime, but the StreamInput constructor reads createdTime before namespace/tags).
+    // The pinned field is tested via XContent round-trip instead.
+
+    @Test
+    public void testToXContentWithAllFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        historyWithAllFields.toXContent(builder, EMPTY_PARAMS);
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        assertNotNull(jsonString);
+
+        assert jsonString.contains("\"owner_id\":\"owner-123\"");
+        assert jsonString.contains("\"memory_container_id\":\"container-123\"");
+        assert jsonString.contains("\"memory_id\":\"memory-456\"");
+        assert jsonString.contains("\"pinned\":true");
+    }
+
+    @Test
+    public void testToXContentWithNullFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        historyWithNullFields.toXContent(builder, EMPTY_PARAMS);
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        assertEquals("{}", jsonString);
+    }
+
+    @Test
+    public void testParseWithAllFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.field("memory_container_id", "container-123");
+        builder.field("memory_id", "memory-456");
+        builder.field("action", "UPDATE");
+        builder.field("before", testBefore);
+        builder.field("after", testAfter);
+        builder.field("namespace", testNamespace);
+        builder.field("tags", testTags);
+        builder.field("created_time", testCreatedTime.toEpochMilli());
+        builder.field("tenant_id", "tenant-789");
+        builder.field("pinned", true);
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+
+        assertEquals("owner-123", parsed.getOwnerId());
+        assertEquals("container-123", parsed.getMemoryContainerId());
+        assertEquals("memory-456", parsed.getMemoryId());
+        assertEquals(MemoryEvent.UPDATE, parsed.getAction());
+        assertEquals(testBefore, parsed.getBefore());
+        assertEquals(testAfter, parsed.getAfter());
+        assertEquals(testNamespace, parsed.getNamespace());
+        assertEquals(testTags, parsed.getTags());
+        assertEquals(testCreatedTime, parsed.getCreatedTime());
+        assertEquals("tenant-789", parsed.getTenantId());
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldXContentRoundTrip() throws IOException {
+        MLMemoryHistory pinnedHistory = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(true)
+            .build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        pinnedHistory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":true");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldDefaultIsNull() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.field("action", "ADD");
+        builder.field("created_time", testCreatedTime.toEpochMilli());
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+        assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldFalse() throws IOException {
+        MLMemoryHistory unpinnedHistory = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(false)
+            .build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        unpinnedHistory.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":false");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+        assertEquals(false, parsed.getPinned());
+    }
+
+    @Test
+    public void testParseWithUnknownFields() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.field("unknown_field", "unknown_value");
+        builder.field("action", "ADD");
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemoryHistory parsed = MLMemoryHistory.parse(parser);
+
+        assertEquals("owner-123", parsed.getOwnerId());
+        assertEquals(MemoryEvent.ADD, parsed.getAction());
+        assertNull(parsed.getPinned());
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemoryHistoryTest.java
@@ -17,11 +17,14 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.TestHelper;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MemoryEvent;
 
@@ -116,10 +119,82 @@ public class MLMemoryHistoryTest {
         assertNull(historyWithNullFields.getPinned());
     }
 
-    // Note: Stream round-trip tests are omitted for MLMemoryHistory because the original writeTo/StreamInput
-    // constructor has a pre-existing serialization order mismatch (writeTo writes namespace/tags before
-    // createdTime, but the StreamInput constructor reads createdTime before namespace/tags).
-    // The pinned field is tested via XContent round-trip instead.
+    @Test
+    public void testStreamInputOutputWithAllFields() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        historyWithAllFields.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertEquals(historyWithAllFields.getOwnerId(), deserialized.getOwnerId());
+        assertEquals(historyWithAllFields.getMemoryContainerId(), deserialized.getMemoryContainerId());
+        assertEquals(historyWithAllFields.getMemoryId(), deserialized.getMemoryId());
+        assertEquals(historyWithAllFields.getAction(), deserialized.getAction());
+        assertEquals(historyWithAllFields.getBefore(), deserialized.getBefore());
+        assertEquals(historyWithAllFields.getAfter(), deserialized.getAfter());
+        assertEquals(historyWithAllFields.getCreatedTime(), deserialized.getCreatedTime());
+        assertEquals(historyWithAllFields.getTenantId(), deserialized.getTenantId());
+        assertEquals(historyWithAllFields.getPinned(), deserialized.getPinned());
+    }
+
+    @Test
+    public void testStreamInputOutputWithNullFields() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        historyWithNullFields.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertNull(deserialized.getOwnerId());
+        assertNull(deserialized.getMemoryContainerId());
+        assertNull(deserialized.getMemoryId());
+        assertNull(deserialized.getAction());
+        assertNull(deserialized.getBefore());
+        assertNull(deserialized.getAfter());
+        assertNull(deserialized.getCreatedTime());
+        assertNull(deserialized.getTenantId());
+        assertNull(deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTrip() throws IOException {
+        MLMemoryHistory pinnedHistory = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        pinnedHistory.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertEquals(true, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTripNull() throws IOException {
+        MLMemoryHistory history = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .action(MemoryEvent.ADD)
+            .createdTime(testCreatedTime)
+            .pinned(null)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        history.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertNull(deserialized.getPinned());
+    }
 
     @Test
     public void testToXContentWithAllFields() throws IOException {
@@ -272,5 +347,31 @@ public class MLMemoryHistoryTest {
         assertEquals("owner-123", parsed.getOwnerId());
         assertEquals(MemoryEvent.ADD, parsed.getAction());
         assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testBackwardCompatStreamFromOldNode() throws IOException {
+        MLMemoryHistory history = MLMemoryHistory
+            .builder()
+            .ownerId("owner-123")
+            .memoryId("memory-456")
+            .action(MemoryEvent.UPDATE)
+            .createdTime(testCreatedTime)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(CommonValue.VERSION_3_5_0);
+        history.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(CommonValue.VERSION_3_5_0);
+        MLMemoryHistory deserialized = new MLMemoryHistory(in);
+
+        assertEquals("owner-123", deserialized.getOwnerId());
+        assertEquals("memory-456", deserialized.getMemoryId());
+        assertEquals(MemoryEvent.UPDATE, deserialized.getAction());
+        assertEquals(testCreatedTime, deserialized.getCreatedTime());
+        assertNull(deserialized.getPinned());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
@@ -126,7 +126,8 @@ public class MLMemorySessionTest {
             testAgents,
             testAdditionalInfo,
             testNamespace,
-            "tenant-456"
+            "tenant-456",
+            true
         );
 
         assertEquals("owner-123", session.getOwnerId());
@@ -138,11 +139,12 @@ public class MLMemorySessionTest {
         assertEquals(testAdditionalInfo, session.getAdditionalInfo());
         assertEquals(testNamespace, session.getNamespace());
         assertEquals("tenant-456", session.getTenantId());
+        assertEquals(true, session.getPinned());
     }
 
     @Test
     public void testConstructorWithNullFields() {
-        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null);
+        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null, null);
 
         assertNull(session.getOwnerId());
         assertNull(session.getSummary());
@@ -153,6 +155,7 @@ public class MLMemorySessionTest {
         assertNull(session.getAdditionalInfo());
         assertNull(session.getNamespace());
         assertNull(session.getTenantId());
+        assertNull(session.getPinned());
     }
 
     @Test
@@ -330,7 +333,7 @@ public class MLMemorySessionTest {
 
     @Test
     public void testSettersAndGetters() {
-        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null);
+        MLMemorySession session = new MLMemorySession(null, null, null, null, null, null, null, null, null, null, null);
 
         // Test setters
         session.setOwnerId("new-owner");
@@ -720,5 +723,87 @@ public class MLMemorySessionTest {
         assertNull(emptySession.getAdditionalInfo());
         assertNull(emptySession.getNamespace());
         assertNull(emptySession.getTenantId());
+        assertNull(emptySession.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldXContentRoundTrip() throws IOException {
+        MLMemorySession pinnedSession = MLMemorySession.builder().ownerId("owner-123").pinned(true).build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        pinnedSession.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":true");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemorySession parsed = MLMemorySession.parse(parser);
+        assertEquals(true, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTrip() throws IOException {
+        MLMemorySession pinnedSession = MLMemorySession.builder().ownerId("owner-123").pinned(true).build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        pinnedSession.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemorySession deserialized = new MLMemorySession(in);
+
+        assertEquals(true, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldDefaultIsNull() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.field("owner_id", "owner-123");
+        builder.endObject();
+
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemorySession parsed = MLMemorySession.parse(parser);
+        assertNull(parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldFalse() throws IOException {
+        MLMemorySession unpinnedSession = MLMemorySession.builder().ownerId("owner-123").pinned(false).build();
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        unpinnedSession.toXContent(builder, EMPTY_PARAMS);
+        String jsonString = TestHelper.xContentBuilderToString(builder);
+
+        assert jsonString.contains("\"pinned\":false");
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString);
+        parser.nextToken();
+
+        MLMemorySession parsed = MLMemorySession.parse(parser);
+        assertEquals(false, parsed.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamRoundTripNull() throws IOException {
+        MLMemorySession session = MLMemorySession.builder().ownerId("owner-123").pinned(null).build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        session.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLMemorySession deserialized = new MLMemorySession(in);
+
+        assertNull(deserialized.getPinned());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MLMemorySessionTest.java
@@ -24,6 +24,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.TestHelper;
 
 public class MLMemorySessionTest {
@@ -189,6 +190,7 @@ public class MLMemorySessionTest {
         assertEquals(sessionWithoutNamespace.getAdditionalInfo(), deserialized.getAdditionalInfo());
         assertEquals(sessionWithoutNamespace.getNamespace(), deserialized.getNamespace());
         assertEquals(sessionWithoutNamespace.getTenantId(), deserialized.getTenantId());
+        assertNull(deserialized.getPinned());
     }
 
     @Test
@@ -804,6 +806,22 @@ public class MLMemorySessionTest {
         StreamInput in = out.bytes().streamInput();
         MLMemorySession deserialized = new MLMemorySession(in);
 
+        assertNull(deserialized.getPinned());
+    }
+
+    @Test
+    public void testBackwardCompatStreamFromOldNode() throws IOException {
+        MLMemorySession session = MLMemorySession.builder().ownerId("owner-123").pinned(true).build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(CommonValue.VERSION_3_5_0);
+        session.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(CommonValue.VERSION_3_5_0);
+        MLMemorySession deserialized = new MLMemorySession(in);
+
+        assertEquals("owner-123", deserialized.getOwnerId());
         assertNull(deserialized.getPinned());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1415,6 +1415,96 @@ public class MemoryConfigurationTests {
     }
 
     @Test
+    public void testUpdate_RetentionPolicy_ExplicitNullFieldRemovalPersists() throws Exception {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Simulate parsing an update that explicitly clears max_count
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"sessions\":{\"max_count\":null}}}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        config.update(updateContent);
+
+        // Merged rule: retention_days preserved, max_count cleared with the explicit-set flag carried through
+        RetentionRule mergedRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
+        assertEquals(Integer.valueOf(30), mergedRule.getRetentionDays());
+        assertNull(mergedRule.getMaxCount());
+        assertTrue(mergedRule.isMaxCountExplicitlySet());
+
+        // Serialized update doc must emit the explicit null so the partial-update merge removes it
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String serialized = builder.toString();
+        assertTrue("expected explicit null max_count in: " + serialized, serialized.contains("\"max_count\":null"));
+        assertTrue("expected retention_days preserved in: " + serialized, serialized.contains("\"retention_days\":30"));
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_ExplicitNullRetentionDaysPersists() throws Exception {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"sessions\":{\"retention_days\":null}}}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        config.update(updateContent);
+
+        RetentionRule mergedRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
+        assertNull(mergedRule.getRetentionDays());
+        assertEquals(Integer.valueOf(100), mergedRule.getMaxCount());
+        assertTrue(mergedRule.isRetentionDaysExplicitlySet());
+
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String serialized = builder.toString();
+        assertTrue("expected explicit null retention_days in: " + serialized, serialized.contains("\"retention_days\":null"));
+        assertTrue("expected max_count preserved in: " + serialized, serialized.contains("\"max_count\":100"));
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_AbsentFieldsOmittedAfterMerge() throws Exception {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
+
+        // Update introduces a rule that only mentions max_count; retention_days was never mentioned
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"sessions\":{\"max_count\":200}}}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        config.update(updateContent);
+
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String serialized = builder.toString();
+        assertTrue("expected max_count in: " + serialized, serialized.contains("\"max_count\":200"));
+        assertFalse("never-mentioned retention_days must be omitted in: " + serialized, serialized.contains("retention_days"));
+    }
+
+    @Test
     public void testRetentionPolicyExplicitNull_RoundTripsThroughXContent() throws Exception {
         // Parse a config with explicit "retention_policy": null (opt-out)
         String json = "{\"index_prefix\":\"test\",\"retention_policy\":null}";

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.common.memorycontainer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -1251,26 +1252,26 @@ public class MemoryConfigurationTests {
     }
 
     @Test
-    public void testUpdate_RetentionPolicy_MergeSemanticsPartialUpdate() {
+    public void testUpdate_RetentionPolicy_TypeLevelReplacement() {
         Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
         existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
         existingPolicy.put(MemoryType.LONG_TERM, new RetentionRule(90, 500));
 
         MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
 
-        // Update only sessions max_count, leaving retention_days unchanged
+        // Update sessions with only max_count — full replacement at type level
         Map<MemoryType, RetentionRule> updatePolicy = new java.util.EnumMap<>(MemoryType.class);
         updatePolicy.put(MemoryType.SESSIONS, new RetentionRule(null, 200));
 
         MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(updatePolicy).build();
         config.update(updateContent);
 
-        // Sessions: retentionDays preserved from existing, maxCount updated
+        // Sessions: fully replaced — retentionDays is now null (not preserved)
         RetentionRule sessionsRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
-        assertEquals(Integer.valueOf(30), sessionsRule.getRetentionDays());
+        assertNull(sessionsRule.getRetentionDays());
         assertEquals(Integer.valueOf(200), sessionsRule.getMaxCount());
 
-        // Long-term: untouched
+        // Long-term: untouched (type not in update)
         RetentionRule longTermRule = config.getRetentionPolicy().get(MemoryType.LONG_TERM);
         assertEquals(Integer.valueOf(90), longTermRule.getRetentionDays());
         assertEquals(Integer.valueOf(500), longTermRule.getMaxCount());
@@ -1328,5 +1329,87 @@ public class MemoryConfigurationTests {
         assertNotNull(historyRule);
         assertNull(historyRule.getRetentionDays());
         assertEquals(Integer.valueOf(500), historyRule.getMaxCount());
+    }
+
+    @Test
+    public void testRetentionPolicy_ConstructorValidation_RejectsWorkingKey() {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.WORKING, new RetentionRule(null, 10));
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build()
+        );
+        assertTrue(e.getMessage().contains("Working memory retention cannot be configured directly"));
+    }
+
+    @Test
+    public void testRetentionPolicy_ConstructorValidation_RejectsHistoryRetentionDays() {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.HISTORY, new RetentionRule(30, null));
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build()
+        );
+        assertTrue(e.getMessage().contains("retention_days is not supported for history memory type"));
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_ExplicitNullWipesPolicy() throws Exception {
+        // Setup: config with existing policy
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Simulate parsing an update with "retention_policy": null
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":null}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        // Verify the flag is set
+        assertTrue(updateContent.isRetentionPolicyExplicitlyNull());
+
+        // Apply update
+        config.update(updateContent);
+
+        // Policy should be wiped
+        assertNull(config.getRetentionPolicy());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_AbsentDoesNotWipe() throws Exception {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Parse an update WITHOUT retention_policy field
+        String json = "{\"index_prefix\":\"test\"}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        // Flag should NOT be set
+        assertFalse(updateContent.isRetentionPolicyExplicitlyNull());
+
+        // Apply update
+        config.update(updateContent);
+
+        // Policy should still be there
+        assertNotNull(config.getRetentionPolicy());
+        assertEquals(1, config.getRetentionPolicy().size());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1413,4 +1413,112 @@ public class MemoryConfigurationTests {
         assertNotNull(config.getRetentionPolicy());
         assertEquals(1, config.getRetentionPolicy().size());
     }
+
+    @Test
+    public void testRetentionPolicyExplicitNull_RoundTripsThroughXContent() throws Exception {
+        // Parse a config with explicit "retention_policy": null (opt-out)
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":null}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration config = MemoryConfiguration.parse(parser);
+        assertTrue(config.isRetentionPolicyExplicitlyNull());
+
+        // Serialize: the opt-out marker must be written as an explicit null field
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String serialized = builder.toString();
+        assertTrue("expected explicit null marker in: " + serialized, serialized.contains("\"retention_policy\":null"));
+
+        // Parse back (simulates reading the container document from the index)
+        org.opensearch.core.xcontent.XContentParser reparser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                serialized
+            );
+        reparser.nextToken();
+        MemoryConfiguration roundTripped = MemoryConfiguration.parse(reparser);
+
+        // Opt-out must survive the round trip so the retention job skips backfill
+        assertTrue(roundTripped.isRetentionPolicyExplicitlyNull());
+        assertNull(roundTripped.getRetentionPolicy());
+    }
+
+    @Test
+    public void testToXContent_NoRetentionPolicy_OmitsField() throws Exception {
+        // "Never had a policy" must remain field-absence (no null marker)
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String serialized = builder.toString();
+        assertFalse("retention_policy should be absent in: " + serialized, serialized.contains("retention_policy"));
+    }
+
+    @Test
+    public void testUpdate_ExplicitNull_PropagatesOptOutFlagForPersistence() throws Exception {
+        // Existing stored config with a policy
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // PUT with "retention_policy": null
+        String json = "{\"retention_policy\":null}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        config.update(updateContent);
+
+        // Merged config must carry the opt-out so serialization writes the null marker,
+        // which removes the old policy during the partial-update doc merge
+        assertNull(config.getRetentionPolicy());
+        assertTrue(config.isRetentionPolicyExplicitlyNull());
+
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        assertTrue(builder.toString().contains("\"retention_policy\":null"));
+    }
+
+    @Test
+    public void testUpdate_NewPolicyClearsOptOutFlag() throws Exception {
+        // Config previously opted out
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
+        config.setRetentionPolicyExplicitlyNull(true);
+
+        // PUT with a concrete policy opts back in
+        Map<MemoryType, RetentionRule> newPolicy = new java.util.EnumMap<>(MemoryType.class);
+        newPolicy.put(MemoryType.SESSIONS, new RetentionRule(7, 50));
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(newPolicy).build();
+
+        config.update(updateContent);
+
+        assertFalse(config.isRetentionPolicyExplicitlyNull());
+        assertNotNull(config.getRetentionPolicy());
+    }
+
+    @Test
+    public void testRetentionPolicyExplicitNull_RoundTripsThroughStream() throws Exception {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
+        config.setRetentionPolicyExplicitlyNull(true);
+
+        org.opensearch.common.io.stream.BytesStreamOutput out = new org.opensearch.common.io.stream.BytesStreamOutput();
+        config.writeTo(out);
+        MemoryConfiguration deserialized = new MemoryConfiguration(out.bytes().streamInput());
+
+        assertTrue(deserialized.isRetentionPolicyExplicitlyNull());
+        assertNull(deserialized.getRetentionPolicy());
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1252,23 +1252,24 @@ public class MemoryConfigurationTests {
     }
 
     @Test
-    public void testUpdate_RetentionPolicy_TypeLevelReplacement() {
+    public void testUpdate_RetentionPolicy_FieldLevelMerge() {
         Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
         existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
         existingPolicy.put(MemoryType.LONG_TERM, new RetentionRule(90, 500));
 
         MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
 
-        // Update sessions with only max_count — full replacement at type level
+        // Update sessions with only max_count — field-level merge preserves existing retention_days
+        // Use 4-arg constructor to simulate JSON parse: max_count explicitly set, retention_days absent
         Map<MemoryType, RetentionRule> updatePolicy = new java.util.EnumMap<>(MemoryType.class);
-        updatePolicy.put(MemoryType.SESSIONS, new RetentionRule(null, 200));
+        updatePolicy.put(MemoryType.SESSIONS, new RetentionRule(null, 200, false, true));
 
         MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(updatePolicy).build();
         config.update(updateContent);
 
-        // Sessions: fully replaced — retentionDays is now null (not preserved)
+        // Sessions: field-level merge — retention_days preserved (not explicitly set in update), max_count updated
         RetentionRule sessionsRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
-        assertNull(sessionsRule.getRetentionDays());
+        assertEquals(Integer.valueOf(30), sessionsRule.getRetentionDays());
         assertEquals(Integer.valueOf(200), sessionsRule.getMaxCount());
 
         // Long-term: untouched (type not in update)

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration.EmbeddingConfig;
 
@@ -1097,5 +1098,238 @@ public class MemoryConfigurationTests {
     public void testBuildIndexPrefix_AcceptsHyphenAndUnderscore() {
         MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("valid_prefix-with-chars").build();
         assertEquals("valid_prefix-with-chars", config.getIndexPrefix());
+    }
+
+    // ==================== Retention Policy Tests ====================
+
+    @Test
+    public void testParse_WithRetentionPolicy() throws Exception {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"sessions\":{\"retention_days\":30,\"max_count\":100},"
+            + "\"long-term\":{\"retention_days\":90,\"max_count\":500}}}";
+
+        XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration config = MemoryConfiguration.parse(parser);
+
+        assertNotNull(config.getRetentionPolicy());
+        assertEquals(2, config.getRetentionPolicy().size());
+
+        RetentionRule sessionsRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
+        assertNotNull(sessionsRule);
+        assertEquals(Integer.valueOf(30), sessionsRule.getRetentionDays());
+        assertEquals(Integer.valueOf(100), sessionsRule.getMaxCount());
+
+        RetentionRule longTermRule = config.getRetentionPolicy().get(MemoryType.LONG_TERM);
+        assertNotNull(longTermRule);
+        assertEquals(Integer.valueOf(90), longTermRule.getRetentionDays());
+        assertEquals(Integer.valueOf(500), longTermRule.getMaxCount());
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_WorkingKeyRejected() {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"working\":{\"max_count\":10}}}";
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+                .xContent()
+                .createParser(
+                    org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                    org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                    json
+                );
+            parser.nextToken();
+            MemoryConfiguration.parse(parser);
+        });
+        assertTrue(e.getMessage().contains("Working memory retention cannot be configured directly"));
+        assertTrue(e.getMessage().contains("sessions"));
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_HistoryWithRetentionDaysRejected() {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"history\":{\"retention_days\":30}}}";
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+                .xContent()
+                .createParser(
+                    org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                    org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                    json
+                );
+            parser.nextToken();
+            MemoryConfiguration.parse(parser);
+        });
+        assertTrue(e.getMessage().contains("retention_days is not supported for history memory type"));
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_UnknownKeyRejected() {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"unknown_type\":{\"max_count\":10}}}";
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+                .xContent()
+                .createParser(
+                    org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                    org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                    json
+                );
+            parser.nextToken();
+            MemoryConfiguration.parse(parser);
+        });
+        assertTrue(e.getMessage().contains("unknown memory type: unknown_type"));
+    }
+
+    @Test
+    public void testRetentionPolicy_XContentRoundTrip() throws Exception {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        policy.put(MemoryType.LONG_TERM, new RetentionRule(90, null));
+        policy.put(MemoryType.HISTORY, new RetentionRule(null, 1000));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build();
+
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.core.xcontent.MediaTypeRegistry
+            .contentBuilder(org.opensearch.common.xcontent.XContentType.JSON);
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String json = org.opensearch.ml.common.TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration parsed = MemoryConfiguration.parse(parser);
+
+        assertNotNull(parsed.getRetentionPolicy());
+        assertEquals(3, parsed.getRetentionPolicy().size());
+        assertEquals(config.getRetentionPolicy().get(MemoryType.SESSIONS), parsed.getRetentionPolicy().get(MemoryType.SESSIONS));
+        assertEquals(config.getRetentionPolicy().get(MemoryType.LONG_TERM), parsed.getRetentionPolicy().get(MemoryType.LONG_TERM));
+        assertEquals(config.getRetentionPolicy().get(MemoryType.HISTORY), parsed.getRetentionPolicy().get(MemoryType.HISTORY));
+    }
+
+    @Test
+    public void testRetentionPolicy_StreamRoundTrip() throws Exception {
+        Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.SESSIONS, new RetentionRule(7, 50));
+        policy.put(MemoryType.LONG_TERM, new RetentionRule(365, 10000));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(policy).build();
+
+        org.opensearch.common.io.stream.BytesStreamOutput output = new org.opensearch.common.io.stream.BytesStreamOutput();
+        config.writeTo(output);
+
+        org.opensearch.core.common.io.stream.StreamInput input = output.bytes().streamInput();
+        MemoryConfiguration deserialized = new MemoryConfiguration(input);
+
+        assertNotNull(deserialized.getRetentionPolicy());
+        assertEquals(2, deserialized.getRetentionPolicy().size());
+        assertEquals(config.getRetentionPolicy().get(MemoryType.SESSIONS), deserialized.getRetentionPolicy().get(MemoryType.SESSIONS));
+        assertEquals(
+            config.getRetentionPolicy().get(MemoryType.LONG_TERM),
+            deserialized.getRetentionPolicy().get(MemoryType.LONG_TERM)
+        );
+    }
+
+    @Test
+    public void testRetentionPolicy_StreamRoundTrip_NullPolicy() throws Exception {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
+
+        org.opensearch.common.io.stream.BytesStreamOutput output = new org.opensearch.common.io.stream.BytesStreamOutput();
+        config.writeTo(output);
+
+        org.opensearch.core.common.io.stream.StreamInput input = output.bytes().streamInput();
+        MemoryConfiguration deserialized = new MemoryConfiguration(input);
+
+        assertNull(deserialized.getRetentionPolicy());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_MergeSemanticsPartialUpdate() {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        existingPolicy.put(MemoryType.LONG_TERM, new RetentionRule(90, 500));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Update only sessions max_count, leaving retention_days unchanged
+        Map<MemoryType, RetentionRule> updatePolicy = new java.util.EnumMap<>(MemoryType.class);
+        updatePolicy.put(MemoryType.SESSIONS, new RetentionRule(null, 200));
+
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(updatePolicy).build();
+        config.update(updateContent);
+
+        // Sessions: retentionDays preserved from existing, maxCount updated
+        RetentionRule sessionsRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
+        assertEquals(Integer.valueOf(30), sessionsRule.getRetentionDays());
+        assertEquals(Integer.valueOf(200), sessionsRule.getMaxCount());
+
+        // Long-term: untouched
+        RetentionRule longTermRule = config.getRetentionPolicy().get(MemoryType.LONG_TERM);
+        assertEquals(Integer.valueOf(90), longTermRule.getRetentionDays());
+        assertEquals(Integer.valueOf(500), longTermRule.getMaxCount());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_AddNewType() {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        Map<MemoryType, RetentionRule> updatePolicy = new java.util.EnumMap<>(MemoryType.class);
+        updatePolicy.put(MemoryType.HISTORY, new RetentionRule(null, 1000));
+
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(updatePolicy).build();
+        config.update(updateContent);
+
+        assertEquals(2, config.getRetentionPolicy().size());
+        assertNotNull(config.getRetentionPolicy().get(MemoryType.SESSIONS));
+        assertEquals(Integer.valueOf(1000), config.getRetentionPolicy().get(MemoryType.HISTORY).getMaxCount());
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_NullIncomingDoesNotRemove() {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Update without retention_policy field — should not touch existing
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().llmId("new-llm").build();
+        config.update(updateContent);
+
+        assertNotNull(config.getRetentionPolicy());
+        assertEquals(1, config.getRetentionPolicy().size());
+    }
+
+    @Test
+    public void testParse_RetentionPolicy_HistoryWithMaxCountOnly() throws Exception {
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"history\":{\"max_count\":500}}}";
+
+        XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration config = MemoryConfiguration.parse(parser);
+
+        assertNotNull(config.getRetentionPolicy());
+        RetentionRule historyRule = config.getRetentionPolicy().get(MemoryType.HISTORY);
+        assertNotNull(historyRule);
+        assertNull(historyRule.getRetentionDays());
+        assertEquals(Integer.valueOf(500), historyRule.getMaxCount());
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1234,10 +1234,7 @@ public class MemoryConfigurationTests {
         assertNotNull(deserialized.getRetentionPolicy());
         assertEquals(2, deserialized.getRetentionPolicy().size());
         assertEquals(config.getRetentionPolicy().get(MemoryType.SESSIONS), deserialized.getRetentionPolicy().get(MemoryType.SESSIONS));
-        assertEquals(
-            config.getRetentionPolicy().get(MemoryType.LONG_TERM),
-            deserialized.getRetentionPolicy().get(MemoryType.LONG_TERM)
-        );
+        assertEquals(config.getRetentionPolicy().get(MemoryType.LONG_TERM), deserialized.getRetentionPolicy().get(MemoryType.LONG_TERM));
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
@@ -14,14 +14,14 @@ import java.io.IOException;
 
 import org.junit.Test;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.common.xcontent.LoggingDeprecationHandler;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.TestHelper;
 
 public class RetentionRuleTests {

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.TestHelper;
+
+public class RetentionRuleTests {
+
+    @Test
+    public void testBothFieldsSet() {
+        RetentionRule rule = new RetentionRule(30, 100);
+        assertEquals(Integer.valueOf(30), rule.getRetentionDays());
+        assertEquals(Integer.valueOf(100), rule.getMaxCount());
+    }
+
+    @Test
+    public void testOnlyRetentionDaysSet() {
+        RetentionRule rule = new RetentionRule(7, null);
+        assertEquals(Integer.valueOf(7), rule.getRetentionDays());
+        assertNull(rule.getMaxCount());
+    }
+
+    @Test
+    public void testOnlyMaxCountSet() {
+        RetentionRule rule = new RetentionRule(null, 50);
+        assertNull(rule.getRetentionDays());
+        assertEquals(Integer.valueOf(50), rule.getMaxCount());
+    }
+
+    @Test
+    public void testBothNull() {
+        RetentionRule rule = new RetentionRule(null, null);
+        assertNull(rule.getRetentionDays());
+        assertNull(rule.getMaxCount());
+    }
+
+    @Test
+    public void testNegativeRetentionDaysThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(-1, null));
+        assertEquals("retention_days must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testZeroRetentionDaysThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(0, null));
+        assertEquals("retention_days must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testNegativeMaxCountThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(null, -5));
+        assertEquals("max_count must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testZeroMaxCountThrows() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new RetentionRule(null, 0));
+        assertEquals("max_count must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testXContentRoundTrip_BothFields() throws IOException {
+        RetentionRule original = new RetentionRule(30, 100);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testXContentRoundTrip_OnlyRetentionDays() throws IOException {
+        RetentionRule original = new RetentionRule(14, null);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testXContentRoundTrip_OnlyMaxCount() throws IOException {
+        RetentionRule original = new RetentionRule(null, 200);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testXContentRoundTrip_BothNull() throws IOException {
+        RetentionRule original = new RetentionRule(null, null);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testStreamRoundTrip_BothFields() throws IOException {
+        RetentionRule original = new RetentionRule(30, 100);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testStreamRoundTrip_OnlyRetentionDays() throws IOException {
+        RetentionRule original = new RetentionRule(7, null);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testStreamRoundTrip_OnlyMaxCount() throws IOException {
+        RetentionRule original = new RetentionRule(null, 50);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testStreamRoundTrip_BothNull() throws IOException {
+        RetentionRule original = new RetentionRule(null, null);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        RetentionRule deserialized = new RetentionRule(input);
+
+        assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testParseFromJsonString() throws IOException {
+        String json = "{\"retention_days\":60,\"max_count\":500}";
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertNotNull(parsed);
+        assertEquals(Integer.valueOf(60), parsed.getRetentionDays());
+        assertEquals(Integer.valueOf(500), parsed.getMaxCount());
+    }
+
+    @Test
+    public void testParseFromJsonString_UnknownFieldsIgnored() throws IOException {
+        String json = "{\"retention_days\":10,\"max_count\":20,\"unknown_field\":\"ignored\"}";
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertEquals(Integer.valueOf(10), parsed.getRetentionDays());
+        assertEquals(Integer.valueOf(20), parsed.getMaxCount());
+    }
+
+    @Test
+    public void testBuilder() {
+        RetentionRule rule = RetentionRule.builder().retentionDays(14).maxCount(50).build();
+        assertEquals(Integer.valueOf(14), rule.getRetentionDays());
+        assertEquals(Integer.valueOf(50), rule.getMaxCount());
+    }
+
+    @Test
+    public void testEquality() {
+        RetentionRule rule1 = new RetentionRule(30, 100);
+        RetentionRule rule2 = new RetentionRule(30, 100);
+        assertEquals(rule1, rule2);
+        assertEquals(rule1.hashCode(), rule2.hashCode());
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
@@ -241,4 +241,22 @@ public class RetentionRuleTests {
         assertEquals(rule1, rule2);
         assertEquals(rule1.hashCode(), rule2.hashCode());
     }
+
+    @Test
+    public void testBuilder_NegativeRetentionDaysThrows() {
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> RetentionRule.builder().retentionDays(-1).maxCount(10).build()
+        );
+        assertEquals("retention_days must be a positive integer or null", e.getMessage());
+    }
+
+    @Test
+    public void testBuilder_ZeroMaxCountThrows() {
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> RetentionRule.builder().retentionDays(5).maxCount(0).build()
+        );
+        assertEquals("max_count must be a positive integer or null", e.getMessage());
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
@@ -144,6 +145,61 @@ public class RetentionRuleTests {
         RetentionRule parsed = RetentionRule.parse(parser);
 
         assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testToXContent_ExplicitNullMaxCountEmitted() throws IOException {
+        RetentionRule rule = new RetentionRule(30, null, false, true);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        rule.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        assertEquals("{\"retention_days\":30,\"max_count\":null}", json);
+    }
+
+    @Test
+    public void testToXContent_ExplicitNullRetentionDaysEmitted() throws IOException {
+        RetentionRule rule = new RetentionRule(null, 100, true, false);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        rule.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        assertEquals("{\"retention_days\":null,\"max_count\":100}", json);
+    }
+
+    @Test
+    public void testToXContent_AbsentFieldsOmitted() throws IOException {
+        RetentionRule rule = new RetentionRule(null, null, false, false);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        rule.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        assertEquals("{}", json);
+    }
+
+    @Test
+    public void testXContentRoundTrip_ExplicitNulls_PreservesFlags() throws IOException {
+        RetentionRule original = new RetentionRule(null, null, true, true);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        assertEquals("{\"retention_days\":null,\"max_count\":null}", json);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertNull(parsed.getRetentionDays());
+        assertNull(parsed.getMaxCount());
+        assertTrue(parsed.isRetentionDaysExplicitlySet());
+        assertTrue(parsed.isMaxCountExplicitlySet());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/model/ModelGuardrailTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/ModelGuardrailTests.java
@@ -23,7 +23,6 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.TestHelper;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;

--- a/common/src/test/java/org/opensearch/ml/common/model/ModelGuardrailTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/ModelGuardrailTests.java
@@ -23,6 +23,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.TestHelper;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
@@ -862,4 +862,57 @@ public class MLAddMemoriesInputTest {
         assertEquals("new-checkpoint-id", input.getCheckpointId());
     }
 
+    @Test
+    public void testPinnedField() {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .pinned(true)
+            .build();
+
+        assertEquals(Boolean.TRUE, input.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldNull() {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .build();
+
+        assertNull(input.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamSerialization() throws IOException {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        input.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLAddMemoriesInput deserialized = new MLAddMemoriesInput(in);
+        assertEquals(Boolean.TRUE, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldParsing() throws IOException {
+        String json = "{\"memory_container_id\":\"container-123\",\"payload_type\":\"conversational\","
+            + "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}],"
+            + "\"pinned\":true}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        MLAddMemoriesInput parsed = MLAddMemoriesInput.parse(parser, "container-123", null);
+        assertEquals(Boolean.TRUE, parsed.getPinned());
+    }
+
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
@@ -876,11 +876,7 @@ public class MLAddMemoriesInputTest {
 
     @Test
     public void testPinnedFieldNull() {
-        MLAddMemoriesInput input = MLAddMemoriesInput
-            .builder()
-            .memoryContainerId("container-123")
-            .messages(testMessages)
-            .build();
+        MLAddMemoriesInput input = MLAddMemoriesInput.builder().memoryContainerId("container-123").messages(testMessages).build();
 
         assertNull(input.getPinned());
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -9,6 +9,9 @@ import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
 
 import java.time.Instant;
+import java.util.Map;
+
+import org.opensearch.common.logging.HeaderWarning;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
@@ -24,6 +27,8 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
@@ -100,6 +105,9 @@ public class TransportCreateMemoryContainerAction extends
 
         // Validate configuration before creating memory container
         validateConfiguration(input.getConfiguration(), ActionListener.wrap(isValid -> {
+            // Emit warning if sessions retention is set on a container with disableSession=true
+            emitDisableSessionRetentionWarning(input.getConfiguration());
+
             // Check if memory container index exists, create if not
             ActionListener<Boolean> indexCheckListener = ActionListener.wrap(created -> {
                 try {
@@ -285,6 +293,20 @@ public class TransportCreateMemoryContainerAction extends
         } catch (Exception e) {
             log.error("Failed to save memory container", e);
             listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            HeaderWarning
+                .addWarning(
+                    "sessions retention_policy has no effect when disableSession=true;"
+                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -11,7 +11,6 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEM
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS;
-import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
 
 import java.time.Instant;
 import java.util.EnumMap;
@@ -162,29 +161,37 @@ public class TransportCreateMemoryContainerAction extends
             }
         }
 
-        // Auto-apply default retention policy when retention is enabled and user did not provide one
+        // Auto-apply admin-configured default retention policy when user did not provide one
         if (configuration != null && !configuration.isRetentionPolicyExplicitlyNull()) {
             Map<MemoryType, RetentionRule> existingPolicy = configuration.getRetentionPolicy();
-            if ((existingPolicy == null || existingPolicy.isEmpty())
-                && ML_COMMONS_MEMORY_RETENTION_ENABLED.get(clusterService.getSettings())) {
-                Map<MemoryType, RetentionRule> defaultPolicy = new EnumMap<>(MemoryType.class);
-                defaultPolicy.put(
-                    MemoryType.SESSIONS,
-                    new RetentionRule(
-                        ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS.get(clusterService.getSettings()),
-                        ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT.get(clusterService.getSettings())
-                    )
-                );
-                defaultPolicy.put(
-                    MemoryType.LONG_TERM,
-                    new RetentionRule(null, ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT.get(clusterService.getSettings()))
-                );
-                defaultPolicy.put(
-                    MemoryType.HISTORY,
-                    new RetentionRule(null, ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT.get(clusterService.getSettings()))
-                );
-                configuration.setRetentionPolicy(defaultPolicy);
-                log.info("Auto-applied default retention policy to new container '{}'", input.getName());
+            if (existingPolicy == null || existingPolicy.isEmpty()) {
+                int sessionRetentionDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS);
+                int sessionMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT);
+                int longTermMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT);
+                int historyMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT);
+
+                boolean anyConfigured = sessionRetentionDays > 0 || sessionMaxCount > 0 || longTermMaxCount > 0 || historyMaxCount > 0;
+                if (anyConfigured) {
+                    Map<MemoryType, RetentionRule> defaultPolicy = new EnumMap<>(MemoryType.class);
+                    if (sessionRetentionDays > 0 || sessionMaxCount > 0) {
+                        defaultPolicy
+                            .put(
+                                MemoryType.SESSIONS,
+                                new RetentionRule(
+                                    sessionRetentionDays > 0 ? sessionRetentionDays : null,
+                                    sessionMaxCount > 0 ? sessionMaxCount : null
+                                )
+                            );
+                    }
+                    if (longTermMaxCount > 0) {
+                        defaultPolicy.put(MemoryType.LONG_TERM, new RetentionRule(null, longTermMaxCount));
+                    }
+                    if (historyMaxCount > 0) {
+                        defaultPolicy.put(MemoryType.HISTORY, new RetentionRule(null, historyMaxCount));
+                    }
+                    configuration.setRetentionPolicy(defaultPolicy);
+                    log.info("Auto-applied default retention policy to new container '{}'", input.getName());
+                }
             }
         }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -11,8 +11,6 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGE
 import java.time.Instant;
 import java.util.Map;
 
-import org.opensearch.common.logging.HeaderWarning;
-
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.index.IndexResponse;
@@ -20,6 +18,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -7,8 +7,14 @@ package org.opensearch.ml.action.memorycontainer;
 
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
 
 import java.time.Instant;
+import java.util.EnumMap;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
@@ -17,6 +23,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -63,6 +70,7 @@ public class TransportCreateMemoryContainerAction extends
     private final ConnectorAccessControlHelper connectorAccessControlHelper;
     private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
     private final MLModelManager mlModelManager;
+    private final ClusterService clusterService;
 
     @Inject
     public TransportCreateMemoryContainerAction(
@@ -73,7 +81,8 @@ public class TransportCreateMemoryContainerAction extends
         MLIndicesHandler mlIndicesHandler,
         ConnectorAccessControlHelper connectorAccessControlHelper,
         MLFeatureEnabledSetting mlFeatureEnabledSetting,
-        MLModelManager mlModelManager
+        MLModelManager mlModelManager,
+        ClusterService clusterService
     ) {
         super(MLCreateMemoryContainerAction.NAME, transportService, actionFilters, MLCreateMemoryContainerRequest::new);
         this.client = client;
@@ -82,6 +91,7 @@ public class TransportCreateMemoryContainerAction extends
         this.connectorAccessControlHelper = connectorAccessControlHelper;
         this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
         this.mlModelManager = mlModelManager;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -149,6 +159,32 @@ public class TransportCreateMemoryContainerAction extends
                 if (strategy.getEnabled() == null) {
                     strategy.setEnabled(true);
                 }
+            }
+        }
+
+        // Auto-apply default retention policy when retention is enabled and user did not provide one
+        if (configuration != null && !configuration.isRetentionPolicyExplicitlyNull()) {
+            Map<MemoryType, RetentionRule> existingPolicy = configuration.getRetentionPolicy();
+            if ((existingPolicy == null || existingPolicy.isEmpty())
+                && ML_COMMONS_MEMORY_RETENTION_ENABLED.get(clusterService.getSettings())) {
+                Map<MemoryType, RetentionRule> defaultPolicy = new EnumMap<>(MemoryType.class);
+                defaultPolicy.put(
+                    MemoryType.SESSIONS,
+                    new RetentionRule(
+                        ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS.get(clusterService.getSettings()),
+                        ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT.get(clusterService.getSettings())
+                    )
+                );
+                defaultPolicy.put(
+                    MemoryType.LONG_TERM,
+                    new RetentionRule(null, ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT.get(clusterService.getSettings()))
+                );
+                defaultPolicy.put(
+                    MemoryType.HISTORY,
+                    new RetentionRule(null, ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT.get(clusterService.getSettings()))
+                );
+                configuration.setRetentionPolicy(defaultPolicy);
+                log.info("Auto-applied default retention policy to new container '{}'", input.getName());
             }
         }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -32,6 +33,8 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerAction;
@@ -186,6 +189,9 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
 
                     // No transition - proceed with normal update
                     updateFields.put(MEMORY_STORAGE_CONFIG_FIELD, currentConfig);
+
+                    // Emit warning if sessions retention is set on a container with disableSession=true
+                    emitDisableSessionRetentionWarning(currentConfig);
                 } catch (Exception e) {
                     log.error("Failed to update configuration for container {}", memoryContainerId, e);
                     actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
@@ -251,6 +257,20 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
                         + "Create a new memory container if you need different embedding configuration."
                 );
             }
+        }
+    }
+
+    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            HeaderWarning
+                .addWarning(
+                    "sessions retention_policy has no effect when disableSession=true;"
+                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -18,13 +18,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -267,10 +267,15 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                         UpdateRequest updateRequest = new UpdateRequest(sessionIndex, sessionId)
                             .doc(Map.of(LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli()))
                             .retryOnConflict(3);
-                        client.update(updateRequest, ActionListener.wrap(
-                            resp -> log.debug("Bumped session {} last_updated_time", sessionId),
-                            e -> log.debug("Failed to bump session {} last_updated_time", sessionId, e)
-                        ));
+                        client
+                            .update(
+                                updateRequest,
+                                ActionListener
+                                    .wrap(
+                                        resp -> log.debug("Bumped session {} last_updated_time", sessionId),
+                                        e -> log.debug("Failed to bump session {} last_updated_time", sessionId, e)
+                                    )
+                            );
                     }
                 }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -34,8 +34,11 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
@@ -306,7 +309,16 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             // Add memory content from input object
             mlAddMemoriesInput.toXContent(builder, ToXContent.EMPTY_PARAMS, true);
 
-            indexRequest.source(builder);
+            // Denormalize session_id to a top-level keyword field (namespace is flat_object and
+            // cannot be aggregated) so the retention job can enumerate sessions efficiently
+            String sessionId = mlAddMemoriesInput.getSessionId();
+            if (sessionId != null) {
+                Map<String, Object> source = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+                source.put(SESSION_ID_FIELD, sessionId);
+                indexRequest.source(source);
+            } else {
+                indexRequest.source(builder);
+            }
             indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             return indexRequest;
         } catch (IOException e) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -123,8 +123,7 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             actionListener
                 .onFailure(
                     new OpenSearchStatusException(
-                        "pinned field is not supported for working memory type."
-                            + " To preserve a conversation, pin the session instead.",
+                        "pinned field is not supported for working memory type." + " To preserve a conversation, pin the session instead.",
                         RestStatus.BAD_REQUEST
                     )
                 );

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -118,6 +118,19 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             return;
         }
 
+        // Reject pinned field — add-memories creates working memory which cannot be pinned
+        if (input.getPinned() != null) {
+            actionListener
+                .onFailure(
+                    new OpenSearchStatusException(
+                        "pinned field is not supported for working memory type."
+                            + " To preserve a conversation, pin the session instead.",
+                        RestStatus.BAD_REQUEST
+                    )
+                );
+            return;
+        }
+
         String memoryContainerId = input.getMemoryContainerId();
 
         if (StringUtils.isBlank(memoryContainerId)) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -31,6 +31,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.commons.authuser.User;
@@ -189,15 +190,15 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                                     NAMESPACE_FIELD,
                                     input.getNamespace(),
                                     CREATED_TIME_FIELD,
-                                    now.getEpochSecond(),
+                                    now.toEpochMilli(),
                                     LAST_UPDATED_TIME_FIELD,
-                                    now.getEpochSecond()
+                                    now.toEpochMilli()
                                 )
                         );
                     indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                     ActionListener<IndexResponse> responseActionListener = ActionListener.<IndexResponse>wrap(r -> {
                         input.getNamespace().put(SESSION_ID_FIELD, r.getId());
-                        processAndIndexMemory(input, container, user, actionListener);
+                        processAndIndexMemory(input, container, user, actionListener, true);
                     }, e -> {
                         log.error("Failed to index session data", e);
                         actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
@@ -219,7 +220,7 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
 
                 memoryProcessingService.summarizeMessages(tenantId, container.getConfiguration(), messages, summaryListener);
             } else {
-                processAndIndexMemory(input, container, user, actionListener);
+                processAndIndexMemory(input, container, user, actionListener, false);
             }
         } catch (Exception e) {
             log.error("Failed to create session", e);
@@ -231,7 +232,8 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
         MLAddMemoriesInput input,
         MLMemoryContainer container,
         User user,
-        ActionListener<MLAddMemoriesResponse> actionListener
+        ActionListener<MLAddMemoriesResponse> actionListener,
+        boolean newlyCreatedSession
     ) {
         try {
             boolean infer = input.isInfer();
@@ -256,6 +258,21 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                     .workingMemoryId(r.getId())
                     .build();
                 actionListener.onResponse(response);
+
+                // Bump last_updated_time on existing sessions
+                if (!newlyCreatedSession && !memoryConfig.isDisableSession()) {
+                    String sessionId = input.getSessionId();
+                    String sessionIndex = memoryConfig.getSessionIndexName();
+                    if (sessionId != null && sessionIndex != null) {
+                        UpdateRequest updateRequest = new UpdateRequest(sessionIndex, sessionId)
+                            .doc(Map.of(LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli()))
+                            .retryOnConflict(3);
+                        client.update(updateRequest, ActionListener.wrap(
+                            resp -> log.debug("Bumped session {} last_updated_time", sessionId),
+                            e -> log.debug("Failed to bump session {} last_updated_time", sessionId, e)
+                        ));
+                    }
+                }
 
                 if (infer) {
                     threadPool.executor(AGENTIC_MEMORY_THREAD_POOL).execute(() -> {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MESSAGES_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.METADATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_BLOB_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SUMMARY_FIELD;
@@ -136,6 +137,20 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
                     return;
                 }
 
+                // Reject pinned field for working memory type
+                Map<String, Object> updateContent = updateRequest.getMlUpdateMemoryInput().getUpdateContent();
+                if (memoryType == MemoryType.WORKING && updateContent.containsKey(PINNED_FIELD)) {
+                    actionListener
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "pinned field is not supported for working memory type."
+                                    + " To preserve a conversation, pin the session instead.",
+                                RestStatus.BAD_REQUEST
+                            )
+                        );
+                    return;
+                }
+
                 // Prepare the update
                 Map<String, Object> newDoc = constructNewDoc(updateRequest.getMlUpdateMemoryInput(), memoryType, originalDoc);
                 IndexRequest indexRequest = new IndexRequest(memoryIndexName).id(memoryId).source(newDoc);
@@ -186,6 +201,9 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
         if (updateContent.containsKey(ADDITIONAL_INFO_FIELD)) {
             updateFields.put(ADDITIONAL_INFO_FIELD, updateContent.get(ADDITIONAL_INFO_FIELD));
         }
+        if (updateContent.containsKey(PINNED_FIELD)) {
+            updateFields.put(PINNED_FIELD, updateContent.get(PINNED_FIELD));
+        }
         return updateFields;
     }
 
@@ -217,6 +235,9 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
         }
         if (updateContent.containsKey(TAGS_FIELD)) {
             updateFields.put(TAGS_FIELD, updateContent.get(TAGS_FIELD));
+        }
+        if (updateContent.containsKey(PINNED_FIELD)) {
+            updateFields.put(PINNED_FIELD, updateContent.get(PINNED_FIELD));
         }
         return updateFields;
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
@@ -184,8 +184,34 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
                     break;
             }
         }
-        updateFields.put(LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli());
+        if (shouldBumpLastUpdatedTime(memoryType, updateContent)) {
+            updateFields.put(LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli());
+        }
         return updateFields;
+    }
+
+    /**
+     * Determines whether last_updated_time should be bumped based on the memory type
+     * and the fields being updated. Only content field changes trigger a timestamp bump.
+     * Non-content fields (tags, pinned, metadata, additional_info, agents) do not.
+     */
+    private boolean shouldBumpLastUpdatedTime(MemoryType memoryType, Map<String, Object> updateContent) {
+        if (memoryType == null) {
+            return false;
+        }
+        switch (memoryType) {
+            case SESSIONS:
+                return updateContent.containsKey(SUMMARY_FIELD);
+            case LONG_TERM:
+                return updateContent.containsKey(MEMORY_FIELD);
+            case WORKING:
+                return updateContent.containsKey(MESSAGES_FIELD)
+                    || updateContent.containsKey(BINARY_DATA_FIELD)
+                    || updateContent.containsKey(STRUCTURED_DATA_FIELD)
+                    || updateContent.containsKey(STRUCTURED_DATA_BLOB_FIELD);
+            default:
+                return false;
+        }
     }
 
     public Map<String, Object> constructSessionMemUpdateFields(Map<String, Object> updateFields, Map<String, Object> updateContent) {

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.action.model_group;
 
 import static org.opensearch.ml.action.handler.MLSearchHandler.wrapRestActionListener;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_RESOURCE_TYPE;
 import static org.opensearch.ml.helper.ModelAccessControlHelper.shouldUseResourceAuthz;
 import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleSearchIndexNotFound;
@@ -128,9 +129,13 @@ public class SearchModelGroupTransportAction extends HandledTransportAction<MLSe
     }
 
     private void search(String tenantId, SearchRequest request, ActionListener<SearchResponse> listener) {
+        String[] indices = request.indices();
+        if (indices == null || indices.length == 0) {
+            indices = new String[] { ML_MODEL_GROUP_INDEX };
+        }
         SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
             .builder()
-            .indices(request.indices())
+            .indices(indices)
             .searchSourceBuilder(request.source())
             .tenantId(tenantId)
             .build();

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -105,7 +105,8 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                 if (mlFeatureEnabledSetting.isAgenticMemoryEnabled()
                     && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
                     && !this.startedMemoryRetentionJob) {
-                    mlTaskManager.indexMemoryRetentionJob();
+                    int intervalHours = MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.get(clusterService.getSettings());
+                    mlTaskManager.indexMemoryRetentionJob(intervalHours);
                     this.startedMemoryRetentionJob = true;
                 }
 

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -21,6 +21,7 @@ import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.autoredeploy.MLModelAutoReDeployer;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
@@ -40,6 +41,7 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
     private final Client client;
     private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
     private boolean startedStatsJob;
+    private boolean startedMemoryRetentionJob;
 
     public MLCommonsClusterEventListener(
         ClusterService clusterService,
@@ -98,6 +100,13 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                     mlTaskManager.indexStatsCollectorJob(true);
                     // using this variable in case if same node has a cluster state change event and the state is not updated yet
                     this.startedStatsJob = true;
+                }
+
+                if (mlFeatureEnabledSetting.isAgenticMemoryEnabled()
+                    && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
+                    && !this.startedMemoryRetentionJob) {
+                    mlTaskManager.indexMemoryRetentionJob();
+                    this.startedMemoryRetentionJob = true;
                 }
 
                 break;

--- a/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
@@ -13,6 +13,7 @@ import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.jobs.processors.MLBatchTaskUpdateProcessor;
 import org.opensearch.ml.jobs.processors.MLStatsJobProcessor;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
@@ -105,6 +106,9 @@ public class MLJobRunner implements ScheduledJobRunner {
                 break;
             case BATCH_TASK_UPDATE:
                 MLBatchTaskUpdateProcessor.getInstance(clusterService, client, threadPool).process(jobParameter, jobExecutionContext);
+                break;
+            case MEMORY_RETENTION:
+                MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool).process(jobParameter, jobExecutionContext);
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported job type " + jobParameter.getJobType());

--- a/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
@@ -26,7 +26,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class MLJobRunner implements ScheduledJobRunner {
 
-    private static MLJobRunner instance;
+    private static volatile MLJobRunner instance;
 
     public static MLJobRunner getInstance() {
         if (instance != null) {
@@ -59,7 +59,7 @@ public class MLJobRunner implements ScheduledJobRunner {
     @Setter
     private MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
-    private boolean initialized;
+    private volatile boolean initialized;
 
     @VisibleForTesting
     MLJobRunner() {
@@ -79,8 +79,8 @@ public class MLJobRunner implements ScheduledJobRunner {
         this.client = client;
         this.sdkClient = sdkClient;
         this.connectorAccessControlHelper = connectorAccessControlHelper;
-        this.initialized = true;
         this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+        this.initialized = true;
     }
 
     @Override

--- a/plugin/src/main/java/org/opensearch/ml/jobs/MLJobType.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/MLJobType.java
@@ -7,7 +7,8 @@ package org.opensearch.ml.jobs;
 
 public enum MLJobType {
     STATS_COLLECTOR("Job to collect static metrics and push to Metrics Registry"),
-    BATCH_TASK_UPDATE("Job to poll and update status of running batch prediction tasks for remote models");
+    BATCH_TASK_UPDATE("Job to poll and update status of running batch prediction tasks for remote models"),
+    MEMORY_RETENTION("Job to enforce retention policies on agentic memory containers");
 
     private final String description;
 

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
@@ -98,6 +99,11 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     public void run() {
         if (ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())) {
             log.warn("Memory retention job skipped: multi-tenancy is enabled and native client lacks tenant routing");
+            return;
+        }
+
+        if (!ML_COMMONS_MEMORY_RETENTION_ENABLED.get(clusterService.getSettings())) {
+            log.info("Memory retention job disabled via cluster setting plugins.ml_commons.memory.retention_enabled=false");
             return;
         }
 
@@ -351,6 +357,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         int maxCount,
         ActionListener<Set<String>> listener
     ) {
+        // Check if pinned count alone exceeds max_count (fire-and-forget warning)
+        checkPinnedExceedsMaxCount(sessionIndex, containerId, "sessions", maxCount);
+
         // Walk sessions sorted by last_updated_time DESC (newest first).
         // Skip the first maxCount sessions; collect the rest as expired.
         Set<String> expiredIds = new HashSet<>();
@@ -377,7 +386,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
             .query(query)
             .size(CONTAINER_PAGE_SIZE)
-            .sort(LAST_UPDATED_TIME_FIELD, SortOrder.DESC)
+            .sort(CREATED_TIME_FIELD, SortOrder.DESC)
             .sort("_id", SortOrder.ASC)
             .fetchSource(false);
 
@@ -566,6 +575,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     }
 
     private void executeLongTermMaxCount(String longTermIndex, String containerId, int maxCount, ActionListener<Long> listener) {
+        // Check if pinned count alone exceeds max_count (fire-and-forget warning)
+        checkPinnedExceedsMaxCount(longTermIndex, containerId, "long_term", maxCount);
+
         // Step 1: count non-pinned long-term docs
         SearchRequest countRequest = new SearchRequest(longTermIndex);
         countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -587,8 +599,8 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 }
 
                 int excess = (int) (totalCount - maxCount);
-                // Step 2: search for oldest excess docs by last_updated_time ASC
-                collectOldestDocIds(longTermIndex, containerId, LAST_UPDATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
+                // Step 2: search for oldest excess docs by created_time ASC
+                collectOldestDocIds(longTermIndex, containerId, CREATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
                     if (idsToDelete.isEmpty()) {
                         listener.onResponse(0L);
                         return;
@@ -722,6 +734,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
         int maxCount = rule.getMaxCount();
 
+        // Check if pinned count alone exceeds max_count (fire-and-forget warning)
+        checkPinnedExceedsMaxCount(historyIndex, containerId, "history", maxCount);
+
         // Step 1: count non-pinned history docs
         SearchRequest countRequest = new SearchRequest(historyIndex);
         countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -792,6 +807,36 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 log.info("[MemoryRetentionJob] container={} working_memory_ttl_deleted={}", containerId, response.getDeleted());
                 listener.onResponse(null);
             }, listener::onFailure));
+        }
+    }
+
+    private void checkPinnedExceedsMaxCount(String index, String containerId, String memoryType, int maxCount) {
+        SearchRequest pinnedCountRequest = new SearchRequest(index);
+        pinnedCountRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder pinnedQuery = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .must(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder pinnedSource = new SearchSourceBuilder().query(pinnedQuery).size(0).trackTotalHits(true);
+        pinnedCountRequest.source(pinnedSource);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(pinnedCountRequest, ActionListener.wrap(pinnedResponse -> {
+                long pinnedCount = pinnedResponse.getHits().getTotalHits().value();
+                if (pinnedCount > maxCount) {
+                    log
+                        .warn(
+                            "[MemoryRetentionJob] container={} type={} pinned_count={} exceeds max_count={}."
+                                + " Container will grow unbounded until pins are removed.",
+                            containerId,
+                            memoryType,
+                            pinnedCount,
+                            maxCount
+                        );
+                }
+            }, e -> { log.debug("Failed to check pinned count for container [{}] type [{}]", containerId, memoryType, e); }));
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -5,11 +5,56 @@
 
 package org.opensearch.ml.jobs.processors;
 
+import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_STORAGE_CONFIG_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -18,6 +63,10 @@ import com.google.common.annotations.VisibleForTesting;
 public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     private static final Logger log = LogManager.getLogger(MemoryRetentionJobProcessor.class);
+
+    private static final int CONTAINER_PAGE_SIZE = 100;
+    private static final int DELETE_BY_QUERY_BATCH_SIZE = 500;
+    private static final int BULK_DELETE_BATCH_SIZE = 1000;
 
     private static MemoryRetentionJobProcessor instance;
 
@@ -52,6 +101,713 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             return;
         }
 
-        log.info("Memory retention job triggered");
+        log.info("Memory retention job started");
+        resolveContainersWithPolicies(null);
+    }
+
+    private void resolveContainersWithPolicies(Object[] searchAfterValues) {
+        SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.existsQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + RETENTION_POLICY_FIELD));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(CONTAINER_PAGE_SIZE)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(true);
+
+        if (searchAfterValues != null) {
+            sourceBuilder.searchAfter(searchAfterValues);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHits hits = response.getHits();
+                SearchHit[] hitArray = hits.getHits();
+
+                if (hitArray.length == 0) {
+                    onJobComplete();
+                    return;
+                }
+
+                processContainerChain(
+                    hitArray,
+                    0,
+                    hitArray.length == CONTAINER_PAGE_SIZE ? hitArray[hitArray.length - 1].getSortValues() : null
+                );
+            }, e -> {
+                log.error("Failed to search for containers with retention policies", e);
+                onJobComplete();
+            }));
+        }
+    }
+
+    private void processContainerChain(SearchHit[] hits, int index, Object[] nextPageSortValues) {
+        if (index >= hits.length) {
+            if (nextPageSortValues != null) {
+                resolveContainersWithPolicies(nextPageSortValues);
+            } else {
+                executeOrphanSweep();
+                onJobComplete();
+            }
+            return;
+        }
+
+        processContainer(hits[index], ActionListener.wrap(v -> scheduleNext(hits, index + 1, nextPageSortValues), e -> {
+            log.error("Failed processing container [{}]", hits[index].getId(), e);
+            scheduleNext(hits, index + 1, nextPageSortValues);
+        }));
+    }
+
+    private void scheduleNext(SearchHit[] hits, int nextIndex, Object[] nextPageSortValues) {
+        int throttleSeconds = ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS.get(clusterService.getSettings());
+        threadPool
+            .schedule(
+                () -> processContainerChain(hits, nextIndex, nextPageSortValues),
+                TimeValue.timeValueSeconds(throttleSeconds),
+                ThreadPool.Names.GENERIC
+            );
+    }
+
+    private void processContainer(SearchHit hit, ActionListener<Void> listener) {
+        String containerId = hit.getId();
+        try {
+            Map<String, Object> source = hit.getSourceAsMap();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> configMap = (Map<String, Object>) source.get(MEMORY_STORAGE_CONFIG_FIELD);
+
+            if (configMap == null) {
+                log.warn("Container [{}] has no configuration field, skipping", containerId);
+                listener.onResponse(null);
+                return;
+            }
+
+            XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(configMap);
+            BytesReference bytes = BytesReference.bytes(xContentBuilder);
+            XContentParser parser = XContentHelper
+                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON);
+            parser.nextToken();
+            MemoryConfiguration config = MemoryConfiguration.parse(parser);
+
+            executeSessionRetention(
+                config,
+                containerId,
+                ActionListener
+                    .wrap(
+                        v -> executeLongTermRetention(
+                            config,
+                            containerId,
+                            ActionListener
+                                .wrap(
+                                    v2 -> executeHistoryRetention(
+                                        config,
+                                        containerId,
+                                        ActionListener
+                                            .wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
+                                    ),
+                                    listener::onFailure
+                                )
+                        ),
+                        listener::onFailure
+                    )
+            );
+        } catch (Exception e) {
+            log.error("Error parsing configuration for container [{}]", containerId, e);
+            listener.onResponse(null);
+        }
+    }
+
+    private void executeSessionRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        String sessionIndex = config.getIndexName(MemoryType.SESSIONS);
+        if (sessionIndex == null) {
+            log.debug("Session index is null for container [{}], skipping session retention", containerId);
+            listener.onResponse(null);
+            return;
+        }
+
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            listener.onResponse(null);
+            return;
+        }
+
+        RetentionRule sessionRule = retentionPolicy.get(MemoryType.SESSIONS);
+        if (sessionRule == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        identifyExpiredSessions(config, containerId, sessionIndex, sessionRule, ActionListener.wrap(expiredSessionIds -> {
+            if (expiredSessionIds.isEmpty()) {
+                log.info("[MemoryRetentionJob] container={} sessions_expired=0", containerId);
+                listener.onResponse(null);
+                return;
+            }
+
+            log.info("[MemoryRetentionJob] container={} sessions_expired={}", containerId, expiredSessionIds.size());
+
+            cascadeDeleteWorkingMemory(
+                config,
+                containerId,
+                expiredSessionIds,
+                ActionListener
+                    .wrap(deletedCount -> deleteSessionDocuments(config, sessionIndex, expiredSessionIds, listener), listener::onFailure)
+            );
+        }, listener::onFailure));
+    }
+
+    private void identifyExpiredSessions(
+        MemoryConfiguration config,
+        String containerId,
+        String sessionIndex,
+        RetentionRule rule,
+        ActionListener<Set<String>> listener
+    ) {
+        Set<String> expiredIds = new HashSet<>();
+
+        ActionListener<Set<String>> timeBasedDone = ActionListener.wrap(timeExpired -> {
+            expiredIds.addAll(timeExpired);
+            if (rule.getMaxCount() != null) {
+                identifyCountBasedExpiredSessions(
+                    config,
+                    containerId,
+                    sessionIndex,
+                    rule.getMaxCount(),
+                    ActionListener.wrap(countExpired -> {
+                        expiredIds.addAll(countExpired);
+                        listener.onResponse(expiredIds);
+                    }, listener::onFailure)
+                );
+            } else {
+                listener.onResponse(expiredIds);
+            }
+        }, listener::onFailure);
+
+        if (rule.getRetentionDays() != null) {
+            identifyTimeBasedExpiredSessions(config, containerId, sessionIndex, rule.getRetentionDays(), timeBasedDone);
+        } else {
+            timeBasedDone.onResponse(new HashSet<>());
+        }
+    }
+
+    private void identifyTimeBasedExpiredSessions(
+        MemoryConfiguration config,
+        String containerId,
+        String sessionIndex,
+        int retentionDays,
+        ActionListener<Set<String>> listener
+    ) {
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays);
+
+        SearchRequest request = new SearchRequest(sessionIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .must(QueryBuilders.rangeQuery(LAST_UPDATED_TIME_FIELD).lt(cutoffMillis))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(CONTAINER_PAGE_SIZE)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(false);
+
+        request.source(sourceBuilder);
+
+        Set<String> expiredIds = new HashSet<>();
+        searchAllPages(request, expiredIds, listener);
+    }
+
+    private void searchAllPages(SearchRequest request, Set<String> accumulator, ActionListener<Set<String>> listener) {
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHit[] hits = response.getHits().getHits();
+                for (SearchHit hit : hits) {
+                    accumulator.add(hit.getId());
+                }
+
+                if (hits.length == CONTAINER_PAGE_SIZE) {
+                    Object[] sortValues = hits[hits.length - 1].getSortValues();
+                    request.source().searchAfter(sortValues);
+                    searchAllPages(request, accumulator, listener);
+                } else {
+                    listener.onResponse(accumulator);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    private void identifyCountBasedExpiredSessions(
+        MemoryConfiguration config,
+        String containerId,
+        String sessionIndex,
+        int maxCount,
+        ActionListener<Set<String>> listener
+    ) {
+        // Walk sessions sorted by last_updated_time DESC (newest first).
+        // Skip the first maxCount sessions; collect the rest as expired.
+        Set<String> expiredIds = new HashSet<>();
+        identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, 0, null, listener);
+    }
+
+    private void identifyCountBasedPage(
+        String containerId,
+        String sessionIndex,
+        int maxCount,
+        Set<String> expiredIds,
+        int seenSoFar,
+        Object[] searchAfter,
+        ActionListener<Set<String>> listener
+    ) {
+        SearchRequest request = new SearchRequest(sessionIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(CONTAINER_PAGE_SIZE)
+            .sort(LAST_UPDATED_TIME_FIELD, SortOrder.DESC)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(false);
+
+        if (searchAfter != null) {
+            sourceBuilder.searchAfter(searchAfter);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHit[] hits = response.getHits().getHits();
+                int currentSeen = seenSoFar;
+
+                for (SearchHit hit : hits) {
+                    currentSeen++;
+                    if (currentSeen > maxCount) {
+                        expiredIds.add(hit.getId());
+                    }
+                }
+
+                if (hits.length == CONTAINER_PAGE_SIZE) {
+                    Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
+                    identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, currentSeen, nextSearchAfter, listener);
+                } else {
+                    listener.onResponse(expiredIds);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    private void cascadeDeleteWorkingMemory(
+        MemoryConfiguration config,
+        String containerId,
+        Set<String> expiredSessionIds,
+        ActionListener<Long> listener
+    ) {
+        String workingMemoryIndex = config.getIndexName(MemoryType.WORKING);
+        if (workingMemoryIndex == null) {
+            listener.onResponse(0L);
+            return;
+        }
+
+        List<List<String>> batches = partition(new ArrayList<>(expiredSessionIds), DELETE_BY_QUERY_BATCH_SIZE);
+        cascadeDeleteBatch(config, workingMemoryIndex, containerId, batches, 0, 0L, listener);
+    }
+
+    private void cascadeDeleteBatch(
+        MemoryConfiguration config,
+        String workingMemoryIndex,
+        String containerId,
+        List<List<String>> batches,
+        int batchIndex,
+        long totalDeleted,
+        ActionListener<Long> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            log.info("[MemoryRetentionJob] container={} cascade_working_memory_deleted={}", containerId, totalDeleted);
+            listener.onResponse(totalDeleted);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingMemoryIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .must(QueryBuilders.termsQuery(NAMESPACE_FIELD + ".session_id", batch))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse bulkResponse) -> {
+                long deleted = bulkResponse.getDeleted();
+                cascadeDeleteBatch(config, workingMemoryIndex, containerId, batches, batchIndex + 1, totalDeleted + deleted, listener);
+            }, listener::onFailure));
+        }
+    }
+
+    private void deleteSessionDocuments(
+        MemoryConfiguration config,
+        String sessionIndex,
+        Set<String> expiredSessionIds,
+        ActionListener<Void> listener
+    ) {
+        List<List<String>> batches = partition(new ArrayList<>(expiredSessionIds), BULK_DELETE_BATCH_SIZE);
+        deleteSessionBatch(config, sessionIndex, batches, 0, listener);
+    }
+
+    private void deleteSessionBatch(
+        MemoryConfiguration config,
+        String sessionIndex,
+        List<List<String>> batches,
+        int batchIndex,
+        ActionListener<Void> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(null);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (String sessionId : batch) {
+            bulkRequest.add(new DeleteRequest(sessionIndex, sessionId));
+        }
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client
+                .bulk(
+                    bulkRequest,
+                    ActionListener
+                        .wrap(
+                            bulkResponse -> deleteSessionBatch(config, sessionIndex, batches, batchIndex + 1, listener),
+                            listener::onFailure
+                        )
+                );
+        }
+    }
+
+    private void executeLongTermRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        String longTermIndex = config.getIndexName(MemoryType.LONG_TERM);
+        if (longTermIndex == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.LONG_TERM)) {
+            listener.onResponse(null);
+            return;
+        }
+
+        RetentionRule rule = retentionPolicy.get(MemoryType.LONG_TERM);
+        if (rule == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        ActionListener<Long> timeBasedDone = ActionListener.wrap(timeDeleted -> {
+            if (rule.getMaxCount() != null) {
+                executeLongTermMaxCount(longTermIndex, containerId, rule.getMaxCount(), ActionListener.wrap(countDeleted -> {
+                    long total = (timeDeleted != null ? timeDeleted : 0L) + countDeleted;
+                    log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, total);
+                    listener.onResponse(null);
+                }, listener::onFailure));
+            } else {
+                log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, timeDeleted != null ? timeDeleted : 0L);
+                listener.onResponse(null);
+            }
+        }, listener::onFailure);
+
+        if (rule.getRetentionDays() != null) {
+            executeLongTermRetentionDays(longTermIndex, containerId, rule.getRetentionDays(), timeBasedDone);
+        } else {
+            timeBasedDone.onResponse(0L);
+        }
+    }
+
+    private void executeLongTermRetentionDays(String longTermIndex, String containerId, int retentionDays, ActionListener<Long> listener) {
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(longTermIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .must(QueryBuilders.rangeQuery(LAST_UPDATED_TIME_FIELD).lt(cutoffMillis))
+                    .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse response) -> {
+                listener.onResponse(response.getDeleted());
+            }, listener::onFailure));
+        }
+    }
+
+    private void executeLongTermMaxCount(String longTermIndex, String containerId, int maxCount, ActionListener<Long> listener) {
+        // Step 1: count non-pinned long-term docs
+        SearchRequest countRequest = new SearchRequest(longTermIndex);
+        countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder countQuery = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder countSource = new SearchSourceBuilder().query(countQuery).size(0).trackTotalHits(true);
+        countRequest.source(countSource);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(countRequest, ActionListener.wrap(countResponse -> {
+                long totalCount = countResponse.getHits().getTotalHits().value();
+                if (totalCount <= maxCount) {
+                    listener.onResponse(0L);
+                    return;
+                }
+
+                int excess = (int) (totalCount - maxCount);
+                // Step 2: search for oldest excess docs by last_updated_time ASC
+                collectOldestDocIds(longTermIndex, containerId, LAST_UPDATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
+                    if (idsToDelete.isEmpty()) {
+                        listener.onResponse(0L);
+                        return;
+                    }
+                    // Step 3: bulk delete those IDs
+                    deleteDocumentsBatch(longTermIndex, new ArrayList<>(idsToDelete), listener);
+                }, listener::onFailure));
+            }, listener::onFailure));
+        }
+    }
+
+    private void collectOldestDocIds(String index, String containerId, String timeField, int limit, ActionListener<Set<String>> listener) {
+        Set<String> collected = new HashSet<>();
+        collectOldestDocIdsPage(index, containerId, timeField, limit, collected, null, listener);
+    }
+
+    private void collectOldestDocIdsPage(
+        String index,
+        String containerId,
+        String timeField,
+        int limit,
+        Set<String> collected,
+        Object[] searchAfter,
+        ActionListener<Set<String>> listener
+    ) {
+        SearchRequest request = new SearchRequest(index);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        int pageSize = Math.min(CONTAINER_PAGE_SIZE, limit - collected.size());
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(pageSize)
+            .sort(timeField, SortOrder.ASC)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(false);
+
+        if (searchAfter != null) {
+            sourceBuilder.searchAfter(searchAfter);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHit[] hits = response.getHits().getHits();
+                for (SearchHit hit : hits) {
+                    collected.add(hit.getId());
+                    if (collected.size() >= limit) {
+                        listener.onResponse(collected);
+                        return;
+                    }
+                }
+
+                if (hits.length == pageSize && collected.size() < limit) {
+                    Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
+                    collectOldestDocIdsPage(index, containerId, timeField, limit, collected, nextSearchAfter, listener);
+                } else {
+                    listener.onResponse(collected);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    private void deleteDocumentsBatch(String index, List<String> ids, ActionListener<Long> listener) {
+        List<List<String>> batches = partition(ids, BULK_DELETE_BATCH_SIZE);
+        deleteDocumentsBatchRecursive(index, batches, 0, 0L, listener);
+    }
+
+    private void deleteDocumentsBatchRecursive(
+        String index,
+        List<List<String>> batches,
+        int batchIndex,
+        long totalDeleted,
+        ActionListener<Long> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(totalDeleted);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (String docId : batch) {
+            bulkRequest.add(new DeleteRequest(index, docId));
+        }
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client
+                .bulk(
+                    bulkRequest,
+                    ActionListener
+                        .wrap(
+                            bulkResponse -> deleteDocumentsBatchRecursive(
+                                index,
+                                batches,
+                                batchIndex + 1,
+                                totalDeleted + batch.size(),
+                                listener
+                            ),
+                            listener::onFailure
+                        )
+                );
+        }
+    }
+
+    private void executeHistoryRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        String historyIndex = config.getIndexName(MemoryType.HISTORY);
+        if (historyIndex == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.HISTORY)) {
+            listener.onResponse(null);
+            return;
+        }
+
+        RetentionRule rule = retentionPolicy.get(MemoryType.HISTORY);
+        if (rule == null || rule.getMaxCount() == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        int maxCount = rule.getMaxCount();
+
+        // Step 1: count non-pinned history docs
+        SearchRequest countRequest = new SearchRequest(historyIndex);
+        countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder countQuery = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder countSource = new SearchSourceBuilder().query(countQuery).size(0).trackTotalHits(true);
+        countRequest.source(countSource);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(countRequest, ActionListener.wrap(countResponse -> {
+                long totalCount = countResponse.getHits().getTotalHits().value();
+                if (totalCount <= maxCount) {
+                    log.info("[MemoryRetentionJob] container={} history_deleted=0", containerId);
+                    listener.onResponse(null);
+                    return;
+                }
+
+                int excess = (int) (totalCount - maxCount);
+                // Step 2: search oldest excess docs by created_time ASC (history uses created_time)
+                collectOldestDocIds(historyIndex, containerId, CREATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
+                    if (idsToDelete.isEmpty()) {
+                        log.info("[MemoryRetentionJob] container={} history_deleted=0", containerId);
+                        listener.onResponse(null);
+                        return;
+                    }
+                    // Step 3: bulk delete those IDs
+                    deleteDocumentsBatch(historyIndex, new ArrayList<>(idsToDelete), ActionListener.wrap(deleted -> {
+                        log.info("[MemoryRetentionJob] container={} history_deleted={}", containerId, deleted);
+                        listener.onResponse(null);
+                    }, listener::onFailure));
+                }, listener::onFailure));
+            }, listener::onFailure));
+        }
+    }
+
+    private void executeWorkingMemoryTTL(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        if (!config.isDisableSession()) {
+            listener.onResponse(null);
+            return;
+        }
+
+        String workingIndex = config.getIndexName(MemoryType.WORKING);
+        if (workingIndex == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        int ttlDays = ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS.get(clusterService.getSettings());
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(ttlDays);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .must(QueryBuilders.rangeQuery(CREATED_TIME_FIELD).lt(cutoffMillis))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse response) -> {
+                log.info("[MemoryRetentionJob] container={} working_memory_ttl_deleted={}", containerId, response.getDeleted());
+                listener.onResponse(null);
+            }, listener::onFailure));
+        }
+    }
+
+    private void executeOrphanSweep() {
+        log.debug("Orphan sweep not yet implemented");
+    }
+
+    private void onJobComplete() {
+        log.info("Memory retention job completed");
+    }
+
+    private static <T> List<List<T>> partition(List<T> list, int size) {
+        List<List<T>> partitions = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += size) {
+            partitions.add(list.subList(i, Math.min(i + size, list.size())));
+        }
+        return partitions;
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -7,12 +7,15 @@ package org.opensearch.ml.jobs.processors;
 
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DISABLE_SESSION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_STORAGE_CONFIG_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SESSION_ID_FIELD;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS;
@@ -68,6 +71,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     private static final int CONTAINER_PAGE_SIZE = 100;
     private static final int DELETE_BY_QUERY_BATCH_SIZE = 500;
     private static final int BULK_DELETE_BATCH_SIZE = 1000;
+    private static final int ORPHAN_SESSION_ID_CAP = 50_000;
+    private static final int ORPHAN_SESSION_BATCH_SIZE = 1000;
+    private static final int ORPHAN_ENUMERATION_PAGE_SIZE = 1000;
 
     private static MemoryRetentionJobProcessor instance;
 
@@ -159,7 +165,6 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 resolveContainersWithPolicies(nextPageSortValues);
             } else {
                 executeOrphanSweep();
-                onJobComplete();
             }
             return;
         }
@@ -841,7 +846,328 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     }
 
     private void executeOrphanSweep() {
-        log.debug("Orphan sweep not yet implemented");
+        resolveOrphanSweepContainers(null);
+    }
+
+    private void resolveOrphanSweepContainers(Object[] searchAfterValues) {
+        SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.existsQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + RETENTION_POLICY_FIELD))
+            .mustNot(QueryBuilders.termQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + DISABLE_SESSION_FIELD, true));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(CONTAINER_PAGE_SIZE)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(true);
+
+        if (searchAfterValues != null) {
+            sourceBuilder.searchAfter(searchAfterValues);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHits hits = response.getHits();
+                SearchHit[] hitArray = hits.getHits();
+
+                if (hitArray.length == 0) {
+                    onJobComplete();
+                    return;
+                }
+
+                Object[] nextPageSort = hitArray.length == CONTAINER_PAGE_SIZE ? hitArray[hitArray.length - 1].getSortValues() : null;
+                processOrphanSweepContainerChain(hitArray, 0, nextPageSort);
+            }, e -> {
+                log.error("Failed to search containers for orphan sweep", e);
+                onJobComplete();
+            }));
+        }
+    }
+
+    private void processOrphanSweepContainerChain(SearchHit[] hits, int index, Object[] nextPageSortValues) {
+        if (index >= hits.length) {
+            if (nextPageSortValues != null) {
+                resolveOrphanSweepContainers(nextPageSortValues);
+            } else {
+                onJobComplete();
+            }
+            return;
+        }
+
+        SearchHit hit = hits[index];
+        String containerId = hit.getId();
+
+        try {
+            Map<String, Object> source = hit.getSourceAsMap();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> configMap = (Map<String, Object>) source.get(MEMORY_STORAGE_CONFIG_FIELD);
+
+            if (configMap == null) {
+                processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+                return;
+            }
+
+            XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(configMap);
+            BytesReference bytes = BytesReference.bytes(xContentBuilder);
+            XContentParser parser = XContentHelper
+                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON);
+            parser.nextToken();
+            MemoryConfiguration config = MemoryConfiguration.parse(parser);
+
+            String workingIndex = config.getIndexName(MemoryType.WORKING);
+            String sessionsIndex = config.getIndexName(MemoryType.SESSIONS);
+
+            if (workingIndex == null || sessionsIndex == null) {
+                processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+                return;
+            }
+
+            sweepOrphansForContainer(
+                config,
+                containerId,
+                workingIndex,
+                sessionsIndex,
+                ActionListener.wrap(v -> processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues), e -> {
+                    log.error("[MemoryRetentionJob] Orphan sweep failed for container [{}]", containerId, e);
+                    processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+                })
+            );
+        } catch (Exception e) {
+            log.error("[MemoryRetentionJob] Error parsing config for orphan sweep container [{}]", containerId, e);
+            processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+        }
+    }
+
+    private void sweepOrphansForContainer(
+        MemoryConfiguration config,
+        String containerId,
+        String workingIndex,
+        String sessionsIndex,
+        ActionListener<Void> listener
+    ) {
+        Set<String> sessionIds = new HashSet<>();
+        enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, null, ActionListener.wrap(collectedIds -> {
+            ActionListener<Long> afterOrphans = ActionListener.wrap(orphansDeleted -> {
+                deleteNullSessionWorkingMemory(containerId, workingIndex, ActionListener.wrap(nullDeleted -> {
+                    log
+                        .info(
+                            "[MemoryRetentionJob] container={} orphans_deleted={} null_session_deleted={}",
+                            containerId,
+                            orphansDeleted,
+                            nullDeleted
+                        );
+                    listener.onResponse(null);
+                }, listener::onFailure));
+            }, listener::onFailure);
+
+            if (collectedIds.isEmpty()) {
+                afterOrphans.onResponse(0L);
+            } else {
+                checkAndDeleteOrphans(containerId, workingIndex, sessionsIndex, collectedIds, afterOrphans);
+            }
+        }, listener::onFailure));
+    }
+
+    private void enumerateSessionIdsFromWorkingMemory(
+        String workingIndex,
+        String containerId,
+        Set<String> sessionIds,
+        Object[] searchAfterValues,
+        ActionListener<Set<String>> listener
+    ) {
+        SearchRequest request = new SearchRequest(workingIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD))
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(ORPHAN_ENUMERATION_PAGE_SIZE)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(new String[] { NAMESPACE_FIELD }, null);
+
+        if (searchAfterValues != null) {
+            sourceBuilder.searchAfter(searchAfterValues);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHit[] hits = response.getHits().getHits();
+
+                for (SearchHit hit : hits) {
+                    Map<String, Object> source = hit.getSourceAsMap();
+                    if (source != null) {
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> namespace = (Map<String, Object>) source.get(NAMESPACE_FIELD);
+                        if (namespace != null) {
+                            String sessionId = (String) namespace.get(SESSION_ID_FIELD);
+                            if (sessionId != null) {
+                                sessionIds.add(sessionId);
+                            }
+                        }
+                    }
+
+                    if (sessionIds.size() >= ORPHAN_SESSION_ID_CAP) {
+                        log
+                            .warn(
+                                "[MemoryRetentionJob] container={} session_id cap ({}) reached during orphan enumeration."
+                                    + " Remaining orphans will be caught on next run.",
+                                containerId,
+                                ORPHAN_SESSION_ID_CAP
+                            );
+                        listener.onResponse(sessionIds);
+                        return;
+                    }
+                }
+
+                if (hits.length == ORPHAN_ENUMERATION_PAGE_SIZE) {
+                    Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
+                    enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, nextSearchAfter, listener);
+                } else {
+                    listener.onResponse(sessionIds);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    private void checkAndDeleteOrphans(
+        String containerId,
+        String workingIndex,
+        String sessionsIndex,
+        Set<String> sessionIds,
+        ActionListener<Long> listener
+    ) {
+        List<List<String>> batches = partition(new ArrayList<>(sessionIds), ORPHAN_SESSION_BATCH_SIZE);
+        Set<String> allOrphanIds = new HashSet<>();
+        checkOrphanBatch(containerId, sessionsIndex, batches, 0, allOrphanIds, ActionListener.wrap(orphanIds -> {
+            if (orphanIds.isEmpty()) {
+                listener.onResponse(0L);
+                return;
+            }
+            deleteOrphanedWorkingMemory(containerId, workingIndex, orphanIds, listener);
+        }, listener::onFailure));
+    }
+
+    private void checkOrphanBatch(
+        String containerId,
+        String sessionsIndex,
+        List<List<String>> batches,
+        int batchIndex,
+        Set<String> allOrphanIds,
+        ActionListener<Set<String>> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(allOrphanIds);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+
+        SearchRequest request = new SearchRequest(sessionsIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termsQuery("_id", batch))
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).size(batch.size()).fetchSource(false);
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                Set<String> existingIds = new HashSet<>();
+                for (SearchHit hit : response.getHits().getHits()) {
+                    existingIds.add(hit.getId());
+                }
+
+                for (String sessionId : batch) {
+                    if (!existingIds.contains(sessionId)) {
+                        allOrphanIds.add(sessionId);
+                    }
+                }
+
+                checkOrphanBatch(containerId, sessionsIndex, batches, batchIndex + 1, allOrphanIds, listener);
+            }, listener::onFailure));
+        }
+    }
+
+    private void deleteOrphanedWorkingMemory(
+        String containerId,
+        String workingIndex,
+        Set<String> orphanSessionIds,
+        ActionListener<Long> listener
+    ) {
+        List<List<String>> batches = partition(new ArrayList<>(orphanSessionIds), DELETE_BY_QUERY_BATCH_SIZE);
+        deleteOrphanBatch(containerId, workingIndex, batches, 0, 0L, listener);
+    }
+
+    private void deleteOrphanBatch(
+        String containerId,
+        String workingIndex,
+        List<List<String>> batches,
+        int batchIndex,
+        long totalDeleted,
+        ActionListener<Long> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(totalDeleted);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .must(QueryBuilders.termsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD, batch))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse bulkResponse) -> {
+                long deleted = bulkResponse.getDeleted();
+                deleteOrphanBatch(containerId, workingIndex, batches, batchIndex + 1, totalDeleted + deleted, listener);
+            }, listener::onFailure));
+        }
+    }
+
+    private void deleteNullSessionWorkingMemory(String containerId, String workingIndex, ActionListener<Long> listener) {
+        int orphanTtlDays = ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS.get(clusterService.getSettings());
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(orphanTtlDays);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD))
+                    .must(QueryBuilders.rangeQuery(CREATED_TIME_FIELD).lt(cutoffMillis))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse response) -> {
+                listener.onResponse(response.getDeleted());
+            }, listener::onFailure));
+        }
     }
 
     private void onJobComplete() {

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.jobs.processors;
+
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class MemoryRetentionJobProcessor extends MLJobProcessor {
+
+    private static final Logger log = LogManager.getLogger(MemoryRetentionJobProcessor.class);
+
+    private static MemoryRetentionJobProcessor instance;
+
+    public static MemoryRetentionJobProcessor getInstance(ClusterService clusterService, Client client, ThreadPool threadPool) {
+        if (instance != null) {
+            return instance;
+        }
+
+        synchronized (MemoryRetentionJobProcessor.class) {
+            if (instance != null) {
+                return instance;
+            }
+
+            instance = new MemoryRetentionJobProcessor(clusterService, client, threadPool);
+            return instance;
+        }
+    }
+
+    @VisibleForTesting
+    public static synchronized void reset() {
+        instance = null;
+    }
+
+    public MemoryRetentionJobProcessor(ClusterService clusterService, Client client, ThreadPool threadPool) {
+        super(clusterService, client, threadPool);
+    }
+
+    @Override
+    public void run() {
+        if (ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())) {
+            log.warn("Memory retention job skipped: multi-tenancy is enabled and native client lacks tenant routing");
+            return;
+        }
+
+        log.info("Memory retention job triggered");
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.jobs.processors;
 
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DISABLE_SESSION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
@@ -15,6 +16,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SESSION_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.USER_ID_FIELD;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT;
@@ -26,21 +28,25 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEM
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.IndicesOptions;
-import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -53,6 +59,7 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.reindex.BulkByScrollResponse;
@@ -61,6 +68,8 @@ import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryType;
 import org.opensearch.ml.common.memorycontainer.RetentionRule;
+import org.opensearch.script.Script;
+import org.opensearch.script.ScriptType;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -81,7 +90,21 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     private static final int ORPHAN_SESSION_BATCH_SIZE = 1000;
     private static final int ORPHAN_ENUMERATION_PAGE_SIZE = 1000;
 
-    private static MemoryRetentionJobProcessor instance;
+    /**
+     * Threshold for detecting legacy epoch-SECOND timestamps. Documents written before
+     * TransportCreateMemorySessionAction switched to toEpochMilli() stored created_time /
+     * last_updated_time as epoch seconds (e.g. 1752400000), which compared against
+     * System.currentTimeMillis() looks like January 1970 and would be evicted immediately.
+     *
+     * Any value below 10 billion is assumed to be epoch seconds:
+     * - 10 billion SECONDS is ~year 2286, so no real epoch-second timestamp exceeds it for centuries.
+     * - 10 billion MILLIS is ~1970-04-26, so no real epoch-millis timestamp for actual data is this small.
+     */
+    private static final long EPOCH_SECOND_DETECTION_THRESHOLD = 10_000_000_000L;
+
+    private static volatile MemoryRetentionJobProcessor instance;
+
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
     public static MemoryRetentionJobProcessor getInstance(ClusterService clusterService, Client client, ThreadPool threadPool) {
         if (instance != null) {
@@ -109,18 +132,28 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     @Override
     public void run() {
-        if (ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())) {
+        if (clusterService.getClusterSettings().get(ML_COMMONS_MULTI_TENANCY_ENABLED)) {
             log.warn("Memory retention job skipped: multi-tenancy is enabled and native client lacks tenant routing");
             return;
         }
 
-        if (!ML_COMMONS_MEMORY_RETENTION_ENABLED.get(clusterService.getSettings())) {
+        if (!clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_ENABLED)) {
             log.info("Memory retention job disabled via cluster setting plugins.ml_commons.memory.retention_enabled=false");
             return;
         }
 
-        log.info("Memory retention job started");
-        resolveContainersWithPolicies(null);
+        if (!isRunning.compareAndSet(false, true)) {
+            log.warn("Memory retention job already in progress, skipping this invocation");
+            return;
+        }
+
+        try {
+            log.info("Memory retention job started");
+            resolveContainersWithPolicies(null);
+        } catch (Exception e) {
+            log.error("Unexpected error starting memory retention job", e);
+            isRunning.set(false);
+        }
     }
 
     private void resolveContainersWithPolicies(Object[] searchAfterValues) {
@@ -178,13 +211,18 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     }
 
     private void scheduleNext(SearchHit[] hits, int nextIndex, Object[] nextPageSortValues) {
-        int throttleSeconds = ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS.get(clusterService.getSettings());
-        threadPool
-            .schedule(
-                () -> processContainerChain(hits, nextIndex, nextPageSortValues),
-                TimeValue.timeValueSeconds(throttleSeconds),
-                ThreadPool.Names.GENERIC
-            );
+        int throttleSeconds = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS);
+        try {
+            threadPool
+                .schedule(
+                    () -> processContainerChain(hits, nextIndex, nextPageSortValues),
+                    TimeValue.timeValueSeconds(throttleSeconds),
+                    ThreadPool.Names.GENERIC
+                );
+        } catch (Exception e) {
+            log.error("Failed to schedule next container processing", e);
+            isRunning.set(false);
+        }
     }
 
     private void processContainer(SearchHit hit, ActionListener<Void> listener) {
@@ -202,10 +240,14 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
             XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(configMap);
             BytesReference bytes = BytesReference.bytes(xContentBuilder);
-            XContentParser parser = XContentHelper
-                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON);
-            parser.nextToken();
-            MemoryConfiguration config = MemoryConfiguration.parse(parser);
+            MemoryConfiguration config;
+            try (
+                XContentParser parser = XContentHelper
+                    .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON)
+            ) {
+                parser.nextToken();
+                config = MemoryConfiguration.parse(parser);
+            }
 
             Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
             if (retentionPolicy == null || retentionPolicy.isEmpty()) {
@@ -214,8 +256,12 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                     listener.onResponse(null);
                     return;
                 }
-                applyDefaultRetentionPolicy(config, containerId, ActionListener.wrap(v -> {
-                    executeRetentionPipeline(config, containerId, listener);
+                applyDefaultRetentionPolicy(config, containerId, ActionListener.wrap(persisted -> {
+                    if (persisted) {
+                        executeRetentionPipeline(config, containerId, listener);
+                    } else {
+                        listener.onResponse(null);
+                    }
                 }, listener::onFailure));
             } else {
                 executeRetentionPipeline(config, containerId, listener);
@@ -240,8 +286,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                                 v2 -> executeHistoryRetention(
                                     config,
                                     containerId,
-                                    ActionListener
-                                        .wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
+                                    ActionListener.wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
                                 ),
                                 listener::onFailure
                             )
@@ -251,54 +296,112 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         );
     }
 
-    private void applyDefaultRetentionPolicy(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
-        int sessionRetentionDays = ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS.get(clusterService.getSettings());
-        int sessionMaxCount = ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT.get(clusterService.getSettings());
-        int longTermMaxCount = ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT.get(clusterService.getSettings());
-        int historyMaxCount = ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT.get(clusterService.getSettings());
+    /**
+     * Backfills the cluster-default retention policy onto a container that has none, using a
+     * conditional ("if-absent") script update so a concurrently user-set policy or opt-out is
+     * never clobbered. Responds {@code true} only if the default policy was actually persisted;
+     * {@code false} means this container must be skipped for this run (no admin default retention
+     * settings are configured, a concurrent user write won, or the persist failed) so deletions
+     * never happen under a policy the user cannot see. Only settings explicitly configured by the
+     * admin (value &gt; 0; the settings default to -1, an unset sentinel) contribute to the policy.
+     */
+    private void applyDefaultRetentionPolicy(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
+        int sessionRetentionDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS);
+        int sessionMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT);
+        int longTermMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT);
+        int historyMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT);
+
+        boolean anyConfigured = sessionRetentionDays > 0 || sessionMaxCount > 0 || longTermMaxCount > 0 || historyMaxCount > 0;
+        if (!anyConfigured) {
+            log
+                .debug(
+                    "Container [{}] has no retention policy and no admin default retention settings are configured; skipping",
+                    containerId
+                );
+            listener.onResponse(false);
+            return;
+        }
 
         Map<MemoryType, RetentionRule> defaultPolicy = new EnumMap<>(MemoryType.class);
-        defaultPolicy.put(MemoryType.SESSIONS, new RetentionRule(sessionRetentionDays, sessionMaxCount));
-        defaultPolicy.put(MemoryType.LONG_TERM, new RetentionRule(null, longTermMaxCount));
-        defaultPolicy.put(MemoryType.HISTORY, new RetentionRule(null, historyMaxCount));
+        if (sessionRetentionDays > 0 || sessionMaxCount > 0) {
+            defaultPolicy
+                .put(
+                    MemoryType.SESSIONS,
+                    new RetentionRule(sessionRetentionDays > 0 ? sessionRetentionDays : null, sessionMaxCount > 0 ? sessionMaxCount : null)
+                );
+        }
+        if (longTermMaxCount > 0) {
+            defaultPolicy.put(MemoryType.LONG_TERM, new RetentionRule(null, longTermMaxCount));
+        }
+        if (historyMaxCount > 0) {
+            defaultPolicy.put(MemoryType.HISTORY, new RetentionRule(null, historyMaxCount));
+        }
 
         config.setRetentionPolicy(defaultPolicy);
 
-        log.info(
-            "[MemoryRetentionJob] container={} auto-applying default retention policy: sessions={}/{}d, long-term={}, history={}",
-            containerId,
-            sessionMaxCount,
-            sessionRetentionDays,
-            longTermMaxCount,
-            historyMaxCount
-        );
+        log
+            .info(
+                "[MemoryRetentionJob] container={} auto-applying default retention policy: sessions={}/{}d, long-term={}, history={}",
+                containerId,
+                sessionMaxCount,
+                sessionRetentionDays,
+                longTermMaxCount,
+                historyMaxCount
+            );
 
         try {
             XContentBuilder policyBuilder = XContentFactory.jsonBuilder().startObject();
-            policyBuilder.startObject(RETENTION_POLICY_FIELD);
             for (Map.Entry<MemoryType, RetentionRule> entry : defaultPolicy.entrySet()) {
                 policyBuilder.field(entry.getKey().getValue());
                 entry.getValue().toXContent(policyBuilder, null);
             }
             policyBuilder.endObject();
-            policyBuilder.endObject();
+            Map<String, Object> policyMap = XContentHelper.convertToMap(BytesReference.bytes(policyBuilder), false, XContentType.JSON).v2();
+
+            // Conditional write: only backfill if the container still has no retention_policy key.
+            // A present key (even with a null value, i.e. an explicit opt-out) means a user write
+            // happened concurrently and takes precedence, so the update becomes a noop.
+            String scriptSource = "Map cfg = (Map) ctx._source.get(params.configField);"
+                + " if (cfg == null || cfg.containsKey(params.policyField)) { ctx.op = 'noop'; }"
+                + " else { cfg.put(params.policyField, params.policy); }";
+            Map<String, Object> scriptParams = Map
+                .of("configField", MEMORY_STORAGE_CONFIG_FIELD, "policyField", RETENTION_POLICY_FIELD, "policy", policyMap);
 
             UpdateRequest updateRequest = new UpdateRequest(ML_MEMORY_CONTAINER_INDEX, containerId)
-                .doc(Map.of(MEMORY_STORAGE_CONFIG_FIELD, XContentHelper.convertToMap(BytesReference.bytes(policyBuilder), false, XContentType.JSON).v2()))
+                .script(new Script(ScriptType.INLINE, "painless", scriptSource, scriptParams))
                 .retryOnConflict(3);
 
             try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
                 client.update(updateRequest, ActionListener.wrap(response -> {
+                    if (response.getResult() == DocWriteResponse.Result.NOOP) {
+                        log.debug("Container [{}] retention policy was set concurrently by a user; skipping default backfill", containerId);
+                        listener.onResponse(false);
+                        return;
+                    }
                     log.debug("Successfully persisted default retention policy on container [{}]", containerId);
-                    listener.onResponse(null);
+                    listener.onResponse(true);
                 }, e -> {
-                    log.warn("Failed to persist default retention policy on container [{}], proceeding with in-memory defaults", containerId, e);
-                    listener.onResponse(null);
+                    if (ExceptionsHelper.unwrapCause(e) instanceof VersionConflictEngineException) {
+                        log
+                            .debug(
+                                "Conflict persisting default retention policy on container [{}]; user's policy takes precedence",
+                                containerId,
+                                e
+                            );
+                    } else {
+                        log
+                            .warn(
+                                "Failed to persist default retention policy on container [{}], skipping retention for this run",
+                                containerId,
+                                e
+                            );
+                    }
+                    listener.onResponse(false);
                 }));
             }
         } catch (Exception e) {
-            log.warn("Failed to build default retention policy for container [{}], proceeding with in-memory defaults", containerId, e);
-            listener.onResponse(null);
+            log.warn("Failed to build default retention policy for container [{}], skipping retention for this run", containerId, e);
+            listener.onResponse(false);
         }
     }
 
@@ -387,6 +490,10 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         SearchRequest request = new SearchRequest(sessionIndex);
         request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
+        // NOTE: legacy sessions written before the epoch-millis fix stored last_updated_time as epoch
+        // SECONDS, which always satisfies lt(cutoffMillis) and would make every pre-upgrade session look
+        // expired. The query therefore only pre-filters candidates; each hit's timestamp is fetched and
+        // re-verified client-side via normalizeTimestamp() before the session is marked expired.
         BoolQueryBuilder query = QueryBuilders
             .boolQuery()
             .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
@@ -397,31 +504,134 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             .query(query)
             .size(CONTAINER_PAGE_SIZE)
             .sort("_id", SortOrder.ASC)
-            .fetchSource(false);
+            .fetchSource(new String[] { LAST_UPDATED_TIME_FIELD }, null);
 
         request.source(sourceBuilder);
 
         Set<String> expiredIds = new HashSet<>();
-        searchAllPages(request, expiredIds, listener);
+        searchAllPages(request, containerId, cutoffMillis, new AtomicBoolean(false), expiredIds, listener);
     }
 
-    private void searchAllPages(SearchRequest request, Set<String> accumulator, ActionListener<Set<String>> listener) {
+    private void searchAllPages(
+        SearchRequest request,
+        String containerId,
+        long cutoffMillis,
+        AtomicBoolean epochSecondWarned,
+        Set<String> accumulator,
+        ActionListener<Set<String>> listener
+    ) {
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
             client.search(request, ActionListener.wrap(response -> {
                 SearchHit[] hits = response.getHits().getHits();
                 for (SearchHit hit : hits) {
-                    accumulator.add(hit.getId());
+                    if (isSessionExpired(hit, containerId, cutoffMillis, epochSecondWarned)) {
+                        accumulator.add(hit.getId());
+                    }
                 }
 
                 if (hits.length == CONTAINER_PAGE_SIZE) {
                     Object[] sortValues = hits[hits.length - 1].getSortValues();
                     request.source().searchAfter(sortValues);
-                    searchAllPages(request, accumulator, listener);
+                    searchAllPages(request, containerId, cutoffMillis, epochSecondWarned, accumulator, listener);
                 } else {
                     listener.onResponse(accumulator);
                 }
             }, listener::onFailure));
         }
+    }
+
+    /**
+     * Re-verifies a session hit against the retention cutoff using a normalized (epoch-millis)
+     * timestamp. Legacy documents that stored last_updated_time in epoch seconds match the range
+     * query unconditionally, so this client-side check is what prevents pre-upgrade sessions from
+     * being mass-evicted. If the timestamp cannot be read from the hit source, the session is
+     * SKIPPED (not deleted) to avoid data loss from unparseable metadata.
+     */
+    private boolean isSessionExpired(SearchHit hit, String containerId, long cutoffMillis, AtomicBoolean epochSecondWarned) {
+        Long lastUpdated = extractTimestamp(hit, LAST_UPDATED_TIME_FIELD);
+        if (lastUpdated == null) {
+            log
+                .warn(
+                    "[MemoryRetentionJob] container={} session={} has unparseable/missing last_updated_time; skipping",
+                    containerId,
+                    hit.getId()
+                );
+            return false;
+        }
+
+        long normalized = normalizeTimestamp(lastUpdated);
+        if (normalized != lastUpdated && epochSecondWarned.compareAndSet(false, true)) {
+            log
+                .warn(
+                    "[MemoryRetentionJob] container={} detected epoch-second timestamp on session {},"
+                        + " converting to millis for comparison. Consider running timestamp migration.",
+                    containerId,
+                    hit.getId()
+                );
+        }
+        return normalized < cutoffMillis;
+    }
+
+    /**
+     * Extracts a timestamp field from a hit's source, tolerating the numeric types the source map
+     * may deserialize to (Integer, Long, Double) as well as numeric strings. Returns {@code null}
+     * when the source or field is unavailable.
+     */
+    private static Long extractTimestamp(SearchHit hit, String field) {
+        Map<String, Object> source = hit.getSourceAsMap();
+        if (source == null) {
+            return null;
+        }
+        Object value = source.get(field);
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Long.parseLong((String) value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Normalizes a stored timestamp to epoch milliseconds. Legacy documents (written before
+     * TransportCreateMemorySessionAction switched to toEpochMilli()) stored timestamps in epoch
+     * SECONDS; comparing those against System.currentTimeMillis() makes them look like January 1970
+     * and would evict all pre-upgrade data on the first job run. Any value below
+     * {@link #EPOCH_SECOND_DETECTION_THRESHOLD} is assumed to be epoch seconds and converted.
+     *
+     * @param timestamp a stored created_time / last_updated_time value (epoch seconds or millis)
+     * @return the timestamp in epoch milliseconds
+     */
+    private static long normalizeTimestamp(long timestamp) {
+        if (timestamp > 0 && timestamp < EPOCH_SECOND_DETECTION_THRESHOLD) {
+            return timestamp * 1000;
+        }
+        return timestamp;
+    }
+
+    /**
+     * Builds an "expired before cutoff" query that applies the {@link #normalizeTimestamp(long)}
+     * heuristic at the query level, for delete-by-query paths where per-document client-side
+     * normalization is not possible. A document is expired when either:
+     * <ul>
+     *   <li>epoch-millis scale ({@code >= EPOCH_SECOND_DETECTION_THRESHOLD}) and {@code < cutoffMillis}, or</li>
+     *   <li>legacy epoch-seconds scale ({@code < EPOCH_SECOND_DETECTION_THRESHOLD}) and
+     *       {@code value * 1000 < cutoffMillis}, i.e. {@code value < cutoffMillis / 1000}.</li>
+     * </ul>
+     * A plain {@code lt(cutoffMillis)} range would match every legacy epoch-second document and
+     * mass-delete pre-upgrade data.
+     */
+    private static BoolQueryBuilder buildEpochAwareCutoffQuery(String timeField, long cutoffMillis) {
+        long secondsScaleCutoff = Math.min(cutoffMillis / 1000, EPOCH_SECOND_DETECTION_THRESHOLD);
+        return QueryBuilders
+            .boolQuery()
+            .should(QueryBuilders.rangeQuery(timeField).gte(EPOCH_SECOND_DETECTION_THRESHOLD).lt(cutoffMillis))
+            .should(QueryBuilders.rangeQuery(timeField).lt(secondsScaleCutoff))
+            .minimumShouldMatch(1);
     }
 
     private void identifyCountBasedExpiredSessions(
@@ -434,8 +644,8 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         // Check if pinned count alone exceeds max_count (fire-and-forget warning)
         checkPinnedExceedsMaxCount(sessionIndex, containerId, "sessions", maxCount);
 
-        // Walk sessions sorted by last_updated_time DESC (newest first).
-        // Skip the first maxCount sessions; collect the rest as expired.
+        // Walk sessions sorted by created_time DESC (newest first). max_count is a cap on total
+        // sessions by creation order; retention_days handles activity-based eviction separately.
         Set<String> expiredIds = new HashSet<>();
         identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, 0, null, listener);
     }
@@ -575,15 +785,17 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
-            client
-                .bulk(
-                    bulkRequest,
-                    ActionListener
-                        .wrap(
-                            bulkResponse -> deleteSessionBatch(config, sessionIndex, batches, batchIndex + 1, listener),
-                            listener::onFailure
-                        )
-                );
+            client.bulk(bulkRequest, ActionListener.wrap(bulkResponse -> {
+                if (bulkResponse.hasFailures()) {
+                    String failureMsg = bulkResponse.buildFailureMessage();
+                    log
+                        .warn(
+                            "[MemoryRetentionJob] Partial session delete failures: {}",
+                            failureMsg.length() > 500 ? failureMsg.substring(0, 500) + "..." : failureMsg
+                        );
+                }
+                deleteSessionBatch(config, sessionIndex, batches, batchIndex + 1, listener);
+            }, listener::onFailure));
         }
     }
 
@@ -631,12 +843,14 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(longTermIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        // Epoch-aware cutoff: legacy docs store last_updated_time in epoch seconds and would all
+        // match a plain lt(cutoffMillis) range. See normalizeTimestamp().
         dbq
             .setQuery(
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
-                    .must(QueryBuilders.rangeQuery(LAST_UPDATED_TIME_FIELD).lt(cutoffMillis))
+                    .must(buildEpochAwareCutoffQuery(LAST_UPDATED_TIME_FIELD, cutoffMillis))
                     .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true))
             );
         dbq.setRefresh(true);
@@ -769,21 +983,18 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
-            client
-                .bulk(
-                    bulkRequest,
-                    ActionListener
-                        .wrap(
-                            bulkResponse -> deleteDocumentsBatchRecursive(
-                                index,
-                                batches,
-                                batchIndex + 1,
-                                totalDeleted + batch.size(),
-                                listener
-                            ),
-                            listener::onFailure
-                        )
-                );
+            client.bulk(bulkRequest, ActionListener.wrap(bulkResponse -> {
+                long batchDeleted = Arrays.stream(bulkResponse.getItems()).filter(i -> !i.isFailed()).count();
+                if (bulkResponse.hasFailures()) {
+                    String failureMsg = bulkResponse.buildFailureMessage();
+                    log
+                        .warn(
+                            "[MemoryRetentionJob] Partial bulk delete failures: {}",
+                            failureMsg.length() > 500 ? failureMsg.substring(0, 500) + "..." : failureMsg
+                        );
+                }
+                deleteDocumentsBatchRecursive(index, batches, batchIndex + 1, totalDeleted + batchDeleted, listener);
+            }, listener::onFailure));
         }
     }
 
@@ -862,17 +1073,19 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             return;
         }
 
-        int ttlDays = ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS.get(clusterService.getSettings());
+        int ttlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS);
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(ttlDays);
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        // Epoch-aware cutoff: legacy docs store created_time in epoch seconds and would all match
+        // a plain lt(cutoffMillis) range. See normalizeTimestamp().
         dbq
             .setQuery(
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
-                    .must(QueryBuilders.rangeQuery(CREATED_TIME_FIELD).lt(cutoffMillis))
+                    .must(buildEpochAwareCutoffQuery(CREATED_TIME_FIELD, cutoffMillis))
             );
         dbq.setRefresh(true);
 
@@ -983,15 +1196,44 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
             XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(configMap);
             BytesReference bytes = BytesReference.bytes(xContentBuilder);
-            XContentParser parser = XContentHelper
-                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON);
-            parser.nextToken();
-            MemoryConfiguration config = MemoryConfiguration.parse(parser);
+            MemoryConfiguration config;
+            try (
+                XContentParser parser = XContentHelper
+                    .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON)
+            ) {
+                parser.nextToken();
+                config = MemoryConfiguration.parse(parser);
+            }
 
             String workingIndex = config.getIndexName(MemoryType.WORKING);
             String sessionsIndex = config.getIndexName(MemoryType.SESSIONS);
 
             if (workingIndex == null || sessionsIndex == null) {
+                processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+                return;
+            }
+
+            // Safety check: if the working memory index doesn't exist there is nothing to sweep,
+            // and if the sessions index doesn't exist the sweep would classify ALL working memory
+            // as orphaned and delete it. Skip the sweep in either case.
+            if (!clusterService.state().metadata().hasIndex(workingIndex)) {
+                log
+                    .debug(
+                        "[MemoryRetentionJob] Skipping orphan sweep for container={}: working memory index {} does not exist",
+                        containerId,
+                        workingIndex
+                    );
+                processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+                return;
+            }
+
+            if (!clusterService.state().metadata().hasIndex(sessionsIndex)) {
+                log
+                    .debug(
+                        "[MemoryRetentionJob] Skipping orphan sweep for container={}: sessions index {} does not exist",
+                        containerId,
+                        sessionsIndex
+                    );
                 processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
                 return;
             }
@@ -1022,10 +1264,10 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         Set<String> sessionIds = new HashSet<>();
         enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, null, ActionListener.wrap(collectedIds -> {
             ActionListener<Long> afterOrphans = ActionListener.wrap(orphansDeleted -> {
-                deleteNullSessionWorkingMemory(containerId, workingIndex, ActionListener.wrap(nullDeleted -> {
+                deleteEmptyNamespaceWorkingMemory(containerId, workingIndex, ActionListener.wrap(nullDeleted -> {
                     log
                         .info(
-                            "[MemoryRetentionJob] container={} orphans_deleted={} null_session_deleted={}",
+                            "[MemoryRetentionJob] container={} orphans_deleted={} empty_namespace_deleted={}",
                             containerId,
                             orphansDeleted,
                             nullDeleted
@@ -1153,9 +1395,24 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).size(batch.size()).fetchSource(false);
 
         request.source(sourceBuilder);
+        request.allowPartialSearchResults(false);
 
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
             client.search(request, ActionListener.wrap(response -> {
+                if (response.getFailedShards() > 0 || response.isTimedOut()) {
+                    listener
+                        .onFailure(
+                            new IllegalStateException(
+                                "Orphan check for container ["
+                                    + containerId
+                                    + "] had "
+                                    + response.getFailedShards()
+                                    + " failed shards or timed out; skipping to avoid incorrect deletions"
+                            )
+                        );
+                    return;
+                }
+
                 Set<String> existingIds = new HashSet<>();
                 for (SearchHit hit : response.getHits().getHits()) {
                     existingIds.add(hit.getId());
@@ -1216,19 +1473,23 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
     }
 
-    private void deleteNullSessionWorkingMemory(String containerId, String workingIndex, ActionListener<Long> listener) {
-        int orphanTtlDays = ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS.get(clusterService.getSettings());
+    private void deleteEmptyNamespaceWorkingMemory(String containerId, String workingIndex, ActionListener<Long> listener) {
+        int orphanTtlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS);
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(orphanTtlDays);
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        // Epoch-aware cutoff: legacy docs store created_time in epoch seconds and would all match
+        // a plain lt(cutoffMillis) range. See normalizeTimestamp().
         dbq
             .setQuery(
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
                     .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD))
-                    .must(QueryBuilders.rangeQuery(CREATED_TIME_FIELD).lt(cutoffMillis))
+                    .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + USER_ID_FIELD))
+                    .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + AGENT_ID_FIELD))
+                    .must(buildEpochAwareCutoffQuery(CREATED_TIME_FIELD, cutoffMillis))
             );
         dbq.setRefresh(true);
 
@@ -1240,6 +1501,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     }
 
     private void onJobComplete() {
+        isRunning.set(false);
         log.info("Memory retention job completed");
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -1650,6 +1650,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             log.debug("[MemoryRetentionJob] container={} deleting orphaned working memory for session ids={}", containerId, batch);
         }
 
+        int orphanTtlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS);
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(orphanTtlDays);
+
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
         dbq
@@ -1658,6 +1661,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
                     .must(buildSessionIdMatchQuery(batch))
+                    .must(buildEpochAwareCutoffQuery(CREATED_TIME_FIELD, cutoffMillis))
             );
         dbq.setRefresh(true);
 

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -33,6 +33,7 @@ import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -72,6 +73,9 @@ import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.opensearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.threadpool.ThreadPool;
@@ -89,6 +93,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     private static final int ORPHAN_SESSION_ID_CAP = 50_000;
     private static final int ORPHAN_SESSION_BATCH_SIZE = 1000;
     private static final int ORPHAN_ENUMERATION_PAGE_SIZE = 1000;
+    private static final String SESSION_IDS_AGG_NAME = "session_ids";
+    private static final String ORPHAN_KEYSPACE_ALPHABET = "-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz";
+    private static final int ORPHAN_START_KEY_LENGTH = 4;
 
     /**
      * Threshold for detecting legacy epoch-SECOND timestamps. Documents written before
@@ -204,9 +211,15 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             return;
         }
 
-        processContainer(hits[index], ActionListener.wrap(v -> scheduleNext(hits, index + 1, nextPageSortValues), e -> {
+        processContainer(hits[index], ActionListener.wrap(hadDeletions -> {
+            if (hadDeletions) {
+                scheduleNext(hits, index + 1, nextPageSortValues);
+            } else {
+                processContainerChain(hits, index + 1, nextPageSortValues);
+            }
+        }, e -> {
             log.error("Failed processing container [{}]", hits[index].getId(), e);
-            scheduleNext(hits, index + 1, nextPageSortValues);
+            processContainerChain(hits, index + 1, nextPageSortValues);
         }));
     }
 
@@ -225,7 +238,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
     }
 
-    private void processContainer(SearchHit hit, ActionListener<Void> listener) {
+    private void processContainer(SearchHit hit, ActionListener<Boolean> listener) {
         String containerId = hit.getId();
         try {
             Map<String, Object> source = hit.getSourceAsMap();
@@ -234,7 +247,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
             if (configMap == null) {
                 log.warn("Container [{}] has no configuration field, skipping", containerId);
-                listener.onResponse(null);
+                listener.onResponse(false);
                 return;
             }
 
@@ -253,14 +266,14 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             if (retentionPolicy == null || retentionPolicy.isEmpty()) {
                 if (config.isRetentionPolicyExplicitlyNull()) {
                     log.debug("Container [{}] explicitly opted out of retention, skipping", containerId);
-                    listener.onResponse(null);
+                    listener.onResponse(false);
                     return;
                 }
                 applyDefaultRetentionPolicy(config, containerId, ActionListener.wrap(persisted -> {
                     if (persisted) {
                         executeRetentionPipeline(config, containerId, listener);
                     } else {
-                        listener.onResponse(null);
+                        listener.onResponse(false);
                     }
                 }, listener::onFailure));
             } else {
@@ -268,25 +281,40 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             }
         } catch (Exception e) {
             log.error("Error parsing configuration for container [{}]", containerId, e);
-            listener.onResponse(null);
+            listener.onResponse(false);
         }
     }
 
-    private void executeRetentionPipeline(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+    private void executeRetentionPipeline(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
         executeSessionRetention(
             config,
             containerId,
             ActionListener
                 .wrap(
-                    v -> executeLongTermRetention(
+                    sessionsDeleted -> executeLongTermRetention(
                         config,
                         containerId,
                         ActionListener
                             .wrap(
-                                v2 -> executeHistoryRetention(
+                                longTermDeleted -> executeHistoryRetention(
                                     config,
                                     containerId,
-                                    ActionListener.wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
+                                    ActionListener
+                                        .wrap(
+                                            historyDeleted -> executeWorkingMemoryTTL(
+                                                config,
+                                                containerId,
+                                                ActionListener
+                                                    .wrap(
+                                                        workingDeleted -> listener
+                                                            .onResponse(
+                                                                sessionsDeleted || longTermDeleted || historyDeleted || workingDeleted
+                                                            ),
+                                                        listener::onFailure
+                                                    )
+                                            ),
+                                            listener::onFailure
+                                        )
                                 ),
                                 listener::onFailure
                             )
@@ -405,30 +433,30 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
     }
 
-    private void executeSessionRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+    private void executeSessionRetention(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
         String sessionIndex = config.getIndexName(MemoryType.SESSIONS);
         if (sessionIndex == null) {
             log.debug("Session index is null for container [{}], skipping session retention", containerId);
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
         if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.SESSIONS)) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         RetentionRule sessionRule = retentionPolicy.get(MemoryType.SESSIONS);
         if (sessionRule == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         identifyExpiredSessions(config, containerId, sessionIndex, sessionRule, ActionListener.wrap(expiredSessionIds -> {
             if (expiredSessionIds.isEmpty()) {
                 log.info("[MemoryRetentionJob] container={} sessions_expired=0", containerId);
-                listener.onResponse(null);
+                listener.onResponse(false);
                 return;
             }
 
@@ -439,7 +467,15 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 containerId,
                 expiredSessionIds,
                 ActionListener
-                    .wrap(deletedCount -> deleteSessionDocuments(config, sessionIndex, expiredSessionIds, listener), listener::onFailure)
+                    .wrap(
+                        deletedCount -> deleteSessionDocuments(
+                            config,
+                            sessionIndex,
+                            expiredSessionIds,
+                            ActionListener.wrap(v -> listener.onResponse(true), listener::onFailure)
+                        ),
+                        listener::onFailure
+                    )
             );
         }, listener::onFailure));
     }
@@ -634,6 +670,20 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             .minimumShouldMatch(1);
     }
 
+    /**
+     * Matches working-memory documents belonging to any of the given session IDs. Prefers the
+     * top-level {@code session_id} keyword field but also matches on the legacy
+     * {@code namespace.session_id} flat_object subpath for pre-upgrade documents that lack the
+     * top-level field.
+     */
+    private static BoolQueryBuilder buildSessionIdMatchQuery(List<String> sessionIds) {
+        return QueryBuilders
+            .boolQuery()
+            .should(QueryBuilders.termsQuery(SESSION_ID_FIELD, sessionIds))
+            .should(QueryBuilders.termsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD, sessionIds))
+            .minimumShouldMatch(1);
+    }
+
     private void identifyCountBasedExpiredSessions(
         MemoryConfiguration config,
         String containerId,
@@ -644,60 +694,29 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         // Check if pinned count alone exceeds max_count (fire-and-forget warning)
         checkPinnedExceedsMaxCount(sessionIndex, containerId, "sessions", maxCount);
 
-        // Walk sessions sorted by created_time DESC (newest first). max_count is a cap on total
-        // sessions by creation order; retention_days handles activity-based eviction separately.
-        Set<String> expiredIds = new HashSet<>();
-        identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, 0, null, listener);
-    }
+        // Step 1: count non-pinned sessions
+        SearchRequest countRequest = new SearchRequest(sessionIndex);
+        countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
-    private void identifyCountBasedPage(
-        String containerId,
-        String sessionIndex,
-        int maxCount,
-        Set<String> expiredIds,
-        int seenSoFar,
-        Object[] searchAfter,
-        ActionListener<Set<String>> listener
-    ) {
-        SearchRequest request = new SearchRequest(sessionIndex);
-        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
-
-        BoolQueryBuilder query = QueryBuilders
+        BoolQueryBuilder countQuery = QueryBuilders
             .boolQuery()
             .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
             .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
 
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
-            .query(query)
-            .size(CONTAINER_PAGE_SIZE)
-            .sort(CREATED_TIME_FIELD, SortOrder.DESC)
-            .sort("_id", SortOrder.ASC)
-            .fetchSource(false);
-
-        if (searchAfter != null) {
-            sourceBuilder.searchAfter(searchAfter);
-        }
-
-        request.source(sourceBuilder);
+        SearchSourceBuilder countSource = new SearchSourceBuilder().query(countQuery).size(0).trackTotalHits(true);
+        countRequest.source(countSource);
 
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
-            client.search(request, ActionListener.wrap(response -> {
-                SearchHit[] hits = response.getHits().getHits();
-                int currentSeen = seenSoFar;
-
-                for (SearchHit hit : hits) {
-                    currentSeen++;
-                    if (currentSeen > maxCount) {
-                        expiredIds.add(hit.getId());
-                    }
+            client.search(countRequest, ActionListener.wrap(countResponse -> {
+                long totalCount = countResponse.getHits().getTotalHits().value();
+                if (totalCount <= maxCount) {
+                    listener.onResponse(new HashSet<>());
+                    return;
                 }
 
-                if (hits.length == CONTAINER_PAGE_SIZE) {
-                    Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
-                    identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, currentSeen, nextSearchAfter, listener);
-                } else {
-                    listener.onResponse(expiredIds);
-                }
+                int excess = (int) (totalCount - maxCount);
+                // Step 2: search for oldest excess sessions by created_time ASC
+                collectOldestDocIds(sessionIndex, containerId, CREATED_TIME_FIELD, excess, listener);
             }, listener::onFailure));
         }
     }
@@ -734,6 +753,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         List<String> batch = batches.get(batchIndex);
+        if (log.isDebugEnabled()) {
+            log.debug("[MemoryRetentionJob] container={} cascade deleting working memory for session ids={}", containerId, batch);
+        }
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingMemoryIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -742,7 +764,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
-                    .must(QueryBuilders.termsQuery(NAMESPACE_FIELD + ".session_id", batch))
+                    .must(buildSessionIdMatchQuery(batch))
             );
         dbq.setRefresh(true);
 
@@ -777,6 +799,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         List<String> batch = batches.get(batchIndex);
+        if (log.isDebugEnabled()) {
+            log.debug("[MemoryRetentionJob] index={} deleting session ids={}", sessionIndex, batch);
+        }
         BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
@@ -799,22 +824,22 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
     }
 
-    private void executeLongTermRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+    private void executeLongTermRetention(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
         String longTermIndex = config.getIndexName(MemoryType.LONG_TERM);
         if (longTermIndex == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
         if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.LONG_TERM)) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         RetentionRule rule = retentionPolicy.get(MemoryType.LONG_TERM);
         if (rule == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
@@ -823,11 +848,12 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 executeLongTermMaxCount(longTermIndex, containerId, rule.getMaxCount(), ActionListener.wrap(countDeleted -> {
                     long total = (timeDeleted != null ? timeDeleted : 0L) + countDeleted;
                     log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, total);
-                    listener.onResponse(null);
+                    listener.onResponse(total > 0);
                 }, listener::onFailure));
             } else {
-                log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, timeDeleted != null ? timeDeleted : 0L);
-                listener.onResponse(null);
+                long total = timeDeleted != null ? timeDeleted : 0L;
+                log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, total);
+                listener.onResponse(total > 0);
             }
         }, listener::onFailure);
 
@@ -840,6 +866,13 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     private void executeLongTermRetentionDays(String longTermIndex, String containerId, int retentionDays, ActionListener<Long> listener) {
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays);
+        log
+            .debug(
+                "[MemoryRetentionJob] container={} long_term retention_days DBQ index={} cutoffMillis={}",
+                containerId,
+                longTermIndex,
+                cutoffMillis
+            );
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(longTermIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -975,6 +1008,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         List<String> batch = batches.get(batchIndex);
+        if (log.isDebugEnabled()) {
+            log.debug("[MemoryRetentionJob] index={} deleting doc ids={}", index, batch);
+        }
         BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
@@ -998,22 +1034,22 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
     }
 
-    private void executeHistoryRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+    private void executeHistoryRetention(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
         String historyIndex = config.getIndexName(MemoryType.HISTORY);
         if (historyIndex == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
         if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.HISTORY)) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         RetentionRule rule = retentionPolicy.get(MemoryType.HISTORY);
         if (rule == null || rule.getMaxCount() == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
@@ -1039,7 +1075,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 long totalCount = countResponse.getHits().getTotalHits().value();
                 if (totalCount <= maxCount) {
                     log.info("[MemoryRetentionJob] container={} history_deleted=0", containerId);
-                    listener.onResponse(null);
+                    listener.onResponse(false);
                     return;
                 }
 
@@ -1048,33 +1084,40 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 collectOldestDocIds(historyIndex, containerId, CREATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
                     if (idsToDelete.isEmpty()) {
                         log.info("[MemoryRetentionJob] container={} history_deleted=0", containerId);
-                        listener.onResponse(null);
+                        listener.onResponse(false);
                         return;
                     }
                     // Step 3: bulk delete those IDs
                     deleteDocumentsBatch(historyIndex, new ArrayList<>(idsToDelete), ActionListener.wrap(deleted -> {
                         log.info("[MemoryRetentionJob] container={} history_deleted={}", containerId, deleted);
-                        listener.onResponse(null);
+                        listener.onResponse(deleted > 0);
                     }, listener::onFailure));
                 }, listener::onFailure));
             }, listener::onFailure));
         }
     }
 
-    private void executeWorkingMemoryTTL(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+    private void executeWorkingMemoryTTL(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
         if (!config.isDisableSession()) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         String workingIndex = config.getIndexName(MemoryType.WORKING);
         if (workingIndex == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         int ttlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS);
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(ttlDays);
+        log
+            .debug(
+                "[MemoryRetentionJob] container={} working_memory TTL DBQ index={} cutoffMillis={}",
+                containerId,
+                workingIndex,
+                cutoffMillis
+            );
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -1092,7 +1135,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
             client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse response) -> {
                 log.info("[MemoryRetentionJob] container={} working_memory_ttl_deleted={}", containerId, response.getDeleted());
-                listener.onResponse(null);
+                listener.onResponse(response.getDeleted() > 0);
             }, listener::onFailure));
         }
     }
@@ -1262,33 +1305,80 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         ActionListener<Void> listener
     ) {
         Set<String> sessionIds = new HashSet<>();
-        enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, null, ActionListener.wrap(collectedIds -> {
-            ActionListener<Long> afterOrphans = ActionListener.wrap(orphansDeleted -> {
-                deleteEmptyNamespaceWorkingMemory(containerId, workingIndex, ActionListener.wrap(nullDeleted -> {
-                    log
-                        .info(
-                            "[MemoryRetentionJob] container={} orphans_deleted={} empty_namespace_deleted={}",
-                            containerId,
-                            orphansDeleted,
-                            nullDeleted
-                        );
-                    listener.onResponse(null);
-                }, listener::onFailure));
-            }, listener::onFailure);
+        String startKey = randomEnumerationStartKey();
+        enumerateSessionIdsFromWorkingMemory(
+            workingIndex,
+            containerId,
+            sessionIds,
+            Map.of(SESSION_ID_FIELD, startKey),
+            startKey,
+            false,
+            ActionListener
+                .wrap(
+                    aggregatedIds -> enumerateLegacySessionIdsFromWorkingMemory(
+                        workingIndex,
+                        containerId,
+                        aggregatedIds,
+                        new Object[] { startKey },
+                        startKey,
+                        false,
+                        ActionListener.wrap(collectedIds -> {
+                            ActionListener<Long> afterOrphans = ActionListener.wrap(orphansDeleted -> {
+                                deleteEmptyNamespaceWorkingMemory(containerId, workingIndex, ActionListener.wrap(nullDeleted -> {
+                                    log
+                                        .info(
+                                            "[MemoryRetentionJob] container={} orphans_deleted={} empty_namespace_deleted={}",
+                                            containerId,
+                                            orphansDeleted,
+                                            nullDeleted
+                                        );
+                                    listener.onResponse(null);
+                                }, listener::onFailure));
+                            }, listener::onFailure);
 
-            if (collectedIds.isEmpty()) {
-                afterOrphans.onResponse(0L);
-            } else {
-                checkAndDeleteOrphans(containerId, workingIndex, sessionsIndex, collectedIds, afterOrphans);
-            }
-        }, listener::onFailure));
+                            if (collectedIds.isEmpty()) {
+                                afterOrphans.onResponse(0L);
+                            } else {
+                                checkAndDeleteOrphans(containerId, workingIndex, sessionsIndex, collectedIds, afterOrphans);
+                            }
+                        }, listener::onFailure)
+                    ),
+                    listener::onFailure
+                )
+        );
     }
 
+    /**
+     * Generates a random keyspace position to start orphan enumeration from. Enumeration begins at
+     * this key, wraps around to the start of the keyspace once exhausted, and stops when it reaches
+     * the start key again. A single run still achieves full coverage when under the cap, but when
+     * ORPHAN_SESSION_ID_CAP truncates enumeration, each run truncates a different keyspace slice so
+     * all regions are probabilistically covered across runs.
+     */
+    private String randomEnumerationStartKey() {
+        Random random = new Random();
+        StringBuilder key = new StringBuilder(ORPHAN_START_KEY_LENGTH);
+        for (int i = 0; i < ORPHAN_START_KEY_LENGTH; i++) {
+            key.append(ORPHAN_KEYSPACE_ALPHABET.charAt(random.nextInt(ORPHAN_KEYSPACE_ALPHABET.length())));
+        }
+        return key.toString();
+    }
+
+    /**
+     * Enumerates distinct session IDs from working memory via a paged composite aggregation on the
+     * top-level {@code session_id} keyword field. Cost is proportional to the number of unique
+     * sessions rather than total documents. Pre-upgrade documents lack the top-level field (the
+     * {@code namespace} field is flat_object and cannot be aggregated) and are picked up separately
+     * by {@link #enumerateLegacySessionIdsFromWorkingMemory}. Enumeration starts at a per-run random
+     * key and wraps around so the ORPHAN_SESSION_ID_CAP truncates a different slice each run.
+     */
     private void enumerateSessionIdsFromWorkingMemory(
         String workingIndex,
         String containerId,
         Set<String> sessionIds,
-        Object[] searchAfterValues,
+        Map<String, Object> afterKey,
+        String startKey,
+        boolean wrapped,
         ActionListener<Set<String>> listener
     ) {
         SearchRequest request = new SearchRequest(workingIndex);
@@ -1296,7 +1386,95 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
         BoolQueryBuilder query = QueryBuilders
             .boolQuery()
+            .must(QueryBuilders.existsQuery(SESSION_ID_FIELD))
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId));
+
+        CompositeAggregationBuilder aggregation = new CompositeAggregationBuilder(
+            SESSION_IDS_AGG_NAME,
+            List.of(new TermsValuesSourceBuilder(SESSION_ID_FIELD).field(SESSION_ID_FIELD))
+        ).size(ORPHAN_SESSION_BATCH_SIZE);
+
+        if (afterKey != null) {
+            aggregation.aggregateAfter(afterKey);
+        }
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).size(0).aggregation(aggregation);
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                CompositeAggregation composite = response.getAggregations() != null
+                    ? response.getAggregations().get(SESSION_IDS_AGG_NAME)
+                    : null;
+                if (composite == null) {
+                    listener.onResponse(sessionIds);
+                    return;
+                }
+
+                for (CompositeAggregation.Bucket bucket : composite.getBuckets()) {
+                    Object sessionId = bucket.getKey().get(SESSION_ID_FIELD);
+                    if (sessionId != null) {
+                        if (wrapped && sessionId.toString().compareTo(startKey) > 0) {
+                            listener.onResponse(sessionIds);
+                            return;
+                        }
+                        sessionIds.add(sessionId.toString());
+                    }
+
+                    if (sessionIds.size() >= ORPHAN_SESSION_ID_CAP) {
+                        log
+                            .warn(
+                                "[MemoryRetentionJob] container={} session_id cap ({}) reached during orphan enumeration."
+                                    + " Remaining orphans will be covered in future runs.",
+                                containerId,
+                                ORPHAN_SESSION_ID_CAP
+                            );
+                        listener.onResponse(sessionIds);
+                        return;
+                    }
+                }
+
+                Map<String, Object> nextAfterKey = composite.afterKey();
+                if (composite.getBuckets().size() == ORPHAN_SESSION_BATCH_SIZE && nextAfterKey != null) {
+                    enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, nextAfterKey, startKey, wrapped, listener);
+                } else if (!wrapped) {
+                    enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, null, startKey, true, listener);
+                } else {
+                    listener.onResponse(sessionIds);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    /**
+     * Backward-compatibility enumeration for pre-upgrade working-memory documents that were indexed
+     * before the top-level {@code session_id} field existed. Scans only documents that have
+     * {@code namespace.session_id} but lack the top-level field, so its cost shrinks to zero as
+     * legacy documents are cleaned up. Like the aggregation path, scanning starts at the per-run
+     * random key in {@code _id} order and wraps around so cap truncation covers a different slice
+     * each run.
+     */
+    private void enumerateLegacySessionIdsFromWorkingMemory(
+        String workingIndex,
+        String containerId,
+        Set<String> sessionIds,
+        Object[] searchAfterValues,
+        String startKey,
+        boolean wrapped,
+        ActionListener<Set<String>> listener
+    ) {
+        if (sessionIds.size() >= ORPHAN_SESSION_ID_CAP) {
+            listener.onResponse(sessionIds);
+            return;
+        }
+
+        SearchRequest request = new SearchRequest(workingIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
             .must(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD))
+            .mustNot(QueryBuilders.existsQuery(SESSION_ID_FIELD))
             .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId));
 
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
@@ -1316,6 +1494,11 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 SearchHit[] hits = response.getHits().getHits();
 
                 for (SearchHit hit : hits) {
+                    if (wrapped && hit.getId().compareTo(startKey) > 0) {
+                        listener.onResponse(sessionIds);
+                        return;
+                    }
+
                     Map<String, Object> source = hit.getSourceAsMap();
                     if (source != null) {
                         @SuppressWarnings("unchecked")
@@ -1332,7 +1515,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                         log
                             .warn(
                                 "[MemoryRetentionJob] container={} session_id cap ({}) reached during orphan enumeration."
-                                    + " Remaining orphans will be caught on next run.",
+                                    + " Remaining orphans will be covered in future runs.",
                                 containerId,
                                 ORPHAN_SESSION_ID_CAP
                             );
@@ -1343,7 +1526,17 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
                 if (hits.length == ORPHAN_ENUMERATION_PAGE_SIZE) {
                     Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
-                    enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, nextSearchAfter, listener);
+                    enumerateLegacySessionIdsFromWorkingMemory(
+                        workingIndex,
+                        containerId,
+                        sessionIds,
+                        nextSearchAfter,
+                        startKey,
+                        wrapped,
+                        listener
+                    );
+                } else if (!wrapped) {
+                    enumerateLegacySessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, null, startKey, true, listener);
                 } else {
                     listener.onResponse(sessionIds);
                 }
@@ -1453,6 +1646,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         List<String> batch = batches.get(batchIndex);
+        if (log.isDebugEnabled()) {
+            log.debug("[MemoryRetentionJob] container={} deleting orphaned working memory for session ids={}", containerId, batch);
+        }
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -1461,7 +1657,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
-                    .must(QueryBuilders.termsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD, batch))
+                    .must(buildSessionIdMatchQuery(batch))
             );
         dbq.setRefresh(true);
 
@@ -1476,6 +1672,13 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     private void deleteEmptyNamespaceWorkingMemory(String containerId, String workingIndex, ActionListener<Long> listener) {
         int orphanTtlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS);
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(orphanTtlDays);
+        log
+            .debug(
+                "[MemoryRetentionJob] container={} empty_namespace DBQ index={} cutoffMillis={}",
+                containerId,
+                workingIndex,
+                cutoffMillis
+            );
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -1486,6 +1689,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .mustNot(QueryBuilders.existsQuery(SESSION_ID_FIELD))
                     .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD))
                     .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + USER_ID_FIELD))
                     .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + AGENT_ID_FIELD))

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -15,6 +15,10 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SESSION_ID_FIELD;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS;
@@ -24,6 +28,7 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MUL
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +39,7 @@ import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.unit.TimeValue;
@@ -121,12 +127,8 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
         request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
-        BoolQueryBuilder query = QueryBuilders
-            .boolQuery()
-            .must(QueryBuilders.existsQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + RETENTION_POLICY_FIELD));
-
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
-            .query(query)
+            .query(QueryBuilders.matchAllQuery())
             .size(CONTAINER_PAGE_SIZE)
             .sort("_id", SortOrder.ASC)
             .fetchSource(true);
@@ -205,30 +207,97 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             parser.nextToken();
             MemoryConfiguration config = MemoryConfiguration.parse(parser);
 
-            executeSessionRetention(
-                config,
-                containerId,
-                ActionListener
-                    .wrap(
-                        v -> executeLongTermRetention(
-                            config,
-                            containerId,
-                            ActionListener
-                                .wrap(
-                                    v2 -> executeHistoryRetention(
-                                        config,
-                                        containerId,
-                                        ActionListener
-                                            .wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
-                                    ),
-                                    listener::onFailure
-                                )
-                        ),
-                        listener::onFailure
-                    )
-            );
+            Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+            if (retentionPolicy == null || retentionPolicy.isEmpty()) {
+                if (config.isRetentionPolicyExplicitlyNull()) {
+                    log.debug("Container [{}] explicitly opted out of retention, skipping", containerId);
+                    listener.onResponse(null);
+                    return;
+                }
+                applyDefaultRetentionPolicy(config, containerId, ActionListener.wrap(v -> {
+                    executeRetentionPipeline(config, containerId, listener);
+                }, listener::onFailure));
+            } else {
+                executeRetentionPipeline(config, containerId, listener);
+            }
         } catch (Exception e) {
             log.error("Error parsing configuration for container [{}]", containerId, e);
+            listener.onResponse(null);
+        }
+    }
+
+    private void executeRetentionPipeline(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        executeSessionRetention(
+            config,
+            containerId,
+            ActionListener
+                .wrap(
+                    v -> executeLongTermRetention(
+                        config,
+                        containerId,
+                        ActionListener
+                            .wrap(
+                                v2 -> executeHistoryRetention(
+                                    config,
+                                    containerId,
+                                    ActionListener
+                                        .wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
+                                ),
+                                listener::onFailure
+                            )
+                    ),
+                    listener::onFailure
+                )
+        );
+    }
+
+    private void applyDefaultRetentionPolicy(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        int sessionRetentionDays = ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS.get(clusterService.getSettings());
+        int sessionMaxCount = ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT.get(clusterService.getSettings());
+        int longTermMaxCount = ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT.get(clusterService.getSettings());
+        int historyMaxCount = ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT.get(clusterService.getSettings());
+
+        Map<MemoryType, RetentionRule> defaultPolicy = new EnumMap<>(MemoryType.class);
+        defaultPolicy.put(MemoryType.SESSIONS, new RetentionRule(sessionRetentionDays, sessionMaxCount));
+        defaultPolicy.put(MemoryType.LONG_TERM, new RetentionRule(null, longTermMaxCount));
+        defaultPolicy.put(MemoryType.HISTORY, new RetentionRule(null, historyMaxCount));
+
+        config.setRetentionPolicy(defaultPolicy);
+
+        log.info(
+            "[MemoryRetentionJob] container={} auto-applying default retention policy: sessions={}/{}d, long-term={}, history={}",
+            containerId,
+            sessionMaxCount,
+            sessionRetentionDays,
+            longTermMaxCount,
+            historyMaxCount
+        );
+
+        try {
+            XContentBuilder policyBuilder = XContentFactory.jsonBuilder().startObject();
+            policyBuilder.startObject(RETENTION_POLICY_FIELD);
+            for (Map.Entry<MemoryType, RetentionRule> entry : defaultPolicy.entrySet()) {
+                policyBuilder.field(entry.getKey().getValue());
+                entry.getValue().toXContent(policyBuilder, null);
+            }
+            policyBuilder.endObject();
+            policyBuilder.endObject();
+
+            UpdateRequest updateRequest = new UpdateRequest(ML_MEMORY_CONTAINER_INDEX, containerId)
+                .doc(Map.of(MEMORY_STORAGE_CONFIG_FIELD, XContentHelper.convertToMap(BytesReference.bytes(policyBuilder), false, XContentType.JSON).v2()))
+                .retryOnConflict(3);
+
+            try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+                client.update(updateRequest, ActionListener.wrap(response -> {
+                    log.debug("Successfully persisted default retention policy on container [{}]", containerId);
+                    listener.onResponse(null);
+                }, e -> {
+                    log.warn("Failed to persist default retention policy on container [{}], proceeding with in-memory defaults", containerId, e);
+                    listener.onResponse(null);
+                }));
+            }
+        } catch (Exception e) {
+            log.warn("Failed to build default retention policy for container [{}], proceeding with in-memory defaults", containerId, e);
             listener.onResponse(null);
         }
     }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1445,10 +1445,15 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_UNIFIED_AGENT_API_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
                 MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED,
+                MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                 MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
                 MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
-                MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1444,7 +1444,11 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_MAX_JSON_SIZE,
                 MLCommonsSettings.ML_COMMONS_UNIFIED_AGENT_API_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
-                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED
+                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED,
+                MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -580,7 +580,7 @@ public class MLTaskManager implements SettingsChangeListener {
         try {
             MLJobParameter jobParameter = new MLJobParameter(
                 MLJobType.MEMORY_RETENTION.name(),
-                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.MINUTES), // DEMO: changed from HOURS to MINUTES
                 120L,
                 null,
                 MLJobType.MEMORY_RETENTION,

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
@@ -41,6 +43,7 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
@@ -591,6 +594,7 @@ public class MLTaskManager implements SettingsChangeListener {
                 .index(CommonValue.ML_JOBS_INDEX)
                 .id(MLJobType.MEMORY_RETENTION.name())
                 .source(jobParameter.toXContent(JsonXContent.contentBuilder(), null))
+                .opType(DocWriteRequest.OpType.CREATE)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             indexJob(indexRequest, MLJobType.MEMORY_RETENTION, () -> {
@@ -655,7 +659,17 @@ public class MLTaskManager implements SettingsChangeListener {
                         if (successCallback != null) {
                             successCallback.run();
                         }
-                    }, e -> log.error("Failed to index {} job", jobType.name(), e)), context::restore));
+                    }, e -> {
+                        if (ExceptionsHelper.unwrapCause(e) instanceof VersionConflictEngineException) {
+                            // The job document already exists (created by this or another node); treat as success
+                            log.debug("{} job already exists, skipping creation", jobType.name());
+                            if (successCallback != null) {
+                                successCallback.run();
+                            }
+                        } else {
+                            log.error("Failed to index {} job", jobType.name(), e);
+                        }
+                    }), context::restore));
                 }
             }
         }, e -> log.error("Failed to initialize ML jobs index", e)));

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -571,7 +571,7 @@ public class MLTaskManager implements SettingsChangeListener {
         }
     }
 
-    public void indexMemoryRetentionJob() {
+    public void indexMemoryRetentionJob(int intervalHours) {
         if (this.memoryRetentionJobStarted) {
             log.debug("Memory retention job already started");
             return;
@@ -580,7 +580,7 @@ public class MLTaskManager implements SettingsChangeListener {
         try {
             MLJobParameter jobParameter = new MLJobParameter(
                 MLJobType.MEMORY_RETENTION.name(),
-                new IntervalSchedule(Instant.now(), 24, ChronoUnit.HOURS),
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
                 120L,
                 null,
                 MLJobType.MEMORY_RETENTION,

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -84,6 +84,7 @@ public class MLTaskManager implements SettingsChangeListener {
     private final Map<MLTaskType, AtomicInteger> runningTasksCount;
     private boolean taskPollingJobStarted;
     private boolean statsCollectorJobStarted;
+    private boolean memoryRetentionJobStarted;
     public static final ImmutableSet<MLTaskState> TASK_DONE_STATES = ImmutableSet
         .of(MLTaskState.COMPLETED, MLTaskState.COMPLETED_WITH_ERROR, MLTaskState.FAILED, MLTaskState.CANCELLED);
 
@@ -567,6 +568,37 @@ public class MLTaskManager implements SettingsChangeListener {
             indexJob(indexRequest, MLJobType.BATCH_TASK_UPDATE, () -> this.taskPollingJobStarted = true);
         } catch (IOException e) {
             log.error("Failed to index task polling job", e);
+        }
+    }
+
+    public void indexMemoryRetentionJob() {
+        if (this.memoryRetentionJobStarted) {
+            log.debug("Memory retention job already started");
+            return;
+        }
+
+        try {
+            MLJobParameter jobParameter = new MLJobParameter(
+                MLJobType.MEMORY_RETENTION.name(),
+                new IntervalSchedule(Instant.now(), 24, ChronoUnit.HOURS),
+                120L,
+                null,
+                MLJobType.MEMORY_RETENTION,
+                true
+            );
+
+            IndexRequest indexRequest = new IndexRequest()
+                .index(CommonValue.ML_JOBS_INDEX)
+                .id(MLJobType.MEMORY_RETENTION.name())
+                .source(jobParameter.toXContent(JsonXContent.contentBuilder(), null))
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+            indexJob(indexRequest, MLJobType.MEMORY_RETENTION, () -> {
+                this.memoryRetentionJobStarted = true;
+                log.debug("Memory retention job started successfully");
+            });
+        } catch (IOException e) {
+            log.error("Failed to index memory retention job", e);
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -583,7 +583,7 @@ public class MLTaskManager implements SettingsChangeListener {
         try {
             MLJobParameter jobParameter = new MLJobParameter(
                 MLJobType.MEMORY_RETENTION.name(),
-                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.MINUTES), // DEMO: changed from HOURS to MINUTES
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
                 120L,
                 null,
                 MLJobType.MEMORY_RETENTION,

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -1939,7 +1939,7 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         assertTrue(captor.getValue().getMessage().contains("Internal server error"));
     }
 
-    // Helper method to mock successful LLM validation (without embedding validation which will be tested)
+    @Test
     public void testDoExecuteSuccess_WithRetentionPolicy() throws InterruptedException {
         // Create config with retention_policy to verify it passes through
         Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);
@@ -1992,6 +1992,7 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         assertEquals(Integer.valueOf(500), configWithRetention.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
     }
 
+    // Helper method to mock successful LLM validation (without embedding validation which will be tested)
     private void mockSuccessfulLLMValidation() {
         // Mock valid LLM model
         MLModel llmModel = mock(MLModel.class);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -21,6 +21,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,8 @@ import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategyType;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerRequest;
@@ -1937,6 +1940,58 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
     }
 
     // Helper method to mock successful LLM validation (without embedding validation which will be tested)
+    public void testDoExecuteSuccess_WithRetentionPolicy() throws InterruptedException {
+        // Create config with retention_policy to verify it passes through
+        Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);
+        retentionPolicy.put(MemoryType.SESSIONS, RetentionRule.builder().retentionDays(30).maxCount(100).build());
+        retentionPolicy.put(MemoryType.LONG_TERM, RetentionRule.builder().maxCount(500).build());
+
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .namespace(List.of(SESSION_ID_FIELD))
+                    .id("strategy-id1")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .build()
+            );
+
+        MemoryConfiguration configWithRetention = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .maxInferSize(5)
+                .strategies(strategies)
+                .retentionPolicy(retentionPolicy)
+                .build()
+        );
+
+        MLCreateMemoryContainerInput retentionInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("retention-container")
+            .description("Container with retention policy")
+            .configuration(configWithRetention)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest retentionRequest = new MLCreateMemoryContainerRequest(retentionInput);
+
+        mockSuccessfulCreatePipeline();
+        mockAndRunExecuteMethod(retentionRequest);
+
+        // Verify the configuration retains the retention policy
+        assertNotNull(configWithRetention.getRetentionPolicy());
+        assertEquals(2, configWithRetention.getRetentionPolicy().size());
+        assertEquals(Integer.valueOf(30), configWithRetention.getRetentionPolicy().get(MemoryType.SESSIONS).getRetentionDays());
+        assertEquals(Integer.valueOf(500), configWithRetention.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
+    }
+
     private void mockSuccessfulLLMValidation() {
         // Mock valid LLM model
         MLModel llmModel = mock(MLModel.class);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -2009,6 +2009,472 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         assertEquals(Integer.valueOf(500), configWithRetention.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
     }
 
+    @Test
+    public void testBuildMemoryContainer_StrategyWithNullIdAndEnabled() throws InterruptedException {
+        // Test that strategies without an ID get one generated, and null enabled defaults to true
+        MemoryStrategy strategyNoId = MemoryStrategy
+            .builder()
+            .namespace(List.of(SESSION_ID_FIELD))
+            .type(MemoryStrategyType.SEMANTIC)
+            .build(); // No id, no enabled
+
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies.add(strategyNoId);
+
+        MemoryConfiguration config = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .maxInferSize(5)
+                .strategies(strategies)
+                .build()
+        );
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("auto-id-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulCreatePipeline();
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+        // Verify the strategy now has an auto-generated ID and enabled=true
+        assertNotNull(strategyNoId.getId());
+        assertFalse(strategyNoId.getId().isBlank());
+        assertEquals(Boolean.TRUE, strategyNoId.getEnabled());
+    }
+
+    @Test
+    public void testBuildMemoryContainer_StrategyWithBlankId() throws InterruptedException {
+        // Test that strategies with blank ID also get one generated
+        MemoryStrategy strategyBlankId = MemoryStrategy
+            .builder()
+            .namespace(List.of(SESSION_ID_FIELD))
+            .id("   ") // blank
+            .enabled(true)
+            .type(MemoryStrategyType.SEMANTIC)
+            .build();
+
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies.add(strategyBlankId);
+
+        MemoryConfiguration config = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .maxInferSize(5)
+                .strategies(strategies)
+                .build()
+        );
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("blank-id-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulCreatePipeline();
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+        // Verify the blank ID was replaced
+        assertNotNull(strategyBlankId.getId());
+        assertFalse(strategyBlankId.getId().isBlank());
+    }
+
+    @Test
+    public void testBuildMemoryContainer_AutoApplyRetentionFromClusterSettings() throws InterruptedException {
+        // Test that default retention policy is auto-applied from cluster settings
+        // when user doesn't specify one
+        Settings settingsWithRetention = Settings
+            .builder()
+            .put("plugins.ml_commons.memory.default_session_retention_days", 30)
+            .put("plugins.ml_commons.memory.default_session_max_count", 100)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", 500)
+            .put("plugins.ml_commons.memory.default_history_max_count", 1000)
+            .build();
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settingsWithRetention, clusterSettingsSet);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        // Configuration WITHOUT retention policy
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .namespace(List.of(SESSION_ID_FIELD))
+                    .id("strategy-id1")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .build()
+            );
+
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-memory-index")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("test-embedding-model")
+            .llmId("test-llm-model")
+            .dimension(768)
+            .maxInferSize(5)
+            .strategies(strategies)
+            .build(); // No retentionPolicy set
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("auto-retention-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulCreatePipeline();
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+
+        // Verify retention policy was auto-applied
+        assertNotNull(config.getRetentionPolicy());
+        assertTrue(config.getRetentionPolicy().containsKey(MemoryType.SESSIONS));
+        assertTrue(config.getRetentionPolicy().containsKey(MemoryType.LONG_TERM));
+        assertTrue(config.getRetentionPolicy().containsKey(MemoryType.HISTORY));
+        assertEquals(Integer.valueOf(30), config.getRetentionPolicy().get(MemoryType.SESSIONS).getRetentionDays());
+        assertEquals(Integer.valueOf(100), config.getRetentionPolicy().get(MemoryType.SESSIONS).getMaxCount());
+        assertEquals(Integer.valueOf(500), config.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
+        assertEquals(Integer.valueOf(1000), config.getRetentionPolicy().get(MemoryType.HISTORY).getMaxCount());
+    }
+
+    @Test
+    public void testBuildMemoryContainer_AutoApplyRetention_OnlySessionDays() throws InterruptedException {
+        // Test partial cluster settings: only session_retention_days is set
+        Settings settingsWithRetention = Settings.builder().put("plugins.ml_commons.memory.default_session_retention_days", 14).build();
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settingsWithRetention, clusterSettingsSet);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-memory-index")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("test-embedding-model")
+            .llmId("test-llm-model")
+            .dimension(768)
+            .build(); // No retentionPolicy, no strategies
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("partial-retention-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+
+        // Verify only SESSIONS rule was created (with retentionDays only, no maxCount)
+        assertNotNull(config.getRetentionPolicy());
+        assertTrue(config.getRetentionPolicy().containsKey(MemoryType.SESSIONS));
+        assertFalse(config.getRetentionPolicy().containsKey(MemoryType.LONG_TERM));
+        assertFalse(config.getRetentionPolicy().containsKey(MemoryType.HISTORY));
+        assertEquals(Integer.valueOf(14), config.getRetentionPolicy().get(MemoryType.SESSIONS).getRetentionDays());
+        assertNull(config.getRetentionPolicy().get(MemoryType.SESSIONS).getMaxCount());
+    }
+
+    @Test
+    public void testBuildMemoryContainer_NoAutoApplyRetention_WhenExplicitlyNull() throws InterruptedException {
+        // Test that retention policy is NOT auto-applied when user explicitly set it to null
+        Settings settingsWithRetention = Settings
+            .builder()
+            .put("plugins.ml_commons.memory.default_session_retention_days", 30)
+            .put("plugins.ml_commons.memory.default_session_max_count", 100)
+            .build();
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settingsWithRetention, clusterSettingsSet);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        MemoryConfiguration config = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .build()
+        );
+        // Simulate user explicitly passing "retention_policy": null
+        when(config.isRetentionPolicyExplicitlyNull()).thenReturn(true);
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("no-retention-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+
+        // Verify retention policy was NOT applied
+        assertNull(config.getRetentionPolicy());
+    }
+
+    @Test
+    public void testEmitDisableSessionRetentionWarning_WithDisableSessionAndSessionsRetention() throws InterruptedException {
+        // Test that warning is emitted when disableSession=true and SESSIONS retention is set
+        Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);
+        retentionPolicy.put(MemoryType.SESSIONS, RetentionRule.builder().retentionDays(30).build());
+
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .namespace(List.of(SESSION_ID_FIELD))
+                    .id("strategy-id1")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .build()
+            );
+
+        MemoryConfiguration config = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .maxInferSize(5)
+                .strategies(strategies)
+                .retentionPolicy(retentionPolicy)
+                .disableSession(true)
+                .build()
+        );
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("disable-session-with-retention")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulCreatePipeline();
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        // Test passes if no exception is thrown - warning is emitted via HeaderWarning
+        verify(actionListener).onResponse(responseCaptor.capture());
+        assertNotNull(responseCaptor.getValue());
+
+        // Acknowledge the expected warning to satisfy OpenSearchTestCase's ensureNoWarnings check
+        assertWarnings(
+            "sessions retention_policy has no effect when disableSession=true;"
+                + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+        );
+    }
+
+    @Test
+    public void testBuildMemoryContainer_NullConfiguration() throws InterruptedException {
+        // Test when configuration is null (edge case)
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("null-config-container")
+            .configuration(null)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        // When config is null, validation should still work (no strategies, no models to validate)
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        // Depending on implementation, may fail or succeed. The goal is to hit the null config branch.
+        // Either onResponse or onFailure is fine as long as we exercise the code path
+    }
+
+    @Test
+    public void testBuildMemoryContainer_NullStrategies() throws InterruptedException {
+        // Test when configuration has null strategies (different from empty list)
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-memory-index")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("test-embedding-model")
+            .llmId("test-llm-model")
+            .dimension(768)
+            .strategies(null)
+            .build();
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("null-strategies-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+        assertNotNull(responseCaptor.getValue());
+    }
+
+    @Test
+    public void testBuildMemoryContainer_ExistingRetentionNotOverwritten() throws InterruptedException {
+        // Test that auto-apply does NOT overwrite an already-set retention policy
+        Settings settingsWithRetention = Settings.builder().put("plugins.ml_commons.memory.default_session_retention_days", 30).build();
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settingsWithRetention, clusterSettingsSet);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        // Config with EXISTING retention policy
+        Map<MemoryType, RetentionRule> existingPolicy = new EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, RetentionRule.builder().retentionDays(7).build());
+
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-memory-index")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("test-embedding-model")
+            .llmId("test-llm-model")
+            .dimension(768)
+            .retentionPolicy(existingPolicy)
+            .build();
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("existing-retention-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+
+        // Verify existing policy was NOT overwritten - still 7 days, not 30
+        assertEquals(Integer.valueOf(7), config.getRetentionPolicy().get(MemoryType.SESSIONS).getRetentionDays());
+    }
+
     // Helper method to mock successful LLM validation (without embedding validation which will be tested)
     private void mockSuccessfulLLMValidation() {
         // Mock valid LLM model

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -51,6 +51,8 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
@@ -68,6 +70,7 @@ import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategyType;
 import org.opensearch.ml.common.memorycontainer.MemoryType;
 import org.opensearch.ml.common.memorycontainer.RetentionRule;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerRequest;
@@ -153,6 +156,18 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
         when(clusterService.getSettings()).thenReturn(settings);
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settings, clusterSettingsSet);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         // Setup admin client chain
         when(client.admin()).thenReturn(adminClient);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -152,6 +152,7 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         threadContext = new ThreadContext(settings);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(clusterService.getSettings()).thenReturn(settings);
 
         // Setup admin client chain
         when(client.admin()).thenReturn(adminClient);
@@ -228,7 +229,8 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
             mlIndicesHandler,
             connectorAccessControlHelper,
             mlFeatureEnabledSetting,
-            mlModelManager
+            mlModelManager,
+            clusterService
         );
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
@@ -166,17 +166,36 @@ public class TransportAddMemoriesActionTests {
     }
 
     @Test
-    public void testDoExecute_BlankMemoryContainerId() {
+    public void testDoExecute_PinnedFieldRejected() {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
-        
+
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
-        when(input.getMemoryContainerId()).thenReturn("");
-        
+        when(input.getPinned()).thenReturn(true);
+
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
         when(request.getMlAddMemoryInput()).thenReturn(input);
-        
+
         transportAddMemoriesAction.doExecute(task, request, actionListener);
-        
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assert captor.getValue() instanceof OpenSearchStatusException;
+        assert captor.getValue().getMessage().contains("pinned field is not supported for working memory type");
+    }
+
+    @Test
+    public void testDoExecute_BlankMemoryContainerId() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
+        when(input.getMemoryContainerId()).thenReturn("");
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
         verify(actionListener).onFailure(any(IllegalArgumentException.class));
     }
 
@@ -185,6 +204,7 @@ public class TransportAddMemoriesActionTests {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
@@ -213,6 +233,7 @@ public class TransportAddMemoriesActionTests {
         List<MessageInput> messages = Arrays.asList(message);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -248,6 +269,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -300,6 +322,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -348,6 +371,7 @@ public class TransportAddMemoriesActionTests {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
@@ -382,6 +406,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -431,6 +456,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id in namespace
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -485,6 +511,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - should trigger session creation
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -556,6 +583,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - should trigger session creation
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -613,6 +641,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "existing-session-123"); // User provided session_id
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -664,6 +693,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - would normally trigger session creation, but getLlmId() is null
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -715,6 +745,7 @@ public class TransportAddMemoriesActionTests {
         Map<String, String> namespace = new HashMap<>();
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -773,6 +804,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -831,6 +863,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(disabledStrategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -890,6 +923,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -949,6 +983,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1014,6 +1049,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy2);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1071,6 +1107,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(disabledStrategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1128,6 +1165,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1184,6 +1222,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1250,6 +1289,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1335,6 +1375,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1430,6 +1471,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1498,6 +1540,7 @@ public class TransportAddMemoriesActionTests {
         Map<String, String> namespace = new HashMap<>();
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.action.memorycontainer.memory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -308,6 +310,112 @@ public class TransportAddMemoriesActionTests {
         // Verify the full flow
         verify(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
         verify(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+    }
+
+    @Test
+    public void testDoExecute_WorkingMemoryIndexedWithTopLevelSessionId() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello world")).role("user").build();
+
+        Map<String, String> namespace = new HashMap<>();
+        namespace.put("session_id", "session-123");
+
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(Arrays.asList(message))
+            .namespace(namespace)
+            .build();
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            when(indexResponse.getId()).thenReturn("working-mem-123");
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        ArgumentCaptor<IndexRequest> requestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(memoryContainerHelper).indexData(any(MemoryConfiguration.class), requestCaptor.capture(), any());
+
+        Map<String, Object> source = requestCaptor.getValue().sourceAsMap();
+        assertEquals("session-123", source.get("session_id"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> indexedNamespace = (Map<String, Object>) source.get("namespace");
+        assertEquals("session-123", indexedNamespace.get("session_id"));
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+    }
+
+    @Test
+    public void testDoExecute_WorkingMemoryIndexedWithoutSessionIdOmitsTopLevelField() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello world")).role("user").build();
+
+        Map<String, String> namespace = new HashMap<>();
+        namespace.put("agent_id", "agent-1");
+
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(Arrays.asList(message))
+            .namespace(namespace)
+            .build();
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+        when(config.isDisableSession()).thenReturn(true);
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            when(indexResponse.getId()).thenReturn("working-mem-123");
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        ArgumentCaptor<IndexRequest> requestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(memoryContainerHelper).indexData(any(MemoryConfiguration.class), requestCaptor.capture(), any());
+
+        Map<String, Object> source = requestCaptor.getValue().sourceAsMap();
+        assertFalse(source.containsKey("session_id"));
         verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
     }
 
@@ -1587,5 +1695,185 @@ public class TransportAddMemoriesActionTests {
         verify(actionListener).onFailure(argThat(exception -> exception instanceof OpenSearchStatusException
             && ((OpenSearchStatusException)exception).status() == RestStatus.BAD_REQUEST
             && exception.getMessage().contains("LLM predict result cannot be extracted")));
+    }
+
+    @Test
+    public void testSessionLastUpdatedTimeBump_ExistingSession() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello world")).role("user").build();
+
+        Map<String, String> namespace = new HashMap<>();
+        namespace.put("session_id", "session-existing");
+
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(Arrays.asList(message))
+            .namespace(namespace)
+            .build();
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getParameters()).thenReturn(new HashMap<>());
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+        when(config.getSessionIndexName()).thenReturn("session-index");
+        when(config.isDisableSession()).thenReturn(false);
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            when(indexResponse.getId()).thenReturn("working-mem-456");
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+
+        org.opensearch.action.update.UpdateResponse updateResponse = mock(org.opensearch.action.update.UpdateResponse.class);
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.update.UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(org.opensearch.action.update.UpdateRequest.class), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        verify(client).update(argThat(req -> {
+            org.opensearch.action.update.UpdateRequest updateReq = (org.opensearch.action.update.UpdateRequest) req;
+            return "session-index".equals(updateReq.index()) && "session-existing".equals(updateReq.id());
+        }), any());
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+    }
+
+    @Test
+    public void testSessionLastUpdatedTimeBump_NewlyCreatedSession_NoBump() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello world")).role("user").build();
+
+        Map<String, String> namespace = new HashMap<>();
+
+        MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
+        when(input.getMemoryContainerId()).thenReturn("container-123");
+        when(input.getMessages()).thenReturn(Arrays.asList(message));
+        when(input.isInfer()).thenReturn(false);
+        when(input.getNamespace()).thenReturn(namespace);
+        when(input.getOwnerId()).thenReturn("user-123");
+        when(input.getPayloadType()).thenReturn(PayloadType.CONVERSATIONAL);
+        when(input.getParameters()).thenReturn(new HashMap<>());
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getParameters()).thenReturn(new HashMap<>());
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+        when(config.getSessionIndexName()).thenReturn("session-index");
+        when(config.isDisableSession()).thenReturn(false);
+        when(config.getLlmId()).thenReturn("llm-model");
+        when(config.getStrategies()).thenReturn(
+            Arrays.asList(MemoryStrategy.builder().type(MemoryStrategyType.SUMMARY).build())
+        );
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(3);
+            listener.onResponse("Summary text");
+            return null;
+        }).when(memoryProcessingService).summarizeMessages(any(), eq(config), any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            when(indexResponse.getId()).thenReturn("new-session-id");
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        verify(client, org.mockito.Mockito.never()).update(
+            any(org.opensearch.action.update.UpdateRequest.class), any()
+        );
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+    }
+
+    @Test
+    public void testSessionLastUpdatedTimeBump_FailureDoesNotFailResponse() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello world")).role("user").build();
+
+        Map<String, String> namespace = new HashMap<>();
+        namespace.put("session_id", "session-bump-fail");
+
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(Arrays.asList(message))
+            .namespace(namespace)
+            .build();
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getParameters()).thenReturn(new HashMap<>());
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+        when(config.getSessionIndexName()).thenReturn("session-index");
+        when(config.isDisableSession()).thenReturn(false);
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            when(indexResponse.getId()).thenReturn("working-mem-789");
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.update.UpdateResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException("Simulated bump failure"));
+            return null;
+        }).when(client).update(any(org.opensearch.action.update.UpdateRequest.class), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+        verify(actionListener, org.mockito.Mockito.never()).onFailure(any());
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
@@ -738,14 +738,38 @@ public class TransportUpdateMemoryActionTests extends OpenSearchTestCase {
 
     @Test
     public void testConstructUpdateFields_UnknownType() {
-        // Test unknown memory type returns empty map
         Map<String, Object> updateContent = new HashMap<>();
         updateContent.put("field", "value");
         MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
 
         Map<String, Object> result = transportUpdateMemoryAction.constructNewDoc(input, null, new HashMap<>());
 
-        assertEquals(1, result.size()); // only last_updated_time is added for unknown types
+        assertEquals(0, result.size());
+        assertNull(result.get("last_updated_time"));
+    }
+
+    @Test
+    public void testNonContentUpdateDoesNotBumpLastUpdatedTime_Session() {
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        updateContent.put("tags", Map.of("tag1", "value1"));
+        updateContent.put("metadata", Map.of("key", "val"));
+        updateContent.put("additional_info", Map.of("extra", "data"));
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+
+        Map<String, Object> result = transportUpdateMemoryAction.constructNewDoc(input, MemoryType.SESSIONS, new HashMap<>());
+
+        assertNull(result.get("last_updated_time"));
+    }
+
+    @Test
+    public void testContentUpdateDoesBumpLastUpdatedTime_Session() {
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("summary", "New summary");
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+
+        Map<String, Object> result = transportUpdateMemoryAction.constructNewDoc(input, MemoryType.SESSIONS, new HashMap<>());
+
         assertNotNull(result.get("last_updated_time"));
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
@@ -795,4 +795,163 @@ public class TransportUpdateMemoryActionTests extends OpenSearchTestCase {
         verify(memoryContainerHelper, never()).indexData(any(), any(), any());
     }
 
+    @Test
+    public void testDoExecute_PinnedRejectedForWorkingMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.WORKING)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.WORKING)).thenReturn("test-working-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) capturedError).status());
+        assertTrue(capturedError.getMessage().contains("pinned field is not supported for working memory type"));
+    }
+
+    @Test
+    public void testDoExecute_PinnedAcceptedForSessionMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.SESSIONS)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        IndexResponse mockIndexResponse = mock(IndexResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.SESSIONS)).thenReturn("test-session-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doAnswer(invocation -> {
+            IndexRequest request = invocation.getArgument(1);
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            // Verify pinned field is included in the indexed document
+            assertTrue(request.sourceAsMap().containsKey("pinned"));
+            assertEquals(true, request.sourceAsMap().get("pinned"));
+            listener.onResponse(mockIndexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(), any(IndexRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        verify(actionListener, times(1)).onResponse(mockIndexResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testDoExecute_PinnedAcceptedForLongTermMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        updateContent.put(MEMORY_FIELD, "some memory text");
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.LONG_TERM)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        IndexResponse mockIndexResponse = mock(IndexResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        sourceMap.put(MEMORY_FIELD, "old memory");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.LONG_TERM)).thenReturn("test-lt-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doAnswer(invocation -> {
+            IndexRequest request = invocation.getArgument(1);
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            assertTrue(request.sourceAsMap().containsKey("pinned"));
+            assertEquals(true, request.sourceAsMap().get("pinned"));
+            listener.onResponse(mockIndexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(), any(IndexRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        verify(actionListener, times(1)).onResponse(mockIndexResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
 }

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.cluster;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -129,7 +130,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager).indexMemoryRetentionJob();
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {
@@ -142,7 +143,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenAgenticMemoryDisabled() {
@@ -154,7 +155,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
     }
 
     private DiscoveryNode createDataNode(Version version) {

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -130,7 +130,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager).indexMemoryRetentionJob(24);
+        verify(mlTaskManager).indexMemoryRetentionJob(2); // DEMO: interval is 2 minutes for local testing
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -120,6 +120,43 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager, never()).indexStatsCollectorJob(anyBoolean());
     }
 
+    public void testClusterChanged_MemoryRetentionJobStarted() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager).indexMemoryRetentionJob();
+    }
+
+    public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings())
+            .thenReturn(org.opensearch.common.settings.Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build());
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+    }
+
+    public void testClusterChanged_MemoryRetentionJobNotStarted_WhenAgenticMemoryDisabled() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+    }
+
     private DiscoveryNode createDataNode(Version version) {
         return new DiscoveryNode(
             "dataNode",

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -130,7 +130,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager).indexMemoryRetentionJob(2); // DEMO: interval is 2 minutes for local testing
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {

--- a/plugin/src/test/java/org/opensearch/ml/jobs/MLJobRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/MLJobRunnerTests.java
@@ -6,16 +6,22 @@
 package org.opensearch.ml.jobs;
 
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutorService;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
+import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
@@ -78,6 +84,22 @@ public class MLJobRunnerTests {
     public void testRunJobWithDisabledJob() {
         when(jobParameter.isEnabled()).thenReturn(false);
         when(jobParameter.getJobType()).thenReturn(MLJobType.STATS_COLLECTOR);
+        jobRunner.runJob(jobParameter, jobExecutionContext);
+    }
+
+    @Test
+    public void testRunJobWithMemoryRetentionType() {
+        MemoryRetentionJobProcessor.reset();
+        when(jobParameter.isEnabled()).thenReturn(true);
+        when(jobParameter.getJobType()).thenReturn(MLJobType.MEMORY_RETENTION);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+
+        LockService lockService = mock(LockService.class);
+        when(jobExecutionContext.getLockService()).thenReturn(lockService);
+
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(threadPool.generic()).thenReturn(executorService);
+
         jobRunner.runJob(jobParameter, jobExecutionContext);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -6,18 +6,57 @@
 package org.opensearch.ml.jobs.processors;
 
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
+@RunWith(MockitoJUnitRunner.class)
 public class MemoryRetentionJobProcessorTests {
+
+    @Rule
+    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
 
     @Mock
     private ClusterService clusterService;
@@ -28,12 +67,34 @@ public class MemoryRetentionJobProcessorTests {
     @Mock
     private Client client;
 
+    private ThreadContext threadContext;
+
     private MemoryRetentionJobProcessor processor;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
         MemoryRetentionJobProcessor.reset();
+
+        // Default settings: multi-tenancy disabled, throttle = 1 second
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        // Use real ThreadContext (it's a final class and cannot be mocked)
+        threadContext = new ThreadContext(Settings.EMPTY);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        // Mock threadPool.schedule to execute immediately
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(threadPool).schedule(any(Runnable.class), any(TimeValue.class), anyString());
+
         processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
     }
 
@@ -51,25 +112,1236 @@ public class MemoryRetentionJobProcessorTests {
 
         processor.run();
 
-        // No exception thrown, method returns early with warning log
+        // Should not search for containers when multi-tenancy is enabled
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
     }
 
     @Test
     public void testRunExecutesWhenMultiTenancyDisabled() {
-        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", false).build();
-        when(clusterService.getSettings()).thenReturn(settings);
+        // Return empty containers
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
 
         processor.run();
 
-        // No exception thrown, logs "Memory retention job triggered"
+        // Verify container search is initiated
+        verify(client, atLeastOnce()).search(any(SearchRequest.class), isA(ActionListener.class));
     }
 
     @Test
     public void testRunExecutesWithDefaultSettings() {
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
+        // Return empty containers
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
         processor.run();
 
         // Default multi_tenancy_enabled is false, so job should execute
+        verify(client, atLeastOnce()).search(any(SearchRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testNoContainersWithPolicy() {
+        // Container search returns empty hits -> job completes
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).search(any(SearchRequest.class), isA(ActionListener.class));
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testContainerWithSessionRetentionTimeBased() {
+        // 1 container with retention_days=7, mock 3 expired sessions -> verify cascade + bulk delete
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-time",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Session search returns 3 expired sessions
+                SearchHit hit1 = new SearchHit(0, "expired-session-1", null, null);
+                SearchHit hit2 = new SearchHit(1, "expired-session-2", null, null);
+                SearchHit hit3 = new SearchHit(2, "expired-session-3", null, null);
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { hit1, hit2, hit3 },
+                    new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock cascade delete for working memory (Phase 2)
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(10L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for sessions (Phase 3)
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify cascade delete was called on working memory
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        // Verify bulk delete was called on sessions
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testContainerWithSessionRetentionCountBased() {
+        // max_count=5, 10 sessions -> verify 5 oldest deleted
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-count",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", null, 5)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger sessionSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = sessionSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count-based identification: returns 10 sessions sorted by last_updated_time DESC
+                    // First 5 are kept, last 5 are expired
+                    SearchHit[] hits = new SearchHit[10];
+                    for (int i = 0; i < 10; i++) {
+                        hits[i] = new SearchHit(i, "session-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) (10 - i), "session-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits sessionHits = new SearchHits(hits, new TotalHits(10, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse sessionResponse = mock(SearchResponse.class);
+                    when(sessionResponse.getHits()).thenReturn(sessionHits);
+                    listener.onResponse(sessionResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock cascade delete for working memory
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(5L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for sessions
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify cascade delete + bulk delete both called
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testCascadeOrdering() {
+        // Verify delete_by_query (working memory) is called BEFORE bulk delete (sessions)
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-cascade",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Session search returns expired sessions
+                SearchHit hit1 = new SearchHit(0, "session-1", null, null);
+                SearchHit hit2 = new SearchHit(1, "session-2", null, null);
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { hit1, hit2 },
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Track the ordering of operations
+        AtomicInteger orderCounter = new AtomicInteger(0);
+        AtomicInteger cascadeDeleteOrder = new AtomicInteger(-1);
+        AtomicInteger bulkDeleteOrder = new AtomicInteger(-1);
+
+        // Mock cascade delete-by-query for working memory (Phase 2)
+        BulkByScrollResponse workingDeleteResponse = mock(BulkByScrollResponse.class);
+        when(workingDeleteResponse.getDeleted()).thenReturn(5L);
+
+        doAnswer(invocation -> {
+            cascadeDeleteOrder.set(orderCounter.getAndIncrement());
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(workingDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for sessions (Phase 3)
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            bulkDeleteOrder.set(orderCounter.getAndIncrement());
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Working memory delete (cascade) must happen BEFORE session delete (bulk)
+        assertTrue(
+            "Working memory cascade delete should execute before session bulk delete",
+            cascadeDeleteOrder.get() < bulkDeleteOrder.get()
+        );
+        assertTrue("Cascade delete should have been called", cascadeDeleteOrder.get() >= 0);
+        assertTrue("Bulk delete should have been called", bulkDeleteOrder.get() >= 0);
+    }
+
+    @Test
+    public void testPinnedSessionsExcluded() {
+        // Pinned sessions older than retention_days -> not deleted
+        // The processor's query uses mustNot(pinned=true), so we verify the query contains pinned filter
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-pinned",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Verify the query excludes pinned=true
+                String queryString = request.source().query().toString();
+                assertTrue("Query should exclude pinned documents (must_not pinned:true)", queryString.contains("pinned"));
+
+                // Return empty result - all sessions are pinned and excluded
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify session search was made (with pinned exclusion)
+        verify(client, atLeast(2)).search(any(SearchRequest.class), isA(ActionListener.class));
+        // No deletions should occur since all sessions are pinned (excluded by query)
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testBatching() {
+        // 600 expired sessions -> verify 2 delete_by_query calls (500 + 100) for working memory cascade
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-batch",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger sessionPageCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Return 600 expired sessions across 6 full pages of 100, then an empty page
+                int pageNum = sessionPageCount.getAndIncrement();
+                if (pageNum < 6) {
+                    // Full page of 100 hits (triggers pagination)
+                    SearchHit[] hits = new SearchHit[100];
+                    for (int i = 0; i < 100; i++) {
+                        int globalIdx = pageNum * 100 + i;
+                        hits[i] = new SearchHit(globalIdx, "session-" + globalIdx, null, null);
+                        hits[i].sortValues(new Object[] { "session-" + globalIdx }, new DocValueFormat[] { DocValueFormat.RAW });
+                    }
+                    SearchHits sessionHits = new SearchHits(hits, new TotalHits(600, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse sessionResponse = mock(SearchResponse.class);
+                    when(sessionResponse.getHits()).thenReturn(sessionHits);
+                    listener.onResponse(sessionResponse);
+                } else {
+                    // Final page: empty (terminates pagination)
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Track cascade delete calls
+        AtomicInteger cascadeDeleteCount = new AtomicInteger(0);
+
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(100L);
+
+        doAnswer(invocation -> {
+            cascadeDeleteCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // With 600 sessions and DELETE_BY_QUERY_BATCH_SIZE=500, expect 2 cascade delete calls
+        assertTrue("Should have at least 2 cascade delete-by-query calls for 600 sessions (batch size 500)", cascadeDeleteCount.get() >= 2);
+    }
+
+    @Test
+    public void testEmptyExpiredSet() {
+        // No sessions match retention criteria -> phases 2-3 skipped
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-empty",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // No expired sessions found
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify no cascade delete or bulk delete was called
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testContainerProcessingError() {
+        // One container fails -> next container still processed
+        String sourceJson1 = "{\"configuration\":{\"index_prefix\":\"prefix1\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+        String sourceJson2 = "{\"configuration\":{\"index_prefix\":\"prefix2\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchHit hit1 = new SearchHit(0, "container-fail", null, null);
+        hit1.sourceRef(new BytesArray(sourceJson1));
+        hit1.sortValues(new Object[] { "container-fail" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchHit hit2 = new SearchHit(1, "container-success", null, null);
+        hit2.sourceRef(new BytesArray(sourceJson2));
+        hit2.sortValues(new Object[] { "container-success" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchResponse containerSearchResponse = mock(SearchResponse.class);
+        // Less than page size (100) so no pagination
+        SearchHits containerHits = new SearchHits(new SearchHit[] { hit1, hit2 }, new TotalHits(2, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(containerSearchResponse.getHits()).thenReturn(containerHits);
+
+        AtomicInteger sessionSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                listener.onResponse(containerSearchResponse);
+            } else {
+                int count = sessionSearchCount.getAndIncrement();
+                if (count == 0) {
+                    // First container's session search fails
+                    listener.onFailure(new RuntimeException("Simulated search failure"));
+                } else {
+                    // Second container's session search succeeds with empty results
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify that we searched at least twice (once for each container's sessions)
+        assertTrue("Both containers should be processed, second container search made", sessionSearchCount.get() >= 2);
+    }
+
+    @Test
+    public void testNullSessionIndex() {
+        // Container with disableSession=true -> session retention skipped, but working memory TTL fires (Phase 6)
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-session", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for Phase 6 working memory TTL (disableSession=true triggers it)
+        BulkByScrollResponse ttlResponse = mock(BulkByScrollResponse.class);
+        when(ttlResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ttlResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Session retention is skipped (session index is null), but Phase 6 working memory TTL fires
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        // No bulk deletes (no sessions to delete, no count-based eviction)
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testMultipleContainersProcessed() {
+        // 2 containers -> both processed sequentially
+        String sourceJson1 = "{\"configuration\":{\"index_prefix\":\"prefix1\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+        String sourceJson2 = "{\"configuration\":{\"index_prefix\":\"prefix2\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":30}}}}";
+
+        SearchHit hit1 = new SearchHit(0, "container-1", null, null);
+        hit1.sourceRef(new BytesArray(sourceJson1));
+        hit1.sortValues(new Object[] { "container-1" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchHit hit2 = new SearchHit(1, "container-2", null, null);
+        hit2.sourceRef(new BytesArray(sourceJson2));
+        hit2.sortValues(new Object[] { "container-2" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchResponse containerSearchResponse = mock(SearchResponse.class);
+        SearchHits containerHits = new SearchHits(new SearchHit[] { hit1, hit2 }, new TotalHits(2, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(containerSearchResponse.getHits()).thenReturn(containerHits);
+
+        AtomicInteger sessionSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                listener.onResponse(containerSearchResponse);
+            } else {
+                sessionSearchCount.incrementAndGet();
+                // Return 1 expired session for each container
+                SearchHit expiredHit = new SearchHit(0, "expired-session-" + sessionSearchCount.get(), null, null);
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { expiredHit },
+                    new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock cascade delete
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(1L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Both containers should have been processed: at least 2 session searches
+        assertTrue("Both containers should be processed with session searches", sessionSearchCount.get() >= 2);
+        // Verify cascade delete was called for both containers
+        verify(client, atLeast(2)).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        // Verify bulk delete was called for both containers
+        verify(client, atLeast(2)).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    // --- Phase 4: Long-Term Retention Tests ---
+
+    @Test
+    public void testLongTermRetentionDays() {
+        // Container with LTM policy retention_days=30 -> verify _delete_by_query on long-term index
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":30}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-days", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // No expired sessions (no session retention rule)
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for long-term retention_days
+        BulkByScrollResponse ltmDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ltmDeleteResponse.getDeleted()).thenReturn(5L);
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            // Verify the query targets long-term index and uses last_updated_time
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Should filter by memory_container_id", queryString.contains("memory_container_id"));
+            assertTrue("Should use last_updated_time for long-term", queryString.contains("last_updated_time"));
+            assertTrue("Should exclude pinned docs", queryString.contains("pinned"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ltmDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testLongTermMaxCount() {
+        // Container with LTM policy max_count=100, 150 docs -> verify search for oldest 50 IDs + bulk delete
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"max_count\":100}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-count", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query: return totalHits=150
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(150, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Search for oldest 50 IDs: return 50 hits
+                    SearchHit[] hits = new SearchHit[50];
+                    for (int i = 0; i < 50; i++) {
+                        hits[i] = new SearchHit(i, "ltm-doc-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "ltm-doc-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(50, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify bulk delete called for the 50 excess docs
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testLongTermPinnedExclusion() {
+        // Verify mustNot(pinned=true) in long-term retention_days delete query
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-pinned", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Capture the DeleteByQueryRequest to verify pinned exclusion
+        BulkByScrollResponse ltmDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ltmDeleteResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Long-term delete query should exclude pinned=true", queryString.contains("pinned"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ltmDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testNullLtmIndex() {
+        // Container without LLM/strategies -> getIndexName(LONG_TERM) returns null -> LTM phase skipped
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":30}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-llm", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // No delete-by-query or bulk delete should fire (LTM phase skipped due to null index)
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testLongTermBothRetentionDaysAndMaxCount() {
+        // Both retention_days AND max_count set -> verify both operations fire sequentially
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":30,\"max_count\":100}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-both", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query for max_count: return 120
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(120, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Search for oldest 20 IDs
+                    SearchHit[] hits = new SearchHit[20];
+                    for (int i = 0; i < 20; i++) {
+                        hits[i] = new SearchHit(i, "ltm-excess-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "ltm-excess-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(20, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for retention_days
+        BulkByScrollResponse ltmDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ltmDeleteResponse.getDeleted()).thenReturn(3L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ltmDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for max_count
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Both operations should have fired
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    // --- Phase 5: History Retention Tests ---
+
+    @Test
+    public void testHistoryMaxCount() {
+        // Container with history policy max_count=500, 600 docs -> verify search sorted by created_time ASC
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"history\":{\"max_count\":500}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-history-count", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query: return totalHits=600
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(600, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Search for oldest 100 IDs — verify sort field is created_time
+                    String sourceStr = request.source().toString();
+                    assertTrue("History search should sort by created_time", sourceStr.contains("created_time"));
+
+                    SearchHit[] hits = new SearchHit[100];
+                    for (int i = 0; i < 100; i++) {
+                        hits[i] = new SearchHit(i, "history-doc-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "history-doc-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(100, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testHistoryUsesCreatedTime() {
+        // Verify the sort field in history search is created_time, not last_updated_time
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"history\":{\"max_count\":10}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-history-time", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+        AtomicInteger verifiedCreatedTime = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query: return 15 docs (exceeds max_count=10)
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(15, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Verify sort uses created_time, NOT last_updated_time
+                    String sourceStr = request.source().toString();
+                    assertTrue("History must use created_time for sorting", sourceStr.contains("created_time"));
+                    assertTrue("History must NOT use last_updated_time", !sourceStr.contains("last_updated_time"));
+                    verifiedCreatedTime.incrementAndGet();
+
+                    SearchHit[] hits = new SearchHit[5];
+                    for (int i = 0; i < 5; i++) {
+                        hits[i] = new SearchHit(i, "hist-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "hist-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Should have verified created_time sort field", verifiedCreatedTime.get() > 0);
+    }
+
+    // --- Phase 6: Working Memory TTL Tests ---
+
+    @Test
+    public void testWorkingMemoryTTLDisableSessionTrue() {
+        // Container with disableSession=true -> verify _delete_by_query on working index with created_time range
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ttl-enabled", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for working memory TTL
+        BulkByScrollResponse ttlDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ttlDeleteResponse.getDeleted()).thenReturn(8L);
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Working memory TTL should filter by memory_container_id", queryString.contains("memory_container_id"));
+            assertTrue("Working memory TTL should use created_time", queryString.contains("created_time"));
+            // Working memory does NOT support pinning, so no pinned filter
+            assertTrue("Working memory TTL should NOT exclude pinned (no pinning support)", !queryString.contains("pinned"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ttlDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testWorkingMemoryTTLDisableSessionFalse() {
+        // Container with disableSession=false -> Phase 6 skipped entirely
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":false,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ttl-skipped", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Session search returns no expired sessions
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // No delete-by-query should be called (session expired=0, and working memory TTL is skipped)
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    // --- All phases chain test ---
+
+    @Test
+    public void testAllPhasesChainCorrectly() {
+        // Container with session, long-term, and history policies -> verify all three phases run
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{"
+            + "\"sessions\":{\"retention_days\":7},"
+            + "\"long-term\":{\"retention_days\":30},"
+            + "\"history\":{\"max_count\":500}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-all-phases", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger deleteByQueryCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // For count queries return 0 (under threshold), for other searches return empty
+                SearchResponse countResp = mock(SearchResponse.class);
+                SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                when(countResp.getHits()).thenReturn(countHits);
+                listener.onResponse(countResp);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query — should be called for session phase and long-term retention_days
+        BulkByScrollResponse dbqResponse = mock(BulkByScrollResponse.class);
+        when(dbqResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            deleteByQueryCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(dbqResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Long-term retention_days should trigger a delete_by_query
+        assertTrue("At least one delete_by_query should have been called for long-term retention_days", deleteByQueryCount.get() >= 1);
+    }
+
+    // --- Helper methods ---
+
+    private SearchResponse createContainerSearchResponseFromJson(String containerId, String sourceJson) {
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        SearchHit hit = new SearchHit(0, containerId, null, null);
+        hit.sourceRef(new BytesArray(sourceJson));
+        SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(searchResponse.getHits()).thenReturn(hits);
+        return searchResponse;
+    }
+
+    private SearchResponse createContainerSearchResponse(
+        String containerId,
+        String indexPrefix,
+        boolean useSystemIndex,
+        Map<String, Object> retentionPolicy
+    ) {
+        // Build the JSON source for the container hit
+        StringBuilder retentionJson = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, Object> entry : retentionPolicy.entrySet()) {
+            if (!first)
+                retentionJson.append(",");
+            first = false;
+            @SuppressWarnings("unchecked")
+            Map<String, Object> rule = (Map<String, Object>) entry.getValue();
+            retentionJson.append("\"").append(entry.getKey()).append("\":{");
+            boolean ruleFirst = true;
+            if (rule.containsKey("retention_days")) {
+                retentionJson.append("\"retention_days\":").append(rule.get("retention_days"));
+                ruleFirst = false;
+            }
+            if (rule.containsKey("max_count")) {
+                if (!ruleFirst)
+                    retentionJson.append(",");
+                retentionJson.append("\"max_count\":").append(rule.get("max_count"));
+            }
+            retentionJson.append("}");
+        }
+        retentionJson.append("}");
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\""
+            + indexPrefix
+            + "\","
+            + "\"use_system_index\":"
+            + useSystemIndex
+            + ","
+            + "\"retention_policy\":"
+            + retentionJson.toString()
+            + "}}";
+
+        return createContainerSearchResponseFromJson(containerId, sourceJson);
+    }
+
+    private Map<String, Object> createRetentionPolicyMap(String memoryType, Integer retentionDays, Integer maxCount) {
+        Map<String, Object> retentionPolicy = new HashMap<>();
+        Map<String, Object> rule = new HashMap<>();
+        if (retentionDays != null) {
+            rule.put("retention_days", retentionDays);
+        }
+        if (maxCount != null) {
+            rule.put("max_count", maxCount);
+        }
+        retentionPolicy.put(memoryType, rule);
+        return retentionPolicy;
+    }
+
+    private SearchResponse emptySearchResponse() {
+        SearchResponse response = mock(SearchResponse.class);
+        SearchHits hits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(response.getHits()).thenReturn(hits);
+        return response;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.jobs.processors;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+public class MemoryRetentionJobProcessorTests {
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private Client client;
+
+    private MemoryRetentionJobProcessor processor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        MemoryRetentionJobProcessor.reset();
+        processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+    }
+
+    @Test
+    public void testGetInstance() {
+        MemoryRetentionJobProcessor instance1 = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+        MemoryRetentionJobProcessor instance2 = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+        assertSame(instance1, instance2);
+    }
+
+    @Test
+    public void testRunSkipsWhenMultiTenancyEnabled() {
+        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        processor.run();
+
+        // No exception thrown, method returns early with warning log
+    }
+
+    @Test
+    public void testRunExecutesWhenMultiTenancyDisabled() {
+        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", false).build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        processor.run();
+
+        // No exception thrown, logs "Memory retention job triggered"
+    }
+
+    @Test
+    public void testRunExecutesWithDefaultSettings() {
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+
+        processor.run();
+
+        // Default multi_tenancy_enabled is false, so job should execute
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,11 +34,16 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -46,6 +52,7 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryAction;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -79,9 +86,40 @@ public class MemoryRetentionJobProcessorTests {
         Settings settings = Settings
             .builder()
             .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
             .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", -1)
+            .put("plugins.ml_commons.memory.default_session_max_count", -1)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", -1)
+            .put("plugins.ml_commons.memory.default_history_max_count", -1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
             .build();
         when(clusterService.getSettings()).thenReturn(settings);
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settings, clusterSettingsSet);
+        lenient().when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        // Default cluster state: all memory indices exist (orphan sweep runs)
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        lenient().when(clusterService.state()).thenReturn(clusterState);
+        lenient().when(clusterState.metadata()).thenReturn(metadata);
+        lenient().when(metadata.hasIndex(anyString())).thenReturn(true);
 
         // Use real ThreadContext (it's a final class and cannot be mocked)
         threadContext = new ThreadContext(Settings.EMPTY);
@@ -109,6 +147,21 @@ public class MemoryRetentionJobProcessorTests {
     public void testRunSkipsWhenMultiTenancyEnabled() {
         Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build();
         when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
 
         processor.run();
 
@@ -124,6 +177,21 @@ public class MemoryRetentionJobProcessorTests {
             .put("plugins.ml_commons.memory.retention_enabled", false)
             .build();
         when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
 
         processor.run();
 
@@ -148,7 +216,23 @@ public class MemoryRetentionJobProcessorTests {
 
     @Test
     public void testRunExecutesWithDefaultSettings() {
-        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        Settings defaultSettings = Settings.EMPTY;
+        when(clusterService.getSettings()).thenReturn(defaultSettings);
+        java.util.Set<Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(defaultSettings, s));
 
         // Return empty containers
         doAnswer(invocation -> {
@@ -202,10 +286,11 @@ public class MemoryRetentionJobProcessorTests {
                     listener.onResponse(emptySearchResponse());
                 }
             } else {
-                // Session search returns 3 expired sessions
-                SearchHit hit1 = new SearchHit(0, "expired-session-1", null, null);
-                SearchHit hit2 = new SearchHit(1, "expired-session-2", null, null);
-                SearchHit hit3 = new SearchHit(2, "expired-session-3", null, null);
+                // Session search returns 3 expired sessions with old last_updated_time
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+                SearchHit hit1 = createHitWithSource("expired-session-1", Map.of("last_updated_time", oldTimestamp));
+                SearchHit hit2 = createHitWithSource("expired-session-2", Map.of("last_updated_time", oldTimestamp));
+                SearchHit hit3 = createHitWithSource("expired-session-3", Map.of("last_updated_time", oldTimestamp));
                 SearchHits sessionHits = new SearchHits(
                     new SearchHit[] { hit1, hit2, hit3 },
                     new TotalHits(3, TotalHits.Relation.EQUAL_TO),
@@ -230,6 +315,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete for sessions (Phase 3)
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -311,6 +398,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete for sessions
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -348,9 +437,10 @@ public class MemoryRetentionJobProcessorTests {
                     listener.onResponse(emptySearchResponse());
                 }
             } else {
-                // Session search returns expired sessions
-                SearchHit hit1 = new SearchHit(0, "session-1", null, null);
-                SearchHit hit2 = new SearchHit(1, "session-2", null, null);
+                // Session search returns expired sessions with old timestamps
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+                SearchHit hit1 = createHitWithSource("session-1", Map.of("last_updated_time", oldTimestamp));
+                SearchHit hit2 = createHitWithSource("session-2", Map.of("last_updated_time", oldTimestamp));
                 SearchHits sessionHits = new SearchHits(
                     new SearchHit[] { hit1, hit2 },
                     new TotalHits(2, TotalHits.Relation.EQUAL_TO),
@@ -381,6 +471,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete for sessions (Phase 3)
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             bulkDeleteOrder.set(orderCounter.getAndIncrement());
@@ -468,13 +560,14 @@ public class MemoryRetentionJobProcessorTests {
                 }
             } else {
                 // Return 600 expired sessions across 6 full pages of 100, then an empty page
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
                 int pageNum = sessionPageCount.getAndIncrement();
                 if (pageNum < 6) {
                     // Full page of 100 hits (triggers pagination)
                     SearchHit[] hits = new SearchHit[100];
                     for (int i = 0; i < 100; i++) {
                         int globalIdx = pageNum * 100 + i;
-                        hits[i] = new SearchHit(globalIdx, "session-" + globalIdx, null, null);
+                        hits[i] = createHitWithSource("session-" + globalIdx, Map.of("last_updated_time", oldTimestamp));
                         hits[i].sortValues(new Object[] { "session-" + globalIdx }, new DocValueFormat[] { DocValueFormat.RAW });
                     }
                     SearchHits sessionHits = new SearchHits(hits, new TotalHits(600, TotalHits.Relation.EQUAL_TO), Float.NaN);
@@ -504,6 +597,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -681,8 +776,12 @@ public class MemoryRetentionJobProcessorTests {
                 listener.onResponse(containerSearchResponse);
             } else {
                 sessionSearchCount.incrementAndGet();
-                // Return 1 expired session for each container
-                SearchHit expiredHit = new SearchHit(0, "expired-session-" + sessionSearchCount.get(), null, null);
+                // Return 1 expired session for each container with old timestamp
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(60);
+                SearchHit expiredHit = createHitWithSource(
+                    "expired-session-" + sessionSearchCount.get(),
+                    Map.of("last_updated_time", oldTimestamp)
+                );
                 SearchHits sessionHits = new SearchHits(
                     new SearchHit[] { expiredHit },
                     new TotalHits(1, TotalHits.Relation.EQUAL_TO),
@@ -707,6 +806,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -838,6 +939,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -1003,6 +1106,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete for max_count
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -1137,6 +1242,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -1215,6 +1322,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -1681,6 +1790,146 @@ public class MemoryRetentionJobProcessorTests {
     }
 
     @Test
+    public void testOrphanSweepSkippedWhenSessionsIndexDoesNotExist() {
+        // Sessions index does not exist in cluster state: sweep must be skipped entirely,
+        // otherwise all working memory would be classified as orphaned and deleted.
+        lenient().when(clusterService.state().metadata().hasIndex(anyString())).thenAnswer(invocation -> {
+            String indexName = invocation.getArgument(0);
+            return !indexName.contains("sessions");
+        });
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-idx-missing", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger workingMemorySearchCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                if (inOrphanPhase[0] && request.indices()[0].contains("working")) {
+                    workingMemorySearchCount.incrementAndGet();
+                }
+                if (request.source() != null && request.source().size() == 0) {
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        AtomicInteger orphanDbqCount = new AtomicInteger(0);
+
+        BulkByScrollResponse dbqResponse = mock(BulkByScrollResponse.class);
+        lenient().when(dbqResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            if (inOrphanPhase[0]) {
+                orphanDbqCount.incrementAndGet();
+            }
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(dbqResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Orphan sweep must not enumerate working memory when sessions index is missing", workingMemorySearchCount.get() == 0);
+        assertTrue("Orphan sweep must not delete anything when sessions index is missing", orphanDbqCount.get() == 0);
+    }
+
+    @Test
+    public void testOrphanSweepSkippedWhenWorkingMemoryIndexDoesNotExist() {
+        // Working memory index does not exist: nothing to sweep, skip.
+        lenient().when(clusterService.state().metadata().hasIndex(anyString())).thenAnswer(invocation -> {
+            String indexName = invocation.getArgument(0);
+            return !indexName.contains("working");
+        });
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-wm-missing", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger workingMemorySearchCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                if (inOrphanPhase[0] && request.indices()[0].contains("working")) {
+                    workingMemorySearchCount.incrementAndGet();
+                }
+                if (request.source() != null && request.source().size() == 0) {
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse dbqResponse = mock(BulkByScrollResponse.class);
+        lenient().when(dbqResponse.getDeleted()).thenReturn(0L);
+
+        AtomicInteger orphanDbqCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            if (inOrphanPhase[0]) {
+                orphanDbqCount.incrementAndGet();
+            }
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(dbqResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue(
+            "Orphan sweep must not enumerate working memory when working memory index is missing",
+            workingMemorySearchCount.get() == 0
+        );
+        assertTrue("Orphan sweep must not delete anything when working memory index is missing", orphanDbqCount.get() == 0);
+    }
+
+    @Test
     public void testSessionsIndexMissing() {
         String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
             + "\"use_system_index\":true,"
@@ -1867,5 +2116,26 @@ public class MemoryRetentionJobProcessorTests {
         SearchHits hits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
         when(response.getHits()).thenReturn(hits);
         return response;
+    }
+
+    private SearchHit createHitWithSource(String id, Map<String, Object> sourceMap) {
+        SearchHit hit = new SearchHit(id.hashCode(), id, null, null);
+        StringBuilder json = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, Object> entry : sourceMap.entrySet()) {
+            if (!first)
+                json.append(",");
+            json.append("\"").append(entry.getKey()).append("\":");
+            Object val = entry.getValue();
+            if (val instanceof String) {
+                json.append("\"").append(val).append("\"");
+            } else {
+                json.append(val);
+            }
+            first = false;
+        }
+        json.append("}");
+        hit.sourceRef(new BytesArray(json.toString()));
+        return hit;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -56,6 +57,8 @@ import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.Aggregations;
+import org.opensearch.search.aggregations.bucket.composite.CompositeAggregation;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -364,18 +367,23 @@ public class MemoryRetentionJobProcessorTests {
                     when(pinnedResp.getHits()).thenReturn(pinnedHits);
                     listener.onResponse(pinnedResp);
                 } else if (searchNum == 1) {
-                    // Count-based identification: returns 10 sessions sorted by last_updated_time DESC
-                    // First 5 are kept, last 5 are expired
-                    SearchHit[] hits = new SearchHit[10];
-                    for (int i = 0; i < 10; i++) {
+                    // Count query: return totalHits=10 (exceeds max_count=5)
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(10, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else if (searchNum == 2) {
+                    // Search for oldest 5 excess sessions by created_time ASC
+                    SearchHit[] hits = new SearchHit[5];
+                    for (int i = 0; i < 5; i++) {
                         hits[i] = new SearchHit(i, "session-" + i, null, null);
                         hits[i]
                             .sortValues(
-                                new Object[] { (long) (10 - i), "session-" + i },
+                                new Object[] { (long) i, "session-" + i },
                                 new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
                             );
                     }
-                    SearchHits sessionHits = new SearchHits(hits, new TotalHits(10, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchHits sessionHits = new SearchHits(hits, new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
                     SearchResponse sessionResponse = mock(SearchResponse.class);
                     when(sessionResponse.getHits()).thenReturn(sessionHits);
                     listener.onResponse(sessionResponse);
@@ -412,6 +420,57 @@ public class MemoryRetentionJobProcessorTests {
         // Verify cascade delete + bulk delete both called
         verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
         verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testSessionMaxCountShortCircuitsWhenUnderLimit() {
+        // max_count=5, only 3 non-pinned sessions -> count query short-circuits: no ID search, no deletes
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-count-under",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", null, 5)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger sessionSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = sessionSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else {
+                    // Count query: return totalHits=3 (under max_count=5)
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(3, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Only the pinned check and the count query should have hit the session index
+        assertTrue("Only pinned check + count query should fire when under max_count", sessionSearchCount.get() == 2);
+        // No deletions since totalCount (3) <= max_count (5)
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
     }
 
     @Test
@@ -696,6 +755,108 @@ public class MemoryRetentionJobProcessorTests {
 
         // Verify that we searched at least twice (once for each container's sessions)
         assertTrue("Both containers should be processed, second container search made", sessionSearchCount.get() >= 2);
+        // Neither container deleted anything (first failed, second had no expired data) -> no throttle
+        verify(threadPool, never()).schedule(any(Runnable.class), any(TimeValue.class), anyString());
+    }
+
+    @Test
+    public void testNoOpContainerSkipsThrottle() {
+        // Container with a policy but no expired data -> no deletions -> no inter-container throttle
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-noop",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // No expired sessions found
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Job still advances to the next step (orphan sweep container search) without any throttle
+        assertTrue("Job should proceed past the no-op container", containerSearchCount.get() >= 2);
+        verify(threadPool, never()).schedule(any(Runnable.class), any(TimeValue.class), anyString());
+    }
+
+    @Test
+    public void testContainerWithDeletionsSchedulesThrottle() {
+        // Container with expired sessions -> deletions occur -> throttle scheduled before next container
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-throttled",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+                SearchHit expiredHit = createHitWithSource("expired-session-1", Map.of("last_updated_time", oldTimestamp));
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { expiredHit },
+                    new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock cascade delete for working memory
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(2L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for sessions
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Throttle (retention_job_throttle_seconds=1) is scheduled after the container with deletions
+        verify(threadPool, atLeastOnce()).schedule(any(Runnable.class), eq(TimeValue.timeValueSeconds(1)), anyString());
     }
 
     @Test
@@ -1576,6 +1737,167 @@ public class MemoryRetentionJobProcessorTests {
     }
 
     @Test
+    public void testOrphanEnumerationUsesCompositeAggregation() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-agg", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger compositeAggSearchCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+
+        CompositeAggregation.Bucket bucket = mock(CompositeAggregation.Bucket.class);
+        when(bucket.getKey()).thenReturn(Map.of("session_id", "session-gone"));
+        CompositeAggregation composite = mock(CompositeAggregation.class);
+        when(composite.getName()).thenReturn("session_ids");
+        doReturn(java.util.List.of(bucket)).when(composite).getBuckets();
+        when(composite.afterKey()).thenReturn(null);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                String targetIndex = request.indices()[0];
+
+                if (!inOrphanPhase[0]) {
+                    if (request.source() != null && request.source().size() == 0) {
+                        SearchResponse countResp = mock(SearchResponse.class);
+                        SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                        when(countResp.getHits()).thenReturn(countHits);
+                        listener.onResponse(countResp);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                } else if (targetIndex.contains("working") && request.source() != null && request.source().aggregations() != null) {
+                    compositeAggSearchCount.incrementAndGet();
+                    SearchResponse aggResponse = mock(SearchResponse.class);
+                    when(aggResponse.getAggregations()).thenReturn(new Aggregations(java.util.List.of(composite)));
+                    listener.onResponse(aggResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse orphanDeleteResponse = mock(BulkByScrollResponse.class);
+        when(orphanDeleteResponse.getDeleted()).thenReturn(1L);
+
+        AtomicInteger dbqCount = new AtomicInteger(0);
+        java.util.List<String> dbqQueries = new java.util.ArrayList<>();
+
+        doAnswer(invocation -> {
+            dbqCount.incrementAndGet();
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            dbqQueries.add(dbq.getSearchRequest().source().query().toString());
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(orphanDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Orphan enumeration should use a composite aggregation search", compositeAggSearchCount.get() >= 1);
+        assertTrue("Orphan delete and empty-namespace DBQ should fire", dbqCount.get() >= 2);
+        assertTrue(
+            "Orphan DBQ should match the aggregated session id on the top-level session_id field",
+            dbqQueries.stream().anyMatch(q -> q.contains("session-gone") && q.contains("\"session_id\""))
+        );
+    }
+
+    @Test
+    public void testOrphanEnumerationStartsAtRandomKeyAndWrapsAround() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-random-start", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+        java.util.List<String> compositeAggSources = new java.util.ArrayList<>();
+
+        CompositeAggregation.Bucket bucket = mock(CompositeAggregation.Bucket.class);
+        when(bucket.getKey()).thenReturn(Map.of("session_id", "session-gone"));
+        CompositeAggregation composite = mock(CompositeAggregation.class);
+        when(composite.getName()).thenReturn("session_ids");
+        doReturn(java.util.List.of(bucket)).when(composite).getBuckets();
+        when(composite.afterKey()).thenReturn(null);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                String targetIndex = request.indices()[0];
+
+                if (!inOrphanPhase[0]) {
+                    if (request.source() != null && request.source().size() == 0) {
+                        SearchResponse countResp = mock(SearchResponse.class);
+                        SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                        when(countResp.getHits()).thenReturn(countHits);
+                        listener.onResponse(countResp);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                } else if (targetIndex.contains("working") && request.source() != null && request.source().aggregations() != null) {
+                    compositeAggSources.add(request.source().toString());
+                    SearchResponse aggResponse = mock(SearchResponse.class);
+                    when(aggResponse.getAggregations()).thenReturn(new Aggregations(java.util.List.of(composite)));
+                    listener.onResponse(aggResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse orphanDeleteResponse = mock(BulkByScrollResponse.class);
+        when(orphanDeleteResponse.getDeleted()).thenReturn(1L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(orphanDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Orphan enumeration should issue at least the initial composite search", compositeAggSources.size() >= 1);
+        assertTrue(
+            "First composite search must start from a randomized after key so cap truncation covers a different slice each run",
+            compositeAggSources.get(0).contains("\"after\"")
+        );
+        assertTrue(
+            "Enumeration must wrap around to the start of the keyspace after exhausting the first slice",
+            compositeAggSources.size() >= 2 && !compositeAggSources.get(compositeAggSources.size() - 1).contains("\"after\"")
+        );
+    }
+
+    @Test
     public void testNullSessionIdDeletedAfterGracePeriod() {
         Settings settings = Settings
             .builder()
@@ -2042,6 +2364,435 @@ public class MemoryRetentionJobProcessorTests {
         processor.run();
 
         assertTrue("Both retention and orphan sweep container searches should fire", containerSearchCount.get() >= 2);
+    }
+
+    @Test
+    public void testApplyDefaultRetentionPolicy_IssuesUpdateWhenDefaultsConfigured() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", 30)
+            .put("plugins.ml_commons.memory.default_session_max_count", 100)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", 500)
+            .put("plugins.ml_commons.memory.default_history_max_count", -1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<org.opensearch.common.settings.Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\",\"use_system_index\":true}}";
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-policy", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        java.util.concurrent.atomic.AtomicBoolean updateCalled = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            updateCalled.set(true);
+            org.opensearch.action.update.UpdateRequest req = invocation.getArgument(0);
+            assertTrue("Update should use a script", req.script() != null);
+            assertTrue("Script should contain noop logic", req.script().getIdOrCode().contains("noop"));
+            ActionListener<org.opensearch.action.update.UpdateResponse> listener = invocation.getArgument(1);
+            org.opensearch.action.update.UpdateResponse resp = mock(org.opensearch.action.update.UpdateResponse.class);
+            when(resp.getResult()).thenReturn(org.opensearch.action.DocWriteResponse.Result.UPDATED);
+            listener.onResponse(resp);
+            return null;
+        }).when(client).update(any(org.opensearch.action.update.UpdateRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("client.update should be called to backfill default policy", updateCalled.get());
+    }
+
+    @Test
+    public void testApplyDefaultRetentionPolicy_NoopSkipsContainer() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", 30)
+            .put("plugins.ml_commons.memory.default_session_max_count", -1)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", -1)
+            .put("plugins.ml_commons.memory.default_history_max_count", -1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<org.opensearch.common.settings.Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\",\"use_system_index\":true}}";
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-policy-noop", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.update.UpdateResponse> listener = invocation.getArgument(1);
+            org.opensearch.action.update.UpdateResponse resp = mock(org.opensearch.action.update.UpdateResponse.class);
+            when(resp.getResult()).thenReturn(org.opensearch.action.DocWriteResponse.Result.NOOP);
+            listener.onResponse(resp);
+            return null;
+        }).when(client).update(any(org.opensearch.action.update.UpdateRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testApplyDefaultRetentionPolicy_AllDefaultsMinusOne_NoUpdate() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\",\"use_system_index\":true}}";
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-all-minus-one", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, never()).update(any(org.opensearch.action.update.UpdateRequest.class), isA(ActionListener.class));
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testEpochSecondNormalization_NewerTimestampNotDeleted() {
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-epoch",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        java.util.List<String> deletedIds = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+
+        long nowMillis = System.currentTimeMillis();
+        long cutoffMillis = nowMillis - java.util.concurrent.TimeUnit.DAYS.toMillis(7);
+        long epochSecNewSession = (nowMillis - java.util.concurrent.TimeUnit.DAYS.toMillis(3)) / 1000;
+        long epochMillisOldSession = cutoffMillis - 10_000;
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                SearchHit hitNew = createHitWithSource("session-epoch-new", Map.of("last_updated_time", epochSecNewSession));
+                SearchHit hitOld = createHitWithSource("session-epoch-old", Map.of("last_updated_time", epochMillisOldSession));
+                SearchHit hitMissing = createHitWithSource("session-missing-ts", Map.of("other_field", "value"));
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { hitNew, hitOld, hitMissing },
+                    new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(1L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            BulkRequest bulkReq = invocation.getArgument(0);
+            bulkReq.requests().forEach(r -> deletedIds.add(((org.opensearch.action.delete.DeleteRequest) r).id()));
+            BulkResponse bulkResponse = mock(BulkResponse.class);
+            lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+            lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Epoch-second session newer than cutoff should NOT be deleted", !deletedIds.contains("session-epoch-new"));
+        assertTrue("Epoch-millis session older than cutoff SHOULD be deleted", deletedIds.contains("session-epoch-old"));
+        assertTrue("Session with missing timestamp should NOT be deleted", !deletedIds.contains("session-missing-ts"));
+    }
+
+    @Test
+    public void testBuildEpochAwareCutoffQuery_Structure() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-dbq-cutoff", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        java.util.concurrent.atomic.AtomicReference<String> capturedQuery = new java.util.concurrent.atomic.AtomicReference<>();
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            capturedQuery.set(dbq.getSearchRequest().source().query().toString());
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            BulkByScrollResponse resp = mock(BulkByScrollResponse.class);
+            when(resp.getDeleted()).thenReturn(0L);
+            listener.onResponse(resp);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        String query = capturedQuery.get();
+        assertTrue("Query must contain gte threshold clause", query != null && query.contains("10000000000"));
+        assertTrue("Query must contain minimum_should_match=1", query.contains("minimum_should_match") && query.contains("1"));
+        assertTrue("Query must have two should clauses for epoch-aware cutoff", query.contains("should"));
+    }
+
+    @Test
+    public void testDebugLogsSessionDeletionIds() {
+        org.apache.logging.log4j.core.LoggerContext context =
+            (org.apache.logging.log4j.core.LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
+        org.apache.logging.log4j.core.config.LoggerConfig loggerConfig = context
+            .getConfiguration()
+            .getLoggerConfig(MemoryRetentionJobProcessor.class.getName());
+        org.apache.logging.log4j.Level originalLevel = loggerConfig.getLevel();
+        loggerConfig.setLevel(org.apache.logging.log4j.Level.DEBUG);
+        context.updateLoggers();
+
+        java.util.List<String> capturedMessages = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+        org.apache.logging.log4j.core.appender.AbstractAppender appender = new org.apache.logging.log4j.core.appender.AbstractAppender(
+            "test-debug-appender",
+            null,
+            org.apache.logging.log4j.core.layout.PatternLayout.createDefaultLayout(),
+            false
+        ) {
+            @Override
+            public void append(org.apache.logging.log4j.core.LogEvent event) {
+                capturedMessages.add(event.getLevel() + ": " + event.getMessage().getFormattedMessage());
+            }
+        };
+        appender.start();
+        loggerConfig.addAppender(appender, org.apache.logging.log4j.Level.DEBUG, null);
+        context.updateLoggers();
+
+        try {
+            SearchResponse containerSearchResponse = createContainerSearchResponse(
+                "container-debug",
+                "test-prefix",
+                true,
+                createRetentionPolicyMap("sessions", 7, null)
+            );
+
+            AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+            doAnswer(invocation -> {
+                SearchRequest request = invocation.getArgument(0);
+                ActionListener<SearchResponse> listener = invocation.getArgument(1);
+                if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                    if (containerSearchCount.getAndIncrement() == 0) {
+                        listener.onResponse(containerSearchResponse);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                } else {
+                    long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+                    SearchHit hit1 = createHitWithSource("debug-session-1", Map.of("last_updated_time", oldTimestamp));
+                    SearchHit hit2 = createHitWithSource("debug-session-2", Map.of("last_updated_time", oldTimestamp));
+                    SearchHits sessionHits = new SearchHits(
+                        new SearchHit[] { hit1, hit2 },
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        Float.NaN
+                    );
+                    SearchResponse sessionResponse = mock(SearchResponse.class);
+                    when(sessionResponse.getHits()).thenReturn(sessionHits);
+                    listener.onResponse(sessionResponse);
+                }
+                return null;
+            }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+            BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+            when(cascadeResponse.getDeleted()).thenReturn(2L);
+            doAnswer(invocation -> {
+                ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+                listener.onResponse(cascadeResponse);
+                return null;
+            }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+            BulkResponse bulkResponse = mock(BulkResponse.class);
+            when(bulkResponse.hasFailures()).thenReturn(false);
+            when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
+            doAnswer(invocation -> {
+                ActionListener<BulkResponse> listener = invocation.getArgument(1);
+                listener.onResponse(bulkResponse);
+                return null;
+            }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+            processor.run();
+
+            boolean foundDebugIds = capturedMessages
+                .stream()
+                .anyMatch(m -> m.startsWith("DEBUG:") && m.contains("deleting session ids=") && m.contains("debug-session-1"));
+            assertTrue("DEBUG log should contain session IDs being deleted", foundDebugIds);
+
+            boolean foundInfoAggregate = capturedMessages.stream().anyMatch(m -> m.startsWith("INFO:") && m.contains("sessions_expired=2"));
+            assertTrue("INFO aggregate log should be unchanged", foundInfoAggregate);
+        } finally {
+            loggerConfig.removeAppender(appender.getName());
+            appender.stop();
+            loggerConfig.setLevel(originalLevel);
+            context.updateLoggers();
+        }
+    }
+
+    @Test
+    public void testRetentionPolicyNullOptOut_SkipsEverything() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", 30)
+            .put("plugins.ml_commons.memory.default_session_max_count", 100)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", 500)
+            .put("plugins.ml_commons.memory.default_history_max_count", 200)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<org.opensearch.common.settings.Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\",\"use_system_index\":true,\"retention_policy\":null}}";
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-opt-out", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, never()).update(any(org.opensearch.action.update.UpdateRequest.class), isA(ActionListener.class));
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
     }
 
     // --- Helper methods ---

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -1371,6 +1371,430 @@ public class MemoryRetentionJobProcessorTests {
         assertTrue("At least one delete_by_query should have been called for long-term retention_days", deleteByQueryCount.get() >= 1);
     }
 
+    // --- Phase 7: Orphan Sweep Tests ---
+
+    @Test
+    public void testOrphanDetectedAndDeleted() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-orphan", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger orphanPhaseSearchCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                String targetIndex = request.indices()[0];
+
+                if (!inOrphanPhase[0]) {
+                    if (request.source() != null && request.source().size() == 0) {
+                        SearchResponse countResp = mock(SearchResponse.class);
+                        SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                        when(countResp.getHits()).thenReturn(countHits);
+                        listener.onResponse(countResp);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                } else {
+                    orphanPhaseSearchCount.incrementAndGet();
+                    if (targetIndex.contains("working")) {
+                        SearchHit hit1 = new SearchHit(0, "working-1", null, null);
+                        hit1.sourceRef(new BytesArray("{\"namespace\":{\"session_id\":\"session-exists\"}}"));
+                        hit1.sortValues(new Object[] { "working-1" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+                        SearchHit hit2 = new SearchHit(1, "working-2", null, null);
+                        hit2.sourceRef(new BytesArray("{\"namespace\":{\"session_id\":\"session-gone\"}}"));
+                        hit2.sortValues(new Object[] { "working-2" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+                        SearchHits workingHits = new SearchHits(
+                            new SearchHit[] { hit1, hit2 },
+                            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                            Float.NaN
+                        );
+                        SearchResponse workingResponse = mock(SearchResponse.class);
+                        when(workingResponse.getHits()).thenReturn(workingHits);
+                        listener.onResponse(workingResponse);
+                    } else if (targetIndex.contains("sessions")) {
+                        SearchHit existsHit = new SearchHit(0, "session-exists", null, null);
+                        SearchHits sessionHits = new SearchHits(
+                            new SearchHit[] { existsHit },
+                            new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+                            Float.NaN
+                        );
+                        SearchResponse sessionResponse = mock(SearchResponse.class);
+                        when(sessionResponse.getHits()).thenReturn(sessionHits);
+                        listener.onResponse(sessionResponse);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse orphanDeleteResponse = mock(BulkByScrollResponse.class);
+        when(orphanDeleteResponse.getDeleted()).thenReturn(3L);
+
+        AtomicInteger dbqCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            dbqCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(orphanDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Orphan sweep should have searched working memory", orphanPhaseSearchCount.get() >= 1);
+        assertTrue("Delete-by-query should fire for orphans and null sessions", dbqCount.get() >= 2);
+    }
+
+    @Test
+    public void testNullSessionIdDeletedAfterGracePeriod() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-null-session", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0 || count == 1) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                if (request.source() != null && request.source().size() == 0) {
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse nullDeleteResponse = mock(BulkByScrollResponse.class);
+        when(nullDeleteResponse.getDeleted()).thenReturn(5L);
+
+        AtomicInteger deleteByQueryCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            deleteByQueryCount.incrementAndGet();
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Null session delete should use created_time range", queryString.contains("created_time"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(nullDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Null session delete_by_query should fire", deleteByQueryCount.get() >= 1);
+    }
+
+    @Test
+    public void testNullSessionIdWithinGracePeriodNotDeleted() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-grace", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0 || count == 1) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                if (request.source() != null && request.source().size() == 0) {
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse graceResponse = mock(BulkByScrollResponse.class);
+        when(graceResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Null session delete should use created_time range for grace period", queryString.contains("created_time"));
+            assertTrue("Should filter docs without session_id", queryString.contains("session_id"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(graceResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testNoOrphansFound() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-orphans", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger deleteByQueryCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                String targetIndex = request.indices()[0];
+
+                if (!inOrphanPhase[0]) {
+                    if (request.source() != null && request.source().size() == 0) {
+                        SearchResponse countResp = mock(SearchResponse.class);
+                        SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                        when(countResp.getHits()).thenReturn(countHits);
+                        listener.onResponse(countResp);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                } else {
+                    if (targetIndex.contains("working")) {
+                        SearchHit hit1 = new SearchHit(0, "w-1", null, null);
+                        hit1.sourceRef(new BytesArray("{\"namespace\":{\"session_id\":\"s-1\"}}"));
+                        hit1.sortValues(new Object[] { "w-1" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+                        SearchHit hit2 = new SearchHit(1, "w-2", null, null);
+                        hit2.sourceRef(new BytesArray("{\"namespace\":{\"session_id\":\"s-2\"}}"));
+                        hit2.sortValues(new Object[] { "w-2" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+                        SearchHits workingHits = new SearchHits(
+                            new SearchHit[] { hit1, hit2 },
+                            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                            Float.NaN
+                        );
+                        SearchResponse workingResponse = mock(SearchResponse.class);
+                        when(workingResponse.getHits()).thenReturn(workingHits);
+                        listener.onResponse(workingResponse);
+                    } else if (targetIndex.contains("sessions")) {
+                        SearchHit exist1 = new SearchHit(0, "s-1", null, null);
+                        SearchHit exist2 = new SearchHit(1, "s-2", null, null);
+                        SearchHits sessionHits = new SearchHits(
+                            new SearchHit[] { exist1, exist2 },
+                            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                            Float.NaN
+                        );
+                        SearchResponse sessionResponse = mock(SearchResponse.class);
+                        when(sessionResponse.getHits()).thenReturn(sessionHits);
+                        listener.onResponse(sessionResponse);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse nullResponse = mock(BulkByScrollResponse.class);
+        when(nullResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            deleteByQueryCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(nullResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Only null session cleanup DBQ should fire (no orphans)", deleteByQueryCount.get() == 1);
+    }
+
+    @Test
+    public void testSessionsIndexMissing() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-sessions-idx", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger orphanDbqCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse ttlResponse = mock(BulkByScrollResponse.class);
+        when(ttlResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            orphanDbqCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ttlResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Only Phase 6 TTL DBQ should fire, not orphan sweep", orphanDbqCount.get() == 1);
+    }
+
+    @Test
+    public void testDisableSessionTrueContainerSkippedInOrphanSweep() {
+        String sourceJsonSessionEnabled = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        String sourceJsonSessionDisabled = "{\"configuration\":{\"index_prefix\":\"other-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchHit hit1 = new SearchHit(0, "container-with-session", null, null);
+        hit1.sourceRef(new BytesArray(sourceJsonSessionEnabled));
+        hit1.sortValues(new Object[] { "container-with-session" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchHit hit2 = new SearchHit(1, "container-no-session", null, null);
+        hit2.sourceRef(new BytesArray(sourceJsonSessionDisabled));
+        hit2.sortValues(new Object[] { "container-no-session" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchResponse retentionContainerResponse = mock(SearchResponse.class);
+        SearchHits retentionContainerHits = new SearchHits(
+            new SearchHit[] { hit1, hit2 },
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+            Float.NaN
+        );
+        when(retentionContainerResponse.getHits()).thenReturn(retentionContainerHits);
+
+        SearchResponse orphanContainerResponse = createContainerSearchResponseFromJson("container-with-session", sourceJsonSessionEnabled);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(retentionContainerResponse);
+                } else if (count == 1) {
+                    listener.onResponse(orphanContainerResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                if (request.source() != null && request.source().size() == 0) {
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse dbqResponse = mock(BulkByScrollResponse.class);
+        when(dbqResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(dbqResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Both retention and orphan sweep container searches should fire", containerSearchCount.get() >= 2);
+    }
+
     // --- Helper methods ---
 
     private SearchResponse createContainerSearchResponseFromJson(String containerId, String sourceJson) {

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -117,6 +117,21 @@ public class MemoryRetentionJobProcessorTests {
     }
 
     @Test
+    public void testRunSkipsWhenRetentionDisabled() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", false)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        processor.run();
+
+        // Should not search for containers when retention is disabled
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
     public void testRunExecutesWhenMultiTenancyDisabled() {
         // Return empty containers
         doAnswer(invocation -> {
@@ -256,6 +271,12 @@ public class MemoryRetentionJobProcessorTests {
             } else {
                 int searchNum = sessionSearchCount.getAndIncrement();
                 if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
                     // Count-based identification: returns 10 sessions sorted by last_updated_time DESC
                     // First 5 are kept, last 5 are expired
                     SearchHit[] hits = new SearchHit[10];
@@ -784,6 +805,12 @@ public class MemoryRetentionJobProcessorTests {
             } else {
                 int searchNum = nonContainerSearchCount.getAndIncrement();
                 if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
                     // Count query: return totalHits=150
                     SearchResponse countResp = mock(SearchResponse.class);
                     SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(150, TotalHits.Relation.EQUAL_TO), Float.NaN);
@@ -933,6 +960,12 @@ public class MemoryRetentionJobProcessorTests {
             } else {
                 int searchNum = nonContainerSearchCount.getAndIncrement();
                 if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
                     // Count query for max_count: return 120
                     SearchResponse countResp = mock(SearchResponse.class);
                     SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(120, TotalHits.Relation.EQUAL_TO), Float.NaN);
@@ -984,6 +1017,61 @@ public class MemoryRetentionJobProcessorTests {
         verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
     }
 
+    // --- Pinned Exceeds max_count Warning Tests ---
+
+    @Test
+    public void testPinnedExceedsMaxCountWarningFires() {
+        // Container with long-term max_count=10, pinned count returns 15 -> verify warning fires (no exception)
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"max_count\":10}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-pin-warn", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Pinned count check: return 15 pinned docs (exceeds max_count=10)
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(15, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
+                    // Count query for max_count: return 5 non-pinned (under limit, no eviction)
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Pinned count check and normal count query both fired (at least 2 non-container searches)
+        assertTrue("Pinned count check and count query should both fire", nonContainerSearchCount.get() >= 2);
+        // No bulk delete since non-pinned count (5) is under max_count (10)
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
     // --- Phase 5: History Retention Tests ---
 
     @Test
@@ -1013,6 +1101,12 @@ public class MemoryRetentionJobProcessorTests {
             } else {
                 int searchNum = nonContainerSearchCount.getAndIncrement();
                 if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
                     // Count query: return totalHits=600
                     SearchResponse countResp = mock(SearchResponse.class);
                     SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(600, TotalHits.Relation.EQUAL_TO), Float.NaN);
@@ -1083,6 +1177,12 @@ public class MemoryRetentionJobProcessorTests {
             } else {
                 int searchNum = nonContainerSearchCount.getAndIncrement();
                 if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
                     // Count query: return 15 docs (exceeds max_count=10)
                     SearchResponse countResp = mock(SearchResponse.class);
                     SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(15, TotalHits.Relation.EQUAL_TO), Float.NaN);


### PR DESCRIPTION
### Description

Implements the agentic memory retention lifecycle (RFC #4859). Adds a background Job Scheduler job that enforces per-container lifecycle rules (`retention_days`, `max_count`) on sessions, long-term memory, and history — preventing unbounded storage growth and context window pollution.

**Core features:**

- `retention_policy` configuration on memory containers with per-memory-type rules
- Background retention job (default 24h interval) with FIFO eviction of expired/over-count memories
- Session deletion cascades to working memory (working memory first → session — prevents orphans)
- Orphan sweep with 7-day age guard catches working memory pointing to non-existent sessions
- `pinned: true` field exempts individual memories from eviction
- Cluster-level admin defaults auto-apply to containers without a policy (conditional script update, never clobbers user-set policies or explicit-null opt-outs)
- Working memory TTL for session-less containers (`disableSession=true`)
- Epoch-second detection prevents mass-eviction of pre-upgrade legacy data
- Backward compatible: VERSION_3_8_0 guards on all new serialized fields

**Also fixes:** A latent bug in `SearchModelGroupTransportAction.search()` where an empty indices array caused all-indices search — exposed by the new retention job document in `.plugins-ml-jobs`.

### Related Issues

Resolves #4859

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin)